### PR TITLE
CI: job timeouts, verified pinned rclone download, pip caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Every job below sets timeout-minutes. GitHub's default with none set is 360
+# (6 hours) — and a stalled `apt-get update` against the Ubuntu archive mirror
+# has actually hit that ceiling more than once (multiple jobs across two
+# separate runs, each stuck for the full 360 minutes on nothing but "Install
+# rclone"/"Install desktop-file-utils"). Without a job-level timeout that kind
+# of hang doesn't fail — it just sits there until GitHub kills it 6 hours
+# later, silently blocking the PR the whole time. Each value below is picked
+# with headroom over that job's observed successful duration, not a guess.
+
 permissions:
   contents: read
   pull-requests: read # for dorny/paths-filter on pull_request
@@ -19,6 +28,7 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       app: ${{ steps.filter.outputs.app }}
       linux_desktop: ${{ steps.filter.outputs.linux_desktop }}
@@ -105,6 +115,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.app == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
 
@@ -156,6 +167,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
@@ -167,6 +179,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install fused-render (dev extra)
         run: pip install -e ".[dev]"
@@ -174,10 +188,27 @@ jobs:
       # shell/mounts.py shells out to rclone (D102/D103); not bundled outside
       # the packaged macOS app, so CI installs the real binary like a dev
       # machine would (README's "Remote storage (mounts)" section).
+      #
+      # Downloaded directly rather than `apt-get install rclone`: that needs a
+      # full `apt-get update` against the Ubuntu archive mirror just to install
+      # one package, and that mirror has hung outright (see the timeout-minutes
+      # note above) rather than erroring. Same pinned version + published
+      # SHA256 the desktop builds bundle (scripts/build_linux_appimage.sh) —
+      # verified before use, so a bad download fails in seconds, not silently.
       - name: Install rclone
         run: |
-          sudo apt-get update
-          sudo apt-get install -y rclone
+          set -euo pipefail
+          RCLONE_VERSION="1.74.4"
+          RCLONE_SHA256="fe435e0c36228e7c2f116a8701f01127bb1f694005fc11d1f27186c8bca4115d"
+          RCLONE_ZIP="rclone-v${RCLONE_VERSION}-linux-amd64.zip"
+          curl -fsSL --max-time 120 --retry 2 \
+            "https://downloads.rclone.org/v${RCLONE_VERSION}/${RCLONE_ZIP}" \
+            -o "$RCLONE_ZIP"
+          echo "${RCLONE_SHA256}  ${RCLONE_ZIP}" | sha256sum --check --status \
+            || { echo "::error::rclone zip SHA256 mismatch"; exit 1; }
+          sudo unzip -jo "$RCLONE_ZIP" "*/rclone" -d /usr/local/bin
+          sudo chmod +x /usr/local/bin/rclone
+          rclone version
 
       - name: Run tests
         run: >
@@ -238,6 +269,7 @@ jobs:
     needs: [detect-changes, frontend]
     if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 
@@ -280,11 +312,23 @@ jobs:
       - name: Install fused-render (dev + fused extras)
         run: pip install -e ".[dev,fused]"
 
-      # shell/mounts.py shells out to rclone (D102/D103), as in test-python.
+      # shell/mounts.py shells out to rclone (D102/D103), as in test-python —
+      # same pinned-zip install as that job (see its comment for why apt is
+      # avoided here).
       - name: Install rclone
         run: |
-          sudo apt-get update
-          sudo apt-get install -y rclone
+          set -euo pipefail
+          RCLONE_VERSION="1.74.4"
+          RCLONE_SHA256="fe435e0c36228e7c2f116a8701f01127bb1f694005fc11d1f27186c8bca4115d"
+          RCLONE_ZIP="rclone-v${RCLONE_VERSION}-linux-amd64.zip"
+          curl -fsSL --max-time 120 --retry 2 \
+            "https://downloads.rclone.org/v${RCLONE_VERSION}/${RCLONE_ZIP}" \
+            -o "$RCLONE_ZIP"
+          echo "${RCLONE_SHA256}  ${RCLONE_ZIP}" | sha256sum --check --status \
+            || { echo "::error::rclone zip SHA256 mismatch"; exit 1; }
+          sudo unzip -jo "$RCLONE_ZIP" "*/rclone" -d /usr/local/bin
+          sudo chmod +x /usr/local/bin/rclone
+          rclone version
 
       - name: Prove the engine tests run rather than skip
         # The failure mode this job exists to avoid is looking like coverage
@@ -348,6 +392,7 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.app == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
 
@@ -380,6 +425,7 @@ jobs:
     needs: [detect-changes, frontend]
     if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
@@ -391,6 +437,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - uses: astral-sh/setup-uv@v9.0.0
 
@@ -458,12 +506,15 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.windows_desktop == 'true'
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install fused-render (dev + windows-desktop extras)
         run: python -m pip install -e ".[dev,windows-desktop]"
@@ -518,6 +569,7 @@ jobs:
     needs: [detect-changes, frontend]
     if: needs.detect-changes.outputs.macos_desktop == 'true' && needs.frontend.result == 'success'
     runs-on: macos-14
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
@@ -536,6 +588,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install fused-render (dev extra)
         run: pip install -e ".[dev]"
@@ -561,6 +615,7 @@ jobs:
   test-status:
     name: Test Status
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [detect-changes, frontend, test-python, fused-engine, bundle-contents, linux-desktop, windows-desktop, macos-desktop]
     if: always()
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Every job below sets timeout-minutes. GitHub's default with none set is 360
-# (6 hours) — and a stalled `apt-get update` against the Ubuntu archive mirror
-# has actually hit that ceiling more than once (multiple jobs across two
-# separate runs, each stuck for the full 360 minutes on nothing but "Install
-# rclone"/"Install desktop-file-utils"). Without a job-level timeout that kind
-# of hang doesn't fail — it just sits there until GitHub kills it 6 hours
-# later, silently blocking the PR the whole time. Each value below is picked
-# with headroom over that job's observed successful duration, not a guess.
-
 permissions:
   contents: read
   pull-requests: read # for dorny/paths-filter on pull_request


### PR DESCRIPTION
## Summary

While driving #671 to green, `test-python (3.10)` and `(3.11)` both got stuck on the "Install rclone" step (`apt-get update && apt-get install -y rclone`), and I had to manually cancel + re-run to get past it. Pulling the last day of CI runs turned up the same thing happening unattended, worse: two separate runs each had **multiple jobs stuck for the full 360-minute GitHub default job timeout** — `test-python (3.11)`'s Install rclone alone in one run; `fused-engine`, `linux-desktop`, and two `test-python` matrix entries all at once in another — every one of them hung on an `apt-get update` against the Ubuntu archive mirror, not on anything this repo's own code does. With no `timeout-minutes` set anywhere in `test.yml`, a hang like that doesn't fail — it just silently blocks the PR for 6 hours until GitHub kills it.

## Changes

- **`timeout-minutes` on every job**, sized with headroom over that job's observed successful duration (5 min for the trivial jobs up to 30 min for the Python matrix / desktop packaging jobs). A hang now fails loudly in minutes instead of silently for hours — a rerun clears it instead of someone having to notice and manually intervene.
- **`test-python` and `fused-engine` download rclone directly instead of `apt-get install`**: same pinned version (`1.74.4`) + published SHA256 the desktop builds already bundle (`scripts/build_linux_appimage.sh`), verified with `sha256sum --check` before use, with `curl --max-time 120 --retry 2` so even the download itself can't hang unbounded. This sidesteps the flaky apt mirror entirely for what's really just fetching one static binary. (`linux-desktop`'s separate `apt-get install desktop-file-utils` step is untouched — it isn't a single-binary package with a pinned-zip distribution the way rclone is — but it's now covered by the same job-level timeout.)
- **`cache: pip` added to every `setup-python` step that was missing it** (`test-python`, `linux-desktop`, `windows-desktop`, `macos-desktop`), matching the pattern `fused-engine`/`bundle-contents` already used.

I couldn't execute the rclone download from my sandboxed session to test it directly (network policy blocks `downloads.rclone.org` there), but it's the exact URL/version/SHA256 `scripts/build_linux_appimage.sh` already downloads successfully in this repo's real release pipeline, so I'm confident it works the same way from an actual GitHub-hosted runner.

## Also checked (no code change)

Per a request to check `tests/test_canvases.py::test_sync_merge_rolls_back_when_it_breaks_validation` (which I saw fail once, on 3.10 only, under `pytest-xdist`) for worker-isolation issues: I traced the cleanup path and it's actually correct — an `autouse=True` fixture (`_reset_module_state`) clears the module-level `_syncs` registry and stops every sync manager's background thread after **every** test, including on failure, so there's no cross-test state leak. The real fragility is that the test monkeypatches the sync engine's poll/debounce intervals down to 50–300ms and then waits on a real background thread via `_wait_status`'s fixed **8-second wall-clock** deadline — under `-n auto` CPU contention that budget can plausibly get missed on whichever worker happens to be under load at that moment, which fits what I saw (3.10 failed, 3.11/3.12/3.13 passed the identical commit). I didn't change anything here since it was a "check", not a "fix" — happy to bump the timeout or otherwise harden it if wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTY7QNiSjzKyzHxH1qEBPx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to `.github/workflows/test.yml` with no application code or security surface changes; rclone pinning matches existing release build scripts.
> 
> **Overview**
> Hardens the **test** workflow against hung jobs and flaky Ubuntu `apt` mirrors.
> 
> **Job timeouts** (`timeout-minutes`) are set on every job (5–30 minutes by job type) so a stuck step fails quickly instead of sitting on GitHub’s 6-hour default.
> 
> **`test-python` and `fused-engine`** no longer install rclone via `apt-get`; they download the same **pinned** `1.74.4` linux-amd64 zip as `scripts/build_linux_appimage.sh`, verify SHA256, and install to `/usr/local/bin`, with bounded `curl` retries. **`linux-desktop`** still uses apt for `desktop-file-utils` but inherits the job timeout.
> 
> **Pip caching** (`cache: pip` + `pyproject.toml`) is added to `setup-python` on `test-python`, `linux-desktop`, `windows-desktop`, and `macos-desktop`, matching jobs that already cached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c73d1df31f6af3bc7133e63e41e0c6647c20f21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->