### PR TITLE
Tasks List: wheel-scroll works anywhere on the page, not just over the card

### DIFF
--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1102,6 +1102,49 @@ export function TaskList({
     remember({ ...memory.current, expanded: [...expanded] });
   }, [expanded]);
 
+  // ---- the wheel works in the margins too -------------------------------------
+  // `.schedule-main` is capped at 1050px and centred, so a wide window leaves a
+  // band of empty page either side of the card — and the card is the scroller,
+  // so a wheel out in that band lands on `.schedule-page`, which is
+  // `overflow: hidden` and scrolls nothing: the reader had to aim at the card
+  // (Akshil, 2026-08-20). Making the scroller full-width instead was tried first
+  // and traded this for two worse bugs — the card's frame scrolled away with its
+  // content, and the reserved scrollbar gutters pushed the card off the
+  // toolbar's axis (bugbot, #678) — so the geometry stays exactly as it was and
+  // the wheel is forwarded: a wheel anywhere on this page that no scroller of
+  // its own claims is handed to the list. Board and Calendar mount their own
+  // components, so nothing here can touch their scrolling.
+  useEffect(() => {
+    // The page div, NOT via the ref: on the mount this effect runs after, the
+    // rows are usually still in flight and the ref is still null — the page
+    // ancestor is the one element of this pair that is always there. The ref is
+    // read again inside the handler, per wheel, for the same reason.
+    const page = document.querySelector<HTMLElement>(".schedule-page");
+    if (!page) return;
+    const onWheel = (e: WheelEvent) => {
+      const el = listRef.current;
+      if (!el || !(e.target instanceof Element) || e.deltaY === 0) return;
+      // Pinch-zoom arrives as ctrl+wheel; that is a zoom, not a scroll.
+      if (e.ctrlKey) return;
+      // Anything between the pointer and the page that scrolls for itself —
+      // the list, a menu, a popover — keeps its native wheel untouched.
+      for (let n: Element | null = e.target; n && n !== page; n = n.parentElement) {
+        const s = getComputedStyle(n);
+        if (
+          (s.overflowY === "auto" || s.overflowY === "scroll") &&
+          n.scrollHeight > n.clientHeight
+        ) {
+          return;
+        }
+      }
+      // deltaMode 1 is lines (Firefox with a wheel mouse); everything else
+      // that reaches a web page is already pixels.
+      el.scrollTop += e.deltaMode === 1 ? e.deltaY * 16 : e.deltaY;
+    };
+    page.addEventListener("wheel", onWheel, { passive: true });
+    return () => page.removeEventListener("wheel", onWheel);
+  }, []);
+
   const onScroll = () => {
     const el = listRef.current;
     if (!el) return;
@@ -1170,15 +1213,7 @@ export function TaskList({
           The Board keeps this same sentence above its lanes for the same
           reason. */}
       {pageNote && <p className="schedule-tv-note tasks-list-note">{pageNote}</p>}
-      {/* TWO boxes, not one. The outer one is the SCROLLER and runs the whole
-          width of the page; the inner one is the bordered card and is what the
-          1050px measure and the centring apply to. They were the same element
-          until 2026-08-20, which meant the wheel did nothing at all while the
-          pointer sat in the empty page either side of the card — the scroller
-          simply was not under it (Akshil). Same move, same reason, as
-          `.prefs-page`'s full-width scroll container. */}
       <div className="tasks-list" ref={listRef} onScroll={onScroll}>
-      <div className="tasks-list-inner">
       {/* ORDERED BY STATUS, NOT GROUPED BY IT (tasks-lib.sortByLane): Upcoming,
           In Progress, Failed, Done, Archive — rank order, server order inside
           each rank, and no headers, dividers or counts between them.
@@ -1213,7 +1248,6 @@ export function TaskList({
           onSettleAll={settleAll}
         />
       ))}
-      </div>
       </div>
     </>
   );

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1170,7 +1170,15 @@ export function TaskList({
           The Board keeps this same sentence above its lanes for the same
           reason. */}
       {pageNote && <p className="schedule-tv-note tasks-list-note">{pageNote}</p>}
+      {/* TWO boxes, not one. The outer one is the SCROLLER and runs the whole
+          width of the page; the inner one is the bordered card and is what the
+          1050px measure and the centring apply to. They were the same element
+          until 2026-08-20, which meant the wheel did nothing at all while the
+          pointer sat in the empty page either side of the card — the scroller
+          simply was not under it (Akshil). Same move, same reason, as
+          `.prefs-page`'s full-width scroll container. */}
       <div className="tasks-list" ref={listRef} onScroll={onScroll}>
+      <div className="tasks-list-inner">
       {/* ORDERED BY STATUS, NOT GROUPED BY IT (tasks-lib.sortByLane): Upcoming,
           In Progress, Failed, Done, Archive — rank order, server order inside
           each rank, and no headers, dividers or counts between them.
@@ -1205,6 +1213,7 @@ export function TaskList({
           onSettleAll={settleAll}
         />
       ))}
+      </div>
       </div>
     </>
   );

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -369,14 +369,8 @@ export default function Scheduled() {
       {loadError && <ErrorBanner>Failed to load tasks: {loadError}</ErrorBanner>}
       {!state && !loadError && <SkeletonLines rows={2} label="Loading tasks" />}
 
-      {/* `schedule-main--list` widens this section to the full page so the
-          List's scroller can run edge to edge and catch the wheel in the empty
-          margins either side of the card; the 1050px measure moves onto the
-          children (styles/tasks.css). Board and Calendar keep the capped
-          section they have always had — their scrollers are the lane body and
-          the week grid, and both already fill it. */}
       {state && (
-        <section className={"prefs-section schedule-main" + (view === "list" ? " schedule-main--list" : "")}>
+        <section className="prefs-section schedule-main">
           <div className="schedule-toolbar">
             {/* The view toggle leads, at the far left of every view — it is the
                 one control that must never change address, and anchoring it to

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -369,8 +369,14 @@ export default function Scheduled() {
       {loadError && <ErrorBanner>Failed to load tasks: {loadError}</ErrorBanner>}
       {!state && !loadError && <SkeletonLines rows={2} label="Loading tasks" />}
 
+      {/* `schedule-main--list` widens this section to the full page so the
+          List's scroller can run edge to edge and catch the wheel in the empty
+          margins either side of the card; the 1050px measure moves onto the
+          children (styles/tasks.css). Board and Calendar keep the capped
+          section they have always had — their scrollers are the lane body and
+          the week grid, and both already fill it. */}
       {state && (
-        <section className="prefs-section schedule-main">
+        <section className={"prefs-section schedule-main" + (view === "list" ? " schedule-main--list" : "")}>
           <div className="schedule-toolbar">
             {/* The view toggle leads, at the far left of every view — it is the
                 one control that must never change address, and anchoring it to

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -72,8 +72,9 @@ html, body {
      scrolls. Any wheel delta an inner pane doesn't consume chains up to here,
      and macOS answers with the elastic bounce: the whole app lurches and snaps
      back, loudest when a pane hits its end mid-scroll (Akshil, 2026-08-20, the
-     Tasks list). Nothing real is lost by refusing it at the root. */
-  overscroll-behavior: none;
+     Tasks list). The Y axis ONLY: the shorthand would also eat the horizontal
+     swipe-back/forward gesture, which is real navigation here (bugbot, #678). */
+  overscroll-behavior-y: none;
 }
 
 body {

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -68,6 +68,12 @@ table.listing-table th.sortable,
 html, body {
   height: 100%;
   margin: 0;
+  /* The shell is a fixed 100vh flex frame (#app) — the document itself never
+     scrolls. Any wheel delta an inner pane doesn't consume chains up to here,
+     and macOS answers with the elastic bounce: the whole app lurches and snaps
+     back, loudest when a pane hits its end mid-scroll (Akshil, 2026-08-20, the
+     Tasks list). Nothing real is lost by refusing it at the root. */
+  overscroll-behavior: none;
 }
 
 body {

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -34,7 +34,49 @@
   overflow-y: auto;
 }
 
-.tasks-list {
+/* -- The List's scroller is the full page, its card is not ---------------------
+   `.schedule-main` is capped at 1050px and centred for all three views, so on a
+   wide window there is a band of empty page down either side of it. While the
+   scroller WAS that capped box, the wheel over those bands hit `.schedule-page`
+   — which is `overflow: hidden` — and the list did not move: you had to aim at
+   the card to scroll it (Akshil, 2026-08-20).
+
+   So on the List, and only there, the section goes full width and the measure
+   moves inward: every child is re-capped at the same 1050px and centred, except
+   the scroller, which keeps the whole width and hands the 1050px on to
+   `.tasks-list-inner` — the bordered card the reader actually sees. Nothing
+   about the page's proportions changes; what changes is which element is under
+   the pointer out in the margins. `.prefs-page` made exactly this split for
+   exactly this reason (preferences.css: full-width scroll container, capped
+   child) and the scrollbar lands where that one's does, at the page edge rather
+   than against the card.
+
+   Board and Calendar are untouched by every rule here: they never get the
+   modifier class, so their section stays capped and their own scrollers — the
+   lane body and the week grid — keep the boxes they had. */
+.schedule-page > .prefs-section.schedule-main--list {
+  max-width: none;
+}
+
+.schedule-page .schedule-main--list > * {
+  max-width: 1050px;
+  width: 100%;
+  margin-inline: auto;
+}
+
+/* `both-edges` and not the plain `stable` schedule.css gives all three
+   scrollers: the gutter is reserved on one side only, and a 10px notch taken
+   out of the right of a full-width box moves its centred child 5px left of the
+   toolbar above it. Reserving both sides keeps the card and the toolbar on the
+   same axis, and costs 10px of margin nobody was using. */
+.schedule-page .schedule-main--list > .tasks-list {
+  max-width: none;
+  scrollbar-gutter: stable both-edges;
+}
+
+.tasks-list-inner {
+  max-width: 1050px;
+  margin-inline: auto;
   border: 1px solid var(--border);
   border-radius: 8px;
 }

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -34,49 +34,7 @@
   overflow-y: auto;
 }
 
-/* -- The List's scroller is the full page, its card is not ---------------------
-   `.schedule-main` is capped at 1050px and centred for all three views, so on a
-   wide window there is a band of empty page down either side of it. While the
-   scroller WAS that capped box, the wheel over those bands hit `.schedule-page`
-   — which is `overflow: hidden` — and the list did not move: you had to aim at
-   the card to scroll it (Akshil, 2026-08-20).
-
-   So on the List, and only there, the section goes full width and the measure
-   moves inward: every child is re-capped at the same 1050px and centred, except
-   the scroller, which keeps the whole width and hands the 1050px on to
-   `.tasks-list-inner` — the bordered card the reader actually sees. Nothing
-   about the page's proportions changes; what changes is which element is under
-   the pointer out in the margins. `.prefs-page` made exactly this split for
-   exactly this reason (preferences.css: full-width scroll container, capped
-   child) and the scrollbar lands where that one's does, at the page edge rather
-   than against the card.
-
-   Board and Calendar are untouched by every rule here: they never get the
-   modifier class, so their section stays capped and their own scrollers — the
-   lane body and the week grid — keep the boxes they had. */
-.schedule-page > .prefs-section.schedule-main--list {
-  max-width: none;
-}
-
-.schedule-page .schedule-main--list > * {
-  max-width: 1050px;
-  width: 100%;
-  margin-inline: auto;
-}
-
-/* `both-edges` and not the plain `stable` schedule.css gives all three
-   scrollers: the gutter is reserved on one side only, and a 10px notch taken
-   out of the right of a full-width box moves its centred child 5px left of the
-   toolbar above it. Reserving both sides keeps the card and the toolbar on the
-   same axis, and costs 10px of margin nobody was using. */
-.schedule-page .schedule-main--list > .tasks-list {
-  max-width: none;
-  scrollbar-gutter: stable both-edges;
-}
-
-.tasks-list-inner {
-  max-width: 1050px;
-  margin-inline: auto;
+.tasks-list {
   border: 1px solid var(--border);
   border-radius: 8px;
 }

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -32,6 +32,12 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  /* A wheel that reaches the list's end must STOP there. Without this the
+     leftover delta chains up to the document, and macOS answers with the
+     elastic bounce — the whole page lurches and snaps back on every
+     overshoot, which reads as the page saying "nothing to scroll" while the
+     list is scrolling fine (Akshil, 2026-08-20). */
+  overscroll-behavior: contain;
 }
 
 .tasks-list {


### PR DESCRIPTION
## What
Tasks page, List view: mouse-wheel scrolling now works when the pointer is over the empty page either side of the 1050px card — not just over the card itself.

## How
The card keeps its exact geometry (capped, centred, bordered scroller — identical to main). A single `wheel` listener on `.schedule-page` forwards the delta to the list whenever nothing between the pointer and the page claims the scroll itself (the list, a menu, a popover — anything scrollable keeps its native wheel). Ctrl+wheel (pinch-zoom) is ignored; `deltaMode` lines are converted.

The first iteration moved the scroller to full width instead; bugbot correctly flagged that the card's frame scrolled away with the content and the scrollbar gutters broke toolbar alignment at narrow widths. Reworked to the forwarding approach — zero visual change from main.

## Not touched
Board and Calendar: the listener mounts with the List component only and is removed on unmount (verified live across view switches).

## Tested
- `bun test` 1973 pass / 0 fail; frontend build clean.
- Live (cmux browser): wheel in the left margin scrolls the list both directions; wheel over the card scrolls natively; frame/radius stay fixed on the pane; card flush with the toolbar; Board mounts with no listener and no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI scroll behavior in the schedule List view and CSS overscroll tweaks; no auth, data, or API changes.
> 
> **Overview**
> **Tasks List view** keeps the centred 1050px card layout unchanged and adds a passive `wheel` listener on `.schedule-page` that applies the delta to `.tasks-list` when the pointer isn’t over another vertically scrollable ancestor (menus/popovers/list still scroll natively). **Ctrl+wheel** (pinch-zoom) is ignored; **line-based** `deltaMode` is converted to pixels.
> 
> **Global CSS** sets `overscroll-behavior-y: none` on `html`/`body` so unused wheel deltas don’t chain to the document, and `overscroll-behavior: contain` on the tasks list so overscroll at the list ends doesn’t bounce the whole shell. The listener mounts/unmounts with the List component only (Board/Calendar unaffected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22673532aefebbdab18a3b49edb3cb27a281910c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->