### PR TITLE
Tasks: a run's verdict only silences its own echo — a session still working stays In Progress

### DIFF
--- a/fused_render/schedule.py
+++ b/fused_render/schedule.py
@@ -724,6 +724,11 @@ def create(target: str, message: str, due=None, session_id: str = "",
         # call, and reporting that as a send failure would send the user looking
         # in the wrong place.
         "turn": "",
+        # WHEN the turn's verdict landed — stamped by the same write that fills
+        # `turn` in, "" until then. The Tasks page compares it against the
+        # transcript's tail: activity meaningfully after this moment is new
+        # work, not the verdict's own closing echo.
+        "turn_at": "",
         # The Claude Code session this message's turn actually ran in, filled in by
         # the watcher from the run's first reporting tick. Distinct from
         # `session_id` above (the input) precisely so a fresh send does not end up
@@ -1035,6 +1040,7 @@ def _claim_due(now: datetime) -> list[dict]:
                 # `_close_unwatched` uses for a watch that ended without one.
                 if not _is_watched(str(entry.get("id") or "")):
                     entry["turn"] = "unknown"
+                    entry["turn_at"] = now.isoformat()
                     entry["error"] = ("interrupted: the app stopped while this "
                                       "message's turn was running")
                     announce.append((EVENT_FAILED, dict(entry), entry["error"]))
@@ -1202,11 +1208,17 @@ def _turn_tick(entry: dict, run_id: str, agent, data: dict) -> bool:
     if data.get("done"):
         reason = str(data.get("error") or "")
         if reason:
-            _update(entry_id, turn="failed", error=reason)
+            _update(entry_id, turn="failed", error=reason,
+                    turn_at=_now().isoformat())
             _report(entry_id, state="error", message=reason)
             _emit(EVENT_FAILED, entry, reason)
         else:
-            _update(entry_id, turn="ok")
+            # `turn_at` is WHEN the verdict landed, stamped wherever `turn` is
+            # written. The Tasks page needs the moment, not just the word: a
+            # transcript still being written to meaningfully after this stamp
+            # is new work, and only the verdict's own closing echo may be set
+            # aside (`tasks._verdict_outvotes_live`).
+            _update(entry_id, turn="ok", turn_at=_now().isoformat())
             _report(entry_id, state="done", detail="finished")
             _emit(EVENT_DONE, entry)
         return False
@@ -1223,7 +1235,7 @@ def _turn_tick(entry: dict, run_id: str, agent, data: dict) -> bool:
             agent._cancel(run_id)
         except Exception:  # noqa: BLE001 — a cancel that fails is still a stop attempt
             logger.debug("could not cancel scheduled run %s", run_id, exc_info=True)
-        _update(entry_id, turn="cancelled")
+        _update(entry_id, turn="cancelled", turn_at=_now().isoformat())
         _report(entry_id, state="cancelled")
         return False
     return True
@@ -1360,7 +1372,8 @@ def _close_unwatched(entry: dict, reason: str) -> None:
         stored = next((e for e in _read() if e.get("id") == entry_id), None)
         if stored is None or stored.get("state") != SENT or stored.get("turn"):
             return  # already resolved, or never got far enough to need this
-    _update(entry_id, turn="unknown", error=reason)
+    _update(entry_id, turn="unknown", error=reason,
+            turn_at=_now().isoformat())
     _report(entry_id, state="error", message=reason)
     _emit(EVENT_FAILED, entry, reason)
 
@@ -1873,6 +1886,7 @@ def _materialize(now: datetime) -> None:
                 "run_id": "",
                 "error": "",
                 "turn": "",
+                "turn_at": "",
                 "claude_session_id": "",
             }
             fresh.append(occurrence)

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -421,6 +421,11 @@ def _scheduled_message(entry: dict, live: bool, at: float, ran_at: float,
         "at": at,
         "ran_at": ran_at,
         "state": _entry_state(entry),
+        # When the turn's verdict LANDED — 0.0 until it has (and for entries a
+        # pre-stamp version of the store wrote). `ran_at` is when the run
+        # started; this is when it was pronounced over, which is the moment
+        # `_verdict_outvotes_live` measures the transcript's tail against.
+        "turn_at": tasks_store.epoch(entry.get("turn_at")) or 0.0,
         "unread": False,
         "entry_id": str(entry.get("id") or ""),
         "template_id": str(entry.get("template_id") or ""),
@@ -443,6 +448,9 @@ def _chat_message(prompt: dict) -> dict:
         # A typed message was delivered the moment it was typed. The state
         # vocabulary is the schedule's, and `sent` is the word in it for that.
         "state": schedule.SENT,
+        # A typed message carries no verdict stamp — only the watcher writes
+        # one — and 0.0 is how every stamp here says "never".
+        "turn_at": 0.0,
         "unread": False,
         "entry_id": "",
         "template_id": "",
@@ -711,7 +719,16 @@ def _running_now(session_id: str, live: bool, busy: set[str]) -> bool:
     return live or (bool(session_id) and session_id in busy)
 
 
-def _verdict_outvotes_live(messages: list[dict]) -> bool:
+# How much newer than its verdict the transcript's tail must be before the tail
+# stops being the finished turn's own echo and starts being evidence of new
+# work. The closing records land in the same breath as the verdict (the watcher
+# stamps `turn_at` the moment the run reports done, seconds after the last real
+# record) — a couple of seconds absorbs that ordering jitter and clock skew,
+# while a session genuinely still working appends records well past it.
+_VERDICT_ECHO_SEC = 5.0
+
+
+def _verdict_outvotes_live(messages: list[dict], active: float) -> bool:
     """Is the transcript's liveness just the echo of a run that has already
     reported its verdict?
 
@@ -734,6 +751,20 @@ def _verdict_outvotes_live(messages: list[dict]) -> bool:
     prompt a scheduled run fired is consumed by the join (`_merge`) and cannot
     also stand on the chat side, so an equal stamp is the run's own.
 
+    BUT THE VERDICT MAY ONLY SILENCE ITS OWN ECHO (TASK-001, Akshil,
+    2026-08-19: a task wore the green Done ring while Claude was visibly still
+    building the app in its session). A resolved turn is not the end of a
+    conversation — the session can keep working with no new prompt to show for
+    it (follow-up turns, background work), and none of that is a "message"
+    here, so the newest thing that HAPPENED stayed the verdict for as long as
+    the work ran and the suppression never lifted. `active` is the transcript's
+    own answer — the timestamp of its newest real (non-housekeeping) record —
+    and `turn_at` is the moment the watcher pronounced the turn over: a tail
+    meaningfully newer than the verdict (`_VERDICT_ECHO_SEC`) is new work, and
+    the transcript keeps its vote. An entry a pre-stamp store wrote has no
+    `turn_at` and keeps the old rule — by the time such an entry matters its
+    transcript has long gone stale anyway.
+
     Deliberately NOT consulted: `busy_sessions`. The scheduler holding a send in
     flight is an independent claim and `_running_now` keeps asking it whatever
     this answers — this function only decides whether the TRANSCRIPT gets a
@@ -742,14 +773,20 @@ def _verdict_outvotes_live(messages: list[dict]) -> bool:
     if any(_message_running(m) for m in messages):
         return False  # something really is in flight; liveness corroborates it
     verdict_at = 0.0
+    resolved_at = 0.0
     other_at = 0.0
     for message in messages:
         happened = message["ran_at"] or 0.0
         if message["kind"] == "scheduled" and _message_verdict(message) is not None:
             verdict_at = max(verdict_at, happened)
+            resolved_at = max(resolved_at, message["turn_at"] or 0.0)
         else:
             other_at = max(other_at, happened)
-    return verdict_at > 0.0 and verdict_at >= other_at
+    if not (verdict_at > 0.0 and verdict_at >= other_at):
+        return False
+    if resolved_at > 0.0 and active > resolved_at + _VERDICT_ECHO_SEC:
+        return False  # written to well after the verdict: that is a pulse
+    return True
 
 
 def _status(messages: list[dict], filed: bool, session_id: str, live: bool,
@@ -1198,7 +1235,10 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     # `live` — the status, the newest chat message's turn, and the row's own
     # `live` flag — so the row cannot half-agree with itself. See
     # `_verdict_outvotes_live` for why a genuinely new turn is safe.
-    if live and _verdict_outvotes_live(merged):
+    # `active` rides along because it is the tie-breaker the bug demanded:
+    # a transcript still being written to meaningfully after the verdict is a
+    # session that kept working, and only the verdict's own echo is set aside.
+    if live and _verdict_outvotes_live(merged, active):
         live = False
     # BEFORE the cut, from the whole set: the one fact about the future that the
     # three-message window cannot be trusted to hold. See `_next_run`.

--- a/tests/test_schedule_reporting.py
+++ b/tests/test_schedule_reporting.py
@@ -12,6 +12,8 @@ when it happens, so these two surfaces are the feature, not decoration:
 The turn watcher is driven through its `_turn_tick` seam with fabricated `_poll`
 results: no test here runs a real claude, and none waits on a thread.
 """
+import time
+
 import pytest
 
 from fused_render import claude_spawn, jobs, schedule, schedule_wake
@@ -204,7 +206,13 @@ def test_a_finished_turn_lands_ok_on_all_three_surfaces(target, sent):
     assert schedule._turn_tick(entry, "r-1", FakeAgent(),
                                {"done": True, "error": ""}) is False
 
-    assert schedule.list_entries()[0]["turn"] == "ok"
+    stored = schedule.list_entries()[0]
+    assert stored["turn"] == "ok"
+    # …and WHEN it landed rides along: the Tasks page measures the transcript's
+    # tail against this moment to tell the verdict's own echo from a session
+    # that kept working (TASK-001).
+    assert abs(schedule.parse_due(stored["turn_at"]).timestamp()
+               - time.time()) < 30
     assert jobs.list_jobs()[0]["state"] == "done"
     assert _kinds() == [schedule.EVENT_DONE]
 

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1029,8 +1029,8 @@ def test_a_windowed_message_is_the_whole_task_message(client, tmp_path):
     item = _scheduled(client, DAY_START, DAY_END)[0]
     assert item["task_key"] == "pending:e1"
     assert set(item["message"]) == {
-        "message_id", "kind", "body", "at", "ran_at", "state", "unread",
-        "entry_id", "template_id", "turn", "anchor"}
+        "message_id", "kind", "body", "at", "ran_at", "state", "turn_at",
+        "unread", "entry_id", "template_id", "turn", "anchor"}
     assert item["message"]["kind"] == "scheduled"
     assert item["message"]["message_id"] == "MSG-001"
     assert item["message"]["entry_id"] == "e1"
@@ -1530,6 +1530,49 @@ def test_a_new_turn_after_the_resolved_run_still_reads_as_running(
     task = _by_key(client)["sess-a"]
     assert task["live"] is True
     assert task["status"] == "in_progress"
+
+
+def test_transcript_activity_after_the_verdict_restores_the_pulse(
+        client, projects_dir):
+    """TASK-001 (Akshil, 2026-08-19): a task wore the green Done ring while
+    Claude was visibly mid-build in its session. The run's verdict had landed
+    (`turn: ok`, stamped `turn_at`) but the session KEPT WORKING — follow-up
+    turns and background work append real transcript records without adding a
+    single new prompt, so nothing on the chat side of the thread ever outdates
+    the verdict and the transcript's vote stayed suppressed for as long as the
+    work ran. The verdict may only silence its own echo: a tail meaningfully
+    newer than the moment the turn resolved is NEW work, and the task is In
+    Progress."""
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("go", _near_now(-40), uuid="u1"),
+        _assistant("first turn done", _near_now(-32)),
+        _assistant("still building the app", _near_now(-3)),
+    ])
+    _seed_schedule([_entry("e1", "go", _near_now(-40), state=schedule.SENT,
+                           fired=_near_now(-40), turn="ok",
+                           turn_at=_near_now(-30),
+                           claude_session_id="sess-a")])
+    task = _by_key(client)["sess-a"]
+    assert task["live"] is True
+    assert task["status"] == "in_progress"
+
+
+def test_a_stamped_verdicts_own_echo_is_still_set_aside(client, projects_dir):
+    """The rule above must not reopen the split it was cut from: a tail whose
+    freshness IS the finished turn's closing records — written in the same
+    breath as the verdict — is the echo, and the task is done the moment the
+    corner card says so."""
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("go", _near_now(-30), uuid="u1"),
+        _assistant("all done", _near_now(-6)),
+    ])
+    _seed_schedule([_entry("e1", "go", _near_now(-30), state=schedule.SENT,
+                           fired=_near_now(-30), turn="ok",
+                           turn_at=_near_now(-5),
+                           claude_session_id="sess-a")])
+    task = _by_key(client)["sess-a"]
+    assert task["live"] is False
+    assert task["status"] == "done"
 
 
 def test_a_resolved_run_does_not_silence_a_sibling_still_in_flight(


### PR DESCRIPTION
## Bug (TASK-001, 2026-08-19)

A task showed the green **Done** ring in the tasks list while Claude was actively still building the app in its session — marked done while running.

## Root cause

PR #646 added `_verdict_outvotes_live()` (fused_render/server/routers/tasks.py): when the newest thing that *happened* in a thread is a scheduled run with a verdict (`turn: ok/failed`), the transcript's 45s liveness signal is suppressed as the finished turn's own closing echo.

The intended safeguard — a newer prompt or in-flight message restores the vote — only counted **messages**. But a session can keep working after the verdict lands (follow-up turns, background work) without ever appending a new prompt: the transcript's tail keeps getting fresher, yet nothing on the chat side outdates the verdict, so the suppression never lifted and the task read Done for as long as the work ran.

## Fix

- `fused_render/schedule.py`: the watcher stamps `turn_at` (ISO, UTC) wherever it writes `turn` — ok, failed, cancelled, unknown (both `_close_unwatched` and the restart sweep).
- `fused_render/server/routers/tasks.py`: messages carry `turn_at`, and `_verdict_outvotes_live(messages, active)` now also compares the transcript's newest real (non-housekeeping) record against the moment the verdict landed. Tail more than 5s newer than the verdict ⇒ new work, liveness keeps its vote and the task stays **In Progress**. Within the grace ⇒ the echo, set aside exactly as before.
- Pre-stamp entries (no `turn_at`) keep the old rule — their transcripts are long stale by the time they matter.

## Tests

- `test_transcript_activity_after_the_verdict_restores_the_pulse` — reproduces TASK-001 (fails on main, passes here).
- `test_a_stamped_verdicts_own_echo_is_still_set_aside` — the #646 behavior is preserved for a stamped verdict.
- `test_a_finished_turn_lands_ok_on_all_three_surfaces` extended to assert the `turn_at` stamp.

## Gates

- `pytest -n auto tests/test_tasks_api.py tests/test_schedule_queue.py tests/test_queue_dock.py tests/test_schedule_reporting.py` — 194 passed
- `npm run build` — clean
- `bun test` — 1959 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task status derivation and schedule entry shape; behavior is covered by new API and reporting tests but touches core listing liveness logic.
> 
> **Overview**
> Fixes **TASK-001**: tasks could show **Done** while Claude was still working after a scheduled run had already reported `turn: ok`, because `_verdict_outvotes_live` only looked at message timestamps and could not see follow-up work that never added a new prompt.
> 
> The scheduler now writes **`turn_at`** (UTC ISO) wherever it sets **`turn`** — ok, failed, cancelled, or unknown — including restart sweep paths. Task messages expose **`turn_at`**, and **`_verdict_outvotes_live(messages, active)`** compares the transcript’s newest real activity to that stamp: if the tail is more than **5s** newer than the verdict, liveness is kept and the task stays **In Progress**; within the grace window, the old “silence the verdict’s closing echo” behavior is unchanged. Entries without **`turn_at`** still use the previous rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a329c81945ff437e878a07c99901c06517542f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->