### PR TITLE
Simplify UpdateBadge UI for installed state

### DIFF
--- a/frontend/src/platform/ui/ServerStatusBanner.tsx
+++ b/frontend/src/platform/ui/ServerStatusBanner.tsx
@@ -173,8 +173,7 @@ export default function ServerStatusBanner() {
           fused-render v{installedVersion} is installed
         </div>
         <div className="server-status-body">
-          The app is still running v{version}. Restart fused-render to finish the update —
-          refreshing this page isn't enough.
+          The app is still running v{version}. Restart fused-render to finish the update.
         </div>
         {/* fused-render://relaunch: the OS hands the link to the running app,
             which quits through the normal teardown and respawns from the

--- a/frontend/src/platform/ui/UpdateBadge.tsx
+++ b/frontend/src/platform/ui/UpdateBadge.tsx
@@ -9,7 +9,8 @@
 // ServerStatusBanner's 5s one: the two components live in different trees and
 // update state changes rarely. Once the install lands, installed_version
 // drifts from the running version and ServerStatusBanner's restart card takes
-// over — this panel just says "restart to finish" and points there.
+// over — so the row drops to a plain "Ready to restart" status line with
+// nothing to expand, and the restart card carries the button and the wording.
 import { useEffect, useRef, useState } from "react";
 
 import { getConfig, updateInstall, type UpdateStatus } from "@platform/lib/api";
@@ -80,6 +81,27 @@ export default function UpdateBadge() {
     window.setTimeout(() => setCopied(false), 2000);
   };
 
+  const label =
+    status.state === "installing"
+      ? "Updating…"
+      : status.state === "installed"
+        ? "Ready to restart"
+        : `Update available${status.latest_version ? ` — v${status.latest_version}` : ""}`;
+  const dot = <span className="update-badge-dot" aria-hidden="true" />;
+
+  // The installed state has no panel of its own — ServerStatusBanner's restart
+  // card says the rest — so the row is a status line, not a dead toggle.
+  if (status.state === "installed") {
+    return (
+      <div className="update-badge">
+        <div className="update-badge-row update-badge-row-static">
+          {dot}
+          {label}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="update-badge">
       <button
@@ -88,12 +110,8 @@ export default function UpdateBadge() {
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
       >
-        <span className="update-badge-dot" aria-hidden="true" />
-        {status.state === "installing"
-          ? "Updating…"
-          : status.state === "installed"
-            ? "Update installed"
-            : `Update available${status.latest_version ? ` — v${status.latest_version}` : ""}`}
+        {dot}
+        {label}
       </button>
       {open && (
         <div className="update-badge-panel">
@@ -125,12 +143,6 @@ export default function UpdateBadge() {
           {status.state === "installing" && (
             <div className="update-badge-text">
               Downloading… {formatMb(status.progress)}
-            </div>
-          )}
-          {status.state === "installed" && (
-            <div className="update-badge-text">
-              Installed. Restart fused-render to finish — the restart card has a
-              button for it.
             </div>
           )}
           {status.state === "error" && (

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -979,6 +979,13 @@ a.bookmark-name::after {
   background: rgba(var(--tint), 0.12);
 }
 
+/* Installed state: the row is a status line, not a toggle — nothing to click. */
+.update-badge-row-static,
+.update-badge-row-static:hover {
+  background: rgba(var(--tint), 0.07);
+  cursor: default;
+}
+
 .update-badge-dot {
   width: 7px;
   height: 7px;


### PR DESCRIPTION
## Summary
Refactored the UpdateBadge component to display a non-interactive status line when an update is installed, rather than a clickable button with an expandable panel. This aligns the UI with the fact that the ServerStatusBanner's restart card handles the actual restart action and messaging.

## Key Changes
- **Extracted label logic**: Created a reusable `label` variable that generates the appropriate text for all states ("Updating…", "Ready to restart", or "Update available — vX.X.X")
- **Conditional rendering**: Added early return for the `installed` state that renders a static status row instead of an interactive button
- **Removed redundant UI**: Deleted the installed state panel content that duplicated information already shown in the ServerStatusBanner's restart card
- **Updated styling**: Added `.update-badge-row-static` CSS class to style the installed state as a non-interactive status line with default cursor and reduced background opacity
- **Updated messaging**: Changed "Update installed" to "Ready to restart" to better reflect the user action needed

## Implementation Details
- The installed state now renders as a simple `<div>` with the dot indicator and label, without button interactivity
- The button-based UI is preserved for "available" and "installing" states where user interaction is needed
- CSS styling ensures the static row has appropriate visual distinction (no hover effects, default cursor) to indicate it's not clickable

https://claude.ai/code/session_018SpZDpVTg9bG7ZKV7hTdXs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and presentation-only changes in update UI components with no backend or security impact.
> 
> **Overview**
> **UpdateBadge** after a successful install no longer acts like a clickable control with an expandable panel. It shows a static **“Ready to restart”** line (replacing **“Update installed”**), and the installed-state panel copy that pointed users at the restart card is removed so **ServerStatusBanner** owns restart messaging and the **Restart fused-render** action.
> 
> **ServerStatusBanner** trims the update-restart body text by dropping the note that refreshing the page is not enough.
> 
> Sidebar CSS adds **`.update-badge-row-static`** so the installed row reads as status-only (no hover affordance, default cursor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e7e55080dad808906604733a5ab41c5c953d272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->