### PR TITLE
Index scan yields the scheduler: worker self-nices, compaction DuckDB capped, rank stays fast

### DIFF
--- a/fused_render/index/specs/index-store.md
+++ b/fused_render/index/specs/index-store.md
@@ -129,6 +129,15 @@ Three consequences worth knowing:
   deliberately left on disk one compaction longer for a reader that loaded the manifest
   microseconds before the swap.
 
+## 5. Compaction threads
+
+The merge connects through `background_connect()`, which issues
+`SET threads TO compaction_threads()` — a quarter of the cores, at most
+`MAX_COMPACTION_THREADS` (4). Readers get no cap at all (`query.py` connects plain):
+the compaction runs inside a niced scan worker nobody is waiting on, while
+`/api/index/rank` is a keystroke, and an all-cores merge starved it for seconds
+(`scan.md §4`, scheduling priority).
+
 ## Non-goals
 
 - **Queries over these files** — `query.md`.

--- a/fused_render/index/specs/scan.md
+++ b/fused_render/index/specs/scan.md
@@ -93,6 +93,15 @@ The GIL caps one process at roughly 15k dirs/s, so the worker fans out:
 (tmp + `os.replace`) every 500 dirs; the parent globs and sums them every 0.5 s and
 emits one `progress` event. Counters can lag slightly but never double-count.
 
+**Scheduling priority:** all that fan-out is CPU the user did not ask to spend, so the
+worker calls `os.nice(SCAN_NICE_INCREMENT)` (+10) on itself at startup — in the child,
+after exec, never as a `preexec_fn` (which would force the spawn back onto `fork()`).
+Pool children and stat threads inherit it, and so does the compaction, which
+additionally caps DuckDB to `store.compaction_threads()` (`index-store.md §5`). The
+invariant: an interactive `/api/index/rank` keystroke wins the scheduler against a
+scan. Without it a full scan of a big home starved the lock-free rank read path for
+seconds at a time.
+
 **Device ids** are collected during the walk — a root spanning more than one volume
 disqualifies the FSEvents fast path (`scan-incremental.md §3`).
 

--- a/fused_render/index/store.py
+++ b/fused_render/index/store.py
@@ -24,6 +24,26 @@ from fused_render.index.ignore import ignored_for_index
 # of syscalls to wait out.
 NT_LOCK_POLL_S = 0.05
 
+# Cores the background compaction's DuckDB may use. It runs inside a scan
+# worker, against an interactive `/api/index/rank` that gets no cap at all
+# (query.py) — a merge on every core starved the query for seconds, and the
+# user is not waiting on the merge. A quarter of the machine, never more than
+# this many.
+MAX_COMPACTION_THREADS = 4
+
+
+def compaction_threads() -> int:
+    return max(1, min(MAX_COMPACTION_THREADS, (os.cpu_count() or 4) // 4))
+
+
+def background_connect():
+    """An in-memory DuckDB for the scan side, capped to `compaction_threads`."""
+    import duckdb
+
+    con = duckdb.connect()
+    con.execute(f"SET threads TO {compaction_threads()}")
+    return con
+
 
 def _acquire_nt(msvcrt, fileno: int) -> None:
     """Block until the byte is ours, polling the NON-blocking mode.
@@ -380,7 +400,6 @@ def compact(cfg: IndexConfig, root, shards_dir, pa, pq, emit=None,
 
 
 def _compact_locked(cfg: IndexConfig, root, shards_dir, pa, pq, emit=None):
-    import duckdb
     import shutil
 
     def phase(msg):
@@ -391,7 +410,7 @@ def _compact_locked(cfg: IndexConfig, root, shards_dir, pa, pq, emit=None):
     dirs_parquet = cfg.dirs_parquet
     old_manifest = read_manifest(cfg) or {}
     generation = int(old_manifest.get("generation") or 0) + 1
-    con = duckdb.connect()
+    con = background_connect()
     rootp = root.rstrip("/") or "/"
     prefix_like = (like_literal(rootp) + "/") if rootp != "/" else "/"
     outside = (f"(dir <> '{_sql(rootp)}' "

--- a/fused_render/index/worker.py
+++ b/fused_render/index/worker.py
@@ -15,6 +15,23 @@ import sys
 
 from fused_render.index.scan import run_scan
 
+# How far below the server this process (and every pool child and stat thread
+# it goes on to spawn, since niceness is inherited) runs. The invariant it
+# buys: an interactive `/api/index/rank` keystroke wins the scheduler against
+# a scan, which otherwise puts up to ten processes x 16 stat threads plus an
+# all-cores DuckDB compaction against the one thread the user is waiting on.
+SCAN_NICE_INCREMENT = 10
+
+
+def _renice_self() -> None:
+    """Nice this process down, in the child. Never a `preexec_fn` at the
+    spawn: that forces CPython off posix_spawn onto fork(), which is the
+    SIGSEGV this file's other comment is about."""
+    try:
+        os.nice(SCAN_NICE_INCREMENT)
+    except (AttributeError, OSError):
+        pass  # no nice (Windows) or not permitted — scan at full priority
+
 
 def main(argv=None) -> int:
     argv = sys.argv[1:] if argv is None else argv
@@ -34,6 +51,7 @@ def main(argv=None) -> int:
             os.setsid()
         except OSError:
             pass  # already a session leader (spawned from a shell)
+    _renice_self()
     run_scan(argv[0])
     return 0
 

--- a/tests/test_index_rank_concurrency.py
+++ b/tests/test_index_rank_concurrency.py
@@ -9,10 +9,25 @@ therefore yields — it nices itself and caps the compaction's threads — and
 import os
 import subprocess
 import sys
+import time
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
+from fastapi.testclient import TestClient
 
 from fused_render.index import store, worker
+from fused_render.index.config import IndexConfig
+from fused_render.index.store import Sink, compact
+from fused_render.server import create_app
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(h))
+    return h
 
 
 # -- the two knobs, unit-tested ----------------------------------------------
@@ -55,3 +70,85 @@ def test_the_compaction_connection_caps_its_threads():
     got = int(con.execute("SELECT current_setting('threads')").fetchone()[0])
     assert got == store.compaction_threads()
     assert 1 <= got <= store.MAX_COMPACTION_THREADS
+
+
+# -- the regression ----------------------------------------------------------
+
+def _tree(root, n_dirs=400, per_dir=100):
+    """A tree big enough that a full scan of it overlaps a burst of ranks."""
+    os.makedirs(root, exist_ok=True)
+    for d in range(n_dirs):
+        sub = os.path.join(root, f"dir{d:03d}")
+        os.makedirs(sub, exist_ok=True)
+        for i in range(per_dir):
+            with open(os.path.join(sub, f"file{i:03d}_alpha.txt"), "w") as f:
+                f.write("x")
+    return root
+
+
+def _prime_index(tmp_path, root, n=4000):
+    """A real index over `root` so ranking has a full corpus to scan."""
+    cfg = IndexConfig()
+    shards = str(tmp_path / "prime-shards")
+    os.makedirs(shards, exist_ok=True)
+    sink = Sink(shards, "t", pa, pq, cfg.shard_rows)
+    # The root's own dirs row is what `covered` is decided on — without it the
+    # route answers `uncovered` with no hits and the timing means nothing.
+    sink.add(root, "s", ("sig", [], 0, 1_000_000_000, 0))
+    per_dir = 100
+    for d in range(n // per_dir):
+        dirp = os.path.join(root, f"pre{d:04d}")
+        rows = []
+        for i in range(per_dir):
+            name = f"file{i:03d}_alpha.txt"
+            rows.append((os.path.join(dirp, name), dirp, name, "txt",
+                         10 + i, 100.0 + i))
+        sink.add(dirp, "s", ("sig", rows, sum(r[4] for r in rows),
+                             1_000_000_000, 0))
+    sink.close()
+    compact(cfg, root, shards, pa, pq)
+    return cfg
+
+
+def test_rank_route_stays_fast_while_a_real_scan_is_running(home, tmp_path):
+    root = _tree(str(tmp_path / "src"))
+    _prime_index(tmp_path, root)
+    client = TestClient(create_app(start_dir=root))
+
+    started = client.post("/api/index/scan",
+                          json={"root": root, "full": True},
+                          headers={"X-Fused": "1"})
+    assert started.status_code == 200, started.text
+    run_id = started.json()["run_id"]
+
+    def running():
+        return client.get("/api/index/status",
+                          params={"run_id": run_id}).json()["running"]
+
+    latencies = []
+    try:
+        if not running():
+            pytest.skip("the scan finished before the first rank request; "
+                        "cannot observe overlap on this machine")
+        for _ in range(15):
+            if not running():
+                break
+            t0 = time.perf_counter()
+            resp = client.get("/api/index/rank",
+                              params={"root": root, "q": "alpha", "limit": 50})
+            latencies.append(time.perf_counter() - t0)
+            assert resp.status_code == 200, resp.text
+            # Timing an answer the route declined to compute would measure
+            # nothing: every request has to have taken the full ranking plan.
+            body = resp.json()
+            assert body["covered"] is True, body
+            assert body["hits"], body
+    finally:
+        client.post("/api/index/cancel", json={"run_id": run_id},
+                    headers={"X-Fused": "1"})
+        deadline = time.time() + 60
+        while time.time() < deadline and running():
+            time.sleep(0.1)
+
+    assert latencies, "no rank request overlapped the scan"
+    assert max(latencies) < 2.0, latencies

--- a/tests/test_index_rank_concurrency.py
+++ b/tests/test_index_rank_concurrency.py
@@ -3,8 +3,8 @@
 The rank read path is lock-free, so the only thing a concurrent scan can take
 from it is CPU: up to ten detached worker processes, each with a 16-thread
 stat pool, plus a DuckDB compaction that defaults to every core. The scan
-therefore yields — it nices itself — and `/api/index/rank` keeps answering in
-tens of milliseconds.
+therefore yields — it nices itself and caps the compaction's threads — and
+`/api/index/rank` keeps answering in tens of milliseconds.
 """
 import os
 import subprocess
@@ -12,10 +12,10 @@ import sys
 
 import pytest
 
-from fused_render.index import worker
+from fused_render.index import store, worker
 
 
-# -- the scan nices itself ----------------------------------------------
+# -- the two knobs, unit-tested ----------------------------------------------
 
 def test_the_worker_nices_itself_at_startup(monkeypatch, tmp_path):
     """Self-nicing in the child, never a preexec_fn: this repo's spawns must
@@ -48,3 +48,10 @@ def test_renicing_really_lowers_a_real_process_priority():
          "_renice_self();print(os.getpriority(os.PRIO_PROCESS, 0))"],
         capture_output=True, text=True, check=True)
     assert int(out.stdout.strip()) >= worker.SCAN_NICE_INCREMENT
+
+
+def test_the_compaction_connection_caps_its_threads():
+    con = store.background_connect()
+    got = int(con.execute("SELECT current_setting('threads')").fetchone()[0])
+    assert got == store.compaction_threads()
+    assert 1 <= got <= store.MAX_COMPACTION_THREADS

--- a/tests/test_index_rank_concurrency.py
+++ b/tests/test_index_rank_concurrency.py
@@ -1,0 +1,50 @@
+"""A background scan must not starve the interactive home search.
+
+The rank read path is lock-free, so the only thing a concurrent scan can take
+from it is CPU: up to ten detached worker processes, each with a 16-thread
+stat pool, plus a DuckDB compaction that defaults to every core. The scan
+therefore yields — it nices itself — and `/api/index/rank` keeps answering in
+tens of milliseconds.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+from fused_render.index import worker
+
+
+# -- the scan nices itself ----------------------------------------------
+
+def test_the_worker_nices_itself_at_startup(monkeypatch, tmp_path):
+    """Self-nicing in the child, never a preexec_fn: this repo's spawns must
+    stay on posix_spawn (PROJ's atfork handler SIGSEGVs a fork)."""
+    seen = []
+    monkeypatch.setattr(os, "nice", lambda inc: seen.append(inc) or 0)
+    ran = []
+    monkeypatch.setattr(worker, "run_scan", ran.append)
+    assert worker.main([str(tmp_path)]) == 0
+    assert seen == [worker.SCAN_NICE_INCREMENT]
+    assert ran == [str(tmp_path)]
+
+
+def test_a_worker_on_a_platform_without_nice_still_scans(monkeypatch, tmp_path):
+    monkeypatch.delattr(os, "nice", raising=False)
+    ran = []
+    monkeypatch.setattr(worker, "run_scan", ran.append)
+    assert worker.main([str(tmp_path)]) == 0
+    assert ran == [str(tmp_path)]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="no nice on Windows")
+def test_renicing_really_lowers_a_real_process_priority():
+    """The monkeypatched test above proves `main` calls it; this one proves the
+    call does something, in a process that is not this one (nicing is one-way,
+    so pytest must not do it to itself)."""
+    out = subprocess.run(
+        [sys.executable, "-c",
+         "import os;from fused_render.index.worker import _renice_self;"
+         "_renice_self();print(os.getpriority(os.PRIO_PROCESS, 0))"],
+        capture_output=True, text=True, check=True)
+    assert int(out.stdout.strip()) >= worker.SCAN_NICE_INCREMENT


### PR DESCRIPTION
## Summary

- Fixes intermittent 4+ second `/api/index/rank` responses (home search) when a background index scan runs concurrently — [jam](https://jam.dev/c/7bc57fda-bf5a-46bb-87a0-a19a1f30e143). The stall was never a lock: readers are lock-free and the manifest swap is atomic. It was CPU starvation — a scan puts up to `min(10, cpu_count)` unniced worker processes × 16 stat threads each, plus an all-cores DuckDB compaction, against the one thread an interactive rank query runs on.
- The scan worker now **nices itself** (+10) at startup, in the child, so every pool child and stat thread it spawns inherits the lower priority. Deliberately *not* a `preexec_fn`: that would force CPython off `posix_spawn` onto `fork()`, re-opening the PROJ/SQLite atfork SIGSEGV class this repo has already fixed twice.
- The compaction's DuckDB connection is **capped to a quarter of the cores (max 4)** via a new `background_connect()`. The interactive query path (`query.py`) stays uncapped — only the background writer yields.
- #649 (3s freshness delay) only moved one trigger's start time and didn't help; this addresses the mechanism itself for every scan trigger path. That delay is left in place.

## Visuals

```mermaid
flowchart TD
    A[Scan worker process starts] --> B[os.nice +10<br/>self, in the child]
    B --> C[pool children + stat threads<br/>inherit low priority]
    B --> D[compaction via background_connect<br/>SET threads TO cores/4, max 4]
    E[/api/index/rank keystroke/] --> F[DuckDB query + fuzzy rank<br/>uncapped, normal priority]
    C -. scheduler yields to .-> F
    D -. scheduler yields to .-> F
```

## Usage

Not user-invocable — behavior change only. Home search (`/api/index/rank`) stays responsive while a scan or re-index runs; scans take marginally longer only on a busy machine, unchanged on an idle one.

## Test Plan

- [x] New `tests/test_index_rank_concurrency.py` (5 tests): worker self-nices at startup (monkeypatched), survives platforms without `os.nice`, a real subprocess verifiably lowers `os.getpriority`, `background_connect()`'s `current_setting('threads')` is capped, and the end-to-end regression test — a real `full=true` scan over a 40k-file tree while up to 15 `/api/index/rank` requests assert `covered`, non-empty hits, and `max latency < 2.0s` (skips loudly, never passes vacuously, if the scan wins the race). Run 3× consecutively, stable.
- [x] All 14 index/search test files under `-n auto`: 439 passed.
- [ ] Full local suite + CI (this PR stays draft until both are green).
- Caveat: the timing test does not go red pre-fix on dev hardware — the 4s stall needs a ~1M-entry home index. The mechanism (nice + thread cap) is covered deterministically by the unit tests; the e2e test guards real overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
