### PR TITLE
Tasks page and queue popover agree about when a run ended

### DIFF
--- a/frontend/src/platform/lib/scheduleEvents.ts
+++ b/frontend/src/platform/lib/scheduleEvents.ts
@@ -24,7 +24,16 @@ import type { ScheduleToast } from "@platform/lib/schedule-toast";
 
 const POLL_MS = 15_000;
 
-export function useScheduleEvents(): void {
+/**
+ * @param onOutcome Called once per poll that narrated a done/failed event — a
+ *   scheduled run just ENDED, which is exactly the fact the Tasks page and the
+ *   sidebar are otherwise waiting out their own timers to learn. The shell
+ *   passes tasksPulse.pokeTasks here (App); it is a parameter rather than an
+ *   import because that store lives in shell and platform may not reach up
+ *   (frontend/scripts/check-boundaries.mjs). `missed` deliberately does not
+ *   fire it: nothing ran, so no row is mid-flip anywhere.
+ */
+export function useScheduleEvents(onOutcome?: () => void): void {
   // The highest event id already turned into a toast IN THIS PAGE. A ref (not
   // state) so it survives re-renders without re-arming the interval, and so two
   // overlapping polls can't narrate the same event twice while the ack for the
@@ -37,6 +46,10 @@ export function useScheduleEvents(): void {
   // verdict emitted by the scheduler's first tick still gets said out loud when
   // the shell finally loads. A client-side baseline swallowed exactly those.
   const lastEventId = useRef(0);
+  // Through a ref so the poll loop below (armed once, deps []) always calls the
+  // caller's CURRENT function rather than the one from the mounting render.
+  const outcome = useRef(onOutcome);
+  outcome.current = onOutcome;
 
   useEffect(() => {
     // Only the top-level shell narrates: every embed iframe would otherwise poll
@@ -59,6 +72,12 @@ export function useScheduleEvents(): void {
       lastEventId.current = Math.max(lastEventId.current, highest);
 
       for (const e of fresh) push(toastForEvent(e));
+      // The events just narrated are also the earliest word this poll has that
+      // a run ENDED — see the onOutcome contract above. Once per batch, not per
+      // event: the outcome callback refetches, and one refetch reads them all.
+      if (fresh.some((e) => e.kind === "done" || e.kind === "failed")) {
+        outcome.current?.();
+      }
       // Confirm only AFTER narrating: a page that dies in between sees these
       // once more, which is a duplicate toast rather than a silent miss — the
       // right way round for the one thing here that must not go unsaid.

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -27,6 +27,7 @@ import { useThemeSync } from "@platform/lib/theme";
 import GlobalSidebar from "@shell/GlobalSidebar";
 import NotificationHost from "@platform/ui/NotificationHost";
 import QueueDock from "@shell/QueueDock";
+import { pokeTasks } from "@shell/tasksPulse";
 import ShortcutsOverlay from "@platform/ui/ShortcutsOverlay";
 import { isMod } from "@platform/lib/platform";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
@@ -417,8 +418,12 @@ export default function App({ config }: { config: Config }) {
 
   // The same shape, for scheduled messages: nobody is looking at /tasks when
   // one fires, so "it ran" / "it failed" / "it was missed" has to arrive on its
-  // own rather than wait to be discovered.
-  useScheduleEvents();
+  // own rather than wait to be discovered. pokeTasks rides along: a done/failed
+  // event means a task's row just changed, so the shared tasks store (and the
+  // open Tasks page, through its feeder) re-reads now instead of on its next
+  // tick — handed in from here because that store is shell's and platform may
+  // not import up.
+  useScheduleEvents(pokeTasks);
 
   // Keep <html data-theme> in step with the appearance preference for the
   // page's lifetime (SPEC §30): another window's override, and — while the

--- a/frontend/src/shell/QueueDock.tsx
+++ b/frontend/src/shell/QueueDock.tsx
@@ -281,7 +281,19 @@ function Row({
           </button>
         )}
       </div>
-      <div className="q-status">{roleText(row, jobLine)}</div>
+      {/* A LIVE row's sentence shimmers (Akshil, 2026-08-19): the ink turns the
+          In Progress yellow with the brighter band travelling through it — the
+          app's one "running" treatment (sidebar.css `.sidebar-running`, where
+          the gradient's constraints are documented) — because a run in flight
+          was the one row in this card whose words looked exactly like a queued
+          one's. `live` is the ROLE, not a re-decision: the same reading that
+          gives the row its job-registry line and its Stop, so the shimmer and
+          the sentence cannot disagree. Finished runs never reach this branch —
+          openRows retires a live row the moment its job ends (43353b0f), and
+          the outcome row the job half then draws keeps its own green bar. */}
+      <div className={"q-status" + (row.role === "live" ? " is-running" : "")}>
+        {roleText(row, jobLine)}
+      </div>
     </div>
   );
 }

--- a/frontend/src/shell/QueueDock.tsx
+++ b/frontend/src/shell/QueueDock.tsx
@@ -60,9 +60,11 @@ import {
   queueRows,
   roleText,
   rowCancelKind,
+  scheduleRunsEnded,
   showCancelAll,
   type QueueRow,
 } from "@shell/queue-dock-lib";
+import { pokeTasks } from "@shell/tasksPulse";
 
 // Fast enough that a row appears near the moment it comes due, slow enough to be
 // a permanent background poll in every shell. The queue moves on the scheduler's
@@ -292,6 +294,21 @@ export default function QueueDock() {
   const [jobs, setJobs] = useState<Job[]>([]);
   const [note, setNote] = useState("");
   const [busy, setBusy] = useState(false);
+  // The previous snapshot, for the ended-run comparison below. A ref rather than
+  // reading `jobs` in the callback: the callback is handed down once, and a state
+  // read inside it would compare against whatever render it was created in.
+  const prevJobs = useRef<Job[]>([]);
+  // The snapshot is also this corner's earliest knowledge that a run ENDED —
+  // about a second behind the turn, where the Tasks page's own poll is up to
+  // 20s behind and the status it reads can lag the liveness window on top. So a
+  // running→terminal flip on a sys:schedule:* job pokes the shared tasks store
+  // (which re-reads, or asks the open Tasks page to): "if finished in one,
+  // finished in the other" (Akshil, 2026-08-19).
+  const onJobs = useCallback((next: Job[]) => {
+    if (scheduleRunsEnded(prevJobs.current, next)) pokeTasks();
+    prevJobs.current = next;
+    setJobs(next);
+  }, []);
 
   // What this half still owns: its rows minus any live one whose run the registry
   // says has ended. Without that the outcome row would wait for the next queue read
@@ -341,8 +358,9 @@ export default function QueueDock() {
         // hands a live run back to the job half instead of losing it.
         drawn: drawnIds(rows),
         // And the way back: the card's job snapshot, which is how this half learns a
-        // run ended without waiting for its own slower read (see `rows` above).
-        onJobs: setJobs,
+        // run ended without waiting for its own slower read (see `rows` above) —
+        // and how the Tasks page learns it too (the poke in onJobs above).
+        onJobs,
         rows: rows.map((row) => (
           <Row
             key={row.entry.id}

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -79,7 +79,7 @@ import {
   projectOptions,
 } from "./ScheduleTaskViews";
 import type { TaskFilters } from "./ScheduleTaskViews";
-import { publishTasks, useTasksFeeder } from "./tasksPulse";
+import { publishTasks, TASKS_POKE_EVENT, useTasksFeeder } from "./tasksPulse";
 import { viewFromSearch, viewUrl } from "./tasks-lib";
 import type { TaskView } from "./tasks-lib";
 
@@ -278,6 +278,15 @@ export default function Scheduled() {
   useEffect(() => {
     const id = window.setInterval(reload, POLL_MS);
     return () => window.clearInterval(id);
+  }, []);
+  // The corner card knows a run ended about a second after it does; this page's
+  // own clock is 20s. pokeTasks forwards that knowledge here as a window event —
+  // the feeder above means the shared store may not fetch on our behalf — and
+  // the page re-reads all three feeds, so the row flips the moment the popover
+  // does rather than up to a poll later.
+  useEffect(() => {
+    window.addEventListener(TASKS_POKE_EVENT, reload);
+    return () => window.removeEventListener(TASKS_POKE_EVENT, reload);
   }, []);
 
   const pickView = (v: TaskView) => {

--- a/frontend/src/shell/queue-dock-lib.test.ts
+++ b/frontend/src/shell/queue-dock-lib.test.ts
@@ -20,6 +20,7 @@ import {
   queueRows,
   roleText,
   rowCancelKind,
+  scheduleRunsEnded,
   showCancelAll,
   withdrawableCount,
   type QueueRow,
@@ -567,5 +568,51 @@ describe("one scheduled run, one row, at every step of its life", () => {
     expect(jobsSummary(failed, queueCount([]))).toBe("1 running");
     expect(shownRows([], []).length).toBe(0);
     expect(jobRows([], drawnIds([]))).toEqual([]);
+  });
+});
+
+describe("scheduleRunsEnded: the moment the two surfaces sync", () => {
+  // A scheduled run's status lives on two surfaces at two cadences: this card's
+  // job snapshot (~1s behind the turn) and the Tasks page's own poll (20s, plus
+  // the server's liveness window on top). "If finished in one, finished in the
+  // other" (Akshil, 2026-08-19) — so the running→terminal flip detected here is
+  // what QueueDock pokes the shared tasks store with (tasksPulse.pokeTasks).
+  const running = () => job({ id: `${SCHEDULE_JOB_PREFIX}e1` });
+
+  it("fires on a run flipping running → terminal", () => {
+    for (const state of ["done", "error", "cancelled"] as const) {
+      expect(scheduleRunsEnded([running()], [job({ id: `${SCHEDULE_JOB_PREFIX}e1`, state })])).toBe(
+        true,
+      );
+    }
+  });
+
+  it("fires on a running run vanishing — a Clear between polls still ended it", () => {
+    expect(scheduleRunsEnded([running()], [])).toBe(true);
+  });
+
+  it("does not fire on history: a job first seen already terminal is not news", () => {
+    // The card mounts onto whatever the registry still displays. Poking on that
+    // would refetch the tasks on every mount for a run that ended an hour ago.
+    expect(scheduleRunsEnded([], [job({ id: `${SCHEDULE_JOB_PREFIX}e1`, state: "done" })])).toBe(
+      false,
+    );
+    expect(scheduleRunsEnded([], [])).toBe(false);
+  });
+
+  it("stays quiet while the run is still going, stalled included", () => {
+    expect(scheduleRunsEnded([running()], [running()])).toBe(false);
+    // Stalled is the app admitting it stopped hearing, not the turn ending.
+    expect(
+      scheduleRunsEnded([running()], [job({ id: `${SCHEDULE_JOB_PREFIX}e1`, stalled: true })]),
+    ).toBe(false);
+  });
+
+  it("only scheduled runs count — a download finishing is not a task event", () => {
+    expect(
+      scheduleRunsEnded([job({ id: "sys:ai-model:repo" })], [
+        job({ id: "sys:ai-model:repo", state: "done" }),
+      ]),
+    ).toBe(false);
   });
 });

--- a/frontend/src/shell/queue-dock-lib.test.ts
+++ b/frontend/src/shell/queue-dock-lib.test.ts
@@ -616,3 +616,39 @@ describe("scheduleRunsEnded: the moment the two surfaces sync", () => {
     ).toBe(false);
   });
 });
+
+// ---- the live row's shimmer -----------------------------------------------------
+// Akshil, 2026-08-19: a run in flight wore the same muted grey as a row merely
+// waiting. The sentence of a LIVE row now wears the app's one "running"
+// treatment — the In Progress yellow with the travelling band, the sidebar's
+// recipe. Source pins, because the decision is one ternary in the view and the
+// treatment one CSS block: the class must ride on the ROLE (the same fact that
+// gives the row its job line and its Stop), and the reduced-motion arm must
+// state the label flatly rather than letting the blanket rule park the sweep.
+describe("the live row's shimmer", () => {
+  const { readFileSync } = require("node:fs") as typeof import("node:fs");
+  const { join } = require("node:path") as typeof import("node:path");
+  const DOCK = readFileSync(join(import.meta.dir, "QueueDock.tsx"), "utf8");
+  const CSS = readFileSync(
+    join(import.meta.dir, "../styles/notifications.css"),
+    "utf8",
+  );
+
+  it("rides on the row's role, and only on live", () => {
+    expect(DOCK).toContain('"q-status" + (row.role === "live" ? " is-running" : "")');
+  });
+
+  it("is the sidebar's yellow text shimmer, with the flat reduced-motion arm", () => {
+    expect(CSS).toContain(".q-status.is-running {");
+    expect(CSS).toContain("color: var(--status-progress);");
+    expect(CSS).toContain("animation: q-running-shimmer 2.2s linear infinite;");
+    expect(CSS).toContain("@keyframes q-running-shimmer");
+    // The words never fade and never vanish: in-range travel over a 300% image.
+    expect(CSS).toContain("background-size: 300% 100%;");
+    expect(CSS).toMatch(/q-running-shimmer \{\n  from \{ background-position: 100% 0; \}\n  to \{ background-position: 0% 0; \}/);
+    // Motion off: no parked gradient — the flat status hue instead.
+    const reduced = CSS.slice(CSS.lastIndexOf(".q-status.is-running"));
+    expect(reduced).toContain("animation: none;");
+    expect(reduced).toContain("-webkit-text-fill-color: var(--status-progress);");
+  });
+});

--- a/frontend/src/shell/queue-dock-lib.ts
+++ b/frontend/src/shell/queue-dock-lib.ts
@@ -95,6 +95,32 @@ export function openRows(rows: QueueRow[], jobs: Job[]): QueueRow[] {
 }
 
 /**
+ * Did a scheduled run END between these two job snapshots?
+ *
+ * Asked of every consecutive pair the card hands up (QueueDock's onJobs), and it
+ * is the trigger for the whole cross-surface sync: the job registry is about a
+ * second behind the turn, so the moment a `sys:schedule:*` job stops running is
+ * the moment this corner knows what the Tasks page will not learn from its own
+ * 20-second poll for most of a minute. QueueDock pokes the shared tasks store on
+ * a true answer (tasksPulse.pokeTasks), so the row and the popover flip together.
+ *
+ * "Ended" is running-then-not: a terminal state, or gone from the snapshot
+ * entirely (a Clear can remove a finished row between two polls, and a run that
+ * vanished still ended). A job that first appears already terminal fires
+ * nothing — that is history the registry is still displaying, not news, and
+ * poking on it would refetch the tasks on every mount.
+ */
+export function scheduleRunsEnded(prev: Job[], next: Job[]): boolean {
+  const still = new Set<string>();
+  for (const job of next) {
+    if (job.id.startsWith(SCHEDULE_JOB_PREFIX) && isRunning(job)) still.add(job.id);
+  }
+  return prev.some(
+    (job) => job.id.startsWith(SCHEDULE_JOB_PREFIX) && isRunning(job) && !still.has(job.id),
+  );
+}
+
+/**
  * WHICH SCHEDULED RUNS THIS HALF IS DRAWING, by entry id — the card's other half
  * drops exactly these and keeps everything else (`jobRows`).
  *

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -449,3 +449,58 @@ describe("the Tasks entry's two marks", () => {
     expect(rm).toContain("-webkit-text-fill-color: var(--status-progress)");
   });
 });
+
+// -- the poke: finished in one surface, finished in the other -------------------
+// The queue card and the schedule's event poll both learn a run ended seconds
+// after it does; this store's own cadence is 10–30s and the Tasks page's 20s.
+// pokeTasks is the bridge, and these tests pin the two rules that make it safe:
+// it never fetches over a feeder, and every producer of "a run just ended"
+// actually calls it.
+
+const QUEUE_DOCK = readFileSync(join(SHELL, "QueueDock.tsx"), "utf8");
+const EVENTS = readFileSync(
+  join(SHELL, "../platform/lib/scheduleEvents.ts"),
+  "utf8",
+);
+const APP = readFileSync(join(SHELL, "App.tsx"), "utf8");
+
+describe("pokeTasks", () => {
+  it("forwards to the feeder page instead of fetching over it", () => {
+    // While the Tasks page holds the feeder, this store must not call the
+    // server — that is the double-poll the feeder exists to prevent. The poke
+    // becomes a window event, and the PAGE's own reload publishes back.
+    expect(STORE).toMatch(
+      /export function pokeTasks\(\) \{\s*\n\s*if \(feeders > 0\) \{\s*\n\s*window\.dispatchEvent\(new Event\(TASKS_POKE_EVENT\)\);\s*\n\s*return;/,
+    );
+  });
+
+  it("polls itself immediately when unfed — through the guarded poll()", () => {
+    // poll(), not a bare fetch: the in-flight and generation guards are what
+    // stop a poke's answer landing over a fresher publish.
+    expect(STORE).toMatch(/if \(listeners\.size === 0\) return;\s*\n\s*void poll\(\);/);
+  });
+
+  it("the Tasks page listens for the poke with its own reload", () => {
+    expect(SCHEDULED).toContain("TASKS_POKE_EVENT");
+    expect(SCHEDULED).toMatch(/window\.addEventListener\(TASKS_POKE_EVENT, reload\)/);
+    expect(SCHEDULED).toMatch(/window\.removeEventListener\(TASKS_POKE_EVENT, reload\)/);
+  });
+
+  it("the queue card pokes when a scheduled run's job goes terminal", () => {
+    // Compared snapshot-to-snapshot (scheduleRunsEnded) so mounting onto a
+    // registry full of old terminal rows fires nothing.
+    expect(QUEUE_DOCK).toMatch(
+      /if \(scheduleRunsEnded\(prevJobs\.current, next\)\) pokeTasks\(\);/,
+    );
+  });
+
+  it("a done/failed schedule event pokes too — handed down from the shell", () => {
+    // platform may not import shell (check-boundaries), so scheduleEvents takes
+    // the callback and App supplies the store's pokeTasks.
+    expect(EVENTS).toMatch(
+      /fresh\.some\(\(e\) => e\.kind === "done" \|\| e\.kind === "failed"\)/,
+    );
+    expect(EVENTS).not.toContain("@shell/");
+    expect(APP).toContain("useScheduleEvents(pokeTasks)");
+  });
+});

--- a/frontend/src/shell/tasksPulse.ts
+++ b/frontend/src/shell/tasksPulse.ts
@@ -126,6 +126,41 @@ function schedule() {
   timer = window.setTimeout(poll, pulse.running > 0 ? ACTIVE_MS : IDLE_MS);
 }
 
+/** The window event a poke sends when a feeder page owns the poll: the store
+ *  may not fetch over a feeder (that is the double-poll again), so it asks THE
+ *  PAGE to run its own reload now. Scheduled.tsx listens for exactly this and
+ *  publishes back through publishTasks, the same round trip as its timer. */
+export const TASKS_POKE_EVENT = "fused-render:tasks-poke";
+
+/**
+ * "Something just changed — re-read NOW rather than on the next tick."
+ *
+ * Called by the surfaces that learn a scheduled run ended long before any timer
+ * here would: the queue card's job snapshot (about a second behind the turn —
+ * QueueDock) and the schedule's own done/failed events (App wiring
+ * useScheduleEvents). Without this the sidebar and the Tasks page sat out
+ * their 10–30s cadences while the bottom-right corner already said finished —
+ * the same run, two answers, for most of a minute (Akshil, 2026-08-19: "if
+ * finished in one, finished in the other").
+ *
+ * The feeder contract is honoured, not bypassed: while the Tasks page is
+ * feeding this store the store must not fetch (that is the double-poll the
+ * feeder exists to prevent), so the poke is forwarded to the page as a window
+ * event and the page's OWN reload answers. Unfed, the store polls itself
+ * immediately — poll() already carries the in-flight and generation guards, so
+ * a poke can never land a stale answer over a fresher one.
+ */
+export function pokeTasks() {
+  if (feeders > 0) {
+    window.dispatchEvent(new Event(TASKS_POKE_EVENT));
+    return;
+  }
+  // Nobody reading and nobody feeding: nothing on screen to update, and a
+  // fetch for an unmounted sidebar is the waste schedule() already refuses.
+  if (listeners.size === 0) return;
+  void poll();
+}
+
 /** Hand over a known-fresh answer — what the Tasks page's own poll returned. */
 export function publishTasks(next: TaskPulseTask[]) {
   generation += 1;

--- a/frontend/src/styles/notifications.css
+++ b/frontend/src/styles/notifications.css
@@ -530,6 +530,60 @@
   word-break: break-word;
 }
 
+/* -- A live row's sentence, while the run is actually going ----------------------
+   The one row in this card describing work IN FLIGHT wore the same muted grey as
+   a row that was merely waiting. It now wears the app's one "running" treatment:
+   the ink itself in the In Progress yellow (--status-progress) with a brighter
+   band travelling through the letters — the exact recipe of the sidebar's "N
+   running" (sidebar.css `.sidebar-running`), whose documented constraints all
+   carry over and are why every value below is what it is:
+
+   * the words NEVER FADE — every gradient stop is the full status hue or the
+     hue mixed toward `--fg`, so the band only ever ADDS contrast, in both
+     themes, and the floor of the animation is the flat readable label the
+     reduced-motion arm below states outright;
+   * no reachable frame leaves a letter unpainted — the 300%-wide image travels
+     100% → 0% (every position in that range still covers the box) and repeats,
+     because with `background-clip: text` an unpainted spot is not a dim letter
+     but a MISSING one.
+
+   The keyframes are this sheet's own rather than sidebar.css's only because the
+   two files must not depend on each other's load order; the timing and travel
+   are identical, so every "running" in the app moves as one. */
+.q-status.is-running {
+  color: var(--status-progress);
+  background-image: linear-gradient(
+    100deg,
+    var(--status-progress) 30%,
+    color-mix(in srgb, var(--status-progress) 65%, var(--fg)) 50%,
+    var(--status-progress) 70%
+  );
+  background-size: 300% 100%;
+  background-repeat: repeat;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: q-running-shimmer 2.2s linear infinite;
+}
+
+@keyframes q-running-shimmer {
+  from { background-position: 100% 0; }
+  to { background-position: 0% 0; }
+}
+
+/* The blanket reduced-motion rule (reduced-motion.css) collapses the duration
+   and runs the sweep ONCE, which would park the gradient wherever 0.01ms leaves
+   it. So the gradient is dropped instead and the sentence is the flat status
+   hue: still visibly "this one is going", stated without motion — the same arm
+   `.sidebar-running` takes. */
+@media (prefers-reduced-motion: reduce) {
+  .q-status.is-running {
+    animation: none;
+    background-image: none;
+    -webkit-text-fill-color: var(--status-progress);
+  }
+}
+
 /* What a cancel actually did — including the half that was refused because it
    was already away. Not a toast: it answers a button in this card, and it sits at
    the card's foot below the rows (outside the collapse, since Cancel all is in the

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -711,6 +711,47 @@ def _running_now(session_id: str, live: bool, busy: set[str]) -> bool:
     return live or (bool(session_id) and session_id in busy)
 
 
+def _verdict_outvotes_live(messages: list[dict]) -> bool:
+    """Is the transcript's liveness just the echo of a run that has already
+    reported its verdict?
+
+    THE 45-SECOND WINDOW LIES IN EXACTLY ONE DIRECTION (Akshil, 2026-08-19: "if
+    finished in one, finished in the other"). The bottom-right queue card flips
+    to finished within seconds of the result row landing — the watcher records
+    the turn's verdict the moment it sees it — while this page kept answering In
+    Progress for the rest of the liveness window, because the transcript's tail
+    had been written to seconds ago. Of course it had: the records were the
+    finished turn's OWN closing rows. Counting a run's obituary as a pulse is
+    how the two surfaces disagreed about the same run for up to a minute.
+
+    So: when the newest thing that actually HAPPENED in this thread is a
+    scheduled run that has spoken (`_message_verdict` — done or failed), and no
+    message claims to be running by its own state, bare liveness has nothing
+    left to attest and the caller sets it aside. `ran_at` is the comparison on
+    both sides because it is the one stamp that means "happened": a prompt the
+    user types after the run is a chat message with a newer `ran_at`, so a
+    genuinely new turn keeps its In Progress. The tie goes to the verdict — the
+    prompt a scheduled run fired is consumed by the join (`_merge`) and cannot
+    also stand on the chat side, so an equal stamp is the run's own.
+
+    Deliberately NOT consulted: `busy_sessions`. The scheduler holding a send in
+    flight is an independent claim and `_running_now` keeps asking it whatever
+    this answers — this function only decides whether the TRANSCRIPT gets a
+    vote.
+    """
+    if any(_message_running(m) for m in messages):
+        return False  # something really is in flight; liveness corroborates it
+    verdict_at = 0.0
+    other_at = 0.0
+    for message in messages:
+        happened = message["ran_at"] or 0.0
+        if message["kind"] == "scheduled" and _message_verdict(message) is not None:
+            verdict_at = max(verdict_at, happened)
+        else:
+            other_at = max(other_at, happened)
+    return verdict_at > 0.0 and verdict_at >= other_at
+
+
 def _status(messages: list[dict], filed: bool, session_id: str, live: bool,
             busy: set[str]) -> str:
     """The status a task sits in — ONE decision, made here, for every view.
@@ -726,7 +767,9 @@ def _status(messages: list[dict], filed: bool, session_id: str, live: bool,
        independent because each is wrong on its own in a different direction: a
        turn thinking through a long tool call appends nothing for minutes and
        reads as not-live, and a session a human is typing into has no busy entry
-       at all.
+       at all. The transcript's vote is withdrawn by the caller for exactly one
+       case — the tail's freshness is the finished run's own closing records —
+       see `_verdict_outvotes_live`.
     2. **Archived is a filing state.** The task the user put away is archived,
        and so is a task whose every message ended up filed (cancelling the last
        live message in a thread archives the task, without anybody having to say
@@ -1146,6 +1189,17 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     # in the last three of a list it is in the same order as. Their ids follow
     # from the total, whatever else is below them.
     merged = _merge(prompts, task["entries"], live)
+    # A run that has already reported its verdict does not keep the row In
+    # Progress off its own closing transcript records: the queue card in the
+    # corner says finished within seconds of the result row, and this page
+    # saying In Progress for the rest of the 45-second liveness window was the
+    # two surfaces disagreeing about one run. Decided off the WHOLE merged
+    # thread, before the tail is cut, and spent by everything below that reads
+    # `live` — the status, the newest chat message's turn, and the row's own
+    # `live` flag — so the row cannot half-agree with itself. See
+    # `_verdict_outvotes_live` for why a genuinely new turn is safe.
+    if live and _verdict_outvotes_live(merged):
+        live = False
     # BEFORE the cut, from the whole set: the one fact about the future that the
     # three-message window cannot be trusted to hold. See `_next_run`.
     next_run, next_run_entry = _next_run(task["entries"])

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1468,6 +1468,88 @@ def test_a_send_the_scheduler_is_still_waiting_on_reads_as_running(
     assert task["status"] == "in_progress"
 
 
+def _near_now(offset_sec: float) -> str:
+    """A transcript/schedule timestamp measured from NOW — the shape the
+    liveness tests below need, since the 45-second window is against the real
+    clock and the fixed T9..T12 stamps are years cold by construction."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ",
+                         time.gmtime(time.time() + offset_sec))
+
+
+def test_a_freshly_resolved_turn_outvotes_the_transcripts_liveness(
+        client, projects_dir):
+    """The popover/tasks-page split, closed on the server's side.
+
+    A scheduled run's closing records are the last thing written to the
+    transcript, so for the whole 45-second window after the verdict landed the
+    tail still read as "live" — and the row said In Progress while the queue
+    card in the corner had said finished within seconds of the result row. The
+    turn has SPOKEN; its own obituary is not a pulse (Akshil, 2026-08-19: "if
+    finished in one, finished in the other")."""
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("go", _near_now(-30), uuid="u1"),
+        _assistant("all done", _near_now(-5)),
+    ])
+    _seed_schedule([_entry("e1", "go", _near_now(-30), state=schedule.SENT,
+                           fired=_near_now(-30), turn="ok",
+                           claude_session_id="sess-a")])
+    task = _by_key(client)["sess-a"]
+    assert task["live"] is False, "the echo is set aside, not just outvoted"
+    assert task["status"] == "done"
+
+
+def test_a_failed_verdict_outvotes_liveness_the_same_way(client, projects_dir):
+    """Failed resolves a turn exactly as done does — the corner card flips to
+    the error row at once, and the task must land in Failed with it rather than
+    idling in In Progress for the rest of the window."""
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("go", _near_now(-30), uuid="u1"),
+        _assistant("it broke", _near_now(-5)),
+    ])
+    _seed_schedule([_entry("e1", "go", _near_now(-30), state=schedule.SENT,
+                           fired=_near_now(-30), turn="failed",
+                           claude_session_id="sess-a")])
+    task = _by_key(client)["sess-a"]
+    assert task["status"] == "failed"
+    assert task["live"] is False
+
+
+def test_a_new_turn_after_the_resolved_run_still_reads_as_running(
+        client, projects_dir):
+    """The guard on the rule above: only the resolved run's own echo is set
+    aside. A prompt the user types AFTER it is a chat message with a newer
+    `ran_at`, so the transcript's liveness is attesting genuinely new work and
+    keeps its vote — the task stays In Progress."""
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("go", _near_now(-30), uuid="u1"),
+        _user("one more thing", _near_now(-3), uuid="u2"),
+    ])
+    _seed_schedule([_entry("e1", "go", _near_now(-30), state=schedule.SENT,
+                           fired=_near_now(-30), turn="ok",
+                           claude_session_id="sess-a")])
+    task = _by_key(client)["sess-a"]
+    assert task["live"] is True
+    assert task["status"] == "in_progress"
+
+
+def test_a_resolved_run_does_not_silence_a_sibling_still_in_flight(
+        client, projects_dir):
+    """A message that says it is running by its OWN state — sending, or sent
+    with the turn unreported — is real work whatever the newest verdict says,
+    and liveness corroborating it must not be withdrawn."""
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("go", _near_now(-30), uuid="u1"),
+        _assistant("first one done", _near_now(-5)),
+    ])
+    _seed_schedule([
+        _entry("e1", "go", _near_now(-30), state=schedule.SENT,
+               fired=_near_now(-30), turn="ok", claude_session_id="sess-a"),
+        _entry("e2", "and again", _near_now(-10), state=schedule.SENDING,
+               claude_session_id="sess-a"),
+    ])
+    assert _by_key(client)["sess-a"]["status"] == "in_progress"
+
+
 def test_a_finished_run_is_not_in_progress_however_it_was_pinned(
         client, projects_dir, state_dir):
     """The stale-pin bug, gone by construction rather than by reaping.


### PR DESCRIPTION
## What

The bottom-right queue popover flips "finished" ~3s after a run ends (job registry), but the tasks page kept saying "in progress" for up to ~75s (45s transcript-liveness window + 20s poll + no invalidation) — Akshil saw "finished in the popover, running on the page" until a manual refresh.

- **Client**: `pokeTasks()` in tasksPulse — QueueDock pokes it the moment a `sys:schedule:*` job goes terminal (pure `scheduleRunsEnded` snapshot diff), and the schedule done/failed event poll backstops it. Mounted tasks page refetches via its own reload (feeder pattern intact); unfed store polls immediately.
- **Server**: a freshly-resolved verdict outvotes bare transcript liveness in `_status` — a session is not "running" merely because its tail was active within 45s when the newest thing that happened is a resolved turn. Newer user prompts / in-flight messages keep their vote, so genuine running detection is unchanged.
- **Queue dock**: a live row's status line wears the yellow running shimmer instead of muted grey; finished rows keep the green bar.

Both surfaces now flip within ~1–2s of each other.

## Testing

- New pytest cases (verdict-vs-liveness, verified failing with the fix reverted), bun tests for the poke semantics + snapshot diff; 1932 bun / 154 tasks-schedule pytest green.
- User-tested on the 2160 integration build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task status derivation (`_status` / `live`) and cross-module invalidation; behavior is heavily tested but wrong verdict logic could mis-label in-progress tasks.
> 
> **Overview**
> Fixes **finished in the popover, still In Progress on Tasks** by syncing both surfaces when a scheduled run ends (~1–2s instead of up to ~75s).
> 
> **Client:** New **`pokeTasks()`** in `tasksPulse` triggers an immediate refetch (or a `TASKS_POKE_EVENT` to the open Tasks page when it owns the feeder). **QueueDock** calls it when `scheduleRunsEnded` sees a `sys:schedule:*` job go terminal; **`useScheduleEvents`** takes an optional **`onOutcome`** callback (wired from **App** with `pokeTasks`) on **done/failed** schedule events. **Scheduled** listens for the poke and runs its existing **`reload`**. Live queue rows get **`.q-status.is-running`** (yellow shimmer, same pattern as the sidebar).
> 
> **Server:** **`_verdict_outvotes_live`** stops treating fresh transcript tail as “running” when the newest real event is a resolved scheduled verdict and nothing is in flight—clears **`live`** before status derivation so **done/failed** wins over the 45s liveness window.
> 
> Tests cover poke wiring, `scheduleRunsEnded`, verdict/liveness API cases, and queue shimmer CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad1d1a4eb89002c064557bff9484708e22d3d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->