### PR TITLE
Chat pane: conversation no longer follows the selection onto other folders

### DIFF
--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -43,6 +43,7 @@ import { ModeMenu } from "@apps/explorer/BarMenu";
 import { SideCloseButton, paneSideIcon } from "@apps/explorer/SideChrome";
 import { withNoFocus } from "@platform/lib/frame-focus";
 import { usePaneFocusGuard } from "@apps/explorer/listing/usePaneFocusGuard";
+import { dropStaleChatParams } from "@apps/explorer/listing/chat-params";
 import Listing from "@apps/explorer/Listing";
 import {
   activePaneMode,
@@ -223,6 +224,19 @@ export default function ListingPreviewPane({
   // contract — platform/lib/frame-focus.ts). Also a hook, so also before the early
   // returns; the branches it guards are the ones that render a frame.
   const { rootRef, guardProps } = usePaneFocusGuard<HTMLDivElement>();
+
+  // Retargeting the chat takes its params off the URL (listing/chat-params.ts has
+  // the why). The condition mirrors the Claude branch below exactly, so the target
+  // is only claimed on renders where the chat iframe is actually up — a skeleton
+  // frame or a flip through Git never reads as a retarget. A hook, so above the
+  // early returns like the two before it.
+  const chatTarget =
+    !undecided && side === "claude" && sideEntries.claude && sideEntries.claude.path !== null
+      ? paneSideTarget("claude", folder, row && !row.self ? row.path : null)
+      : null;
+  useEffect(() => {
+    dropStaleChatParams(chatTarget);
+  }, [chatTarget]);
 
   // --- the pane's modes (listing/pane-side.ts) --------------------------------
   // EVERY MODE THE PANE MAY BE ON, and never fewer: an unofferable COMPANION is

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -238,10 +238,18 @@ export default function ListingPreviewPane({
     !undecided && side === "claude" && sideEntries.claude && sideEntries.claude.path !== null
       ? paneSideTarget("claude", folder, row && !row.self ? row.path : null)
       : null;
+  // `?sel=` decodes against the SAME base the rows are built on — Listing's
+  // fsPath with its trailing slash stripped (useListingSelection) — or the two
+  // spellings diverge exactly at the roots: "/" would decode `?sel=x` to "//x"
+  // while the row is "/x", and "C:/" likewise, so a seeded hop at a root would
+  // never count as url-named and a deep link's params would be stripped there.
   const urlNamedTarget =
     chatTarget !== null &&
     chatTarget ===
-      (pathFromSelParam(folder, new URLSearchParams(location.search).get("sel")) ?? folder);
+      (pathFromSelParam(
+        folder.replace(/\/$/, ""),
+        new URLSearchParams(location.search).get("sel")
+      ) ?? folder);
   useEffect(() => {
     dropStaleChatParams(chatTarget, urlNamedTarget);
   }, [chatTarget, urlNamedTarget]);

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -44,6 +44,7 @@ import { SideCloseButton, paneSideIcon } from "@apps/explorer/SideChrome";
 import { withNoFocus } from "@platform/lib/frame-focus";
 import { usePaneFocusGuard } from "@apps/explorer/listing/usePaneFocusGuard";
 import { dropStaleChatParams } from "@apps/explorer/listing/chat-params";
+import { pathFromSelParam } from "@apps/explorer/listing/selection";
 import Listing from "@apps/explorer/Listing";
 import {
   activePaneMode,
@@ -229,14 +230,21 @@ export default function ListingPreviewPane({
   // the why). The condition mirrors the Claude branch below exactly, so the target
   // is only claimed on renders where the chat iframe is actually up — a skeleton
   // frame or a flip through Git never reads as a retarget. A hook, so above the
-  // early returns like the two before it.
+  // early returns like the two before it. `urlNamed` — this target is the one the
+  // url's own `?sel=` (or its absence) points at, i.e. a seeded selection playing
+  // out rather than the user clicking away from a chat — is what keeps a deep
+  // link's params alive through the mount-time folder→row hop (chat-params.ts).
   const chatTarget =
     !undecided && side === "claude" && sideEntries.claude && sideEntries.claude.path !== null
       ? paneSideTarget("claude", folder, row && !row.self ? row.path : null)
       : null;
+  const urlNamedTarget =
+    chatTarget !== null &&
+    chatTarget ===
+      (pathFromSelParam(folder, new URLSearchParams(location.search).get("sel")) ?? folder);
   useEffect(() => {
-    dropStaleChatParams(chatTarget);
-  }, [chatTarget]);
+    dropStaleChatParams(chatTarget, urlNamedTarget);
+  }, [chatTarget, urlNamedTarget]);
 
   // --- the pane's modes (listing/pane-side.ts) --------------------------------
   // EVERY MODE THE PANE MAY BE ON, and never fewer: an unofferable COMPANION is

--- a/frontend/src/apps/explorer/listing/chat-params.test.ts
+++ b/frontend/src/apps/explorer/listing/chat-params.test.ts
@@ -1,0 +1,103 @@
+// The reproduction these tests encode: chat in the pane about one folder row,
+// click a sibling row — a selection change, not a navigation — and the
+// conversation followed the click, because `session_id`/`run` live on the shell
+// url and nothing took them off it (found by duplicating an app folder and
+// switching between the two). The module's job is exactly that removal, and
+// only on a genuine retarget: the first target a fresh page shows keeps its
+// params, because that is a deep link doing what deep links are for.
+import { beforeEach, expect, test } from "bun:test";
+
+// chat-params.ts reaches for `location` and (through router.ts) `history`; bun
+// has no DOM. Same shim as router.test.ts — and grabbed back off globalThis
+// after the ??=, so the fields mutated here are the ones the module reads even
+// when another test file installed the shim first.
+(globalThis as { location?: unknown }).location ??= {
+  pathname: "/",
+  search: "",
+  href: "http://localhost/",
+};
+(globalThis as { history?: unknown }).history ??= {
+  state: null,
+  pushState() {},
+  replaceState() {},
+};
+(globalThis as { window?: unknown }).window ??= {
+  dispatchEvent() {},
+  setTimeout: globalThis.setTimeout.bind(globalThis),
+  clearTimeout: globalThis.clearTimeout.bind(globalThis),
+};
+const loc = (globalThis as unknown as { location: { pathname: string; search: string } })
+  .location;
+const hist = (globalThis as unknown as {
+  history: { replaceState(s: unknown, t: string, url?: string | null): void };
+}).history;
+
+const {
+  dropStaleChatParams,
+  resetChatParamTracking,
+  searchWithoutChatParams,
+} = await import("./chat-params");
+
+let written: string[] = [];
+hist.replaceState = (_s: unknown, _t: string, url?: string | null) => {
+  if (typeof url === "string") written.push(url);
+};
+
+beforeEach(() => {
+  resetChatParamTracking();
+  written = [];
+  loc.pathname = "/explorer/view/Users/me/apps";
+  loc.search = "?_side=claude&session_id=s-1&run=r-1&msg=u-1";
+});
+
+// ---- the pure half ----------------------------------------------------------
+
+test("strips exactly the chat's params and keeps everyone else's", () => {
+  expect(searchWithoutChatParams("?_side=claude&session_id=a&run=b&msg=c&sel=x"))
+    .toBe("?_side=claude&sel=x");
+});
+
+test("nothing to strip is null, so the caller can skip the URL write", () => {
+  expect(searchWithoutChatParams("?_side=claude&sel=x")).toBeNull();
+  expect(searchWithoutChatParams("")).toBeNull();
+});
+
+test("a url that was only chat params strips to an empty search", () => {
+  expect(searchWithoutChatParams("?session_id=a")).toBe("");
+});
+
+// ---- the stateful half ------------------------------------------------------
+
+test("the first target a fresh page shows keeps its params (deep link)", () => {
+  dropStaleChatParams("/Users/me/apps/original");
+  expect(written).toEqual([]);
+});
+
+test("the same target again is not a retarget", () => {
+  dropStaleChatParams("/Users/me/apps/original");
+  dropStaleChatParams("/Users/me/apps/original");
+  expect(written).toEqual([]);
+});
+
+test("a changed target takes the chat params off the url", () => {
+  dropStaleChatParams("/Users/me/apps/original");
+  dropStaleChatParams("/Users/me/apps/original copy");
+  expect(written).toEqual(["/explorer/view/Users/me/apps?_side=claude"]);
+});
+
+test("null holds the tracked target — a Git flip or skeleton is not a retarget", () => {
+  dropStaleChatParams("/Users/me/apps/original");
+  dropStaleChatParams(null);
+  dropStaleChatParams("/Users/me/apps/original");
+  expect(written).toEqual([]);
+  dropStaleChatParams(null);
+  dropStaleChatParams("/Users/me/apps/original copy");
+  expect(written).toEqual(["/explorer/view/Users/me/apps?_side=claude"]);
+});
+
+test("a retarget with nothing on the url writes nothing", () => {
+  loc.search = "?_side=claude";
+  dropStaleChatParams("/Users/me/apps/original");
+  dropStaleChatParams("/Users/me/apps/original copy");
+  expect(written).toEqual([]);
+});

--- a/frontend/src/apps/explorer/listing/chat-params.test.ts
+++ b/frontend/src/apps/explorer/listing/chat-params.test.ts
@@ -3,14 +3,15 @@
 // conversation followed the click, because `session_id`/`run` live on the shell
 // url and nothing took them off it (found by duplicating an app folder and
 // switching between the two). The module's job is exactly that removal, and
-// only on a genuine retarget: the first target a fresh page shows keeps its
-// params, because that is a deep link doing what deep links are for.
+// only on a genuine retarget: the first target after a page load OR a
+// navigation keeps its params, because that is a deep link doing what deep
+// links are for.
 import { beforeEach, expect, test } from "bun:test";
 
-// chat-params.ts reaches for `location` and (through router.ts) `history`; bun
-// has no DOM. Same shim as router.test.ts — and grabbed back off globalThis
-// after the ??=, so the fields mutated here are the ones the module reads even
-// when another test file installed the shim first.
+// router.ts (imported by chat-params) reads `location` at module scope; bun has
+// no DOM. Same shim as router.test.ts. The module's own reads/writes go through
+// the injected io below instead — the suite shares these globals across files,
+// so tests that staged state IN them raced other files' shims.
 (globalThis as { location?: unknown }).location ??= {
   pathname: "/",
   search: "",
@@ -26,11 +27,6 @@ import { beforeEach, expect, test } from "bun:test";
   setTimeout: globalThis.setTimeout.bind(globalThis),
   clearTimeout: globalThis.clearTimeout.bind(globalThis),
 };
-const loc = (globalThis as unknown as { location: { pathname: string; search: string } })
-  .location;
-const hist = (globalThis as unknown as {
-  history: { replaceState(s: unknown, t: string, url?: string | null): void };
-}).history;
 
 const {
   dropStaleChatParams,
@@ -39,15 +35,17 @@ const {
 } = await import("./chat-params");
 
 let written: string[] = [];
-hist.replaceState = (_s: unknown, _t: string, url?: string | null) => {
-  if (typeof url === "string") written.push(url);
+let search = "";
+const io = {
+  pathname: () => "/explorer/view/Users/me/apps",
+  search: () => search,
+  write: (url: string) => written.push(url),
 };
 
 beforeEach(() => {
   resetChatParamTracking();
   written = [];
-  loc.pathname = "/explorer/view/Users/me/apps";
-  loc.search = "?_side=claude&session_id=s-1&run=r-1&msg=u-1";
+  search = "?_side=claude&session_id=s-1&run=r-1&msg=u-1";
 });
 
 // ---- the pure half ----------------------------------------------------------
@@ -69,35 +67,76 @@ test("a url that was only chat params strips to an empty search", () => {
 // ---- the stateful half ------------------------------------------------------
 
 test("the first target a fresh page shows keeps its params (deep link)", () => {
-  dropStaleChatParams("/Users/me/apps/original");
+  dropStaleChatParams("/Users/me/apps/original", false, io);
   expect(written).toEqual([]);
 });
 
 test("the same target again is not a retarget", () => {
-  dropStaleChatParams("/Users/me/apps/original");
-  dropStaleChatParams("/Users/me/apps/original");
+  dropStaleChatParams("/Users/me/apps/original", false, io);
+  dropStaleChatParams("/Users/me/apps/original", false, io);
   expect(written).toEqual([]);
 });
 
 test("a changed target takes the chat params off the url", () => {
-  dropStaleChatParams("/Users/me/apps/original");
-  dropStaleChatParams("/Users/me/apps/original copy");
+  dropStaleChatParams("/Users/me/apps/original", false, io);
+  dropStaleChatParams("/Users/me/apps/original copy", false, io);
   expect(written).toEqual(["/explorer/view/Users/me/apps?_side=claude"]);
 });
 
 test("null holds the tracked target — a Git flip or skeleton is not a retarget", () => {
-  dropStaleChatParams("/Users/me/apps/original");
-  dropStaleChatParams(null);
-  dropStaleChatParams("/Users/me/apps/original");
+  dropStaleChatParams("/Users/me/apps/original", false, io);
+  dropStaleChatParams(null, false, io);
+  dropStaleChatParams("/Users/me/apps/original", false, io);
   expect(written).toEqual([]);
-  dropStaleChatParams(null);
-  dropStaleChatParams("/Users/me/apps/original copy");
+  dropStaleChatParams(null, false, io);
+  dropStaleChatParams("/Users/me/apps/original copy", false, io);
   expect(written).toEqual(["/explorer/view/Users/me/apps?_side=claude"]);
 });
 
 test("a retarget with nothing on the url writes nothing", () => {
-  loc.search = "?_side=claude";
-  dropStaleChatParams("/Users/me/apps/original");
-  dropStaleChatParams("/Users/me/apps/original copy");
+  search = "?_side=claude";
+  dropStaleChatParams("/Users/me/apps/original", false, io);
+  dropStaleChatParams("/Users/me/apps/original copy", false, io);
   expect(written).toEqual([]);
+});
+
+// ---- the navigation reset ---------------------------------------------------
+// A navigation (router NAV_EVENT, popstate — both call resetChatParamTracking)
+// makes the NEXT target a first sighting: an SPA hop from the Tasks page lands
+// with deep-link params for a different folder, and stripping them there was
+// the bug the reset exists for.
+
+test("after a navigation the new entry's first target adopts, never strips", () => {
+  dropStaleChatParams("/Users/me/apps/original", false, io);
+  resetChatParamTracking();
+  dropStaleChatParams("/Users/me/other/folder", false, io);
+  expect(written).toEqual([]);
+});
+
+test("the retarget rule resumes after the post-navigation adoption", () => {
+  dropStaleChatParams("/Users/me/apps/original", false, io);
+  resetChatParamTracking();
+  dropStaleChatParams("/Users/me/other/folder", false, io);
+  dropStaleChatParams("/Users/me/other/folder sibling", false, io);
+  expect(written).toEqual(["/explorer/view/Users/me/apps?_side=claude"]);
+});
+
+// ---- the url-named hop ------------------------------------------------------
+// A deep link `?sel=…&session_id=…` mounts the pane on the FOLDER while the
+// rows load, then the seeded selection retargets it to the row the link named.
+// That hop is the URL playing out, not the user leaving a chat — it adopts. A
+// real click is never url-named at the moment it retargets (the `?sel=` mirror
+// trails the click), so the strip is untouched.
+
+test("the seeded-selection hop keeps a deep link's params", () => {
+  dropStaleChatParams("/Users/me/apps", false, io); // mount: folder, rows loading
+  dropStaleChatParams("/Users/me/apps/original", true, io); // ?sel= resolves
+  expect(written).toEqual([]);
+});
+
+test("after the seeded hop, a real click still strips", () => {
+  dropStaleChatParams("/Users/me/apps", false, io);
+  dropStaleChatParams("/Users/me/apps/original", true, io);
+  dropStaleChatParams("/Users/me/apps/original copy", false, io);
+  expect(written).toEqual(["/explorer/view/Users/me/apps?_side=claude"]);
 });

--- a/frontend/src/apps/explorer/listing/chat-params.ts
+++ b/frontend/src/apps/explorer/listing/chat-params.ts
@@ -16,10 +16,19 @@
 // So the pane drops the chat params whenever its chat TARGET changes. Module
 // state rather than component state, deliberately: ListingPreviewPane remounts,
 // and a per-mount ref would read every remount as a first mount and never see
-// the change. A page load resets the module, which is exactly the boundary a
-// deep link needs — the first chat target a fresh page shows keeps whatever
-// params the link carried; only a change AFTER that is a retarget.
-import { replaceSearch } from "@platform/lib/router";
+// the change.
+//
+// What resets the tracking is a NAVIGATION, any navigation: whatever params the
+// arriving entry carries are that entry's own — navigate() already strips them,
+// and a deep link (a Tasks row, a bookmark through navigateUrl) carries them on
+// purpose — so the first chat target the new entry shows ADOPTS its params
+// rather than stripping them. A hard page load resets by reloading the module;
+// in-app pushes say so through the router's own NAV_EVENT, and Back/Forward
+// through popstate. Without those two listeners an SPA hop from the Tasks page
+// would land on a pane whose tracked target is still the folder the user left,
+// read the hop as a retarget, and strip the very deep-link params it arrived
+// with.
+import { NAV_EVENT, replaceSearch } from "@platform/lib/router";
 
 // What the chat template owns on the shell url. `split` is layout, not
 // conversation, and stays; `msg` goes with the session it anchors into.
@@ -44,22 +53,61 @@ export function searchWithoutChatParams(search: string): string | null {
   return qs ? "?" + qs : "";
 }
 
+// The module's three touches of the page, injectable so the tests can drive
+// the state machine without staging `location`/`history` globals (which the
+// bun suite shares across files — a shim staged here collided with other
+// files' shims depending on run order).
+export interface ChatParamIo {
+  pathname(): string;
+  search(): string;
+  write(url: string): void;
+}
+
+const pageIo: ChatParamIo = {
+  pathname: () => location.pathname,
+  search: () => location.search,
+  write: replaceSearch,
+};
+
 // Called with the pane's current chat target on every render where the chat is
 // what the pane shows, and with null otherwise. Null holds the tracked target
 // rather than clearing it: the pane flipping to Git and back is not a retarget,
 // and neither is the skeleton frame while companion probes are out.
-export function dropStaleChatParams(target: string | null): void {
+//
+// `urlNamed` says the target IS what the current url itself names — the row its
+// `?sel=` points at, or the folder when there is no `?sel=`. Such a hop adopts
+// rather than strips, because it is the URL playing out, not the user leaving a
+// chat: a deep link with `?sel=…&session_id=…` mounts the pane on the FOLDER for
+// a beat while the rows load, and the seeded selection then retargets it to the
+// very row the link named — stripping there threw away the link's own params.
+// A user's row CLICK is never url-named at the moment it retargets: the `?sel=`
+// mirror trails the click by its debounce, so the url still names the row being
+// LEFT, and the strip goes through exactly as before.
+export function dropStaleChatParams(
+  target: string | null,
+  urlNamed: boolean,
+  io: ChatParamIo = pageIo
+): void {
   if (target === null) return;
-  if (lastTarget === null || target === lastTarget) {
+  if (lastTarget === null || target === lastTarget || urlNamed) {
     lastTarget = target;
     return;
   }
   lastTarget = target;
-  const stripped = searchWithoutChatParams(location.search);
-  if (stripped !== null) replaceSearch(location.pathname + stripped);
+  const stripped = searchWithoutChatParams(io.search());
+  if (stripped !== null) io.write(io.pathname() + stripped);
 }
 
-// Tests only: the module state IS the feature, so tests must be able to start over.
+// The navigation reset (see the module comment). Exported for the listeners
+// below and for tests.
 export function resetChatParamTracking(): void {
   lastTarget = null;
+}
+
+// Registered at module load, once, for the page the module actually runs in.
+// Guarded because the bun test environment has no full `window`; the browser
+// always does.
+if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+  window.addEventListener(NAV_EVENT, resetChatParamTracking);
+  window.addEventListener("popstate", resetChatParamTracking);
 }

--- a/frontend/src/apps/explorer/listing/chat-params.ts
+++ b/frontend/src/apps/explorer/listing/chat-params.ts
@@ -1,0 +1,65 @@
+// The chat's URL params, and when the pane must take them back off the URL.
+//
+// The claude pane's template writes its own state — `session_id`, `run`, the
+// `msg` anchor — onto the SHELL's url (it sets no `_fusedParamBoundary`, so the
+// runtime's ancestor-climb lands there; templates/claude/template.html). That is
+// what lets a task deep-link open the right conversation. But switching the
+// pane's SUBJECT by clicking another row is a selection change, not a
+// navigation: router.navigate() never runs, the `?sel=` mirror rewrites only its
+// own key, and the three chat params survive onto a target they say nothing
+// about. The pane's iframe reboots on the new `_file`, reads the stale params
+// back off the shell url, and the old conversation follows the selection — a
+// live run's whole transcript re-attached under whichever folder is clicked
+// (the reported shape: duplicate a folder, chat in the duplicate, click the
+// original — same conversation on both).
+//
+// So the pane drops the chat params whenever its chat TARGET changes. Module
+// state rather than component state, deliberately: ListingPreviewPane remounts,
+// and a per-mount ref would read every remount as a first mount and never see
+// the change. A page load resets the module, which is exactly the boundary a
+// deep link needs — the first chat target a fresh page shows keeps whatever
+// params the link carried; only a change AFTER that is a retarget.
+import { replaceSearch } from "@platform/lib/router";
+
+// What the chat template owns on the shell url. `split` is layout, not
+// conversation, and stays; `msg` goes with the session it anchors into.
+const CHAT_PARAMS = ["session_id", "run", "msg"];
+
+let lastTarget: string | null = null;
+
+// The search string with the chat params removed, or null when none were
+// present (so the caller can skip the URL write entirely). Pure — the stateful
+// wrapper below and the tests share it.
+export function searchWithoutChatParams(search: string): string | null {
+  const params = new URLSearchParams(search);
+  let changed = false;
+  for (const key of CHAT_PARAMS) {
+    if (params.has(key)) {
+      params.delete(key);
+      changed = true;
+    }
+  }
+  if (!changed) return null;
+  const qs = params.toString();
+  return qs ? "?" + qs : "";
+}
+
+// Called with the pane's current chat target on every render where the chat is
+// what the pane shows, and with null otherwise. Null holds the tracked target
+// rather than clearing it: the pane flipping to Git and back is not a retarget,
+// and neither is the skeleton frame while companion probes are out.
+export function dropStaleChatParams(target: string | null): void {
+  if (target === null) return;
+  if (lastTarget === null || target === lastTarget) {
+    lastTarget = target;
+    return;
+  }
+  lastTarget = target;
+  const stripped = searchWithoutChatParams(location.search);
+  if (stripped !== null) replaceSearch(location.pathname + stripped);
+}
+
+// Tests only: the module state IS the feature, so tests must be able to start over.
+export function resetChatParamTracking(): void {
+  lastTarget = null;
+}

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -2409,12 +2409,35 @@ def _segments_from_rows(rows: list) -> list:
     return out
 
 
-def _poll(run_id: str) -> dict:
+def _poll(run_id: str, file: str = "") -> dict:
     run_dir = os.path.join(RUNS, run_id)
     if _bad_id(run_id) or not os.path.isdir(run_dir):
         return {"text": "", "done": True, "session_id": "", "error": "unknown run_id",
                 "permissions": [], "app_state": [], "skills": [], "retry": None,
                 "retry_total": 0, "retry_status": 0, "segments": []}
+
+    # A page may only attach to a run about ITS OWN target. Run ids are global
+    # (RUNS is one flat dir), and the `run` url param survives some hops the
+    # target does not — the listing pane retargeting `_file` on a selection
+    # change is the reported one — so an id alone must not be enough: without
+    # this check a stale param re-attached a live run's whole conversation
+    # under whichever folder the pane was pointed at next. Refused ONLY on a
+    # provable mismatch: `file` is optional (claude_spawn's bookkeeping loop
+    # polls with no page and no target), and a meta.json without `file` — or
+    # unreadable entirely — proves nothing and keeps the historical behavior.
+    # The wire shape matches "unknown run_id" so the page's existing stale-param
+    # recovery (clear the param, no error banner) covers this case too.
+    if file:
+        try:
+            with open(os.path.join(run_dir, "meta.json"), encoding="utf-8") as fh:
+                run_file = json.load(fh).get("file", "")
+        except (OSError, ValueError):
+            run_file = ""
+        if run_file and os.path.abspath(run_file) != os.path.abspath(file):
+            return {"text": "", "done": True, "session_id": "",
+                    "error": "run is for another target",
+                    "permissions": [], "app_state": [], "skills": [], "retry": None,
+                    "retry_total": 0, "retry_status": 0, "segments": []}
 
     text_parts = []
     result_text = None
@@ -3408,7 +3431,10 @@ def main(action: str = "start", file: str = "", message: str = "",
         return _start(file, message, session_id, model, effort, permission_mode,
                       has_pane=None if has_pane == "" else has_pane != "0")
     if action == "poll":
-        return _poll(run_id)
+        # `file` rides along so the poll can refuse a run that is not about
+        # this page's target (see _poll) — optional, because not every caller
+        # has a page (claude_spawn's record loop).
+        return _poll(run_id, file)
     if action == "decide":
         # `answers` arrives as a JSON string for the same reason `state` does
         # below — params cross into python string-shaped — and is only read for

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -12004,7 +12004,7 @@ async function pollLoop(run_id) {
   let tick = 0;
   try {
     while (true) {
-      const data = await fused.runPython(AGENT, { action: "poll", run_id }, { key: null });
+      const data = await fused.runPython(AGENT, { action: "poll", run_id, file: FILE }, { key: null });
       if (data.session_id) { fused.params.set("session_id", String(data.session_id)); showSession(); }
       // Not awaited, for the same reason the app-state answer below is not: a
       // strip of chips may never hold up the streaming reply by a single frame.
@@ -13112,7 +13112,7 @@ async function resumeRun(run_id, opts) {
   if (sending) return;
   sending = true;
   try {
-    let probe = await fused.runPython(AGENT, { action: "poll", run_id }, { key: null });
+    let probe = await fused.runPython(AGENT, { action: "poll", run_id, file: FILE }, { key: null });
     if (probe.error === "unknown run_id" && retryUnknown) {
       // A frame handed a run id by its EMBEDDER (the canvases workspace's
       // "Fix with Claude" navigates this iframe with ?run= the moment the
@@ -13121,12 +13121,14 @@ async function resumeRun(run_id, opts) {
       // retries tell the two apart; only then is the id written off.
       for (let i = 0; i < 5 && probe.error === "unknown run_id"; i++) {
         await new Promise((r) => setTimeout(r, 700));
-        probe = await fused.runPython(AGENT, { action: "poll", run_id }, { key: null });
+        probe = await fused.runPython(AGENT, { action: "poll", run_id, file: FILE }, { key: null });
       }
     }
-    if (probe.error === "unknown run_id") {
-      // stale param (bookmarked mid-run URL, pruned tmp) — nothing to attach
-      // to, and nothing to hand annotations back to: resolve any stragglers
+    if (probe.error === "unknown run_id" || probe.error === "run is for another target") {
+      // stale param — a bookmarked mid-run URL, a pruned tmp, or a run id that
+      // survived onto a DIFFERENT target's page (the agent refuses those now,
+      // same recovery) — nothing to attach to, and nothing to hand annotations
+      // back to: resolve any stragglers
       fused.params.set("run", "", { history: "replace", default: "" });
       annResolveSent();
       return;

--- a/tests/test_claude_poll_target.py
+++ b/tests/test_claude_poll_target.py
@@ -1,0 +1,136 @@
+"""A poll may only attach to a run about its own target (claude template).
+
+Run ids are global — RUNS is one flat directory — and the `run` url param
+survives some hops the target does not. The reproduction: open a folder
+listing's claude pane, send a message, then click a SIBLING row. That is a
+selection change, not a navigation, so the shell url keeps `run` while the
+pane's `_file` moves to the new row — and the old conversation re-attached,
+streaming, under whichever folder was clicked (found by duplicating an app
+folder and switching between the two).
+
+Two halves. The pane now drops the chat params on a retarget
+(frontend listing/chat-params.ts — its own tests), and the agent refuses the
+attach outright when the caller's target provably is not the run's: the belt
+these tests cover.
+"""
+import importlib.util
+import json
+import os
+import re
+
+import pytest
+
+
+def _load_agent():
+    path = os.path.join("fused_render", "templates", "claude", "agent.py")
+    spec = importlib.util.spec_from_file_location("claude_agent", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+TEMPLATE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "templates", "claude", "template.html")
+
+
+@pytest.fixture(scope="module")
+def html_pane():
+    """The template with `// …` comments stripped, so a source pin cannot be
+    satisfied by prose that merely NAMES the call it is looking for. Same guard
+    as test_claude_kind.py's _pane_code."""
+    with open(TEMPLATE, encoding="utf-8") as f:
+        return re.sub(r"(?m)^\s*//.*$", "", f.read())
+
+
+@pytest.fixture()
+def agent(tmp_path, monkeypatch):
+    mod = _load_agent()
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    monkeypatch.setattr(mod, "RUNS", str(runs))
+    return mod
+
+
+@pytest.fixture()
+def target(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    f = d / "index.html"
+    f.write_text("<html></html>")
+    return str(f)
+
+
+def _run_dir(agent, name, *, meta):
+    d = os.path.join(agent.RUNS, name)
+    os.makedirs(d)
+    with open(os.path.join(d, "meta.json"), "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+    with open(os.path.join(d, "pid"), "w", encoding="utf-8") as f:
+        f.write("2147483646")  # a pid that cannot exist — the run is over
+    return d
+
+
+MISMATCH = "run is for another target"
+
+
+def test_polling_someone_else_s_run_is_refused(agent, target, tmp_path):
+    _run_dir(agent, "20260819-120000-aaa", meta={"file": target, "message": "hi"})
+    other = str(tmp_path / "proj-copy")
+    out = agent._poll("20260819-120000-aaa", file=other)
+    assert out["error"] == MISMATCH
+    assert out["done"] is True
+    assert out["text"] == "" and out["segments"] == []
+
+
+def test_the_run_s_own_target_still_polls(agent, target):
+    _run_dir(agent, "20260819-120000-bbb", meta={"file": target, "message": "hi"})
+    assert agent._poll("20260819-120000-bbb", file=target)["error"] != MISMATCH
+
+
+def test_the_same_target_spelled_unnormalized_still_polls(agent, target):
+    """The check compares abspaths, not strings: `_file` off a url and the
+    path `_start` wrote to meta.json may spell one target two ways."""
+    _run_dir(agent, "20260819-120000-fff", meta={"file": target, "message": "hi"})
+    spelled = os.path.join(os.path.dirname(target), ".", "index.html")
+    assert agent._poll("20260819-120000-fff", file=spelled)["error"] != MISMATCH
+
+
+def test_a_caller_with_no_target_is_not_refused(agent, target):
+    """claude_spawn's record loop polls with no page and no target — the check
+    must never take a run away from its own bookkeeping."""
+    _run_dir(agent, "20260819-120000-ccc", meta={"file": target, "message": "hi"})
+    assert agent._poll("20260819-120000-ccc")["error"] != MISMATCH
+
+
+def test_a_run_that_never_recorded_a_target_is_not_refused(agent, target):
+    """Refused only on a PROVABLE mismatch: a meta.json without `file` proves
+    nothing, and an old run must keep re-attaching the way it always did."""
+    _run_dir(agent, "20260819-120000-ddd", meta={"message": "hi"})
+    assert agent._poll("20260819-120000-ddd", file=target)["error"] != MISMATCH
+
+
+def test_an_unreadable_meta_is_not_refused(agent, target):
+    d = _run_dir(agent, "20260819-120000-eee", meta={"file": target})
+    with open(os.path.join(d, "meta.json"), "w", encoding="utf-8") as f:
+        f.write("{not json")
+    assert agent._poll("20260819-120000-eee", file=target)["error"] != MISMATCH
+
+
+# ---- the page's half ---------------------------------------------------------
+
+def test_every_poll_call_names_the_page_s_target(html_pane):
+    """All of the page's polls carry `file: FILE`, or the agent's check never
+    runs for the very caller it exists for."""
+    calls = re.findall(r'action:\s*"poll"[^}]*', html_pane)
+    assert calls, "no poll calls found — did the action move?"
+    for call in calls:
+        assert "file: FILE" in call, call
+
+
+def test_the_page_recovers_from_a_mismatch_like_a_stale_param(html_pane):
+    """resumeRun's unknown-run branch — clear the `run` param, no error banner —
+    is the recovery for a refused target too."""
+    assert re.search(
+        r'probe\.error === "unknown run_id" \|\| probe\.error === "run is for another target"',
+        html_pane)


### PR DESCRIPTION
## The bug

Duplicate an app folder, start a chat in the duplicate from the listing's Claude pane, then click the original's row — the duplicate's conversation shows up there too, still streaming. Any two sibling rows do this; the duplicate just makes it obvious.

## Root cause

- The chat template's `session_id`/`run` params live on the **shell URL** (the pane sets no `_fusedParamBoundary`, so the runtime's ancestor-climb lands there).
- Clicking another row is a **selection change, not a navigation**: `navigate()` never runs, the `?sel=` mirror rewrites only its own key, and the chat params survive onto a target they say nothing about.
- The pane's iframe reboots on the new `_file`, reads the stale params back, and `_poll` re-attached the run **with no target check** — run ids are global.

A stale `session_id` alone renders an empty chat (history is scoped to the folder's project dir), which is why this went unnoticed until a *live run* + row-switching lined up.

## The fix

- **`listing/chat-params.ts`** — the pane drops `session_id`/`run`/`msg` whenever its chat target changes. Module-level tracking (the pane remounts per selection). The first target a fresh page shows keeps its params, so Tasks deep-links (`?session_id=…&msg=…`) are untouched.
- **`agent.py _poll(run_id, file="")`** — refuses a poll whose caller names a different target than the run's `meta.json` records. Only on a provable mismatch: no `file` from the caller (claude_spawn's pageless bookkeeping loop), or no `file` in an old run's meta, keeps the historical behavior. Wire shape matches the existing stale-param recovery.
- **`template.html`** — every poll carries `file: FILE`; `resumeRun` treats the refusal exactly like `unknown run_id` (clear the param, no error banner).

## Verified

- Browser (cmux): chat started on folder A streams; select sibling B → B's own clean landing, params gone from the URL; back on A → the chat sits in A's Recent Chats with the live dot.
- New tests: `tests/test_claude_poll_target.py` (7), `frontend/.../chat-params.test.ts` (8). Full suites: 8228 python pass (remaining failures reproduce on main — machine-env claude-binary tests, the known `test_calls` race, one xdist flake that passes alone), 1936 frontend pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shell URL sync and Claude run attachment with several edge cases (deep links, navigation reset); behavior is narrow and heavily tested, but mistakes could break task deep-links or live-run resume.
> 
> **Overview**
> Fixes a bug where **clicking another listing row** (selection change, not navigation) left the shell URL’s **`session_id` / `run` / `msg`** in place, so the Claude iframe rebooted on the new `_file` and **re-attached the previous folder’s live conversation**.
> 
> **Frontend:** New **`listing/chat-params.ts`** tracks the pane’s chat target in module state and calls **`dropStaleChatParams`** from **`ListingPreviewPane`** when the Claude iframe is actually shown. On a genuine retarget it strips only the chat-owned query keys via **`replaceSearch`**, while **deep links** and the **folder→row `?sel=` hop** adopt params instead of stripping (`urlNamed` + **`pathFromSelParam`** aligned with listing row paths). **`resetChatParamTracking`** runs on **`NAV_EVENT`** and **`popstate`** so SPA navigations don’t treat the next target as a stale retarget.
> 
> **Backend / template:** **`_poll(run_id, file="")`** in **`agent.py`** compares the caller’s target to **`meta.json`’s `file`** (optional `file`, abspath match) and returns the same stale shape as unknown runs when they disagree. **`template.html`** passes **`file: FILE`** on every poll and clears **`run`** for **`run is for another target`** like **`unknown run_id`**.
> 
> New coverage: **`chat-params.test.ts`** and **`test_claude_poll_target.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9066a85127140d2667ee6df2e4079740c4998e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->