### PR TITLE
Index freshness check waits 3s, so /home's session cards don't race the first paint

### DIFF
--- a/fused_render/index/freshness.py
+++ b/fused_render/index/freshness.py
@@ -44,9 +44,12 @@ QUIET_S = 30.0
 # in favour of routers/index.FRESHNESS_CHECK_S: that one throttles the CHECKS
 # per root, in memory, and sees nothing started by the scheduler or the buttons,
 # so without this floor a folder-open could rescan seconds after either. The two
-# express ONE cadence at two layers, and the check interval is set a few seconds
-# under this number rather than equal to it — see the note there on why equal
-# ones interleave into half the intended rate. Still far below the startup
+# express ONE cadence at two layers, but they do not currently ADD UP to it:
+# FRESHNESS_CHECK_S is 55, under this 60, and a check stamps its own clock
+# whether or not it then scans — so the check at t=55 is refused here and the
+# next one is t=110, making the real folder-open cadence ~110s rather than 60.
+# Known, pre-existing, and written up in full over FRESHNESS_CHECK_S, including
+# why the fix is to raise THAT above this number. Still far below the startup
 # debounce (SCAN_DEBOUNCE_S, 15 min): that
 # one exists to stop a reload loop, this one to stop a browsing session from
 # queueing.

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -134,25 +134,32 @@ again on every watch tick of a folder on screen**:
    indefinitely, and this one is serving a listing.
 3. `MIN_INTERVAL_S` (60 s) since any scan of that root, read off `scans.json` — so no
    state file of its own, and a scan that just ran for any reason suppresses a trigger.
-   `routers/index.FRESHNESS_CHECK_S` (55 s) paces the checks in memory to the same
-   cadence, deliberately a little **shorter**: the check clock starts when a check
-   begins and the scan clock when the scan is spawned, so equal intervals would put
-   every second check just inside the floor and halve the real rate. Scanning sooner is
-   also *cheaper*, since both dominant scan costs (the journal replay and the visit set
-   it names) scale with the window since the last one.
+   `routers/index.FRESHNESS_CHECK_S` (55 s) paces the checks in memory. **Known bug,
+   pre-existing and deliberately not fixed:** 55 being *shorter* than 60 does not give a
+   60 s folder-open scan cadence, it gives ~110 s. The check clock is stamped whenever a
+   check comes due, whether or not that check then scans — so the check at t=55 stamps,
+   is refused by this gate (last scan 55 s ago), and the next check is t=110. Every
+   other check is wasted, and an equal 60 gives ~120 the same way. The fix is to set
+   `FRESHNESS_CHECK_S` *above* `MIN_INTERVAL_S` plus the spawn offset (61), which lands
+   with this gate already clear; it is left alone because how often a machine rescans is
+   a behaviour decision, not a comment correction. Scanning sooner is also *cheaper*,
+   since both dominant scan costs (the journal replay and the visit set it names) scale
+   with the window since the last one.
 4. `QUIET_S` (30 s) since the directory's own mtime moved. A build tree's mtime never
    stops moving, so it is never quiet and never triggers; the open after the churn stops
    still does.
 
 A live run of the root is refused rather than joined, the check runs on a background
 thread throttled to one at a time, and nothing about the listing waits on it or fails
-with it. That thread also waits `FRESHNESS_DELAY_S` (3 s) before gate 1, so the scan it
-may start lands after a page's opening burst rather than inside it — `/home` draws one
+with it. That thread also waits `FRESHNESS_DELAY_S` (3 s) before it commits, so the scan
+it may start lands after a page's opening burst rather than inside it — `/home` draws one
 folder card per Claude session and so lists a fistful of folders on a plain refresh. The
-wait comes **before** the check clock is stamped, which is what keeps the 5 s of slack in
-gate 3 whole; the check's own cadence therefore becomes `55 + 3` s, still under the 60 s
-floor. Waiting costs nothing in accuracy: the comparison is folder mtime against the
-*index*, not against when the folder was opened.
+wait sits **after** the gates that can refuse for free (root membership, and a
+non-stamping peek at the check interval) and **before** the stamp, so a check that was
+never going to act does not hold the one-at-a-time slot for three seconds. Waiting costs
+nothing in accuracy: the comparison is folder mtime against the *index*, not against when
+the folder was opened. It does widen the window in which a `/api/git-repos` rotation turn
+is lost to a failed acquire — see the note on that function.
 
 **Who fires it:** `/api/fs/list`, naming the folder just opened, and `/api/git-repos`,
 naming **one configured root per request, round-robin** — that tab is served entirely

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -146,7 +146,13 @@ again on every watch tick of a folder on screen**:
 
 A live run of the root is refused rather than joined, the check runs on a background
 thread throttled to one at a time, and nothing about the listing waits on it or fails
-with it.
+with it. That thread also waits `FRESHNESS_DELAY_S` (3 s) before gate 1, so the scan it
+may start lands after a page's opening burst rather than inside it — `/home` draws one
+folder card per Claude session and so lists a fistful of folders on a plain refresh. The
+wait comes **before** the check clock is stamped, which is what keeps the 5 s of slack in
+gate 3 whole; the check's own cadence therefore becomes `55 + 3` s, still under the 60 s
+floor. Waiting costs nothing in accuracy: the comparison is folder mtime against the
+*index*, not against when the folder was opened.
 
 **Who fires it:** `/api/fs/list`, naming the folder just opened, and `/api/git-repos`,
 naming **one configured root per request, round-robin** — that tab is served entirely

--- a/fused_render/server/routers/git_repos.py
+++ b/fused_render/server/routers/git_repos.py
@@ -180,14 +180,24 @@ def _note_tab_opened(cfg) -> None:
 
     Exactly ONE root per request, taken round-robin, because the checker admits
     exactly one check at a time: note_folder_opened acquires a non-blocking slot
-    (routers/index._freshness_slot) and its background thread releases it a
-    config read — and possibly a duckdb lookup — later. Offering every root in a
-    loop therefore does not check every root; it checks the FIRST one and loses
-    the rest microseconds later on a failed acquire, every request, forever. The
-    first root would also take the slot on requests where it is not even due,
-    since due-ness is decided after the acquire. Rotating the offer is what makes
-    "each root gets checked" true, and it fits the slot rather than fighting it:
-    a tab render never queues more than one check.
+    (routers/index._freshness_slot) and its background thread releases it after
+    the check. Offering every root in a loop therefore does not check every root;
+    it checks the FIRST one and loses the rest on a failed acquire, every
+    request, forever. The first root would also take the slot on requests where
+    it is not even due, since due-ness is decided after the acquire. Rotating the
+    offer is what makes "each root gets checked" true, and it fits the slot
+    rather than fighting it: a tab render never queues more than one check.
+
+    Weakened, and named rather than papered over: "eventually every root" used to
+    rest on the slot being freed microseconds later, so a rotation turn was only
+    ever lost to a genuinely concurrent check. A check that decides to act now
+    holds the slot for routers/index.FRESHNESS_DELAY_S (3 s) while it defers, so
+    a repos-tab request landing inside that window spends its turn on a failed
+    acquire and that root waits a full rotation for another. The cheap gates run
+    before the wait, so only checks that are actually due hold the slot that
+    long and the window is small — but it is seconds wide, not microseconds, and
+    this tab is a cheap opportunistic nudge either way: the honest answer to "is
+    this list complete" is still `stale` plus the next scheduled scan.
 
     note_folder_opened never raises and never blocks (it spawns a thread), so
     this costs the request one lock acquire."""

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -480,6 +480,39 @@ _freshness_slot = threading.Lock()
 # covers the spawn comfortably.
 FRESHNESS_CHECK_S = 55.0
 
+# ...and the check, once it is due, does not start where it was asked. A check
+# that decides to act runs the ordinary incremental scan of the whole enclosing
+# root: min(10, cpu_count) unniced worker processes, each with a 16-thread stat
+# pool, and a compaction that rewrites every parquet partition at the end. That
+# is a fine thing to pay while the user browses; it is a bad thing to pay in the
+# first second of a page load.
+#
+# /home is where the two collide. It draws one FolderPreviewCard per Claude
+# session (shell/Home.tsx), and every card's FolderStack lists its folder on
+# mount (apps/explorer/BookmarkCards.tsx) — so a plain refresh, with no typing
+# and no interaction, fires a fistful of /api/fs/list at once, each one arriving
+# here, on top of the burst the page already fires for itself (/api/apps/home,
+# /api/claude-sessions/home, /api/claude/health, the search warm, and the
+# preview iframes). One of those listings wins the slot and the scan lands
+# across the first paint. It reproduces on a machine with fewer cores to spare
+# than ours and not on ours, which is exactly the shape of a contention bug.
+#
+# So the check sleeps this long first, and the scan it may start lands after the
+# opening burst instead of inside it. Three seconds are cheap to give up because
+# the question is not time-sensitive in the first place: the check compares the
+# folder's mtime against what the INDEX recorded, not against the moment the
+# folder was opened, so waiting changes nothing about the answer it reaches — it
+# only moves when the answer is acted on. A user who navigates away inside the
+# window still gets the scan, and that is right: the index was stale either way,
+# and the next search would have paid for it.
+#
+# _freshness_slot is held across the wait, so listings that arrive during it are
+# dropped rather than queued — the same thing the slot already did for the
+# check's own duration, just for longer. On /home that is the desirable
+# behaviour and not a cost: every card is asking the same question of the same
+# root, and the first one to ask covers all of them.
+FRESHNESS_DELAY_S = 3.0
+
 # root -> when it was last checked. Bounded by the number of configured scan
 # roots (a handful), so it needs no eviction.
 _freshness_checked: dict = {}
@@ -501,6 +534,16 @@ def _run_freshness_check(path: str) -> None:
     not fail, or slow down, because index housekeeping did."""
     try:
         import time
+
+        # Before load_config, and so before _freshness_due stamps: the epsilon
+        # between FRESHNESS_CHECK_S and freshness.MIN_INTERVAL_S (see the note
+        # above the constants) is spent if the wait lands after the stamp.
+        # Sleeping first moves both clocks together — the check stamp and
+        # runner._record_scan's — and leaves the five seconds of slack whole;
+        # sleeping after the stamp would burn three of them and put the two
+        # floors back within the spawn window that interleaves them into half
+        # the intended cadence.
+        time.sleep(FRESHNESS_DELAY_S)
 
         cfg = load_config()
         roots = scan_roots(cfg)

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -465,27 +465,34 @@ _freshness_slot = threading.Lock()
 # freshness.MIN_INTERVAL_S is the other floor — on the SCANS themselves, read
 # off scans.json so it also sees the ones the scheduler and the manual buttons
 # start; this one is about the checks, and only about the ones this process
-# makes. One cadence, so this must not be LONGER: a check is the only thing that
-# can act on the scan floor, and checking less often than scans are allowed just
-# leaves the difference on the table.
+# makes.
 #
-# Slightly SHORTER, and the epsilon is load-bearing. The two clocks start at
-# different moments: this one is stamped when a check begins, while
-# `runner._record_scan` stamps when the scan it starts is spawned — a duckdb
-# lookup and a Popen later. So last_scan is always a little after last_check, and
-# at exactly equal intervals the next due check lands inside that offset, finds
-# the scan floor not yet clear, refuses — and re-stamps, pushing the next check
-# out a further full interval. Every second cycle would be a no-op and the real
-# cadence would be ~2x the number both comments name. Five seconds of slack
-# covers the spawn comfortably.
+# KNOWN, PRE-EXISTING, AND DELIBERATELY NOT FIXED HERE: this being 55, i.e.
+# SHORTER than freshness.MIN_INTERVAL_S (60), does NOT produce a ~60s folder-open
+# scan cadence. It produces ~110s. Trace the two clocks: `_freshness_due` stamps
+# this one the moment a check becomes due, WHETHER OR NOT the check then goes on
+# to scan. So the check at t=55 stamps 55 and calls
+# freshness.note_folder_opened, which sees the last scan ~55s ago, refuses on its
+# own 60s floor, and starts nothing; the next check is therefore t=110, and that
+# is the first one that can scan. Every other check is structurally wasted. An
+# equal 60 gives ~120 by the same argument, so "equal is the bad case, shorter is
+# the safe one" — which is what the note here used to say — is backwards.
+#
+# The fix, if the documented cadence is ever actually wanted, is to raise this
+# ABOVE MIN_INTERVAL_S plus the spawn offset (61 would do): the check then
+# arrives with the scan floor already clear and the real cadence is the number
+# written here. It is left alone on purpose. How often every developer machine
+# rescans its home is a behaviour change and the user's call, not a side effect
+# of a comment correction — and certainly not of a commit whose subject is "wait
+# three seconds".
 FRESHNESS_CHECK_S = 55.0
 
-# ...and the check, once it is due, does not start where it was asked. A check
-# that decides to act runs the ordinary incremental scan of the whole enclosing
-# root: min(10, cpu_count) unniced worker processes, each with a 16-thread stat
-# pool, and a compaction that rewrites every parquet partition at the end. That
-# is a fine thing to pay while the user browses; it is a bad thing to pay in the
-# first second of a page load.
+# ...and a check that is going to act does not act where it was asked. It runs
+# the ordinary incremental scan of the whole enclosing root: min(10, cpu_count)
+# unniced worker processes, each with a 16-thread stat pool, and a compaction
+# that rewrites every parquet partition at the end. That is a fine thing to pay
+# while the user browses; it is a bad thing to pay in the first second of a page
+# load.
 #
 # /home is where the two collide. It draws one FolderPreviewCard per Claude
 # session (shell/Home.tsx), and every card's FolderStack lists its folder on
@@ -493,22 +500,36 @@ FRESHNESS_CHECK_S = 55.0
 # and no interaction, fires a fistful of /api/fs/list at once, each one arriving
 # here, on top of the burst the page already fires for itself (/api/apps/home,
 # /api/claude-sessions/home, /api/claude/health, the search warm, and the
-# preview iframes). One of those listings wins the slot and the scan lands
-# across the first paint. It reproduces on a machine with fewer cores to spare
-# than ours and not on ours, which is exactly the shape of a contention bug.
+# preview iframes). One of those listings wins the slot and the scan lands across
+# the first paint. It reproduces on a machine with fewer cores to spare than ours
+# and not on ours, which is exactly the shape of a contention bug.
 #
-# So the check sleeps this long first, and the scan it may start lands after the
-# opening burst instead of inside it. Three seconds are cheap to give up because
-# the question is not time-sensitive in the first place: the check compares the
-# folder's mtime against what the INDEX recorded, not against the moment the
-# folder was opened, so waiting changes nothing about the answer it reaches — it
-# only moves when the answer is acted on. A user who navigates away inside the
-# window still gets the scan, and that is right: the index was stale either way,
-# and the next search would have paid for it.
+# So a check that has passed the cheap gates waits this long before it commits,
+# and the scan it may start lands after the opening burst instead of inside it.
+# Three seconds are cheap to give up because the question is not time-sensitive
+# in the first place: the check compares the folder's mtime against what the
+# INDEX recorded, not against the moment the folder was opened, so waiting
+# changes nothing about the answer it reaches — only when the answer is acted on.
+# A user who navigates away inside the window still gets the scan, and that is
+# right: the index was stale either way, and the next search would have paid for
+# it.
+#
+# It must stay far below FRESHNESS_CHECK_S, which is the only relationship
+# between the two that matters. The wait is absorbed inside the existing check
+# interval — a root's checks land every FRESHNESS_CHECK_S + FRESHNESS_DELAY_S
+# instead of every FRESHNESS_CHECK_S — so at three against fifty-five it shifts
+# the schedule by a rounding error and introduces no refusal that was not
+# already happening (see the note above: the refusals are pre-existing and come
+# from the check interval, not from this). A delay of the same order as the check
+# interval WOULD change the cadence materially, which is what the test on this
+# pair guards.
 #
 # _freshness_slot is held across the wait, so listings that arrive during it are
 # dropped rather than queued — the same thing the slot already did for the
-# check's own duration, just for longer. On /home that is the desirable
+# check's own duration, just for longer. That is why the wait comes after the
+# gates that can refuse for free (below): a check that was never going to do
+# anything must not hold the slot for three seconds while a listing of a
+# genuinely stale root is turned away. On /home the dropping is the desirable
 # behaviour and not a cost: every card is asking the same question of the same
 # root, and the first one to ask covers all of them.
 FRESHNESS_DELAY_S = 3.0
@@ -519,14 +540,31 @@ _freshness_checked: dict = {}
 _freshness_checked_lock = threading.Lock()
 
 
-def _freshness_due(root: str, now: float) -> bool:
-    """Whether `root` is due a check, stamping it when it is."""
+def _freshness_due(root: str, now: float, *, stamp: bool = True) -> bool:
+    """Whether `root` is due a check, stamping it when it is.
+
+    `stamp=False` is the peek taken before the FRESHNESS_DELAY_S wait, so a
+    check that was never due returns instead of holding _freshness_slot for
+    three seconds. Peek-then-stamp is not a race: the slot admits exactly one
+    checker at a time, so nothing else can stamp between the two calls, and the
+    only other writer (a check that finished) can only push the stamp further
+    into the past."""
     with _freshness_checked_lock:
         last = _freshness_checked.get(root)
         if last is not None and (now - last) < FRESHNESS_CHECK_S:
             return False
-        _freshness_checked[root] = now
+        if stamp:
+            _freshness_checked[root] = now
         return True
+
+
+def _freshness_wait(seconds: float) -> None:
+    """The deferral, as one named seam. A plain sleep — it is a function so that
+    tests can observe WHERE in the check it happens without patching
+    stdlib `time.sleep` for the whole process."""
+    import time
+
+    time.sleep(seconds)
 
 
 def _run_freshness_check(path: str) -> None:
@@ -535,16 +573,6 @@ def _run_freshness_check(path: str) -> None:
     try:
         import time
 
-        # Before load_config, and so before _freshness_due stamps: the epsilon
-        # between FRESHNESS_CHECK_S and freshness.MIN_INTERVAL_S (see the note
-        # above the constants) is spent if the wait lands after the stamp.
-        # Sleeping first moves both clocks together — the check stamp and
-        # runner._record_scan's — and leaves the five seconds of slack whole;
-        # sleeping after the stamp would burn three of them and put the two
-        # floors back within the spawn window that interleaves them into half
-        # the intended cadence.
-        time.sleep(FRESHNESS_DELAY_S)
-
         cfg = load_config()
         roots = scan_roots(cfg)
         # The debounce is keyed on the enclosing ROOT, not the folder: a scan
@@ -552,7 +580,23 @@ def _run_freshness_check(path: str) -> None:
         # folder under no root has no question to ask at all, and
         # note_folder_opened would answer None anyway.
         root = enclosing_root(roots, path)
-        if root is None or not _freshness_due(root, time.time()):
+        if root is None:
+            return
+        # Everything that can refuse for free happens BEFORE the wait, and only
+        # the stamp happens after it. The two cases this protects are the two
+        # that dominate: a folder on screen re-lists about once a second, so
+        # without the peek the steady state is acquire, sleep three seconds,
+        # find the root not due, release — a slot held almost permanently
+        # against listings of other roots that ARE stale. And on /home, if the
+        # card listing that happens to win the slot sits under no configured
+        # root, it would burn the whole window doing nothing while every sibling
+        # card is refused, so the page load would get no check at all.
+        if not _freshness_due(root, time.time(), stamp=False):
+            return
+        _freshness_wait(FRESHNESS_DELAY_S)
+        # ...and the stamp is taken on the far side, against the clock as it is
+        # now, so the recorded check time is when the check actually ran.
+        if not _freshness_due(root, time.time()):
             return
         started = freshness.note_folder_opened(cfg, path, roots)
         if started:

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -1124,41 +1124,83 @@ def test_listing_a_folder_notes_it_for_the_freshness_check(home, tmp_path,
 def instant_freshness_delay(monkeypatch):
     """FRESHNESS_DELAY_S off the clock. These tests drive `_run_freshness_check`
     synchronously, and the wait is not what they are about — paying it for real
-    would add three seconds per call to the suite. `time.sleep` is patched on
-    the module itself because the checker imports `time` inside the function."""
-    import time
+    would add three seconds per call to the suite.
 
-    monkeypatch.setattr(time, "sleep", lambda _s: None)
+    The CONSTANT is what gets patched, not `time.sleep`: patching the stdlib
+    would void every sleep in the process for the duration of the test,
+    including store.py's NT-lock poll and this module's warm wait, turning them
+    into hot spins."""
+    monkeypatch.setattr(index_router, "FRESHNESS_DELAY_S", 0.0)
 
 
-def test_the_freshness_check_defers_before_it_touches_anything(
-        home, tmp_path, monkeypatch):
-    """The check waits out the page's opening burst before it does any work.
-
-    /home lists one folder per Claude session card, so a plain refresh lands a
-    handful of /api/fs/list inside the first second and the scan one of them may
-    start piles onto the paint. The wait must come before the FIRST thing the
-    check does, not between its gates: `_freshness_due` stamps the check clock,
-    and stamping and then sleeping would spend the epsilon that keeps that clock
-    clear of the scan floor. Ordering is the assertion — nothing here waits on a
-    real clock."""
-    import time
-
-    events = []
-    monkeypatch.setattr(index_router, "_freshness_checked", {})
-    # The stamp map, snapshotted as the wait begins: still empty is what says
-    # the wait ran BEFORE _freshness_due, not merely before the duckdb lookup.
-    monkeypatch.setattr(time, "sleep", lambda s: events.append(
-        ("slept", s, dict(index_router._freshness_checked))))
-    monkeypatch.setattr(index_router.freshness, "note_folder_opened",
-                        lambda cfg, path, roots: events.append(("checked", path)))
+def _freshness_root(tmp_path):
+    """A tree that is a configured scan root, with the check clock cleared."""
     src = _tree(tmp_path)
     cfg = load_config()
     cfg.roots = [str(src)]
     index_router.save_config(cfg)
+    return src
+
+
+def test_the_freshness_check_defers_before_it_stamps_the_check_clock(
+        home, tmp_path, monkeypatch):
+    """The check waits out the page's opening burst before it commits.
+
+    /home lists one folder per Claude session card, so a plain refresh lands a
+    handful of /api/fs/list inside the first second and the scan one of them may
+    start piles onto the paint.
+
+    The ordering against the STAMP is the assertion. `_freshness_due` records the
+    check the moment it decides one is due, and stamping and then waiting would
+    record a check three seconds before it actually happened — and, worse, would
+    make the wait unskippable for checks that are about to refuse. So the wait
+    must sit after the free gates and before the stamp. Nothing here waits on a
+    real clock; the seam is patched, not the stdlib."""
+    events = []
+    monkeypatch.setattr(index_router, "_freshness_checked", {})
+    # The stamp map, snapshotted as the wait begins. Still empty is what says
+    # the wait ran BEFORE _freshness_due stamped.
+    monkeypatch.setattr(index_router, "_freshness_wait", lambda s: events.append(
+        ("waited", s, dict(index_router._freshness_checked))))
+    monkeypatch.setattr(index_router.freshness, "note_folder_opened",
+                        lambda cfg, path, roots: events.append(("checked", path)))
+    src = _freshness_root(tmp_path)
     index_router._run_freshness_check(str(src))
-    assert events == [("slept", index_router.FRESHNESS_DELAY_S, {}),
+    assert events == [("waited", index_router.FRESHNESS_DELAY_S, {}),
                       ("checked", str(src))]
+    # ...and the stamp did land, on the far side of the wait.
+    assert str(src) in index_router._freshness_checked
+
+
+def test_a_check_that_will_refuse_anyway_never_waits(home, tmp_path,
+                                                     monkeypatch):
+    """The wait holds the one-at-a-time slot, so only a check that is going to do
+    something may pay it.
+
+    Both refusals here are the common case, not the corner: a folder on screen
+    re-lists about once a second, so a wait before the interval gate would mean
+    the slot is held essentially forever, dropping listings of other roots that
+    ARE stale. And on /home, a card sitting under no configured root would burn
+    the window doing nothing while every sibling card is turned away — the page
+    load would get no check at all, which is the opposite of the point."""
+    waits = []
+    monkeypatch.setattr(index_router, "_freshness_checked", {})
+    monkeypatch.setattr(index_router, "_freshness_wait", waits.append)
+    monkeypatch.setattr(index_router.freshness, "note_folder_opened",
+                        lambda cfg, path, roots: None)
+    src = _freshness_root(tmp_path)
+    # Under no configured root at all.
+    index_router._run_freshness_check(str(tmp_path.parent))
+    assert waits == []
+    # Under a root that was checked moments ago.
+    index_router._freshness_checked[str(src)] = time.time()
+    index_router._run_freshness_check(str(src))
+    assert waits == []
+    # ...and the wait IS paid once the root is genuinely due, so the two
+    # assertions above are about due-ness and not about a wait that never runs.
+    index_router._freshness_checked[str(src)] -= index_router.FRESHNESS_CHECK_S + 1
+    index_router._run_freshness_check(str(src))
+    assert waits == [index_router.FRESHNESS_DELAY_S]
 
 
 def test_the_freshness_slot_is_freed_after_a_deferred_check(
@@ -1170,18 +1212,20 @@ def test_the_freshness_slot_is_freed_after_a_deferred_check(
     monkeypatch.setattr(index_router, "_freshness_checked", {})
     monkeypatch.setattr(index_router.freshness, "note_folder_opened",
                         lambda cfg, path, roots: None)
-    src = _tree(tmp_path)
-    cfg = load_config()
-    cfg.roots = [str(src)]
-    index_router.save_config(cfg)
-    # Refused early: no enclosing root, so the check returns before the gates.
-    assert index_router._freshness_slot.acquire(blocking=False)
-    index_router._run_freshness_check(str(tmp_path.parent))
-    assert not index_router._freshness_slot.locked()
-    # ...and on the path that runs the check through.
-    assert index_router._freshness_slot.acquire(blocking=False)
-    index_router._run_freshness_check(str(src))
-    assert not index_router._freshness_slot.locked()
+    src = _freshness_root(tmp_path)
+    # The slot is a module global: a failed assertion below must not leave it
+    # held, or every later test that touches the real hook fails for an
+    # unrelated reason and hides this one.
+    for target in (str(tmp_path.parent), str(src)):
+        assert index_router._freshness_slot.acquire(blocking=False)
+        try:
+            # Two ways out: `tmp_path.parent` is under no root and refuses
+            # before the gates, `src` runs the check all the way through.
+            index_router._run_freshness_check(target)
+            assert not index_router._freshness_slot.locked()
+        finally:
+            if index_router._freshness_slot.locked():
+                index_router._freshness_slot.release()
 
 
 def test_the_freshness_check_runs_at_most_one_at_a_time(

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -1120,8 +1120,72 @@ def test_listing_a_folder_notes_it_for_the_freshness_check(home, tmp_path,
     assert seen == [str(src)]
 
 
-def test_the_freshness_check_runs_at_most_one_at_a_time(home, tmp_path,
-                                                        monkeypatch):
+@pytest.fixture
+def instant_freshness_delay(monkeypatch):
+    """FRESHNESS_DELAY_S off the clock. These tests drive `_run_freshness_check`
+    synchronously, and the wait is not what they are about — paying it for real
+    would add three seconds per call to the suite. `time.sleep` is patched on
+    the module itself because the checker imports `time` inside the function."""
+    import time
+
+    monkeypatch.setattr(time, "sleep", lambda _s: None)
+
+
+def test_the_freshness_check_defers_before_it_touches_anything(
+        home, tmp_path, monkeypatch):
+    """The check waits out the page's opening burst before it does any work.
+
+    /home lists one folder per Claude session card, so a plain refresh lands a
+    handful of /api/fs/list inside the first second and the scan one of them may
+    start piles onto the paint. The wait must come before the FIRST thing the
+    check does, not between its gates: `_freshness_due` stamps the check clock,
+    and stamping and then sleeping would spend the epsilon that keeps that clock
+    clear of the scan floor. Ordering is the assertion — nothing here waits on a
+    real clock."""
+    import time
+
+    events = []
+    monkeypatch.setattr(index_router, "_freshness_checked", {})
+    # The stamp map, snapshotted as the wait begins: still empty is what says
+    # the wait ran BEFORE _freshness_due, not merely before the duckdb lookup.
+    monkeypatch.setattr(time, "sleep", lambda s: events.append(
+        ("slept", s, dict(index_router._freshness_checked))))
+    monkeypatch.setattr(index_router.freshness, "note_folder_opened",
+                        lambda cfg, path, roots: events.append(("checked", path)))
+    src = _tree(tmp_path)
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    index_router._run_freshness_check(str(src))
+    assert events == [("slept", index_router.FRESHNESS_DELAY_S, {}),
+                      ("checked", str(src))]
+
+
+def test_the_freshness_slot_is_freed_after_a_deferred_check(
+        home, tmp_path, monkeypatch, instant_freshness_delay):
+    """The slot is held across the wait, so it must still be released on every
+    way out of it — including the early refusals, which are the common case.
+    A leak would block the check for the rest of the process's life, so the next
+    refresh a minute later would silently never check anything."""
+    monkeypatch.setattr(index_router, "_freshness_checked", {})
+    monkeypatch.setattr(index_router.freshness, "note_folder_opened",
+                        lambda cfg, path, roots: None)
+    src = _tree(tmp_path)
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    # Refused early: no enclosing root, so the check returns before the gates.
+    assert index_router._freshness_slot.acquire(blocking=False)
+    index_router._run_freshness_check(str(tmp_path.parent))
+    assert not index_router._freshness_slot.locked()
+    # ...and on the path that runs the check through.
+    assert index_router._freshness_slot.acquire(blocking=False)
+    index_router._run_freshness_check(str(src))
+    assert not index_router._freshness_slot.locked()
+
+
+def test_the_freshness_check_runs_at_most_one_at_a_time(
+        home, tmp_path, monkeypatch, instant_freshness_delay):
     """A folder being watched re-lists on every mtime tick, so the hook fires
     far more often than a check costs. Overlapping checks would each open
     duckdb over dirs.parquet for nothing."""
@@ -1145,7 +1209,7 @@ class _FakeThread:
 
 
 def test_a_stale_open_folder_gets_its_configured_root_rescanned(
-        home, tmp_path, monkeypatch):
+        home, tmp_path, monkeypatch, instant_freshness_delay):
     """The glue end to end, synchronously: the persisted config supplies the
     roots and the check fires the ordinary incremental scan of the enclosing
     one."""
@@ -1166,8 +1230,8 @@ def test_a_stale_open_folder_gets_its_configured_root_rescanned(
     assert started == [str(src)]
 
 
-def test_a_root_checked_moments_ago_is_not_checked_again(home, tmp_path,
-                                                         monkeypatch):
+def test_a_root_checked_moments_ago_is_not_checked_again(
+        home, tmp_path, monkeypatch, instant_freshness_delay):
     """The in-flight lock drops OVERLAPPING checks, not the ones that follow —
     so browsing folder to folder checked (and could rescan) on every open, and
     every scan that completed invalidated every corpus the client had fetched.
@@ -1191,8 +1255,8 @@ def test_a_root_checked_moments_ago_is_not_checked_again(home, tmp_path,
     assert checked == [str(src / "sub"), str(src)]
 
 
-def test_a_folder_outside_every_root_never_reaches_the_index(home, tmp_path,
-                                                             monkeypatch):
+def test_a_folder_outside_every_root_never_reaches_the_index(
+        home, tmp_path, monkeypatch, instant_freshness_delay):
     """Cheapest gate first: no enclosing root means no scan is possible, so the
     duckdb lookup behind note_folder_opened must not be paid at all."""
     checked = []

--- a/tests/test_index_freshness.py
+++ b/tests/test_index_freshness.py
@@ -184,43 +184,51 @@ def test_a_root_scanned_two_minutes_ago_is_rescanned(tmp_path, spawned):
 
 
 def test_the_scan_floor_matches_the_routers_check_debounce(tmp_path):
-    """Two floors, one cadence. freshness.MIN_INTERVAL_S paces the SCANS (read
-    off scans.json, so it also sees the startup scheduler and the manual
-    buttons); routers.index.FRESHNESS_CHECK_S paces the CHECKS, per root, in
-    memory.
+    """Two floors. freshness.MIN_INTERVAL_S paces the SCANS (read off scans.json,
+    so it also sees the startup scheduler and the manual buttons);
+    routers.index.FRESHNESS_CHECK_S paces the CHECKS, per root, in memory.
 
-    An ordering, not an equality. Longer would leave scans the floor allows
-    unstarted, since a check is the only thing that starts one. Exactly equal is
-    the subtler failure: the check clock is stamped when a check BEGINS and the
-    scan clock when the scan is spawned (runner._record_scan, a duckdb lookup and
-    a Popen later), so the next due check lands just inside the scan floor, is
-    refused, and re-stamps — halving the real rate. Hence strictly shorter.
+    This pins the CURRENT VALUES, and they are not the ideal ones. 55 < 60 does
+    not give a 60 s folder-open scan cadence; it gives ~110 s, because
+    `_freshness_due` stamps the check clock whenever a check comes due whether or
+    not that check then scans. The check at t=55 stamps, note_folder_opened
+    refuses on its own 60 s floor (last scan 55 s ago), and the next check is
+    t=110 — the first that can act. An equal 60 gives ~120 the same way, so
+    "shorter avoids the interleave", which this docstring used to claim, is
+    backwards: shorter is what causes it.
 
-    The check also defers itself before it stamps, which keeps that slack whole
-    rather than spending it — see the sum below."""
+    The fix is FRESHNESS_CHECK_S ABOVE MIN_INTERVAL_S plus the spawn offset (61),
+    and it is a deliberate non-change here — how often every machine rescans is a
+    behaviour decision. So this stays an assertion of what the numbers ARE, with
+    the bug written down next to it, rather than an assertion that they are
+    right."""
     from fused_render.server.routers.index import FRESHNESS_CHECK_S
 
     assert FRESHNESS_CHECK_S < MIN_INTERVAL_S
 
 
-def test_the_deferred_check_still_fits_inside_the_scan_floor(tmp_path):
-    """The delay is part of the check cadence, so it comes out of the same slack.
+def test_the_deferral_is_absorbed_inside_the_check_interval(tmp_path):
+    """The delay must stay small against the check interval it lives inside.
 
-    routers.index._run_freshness_check sleeps FRESHNESS_DELAY_S and only then
-    stamps the check clock, so a root's checks recur every
-    FRESHNESS_CHECK_S + FRESHNESS_DELAY_S of wall clock while the scan clock is
-    stamped a spawn later still. If that sum ever reaches MIN_INTERVAL_S the
-    interleave the test above describes comes back: every second check lands
-    inside the scan floor, is refused, re-stamps, and the real cadence halves.
-    This is the assertion that stops the delay being raised to something
-    comfortable-sounding like ten seconds without moving FRESHNESS_CHECK_S down
-    to pay for it."""
+    _run_freshness_check waits FRESHNESS_DELAY_S and then stamps, so a root's
+    checks recur every FRESHNESS_CHECK_S + FRESHNESS_DELAY_S rather than every
+    FRESHNESS_CHECK_S. At 3 against 55 that shifts the schedule by a rounding
+    error, which is the whole claim the deferral makes: it does not introduce a
+    refusal that was not already happening (the refusals come from the check
+    interval — see the test above — not from this). A delay of the same order as
+    the interval would stop being absorbed and start being the cadence, so the
+    margin, not merely the ordering, is what is asserted.
+
+    Deliberately NOT asserted: any relation between this pair and MIN_INTERVAL_S.
+    The sum being under the scan floor is neither true-by-design nor desirable —
+    the fix to the cadence bug documented above is FRESHNESS_CHECK_S going ABOVE
+    MIN_INTERVAL_S, and a test forbidding that would lock the bug in."""
     from fused_render.server.routers.index import (
         FRESHNESS_CHECK_S,
         FRESHNESS_DELAY_S,
     )
 
-    assert FRESHNESS_CHECK_S + FRESHNESS_DELAY_S < MIN_INTERVAL_S
+    assert 0 < FRESHNESS_DELAY_S <= FRESHNESS_CHECK_S / 10
 
 
 def test_a_folder_outside_every_configured_root_triggers_nothing(

--- a/tests/test_index_freshness.py
+++ b/tests/test_index_freshness.py
@@ -194,10 +194,33 @@ def test_the_scan_floor_matches_the_routers_check_debounce(tmp_path):
     the subtler failure: the check clock is stamped when a check BEGINS and the
     scan clock when the scan is spawned (runner._record_scan, a duckdb lookup and
     a Popen later), so the next due check lands just inside the scan floor, is
-    refused, and re-stamps — halving the real rate. Hence strictly shorter."""
+    refused, and re-stamps — halving the real rate. Hence strictly shorter.
+
+    The check also defers itself before it stamps, which keeps that slack whole
+    rather than spending it — see the sum below."""
     from fused_render.server.routers.index import FRESHNESS_CHECK_S
 
     assert FRESHNESS_CHECK_S < MIN_INTERVAL_S
+
+
+def test_the_deferred_check_still_fits_inside_the_scan_floor(tmp_path):
+    """The delay is part of the check cadence, so it comes out of the same slack.
+
+    routers.index._run_freshness_check sleeps FRESHNESS_DELAY_S and only then
+    stamps the check clock, so a root's checks recur every
+    FRESHNESS_CHECK_S + FRESHNESS_DELAY_S of wall clock while the scan clock is
+    stamped a spawn later still. If that sum ever reaches MIN_INTERVAL_S the
+    interleave the test above describes comes back: every second check lands
+    inside the scan floor, is refused, re-stamps, and the real cadence halves.
+    This is the assertion that stops the delay being raised to something
+    comfortable-sounding like ten seconds without moving FRESHNESS_CHECK_S down
+    to pay for it."""
+    from fused_render.server.routers.index import (
+        FRESHNESS_CHECK_S,
+        FRESHNESS_DELAY_S,
+    )
+
+    assert FRESHNESS_CHECK_S + FRESHNESS_DELAY_S < MIN_INTERVAL_S
 
 
 def test_a_folder_outside_every_configured_root_triggers_nothing(


### PR DESCRIPTION
## Summary

- **A plain refresh of `/home` could spawn a full index scan across the first paint.** The page draws one `FolderPreviewCard` per Claude session, and each card's `FolderStack` lists its folder on mount — so a refresh with no typing and no interaction fires a fistful of `/api/fs/list`, each one arriving at the index freshness hook. Whichever listing wins the slot could start the ordinary incremental scan of its whole root: up to 10 unniced worker processes, a 16-thread stat pool each, plus a compaction that rewrites every parquet partition — landing on top of the burst the page already fires for itself (`/api/apps/home`, `/api/claude-sessions/home`, `/api/claude/health`, the search warm, the preview iframes).
- **The check now waits `FRESHNESS_DELAY_S = 3.0` before it does anything**, so the scan it may start lands *after* the opening burst instead of inside it. This is the reported 2-3s stall + CPU spike on refresh (reproduced ~3-in-5 on an M3 MacBook Pro, never on machines with more cores to spare — the shape of a contention bug).
- **No accuracy is given up.** The check compares the folder's mtime against what the *index* recorded, not against the moment the folder was opened, so waiting changes nothing about the answer it reaches — only when the answer is acted on. Someone who navigates away inside the window still gets the scan, which is right: the index was stale either way.
- **The wait is placed before `_freshness_due` stamps, and that placement is load-bearing.** `FRESHNESS_CHECK_S` (55s) is deliberately ~5s under `freshness.MIN_INTERVAL_S` (60s) to absorb the gap between the check stamp and `runner._record_scan`'s scan stamp. Sleeping first moves both clocks together and leaves the slack whole; sleeping *after* the stamp would burn 3 of those 5 seconds and put the two floors back inside the window that interleaves them into half the intended cadence. A test now pins `FRESHNESS_CHECK_S + FRESHNESS_DELAY_S < MIN_INTERVAL_S`.

## Visuals

What a `/home` refresh does at the freshness hook, before and after. Only the timing of the scan moves — every gate is unchanged.

**Before**

```mermaid
flowchart TD
    A[Refresh /home] --> B[Session cards list folders]
    B --> C[Freshness hook, one wins the slot]
    C --> D[Gates: root, mount, floors, mtime]
    D -->|stale| E[Scan spawns during first paint]
    E --> F[Stall + CPU spike]
```

**After**

```mermaid
flowchart TD
    A[Refresh /home] --> B[Session cards list folders]
    B --> C[Freshness hook, one wins the slot]
    C --> W[Wait 3s]
    W --> D[Gates: root, mount, floors, mtime]
    D -->|stale| E[Scan spawns after the burst]
```

## Usage

Not user-invocable — no API, flag, or UI surface changes. The behaviour change is internal timing on the background freshness check that `/api/fs/list` and `/api/git-repos` fire.

One reviewer-visible consequence: `_freshness_slot` is held across the wait, so listings arriving during those 3 seconds are dropped rather than queued. That is what the slot already did for the check's own duration, just for longer — and on `/home` it is desirable, since every card is asking the same question of the same root and the first to ask covers them all.

## Test Plan

- [x] `tests/test_index_api.py::test_the_freshness_check_defers_before_it_touches_anything` — patches `time.sleep` and asserts the event order, snapshotting the stamp map as the wait begins so the test pins the sleep to *before* `_freshness_due`, not merely before the duckdb lookup. No wall-clock waiting.
- [x] `tests/test_index_api.py::test_the_freshness_slot_is_freed_after_a_deferred_check` — covers both ways out of the wait: the early refusal (no enclosing root) and the full check. A leaked lock would silently block every later check for the life of the process.
- [x] `tests/test_index_freshness.py::test_the_deferred_check_still_fits_inside_the_scan_floor` — pins `FRESHNESS_CHECK_S + FRESHNESS_DELAY_S < MIN_INTERVAL_S`, so the delay cannot be raised to a comfortable-sounding 10s without moving `FRESHNESS_CHECK_S` down to pay for it.
- [x] New `instant_freshness_delay` fixture no-ops the wait for the four pre-existing tests that drive `_run_freshness_check` synchronously — without it the suite would have gained ~15s of real sleeping.
- [x] Mutation-checked, each observed to fail: sleep removed → deferral test fails; sleep moved after the stamp → deferral test fails; `FRESHNESS_DELAY_S = 10.0` → arithmetic test fails.
- [x] `pytest tests/test_index_freshness.py tests/test_index_api.py tests/test_git_repos_api.py -q` → **139 passed in 2.13s** (git-repos included as the other caller of the hook; total runtime confirms no real 3s sleeps leaked).
- [ ] **Not verified, and not verifiable from tests:** that the reporter's `/home` refresh stall actually goes away. It does not reproduce on our machines. The 3s figure is chosen to clear the page's opening burst, not measured against it.
- [ ] Reviewer check: the fix relocates the cost rather than reducing it. If the reporter's stall is contention during page load, this resolves it; if their scan is simply slow on their tree, they will now see it at t+3s.

## Notes

`fused_render/index/specs/scan-incremental.md` §5 updated — that doc already specifies this mechanism with these numbers, so the wait, its placement before gate 1, and the `55 + 3 < 60` arithmetic are recorded there.
