### PR TITLE
Claude template: the back button works mid-turn

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -1813,6 +1813,34 @@ def _alive(run_dir: str) -> bool:
         return False
 
 
+def _session_from_out(run_dir: str) -> str:
+    """The session id the CLI announced in its first system row, or "".
+
+    A fallback for the `session` file, which only exists once a poll has run
+    (see _poll): the id is sitting in the head of out.jsonl the moment claude
+    starts, and a lookup that needs it before any poll happened (see _live_run)
+    can read it there. Head-bounded — the announcement is the first row the CLI
+    writes, so anything past a handful of lines is a run whose head we cannot
+    parse, not one still warming up."""
+    try:
+        with open(os.path.join(run_dir, "out.jsonl"), encoding="utf-8",
+                  errors="replace") as fh:
+            for _ in range(5):
+                line = fh.readline()
+                if not line:
+                    break
+                try:
+                    row = json.loads(line)
+                except ValueError:
+                    continue  # half-written head; a later caller gets it
+                sid = row.get("session_id")
+                if sid:
+                    return str(sid)
+    except OSError:
+        pass
+    return ""
+
+
 # How far back a live-run lookup bothers to look. Run dirs are named
 # "<YYYYmmdd-HHMMSS>-<hex>", so a reverse sort is newest-first and a run that is
 # still going is by construction among the newest few — a turn does not outlive
@@ -1837,7 +1865,10 @@ def _live_run(file: str, session_id: str = "", limit: int | None = _LIVE_SCAN_LI
     one. Two ids can identify the same chat — the session the run resumed
     (`resumed_from` in meta.json) and the session the CLI minted for it (written
     to the `session` file by the first poll that sees one, because
-    `--fork-session` can hand back a NEW id) — so either matching is a match.
+    `--fork-session` can hand back a NEW id) — so either matching is a match,
+    and a run with no `session` file yet falls back to the id in out.jsonl's
+    head (_session_from_out), because "no poll ever ran" is precisely the state
+    a Back-mid-start leaves behind.
 
     `limit` is how many run dirs (newest first) the scan reads; `limit=None`
     reads all of them. The default cap is right for the ORIGINAL caller — a page
@@ -1875,6 +1906,18 @@ def _live_run(file: str, session_id: str = "", limit: int | None = _LIVE_SCAN_LI
                     own = fh.read().strip()
             except OSError:
                 pass
+            if not own:
+                # The `session` file is written by the FIRST POLL that sees the
+                # id (see _poll) — so a run nobody ever polled has none. That is
+                # not an exotic state: it is exactly what leaving mid-start
+                # leaves behind (Akshil, 2026-08-19 — the reopened chat "does
+                # not show me the streaming thing"): the page left before its
+                # first poll, a NEW chat has no `resumed_from` either, and this
+                # lookup answered "" for a run that was alive the whole time.
+                # The CLI announces the id in its first system row, so read it
+                # from the head of out.jsonl ourselves — a few lines, never the
+                # transcript.
+                own = _session_from_out(run_dir)
             if session_id not in (meta.get("resumed_from", ""), own):
                 continue
         # Liveness LAST: it is the only check that touches a pid, and the two

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -13919,7 +13919,15 @@ for (const [name, id] of [["recent", "tab-recent"], ["artifacts", "tab-artifacts
   };
 }
 
+let recentSeq = 0;
 async function loadRecent() {
+  // Reads overlap by design now (the back handler retries over a just-left
+  // run's spawn window), so only the NEWEST call may write: a slower older
+  // read finishing late would clobber the fresher list — including the very
+  // row the retry existed to add (Bugbot, PR #653). Same seat idiom as
+  // sendSeq/loopSeq: take a number, and prove it is still the latest before
+  // touching anything after the await.
+  const seat = ++recentSeq;
   const list = document.getElementById("recentlist");
   // The skeleton stands in for rows we do not have yet — never for rows that
   // are already up. A re-read over a drawn list (the back handler's mid-turn
@@ -13929,6 +13937,7 @@ async function loadRecent() {
   syncLists();  // the skeleton needs its section shown
   try {
     const { sessions, error } = await fused.runPython(AGENT, { action: "sessions", file: FILE }, { key: null });
+    if (recentSeq !== seat) return;  // a newer read owns the list now
     if (error) throw new Error(error);
     list.innerHTML = "";  // drop the skeleton now that we know the real state
     // Name the snapshot runs from the SAME strings these rows are labelled with,
@@ -13968,6 +13977,10 @@ async function loadRecent() {
     recentCount = sessions.length;
     for (const s of sessions) addChatRow(list, s);
   } catch (err) {
+    // The seat check above never runs when the read itself REJECTS, so a
+    // stale retry that died late must be caught here too — its failure says
+    // nothing about the list a newer read already drew (Bugbot, PR #653).
+    if (recentSeq !== seat) return;
     list.innerHTML = "";
     // A list that could not be read is not a list with nothing in it, but it
     // renders the same way here: no heading, no empty state, no error.

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -9782,6 +9782,11 @@ document.getElementById("back").onclick = () => {
   // actually retires the streaming loop — it bails on the next poll instead
   // of writing into the wiped transcript below.
   logGen += 1;
+  // Whether this leave abandons a LIVE turn, read before the lines below erase
+  // the evidence: `activeRun` is a streaming loop, `sending` is a turn still in
+  // its start, and the `run` param is a resumed run this frame may not have
+  // polled yet. `loadRecent` below needs to know — see the retries beside it.
+  const leftLive = !!(activeRun || sending || fused.params.get("run"));
   // The landing must not inherit the turn's chrome (Bugbot, PR #653): with
   // activeRun still set, the home composer wore the Stop square and its
   // submit CANCELLED the run this button deliberately leaves running. The
@@ -9840,6 +9845,23 @@ document.getElementById("back").onclick = () => {
   // a stale count for a moment is quieter than a section that blinks. Boot is
   // the only place the "not read yet" state is real.
   loadRecent();
+  // A chat left MID-TURN may not be in that list yet (Akshil, 2026-08-19 — "the
+  // chat doesn't show in recent chats until the run completes"): the list is
+  // the transcripts in the cwd's project dir (agent.py `_sessions`), and a
+  // brand-new session's transcript appears only once the CLI has written its
+  // first rows — seconds after this read, on a leave this quick. Not a poll
+  // loop: two more looks a few seconds apart cover the write, and after that
+  // the list is what it honestly is. Gated on still being ON the landing —
+  // re-entering a chat makes the repaint someone else's business — and
+  // loadRecent's own skeleton guard keeps these from blinking rows that are
+  // already up.
+  if (leftLive) {
+    for (const wait of [2500, 6000]) {
+      setTimeout(() => {
+        if (chatEl.classList.contains("home")) loadRecent();
+      }, wait);
+    }
+  }
   // The chips belonged to the conversation being left; the section below the
   // composer is the cross-session view and is re-read from the index instead.
   clearArtStrip();
@@ -13458,22 +13480,63 @@ setInterval(pollScheduledRuns, SCHEDULE_POLL_MS);
 // answers with the id of a run for this chat that is still alive. resumeRun has
 // always been able to adopt a run this frame did not start (the scheduled-send
 // path does exactly this); it just was never given the id.
+//
+// A WATCH, not a one-shot question (Akshil, 2026-08-19 — the reopened chat "does
+// not show me the streaming thing"). The one-shot version had two silent
+// give-ups, and each was a live turn the chat never showed again:
+//
+//   * `if (sending || activeRun) return` — the gate can be HELD at the one
+//     instant this fires (a second click's loadHistory mid-flight, an abandoned
+//     turn's finally a poll away from releasing), and "held right now" was read
+//     as "nothing to do, ever". The gate clears within a tick; the answer to it
+//     is to look again, not to leave.
+//   * a `live_run` that answers "" — which is the truth for an idle chat, but
+//     also what the server says while the run this very reopen is chasing is
+//     still being SPAWNED (Back landed during `start`; the run dir gains its
+//     pid a beat later). One answer, two meanings, and only time tells them
+//     apart: a short watch at the poll cadence covers the spawn window, and an
+//     idle chat costs a few cheap lookups that all agree before it goes quiet.
+//
+// Gen-guarded like every other loop that outlives an await: leaving the chat
+// bumps logGen and the watch dies with the transcript it was watching.
 async function adoptLiveRun(session_id) {
-  if (sending || activeRun) return;   // this frame already owns a turn
-  let live = null;
-  try {
-    live = await fused.runPython(AGENT, {
-      action: "live_run", file: FILE, session_id: session_id || "",
-    }, { key: null });
-  } catch (e) {
-    return;   // a failed lookup leaves the transcript exactly as it rendered
+  const gen = logGen;
+  // ~3s of looking: one tick is the common case (the reopen itself), the tail
+  // exists for the spawn window above. Each miss waits one poll interval, so
+  // the working row appears within ~400ms of the run becoming visible.
+  for (let tries = 0; tries < 8; tries++) {
+    if (tries) await sleep(400);
+    if (logGen !== gen) return;       // the reader left; nothing here is ours
+    if (activeRun) return;            // a turn is attached — adopted, or the user's own
+    if (sending) continue;            // gate held THIS tick; look again, don't give up
+    let live = null;
+    try {
+      live = await fused.runPython(AGENT, {
+        action: "live_run", file: FILE, session_id: session_id || "",
+      }, { key: null });
+    } catch (e) {
+      return;   // a failed lookup leaves the transcript exactly as it rendered
+    }
+    // Both can have changed across the await; re-check before acting on the
+    // answer — adopting into a wiped log, or over a turn the user started
+    // meanwhile, is worse than the miss this watch exists to fix.
+    if (logGen !== gen || activeRun) return;
+    const id = live && live.run_id;
+    if (!id) continue;
+    if (sending) continue;            // taken mid-lookup — same answer as above
+    // Same `replace` posture as every other `run` write: it is bookkeeping about
+    // the frame's state, not a step the reader took, so it must not cost an entry.
+    fused.params.set("run", id, { history: "replace" });
+    // resumeRun can itself bail on a gate grabbed between these two lines — the
+    // loop, not this call, is the guarantee: a bailed attempt comes back around,
+    // and the `activeRun` check above ends the watch once anyone has attached.
+    await resumeRun(id);
+    // resumeRun resolves at the END of the turn, so a completed call means the
+    // run was handled — its done branch cleared the param. The one call that
+    // resolves with the param still reading `id` is the bail above, and only
+    // that one earns another lap.
+    if (fused.params.get("run") !== id) return;
   }
-  const id = live && live.run_id;
-  if (!id) return;
-  // Same `replace` posture as every other `run` write: it is bookkeeping about
-  // the frame's state, not a step the reader took, so it must not cost an entry.
-  fused.params.set("run", id, { history: "replace" });
-  await resumeRun(id);
 }
 
 async function resumeRun(run_id, opts) {
@@ -13858,7 +13921,11 @@ for (const [name, id] of [["recent", "tab-recent"], ["artifacts", "tab-artifacts
 
 async function loadRecent() {
   const list = document.getElementById("recentlist");
-  renderRecentSkeleton(list);
+  // The skeleton stands in for rows we do not have yet — never for rows that
+  // are already up. A re-read over a drawn list (the back handler's mid-turn
+  // retries) repaints in place; blinking good rows into placeholder bars would
+  // make every retry look like the list lost the chats it is about to reprint.
+  if (!list.querySelector(".chat-row")) renderRecentSkeleton(list);
   syncLists();  // the skeleton needs its section shown
   try {
     const { sessions, error } = await fused.runPython(AGENT, { action: "sessions", file: FILE }, { key: null });

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -9774,7 +9774,14 @@ function consumeAnchor() {
 // Clear the session param so a reload lands on the landing page,
 // wipe the visible transcript, and rebuild the session list.
 document.getElementById("back").onclick = () => {
-  if (sending) return;  // mid-turn reset would orphan the streaming run's UI
+  // Live even mid-turn (Akshil, 2026-08-19 — "when it is working I can't
+  // click back"). The old `if (sending) return` guarded against orphaning the
+  // streaming run's UI, but the architecture already survives leaving: the
+  // run id rides in `?run=`, the subprocess keeps going, and resumeRun
+  // re-attaches from the session list. Bumping the log generation is what
+  // actually retires the streaming loop — it bails on the next poll instead
+  // of writing into the wiped transcript below.
+  logGen += 1;
   // `{default: ""}`, because this button is live on a chat that has no session
   // yet — "New chat" enters the chat view and `session_id` is not written until
   // the first turn's poll answers. Clearing an already-absent param is a
@@ -12280,6 +12287,11 @@ function unqueueAll(entries) {
 // One turn at a time: concurrent turns would share the session_id param and
 // launch parallel claude runs against the same resumed session.
 let sending = false;
+// The generation of the visible log. The back button bumps it when it wipes
+// the transcript, and a streaming pollLoop that wakes to a bumped number
+// bails before touching the DOM or the URL params — the run itself keeps
+// going server-side, and resumeRun re-attaches to it from the session list.
+let logGen = 0;
 
 // Stream one run into the log. The `run` URL param marks the run as in-flight
 // for the page's whole life — if this frame dies mid-loop, the subprocess
@@ -12291,6 +12303,12 @@ async function pollLoop(run_id) {
   activeRun = run_id;
   activeWorking = w;
   setRunningUi(true);
+  // The log this loop is allowed to write. The back button bumps the number
+  // when it wipes the transcript; this loop notices on its next poll and
+  // bails through the finally below — BEFORE any effect, because its first
+  // effects re-write the very params (session_id) the back button just
+  // cleared, which would march the page straight back into the chat it left.
+  const gen = logGen;
   let reply = null;
   let typer = null;
   let segBody = null;    // the element the segment views are rendered into
@@ -12303,6 +12321,7 @@ async function pollLoop(run_id) {
   try {
     while (true) {
       const data = await fused.runPython(AGENT, { action: "poll", run_id, file: FILE }, { key: null });
+      if (logGen !== gen) break;  // the reader left; the run continues without this page
       if (data.session_id) { fused.params.set("session_id", String(data.session_id)); showSession(); }
       // Not awaited, for the same reason the app-state answer below is not: a
       // strip of chips may never hold up the streaming reply by a single frame.

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -12311,6 +12311,15 @@ function unqueueAll(entries) {
 // One turn at a time: concurrent turns would share the session_id param and
 // launch parallel claude runs against the same resumed session.
 let sending = false;
+// Which action OWNS `sending`, and which loop owns the running chrome. Both
+// are monotonic seats: a finally that wakes late (its action was abandoned by
+// the back button, or superseded by a re-attach to the same run id) proves it
+// is still the newest holder before it releases anything — equality on the
+// flag, or even on the run id, is not proof (Bugbot, PR #653: a reopened chat
+// re-attaches to the SAME run_id, and the abandoned loop's finally stripped
+// the new loop's Stop chrome; a new send's gate was wiped the same way).
+let sendSeq = 0;
+let loopSeq = 0;
 // The generation of the visible log. The back button bumps it when it wipes
 // the transcript, and a streaming pollLoop that wakes to a bumped number
 // bails before touching the DOM or the URL params — the run itself keeps
@@ -12321,6 +12330,7 @@ let logGen = 0;
 // for the page's whole life — if this frame dies mid-loop, the subprocess
 // keeps going and the next boot re-attaches via resumeRun.
 async function pollLoop(run_id, gen = logGen) {
+  const seat = ++loopSeq;
   const w = addWorking();
   // This run is now the one the stop button and Escape aim at. Set here, the one
   // place a run is ever in flight, which covers a re-attached run for free.
@@ -12450,11 +12460,12 @@ async function pollLoop(run_id, gen = logGen) {
     if (w.el.isConnected) w.el.remove();
     // Nothing is interruptible any more. Cleared even when the loop threw: an
     // Escape landing after this must not cancel a finished run and then mislabel
-    // the NEXT turn's ending as a stop. OWNERSHIP-GUARDED (Bugbot, PR #653):
-    // a loop that bailed because the reader left finishes after the leave — by
-    // then a new turn may own this chrome, and an unconditional clear here
-    // stripped the new run's Stop square and its Escape target.
-    if (activeRun === run_id) {
+    // the NEXT turn's ending as a stop. OWNERSHIP-GUARDED (Bugbot, PR #653),
+    // and ownership means being the NEWEST loop, not matching the run id: a
+    // chat left mid-turn and reopened re-attaches to the SAME run_id, and the
+    // abandoned loop's late finally matched it and stripped the new loop's
+    // Stop square and Escape target.
+    if (loopSeq === seat) {
       activeRun = null;
       activeWorking = null;
       activeSegBody = null;
@@ -12482,6 +12493,7 @@ function setRunningUi(on) {
 async function sendMessage(message) {
   if (sending) return;
   sending = true;
+  const seat = ++sendSeq;
   // Sampled before anything is awaited: a Back landing mid-start outdates this
   // number, and everything below that touches the page (the run param, the
   // streaming loop, the queue drain) checks it first (Bugbot, PR #653).
@@ -12678,7 +12690,7 @@ async function sendMessage(message) {
     }
     addError(err.message);
   } finally {
-    sending = false;
+    if (sendSeq === seat) sending = false;
   }
   scrollBottom();
   focusBox(box);
@@ -13469,6 +13481,7 @@ async function resumeRun(run_id, opts) {
   const retryUnknown = !!(opts && opts.retryUnknown);
   if (sending) return;
   sending = true;
+  const seat = ++sendSeq;
   // Sampled before the probe, same reason as sendMessage's (Bugbot, PR #653):
   // a Back landing during the awaited probe must outdate the loop's number.
   const gen = logGen;
@@ -13559,7 +13572,7 @@ async function resumeRun(run_id, opts) {
   } catch (err) {
     console.warn("run re-attach failed:", err.message);
   } finally {
-    sending = false;
+    if (sendSeq === seat) sending = false;
     focusBox(box);
   }
   // Same-generation only — see sendMessage's tail (Bugbot, PR #653).
@@ -13664,6 +13677,7 @@ async function loadHistory(session_id) {
   // appended first and the older history turns dumped after it.
   if (sending) return;
   sending = true;
+  const seat = ++sendSeq;
   permCards.clear();
   notedSkills.clear();
   resetCardPolicy();  // ...and the overrides: every card of the restored transcript starts folded
@@ -13705,7 +13719,7 @@ async function loadHistory(session_id) {
     log.innerHTML = "";
     console.warn("history restore failed:", err.message);
   } finally {
-    sending = false;
+    if (sendSeq === seat) sending = false;
   }
 }
 

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -9782,6 +9782,19 @@ document.getElementById("back").onclick = () => {
   // actually retires the streaming loop — it bails on the next poll instead
   // of writing into the wiped transcript below.
   logGen += 1;
+  // The landing must not inherit the turn's chrome (Bugbot, PR #653): with
+  // activeRun still set, the home composer wore the Stop square and its
+  // submit CANCELLED the run this button deliberately leaves running. The
+  // loop's own finally repeats this cleanup harmlessly when it bails.
+  activeRun = null;
+  activeWorking = null;
+  setRunningUi(false);
+  // Parked follow-ups belong to the conversation being left. Their
+  // sessionStorage mirror keeps them for the session's next open — persistQueue
+  // is deliberately NOT called (the params below are about to be cleared, and
+  // persisting an empty list under the leaving session's key would erase the
+  // mirror this is counting on). The rows themselves go with the log wipe.
+  queuedMsgs.length = 0;
   // `{default: ""}`, because this button is live on a chat that has no session
   // yet — "New chat" enters the chat view and `session_id` is not written until
   // the first turn's poll answers. Clearing an already-absent param is a
@@ -12296,19 +12309,19 @@ let logGen = 0;
 // Stream one run into the log. The `run` URL param marks the run as in-flight
 // for the page's whole life — if this frame dies mid-loop, the subprocess
 // keeps going and the next boot re-attaches via resumeRun.
-async function pollLoop(run_id) {
+async function pollLoop(run_id, gen = logGen) {
   const w = addWorking();
   // This run is now the one the stop button and Escape aim at. Set here, the one
   // place a run is ever in flight, which covers a re-attached run for free.
   activeRun = run_id;
   activeWorking = w;
   setRunningUi(true);
-  // The log this loop is allowed to write. The back button bumps the number
-  // when it wipes the transcript; this loop notices on its next poll and
-  // bails through the finally below — BEFORE any effect, because its first
-  // effects re-write the very params (session_id) the back button just
-  // cleared, which would march the page straight back into the chat it left.
-  const gen = logGen;
+  // `gen` is the log generation this loop is allowed to write, and it is the
+  // CALLER'S sample, not one taken here (Bugbot, PR #653): sendMessage and
+  // resumeRun sample it before their own awaited start/probe, so a Back that
+  // lands during those awaits already outdates the number this loop compares
+  // against — sampled here instead, the loop would adopt the wiped landing as
+  // its log and re-write the very params (session_id) the leave just cleared.
   let reply = null;
   let typer = null;
   let segBody = null;    // the element the segment views are rendered into
@@ -12453,6 +12466,10 @@ function setRunningUi(on) {
 async function sendMessage(message) {
   if (sending) return;
   sending = true;
+  // Sampled before anything is awaited: a Back landing mid-start outdates this
+  // number, and everything below that touches the page (the run param, the
+  // streaming loop, the queue drain) checks it first (Bugbot, PR #653).
+  const gen = logGen;
   // Fold pending annotations into the outgoing message and stamp them `sent`.
   // If the start below never launches a run, the stamp (and the receipt) are
   // rolled back so the notes stay editable and re-sendable.
@@ -12610,8 +12627,12 @@ async function sendMessage(message) {
     // any kind buys the visit's one entry (PR-3): the push belongs to the first
     // thing the user actually does, and a Back onto a finished run's id is a
     // history entry that restores nothing.
-    fused.params.set("run", run_id, { history: "replace" });
-    await pollLoop(run_id);
+    if (logGen === gen) {
+      fused.params.set("run", run_id, { history: "replace" });
+      await pollLoop(run_id, gen);
+    }
+    // else: the reader left during start — the run continues server-side and
+    // resumeRun/adoptLiveRun can re-attach; the landing gains no run param.
   } catch (err) {
     // The run never launched, so the agent never saw the annotations: give
     // them back as pending (and pull the receipt) so they can be re-sent.
@@ -12645,7 +12666,11 @@ async function sendMessage(message) {
   }
   scrollBottom();
   focusBox(box);
-  drainQueue();
+  // Same-generation only: after a Back, the parked follow-ups belong to the
+  // conversation that was left — firing them from the landing would launch a
+  // hidden new chat (Bugbot, PR #653). Their sessionStorage mirror survives,
+  // so reopening the session restores them, still queued.
+  if (logGen === gen) drainQueue();
 }
 
 // Re-attach to a run that was streaming when this page last unloaded (mode
@@ -13428,8 +13453,12 @@ async function resumeRun(run_id, opts) {
   const retryUnknown = !!(opts && opts.retryUnknown);
   if (sending) return;
   sending = true;
+  // Sampled before the probe, same reason as sendMessage's (Bugbot, PR #653):
+  // a Back landing during the awaited probe must outdate the loop's number.
+  const gen = logGen;
   try {
     let probe = await fused.runPython(AGENT, { action: "poll", run_id, file: FILE }, { key: null });
+    if (logGen !== gen) return;  // the reader left mid-probe; nothing here is theirs to redraw
     if (probe.error === "unknown run_id" && retryUnknown) {
       // A frame handed a run id by its EMBEDDER (the canvases workspace's
       // "Fix with Claude" navigates this iframe with ?run= the moment the
@@ -13510,14 +13539,15 @@ async function resumeRun(run_id, opts) {
     } else if (probeMsg) {
       addUser(probeMsg);
     }
-    await pollLoop(run_id);
+    await pollLoop(run_id, gen);
   } catch (err) {
     console.warn("run re-attach failed:", err.message);
   } finally {
     sending = false;
     focusBox(box);
   }
-  drainQueue();
+  // Same-generation only — see sendMessage's tail (Bugbot, PR #653).
+  if (logGen === gen) drainQueue();
 }
 
 function submitChat() {

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -9793,8 +9793,19 @@ document.getElementById("back").onclick = () => {
   // sessionStorage mirror keeps them for the session's next open — persistQueue
   // is deliberately NOT called (the params below are about to be cleared, and
   // persisting an empty list under the leaving session's key would erase the
-  // mirror this is counting on). The rows themselves go with the log wipe.
+  // mirror this is counting on). The bubbles are removed here by hand: #queue
+  // is a SIBLING of #log, so the transcript wipe below never touches them, and
+  // a bubble that outlived its entry reappeared on the next enterChat,
+  // detached from everything (Bugbot, PR #653).
+  for (const q of queuedMsgs) q.el.remove();
   queuedMsgs.length = 0;
+  // The abandoned turn's sendMessage/resumeRun still holds `sending` until its
+  // loop bails (one poll away) — long enough for the landing composer's submit
+  // to hit `if (sending) return` and drop the click (Bugbot, PR #653). The
+  // landing is a new life for the flag, so it releases HERE; the old loop's
+  // cleanup is ownership-guarded, so its late finally cannot strip a run this
+  // page starts in the meantime.
+  sending = false;
   // `{default: ""}`, because this button is live on a chat that has no session
   // yet — "New chat" enters the chat view and `session_id` is not written until
   // the first turn's poll answers. Clearing an already-absent param is a
@@ -12439,11 +12450,16 @@ async function pollLoop(run_id, gen = logGen) {
     if (w.el.isConnected) w.el.remove();
     // Nothing is interruptible any more. Cleared even when the loop threw: an
     // Escape landing after this must not cancel a finished run and then mislabel
-    // the NEXT turn's ending as a stop.
-    activeRun = null;
-    activeWorking = null;
-    activeSegBody = null;
-    setRunningUi(false);
+    // the NEXT turn's ending as a stop. OWNERSHIP-GUARDED (Bugbot, PR #653):
+    // a loop that bailed because the reader left finishes after the leave — by
+    // then a new turn may own this chrome, and an unconditional clear here
+    // stripped the new run's Stop square and its Escape target.
+    if (activeRun === run_id) {
+      activeRun = null;
+      activeWorking = null;
+      activeSegBody = null;
+      setRunningUi(false);
+    }
   }
 }
 

--- a/tests/test_claude_live_run.py
+++ b/tests/test_claude_live_run.py
@@ -124,6 +124,32 @@ def test_a_forked_session_id_still_matches(agent, target):
     assert agent._live_run(target, "sess-other") == {"run_id": ""}
 
 
+def test_an_unpolled_new_chat_is_still_found_by_its_cli_minted_id(agent, target):
+    """The Back-mid-start blind spot (Akshil, 2026-08-19): a NEW chat left
+    before its first poll has an empty `resumed_from` AND no `session` file —
+    the first poll is what writes that file, and no poll ever ran. The id the
+    reopened page holds (the transcript's filename) is sitting in out.jsonl's
+    first system row, so the lookup falls back to reading it there; without the
+    fallback this run was invisible and the reopened chat never streamed."""
+    d = _run_dir(agent, "20260819-090000-abc", file=target, resumed_from="")
+    with open(os.path.join(d, "out.jsonl"), "w", encoding="utf-8") as f:
+        f.write(json.dumps({"type": "system", "subtype": "init",
+                            "session_id": "sess-minted"}) + "\n")
+    assert agent._live_run(target, "sess-minted") == {"run_id": "20260819-090000-abc"}
+    # The fallback widens what can MATCH, never what matches anything: an id
+    # that is neither still finds no run.
+    assert agent._live_run(target, "sess-other") == {"run_id": ""}
+
+
+def test_an_unpolled_run_with_no_output_yet_stays_invisible_by_id(agent, target):
+    """The narrowest honest answer for a run whose CLI has not spoken: no
+    out.jsonl (or an unparsable head) yields no id, so a session-scoped lookup
+    finds nothing — while the target-only form still can."""
+    _run_dir(agent, "20260819-091500-def", file=target, resumed_from="")
+    assert agent._live_run(target, "sess-minted") == {"run_id": ""}
+    assert agent._live_run(target, "") == {"run_id": "20260819-091500-def"}
+
+
 def test_the_newest_live_run_wins(agent, target):
     _run_dir(agent, "20260817-090000-old", file=target, resumed_from="sess-A")
     _run_dir(agent, "20260817-150000-new", file=target, resumed_from="sess-A")
@@ -240,20 +266,33 @@ def test_the_first_poll_records_the_session_the_cli_minted(agent):
 
 
 # adoptLiveRun touches no DOM — it is a lookup, a param write and a handoff — so
-# it runs under node against stubs that record the order of all three.
+# it runs under node against stubs that record the order of all three. Since
+# the one-shot became a WATCH (Akshil, 2026-08-19: a reopened mid-turn chat has
+# to show its streaming row even when the gate is briefly held or the run is
+# still spawning), the stubs also carry the watch's world: `logGen` (leaving
+# bumps it), a `sleep` collapsed to a real 0ms timer so a test can change the
+# world "one lap later", and a param STORE — the watch reads `run` back to tell
+# a completed resumeRun from one that bailed, and the resumeRun stub clears it
+# the way the real one's done-branch does.
 _ADOPT_STUBS = """
 const calls = [];
-let sending = false, activeRun = null, answer = { run_id: "run-1" }, boom = false;
+let sending = false, activeRun = null, logGen = 0,
+    answer = { run_id: "run-1" }, boom = false;
 const AGENT = "agent.py", FILE = "/proj/index.html";
+const sleep = () => new Promise((r) => setTimeout(r, 0));
+const store = {};
 const fused = {
   runPython: async (agent, args) => {
     calls.push(["ask", args.action, args.file, args.session_id]);
     if (boom) throw new Error("python is down");
     return answer;
   },
-  params: { set: (k, v, o) => calls.push(["param", k, v, (o || {}).history]) },
+  params: {
+    set: (k, v, o) => { store[k] = v; calls.push(["param", k, v, (o || {}).history]); },
+    get: (k) => store[k] || "",
+  },
 };
-const resumeRun = async (id) => { calls.push(["resume", id]); };
+const resumeRun = async (id) => { calls.push(["resume", id]); store.run = ""; };
 """
 
 
@@ -286,7 +325,9 @@ console.log(JSON.stringify(calls));
 
 def test_a_frame_that_owns_a_turn_never_adopts_another(html_pane):
     """Two attachments to one run would double every streamed chunk, and the
-    guard is cheaper than the lookup it skips."""
+    guard is cheaper than the lookup it skips. `activeRun` ends the watch for
+    good; a `sending` that never releases spends the whole budget looking at
+    the gate and still asks the server nothing."""
     for setup in ("sending = true;", "activeRun = 'run-9';"):
         calls = _adopt(html_pane, setup + """
 await adoptLiveRun("sess-A");
@@ -297,9 +338,60 @@ console.log(JSON.stringify(calls));
 
 def test_nothing_running_leaves_the_transcript_alone(html_pane):
     """An empty answer is the common case — most chats are opened cold — so it
-    must not write a param or start a loop."""
+    must not write a param or start a loop. It IS asked again for a few laps
+    (the same "" also comes back while a just-left run is still spawning — see
+    the watch's comment), so the pin is on the shape: only asks, a bounded
+    number of them, and then quiet."""
     calls = _adopt(html_pane, """
 answer = { run_id: "" };
+await adoptLiveRun("sess-A");
+console.log(JSON.stringify(calls));
+""")
+    assert calls, "an idle chat is still asked at least once"
+    assert set(map(tuple, calls)) == {
+        ("ask", "live_run", "/proj/index.html", "sess-A")}
+    assert len(calls) <= 8, "the watch is a budget, not a poll loop"
+
+
+def test_a_briefly_held_gate_is_looked_past_not_obeyed(html_pane):
+    """The reopen race itself (Akshil, 2026-08-19): `sending` is held at the one
+    instant the adoption fires — a second click's loadHistory mid-flight, an
+    abandoned turn's finally a tick from releasing — and the one-shot read
+    "held right now" as "nothing to do, ever". The watch looks again: the gate
+    clears a lap later and the run is adopted."""
+    calls = _adopt(html_pane, """
+sending = true;
+setTimeout(() => { sending = false; }, 0);
+await adoptLiveRun("sess-A");
+console.log(JSON.stringify(calls));
+""")
+    assert calls[-2:] == [["param", "run", "run-1", "replace"],
+                          ["resume", "run-1"]]
+
+
+def test_a_run_still_spawning_is_caught_by_a_later_look(html_pane):
+    """Back landed during `start`: the server honestly answers "" until the run
+    dir has its pid, moments after the reopen asks. The watch's later laps are
+    what turn that from a chat that never streams again into a working row one
+    tick late."""
+    calls = _adopt(html_pane, """
+answer = { run_id: "" };
+setTimeout(() => { answer = { run_id: "run-1" }; }, 0);
+await adoptLiveRun("sess-A");
+console.log(JSON.stringify(calls));
+""")
+    assert calls[-2:] == [["param", "run", "run-1", "replace"],
+                          ["resume", "run-1"]]
+
+
+def test_leaving_ends_the_watch(html_pane):
+    """The watch is gen-guarded like every loop that outlives an await: Back
+    bumps logGen, and a watch still looking for a run must die with the
+    transcript it was watching — its lookups are not the landing page's to
+    spend, and its adoption would write a run param the leave just cleared."""
+    calls = _adopt(html_pane, """
+answer = { run_id: "" };
+setTimeout(() => { logGen += 1; answer = { run_id: "run-1" }; }, 0);
 await adoptLiveRun("sess-A");
 console.log(JSON.stringify(calls));
 """)


### PR DESCRIPTION
While a turn streamed, ← Chats was a silent no-op (`if (sending) return`) for the turn's whole life. The guard protected against a stale poll loop re-writing the session params after the leave — so the fix guards the loop instead of the button: the log carries a generation, the back handler bumps it as it wipes the transcript, and pollLoop bails before any effect on the next poll. The run itself keeps going server-side (`?run=` + resumeRun re-attach, unchanged).

Testing: 364 template pytest green; browser QA on the 2160 integration build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chat lifecycle (streaming loops, URL params, live-run matching) across a large template surface; behavior is heavily tested but regressions could affect turn state or session re-attach.
> 
> **Overview**
> **← Chats works during an active turn** instead of blocking on `sending`. Leaving bumps **`logGen`**, clears run chrome and queued bubbles, and lets **`pollLoop`** exit on the next poll so it does not rewrite the wiped landing or URL params; the detached run keeps going and can be resumed from the session list.
> 
> **Re-opening a chat mid-turn** is more reliable: **`adoptLiveRun`** polls `live_run` for ~3s (spawn window, briefly held `sending`) instead of a single lookup; **`agent._live_run`** can match session id from **`out.jsonl`** when the `session` file does not exist yet (left before first poll).
> 
> **Race guards (PR #653)** use monotonic seats: **`sendSeq` / `loopSeq` / `recentSeq`** so abandoned **`sendMessage`**, **`pollLoop`**, or **`loadRecent`** callbacks cannot clear Stop UI, drain the queue on the landing, or overwrite a fresher recent list. After leaving a live turn, **`loadRecent`** retries at 2.5s and 6s so new sessions appear once the CLI writes the transcript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ec992e5128a67b1b3501381e41ca073cacc435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->