### PR TITLE
Queue dock: run-start pokes the tasks store, and main's queue-dock pin mended

### DIFF
--- a/frontend/src/shell/QueueDock.tsx
+++ b/frontend/src/shell/QueueDock.tsx
@@ -318,11 +318,21 @@ export default function QueueDock() {
   // (which re-reads, or asks the open Tasks page to): "if finished in one,
   // finished in the other" (Akshil, 2026-08-19).
   // …and the earliest that one STARTED (Akshil, 2026-08-19: the popover read
-  // "thinking" while the Tasks list sat on Upcoming until a reload). First
-  // snapshot is exempt: with nothing to compare against, every running job
-  // would read as news, and the Tasks surfaces fetch on their own mount.
+  // "thinking" while the Tasks list sat on Upcoming until a reload). The first
+  // REAL snapshot is exempt: with nothing to compare against, every already-
+  // running job would read as news, and the Tasks surfaces fetch on their own
+  // mount. DownloadManager's slot effect also echoes useJobs' initial [] once
+  // before any poll answers — that echo is not a snapshot and must not spend
+  // the exemption, or the true first response gets compared against [] and an
+  // in-flight run pokes on every shell mount (Bugbot, PR #648).
+  const sawEcho = useRef(false);
   const sawJobs = useRef(false);
   const onJobs = useCallback((next: Job[]) => {
+    if (!sawEcho.current) {
+      sawEcho.current = true;
+      setJobs(next);
+      return;
+    }
     const news =
       sawJobs.current &&
       (scheduleRunsEnded(prevJobs.current, next) ||

--- a/frontend/src/shell/QueueDock.tsx
+++ b/frontend/src/shell/QueueDock.tsx
@@ -61,6 +61,7 @@ import {
   roleText,
   rowCancelKind,
   scheduleRunsEnded,
+  scheduleRunsStarted,
   showCancelAll,
   type QueueRow,
 } from "@shell/queue-dock-lib";
@@ -316,8 +317,18 @@ export default function QueueDock() {
   // running→terminal flip on a sys:schedule:* job pokes the shared tasks store
   // (which re-reads, or asks the open Tasks page to): "if finished in one,
   // finished in the other" (Akshil, 2026-08-19).
+  // …and the earliest that one STARTED (Akshil, 2026-08-19: the popover read
+  // "thinking" while the Tasks list sat on Upcoming until a reload). First
+  // snapshot is exempt: with nothing to compare against, every running job
+  // would read as news, and the Tasks surfaces fetch on their own mount.
+  const sawJobs = useRef(false);
   const onJobs = useCallback((next: Job[]) => {
-    if (scheduleRunsEnded(prevJobs.current, next)) pokeTasks();
+    const news =
+      sawJobs.current &&
+      (scheduleRunsEnded(prevJobs.current, next) ||
+        scheduleRunsStarted(prevJobs.current, next));
+    if (news) pokeTasks();
+    sawJobs.current = true;
     prevJobs.current = next;
     setJobs(next);
   }, []);

--- a/frontend/src/shell/queue-dock-lib.test.ts
+++ b/frontend/src/shell/queue-dock-lib.test.ts
@@ -21,6 +21,7 @@ import {
   roleText,
   rowCancelKind,
   scheduleRunsEnded,
+  scheduleRunsStarted,
   showCancelAll,
   withdrawableCount,
   type QueueRow,
@@ -650,5 +651,28 @@ describe("the live row's shimmer", () => {
     const reduced = CSS.slice(CSS.lastIndexOf(".q-status.is-running"));
     expect(reduced).toContain("animation: none;");
     expect(reduced).toContain("-webkit-text-fill-color: var(--status-progress);");
+  });
+});
+
+// PR #647: a run STARTING is news the same way one ending is (Akshil,
+// 2026-08-19: the popover said "thinking" while the Tasks list sat on
+// Upcoming until a reload) — same prefix rule, opposite transition.
+describe("scheduleRunsStarted", () => {
+  it("reads a schedule job newly running as a start", () => {
+    const prev = [{ id: "sys:schedule:9", state: "queued" }] as never;
+    const next = [{ id: "sys:schedule:9", state: "running" }] as never;
+    expect(scheduleRunsStarted(prev, next)).toBe(true);
+  });
+
+  it("counts a job the registry only just learned about", () => {
+    const next = [{ id: "sys:schedule:9", state: "running" }] as never;
+    expect(scheduleRunsStarted([], next)).toBe(true);
+  });
+
+  it("stays quiet for still-running and for non-schedule jobs", () => {
+    const running = [{ id: "sys:schedule:9", state: "running" }] as never;
+    expect(scheduleRunsStarted(running, running)).toBe(false);
+    const other = [{ id: "dl:1", state: "running" }] as never;
+    expect(scheduleRunsStarted([], other)).toBe(false);
   });
 });

--- a/frontend/src/shell/queue-dock-lib.ts
+++ b/frontend/src/shell/queue-dock-lib.ts
@@ -121,6 +121,25 @@ export function scheduleRunsEnded(prev: Job[], next: Job[]): boolean {
 }
 
 /**
+ * And did one START? The same question from the other end (Akshil, 2026-08-19:
+ * the popover said "thinking" within a second of a run spawning while the
+ * Tasks page sat on Upcoming until its 20s poll) — a `sys:schedule:*` job
+ * running in this snapshot that was not running in the last one, including a
+ * job the registry only just learned about. The caller skips the comparison
+ * for its very first snapshot: everything is "new" on mount, and the Tasks
+ * surfaces fetch on their own mount anyway.
+ */
+export function scheduleRunsStarted(prev: Job[], next: Job[]): boolean {
+  const was = new Set<string>();
+  for (const job of prev) {
+    if (job.id.startsWith(SCHEDULE_JOB_PREFIX) && isRunning(job)) was.add(job.id);
+  }
+  return next.some(
+    (job) => job.id.startsWith(SCHEDULE_JOB_PREFIX) && isRunning(job) && !was.has(job.id),
+  );
+}
+
+/**
  * WHICH SCHEDULED RUNS THIS HALF IS DRAWING, by entry id — the card's other half
  * drops exactly these and keeps everything else (`jobRows`).
  *

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -486,12 +486,14 @@ describe("pokeTasks", () => {
     expect(SCHEDULED).toMatch(/window\.removeEventListener\(TASKS_POKE_EVENT, reload\)/);
   });
 
-  it("the queue card pokes when a scheduled run's job goes terminal", () => {
-    // Compared snapshot-to-snapshot (scheduleRunsEnded) so mounting onto a
-    // registry full of old terminal rows fires nothing.
-    expect(QUEUE_DOCK).toMatch(
-      /if \(scheduleRunsEnded\(prevJobs\.current, next\)\) pokeTasks\(\);/,
-    );
+  it("the queue card pokes when a scheduled run's job starts or goes terminal", () => {
+    // Compared snapshot-to-snapshot (scheduleRunsEnded / scheduleRunsStarted)
+    // so mounting onto a registry full of old rows fires nothing — including
+    // the slot's initial [] echo, which must not become the baseline.
+    expect(QUEUE_DOCK).toMatch(/scheduleRunsEnded\(prevJobs\.current, next\)/);
+    expect(QUEUE_DOCK).toMatch(/scheduleRunsStarted\(prevJobs\.current, next\)/);
+    expect(QUEUE_DOCK).toMatch(/if \(news\) pokeTasks\(\);/);
+    expect(QUEUE_DOCK).toMatch(/sawEcho\.current = true;/);
   });
 
   it("a done/failed schedule event pokes too — handed down from the shell", () => {

--- a/tests/test_queue_dock.py
+++ b/tests/test_queue_dock.py
@@ -350,7 +350,10 @@ def test_the_two_halves_share_one_job_snapshot_so_the_handover_is_not_a_race(doc
     It also deletes what used to be a second forever-poll of the same endpoint."""
     assert "onJobs?: (jobs: Job[]) => void" in card, "the slot has to carry the way back"
     assert "onJobs?.(reported)" in card, "the FULL list, not the rows this card draws"
-    assert "onJobs: setJobs" in dock
+    # Not a bare setState any more: the callback also POKES the tasks store on a
+    # run starting or ending (PR #646) — the pin follows the handoff, which is
+    # what the two-halves contract actually needs.
+    assert "onJobs," in dock and "const onJobs = useCallback(" in dock
     assert "openRows(queueRows(" in dock, "the rows are filtered before anything is told"
     assert "fetchJobs" not in dock, "the queue half must not poll the job registry itself"
     # and the exemption that was the duplicate is gone from the rule


### PR DESCRIPTION
Follow-up to #646: the popover said "thinking" within a second of a run spawning while the Tasks page sat on Upcoming until its 20s poll — scheduleRunsStarted mirrors the ended-detection and onJobs pokes on both edges (first snapshot exempt). Also fixes the test_queue_dock pin #646 left expecting the old `onJobs: setJobs` handoff, which is currently red on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized shell sync logic with explicit first-snapshot and echo exemptions; covered by unit and integration pin tests.
> 
> **Overview**
> **Keeps the Tasks list in sync when a scheduled run starts**, not only when it finishes. The queue popover could show a run as active while `/tasks` stayed on Upcoming until its slower poll or a reload.
> 
> Adds `scheduleRunsStarted` in `queue-dock-lib` (mirror of `scheduleRunsEnded` for `sys:schedule:*` jobs entering `running`). `QueueDock`’s `onJobs` callback now calls `pokeTasks()` when either helper sees a transition, with guards so the first real job snapshot does not treat every in-flight job as new and the DownloadManager slot’s initial `[]` echo is not used as the comparison baseline.
> 
> Tests and the `test_queue_dock.py` pin are updated for the new poke logic and the fact that `onJobs` is no longer a bare `setJobs` handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55dd34d22df4dc8b5b6ec5844d1cc6576770b453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->