### PR TITLE
Home: fetch the cards the row draws, and open one transcript per project

### DIFF
--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -29,11 +29,35 @@ import { ClaudeHealthStrip } from "@platform/ui/ClaudeHealthStrip";
 // Card width + gap must match the .home-row CSS.
 const CARD_W = 330;
 const CARD_GAP = 16;
-// How many entries each section fetches/keeps — enough for a very wide window.
+// The ceiling on what a section may fetch/keep — enough for a very wide
+// window, and the same cap the two endpoints apply to `limit` themselves
+// (HOME_APPS_LIMIT / HOME_SESSION_LIMIT). NOT the number either one asks for:
+// see useStripCount.
 const MAX_ROW = 12;
 
-// How many cards fit across the sections' shared container right now.
+// How many cards fit across the sections' shared container right now, plus the
+// most that have ever fit — the number the fetches ask for.
 // One ResizeObserver on the wrapper, one count for all three strips.
+//
+// The two numbers are not the same, and the difference is load-bearing. Asking
+// for MAX_ROW when the row draws three cards is what made the server's
+// recents-first fast path unreachable: /api/apps/home skips its exhaustive
+// workspace walk only once the recents FILL the request (routers/apps.py), so a
+// request for twelve walked the whole workspace on every visit for anyone with
+// fewer than twelve opened apps — which is nearly everyone. A row that asks for
+// what it can draw puts that walk back to being the fallback it is documented
+// as, and the session row's per-directory transcript reads (its endpoint stops
+// as soon as `limit` folders land) shrink with it.
+//
+// `count` is null until the wrapper has actually been MEASURED, and both
+// fetches wait for it. A guess would be a request for cards the row cannot
+// show, which is the same bug in smaller print. Nothing flashes for it: a
+// callback ref runs in the commit phase, so the measured value is in before the
+// browser paints.
+//
+// `limit` is the PEAK count, never the current one — widening the window needs
+// cards the first fetch did not ask for, while narrowing it already holds
+// enough, so a drag that shrinks the row refetches nothing.
 //
 // A CALLBACK ref, not useRef+useEffect: the measured wrapper UNMOUNTS while a
 // search is live (`searching ? null : <div ref=…>`), and a mount-once effect
@@ -43,20 +67,38 @@ const MAX_ROW = 12;
 // The callback re-runs on each mount/unmount: it tears the old observer down
 // and measures the element actually on screen.
 function useStripCount() {
-  const [count, setCount] = useState(3);
+  // One state, not two: `limit` is derived from the same measurement as
+  // `count`, and splitting them would let a render see a count the limit had
+  // not accounted for yet.
+  const [size, setSize] = useState<{ count: number | null; limit: number | null }>({
+    count: null,
+    limit: null,
+  });
   const roRef = useRef<ResizeObserver | null>(null);
   const ref = useCallback((el: HTMLDivElement | null) => {
     roRef.current?.disconnect();
     roRef.current = null;
     if (!el) return;
-    const measure = () =>
-      setCount(Math.max(1, Math.floor((el.clientWidth + CARD_GAP) / (CARD_W + CARD_GAP))));
+    const measure = () => {
+      const fits = Math.max(
+        1,
+        Math.floor((el.clientWidth + CARD_GAP) / (CARD_W + CARD_GAP)),
+      );
+      // Same object back when the count is unchanged: a ResizeObserver fires
+      // for every pixel of a window drag, and only a changed card count is a
+      // reason to re-render (or, via `limit`, to fetch).
+      setSize((prev) =>
+        prev.count === fits
+          ? prev
+          : { count: fits, limit: Math.max(prev.limit ?? 0, fits) },
+      );
+    };
     measure();
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     roRef.current = ro;
   }, []);
-  return { ref, count };
+  return { ref, count: size.count, limit: size.limit };
 }
 
 // Section chrome: title row with the "See all" action on the right edge.
@@ -102,14 +144,21 @@ export default function Home({ config }: { config: Config }) {
   const home = config.home.replace(/\\/g, "/");
   useRecentsVersion();
 
+  // Ahead of the two fetches below, which size their request by it.
+  const { ref: stripRef, count, limit } = useStripCount();
+  // Slice width while the wrapper is still unmeasured. Pre-paint only — see
+  // useStripCount — so an empty row is never actually seen.
+  const shown = count ?? 0;
+
   // Fused apps — hydrate the recent row first. The server only scans the full
   // workspace when valid recents do not fill it, preserving discovery and the
   // showcase fallback without charging returning visits for an exhaustive walk.
   const [apps, setApps] = useState<AppInfo[] | null>(null);
   const [appsError, setAppsError] = useState<string | null>(null);
   useEffect(() => {
+    if (limit === null) return;
     let alive = true;
-    getHomeApps(MAX_ROW).then(
+    getHomeApps(Math.min(limit, MAX_ROW)).then(
       (r) => alive && setApps(r.apps.slice(0, MAX_ROW)),
       (e: Error) => {
         if (!alive) return;
@@ -120,21 +169,22 @@ export default function Home({ config }: { config: Config }) {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [limit]);
 
   // Claude session folders — Home's endpoint orders transcript mtimes first,
   // then opens only enough newest JSONL files to fill this one row.
   const [sessions, setSessions] = useState<ClaudeSessionFolder[] | null>(null);
   useEffect(() => {
+    if (limit === null) return;
     let alive = true;
-    getHomeClaudeSessionFolders(MAX_ROW).then(
+    getHomeClaudeSessionFolders(Math.min(limit, MAX_ROW)).then(
       (r) => alive && setSessions(r.folders.slice(0, MAX_ROW)),
       () => alive && setSessions([]),
     );
     return () => {
       alive = false;
     };
-  }, []);
+  }, [limit]);
 
   // Recents come from the same client cache the explorer home reads (raw MRU).
   const recents = loadRecents().entries.slice(0, MAX_ROW);
@@ -145,8 +195,6 @@ export default function Home({ config }: { config: Config }) {
   const [searching, setSearching] = useState(false);
   const indexScan = useIndexStatus(searching);
   const initialQuery = useRef(new URLSearchParams(location.search).get("q") || "").current;
-
-  const { ref: stripRef, count } = useStripCount();
 
   return (
     <div className="files-home">
@@ -165,7 +213,14 @@ export default function Home({ config }: { config: Config }) {
           // exactly as wide as the cards that fit and centered, so the section
           // titles and "See all" stay flush with the cards' edges.
           <div ref={stripRef}>
-            <div className="home-strips" style={{ width: count * (CARD_W + CARD_GAP) - CARD_GAP }}>
+            <div
+              className="home-strips"
+              style={
+                count === null
+                  ? undefined
+                  : { width: count * (CARD_W + CARD_GAP) - CARD_GAP }
+              }
+            >
             {/* Above the strips, because on a machine where Claude Code is not
                 set up this is the only thing on the page the user can act on —
                 and it renders nothing at all once there is nothing to say.
@@ -178,7 +233,7 @@ export default function Home({ config }: { config: Config }) {
                 <p className="fh-empty">Loading apps…</p>
               ) : apps.length ? (
                 <div className="home-row">
-                  {apps.slice(0, count).map((app) => (
+                  {apps.slice(0, shown).map((app) => (
                     <AppPreviewCard key={app.path} app={app} />
                   ))}
                 </div>
@@ -194,7 +249,7 @@ export default function Home({ config }: { config: Config }) {
                 <p className="fh-empty">Looking for sessions…</p>
               ) : sessions.length ? (
                 <div className="home-row">
-                  {sessions.slice(0, count).map((f) => (
+                  {sessions.slice(0, shown).map((f) => (
                     <FolderPreviewCard key={f.path} path={f.path} />
                   ))}
                 </div>
@@ -206,7 +261,7 @@ export default function Home({ config }: { config: Config }) {
             <Section title="Recent files" seeAllHref="/explorer?tab=recents">
               {recents.length ? (
                 <div className="home-row">
-                  {recents.slice(0, count).map((r) => {
+                  {recents.slice(0, shown).map((r) => {
                     const fsPath = recentFsPath(r.url);
                     return (
                       <RecentPreviewCard

--- a/frontend/src/shell/home-performance.test.ts
+++ b/frontend/src/shell/home-performance.test.ts
@@ -36,13 +36,31 @@ test("shared explorer previews enter the scheduler only near the viewport", () =
 
 test("Home requests the recent-first app row instead of the exhaustive catalog", () => {
   const home = readFileSync(join(import.meta.dir, "Home.tsx"), "utf8");
-  expect(home).toContain("getHomeApps(MAX_ROW)");
+  expect(home).toContain("getHomeApps(Math.min(limit, MAX_ROW))");
   expect(home).not.toContain("getApps()");
   expect(home).not.toContain("sortApps(");
 });
 
 test("Home requests the early-stopping Claude session row", () => {
   const home = readFileSync(join(import.meta.dir, "Home.tsx"), "utf8");
-  expect(home).toContain("getHomeClaudeSessionFolders(MAX_ROW)");
+  expect(home).toContain("getHomeClaudeSessionFolders(Math.min(limit, MAX_ROW))");
   expect(home).not.toContain("getClaudeSessionFolders()");
+});
+
+// The row asks for the cards it can draw, because the server's fast path is
+// gated on the recents FILLING the request: /api/apps/home only skips its
+// exhaustive workspace walk when it has `limit` recents, so a fixed request for
+// MAX_ROW=12 walked the whole workspace on every Home visit for anyone with
+// fewer than twelve opened apps. Pinned as source structure rather than
+// behaviour because mounting Home would need a DOM with a real clientWidth.
+test("Home sizes both row requests by the measured card count, never a constant", () => {
+  const home = readFileSync(join(import.meta.dir, "Home.tsx"), "utf8");
+  // Unmeasured means UNKNOWN, not a guess: a fetch before the wrapper has a
+  // width would ask for cards the row cannot show.
+  expect(home).toContain("count: null");
+  expect(home.match(/if \(limit === null\) return;/g)?.length).toBe(2);
+  expect(home.match(/\}, \[limit\]\);/g)?.length).toBe(2);
+  // Grow-only, so narrowing the window refetches nothing.
+  expect(home).toContain("limit: Math.max(prev.limit ?? 0, fits)");
+  expect(home).not.toContain("useState(3)");
 });

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1487,7 +1487,7 @@ describe("the folder recents come from the app's own recents", () => {
     // endpoint; the form retains the exhaustive API and slices its five rows.
     expect(src).toContain("getClaudeSessionFolders()");
     expect(readFileSync(join(import.meta.dir, "Home.tsx"), "utf8"))
-      .toContain("getHomeClaudeSessionFolders(MAX_ROW)");
+      .toContain("getHomeClaudeSessionFolders(Math.min(limit, MAX_ROW))");
     // Five, and the server already answers newest-session-first, so the slice
     // is the whole of the ordering — the folders reach the list in the order
     // they arrived in, with no client-side re-sort to disagree with the strip.

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -5,8 +5,8 @@ Three endpoints, same on-disk source (~/.claude/projects/<encoded-cwd>/*.jsonl):
 * ``GET /api/claude-sessions`` — one row per real project *folder*, for the
   exhaustive folder listing.
 * ``GET /api/claude-sessions/home`` — the newest project folders for Home. It
-  orders candidates by transcript mtime first, then opens only enough
-  transcripts to fill Home's single row.
+  orders candidates by transcript mtime first, then opens at most one transcript
+  per project directory and stops as soon as Home's single row is full.
 * ``GET /api/claude-sessions/summaries`` — one row per *session*, for the
   React shell's Schedule page. Mirrors the bundled sessions inbox app
   (core_apps/sessions/sessions/sessions.py + core_apps/sessions/inbox.py):
@@ -124,30 +124,79 @@ def _transcripts_newest_first() -> list[tuple[float, str]]:
     """All transcript paths ordered by mtime without opening their contents.
 
     Establishing the true newest folders requires seeing every transcript's
-    cheap filesystem timestamp. The Home saving is after this pass: JSONL files
-    are opened newest-first and parsing stops as soon as the row is full.
+    cheap filesystem timestamp, and there is no coarser stat that could stand in
+    for the pass: Claude Code APPENDS to an existing transcript, which does not
+    touch the parent directory's own mtime, so a directory-level sweep would
+    rank a project by when a session was last STARTED there. The Home saving is
+    after this pass — one transcript OPENED per project directory, stopping as
+    soon as the row is full.
+
+    `os.scandir`, not glob + getmtime: the type and the stat come off the
+    directory read the walk is already doing, instead of a fresh path resolution
+    per name (~2x on this machine's 292-transcript store).
     """
     candidates: list[tuple[float, str]] = []
-    if not os.path.isdir(PROJECTS_DIR):
+    try:
+        with os.scandir(PROJECTS_DIR) as projects:
+            for project in projects:
+                try:
+                    if not project.is_dir():
+                        continue
+                    with os.scandir(project.path) as entries:
+                        for entry in entries:
+                            if not entry.name.endswith(".jsonl"):
+                                continue
+                            try:
+                                candidates.append(
+                                    (entry.stat().st_mtime, entry.path))
+                            except OSError:
+                                continue
+                # One unreadable project directory must not lose the rest.
+                except OSError:
+                    continue
+    except OSError:
+        # No projects dir (or it is not a directory): no sessions, not an error.
         return candidates
-    for jsonl_path in glob.iglob(os.path.join(PROJECTS_DIR, "*", "*.jsonl")):
-        try:
-            candidates.append((os.path.getmtime(jsonl_path), jsonl_path))
-        except OSError:
-            continue
     candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
     return candidates
 
 
 @router.get("/api/claude-sessions/home")
 def api_home_claude_sessions(limit: int = HOME_SESSION_LIMIT):
-    """The newest unique, existing Claude project folders needed by Home."""
+    """The newest unique, existing Claude project folders needed by Home.
+
+    At most ONE transcript is opened per project DIRECTORY. A directory name is
+    the encoded cwd, so every transcript inside it records the same one and the
+    newest answers for all of them; the older ones are file opens that can only
+    reproduce a cwd already in hand. That is what bounds the cost by directories
+    touched rather than by sessions held: measured on a 292-transcript store in
+    73 directories, filling a five-folder row went from 24 opens to 8 and a
+    twelve-folder row from 71 to 21 — and every one of those opens reads the head
+    of a file that can be multiple megabytes.
+
+    A directory counts as resolved only once a cwd has actually been READ, so a
+    truncated or headless newest transcript still falls through to the older
+    ones behind it rather than dropping the folder.
+
+    The per-cwd `seen` set stays on top of that, because the two dedupes are not
+    the same rule: the encoding is lossy (both "/" and "-" become "-"), so one
+    directory CAN hold transcripts from two real folders. This row shows the
+    newest of them; the exhaustive endpoint above reads every transcript and is
+    where both appear.
+    """
     limit = max(1, min(limit, HOME_SESSION_LIMIT))
     folders = []
     seen: set[str] = set()
+    resolved_dirs: set[str] = set()
     for mtime, jsonl_path in _transcripts_newest_first():
+        project_dir = os.path.dirname(jsonl_path)
+        if project_dir in resolved_dirs:
+            continue
         cwd = _session_cwd(jsonl_path)
-        if not cwd or cwd in seen:
+        if not cwd:
+            continue
+        resolved_dirs.add(project_dir)
+        if cwd in seen:
             continue
         # Mark before the probe: repeated sessions for a stale folder cannot
         # become valid during this one request and should not repeat the syscall.

--- a/tests/test_claude_sessions_api.py
+++ b/tests/test_claude_sessions_api.py
@@ -136,7 +136,85 @@ def test_home_skips_duplicate_and_missing_folders_until_the_row_is_full(
     data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
 
     assert [f["path"] for f in data["folders"]] == [str(a), str(b), str(c)]
-    assert len(opened) == 5
+    # Four, not five: a/old is never opened. Its directory was already resolved
+    # by a/new, and a directory name IS the encoded cwd, so the second file
+    # could only have reproduced a folder already in the row.
+    assert len(opened) == 4
+
+
+def test_home_opens_one_transcript_per_project_directory(
+        client, projects_dir, tmp_path, monkeypatch):
+    """The row's cost is directories touched, not sessions held.
+
+    A long-running project accumulates transcripts; every one of them records
+    the same cwd, and each open reads the head of a file that can be megabytes.
+    """
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    for i in range(10):
+        _session(projects_dir, "proj", f"s{i}", str(proj), mtime=1000 + i)
+
+    opened = []
+    real_session_cwd = claude_sessions_mod._session_cwd
+
+    def counted_session_cwd(path):
+        opened.append(path)
+        return real_session_cwd(path)
+
+    monkeypatch.setattr(claude_sessions_mod, "_session_cwd", counted_session_cwd)
+    data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
+
+    assert [f["path"] for f in data["folders"]] == [str(proj)]
+    assert opened == [str(projects_dir / "proj" / "s9.jsonl")]
+
+
+def test_home_falls_through_to_older_transcripts_of_an_unreadable_newest(
+        client, projects_dir, tmp_path, monkeypatch):
+    """A directory counts as resolved only once a cwd was actually read.
+
+    The newest transcript is the one still being written, so a truncated first
+    line is the normal way this happens - dropping the folder for it would hide
+    the project the user is working in right now, which is the row's whole point.
+    """
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _session(projects_dir, "proj", "readable", str(proj), mtime=1000)
+    headless = projects_dir / "proj" / "truncated.jsonl"
+    headless.write_text('{"cwd": "/tmp/half-writ')  # no closing brace: unparseable
+    os.utime(headless, (2000, 2000))
+
+    opened = []
+    real_session_cwd = claude_sessions_mod._session_cwd
+
+    def counted_session_cwd(path):
+        opened.append(path)
+        return real_session_cwd(path)
+
+    monkeypatch.setattr(claude_sessions_mod, "_session_cwd", counted_session_cwd)
+    data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
+
+    assert [f["path"] for f in data["folders"]] == [str(proj)]
+    assert opened == [str(headless), str(projects_dir / "proj" / "readable.jsonl")]
+
+
+def test_home_collapses_a_collided_directory_to_its_newest_folder(
+        client, projects_dir, tmp_path):
+    """Two real folders can encode to one directory, since both the separator
+    and a literal hyphen become "-". The row shows the newest of them; the
+    exhaustive endpoint above is the one that reads every transcript and lists
+    both."""
+    hyphened = tmp_path / "my-project"
+    nested = tmp_path / "my" / "project"
+    hyphened.mkdir()
+    nested.mkdir(parents=True)
+    _session(projects_dir, "collide", "older", str(nested), mtime=1000)
+    _session(projects_dir, "collide", "newer", str(hyphened), mtime=2000)
+
+    data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
+    assert [f["path"] for f in data["folders"]] == [str(hyphened)]
+    exhaustive = client.get("/api/claude-sessions").json()
+    assert sorted(f["path"] for f in exhaustive["folders"]) == sorted(
+        [str(hyphened), str(nested)])
 
 
 def test_home_session_limit_is_capped_to_its_single_row(


### PR DESCRIPTION
Two costs Home paid on every visit, both from asking for more than it shows.

## The row asked for twelve

`/api/apps/home` skips its exhaustive workspace walk only once the recents **fill** the request (`routers/apps.py`) — so `getHomeApps(MAX_ROW)` made the fast path unreachable for anyone with fewer than twelve opened apps, i.e. nearly everyone. #633 built the fast path; the client never let it fire.

Measured against a real store (89 apps, 7 recents):

| requested | apps returned | workspace walks |
|---|---|---|
| 3 | 3 | **0** |
| 4 | 4 | **0** |
| 6 | 6 | **0** |
| 12 (before) | 12 | 1 |

`useStripCount` now reports two numbers. `count` is the cards that fit and is `null` until the wrapper has been **measured** — a guess would be a request for cards the row cannot draw, the same bug in smaller print — and both fetches wait for it. `limit` is the **peak** count, so widening the window fetches what it newly needs and narrowing it refetches nothing. Nothing flashes for the null: a callback ref runs in the commit phase, so the measurement lands before paint.

Output is unchanged. Recents already sorted ahead of discovered apps, so the first N cards were these N cards.

## The session row opened a transcript per session

It only needs the folder, and a project directory's name **is** the encoded cwd — every transcript inside one records the same folder, so the older ones are file opens that can only reproduce a cwd already in hand.

292-transcript store in 73 directories:

| row | opens before | opens after |
|---|---|---|
| 5 folders | 24 | **8** |
| 12 folders | 71 | **21** |

With the row now asking for what it draws, that is **71 → 5** end to end. Each open reads the head of a file that can be multiple megabytes.

A directory counts as resolved only once a cwd has actually been **read**, so a truncated newest transcript — the normal case, since the newest is the one being written — falls through to the older ones instead of dropping the folder the user is working in right now. The per-cwd dedupe stays on top of the per-directory one: the encoding is lossy (both `/` and `-` become `-`), so one directory can hold two real folders; this row shows the newest and the exhaustive endpoint still lists both.

The mtime pass stays exhaustive and **cannot** shrink: Claude Code appends to an existing transcript, which leaves the parent directory's mtime alone, so a directory-level sweep would rank a project by when a session last *started* there. It moves to `os.scandir` (~2x — the stat comes off the directory read already happening); a footnote, not the fix.

## Not touched

The exhaustive `GET /api/claude-sessions` still opens every transcript (292 here; logged at 672 ms avg, **12.9 s max** cold), and both `NewJobModal` and the explorer's sessions tab still call it. Same one-open-per-directory rule would cut it 292 → 73, at the cost of the collision case above — worth a follow-up decision rather than a silent change to an endpoint whose name promises exhaustiveness.

## Tests

* `tests/test_claude_sessions_api.py` — the duplicate-folder case now opens 4 files, not 5 (that delta *is* the fix); new cases for one-open-per-directory with 10 sessions in a folder, fall-through past an unparseable newest transcript, and a collided directory collapsing to its newest folder while the exhaustive endpoint keeps both.
* `frontend/src/shell/home-performance.test.ts` — both request shapes re-pinned, plus a new guard that the requests are sized by the measured count and never by a constant (source-grep, matching that file's style: mounting Home needs a DOM with a real `clientWidth`).

`bun test`: 1900 pass. `pytest tests/test_apps_api.py tests/test_claude_sessions_api.py tests/test_app_listing.py`: 126 pass. Full `pytest`: the 19 pre-existing environment failures on this machine only (claude_health needs a real CLI, `templates/map` needs the geo stack D276 removed from `[bundled]`, `test_calls` reads `/proc/self/fd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes how many items Home requests and how session folders are resolved on the home endpoint; edge cases (unmeasured layout, truncated newest transcript, collided encodings) are explicitly handled but warrant regression checks on real stores.
> 
> **Overview**
> **Home defers and right-sizes its two server fetches.** `useStripCount` now exposes both the current fit count (`count`, null until measured) and a grow-only peak (`limit`) used as `Math.min(limit, MAX_ROW)` for `getHomeApps` and `getHomeClaudeSessionFolders`, so requests match visible cards and `/api/apps/home` can use its recents-first fast path instead of always asking for twelve. Fetches wait until `limit` is known; strip layout uses `shown` and omits width until measurement lands.
> 
> **`/api/claude-sessions/home` cuts redundant transcript reads.** After the full mtime ordering pass (now via `os.scandir` instead of `glob` + `getmtime`), the handler opens at most one JSONL per project directory, skips further files in that directory once a cwd is read, and still falls through older transcripts when the newest is unreadable. Per-cwd dedupe remains for lossy directory collisions; tests cover one-open-per-dir, fall-through, and collision vs exhaustive listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156fe1b7055852f30291ed67c99028c87837e298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->