### PR TITLE
Fix UTF-8 encoding issues in permission server on Windows

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -1073,7 +1073,20 @@ def _write_mcp_config(run_dir: str, pane: bool = True) -> str:
             # (executor.py): in the packaged .app that is the bundled python.
             "command": sys.executable,
             "args": args,
-            "env": {"FUSED_RENDER_PERMISSION_TIMEOUT": str(PERMISSION_WAIT)},
+            "env": {
+                "FUSED_RENDER_PERMISSION_TIMEOUT": str(PERMISSION_WAIT),
+                # UTF-8 stdio for the server, whatever the machine's locale is.
+                # The CLI's MCP client is Node: it writes raw UTF-8 JSON with
+                # non-ASCII unescaped, while Python decodes a pipe at the LOCALE
+                # encoding — the ANSI code page on Windows, where a curly quote
+                # in a `Write` payload used to kill the server before it parked
+                # the request (no card, dead permission bridge, a turn that
+                # simply stopped; see permission_server._utf8_stdio). It has to
+                # be named HERE to reach the child at all: the MCP client passes
+                # an allowlist of env vars plus exactly this dict, so an ambient
+                # PYTHONUTF8 would not survive the spawn.
+                "PYTHONUTF8": "1",
+            },
             # Hard per-call ceiling for this server, and a permission card is a
             # tool call that lasts as long as the user takes to look at it. Set
             # above the server's own wait so an unanswered card returns OUR

--- a/fused_render/templates/claude/permission_server.py
+++ b/fused_render/templates/claude/permission_server.py
@@ -118,6 +118,51 @@ def _log(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
+def _utf8_stdio() -> None:
+    """Read and write the MCP wire as UTF-8, whatever the machine's locale is.
+
+    The client on the other end of these pipes is Node: it writes
+    `JSON.stringify(message) + "\\n"`, which leaves non-ASCII UNESCAPED and goes
+    out as UTF-8. Python decodes a PIPE at the locale encoding, and that is
+    UTF-8 on macOS and on Linux (where a C/POSIX locale additionally turns
+    PEP 540 UTF-8 mode on) but the ANSI code page on Windows — cp1252 on a
+    typical Western install, which leaves 0x81/0x8D/0x8F/0x90/0x9D UNDEFINED.
+
+    Those five bytes are ordinary UTF-8 continuation bytes, so on Windows the
+    first typographic character in a tool payload killed this server outright:
+    `Write` an index.html containing a curly quote (U+201D is E2 80 9D) and the
+    read loop in `main` raised UnicodeDecodeError *before* the request was
+    parked. No card ever appeared in the chat, the CLI's pending `approve` call
+    died with the transport, and the turn went nowhere — "it just got stuck
+    writing index.html", with no prompt to answer and nothing in the run dir to
+    say why. Nothing about it was rare: model-written HTML is full of curly
+    quotes, en dashes and emoji.
+
+    Two halves ship, because either can be absent. agent.py stamps `PYTHONUTF8`
+    into this server's env (the CLI's MCP client passes an allowlist of env vars
+    plus that dict, so it has to be named there to survive at all); this is the
+    half that does not depend on the client forwarding an env, or on the config
+    having been written by a version of agent.py that names it.
+
+    `errors="replace"` on the way IN, deliberately: an undecodable byte costs
+    one character of a payload the user is about to read on a card, and dying
+    costs them the whole turn with no way to answer it. On the way OUT the JSON
+    is `ensure_ascii` today, so the encoding is belt and braces — but
+    `newline="\\n"` is not: a Windows text stream would otherwise turn the
+    framing newline into CRLF.
+
+    Never raises. A stream that has already been read cannot be reconfigured,
+    and `sys.stdout` can be None where there is no stdio at all; neither is a
+    reason to refuse to serve, and both are worth a line on stderr.
+    """
+    for stream, extra in ((sys.stdin, {"errors": "replace"}),
+                          (sys.stdout, {"newline": "\n"})):
+        try:
+            stream.reconfigure(encoding="utf-8", **extra)
+        except (AttributeError, ValueError, OSError) as exc:
+            _log("permission_server.py: could not force UTF-8 stdio (%s)" % exc)
+
+
 def _send(payload: dict) -> None:
     with _stdout_lock:
         sys.stdout.write(json.dumps(payload) + "\n")
@@ -522,6 +567,9 @@ def _serve_request(req_id, method: str, params: dict) -> None:
 
 
 def main() -> int:
+    # Before the first read of stdin, which is what fixes the encoding: a
+    # TextIOWrapper cannot be reconfigured once it has read anything.
+    _utf8_stdio()
     if not PERM_DIR:
         _log("permission_server.py: missing perm-dir argument")
         return 2

--- a/tests/_mcp_stdio.py
+++ b/tests/_mcp_stdio.py
@@ -73,7 +73,12 @@ class MCPServer:
         self.proc = subprocess.Popen(
             [str(a) for a in argv],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            text=True, env={**os.environ, **(env or {})})
+            # encoding, not bare text=True: the real client is Node, which writes
+            # `JSON.stringify(msg) + "\n"` as UTF-8 with non-ASCII unescaped. A
+            # locale-encoded pipe here would make a non-ASCII payload depend on
+            # the runner's LANG instead of pinning what the server actually
+            # receives (test_a_windows_locale_stdio_still_parks_a_non_ascii_write).
+            text=True, encoding="utf-8", env={**os.environ, **(env or {})})
         self._lock = threading.Lock()
         self._next_id = 0
         self._pending = {}      # id -> Pending, awaiting a response

--- a/tests/_mcp_stdio.py
+++ b/tests/_mcp_stdio.py
@@ -146,9 +146,14 @@ class MCPServer:
             pending.failure = failure
             pending.done.set()
             return pending
+        # ensure_ascii=False, matching Node's JSON.stringify: the real client
+        # puts non-ASCII on the wire as UTF-8 BYTES, not as \uXXXX escapes, and
+        # an escaping serializer here cannot reach the decoder at all — every
+        # payload would be pure ASCII, which any codec accepts (Bugbot, PR #677:
+        # the Windows-locale test passed with the fix reverted).
         self.proc.stdin.write(json.dumps({
             "jsonrpc": "2.0", "id": pending.id, "method": method,
-            "params": params or {}}) + "\n")
+            "params": params or {}}, ensure_ascii=False) + "\n")
         self.proc.stdin.flush()
         return pending
 

--- a/tests/test_claude_permission_bridge.py
+++ b/tests/test_claude_permission_bridge.py
@@ -135,6 +135,55 @@ def _result_payload(response):
 # claim and it is no longer true of any shipping server.
 
 
+def test_a_windows_locale_stdio_still_parks_a_non_ascii_write(tmp_path, agent):
+    """A payload with typographic characters must survive a NON-UTF-8 locale.
+
+    The Windows bug, reproduced on any platform by giving the child the stdio
+    encoding Windows gives it. The CLI's client is Node — raw UTF-8 on the wire,
+    non-ASCII unescaped — while Python decodes a pipe at the locale encoding,
+    which on Windows is the ANSI code page. cp1252 leaves 0x9D undefined, and
+    0x9D is the third byte of U+201D, so `Write`-ing an index.html with a curly
+    quote in it raised UnicodeDecodeError in the read loop: the server died
+    BEFORE parking the request, so no card ever reached the chat, the CLI's
+    pending `approve` call went down with the transport, and the turn stopped
+    with nothing to answer. Model-written HTML has curly quotes in it as a
+    matter of course, which is why this read as "it gets stuck writing
+    index.html".
+
+    Asserts the whole round trip, not just that the process survived: the parked
+    request has to carry the content the CLI sent, character for character, and
+    the allow has to hand that same content back — `updatedInput` is what the
+    tool then writes to disk, so a mojibake'd or replacement-charactered payload
+    here would silently corrupt the user's file instead of hanging their turn.
+    """
+    perm_dir = tmp_path / "perm"
+    # PYTHONIOENCODING rather than a real Windows box: it sets exactly what is
+    # wrong there (the std streams' codec) and nothing else, and it also OUTRANKS
+    # UTF-8 mode — so this pins the in-process reconfigure on its own, without
+    # the PYTHONUTF8 that agent.py stamps into the server's env.
+    s = _Server(perm_dir, env={"PYTHONIOENCODING": "cp1252"})
+    try:
+        s.call("initialize", {"protocolVersion": "2025-06-18",
+                              "capabilities": {}, "clientInfo": {"name": "test"}})
+        content = ('<h1>Caf\u00e9 \u2014 \u201cwelcome\u201d</h1>\n'
+                   '<p>na\u00efve \u2192 r\u00e9sum\u00e9 \U0001f600</p>\n')
+        tool_input = {"file_path": "C:/Users/x/app/index.html", "content": content}
+        pending = s.send_async("tools/call", {
+            "name": "approve",
+            "arguments": {"tool_name": "Write", "input": tool_input,
+                          "tool_use_id": "toolu_utf8"}})
+
+        req = _wait_for_request(perm_dir)
+        assert req["input"]["content"] == content
+        assert agent._write_decision(str(perm_dir), req["id"],
+                                     {"decision": "allow", "scope": "once"})
+        payload = _result_payload(pending.result(10))
+        assert payload["behavior"] == "allow"
+        assert payload["updatedInput"] == tool_input
+    finally:
+        s.close()
+
+
 def test_allow_round_trip_returns_the_tool_input_unchanged(tmp_path, agent, server):
     perm_dir = tmp_path / "perm"
     tool_input = {"command": "ls -la", "description": "list"}
@@ -1528,6 +1577,24 @@ def test_start_asks_the_cli_to_route_permissions_here(agent, tmp_path, monkeypat
     # in first and reports an MCP timeout instead of "nobody answered".
     assert entry["timeout"] > agent.PERMISSION_WAIT * 1000
     assert entry["env"]["FUSED_RENDER_PERMISSION_TIMEOUT"] == str(agent.PERMISSION_WAIT)
+
+
+def test_the_mcp_config_forces_utf8_stdio_on_the_server(agent, tmp_path):
+    """The spawn's half of the encoding fix.
+
+    permission_server reconfigures its own streams, but the config is where the
+    variable has to be NAMED: the CLI's MCP client hands the child an allowlist
+    of env vars plus this dict and nothing else, so an ambient PYTHONUTF8 (or
+    a UTF-8 mode the server itself was started in) does not reach it. Belt and
+    braces with the reconfigure — either alone is enough, and the failure they
+    prevent is a dead permission bridge on Windows the moment a payload carries
+    a curly quote.
+    """
+    run_dir = tmp_path / "run"
+    os.makedirs(run_dir / "perm")
+    config = json.loads(open(agent._write_mcp_config(str(run_dir))).read())
+    env = config["mcpServers"][agent.PERMISSION_SERVER]["env"]
+    assert env["PYTHONUTF8"] == "1"
 
 
 def test_the_server_path_resolves_when_the_engine_execs_us_without_dunder_file(tmp_path):

--- a/tests/test_claude_permission_bridge.py
+++ b/tests/test_claude_permission_bridge.py
@@ -184,6 +184,33 @@ def test_a_windows_locale_stdio_still_parks_a_non_ascii_write(tmp_path, agent):
         s.close()
 
 
+def test_forcing_utf8_stdio_never_refuses_to_serve(monkeypatch, capsys):
+    """`_utf8_stdio` degrades to a stderr line, and never raises.
+
+    Both of its real failure modes, in-process, because neither is reachable
+    from the subprocess tests: a stream that has already been read (a
+    TextIOWrapper cannot be reconfigured after the first read, which is why the
+    call sits at the top of `main`) and no stdio object at all (`sys.stdout is
+    None`, which a windowless interpreter can produce). This server exists to
+    answer a tool call the model is BLOCKED on, so an unsettable encoding has to
+    cost a diagnostic and not the whole session — the wire is ASCII often enough
+    that a mis-encoded stream may never matter on that run.
+    """
+    srv = _load("permission_server")
+
+    class _Read:
+        def reconfigure(self, **kw):
+            raise ValueError("can't set encoding after the first read")
+
+    monkeypatch.setattr(srv.sys, "stdin", _Read())
+    # Something with no `reconfigure` at all — what `sys.stdout is None` reaches
+    # (AttributeError), without nulling the stream pytest is capturing through.
+    monkeypatch.setattr(srv.sys, "stdout", object())
+    srv._utf8_stdio()                              # the assertion: it returns
+    err = capsys.readouterr().err
+    assert err.count("could not force UTF-8 stdio") == 2, err
+
+
 def test_allow_round_trip_returns_the_tool_input_unchanged(tmp_path, agent, server):
     perm_dir = tmp_path / "perm"
     tool_input = {"command": "ls -la", "description": "list"}


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where the permission server would crash on Windows when processing tool payloads containing non-ASCII characters (like curly quotes, em dashes, or emoji). The issue occurred because Python was decoding stdin using the Windows ANSI code page (cp1252) instead of UTF-8, while the Node.js MCP client sends raw UTF-8 JSON with unescaped non-ASCII characters.

## Key Changes

- **permission_server.py**: Added `_utf8_stdio()` function that reconfigures stdin and stdout to use UTF-8 encoding before the first read. This is called at the start of `main()` to ensure the server can properly decode UTF-8 payloads from the Node.js client, regardless of the system locale.

- **agent.py**: Updated `_write_mcp_config()` to include `PYTHONUTF8=1` in the environment variables passed to the permission server subprocess. This ensures UTF-8 mode is enabled even if the config is processed by an older version of the code or if the ambient environment doesn't have it set.

- **_mcp_stdio.py**: Modified the test helper's `Popen` call to explicitly specify `encoding="utf-8"` instead of relying on `text=True` with the system locale. This ensures test communication with the server uses UTF-8 consistently.

- **test_claude_permission_bridge.py**: Added comprehensive test `test_a_windows_locale_stdio_still_parks_a_non_ascii_write()` that reproduces the Windows bug by simulating a cp1252 locale and verifies that non-ASCII payloads survive the round trip correctly. Also added `test_the_mcp_config_forces_utf8_stdio_on_the_server()` to verify the config includes the UTF-8 environment variable.

## Implementation Details

The fix uses a two-pronged approach:
1. **Server-side reconfiguration**: `_utf8_stdio()` reconfigures Python's text streams before any I/O occurs, with graceful error handling for edge cases (already-read streams, missing stdio).
2. **Environment variable**: `PYTHONUTF8=1` is explicitly set in the MCP config since the CLI's MCP client only passes an allowlist of env vars plus the config dict, so ambient environment variables don't reach the child process.

The `errors="replace"` parameter on stdin ensures that if an undecodable byte somehow occurs, it's replaced with a replacement character rather than crashing, preserving the user's ability to see and respond to the permission card.

https://claude.ai/code/session_01C5mmDHTKzPmqwd6v9PA2LY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the permission bridge subprocess I/O path on all platforms; behavior is defensive (dual fix, replace-on-decode errors) but a regression could break approvals or corrupt tool input encoding.
> 
> **Overview**
> Fixes a **Windows hang** when tool approvals carry non-ASCII text (curly quotes, emoji, etc. in `Write` payloads): the Node MCP client sends **UTF-8 JSON**, but Python was decoding stdin with the **ANSI code page**, so `UnicodeDecodeError` killed `permission_server` before a permission card could appear.
> 
> **`permission_server.py`** adds `_utf8_stdio()` at the top of `main()` to force UTF-8 on stdin/stdout (`errors="replace"` on input, `\n` newlines on output) without raising if reconfiguration fails.
> 
> **`agent.py`** sets **`PYTHONUTF8=1`** in the MCP server env so UTF-8 mode survives the CLI’s allowlisted env passthrough.
> 
> **Tests** pin UTF-8 on the MCP harness (`encoding="utf-8"`, `ensure_ascii=False`), add a cp1252-locale round-trip for non-ASCII `Write`, assert `PYTHONUTF8` in generated MCP config, and cover graceful `_utf8_stdio` degradation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ae0056fe01dce3e5b2ded9deef59c508777f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->