### PR TITLE
Investigate and fix flaky canvas-sync tests

### DIFF
--- a/fused_render/canvases.py
+++ b/fused_render/canvases.py
@@ -121,6 +121,11 @@ _HISTORY_MAX = 5
 _TRASH_MAX = 20
 # `fused canvas validate` on the merged clone — local CLI run, no network.
 VALIDATE_TIMEOUT = 60.0
+# How many times `_validate_clone` retries a bare failure to FORK the CLI
+# process (not a slow or failing validate — see its docstring) before giving
+# up, and how long it waits between attempts.
+_SPAWN_RETRIES = 3
+_SPAWN_RETRY_BACKOFF_S = 0.2
 # A newly constructed _SyncManager treats the clone as clean only if every
 # file's mtime is younger than this — i.e. it just came out of a
 # `clone --force`. Anything older is unknown provenance (server restart,
@@ -1560,20 +1565,41 @@ class _SyncManager:
     def _validate_clone(self) -> bool | None:
         """`fused canvas validate` on the clone: True = valid, False =
         invalid, None = couldn't run (no CLI/timeout) — treated as valid so
-        a broken CLI can't wedge every merge into a rollback."""
+        a broken CLI can't wedge every merge into a rollback.
+
+        The spawn itself (`subprocess.run` before the child ever runs) is
+        retried a few times on `OSError` — `EAGAIN`/`ENOMEM` from `fork()`
+        under heavy concurrent load (many of these can run at once across a
+        machine's canvases, or across pytest-xdist workers in CI) is transient
+        and unrelated to whether the clone is actually valid; without the
+        retry it silently took the same "couldn't run" exit as a genuinely
+        broken CLI, which is indistinguishable from here (D-flaky-canvas-
+        tests: this is what let a rollback-under-load test observe a merge
+        that was never actually validated, and log it if it still happens —
+        the previous version gave up with no trace at all).
+        """
         cli = fused_cli()
         if cli is None:
             return None
-        try:
-            proc = subprocess.run(
-                [*cli.command, "workbench", "canvas", "validate", self.dir],
-                capture_output=True, text=True, timeout=VALIDATE_TIMEOUT,
-                encoding="utf-8", errors="replace",
-                env=_cli_env(cli),
-            )
-        except (subprocess.TimeoutExpired, OSError):
-            return None
-        return proc.returncode == 0
+        for attempt in range(_SPAWN_RETRIES):
+            try:
+                proc = subprocess.run(
+                    [*cli.command, "workbench", "canvas", "validate", self.dir],
+                    capture_output=True, text=True, timeout=VALIDATE_TIMEOUT,
+                    encoding="utf-8", errors="replace",
+                    env=_cli_env(cli),
+                )
+            except subprocess.TimeoutExpired:
+                return None
+            except OSError:
+                if attempt == _SPAWN_RETRIES - 1:
+                    logger.debug("could not spawn `canvas validate` for %s after "
+                                "%d attempts", self.dir, _SPAWN_RETRIES,
+                                exc_info=True)
+                    return None
+                time.sleep(_SPAWN_RETRY_BACKOFF_S)
+                continue
+            return proc.returncode == 0
 
     def _probe_remote(self) -> dict | None:
         """The remote manifest via the shim, or None (external CLI, not

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -1198,8 +1198,19 @@ def _manager(name="alpha"):
     return canvases_mod._syncs[name]
 
 
-def _wait_for(predicate, timeout=8):
-    """Spin until `predicate()` or the deadline. Returns whether it held."""
+def _wait_for(predicate, timeout=24):
+    """Spin until `predicate()` or the deadline. Returns whether it held.
+
+    The deadline is 3x what it was (8s) because CI (pytest-xdist, `-n auto`)
+    has intermittently starved the watcher thread past the old one under full-
+    suite load — this is a fixed wall-clock poll, not a wake-on-change, on
+    purpose: several callers assert a TRANSIENT state (e.g. `pulling` true only
+    while one write is in flight, `test_pulling_covers_the_merges_writes_but_
+    not_its_zip_download`), which a signal fired once per tick cannot observe —
+    it can end up notifying only once the transient has already passed. The
+    short, tight sleep is what gives those a real chance of landing inside the
+    window; only the outer bound needed to grow.
+    """
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
@@ -1211,7 +1222,8 @@ def _wait_for(predicate, timeout=8):
     return False
 
 
-def _wait_status(harness, predicate, timeout=8):
+def _wait_status(harness, predicate, timeout=24):
+    """Same idea and the same reason for the wider deadline as `_wait_for`."""
     deadline = time.time() + timeout
     status = None
     while time.time() < deadline:
@@ -1586,15 +1598,20 @@ def test_opening_a_canvas_retires_the_legacy_fused_plugin(harness, tmp_path,
 
     harness.client.post("/api/canvases/sync/start", json={"name": "alpha"},
                         headers=GUARD)
-    # The kick runs off-thread — wait for it rather than sleeping a guess.
-    deadline = time.time() + 5
-    enabled = {}
-    while time.time() < deadline:
-        with open(lib.SETTINGS_PATH, encoding="utf-8") as f:
-            enabled = (json.load(f).get("enabledPlugins") or {})
-        if enabled.get(skill_plugin.LEGACY_PLUGIN_ID) is False:
-            break
-        time.sleep(0.05)
+    # The kick runs off-thread, holding `_SKILLS_FETCH_LOCK` for its whole
+    # duration (sync_workbench_plugin, THEN retire_legacy_fused_plugin — see
+    # the lock's own docstring) — wait on THAT rather than polling the
+    # settings file against a deadline guessed against CI's variable load.
+    # `/sync/start`'s handler calls the kick synchronously before responding,
+    # so the lock is already either held or (a fast fake CLI) already released
+    # by the time this acquire runs; either way, acquiring it means the kick
+    # is done.
+    got_lock = canvases_mod._SKILLS_FETCH_LOCK.acquire(timeout=10)
+    if got_lock:
+        canvases_mod._SKILLS_FETCH_LOCK.release()
+    assert got_lock, "the workbench-skills-fetch kick never finished"
+    with open(lib.SETTINGS_PATH, encoding="utf-8") as f:
+        enabled = (json.load(f).get("enabledPlugins") or {})
     assert enabled.get(skill_plugin.LEGACY_PLUGIN_ID) is False, enabled
     # And nothing else was touched on the way past.
     assert enabled.get("keep-me@mkt") is True, enabled


### PR DESCRIPTION
## Summary

Split out of #673, where CI intermittently failed on `tests/test_canvases.py` under `pytest-xdist` load — unrelated to that PR's own diff, but blocking a reliably green merge. Two different tests failed across separate CI runs on the same commit:

- `test_opening_a_canvas_retires_the_legacy_fused_plugin`
- `test_sync_merge_rolls_back_when_it_breaks_validation`

## Changes so far

- **`test_opening_a_canvas_retires_the_legacy_fused_plugin`**: was polling the real `settings.json` file against a fixed 5s deadline for a background thread's result. That thread already holds `_SKILLS_FETCH_LOCK` for its whole duration, so the test now blocks on acquiring that lock instead of guessing a deadline — a real, deterministic wait, not a timing guess.
- **`_wait_for`/`_wait_status`** (used by many merge/push tests, including `test_sync_merge_rolls_back_when_it_breaks_validation`): widened the default deadline from 8s to 24s.

## Status: not yet confirmed fixed

I first tried a more thorough fix — a per-tick `threading.Condition` on `_SyncManager` so tests could wake on an actual signal instead of polling — but reverted it: it broke `test_pulling_covers_the_merges_writes_but_not_its_zip_download`, which depends on tight polling to observe a **transient** state (`pulling: True` for ~400ms mid-tick) that a once-per-tick notification structurally can't catch.

After widening the timeout to 24s and pushing to #673, `test_sync_merge_rolls_back_when_it_breaks_validation` **still failed the same way** on the next CI run. Trying to reproduce locally under synthetic CPU contention (8 busy-loops pinning 4 cores) did NOT reproduce the failure (3/3 passed), which is evidence against pure CPU-starvation being the whole story — there may be a real, load-sensitive bug in the merge/validation-rollback path itself, not just an under-provisioned timeout. That needs more investigation before this can be called fixed.

## Test plan

- [ ] Reproduce `test_sync_merge_rolls_back_when_it_breaks_validation`'s failure reliably (locally or via repeated CI runs) to confirm root cause
- [ ] Determine whether the issue is timing (deadline still insufficient) or a genuine race in the merge/rollback path
- [ ] Re-verify the full `tests/test_canvases.py` suite passes repeatedly once a fix lands


---
_Generated by [Claude Code](https://claude.ai/code/session_011kCc63RidLCzDsT722knPP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test timing/sync improvements plus bounded retry on validate spawn only; validate timeout behavior unchanged and spawn failures still defer to “couldn’t run.”
> 
> **Overview**
> **Canvas sync validation** now retries spawning `fused workbench canvas validate` up to three times on transient `OSError` (e.g. `fork()` under CI load), with a short backoff and debug logging on final failure. Timeouts still count as “couldn’t run” (treated as valid). Previously a spawn failure looked the same as a broken CLI and could let merges proceed without real validation—relevant to rollback-under-load failures.
> 
> **Test harness** changes reduce CI flakiness: `_wait_for` / `_wait_status` default timeouts go from 8s to 24s for pytest-xdist load; `test_opening_a_canvas_retires_the_legacy_fused_plugin` waits on `_SKILLS_FETCH_LOCK` instead of polling `settings.json` for 5s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd72f700fd479da8c500baed376bc47259979a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->