### PR TITLE
Tasks list: a filing press hands the mark slot back to the ring

### DIFF
--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1370,6 +1370,17 @@ function TaskNode({
   // row would leave the reader working out which press each answered.
   const [acting, setActing] = useState(false);
   const [note, setNote] = useState("");
+  // THE FILING PRESS'S RECEIPT (Akshil, 2026-08-19). Clicking Archive keeps the
+  // pointer on the row, and the hover swap above kept right on swapping: the slot
+  // instantly redrew the OPPOSITE verb (Unarchive), so the press's only visible
+  // outcome was an icon flip — no sign the action landed at all. CSS cannot say
+  // "hovered, but the hover already spent its press", so the row says it: this
+  // flag goes up on the press and comes down when the pointer LEAVES the row
+  // (`onMouseLeave` below), and while it is up `.is-refiled` (tasks.css) hands
+  // the mark slot back to the STATUS RING — now drawing the new state, which is
+  // the confirmation — instead of the reveal. Leave and return, and the hover
+  // offers the (now opposite) action again, exactly like any other row.
+  const [refiled, setRefiled] = useState(false);
 
   const runNow = async (intent: TaskRunIntent) => {
     setActing(true);
@@ -1403,6 +1414,12 @@ function TaskNode({
   const refile = async (intent: FilingIntent) => {
     setActing(true);
     setNote("");
+    // On the PRESS, not on the answer: the ring under the suppressed button is
+    // this press's feedback either way — the new state when the call lands, the
+    // unchanged one (plus the note below) when the server refuses. Both
+    // directions, deliberately: Unarchive under a resting pointer flipped to
+    // Archive just as instantly.
+    setRefiled(true);
     try {
       if (intent.kind === "archive") {
         await archiveTask(task.key);
@@ -1646,7 +1663,8 @@ function TaskNode({
     <div className="tasks-node">
       <div
         className={"tasks-row" + (open ? " is-open" : "")
-          + (selected ? " is-selected" : "") + (pressable ? "" : " is-inert")}
+          + (selected ? " is-selected" : "") + (pressable ? "" : " is-inert")
+          + (refiled ? " is-refiled" : "")}
         // The row is a CONTAINER now, not a control: when it has somewhere to go
         // the stretched `<a>` below is the button, the tab stop and the
         // accessible name, and hanging a second role and a second tab stop on
@@ -1669,6 +1687,11 @@ function TaskNode({
                 }
               }
         }
+        // The other half of the filing receipt (Akshil, 2026-08-19): leaving the
+        // row is what re-arms its hover reveal. Handled — not conditional — even
+        // while the flag is down, because a handler that appears and disappears
+        // with the state it clears is a re-render race waiting to be read about.
+        onMouseLeave={() => setRefiled(false)}
       >
         {/* The disclosure gutter is drawn WHETHER OR NOT there is a chevron in it.
             `--tasks-caret-w` is the first term of `--tasks-rail-x`, which every

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -3777,6 +3777,47 @@ describe("the archive action", () => {
     );
   });
 
+  it("hands the slot back to the ring on the press, until the pointer leaves", () => {
+    // The hover swap used to keep swapping THROUGH the press (Akshil,
+    // 2026-08-19): clicking Archive keeps the pointer on the row, the intent
+    // flips on the reload, and the slot instantly redrew the OPPOSITE verb — an
+    // icon flip where a confirmation should be. A spent press now returns the
+    // RING (drawing the new state, which is the feedback) and keeps the button
+    // down until the pointer leaves the row; leave and return, and the reveal
+    // re-arms with the now-opposite action.
+    //
+    // CSS cannot say "hovered, but the hover already spent its press", so the
+    // ROW says it: a flag set on the filing press — on the press, not on the
+    // answer, and for BOTH directions, because Unarchive flipped just as
+    // instantly — and cleared by the row's own mouseleave.
+    expect(NODE).toContain("const [refiled, setRefiled] = useState(false);");
+    const refileAt = NODE.indexOf("const refile = async (intent: FilingIntent)");
+    const refile = NODE.slice(refileAt, NODE.indexOf("\n  };", refileAt));
+    expect(refile).toContain("setRefiled(true);");
+    expect(ROW).toContain('(refiled ? " is-refiled" : "")');
+    expect(ROW).toContain("onMouseLeave={() => setRefiled(false)}");
+    // The suppression outranks the reveal, is scoped to the MARK SLOT's occupant
+    // only, and takes the events down with the ink — so the button's enlarged
+    // ::after zone (which inherits pointer-events) goes intangible with it.
+    const down = block(
+      TASKS_CSS,
+      ".tasks-row.is-refiled:hover .tasks-rowmark .tasks-act:not(:focus-visible)",
+    );
+    expect(down).toContain("opacity: 0");
+    expect(down).toContain("pointer-events: none");
+    // And the ring comes back where the fade above took it away.
+    const back = block(
+      TASKS_CSS,
+      ".tasks-row.is-refiled:hover .tasks-rowmark:not(:has(.tasks-act:focus-visible)) .schedule-ring",
+    );
+    expect(back).toContain("opacity: 1");
+    // NEITHER HALF TOUCHES THE KEYBOARD: both step aside for the button's own
+    // `:focus-visible` — the same arm the reveal and the handover honour — so a
+    // tabbed-to button is never invisible over a faded ring. (That the two
+    // selectors above RESOLVE at all, `:not(:focus-visible)` guards included, is
+    // the claim; `block` throws on a selector list it cannot find.)
+  });
+
   it("is bigger to aim at than it is to look at", () => {
     // 22px was a small target for a control the pointer arrives at sideways, so the
     // ZONE grows and the SKIN does not (Akshil, 2026-08-18). A pseudo-element and

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -795,6 +795,33 @@ button.tasks-caret,
   transition: opacity 0.08s ease;
 }
 
+/* THE PRESS'S RECEIPT (Akshil, 2026-08-19). Clicking Archive keeps the pointer on
+   the row, so the swap above kept right on swapping: the slot instantly redrew the
+   OPPOSITE verb (Unarchive), and the press's only visible outcome was an icon flip
+   — nothing said the action landed. So a spent press hands the slot BACK: the ring
+   returns (drawing the task's new state, which IS the confirmation) and the button
+   stays down for as long as the pointer stays on the row. Leave and return, and
+   the reveal re-arms with the now-opposite action, like any other row.
+
+   `.is-refiled` is the row's own flag — set on the filing press, cleared on the
+   row's mouseleave (ScheduleTaskViews.tsx) — because no selector can say
+   "hovered, but the hover already spent its press". Scoped to the MARK SLOT's
+   occupant only, and still `:hover`-guarded: the flag must change nothing about
+   the keyboard, so both halves step aside for the button's own `:focus-visible` —
+   the same arm the reveal and the fade above honour — rather than leaving a
+   tabbed-to button invisible over a faded ring. The button's suppression takes
+   `pointer-events` down with the ink (invisible means intangible, same rule as
+   `.tasks-act` at rest), so its enlarged ::after zone, which inherits, goes
+   intangible with it and a press lands on the row's link as it does at rest. */
+.tasks-row.is-refiled:hover .tasks-rowmark .tasks-act:not(:focus-visible) {
+  opacity: 0;
+  pointer-events: none;
+}
+.tasks-row.is-refiled:hover .tasks-rowmark:not(:has(.tasks-act:focus-visible)) .schedule-ring {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* -- The same actions on a board card ------------------------------------------
    The card is a `<button>`, so the actions cannot live inside it — nested buttons
    do not parse. They are siblings, and this wrapper is what they are positioned


### PR DESCRIPTION
## Bug (Akshil, 2026-08-19)

In the Tasks LIST view, hovering a row swaps its status ring for the Archive/Unarchive button. Clicking it keeps the pointer on the row, so the slot instantly redrew the OPPOSITE verb — no visual confirmation the action landed; it read as a mere icon toggle.

## Fix

- Per-row `refiled` state in `TaskNode` (`ScheduleTaskViews.tsx`): set on the filing press (both directions, on the press rather than the answer), cleared on the row's `onMouseLeave`.
- While up, `.is-refiled` (`tasks.css`) hands the mark slot back to the **status ring** — now drawing the new state, which is the confirmation — and suppresses the `.tasks-act` reveal (opacity + pointer-events, so the enlarged `::after` hit zone inherits intangibility).
- Pointer leaves and re-enters → hover reveal re-arms with the now-opposite action, like any other row.
- Keyboard untouched: both suppression halves step aside for the button's own `:focus-visible`, matching the existing reveal/fade arms. The tuned derived-inset hit zone is unchanged.

## Board card

Checked and deliberately left alone: the card's archive button is an overlay strip (no ring swap), and a filed card moves lanes on reload — the Archive lane is collapsed by default — so the pointer is never left resting on a flipped button.

## Tests

- New pin in `tasks-lib.test.ts` ("hands the slot back to the ring on the press, until the pointer leaves"): state set in `refile`, cleared on mouseleave, both CSS rules resolve with their `:focus-visible` guards.

## Gate

- `npm run build` ✓
- `bun test` ✓ — 1972 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized list-row hover/CSS and React state; filing APIs and board view are unchanged.
> 
> **Overview**
> Fixes a **Tasks list** UX bug where hovering swapped the status ring for Archive/Unarchive, and clicking with the pointer still on the row immediately showed the **opposite** icon after reload—so the action felt like a meaningless toggle.
> 
> **`TaskNode`** adds **`refiled`**: set on filing press (archive and unarchive), cleared on row **`onMouseLeave`**, and exposed as **`.is-refiled`** on the row. While active, **`tasks.css`** hides the hover **`.tasks-act`** in the mark slot and brings the **status ring** back (updated state as confirmation). Leaving the row re-enables the normal hover reveal.
> 
> Keyboard behavior is unchanged: rules defer to **`:focus-visible`** on the filing button. **`tasks-lib.test.ts`** pins the state wiring and CSS selectors. Board cards are out of scope (no ring swap there).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53ba2cb86405fece9163a4a134a6350e3f39686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->