### PR TITLE
Fix Home page app loading and command display layout

### DIFF
--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -17,6 +17,7 @@ import {
   type Config,
 } from "@platform/lib/api";
 import { useIndexStatus } from "@platform/lib/index-status";
+import { runCommunity } from "@platform/lib/community";
 import { loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
 import { FilesSearch } from "@apps/explorer/FilesHome";
 import { FolderPreviewCard, RecentPreviewCard } from "@apps/explorer/BookmarkCards";
@@ -159,7 +160,35 @@ export default function Home({ config }: { config: Config }) {
     if (limit === null) return;
     let alive = true;
     getHomeApps(Math.min(limit, MAX_ROW)).then(
-      (r) => alive && setApps(r.apps.slice(0, MAX_ROW)),
+      async (r) => {
+        if (!alive) return;
+        if (r.apps.length > 0) {
+          setApps(r.apps.slice(0, MAX_ROW));
+          return;
+        }
+        // Empty on a brand-new install usually isn't "no apps" — it's this
+        // fetch landing before the startup showcase clone (into
+        // <workspace>/showcase, kicked off in the background at server start)
+        // has finished. Apps.tsx already escalates the same "no-cache" catalog
+        // status into a wait-for-clone-then-refetch; Home is the first page a
+        // new user sees, so it needs the same escalation instead of settling
+        // on "No apps yet" forever.
+        try {
+          const local = await runCommunity<{ status?: string }>({ action: "catalog" });
+          if (!alive) return;
+          if (local.status === "no-cache") {
+            await runCommunity({ action: "refresh" });
+            if (!alive) return;
+            const retry = await getHomeApps(Math.min(limit, MAX_ROW));
+            if (!alive) return;
+            setApps(retry.apps.slice(0, MAX_ROW));
+            return;
+          }
+        } catch {
+          // Community backend unreachable — fall through to the empty state.
+        }
+        setApps([]);
+      },
       (e: Error) => {
         if (!alive) return;
         setApps([]);

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -176,14 +176,21 @@ export default function Home({ config }: { config: Config }) {
         try {
           const local = await runCommunity<{ status?: string }>({ action: "catalog" });
           if (!alive) return;
+          // A "no-cache" status means the clone is still missing — wait for
+          // it. But the clone can just as easily land in the gap between the
+          // first empty getHomeApps and this very check, which reports it
+          // "ok" already: that walk never re-ran, so its emptiness is just as
+          // stale. Either way, one more walk is needed before the row really
+          // is empty — retry unconditionally, only waiting on refresh first
+          // when the clone genuinely hasn't landed yet.
           if (local.status === "no-cache") {
             await runCommunity({ action: "refresh" });
             if (!alive) return;
-            const retry = await getHomeApps(Math.min(limit, MAX_ROW));
-            if (!alive) return;
-            setApps(retry.apps.slice(0, MAX_ROW));
-            return;
           }
+          const retry = await getHomeApps(Math.min(limit, MAX_ROW));
+          if (!alive) return;
+          setApps(retry.apps.slice(0, MAX_ROW));
+          return;
         } catch {
           // Community backend unreachable — fall through to the empty state.
         }

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -1021,7 +1021,13 @@ a.bookmark-name::after {
 }
 
 .update-badge-command code {
-  flex: 1;
+  /* Not flex:1 — that stretched the plate to fill the row (the trouble card
+     is up to 640px wide) leaving the copy button stranded far past the end
+     of a short command. Sized to its own content instead, shrinking with
+     min-width:0 so a command too long for the row scrolls inside the plate
+     rather than pushing the button off it. */
+  flex: 0 1 auto;
+  min-width: 0;
   padding: 4px 6px;
   border-radius: 4px;
   background: rgba(var(--tint), 0.09);


### PR DESCRIPTION
## Summary
This PR addresses two UI/UX issues: improving the app loading experience on fresh installations and fixing the layout of command display in the update badge.

## Key Changes

- **Home page app loading**: Enhanced the `getHomeApps` callback to handle the case where the catalog is empty on brand-new installs. When no apps are returned, the code now checks the community catalog status and triggers a refresh if needed, rather than immediately showing an empty state. This prevents users from seeing "No apps yet" while the startup showcase clone is still in progress.

- **Update badge command layout**: Fixed the `.update-badge-command code` element styling by changing from `flex: 1` to `flex: 0 1 auto` with `min-width: 0`. This prevents the code plate from stretching to fill the entire row and pushing the copy button off-screen. Long commands now scroll within the plate instead of breaking the layout.

## Implementation Details

- The Home page now uses `runCommunity` to check catalog status and trigger a refresh when `status === "no-cache"`, matching the behavior already implemented in Apps.tsx
- Added proper cleanup checks (`if (!alive) return`) throughout the async flow to prevent state updates after unmounting
- The CSS change uses flexbox shrinking with `min-width: 0` to allow the code element to be sized to its content while still allowing overflow scrolling

https://claude.ai/code/session_01UTY7QNiSjzKyzHxH1qEBPx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UX: async home fetch escalation and a small CSS flex tweak with no auth, data, or API contract changes.
> 
> **Overview**
> **Home** no longer treats an empty first `getHomeApps` response as permanent on fresh installs. When the Fused Apps row comes back empty, it mirrors **Apps.tsx**: probe the community **catalog**, call **refresh** only when status is `no-cache`, then **always** refetch home apps so a showcase clone that finished between calls still populates the row. Unmount guards stay in place; if community is unreachable, the row still shows the empty state.
> 
> **Update badge** layout: `.update-badge-command code` switches from `flex: 1` to `flex: 0 1 auto` with `min-width: 0` so the command plate sizes to its text (with horizontal scroll when long) instead of stretching across wide trouble cards and stranding the copy button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96456abaa21c4bc7ec8687341fdf9fcf5d823670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->