### PR TITLE
New task: name a folder that doesn't exist yet

### DIFF
--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -111,6 +111,64 @@ const SESSION_FOLDERS_SHOWN = 5;
 // joins) only understands one.
 const normPath = (p: string) => p.replace(/\\/g, "/");
 
+// A path split into the folder it lives in and its last segment. Drive roots
+// keep their slash — bare "C:" reads as cwd-relative elsewhere in the shell,
+// not as the root (the same trap the picker's climb fixed in PR #548).
+export function splitTargetPath(path: string): { parent: string; base: string } {
+  const norm = normPath(path).trim().replace(/\/+$/, "");
+  const cut = norm.lastIndexOf("/");
+  const parent = cut > 0 ? norm.slice(0, cut) : "/";
+  return {
+    parent: /^[A-Za-z]:$/.test(parent) ? parent + "/" : parent,
+    base: norm.slice(cut + 1),
+  };
+}
+
+// ---- What the typed path IS ---------------------------------------------------
+// Three answers, not two (Akshil, 2026-08-20): a path can also be a folder that
+// does not exist YET. Standing in `.../fused/` and typing `ABC1` is how a person
+// says "run this in a new folder called ABC1", and the form used to answer that
+// with a red line refusing to save.
+//
+// ONE new segment, and only one. Its parent has to be somewhere the user can
+// point at, because "make the folder I named" and "build me a tree I typed" are
+// different asks and only the first is one a typo cannot cause. `/a/new1/new2`
+// with no `new1` is the second, and it is refused with the reason.
+//
+// Pure so the decision can be asserted without a DOM (new-task-form.test.ts);
+// the effect below only feeds it what the two listDir calls came back with.
+export type TargetVerdict =
+  | { kind: "ok" }
+  // `name` is the segment that will be created; `parent` is where.
+  | { kind: "new-folder"; name: string; parent: string }
+  | { kind: "bad"; text: string };
+
+export const PATH_MISSING = "This folder or file doesn't exist";
+
+export function twoLevelsMissing(parent: string): string {
+  return `Only one new folder can be created — ${parent} doesn't exist either`;
+}
+
+// `parentNames` is the parent folder's entry names, or null when the PARENT
+// itself could not be listed — which is the two-missing-levels case.
+export function targetVerdict(
+  path: string,
+  parentNames: string[] | null,
+): TargetVerdict {
+  const { parent, base } = splitTargetPath(path);
+  // "." and ".." name a folder that already exists by definition, so reaching
+  // here with one of them means the path was junk rather than a new name.
+  if (!base || base === "." || base === "..") {
+    return { kind: "bad", text: PATH_MISSING };
+  }
+  if (parentNames === null) return { kind: "bad", text: twoLevelsMissing(parent) };
+  // The parent lists and already holds this name: a FILE target, which is legal
+  // — a task can run against a file. (A folder would never have got this far;
+  // listing it directly is what the caller tries first.)
+  if (parentNames.includes(base)) return { kind: "ok" };
+  return { kind: "new-folder", name: base, parent };
+}
+
 
 interface Crumb {
   name: string;
@@ -340,9 +398,36 @@ function ExplorerPanel({
   // the querySelector; recomputed while open because a resize moves both.
   const box = useDialogBox();
 
+  // "New folder" here NAMES one; it does not make one. The folder is created by
+  // the save, exactly as it is for a name typed straight into the path field —
+  // so backing out of the card leaves nothing behind on disk, and the picker
+  // needs no write endpoint to offer the affordance.
+  const [naming, setNaming] = useState(false);
+  const [newName, setNewName] = useState("");
+  const nameRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (naming) nameRef.current?.focus();
+  }, [naming]);
+
   const go = (p: string) => {
     setPath(p);
     setFilter("");
+    // A half-typed name belongs to the folder it was being typed in.
+    setNaming(false);
+    setNewName("");
+  };
+
+  const typedName = newName.trim();
+  // Checked against the listing already on screen — the one place that knows
+  // what is in this folder. A name that is taken is not an error to shout
+  // about, it is a folder the user can just click.
+  const nameTaken = rows?.some((r) => r.name === typedName) ?? false;
+  const nameBad = typedName.includes("/") || typedName === "." || typedName === "..";
+  const canCreate = typedName !== "" && !nameTaken && !nameBad;
+  const confirmName = () => {
+    if (!canCreate) return;
+    onPick(path.replace(/\/+$/, "") + "/" + typedName);
+    onClose();
   };
   const crumbs = collapseCrumbs(crumbsOf(path));
   const shown = rows?.filter((r) =>
@@ -350,11 +435,21 @@ function ExplorerPanel({
   );
 
   // Escape dismisses the PANEL, not the modal behind it — captured before the
-  // modal chassis' own document-level Escape listener can see it.
+  // modal chassis' own document-level Escape listener can see it. Which is also
+  // why the naming row cannot handle its own Escape: this listener sees the key
+  // first, so it has to know there is an inner thing to back out of and undo
+  // that instead. Read through a ref because the listener is bound once.
+  const namingOpen = useRef(false);
+  namingOpen.current = naming;
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopImmediatePropagation();
+        if (namingOpen.current) {
+          setNaming(false);
+          setNewName("");
+          return;
+        }
         onClose();
       }
     };
@@ -399,6 +494,39 @@ function ExplorerPanel({
         onChange={(e) => setFilter(e.target.value)}
       />
       <div className={"schedule-picker-list" + (loading ? " is-loading" : "")}>
+        {/* At the TOP of the listing, where the folder it is about to join
+            would sort — a row being typed, not a dialog over the panel. */}
+        {naming && (
+          <div className="schedule-picker-new">
+            {ICON_FOLDER}
+            <input
+              ref={nameRef}
+              type="text"
+              className="field-control schedule-picker-new-name"
+              placeholder="New folder name"
+              aria-label="New folder name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  confirmName();
+                }
+              }}
+            />
+            <button type="button" className="btn btn-primary schedule-picker-new-ok"
+                    disabled={!canCreate} onClick={confirmName}>
+              Use
+            </button>
+          </div>
+        )}
+        {naming && typedName !== "" && !canCreate && (
+          <p className="schedule-card-why schedule-form-bad">
+            {nameTaken
+              ? `“${typedName}” is already in this folder`
+              : "A folder name can't contain a slash"}
+          </p>
+        )}
         {error && <p className="schedule-card-why">{error}</p>}
         {!error && shown?.length === 0 && !loading && (
           <p className="schedule-card-why">
@@ -426,6 +554,15 @@ function ExplorerPanel({
         ))}
       </div>
       <div className="schedule-picker-foot">
+        {/* Left of the pair, because it acts on the folder you are IN rather
+            than on the errand — same side as the crumbs it reads off. Hidden
+            while a name is being typed: the row above is the control then. */}
+        {!error && !naming && (
+          <button type="button" className="btn btn-secondary schedule-picker-newbtn"
+                  onClick={() => setNaming(true)}>
+            + New folder
+          </button>
+        )}
         <button type="button" className="btn btn-secondary" onClick={onClose}>
           Cancel
         </button>
@@ -2107,38 +2244,37 @@ export default function NewJobModal({
   // Early path validation (Akshil, 2026-08-16 — "detect it before me
   // scanning the input"): a beat after typing stops, ask the server whether
   // the path exists. A folder answers listDir directly; a FILE fails it, so
-  // the parent is listed and the basename looked up — a file target is legal.
-  // null = fine (or still checking); a string is the red line under the row.
+  // the parent is listed and the basename looked up — a file target is legal,
+  // and so, since 2026-08-20, is ONE folder that isn't there yet (targetVerdict).
+  // `pathError` null = fine (or still checking); a string is the red line under
+  // the row. `newFolder` is the name being created, and is NOT a refusal — it
+  // rides alongside as the note saying what saving will do.
   const [pathError, setPathError] = useState<string | null>(null);
+  const [newFolder, setNewFolder] = useState<string | null>(null);
   useEffect(() => {
     const p = target.trim();
     if (!p) {
       setPathError(null);
+      setNewFolder(null);
       return;
     }
     let stale = false;
+    // Neither piece of state is cleared up front: the last verdict stays on
+    // screen until the next one resolves, so the note does not blink off and
+    // back on between keystrokes.
+    const settle = (v: TargetVerdict) => {
+      if (stale) return;
+      setPathError(v.kind === "bad" ? v.text : null);
+      setNewFolder(v.kind === "new-folder" ? v.name : null);
+    };
     const timer = window.setTimeout(() => {
       listDir(p).then(
+        () => settle({ kind: "ok" }),
         () => {
-          if (!stale) setPathError(null);
-        },
-        () => {
-          const norm = normPath(p).replace(/\/+$/, "");
-          const cut = norm.lastIndexOf("/");
-          const parent = cut > 0 ? norm.slice(0, cut) : "/";
-          const base = norm.slice(cut + 1);
+          const { parent } = splitTargetPath(p);
           listDir(parent).then(
-            (r) => {
-              if (stale) return;
-              setPathError(
-                r.entries.some((e) => e.name === base)
-                  ? null
-                  : "This folder or file doesn't exist",
-              );
-            },
-            () => {
-              if (!stale) setPathError("This folder or file doesn't exist");
-            },
+            (r) => settle(targetVerdict(p, r.entries.map((e) => e.name))),
+            () => settle(targetVerdict(p, null)),
           );
         },
       );
@@ -2247,6 +2383,11 @@ export default function NewJobModal({
   // consequence and never blocks Save.
   const pastHintId = useId();
   const pathErrorId = useId();
+  // The new-folder note is described-by too — a screen reader must hear "this
+  // folder is about to be created" from the field, not only from the line under
+  // it. Only ever one of the two is on screen (a refusal and a promise about the
+  // same path cannot both be true), so they share the one slot.
+  const newFolderId = useId();
   // …and the third: what the repeat does to this task's thread, attached to
   // the checkbox that decides it.
   const threadHintId = useId();
@@ -2727,7 +2868,9 @@ export default function NewJobModal({
               type="text"
               className={"field-control" + (pathError ? " is-invalid" : "")}
               aria-invalid={pathError !== null}
-              aria-describedby={pathError ? pathErrorId : undefined}
+              aria-describedby={
+                pathError ? pathErrorId : newFolder ? newFolderId : undefined
+              }
               placeholder="Add folder or file"
               role="combobox"
               aria-expanded={recentsOpen}
@@ -2786,6 +2929,18 @@ export default function NewJobModal({
           <span id={pathErrorId} className="field-hint schedule-form-bad schedule-form-sub"
                 role="alert">
             {pathError}
+          </span>
+        )}
+        {/* Not an alert and not red: nothing is wrong, something is ABOUT to
+            happen. The badge carries the fact ("New folder") and the sentence
+            says when it becomes true, because a badge alone reads as a label on
+            a folder that already exists. Same 26px gutter as the error line, so
+            whichever of the two is showing sits on the same edge. */}
+        {!pathError && newFolder && (
+          <span id={newFolderId} className="field-hint schedule-form-sub schedule-form-new"
+                role="status">
+            <span className="schedule-new-badge">New folder</span>
+            “{newFolder}” is created when the task is saved
           </span>
         )}
         {picking && (

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -24,7 +24,7 @@ import type { Config, RecurrenceRule, ScheduledMessage } from "@platform/lib/api
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { navigateUrl } from "@platform/lib/router";
 import { describeRepeats, describeRule, repeatChoicesFor } from "./schedule-lib";
-import { ICON_CLOCK, ICON_FOLDER } from "./ScheduleCalendar";
+import { ICON_CLOCK, ICON_FOLDER, ICON_PLUS } from "./ScheduleCalendar";
 // This card's own rules live in styles/new-task.css, imported from the
 // shell.css barrel like every other section — no shell component imports its
 // own CSS (tests/test_theme.py pins the barrel against the styles/ directory).
@@ -2930,15 +2930,23 @@ export default function NewJobModal({
               >
                 {/* What the typed path IS, answered where the other answers
                     about folders are — first row, above the folders that
-                    already exist, in the same row shape as them. Not a button:
-                    the path is already in the field, so there is nothing left
-                    to pick; it is the list telling you what it found. The badge
-                    carries the fact and the line under it says when it becomes
-                    true, because a badge alone reads as a label on a folder
-                    that is already there. */}
+                    already exist, in the same row shape as them. A BUTTON like
+                    every row around it: it started as an inert status and a
+                    click on it did nothing, which read as broken next to five
+                    siblings that all accept the click (Akshil, 2026-08-20).
+                    Picking it picks the path the field already holds, so the
+                    click's whole job is to close the list — same ending as
+                    picking any folder above. The badge carries the fact and
+                    the line under it says when it becomes true, because a
+                    badge alone reads as a label on a folder that is already
+                    there. */}
                 {!pathError && newFolder && (
-                  <div id={newFolderId} className="schedule-picker-row schedule-recents-new"
-                       role="status">
+                  <button
+                    type="button"
+                    id={newFolderId}
+                    className="schedule-picker-row schedule-recents-new"
+                    onClick={() => setRecentsOpen(false)}
+                  >
                     {ICON_FOLDER}
                     <span className="schedule-recents-new-text">
                       <span className="schedule-recents-new-top">
@@ -2951,7 +2959,7 @@ export default function NewJobModal({
                         Created when the task is saved
                       </span>
                     </span>
-                  </div>
+                  </button>
                 )}
                 {recents.slice(0, RECENTS_SHOWN).map((p) => (
                   <button
@@ -2993,8 +3001,12 @@ export default function NewJobModal({
                     openPicker(true);
                   }}
                 >
-                  <span className="schedule-picker-gutter" aria-hidden="true" />
-                  + New folder
+                  {/* The plus lives in the icon column, where every folder
+                      above carries its glyph — "+ New folder" as label text put
+                      the word on a different edge from every other label in
+                      the list (Akshil, 2026-08-20). */}
+                  {ICON_PLUS}
+                  New folder
                 </button>
               </div>
             )}

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -2974,6 +2974,12 @@ export default function NewJobModal({
                     {ICON_FOLDER} <span className="schedule-recents-path" title={p}>{p}</span>
                   </button>
                 ))}
+                {/* A separator ELEMENT, not a border-top on Browse: the border
+                    version sat flush against the row's hover wash and read as
+                    part of the button rather than as the line between the
+                    found paths and the verbs (Akshil, 2026-08-20). Full-bleed
+                    across the panel, the way every menu draws this line. */}
+                <div className="schedule-recents-sep" role="separator" />
                 <button
                   type="button"
                   className="schedule-picker-row schedule-recents-browse"

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -2302,22 +2302,14 @@ export default function NewJobModal({
     };
   }, [target]);
 
-  // The verdict now lives in the dropdown, so a verdict that arrives while the
-  // dropdown is shut would be invisible — the list has to come back up to carry
-  // it. Only after a deliberate act on the path (a keystroke, or a folder named
-  // in the picker), never on the prefill an Edit opens with: a card that popped
-  // a list open by itself before the user touched anything would be a jump
-  // scare, not an answer.
-  const revealNew = useRef(false);
-  useEffect(() => {
-    if (!newFolder || pathError || !revealNew.current) return;
-    // Consumed the moment the verdict is on screen, not only when this effect
-    // is the one that put it there: a verdict landing in an already-open list
-    // is revealed too, and a flag left set past that point would reopen the
-    // list on Escape — a dropdown that cannot stay dismissed (bugbot, #679).
-    revealNew.current = false;
-    if (!recentsOpen) openRecents();
-  }, [newFolder, pathError, recentsOpen, openRecents]);
+  // The verdict row rides the dropdown and NEVER forces it open. The reveal
+  // flag this replaced looked helpful — bring the list back so a late verdict
+  // is seen — but the verdict is debounced 400ms behind the keystroke that
+  // armed it, so "type, then click away" had the list popping back OVER
+  // whatever the user had moved on to, and there was no gesture that made it
+  // stay shut (Akshil, 2026-08-20). Typing holds focus and focus holds the
+  // list open, so in practice the verdict is seen exactly when it should be:
+  // while the path is still the thing being worked on.
 
   // The ask shares Title's borderless surface but not its face, and it grows
   // like a note: with the text, from the CSS floor (`.new-task-ask`'s
@@ -2924,12 +2916,7 @@ export default function NewJobModal({
                 openRecents();
               }}
               onClick={openRecents}
-              onChange={(e) => {
-                // Typed, so whatever the path turns out to be is worth showing:
-                // arm the reveal that brings the list back if it was dismissed.
-                revealNew.current = true;
-                setTarget(e.target.value);
-              }}
+              onChange={(e) => setTarget(e.target.value)}
             />
             {recentsOpen && (
               // mousedown preventDefault: keep focus ON the input while a row
@@ -3034,14 +3021,13 @@ export default function NewJobModal({
               setTarget(p);
               rememberRecent(p);
             }}
-            // Mouse path, same ending as the keyboard one: a folder NAMED in
-            // the picker hands focus back to the field and the list comes up
-            // carrying the new-folder row, so both ways of asking for a new
-            // folder are confirmed in the one place that says what will be
-            // created. Only for a named one — a plain "Use this folder" has
-            // nothing to confirm and must not pop a list over the form.
+            // A folder NAMED in the picker hands focus back to the field —
+            // WITHOUT popping the list over the form (Akshil, 2026-08-20: the
+            // dropdown kept coming back after "+ New folder"). The picker was
+            // the confirmation; the field now shows the path, and the list is
+            // one click away if anyone wants the verdict row too.
             onName={() => {
-              revealNew.current = true;
+              suppressOpen.current = true;
               window.setTimeout(() => pathRef.current?.focus(), 0);
             }}
             onClose={() => {

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -2310,9 +2310,13 @@ export default function NewJobModal({
   // scare, not an answer.
   const revealNew = useRef(false);
   useEffect(() => {
-    if (!newFolder || pathError || recentsOpen || !revealNew.current) return;
+    if (!newFolder || pathError || !revealNew.current) return;
+    // Consumed the moment the verdict is on screen, not only when this effect
+    // is the one that put it there: a verdict landing in an already-open list
+    // is revealed too, and a flag left set past that point would reopen the
+    // list on Escape — a dropdown that cannot stay dismissed (bugbot, #679).
     revealNew.current = false;
-    openRecents();
+    if (!recentsOpen) openRecents();
   }, [newFolder, pathError, recentsOpen, openRecents]);
 
   // The ask shares Title's borderless surface but not its face, and it grows

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -319,13 +319,23 @@ function ExplorerPanel({
   onPick,
   onClose,
   closing,
+  startNaming,
+  onName,
 }: {
   start: string;
   onPick: (path: string) => void;
   onClose: () => void;
+  // Fired alongside onPick when the picked path is a folder the user just
+  // NAMED here rather than one they clicked — the caller answers it by showing
+  // that the folder is about to be created.
+  onName?: () => void;
   // Mounted-but-leaving: paints the exit animation while the parent waits to
   // unmount, so the way out mirrors the way in.
   closing?: boolean;
+  // Opened BY "+ New folder" rather than by Browse: the panel comes up with the
+  // naming row already typing, so the button below Browse and the button inside
+  // the panel are one flow and not two (Akshil, 2026-08-20).
+  startNaming?: boolean;
 }) {
   // A file target starts the panel in its PARENT — listing a file's "children"
   // is a guaranteed error banner.
@@ -402,7 +412,7 @@ function ExplorerPanel({
   // the save, exactly as it is for a name typed straight into the path field —
   // so backing out of the card leaves nothing behind on disk, and the picker
   // needs no write endpoint to offer the affordance.
-  const [naming, setNaming] = useState(false);
+  const [naming, setNaming] = useState(!!startNaming);
   const [newName, setNewName] = useState("");
   const nameRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
@@ -427,6 +437,7 @@ function ExplorerPanel({
   const confirmName = () => {
     if (!canCreate) return;
     onPick(path.replace(/\/+$/, "") + "/" + typedName);
+    onName?.();
     onClose();
   };
   const crumbs = collapseCrumbs(crumbsOf(path));
@@ -2131,7 +2142,11 @@ export default function NewJobModal({
       setPickingOut(false);
     }, 180);
   };
-  const openPicker = () => {
+  // Which of the two dropdown verbs opened the panel: Browse lands on the
+  // listing, "+ New folder" lands on the listing WITH the naming row typing.
+  const [pickerNaming, setPickerNaming] = useState(false);
+  const openPicker = (naming = false) => {
+    setPickerNaming(naming);
     if (pickerTimer.current !== null) window.clearTimeout(pickerTimer.current);
     pickerTimer.current = null;
     setPickingOut(false);
@@ -2236,10 +2251,10 @@ export default function NewJobModal({
       return true;
     });
   }, [recentTargets, sessionFolders]);
-  const openRecents = () => {
+  const openRecents = useCallback(() => {
     setRecents(readRecentList());
     setRecentsOpen(true);
-  };
+  }, [readRecentList]);
 
   // Early path validation (Akshil, 2026-08-16 — "detect it before me
   // scanning the input"): a beat after typing stops, ask the server whether
@@ -2248,7 +2263,9 @@ export default function NewJobModal({
   // and so, since 2026-08-20, is ONE folder that isn't there yet (targetVerdict).
   // `pathError` null = fine (or still checking); a string is the red line under
   // the row. `newFolder` is the name being created, and is NOT a refusal — it
-  // rides alongside as the note saying what saving will do.
+  // is shown as a ROW IN THE DROPDOWN (Akshil, 2026-08-20: "this UI should be in
+  // dropdown"), beside the folders that already exist, rather than as an inline
+  // note under the field that pushed the rest of the form down as you typed.
   const [pathError, setPathError] = useState<string | null>(null);
   const [newFolder, setNewFolder] = useState<string | null>(null);
   useEffect(() => {
@@ -2284,6 +2301,19 @@ export default function NewJobModal({
       window.clearTimeout(timer);
     };
   }, [target]);
+
+  // The verdict now lives in the dropdown, so a verdict that arrives while the
+  // dropdown is shut would be invisible — the list has to come back up to carry
+  // it. Only after a deliberate act on the path (a keystroke, or a folder named
+  // in the picker), never on the prefill an Edit opens with: a card that popped
+  // a list open by itself before the user touched anything would be a jump
+  // scare, not an answer.
+  const revealNew = useRef(false);
+  useEffect(() => {
+    if (!newFolder || pathError || recentsOpen || !revealNew.current) return;
+    revealNew.current = false;
+    openRecents();
+  }, [newFolder, pathError, recentsOpen, openRecents]);
 
   // The ask shares Title's borderless surface but not its face, and it grows
   // like a note: with the text, from the CSS floor (`.new-task-ask`'s
@@ -2868,8 +2898,15 @@ export default function NewJobModal({
               type="text"
               className={"field-control" + (pathError ? " is-invalid" : "")}
               aria-invalid={pathError !== null}
+              // The new-folder row only exists while the list is open, so it is
+              // only pointed at while it is there — a describedby aimed at a
+              // node that is not in the document says nothing at all.
               aria-describedby={
-                pathError ? pathErrorId : newFolder ? newFolderId : undefined
+                pathError
+                  ? pathErrorId
+                  : newFolder && recentsOpen
+                    ? newFolderId
+                    : undefined
               }
               placeholder="Add folder or file"
               role="combobox"
@@ -2883,7 +2920,12 @@ export default function NewJobModal({
                 openRecents();
               }}
               onClick={openRecents}
-              onChange={(e) => setTarget(e.target.value)}
+              onChange={(e) => {
+                // Typed, so whatever the path turns out to be is worth showing:
+                // arm the reveal that brings the list back if it was dismissed.
+                revealNew.current = true;
+                setTarget(e.target.value);
+              }}
             />
             {recentsOpen && (
               // mousedown preventDefault: keep focus ON the input while a row
@@ -2895,6 +2937,31 @@ export default function NewJobModal({
                 style={popStyle(pathRef.current, 240, true)}
                 onMouseDown={(e) => e.preventDefault()}
               >
+                {/* What the typed path IS, answered where the other answers
+                    about folders are — first row, above the folders that
+                    already exist, in the same row shape as them. Not a button:
+                    the path is already in the field, so there is nothing left
+                    to pick; it is the list telling you what it found. The badge
+                    carries the fact and the line under it says when it becomes
+                    true, because a badge alone reads as a label on a folder
+                    that is already there. */}
+                {!pathError && newFolder && (
+                  <div id={newFolderId} className="schedule-picker-row schedule-recents-new"
+                       role="status">
+                    {ICON_FOLDER}
+                    <span className="schedule-recents-new-text">
+                      <span className="schedule-recents-new-top">
+                        <span className="schedule-picker-name" title={newFolder}>
+                          {newFolder}
+                        </span>
+                        <span className="schedule-new-badge">New folder</span>
+                      </span>
+                      <span className="schedule-recents-new-why">
+                        Created when the task is saved
+                      </span>
+                    </span>
+                  </div>
+                )}
                 {recents.slice(0, RECENTS_SHOWN).map((p) => (
                   <button
                     key={p}
@@ -2921,6 +2988,23 @@ export default function NewJobModal({
                   <span className="schedule-picker-gutter" aria-hidden="true" />
                   Browse…
                 </button>
+                {/* The second verb, under Browse (Akshil, 2026-08-20). Typing a
+                    name into the field is the fast way to a new folder and
+                    needs no button; this is the way in for someone who does not
+                    yet know it is allowed. It opens the SAME panel Browse does,
+                    already naming — one flow with the picker's own affordance,
+                    not a second one. */}
+                <button
+                  type="button"
+                  className="schedule-picker-row schedule-recents-mk"
+                  onClick={() => {
+                    setRecentsOpen(false);
+                    openPicker(true);
+                  }}
+                >
+                  <span className="schedule-picker-gutter" aria-hidden="true" />
+                  + New folder
+                </button>
               </div>
             )}
           </div>
@@ -2931,28 +3015,30 @@ export default function NewJobModal({
             {pathError}
           </span>
         )}
-        {/* Not an alert and not red: nothing is wrong, something is ABOUT to
-            happen. The badge carries the fact ("New folder") and the sentence
-            says when it becomes true, because a badge alone reads as a label on
-            a folder that already exists. Same 26px gutter as the error line, so
-            whichever of the two is showing sits on the same edge. */}
-        {!pathError && newFolder && (
-          <span id={newFolderId} className="field-hint schedule-form-sub schedule-form-new"
-                role="status">
-            <span className="schedule-new-badge">New folder</span>
-            “{newFolder}” is created when the task is saved
-          </span>
-        )}
         {picking && (
           // Slides in BESIDE the card (position:fixed; the card shifts left
           // via the :has() rule in schedule.css) — inside the card it was
           // "too small to see anything" (Akshil, 2026-08-16).
           <ExplorerPanel
+            // Keyed by which verb opened it, so "+ New folder" always arrives
+            // naming even when it displaces a Browse panel still animating out.
+            key={pickerNaming ? "naming" : "browse"}
+            startNaming={pickerNaming}
             start={target.trim() || home || "/"}
             onPick={(p) => {
               pickedFromBrowser.current = true;
               setTarget(p);
               rememberRecent(p);
+            }}
+            // Mouse path, same ending as the keyboard one: a folder NAMED in
+            // the picker hands focus back to the field and the list comes up
+            // carrying the new-folder row, so both ways of asking for a new
+            // folder are confirmed in the one place that says what will be
+            // created. Only for a named one — a plain "Use this folder" has
+            // nothing to confirm and must not pop a list over the form.
+            onName={() => {
+              revealNew.current = true;
+              window.setTimeout(() => pathRef.current?.focus(), 0);
             }}
             onClose={() => {
               closePicker();

--- a/frontend/src/shell/ScheduleCalendar.tsx
+++ b/frontend/src/shell/ScheduleCalendar.tsx
@@ -207,6 +207,7 @@ const icon = (paths: React.ReactNode) => (
 
 export const ICON_CLOCK = icon(<><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 3" /></>);
 export const ICON_FOLDER = icon(<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />);
+export const ICON_PLUS = icon(<><path d="M12 5v14" /><path d="M5 12h14" /></>);
 export const ICON_SHIELD = icon(<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />);
 export const ICON_EDIT = icon(<><path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" /></>);
 // Filing away — lucide `archive`, the same lidded box the List rows and the

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1646,12 +1646,18 @@ describe("where the new-folder answer is shown", () => {
     expect(src()).toContain("newFolder && recentsOpen");
   });
 
-  test("a verdict that lands on a shut dropdown reopens it", () => {
+  test("a verdict that lands on a shut dropdown reopens it — once", () => {
     const s = src();
     // Armed by a keystroke or by naming a folder in the picker — never by the
     // prefill an Edit opens with, which would pop a list nobody asked for.
     expect(s).toContain("revealNew.current = true;");
-    expect(s).toContain("if (!newFolder || pathError || recentsOpen || !revealNew.current) return;");
+    // The flag is consumed the moment the verdict is VISIBLE, even when the
+    // list was already open — an unconsumed flag would fire on the next
+    // recentsOpen flip and reopen a list the user just dismissed (bugbot,
+    // #679: Escape could never stick while newFolder was set).
+    expect(s).toContain("if (!newFolder || pathError || !revealNew.current) return;");
+    expect(s).toContain("if (!recentsOpen) openRecents();");
+    expect(s).not.toContain("recentsOpen || !revealNew.current");
   });
 });
 

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1674,6 +1674,25 @@ describe("the + New folder button below Browse", () => {
     expect(s).toContain('className="schedule-picker-row schedule-recents-mk"');
   });
 
+  test("its plus is the row's icon, not label text", () => {
+    const s = src();
+    // "+ New folder" as label text put the word on a different edge from every
+    // other label in the list (Akshil, 2026-08-20) — the plus rides the icon
+    // column like the folders' glyphs, and the label is just "New folder".
+    expect(s).toContain("{ICON_PLUS}");
+    expect(s).not.toContain(">\n                  + New folder");
+  });
+
+  test("clicking the verdict row keeps the path and closes the list", () => {
+    const s = src();
+    // It began as an inert role="status" div; a dead click beside five live
+    // rows read as broken (Akshil, 2026-08-20). The path is already in the
+    // field, so the click's whole job is the close.
+    expect(s).toContain('className="schedule-picker-row schedule-recents-new"');
+    const row = s.indexOf("schedule-recents-new\"");
+    expect(s.indexOf("onClick={() => setRecentsOpen(false)}", row)).toBeGreaterThan(row);
+  });
+
   test("it opens the picker already naming — one flow, not a second one", () => {
     const s = src();
     expect(s).toContain("openPicker(true)");

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1646,18 +1646,16 @@ describe("where the new-folder answer is shown", () => {
     expect(src()).toContain("newFolder && recentsOpen");
   });
 
-  test("a verdict that lands on a shut dropdown reopens it — once", () => {
+  test("the verdict never forces the dropdown open", () => {
     const s = src();
-    // Armed by a keystroke or by naming a folder in the picker — never by the
-    // prefill an Edit opens with, which would pop a list nobody asked for.
-    expect(s).toContain("revealNew.current = true;");
-    // The flag is consumed the moment the verdict is VISIBLE, even when the
-    // list was already open — an unconsumed flag would fire on the next
-    // recentsOpen flip and reopen a list the user just dismissed (bugbot,
-    // #679: Escape could never stick while newFolder was set).
-    expect(s).toContain("if (!newFolder || pathError || !revealNew.current) return;");
-    expect(s).toContain("if (!recentsOpen) openRecents();");
-    expect(s).not.toContain("recentsOpen || !revealNew.current");
+    // The reveal flag is GONE (Akshil, 2026-08-20): the verdict is debounced
+    // 400ms behind the keystroke, so any "bring the list back for it" logic
+    // reopened the dropdown after the user had clicked away — a dropdown that
+    // could not stay dismissed. The row rides the open list only.
+    expect(s).not.toContain("revealNew");
+    // A folder named in the picker refocuses the field WITHOUT the focus
+    // handler popping the list over the form.
+    expect(s).toContain("suppressOpen.current = true;\n              window.setTimeout(() => pathRef.current?.focus(), 0);");
   });
 });
 

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1590,7 +1590,7 @@ describe("the path field's verdict on a folder that isn't there yet", () => {
 
   test("a new folder does not block Save — only a bad path does", () => {
     // The verdict feeds two separate pieces of state, and only `bad` becomes
-    // `pathError`. The note under the field is not a refusal.
+    // `pathError`. The new-folder row is not a refusal.
     const src = readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
     expect(src).toContain('setPathError(v.kind === "bad" ? v.text : null);');
     expect(src).toContain('setNewFolder(v.kind === "new-folder" ? v.name : null);');
@@ -1604,5 +1604,86 @@ describe("the path field's verdict on a folder that isn't there yet", () => {
     expect(src).toContain("+ New folder");
     // Escape backs out of the naming row before it backs out of the panel.
     expect(src).toContain("if (namingOpen.current) {");
+  });
+});
+
+// ---- The verdict is shown in the dropdown, not under the field ---------------
+// "this UI should be in dropdown" (Akshil, 2026-08-20). The new-folder answer
+// used to be a row that appeared BELOW the path input and pushed the rest of the
+// card down as you typed; it now renders as the first row of the path field's
+// own dropdown, in the row shape of the folders listed under it.
+describe("where the new-folder answer is shown", () => {
+  const src = () => readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+  const css = () =>
+    readFileSync(join(import.meta.dir, "../styles/schedule.css"), "utf8");
+
+  test("the row lives inside the recents dropdown", () => {
+    const s = src();
+    const open = s.indexOf('className="schedule-recents"');
+    const rowAt = s.indexOf("schedule-recents-new\"");
+    expect(open).toBeGreaterThan(-1);
+    expect(rowAt).toBeGreaterThan(open);
+    // …and BEFORE the recents rows it sorts above.
+    expect(rowAt).toBeLessThan(s.indexOf("recents.slice(0, RECENTS_SHOWN)"));
+  });
+
+  test("no inline note is left under the path field", () => {
+    // The old row's two markers: its own class, and the sentence it carried.
+    expect(src()).not.toContain("schedule-form-new");
+    expect(src()).not.toContain("is created when the task is saved");
+    expect(css()).not.toContain(".schedule-form-new {");
+  });
+
+  test("the badge is kept, and now reads inside a dropdown row", () => {
+    expect(src()).toContain('<span className="schedule-new-badge">New folder</span>');
+    expect(src()).toContain("Created when the task is saved");
+    expect(css()).toContain(".schedule-new-badge {");
+  });
+
+  test("the field only points at the row while the row is on screen", () => {
+    // aria-describedby aimed at a node that is not in the document says nothing,
+    // and the row only exists while the list is open.
+    expect(src()).toContain("newFolder && recentsOpen");
+  });
+
+  test("a verdict that lands on a shut dropdown reopens it", () => {
+    const s = src();
+    // Armed by a keystroke or by naming a folder in the picker — never by the
+    // prefill an Edit opens with, which would pop a list nobody asked for.
+    expect(s).toContain("revealNew.current = true;");
+    expect(s).toContain("if (!newFolder || pathError || recentsOpen || !revealNew.current) return;");
+  });
+});
+
+// ---- The second verb: "+ New folder" under Browse ----------------------------
+describe("the + New folder button below Browse", () => {
+  const src = () => readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+
+  test("it sits after Browse in the same dropdown", () => {
+    const s = src();
+    const browse = s.indexOf("Browse…");
+    const mk = s.indexOf("schedule-recents-mk");
+    expect(browse).toBeGreaterThan(-1);
+    expect(mk).toBeGreaterThan(browse);
+    // Same row vocabulary as Browse, so the prefs-section button skin cannot
+    // shrink-wrap it (that is what .schedule-form .schedule-picker-row fixes).
+    expect(s).toContain('className="schedule-picker-row schedule-recents-mk"');
+  });
+
+  test("it opens the picker already naming — one flow, not a second one", () => {
+    const s = src();
+    expect(s).toContain("openPicker(true)");
+    expect(s).toContain("const [naming, setNaming] = useState(!!startNaming);");
+    // Keyed so it arrives naming even over a Browse panel still animating out.
+    expect(s).toContain('key={pickerNaming ? "naming" : "browse"}');
+  });
+
+  test("a folder named in the picker ends in the same dropdown row", () => {
+    const s = src();
+    // onName is the picker saying "this one was NAMED, not clicked" — only then
+    // does the field take focus back and the list come up with the verdict.
+    expect(s).toContain("onName?.();");
+    expect(s).toContain("onName={() => {");
+    expect(s).toContain("pathRef.current?.focus()");
   });
 });

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -45,6 +45,10 @@ let pastNoteFor: typeof import("./NewJobModal").pastNoteFor;
 let PAST_NOTE_ONE_OFF: typeof import("./NewJobModal").PAST_NOTE_ONE_OFF;
 let PAST_NOTE_CATCH_UP: typeof import("./NewJobModal").PAST_NOTE_CATCH_UP;
 let defaultTargetOf: typeof import("./NewJobModal").defaultTargetOf;
+let targetVerdict: typeof import("./NewJobModal").targetVerdict;
+let splitTargetPath: typeof import("./NewJobModal").splitTargetPath;
+let PATH_MISSING: typeof import("./NewJobModal").PATH_MISSING;
+let twoLevelsMissing: typeof import("./NewJobModal").twoLevelsMissing;
 
 beforeAll(async () => {
   const mod = await import("./NewJobModal");
@@ -73,6 +77,10 @@ beforeAll(async () => {
   PAST_NOTE_ONE_OFF = mod.PAST_NOTE_ONE_OFF;
   PAST_NOTE_CATCH_UP = mod.PAST_NOTE_CATCH_UP;
   defaultTargetOf = mod.defaultTargetOf;
+  targetVerdict = mod.targetVerdict;
+  splitTargetPath = mod.splitTargetPath;
+  PATH_MISSING = mod.PATH_MISSING;
+  twoLevelsMissing = mod.twoLevelsMissing;
 });
 
 // Only the fields these functions read; the rest of a stored entry is noise
@@ -1520,5 +1528,81 @@ describe("the folder recents come from the app's own recents", () => {
     // suggestions, never the form.
     expect(src).toContain("getClaudeSessionFolders().then(");
     expect(src).toContain("      () => {},");
+  });
+});
+
+// ---- One new folder, and only one -------------------------------------------
+// The path field accepts a folder that does not exist YET (Akshil, 2026-08-20).
+// `targetVerdict` is the whole decision: it is handed the path and whatever the
+// PARENT's listing came back with, and answers with one of three things.
+describe("the path field's verdict on a folder that isn't there yet", () => {
+  test("a name the parent already holds is a plain target, not a new folder", () => {
+    // How a FILE target reaches here: listing the path itself failed (it is not
+    // a directory), so the parent was listed and the basename found in it.
+    expect(targetVerdict("/Users/a/fused/notes.md", ["notes.md", "src"]))
+      .toEqual({ kind: "ok" });
+  });
+
+  test("a missing last segment under an existing parent is a new folder", () => {
+    expect(targetVerdict("/Users/a/fused/ABC1", ["src", "notes.md"]))
+      .toEqual({ kind: "new-folder", name: "ABC1", parent: "/Users/a/fused" });
+  });
+
+  test("a trailing slash names the same folder", () => {
+    // Typing a path usually ends with the separator; it must not turn the name
+    // into an empty segment and read as junk.
+    expect(targetVerdict("/Users/a/fused/ABC1/", ["src"]))
+      .toEqual({ kind: "new-folder", name: "ABC1", parent: "/Users/a/fused" });
+  });
+
+  test("a backslash path is normalised before it is split", () => {
+    expect(targetVerdict("C:\\Users\\a\\ABC1", ["Desktop"]))
+      .toEqual({ kind: "new-folder", name: "ABC1", parent: "C:/Users/a" });
+  });
+
+  test("two missing levels is refused, and says which one is missing", () => {
+    // null = the PARENT could not be listed either, so this is not "name me a
+    // folder", it is "build me a tree" — the ask a typo makes by accident.
+    expect(targetVerdict("/Users/a/new1/new2", null)).toEqual({
+      kind: "bad",
+      text: twoLevelsMissing("/Users/a/new1"),
+    });
+    expect(twoLevelsMissing("/Users/a/new1")).toContain("Only one new folder");
+    expect(twoLevelsMissing("/Users/a/new1")).toContain("/Users/a/new1");
+  });
+
+  test("a path with no last segment to create is the old refusal", () => {
+    // "." and ".." name somewhere that exists by definition, so arriving here
+    // with one means the string was junk rather than a new name.
+    expect(targetVerdict("/Users/a/fused/..", ["src"]))
+      .toEqual({ kind: "bad", text: PATH_MISSING });
+    expect(targetVerdict("/Users/a/fused/.", ["src"]))
+      .toEqual({ kind: "bad", text: PATH_MISSING });
+  });
+
+  test("splitTargetPath keeps a drive root's slash", () => {
+    // Bare "C:" reads as cwd-relative everywhere else in the shell.
+    expect(splitTargetPath("C:/ABC1")).toEqual({ parent: "C:/", base: "ABC1" });
+    expect(splitTargetPath("/ABC1")).toEqual({ parent: "/", base: "ABC1" });
+    expect(splitTargetPath("/Users/a/fused/ABC1"))
+      .toEqual({ parent: "/Users/a/fused", base: "ABC1" });
+  });
+
+  test("a new folder does not block Save — only a bad path does", () => {
+    // The verdict feeds two separate pieces of state, and only `bad` becomes
+    // `pathError`. The note under the field is not a refusal.
+    const src = readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+    expect(src).toContain('setPathError(v.kind === "bad" ? v.text : null);');
+    expect(src).toContain('setNewFolder(v.kind === "new-folder" ? v.name : null);');
+  });
+
+  test("the picker's New folder only NAMES one — nothing is written on cancel", () => {
+    const src = readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+    // No /api/fs/mkdir from this modal: the folder is created by the save, so
+    // backing out of the card leaves nothing behind on disk.
+    expect(src).not.toContain("mkdir");
+    expect(src).toContain("+ New folder");
+    // Escape backs out of the naming row before it backs out of the panel.
+    expect(src).toContain("if (namingOpen.current) {");
   });
 });

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -1406,6 +1406,70 @@
   border-top-color: var(--border);
 }
 
+/* "+ New folder" sits directly under Browse and belongs to the same verb group,
+   so it takes Browse's weight but NOT a second hairline — one rule separates
+   the nouns from the verbs, and the bottom rounding moves to whichever verb is
+   last. */
+.schedule-form .schedule-picker-row.schedule-recents-browse {
+  border-radius: 0;
+}
+
+.schedule-form .schedule-picker-row.schedule-recents-mk {
+  font-weight: 500;
+}
+
+.schedule-form .schedule-picker-row.schedule-recents-browse:last-child,
+.schedule-form .schedule-picker-row.schedule-recents-mk:last-child {
+  border-radius: 0 0 8px 8px;
+}
+
+/* The verdict row: what the typed path IS, in the row shape of the folders
+   below it — but never a hover surface or a pointer, because it is the list
+   answering rather than one more thing to click. The hairline under it is the
+   mirror of Browse's: found-things above, existing things below. */
+.schedule-form .schedule-recents-new {
+  align-items: flex-start;
+  cursor: default;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+
+/* No hover wash: it borrows the row shape, not the row's promise that clicking
+   does something. */
+.schedule-form .schedule-recents-new:hover,
+.deploy-body .schedule-form .schedule-recents-new:hover,
+.prefs-section .schedule-form .schedule-recents-new:hover {
+  background: transparent;
+}
+
+.schedule-form .schedule-recents-new svg {
+  /* Pulled onto the first line's baseline now the row is two lines tall. */
+  margin-top: 2px;
+}
+
+.schedule-recents-new-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.schedule-recents-new-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* The line that says WHEN the folder starts existing. Muted and small: the
+   badge above already carried the fact, this only dates it. */
+.schedule-recents-new-why {
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
 /* The empty column where an icon would be, so a row without one still starts
    its label on the icon grid. */
 .schedule-picker-gutter {
@@ -2308,9 +2372,10 @@ input.schedule-when-field {
 }
 
 /* -- Naming a folder that does not exist yet ------------------------------
-   Two surfaces say the same thing: this row inside the picker, and the note
-   under the path field (.schedule-form-new below). Neither writes to disk —
-   the folder is created by the save. */
+   Two surfaces say the same thing: this row inside the picker, and the
+   new-folder row in the path field's dropdown (.schedule-recents-new, up with
+   the rest of that list). Neither writes to disk — the folder is created by
+   the save. The badge at the bottom of this block is shared by both. */
 
 /* Pushed to the far edge, away from Cancel / Use this folder: it acts on the
    folder you are standing IN, not on the errand the pair finishes. */
@@ -2343,17 +2408,6 @@ input.schedule-when-field {
 .schedule-picker-new-ok {
   flex: none;
   padding: 4px 10px;
-}
-
-/* The path field's new-folder note. NOT the error voice (.schedule-form-bad):
-   nothing is wrong, so it stays in the muted hint colour and lets the badge
-   beside it carry the one word that matters. */
-.schedule-form-new {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-  color: var(--fg-muted);
 }
 
 .schedule-new-badge {

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -1390,7 +1390,6 @@
    every label in the list starts on one edge (audit 2026-08-16). */
 .schedule-form .schedule-picker-row.schedule-recents-browse {
   border-top: 1px solid var(--border);
-  border-radius: 0 0 8px 8px;
   margin-top: 4px;
   /* Plain text, not accent (Akshil, 2026-08-16): the hairline and the
      position already say it is the odd row out, and the accent read as a
@@ -1408,19 +1407,12 @@
 
 /* "+ New folder" sits directly under Browse and belongs to the same verb group,
    so it takes Browse's weight but NOT a second hairline — one rule separates
-   the nouns from the verbs, and the bottom rounding moves to whichever verb is
-   last. */
-.schedule-form .schedule-picker-row.schedule-recents-browse {
-  border-radius: 0;
-}
-
+   the nouns from the verbs. Both verbs keep the base row's 6px hover wash —
+   the panel's own 4px padding already holds every wash off its corners, and a
+   square-cornered wash on the last row read as a different kind of row
+   (Akshil, 2026-08-20). */
 .schedule-form .schedule-picker-row.schedule-recents-mk {
   font-weight: 500;
-}
-
-.schedule-form .schedule-picker-row.schedule-recents-browse:last-child,
-.schedule-form .schedule-picker-row.schedule-recents-mk:last-child {
-  border-radius: 0 0 8px 8px;
 }
 
 /* The verdict row: what the typed path IS, in the row shape of the folders

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -1416,23 +1416,23 @@
 }
 
 /* The verdict row: what the typed path IS, in the row shape of the folders
-   below it — but never a hover surface or a pointer, because it is the list
-   answering rather than one more thing to click. The hairline under it is the
-   mirror of Browse's: found-things above, existing things below. */
+   below it — and clickable like them: picking it keeps the path the field
+   already holds and closes the list (it began as an inert status row and a
+   dead click next to five live siblings read as broken — Akshil, 2026-08-20).
+   The base row rule supplies the cursor and the hover wash. The hairline under
+   it is the mirror of Browse's: found-things above, existing things below. */
 .schedule-form .schedule-recents-new {
   align-items: flex-start;
-  cursor: default;
   padding-bottom: 8px;
   border-bottom: 1px solid var(--border);
   margin-bottom: 4px;
 }
 
-/* No hover wash: it borrows the row shape, not the row's promise that clicking
-   does something. */
-.schedule-form .schedule-recents-new:hover,
-.deploy-body .schedule-form .schedule-recents-new:hover,
-.prefs-section .schedule-form .schedule-recents-new:hover {
-  background: transparent;
+/* Same armor as Browse's hairline: the ambient button:hover skins repaint
+   border-color wholesale, and this row's bottom border IS the separator. */
+.deploy-body .schedule-form .schedule-recents-new:hover:not(:disabled),
+.prefs-section .schedule-form .schedule-recents-new:hover:not(:disabled) {
+  border-bottom-color: var(--border);
 }
 
 .schedule-form .schedule-recents-new svg {

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -1382,27 +1382,24 @@
   white-space: nowrap;
 }
 
-/* Browse closes the list of nouns with the one verb, set off by a hairline.
-   The doubled selector outranks the base row rule's border:none. Padding is
-   the recents rows' own (6px 8px, NOT a fattened 8px top): the verb is one
-   more row, so it has to be the same height as the nouns above it — the
-   4px margin is what sets it apart, and it carries the same icon gutter so
-   every label in the list starts on one edge (audit 2026-08-16). */
-.schedule-form .schedule-picker-row.schedule-recents-browse {
-  border-top: 1px solid var(--border);
-  margin-top: 4px;
-  /* Plain text, not accent (Akshil, 2026-08-16): the hairline and the
-     position already say it is the odd row out, and the accent read as a
-     link into somewhere else rather than one more choice in the list. */
-  font-weight: 500;
+/* The line between the found paths and the verbs. Its OWN element, not a
+   border-top on Browse: a border rode inside the button, sat flush against its
+   hover wash, and could be repainted by the ambient button:hover skins — three
+   problems a plain div has none of (Akshil, 2026-08-20: "a proper separator").
+   Full-bleed across the panel (the negative inline margins cancel the panel's
+   4px padding), the way every menu draws this line. */
+.schedule-recents-sep {
+  height: 1px;
+  flex: none;
+  background: var(--border);
+  margin: 4px -4px;
 }
 
-/* `.deploy-body button:hover` repaints border-color wholesale — including the
-   top hairline this row IS — so a hover turned the separator accent-green
-   (audit 2026-08-16). Restated, armored past that skin. */
-.deploy-body .schedule-form .schedule-picker-row.schedule-recents-browse:hover:not(:disabled),
-.prefs-section .schedule-form .schedule-picker-row.schedule-recents-browse:hover:not(:disabled) {
-  border-top-color: var(--border);
+/* Plain text, not accent (Akshil, 2026-08-16): the separator and the position
+   already say Browse is the odd row out, and the accent read as a link into
+   somewhere else rather than one more choice in the list. */
+.schedule-form .schedule-picker-row.schedule-recents-browse {
+  font-weight: 500;
 }
 
 /* "+ New folder" sits directly under Browse and belongs to the same verb group,

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2307,6 +2307,68 @@ input.schedule-when-field {
   gap: 8px;
 }
 
+/* -- Naming a folder that does not exist yet ------------------------------
+   Two surfaces say the same thing: this row inside the picker, and the note
+   under the path field (.schedule-form-new below). Neither writes to disk —
+   the folder is created by the save. */
+
+/* Pushed to the far edge, away from Cancel / Use this folder: it acts on the
+   folder you are standing IN, not on the errand the pair finishes. */
+.schedule-picker-newbtn {
+  margin-right: auto;
+}
+
+/* Sits where the folder it names will sort — first row of the listing — so it
+   reads as a row being typed rather than a dialog laid over the panel.
+   align-self/width for the same reason .schedule-picker-row restates them: the
+   listing is a flex COLUMN with align-content:flex-start, which shrink-wraps a
+   child to its content and left the name box a third of the panel wide. */
+.schedule-picker-new {
+  display: flex;
+  align-self: stretch;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px 8px;
+}
+
+.schedule-picker-new-name {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Matched to the field beside it rather than to the foot's pills: the pair is
+   one control, and a full-height Save-shaped pill next to a 28px input read as
+   two. */
+.schedule-picker-new-ok {
+  flex: none;
+  padding: 4px 10px;
+}
+
+/* The path field's new-folder note. NOT the error voice (.schedule-form-bad):
+   nothing is wrong, so it stays in the muted hint colour and lets the badge
+   beside it carry the one word that matters. */
+.schedule-form-new {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  color: var(--fg-muted);
+}
+
+.schedule-new-badge {
+  flex: none;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-alt);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: none;
+  color: var(--fg);
+}
+
 /* One shape for "this is the commit": the modal's Save, the explorer's "Use
    this folder" and the recurrence section's Done are the same promise, so they
    are the same pill (audit 2026-08-16). */

--- a/fused_render/schedule.py
+++ b/fused_render/schedule.py
@@ -561,7 +561,8 @@ def _from_local(when: datetime) -> datetime:
 def create(target: str, message: str, due=None, session_id: str = "",
            permission_mode: str = "", repeats: str = "",
            rule: dict | None = None, title=None, description=None,
-           new_task_each_run=None, session_learned=None) -> dict:
+           new_task_each_run=None, session_learned=None,
+           create_target: bool = False) -> dict:
     """Validate and store one scheduled message; return the stored entry.
 
     `title` and `description` are the user's own words about the work, both
@@ -610,6 +611,20 @@ def create(target: str, message: str, due=None, session_id: str = "",
     rewritten on every materialization to mirror the next occurrence, and a
     series numbered from a moving anchor would renumber itself every tick.
 
+    `create_target` opts the caller into ONE new folder: a target whose last
+    segment does not exist yet is made here, provided its parent already does.
+    The New task form offers this (it shows the path as a new folder while you
+    type it), so the endpoint behind that form passes it; every other caller
+    leaves it off and keeps the plain "no such file or directory" refusal. It is
+    a flag rather than the default precisely because of the re-send path
+    (`resend` below), where a target that has since been deleted is a fact the
+    user needs told — silently re-making a deleted FILE's name as a directory
+    would be the worst possible answer.
+
+    Exactly one level, never `-p`: two missing segments means the user is not
+    naming a new folder in a place they know, they are typing into a tree that
+    is not there, and inventing both is how a typo becomes a real directory.
+
     Raises ValueError for everything a caller can get wrong (the router maps it
     to a 400). The one validation deliberately NOT here is "is this path
     mount-backed" — that needs the mounts registry, which lives above this
@@ -621,7 +636,31 @@ def create(target: str, message: str, due=None, session_id: str = "",
         raise ValueError("target: required")
     target = os.path.abspath(os.path.expanduser(target))
     if not os.path.exists(target):
-        raise ValueError(f"target: no such file or directory: {target}")
+        if not create_target:
+            raise ValueError(f"target: no such file or directory: {target}")
+        parent = os.path.dirname(target)
+        # abspath has already collapsed "." and "..", so a basename of either is
+        # only reachable at the filesystem root — where there is nothing to make.
+        if not os.path.basename(target) or os.path.basename(target) in (".", ".."):
+            raise ValueError(f"target: no such file or directory: {target}")
+        if not os.path.isdir(parent):
+            raise ValueError(
+                f"target: only one new folder can be created, and {parent} "
+                "does not exist either")
+        try:
+            # mkdir, not makedirs: the one-level rule is enforced by the call
+            # itself, so a parent that vanishes between the check above and here
+            # raises rather than being invented.
+            os.mkdir(target)
+        except FileExistsError:
+            # Someone else made it in the meantime, which is the outcome asked
+            # for. Only a non-directory is a problem, and os.path.exists above
+            # would not have missed one that was already there.
+            if not os.path.isdir(target):
+                raise ValueError(
+                    f"target: {target} exists and is not a folder") from None
+        except OSError as exc:
+            raise ValueError(f"target: could not create {target}: {exc}") from exc
 
     repeats = (repeats or "").strip()
     if rule is not None and repeats:

--- a/fused_render/schedule.py
+++ b/fused_render/schedule.py
@@ -625,6 +625,12 @@ def create(target: str, message: str, due=None, session_id: str = "",
     naming a new folder in a place they know, they are typing into a tree that
     is not there, and inventing both is how a typo becomes a real directory.
 
+    The folder is CHECKED where the target is resolved and MADE at the very
+    bottom, immediately before the entry is stored — so a request refused by a
+    later validation (a cron line, a due date, a permission mode) leaves nothing
+    on disk. Ordering rather than a rollback: an unlink after the fact could
+    remove a directory something else had already raced into.
+
     Raises ValueError for everything a caller can get wrong (the router maps it
     to a 400). The one validation deliberately NOT here is "is this path
     mount-backed" — that needs the mounts registry, which lives above this
@@ -635,6 +641,14 @@ def create(target: str, message: str, due=None, session_id: str = "",
     if not isinstance(target, str) or not target.strip():
         raise ValueError("target: required")
     target = os.path.abspath(os.path.expanduser(target))
+    # The new folder is only CHECKED here; it is made at the very bottom, right
+    # before the entry is stored. Everything between this point and there can
+    # still refuse the request (a cron line that will not parse, an unreadable
+    # due date, an unknown permission mode), and a directory made up here would
+    # outlive that refusal — the user gets a 400 and an empty folder they never
+    # asked for. Deciding now and acting last keeps the create path all-or-
+    # nothing without a rollback that could delete someone else's work.
+    make_target = False
     if not os.path.exists(target):
         if not create_target:
             raise ValueError(f"target: no such file or directory: {target}")
@@ -647,20 +661,7 @@ def create(target: str, message: str, due=None, session_id: str = "",
             raise ValueError(
                 f"target: only one new folder can be created, and {parent} "
                 "does not exist either")
-        try:
-            # mkdir, not makedirs: the one-level rule is enforced by the call
-            # itself, so a parent that vanishes between the check above and here
-            # raises rather than being invented.
-            os.mkdir(target)
-        except FileExistsError:
-            # Someone else made it in the meantime, which is the outcome asked
-            # for. Only a non-directory is a problem, and os.path.exists above
-            # would not have missed one that was already there.
-            if not os.path.isdir(target):
-                raise ValueError(
-                    f"target: {target} exists and is not a folder") from None
-        except OSError as exc:
-            raise ValueError(f"target: could not create {target}: {exc}") from exc
+        make_target = True
 
     repeats = (repeats or "").strip()
     if rule is not None and repeats:
@@ -787,6 +788,24 @@ def create(target: str, message: str, due=None, session_id: str = "",
         # scheduled. Counting only the ones that fired would quietly extend the
         # series every time the app was closed at the wrong moment.
         entry["made"] = 0
+    if make_target:
+        # LAST, after every validation above has had its chance to refuse: from
+        # here on the only thing left is writing the entry, so the folder and
+        # the task appear together or neither does.
+        try:
+            # mkdir, not makedirs: the one-level rule is enforced by the call
+            # itself, so a parent that vanished since the check above raises
+            # rather than being invented.
+            os.mkdir(target)
+        except FileExistsError:
+            # Someone else made it in the meantime, which is the outcome asked
+            # for. Only a non-directory is a problem, and os.path.exists above
+            # would not have missed one that was already there.
+            if not os.path.isdir(target):
+                raise ValueError(
+                    f"target: {target} exists and is not a folder") from None
+        except OSError as exc:
+            raise ValueError(f"target: could not create {target}: {exc}") from exc
     with _lock:
         entries = _read()
         entries.append(entry)

--- a/fused_render/server/routers/schedule.py
+++ b/fused_render/server/routers/schedule.py
@@ -188,7 +188,13 @@ def api_schedule_create(body: dict = Body(...),
             repeats=repeats, rule=rule,
             title=body.get("title"), description=body.get("description"),
             new_task_each_run=body.get("new_task_each_run"),
-            session_learned=body.get("session_learned"))
+            session_learned=body.get("session_learned"),
+            # THE ONE ENDPOINT ALLOWED TO MAKE A FOLDER. The New task form lets
+            # you name a folder that does not exist yet — it shows the path as a
+            # new folder while you type it — and this is where that promise is
+            # kept: one missing leaf under an existing parent is created, two
+            # missing levels are still a 400. See `schedule.create`.
+            create_target=True)
     except ValueError as exc:
         return _error(str(exc), status=400)
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -141,6 +141,28 @@ def test_create_target_makes_one_folder_and_only_one(target):
     assert not (target / "ABC2").exists()
 
 
+def test_a_refused_create_leaves_no_new_folder_behind(target):
+    """The folder is made LAST, after every other validation has had its chance
+    to refuse. A request that 400s on its cron line, its due date or its
+    permission mode used to leave the leaf directory on disk anyway — an empty
+    folder the user never got a task for, and never asked for."""
+    for kwargs, match in (
+        ({"repeats": "not a cron line"}, "cron|field|repeats"),
+        ({"due": "next tuesday"}, "ISO 8601"),
+        ({"permission_mode": "bypassPermissions"}, "permission_mode"),
+        ({"rule": {"freq": "day"}, "due": None}, "due"),
+    ):
+        due = kwargs.pop("due", _in(600))
+        leaf = target / "leaf"
+        with pytest.raises(ValueError, match=match):
+            schedule.create(str(leaf), "hi", due, create_target=True, **kwargs)
+        assert not leaf.exists(), f"{kwargs} left {leaf} behind"
+
+    # And the happy path still makes it, so the reorder did not just drop it.
+    schedule.create(str(target / "leaf"), "hi", _in(600), create_target=True)
+    assert (target / "leaf").is_dir()
+
+
 def test_create_target_leaves_an_existing_target_alone(target):
     """The flag is permission to create, not an instruction to. Something that is
     already there is used as-is — including a FILE target, which stays legal

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -120,6 +120,37 @@ def test_create_rejects_what_a_caller_can_get_wrong(target):
                         permission_mode="bypassPermissions")
 
 
+def test_create_target_makes_one_folder_and_only_one(target):
+    """`create_target` is opt-in, and one level deep. Off, a missing target is
+    the same refusal it always was — which is what the re-send path relies on:
+    a target that has since been deleted is a fact its user needs told, not one
+    to paper over with an empty directory (and re-making a deleted FILE's name
+    as a folder would be the worst answer available)."""
+    schedule.create(str(target / "ABC1"), "hi", _in(600), create_target=True)
+    assert (target / "ABC1").is_dir()
+
+    # Two levels is a tree, not a folder — and nothing is left behind.
+    with pytest.raises(ValueError, match="only one new folder"):
+        schedule.create(str(target / "new1" / "new2"), "hi", _in(600),
+                        create_target=True)
+    assert not (target / "new1").exists()
+
+    # Off by default, so every other caller is unchanged.
+    with pytest.raises(ValueError, match="no such file or directory"):
+        schedule.create(str(target / "ABC2"), "hi", _in(600))
+    assert not (target / "ABC2").exists()
+
+
+def test_create_target_leaves_an_existing_target_alone(target):
+    """The flag is permission to create, not an instruction to. Something that is
+    already there is used as-is — including a FILE target, which stays legal
+    (a task can run against one; the agent works in its parent)."""
+    entry = schedule.create(str(target / "index.html"), "hi", _in(600),
+                            create_target=True)
+    assert entry["target"] == str(target / "index.html")
+    assert (target / "index.html").is_file()
+
+
 def test_a_due_time_days_in_the_past_is_accepted_and_recorded_as_given(target):
     """This used to be REFUSED, and the refusal was right while catch-up was
     bounded: an entry the next tick would sweep to `missed` is better refused

--- a/tests/test_schedule_api.py
+++ b/tests/test_schedule_api.py
@@ -169,6 +169,16 @@ def test_a_new_folder_is_not_created_for_a_request_that_is_refused_later(client,
     assert res.status_code == 400
     assert not (target / "ABC1").exists()
 
+    # And the same holds for the checks INSIDE `schedule.create`, which run
+    # after the target is resolved: an unparseable cron line 400s, and the leaf
+    # must not survive it. This is the one the mkdir used to run ahead of.
+    res = client.post("/api/schedule", headers=WRITE,
+                      json={"target": str(target / "ABC1"), "message": "hi",
+                            "repeats": "every morning"})
+    assert res.status_code == 400
+    assert not (target / "ABC1").exists()
+    assert schedule.list_entries() == []
+
 
 def test_a_mount_backed_target_is_refused(client, target, monkeypatch):
     """The refusal the claude template's own gate exists for: the bytes under a

--- a/tests/test_schedule_api.py
+++ b/tests/test_schedule_api.py
@@ -112,7 +112,11 @@ def test_an_explicit_due_time_is_accepted(client, target):
     # is testing exactly that omission.
     ({"message": "hi", "delay_seconds": 60}, "target"),
     ({"target": "  ", "message": "hi", "delay_seconds": 60}, "target"),
-    ({"target": "/nope/nope", "message": "hi", "delay_seconds": 60}, "no such file"),
+    # TWO missing levels. One missing leaf under an existing parent is legal on
+    # this endpoint now — it creates the folder, see the tests below — so the
+    # refusal a junk path earns is about the parent rather than the leaf.
+    ({"target": "/nope/nope", "message": "hi", "delay_seconds": 60},
+     "only one new folder"),
     ({"target": "TARGET", "message": "   ", "delay_seconds": 60}, "message"),
     ({"target": "TARGET", "delay_seconds": 60}, "message"),
     ({"target": "TARGET", "message": "hi", "delay_seconds": -5}, "positive"),
@@ -125,6 +129,45 @@ def test_bad_requests_are_400s_that_say_why(client, target, body, expect):
     assert res.status_code == 400
     assert expect in res.json()["error"]
     assert schedule.list_entries() == []  # a refused request stores nothing
+
+
+def test_one_new_folder_is_created(client, target):
+    """The New task form lets you name a folder that does not exist yet — you
+    stand in a folder, type `ABC1`, and the task runs in a new `ABC1`. This
+    endpoint is where that promise is kept, because nothing downstream makes
+    directories: the agent's own `_start` refuses a target that is not there."""
+    fresh = target / "ABC1"
+    res = client.post("/api/schedule", headers=WRITE,
+                      json={"target": str(fresh), "message": "hi",
+                            "delay_seconds": 60})
+    assert res.status_code == 200
+    assert fresh.is_dir()
+    # Stored against the folder it just made, not against some resolved parent.
+    assert schedule.list_entries()[0]["target"] == str(fresh)
+
+
+def test_two_missing_levels_is_refused_and_makes_nothing(client, target):
+    """`.../new1/new2` with no `new1` is not "name me a folder", it is "build me
+    a tree I typed" — the ask a typo makes by accident. Refused, and the first
+    level must not be left behind as a souvenir of the attempt."""
+    res = client.post("/api/schedule", headers=WRITE,
+                      json={"target": str(target / "new1" / "new2"),
+                            "message": "hi", "delay_seconds": 60})
+    assert res.status_code == 400
+    assert "only one new folder" in res.json()["error"]
+    assert not (target / "new1").exists()
+    assert schedule.list_entries() == []
+
+
+def test_a_new_folder_is_not_created_for_a_request_that_is_refused_later(client, target):
+    """Order matters: the mount gate runs before anything is made, and a body
+    that fails a LATER check must not leave a directory behind. `delay_seconds`
+    is validated after the target, which is the case to prove."""
+    res = client.post("/api/schedule", headers=WRITE,
+                      json={"target": str(target / "ABC1"), "message": "hi",
+                            "delay_seconds": -5})
+    assert res.status_code == 400
+    assert not (target / "ABC1").exists()
 
 
 def test_a_mount_backed_target_is_refused(client, target, monkeypatch):


### PR DESCRIPTION
## What

The New task path field only accepted folders that already existed. Standing in `.../fused/` and typing `ABC1` — the ordinary way to say "run this in a new folder called ABC1" — got a red line refusing to save.

It now accepts **exactly one** missing leaf under an existing parent, and says what it is going to do.

## Validation rules

| Typed path | Verdict |
|---|---|
| an existing folder | ok, silent |
| an existing file | ok, silent (a task can target a file — unchanged) |
| one missing segment, parent exists | **new folder** — badge + "created when the task is saved"; Save is enabled |
| two or more missing segments | refused: *Only one new folder can be created — `<parent>` doesn't exist either* |
| basename `.` / `..` / empty | the old "This folder or file doesn't exist" |

"Name me a folder" and "build me a tree I typed" are different asks, and only the first is one a typo cannot cause.

## UI

- The decision is one pure function, `targetVerdict(path, parentNames)`, returning `ok` / `new-folder` / `bad`. Only `bad` becomes `pathError`, so a new folder never blocks Save.
- The note under the field is a "New folder" pill plus a sentence, in the muted hint voice — not the error voice, because nothing is wrong. Same 26px gutter as the error line, so whichever is showing sits on the same edge. `aria-describedby` points at whichever one is up.
- The Browse picker gets **+ New folder** in its foot. It *names* a folder rather than making one: the inline row writes into the path field and the save does the rest. So cancelling the card leaves nothing behind on disk, and no write endpoint is involved. Escape backs out of the naming row before it backs out of the panel.

## Server

- `schedule.create` grows an opt-in `create_target`. When on, a target that does not exist is `os.mkdir`'d — one level, never `-p` — provided its parent is already a directory. `FileExistsError` from a race is the outcome asked for; anything else becomes a 400.
- `POST /api/schedule` is the one caller that passes it.
- Opt-in rather than default because of the re-send path: a target that has since been deleted is a fact its user needs told, and silently re-making a deleted FILE's name as a directory would be the worst answer available.

## Test evidence

- `npm run build` (tsc --noEmit + vite) clean.
- `bun test`: **1982 pass, 0 fail** (8 new cases on the verdict, the split, and the two source-level invariants).
- `pytest tests/test_schedule*.py tests/test_queue_dock.py tests/test_claude_*.py tests/test_tasks_store.py`: **all pass**, incl. 5 new cases (one folder made; two levels refused and nothing left behind; a later-failing request creates nothing; off-by-default unchanged; an existing file target untouched).
- Live browser (cmux, dev server on :2453): existing path → no badge; `/tmp/nf-demo/fused/ABC1` → badge appears; `/tmp/nf-demo/fused/new1/new2` → refused with the reason and the field in the error voice; picker → **+ New folder** → named `PickedNew`, **disk still empty**; Save → `PickedNew/` exists on disk and the entry is stored against it. Console and page errors: none.

## Caveats

- A one-missing-leaf target is created at **create** time, not run time, so the folder exists as soon as the task is saved even if the task is later cancelled. That is the same contract the field's copy states.
- Editing a task is cancel + re-create, so re-saving an edit whose folder was deleted in between will re-create it. Consistent with the create rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem creation and schedule target validation on a user-facing create path; behavior is gated and tested but wrong mkdir ordering or opt-in scope could leave stray dirs or surprise callers.
> 
> **Overview**
> The **New task** path field no longer treats a missing folder as a hard error when the parent exists. A new pure **`targetVerdict`** (with **`splitTargetPath`**) classifies paths as ok, **one new leaf**, or bad (including two missing levels); only **bad** blocks Save.
> 
> **UI:** The “new folder” state shows as the first row in the path dropdown (badge + “Created when the task is saved”), not inline under the field. **Browse** gains **+ New folder** in the recents list and in the explorer panel—the picker only **names** a folder; disk creation happens on save. **`ICON_PLUS`** is exported from **`ScheduleCalendar`**.
> 
> **Backend:** **`schedule.create`** adds opt-in **`create_target`**: **`os.mkdir`** for one missing segment when the parent is a directory, performed **after** all other validation so refused requests leave no empty folders. **`POST /api/schedule`** is the only caller that passes **`create_target=True`**.
> 
> Tests cover verdict logic, UI invariants, and API/create ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8476065dc87bbca220fe931723275fadc2270a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->