### PR TITLE
Discover: lazy size fallback, drop unrunnable formats, add int8 FLUX.2 klein option

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,7 +54,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1240,7 +1239,6 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1320,7 +1318,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -1619,7 +1616,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1661,7 +1657,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1877,7 +1872,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,6 +54,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1239,6 +1240,7 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1318,6 +1320,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -1616,6 +1619,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1657,6 +1661,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1872,6 +1877,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2278,6 +2278,25 @@ export function searchHubModels(opts: {
   });
 }
 
+/** One repo's TOTAL size on the Hub — everything in it, not just the weights.
+ *
+ *  The fallback for a row whose `estimatedSize` is null (GGUF, mflux, a
+ *  LoRA): no dtype map means nothing for the search to measure, and the Hub
+ *  will only expand this field one repo at a time. `usedStorage` is null when
+ *  the Hub does not measure the repo either. */
+export interface HubModelSizeResult {
+  id: string;
+  usedStorage: number | null;
+  error?: string;
+}
+
+/** One repo's total size. ONE round trip per call — the Hub's list endpoint
+ *  refuses this field, so callers ask lazily (a card that has scrolled into
+ *  view) and never for a whole page of results at once. */
+export function getHubModelSize(id: string): Promise<HubModelSizeResult> {
+  return postJson<HubModelSizeResult>("/api/ai-models/hub/size", { id });
+}
+
 export interface HubTask {
   /** The Hub's own pipeline tag — what the filter actually sends. */
   tag: string;

--- a/frontend/src/shell/AiModelsDiscover.tsx
+++ b/frontend/src/shell/AiModelsDiscover.tsx
@@ -7,7 +7,10 @@
 // would cost nothing to open — this page can, because its sibling tab already
 // measured exactly that. Second, the SIZE: a cache fills up with multi-GB
 // checkpoints nothing on screen mentions, so "≈16 GB" belongs next to a model's
-// name before anyone decides to fetch it, not after.
+// name before anyone decides to fetch it, not after. When the search reply has
+// no size for a repo — a GGUF or mflux repo publishes no dtype map — the card
+// asks the Hub for the repo's total once it is on screen (`hubSize.ts`), rather
+// than showing a dash for a number huggingface.co is perfectly willing to give.
 //
 // **Everything on this tab is ACTIONABLE, and that is what the tab is for**
 // (D313, narrowed by D316). It used to be two features stacked: a curated list
@@ -52,9 +55,15 @@ import {
 import { refreshAiRuntime } from "./aiRuntime";
 import { ModelProgress } from "./AiProgress";
 import type { Job } from "@platform/lib/jobs";
-import { formatSize, formatParams, timeAgo } from "@platform/lib/format";
+import { formatParams, timeAgo } from "@platform/lib/format";
 import { navigate, urlForFsPath } from "@platform/lib/router";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
+import {
+  hubSizeLabel,
+  hubSizeTitle,
+  knownTotalSize,
+  lookupTotalSize,
+} from "@shell/hubSize";
 import {
   discoverChrome,
   gateChrome,
@@ -183,10 +192,49 @@ function HubCard({
   // unparseable one is a field the card leaves out, not a "NaN ago".
   const updatedAt = model.updated ? Date.parse(model.updated) : NaN;
   const updated = Number.isFinite(updatedAt) ? timeAgo(updatedAt / 1000) : null;
-  const size = model.estimatedSize ? `≈${formatSize(model.estimatedSize)}` : null;
+
+  // The FALLBACK total, for a repo the Hub's dtype map could not measure (see
+  // `hubSize.ts`). Two constraints, and both are about not spending someone
+  // else's rate limit: only a row with no estimate asks at all, and it waits
+  // until this card is actually on screen. A page of two dozen results would
+  // otherwise be two dozen outbound calls on every debounced keystroke.
+  const card = useRef<HTMLDivElement>(null);
+  const wantsTotal = !model.estimatedSize;
+  // Seeded from the page-lifetime cache, so a card scrolled back to paints its
+  // number immediately instead of flashing a dash.
+  const [total, setTotal] = useState<number | null>(
+    (wantsTotal ? knownTotalSize(model.id) : null) ?? null,
+  );
+  useEffect(() => {
+    if (!wantsTotal) return;
+    const known = knownTotalSize(model.id);
+    if (known !== undefined) {
+      setTotal(known);
+      return;
+    }
+    const el = card.current;
+    if (!el) return;
+    let alive = true;
+    const io = new IntersectionObserver((entries) => {
+      if (!entries.some((e) => e.isIntersecting)) return;
+      // Fire once: the number cannot change while this page is open, and a
+      // card scrolled past twice must not be asked about twice.
+      io.disconnect();
+      lookupTotalSize(model.id).then((bytes) => {
+        if (alive) setTotal(bytes);
+      });
+    });
+    io.observe(el);
+    return () => {
+      alive = false;
+      io.disconnect();
+    };
+  }, [model.id, wantsTotal]);
+
+  const size = hubSizeLabel(model, total);
 
   return (
-    <div className="cc-mdcard am-card am-hubcard">
+    <div className="cc-mdcard am-card am-hubcard" ref={card}>
       <div className="cc-mdcard-head">
         {/* The name goes to the Hub, downloaded or not — the same rule the
             cached cards follow, so a model's name means one destination
@@ -215,7 +263,7 @@ function HubCard({
             {gate.pill}
           </span>
         )}
-        <span className="am-card-size" title={sizeTitle(model)}>
+        <span className="am-card-size" title={hubSizeTitle(model, total)}>
           {size ?? "—"}
         </span>
       </div>
@@ -292,19 +340,6 @@ function HubCard({
         </span>
       </div>
     </div>
-  );
-}
-
-function sizeTitle(model: HubModel): string | undefined {
-  if (!model.estimatedSize) {
-    return "No safetensors metadata on the Hub for this repo, so its size can't be computed here.";
-  }
-  // The "≈" is doing real work: the bytes are recovered from the dtype →
-  // parameter-count map the Hub publishes, which is the weights and not the
-  // tokenizer, configs or extra formats sitting beside them.
-  return (
-    `≈${formatSize(model.estimatedSize)} of weights, computed from the parameter counts the Hub ` +
-    "publishes. Other files in the repo are not included."
   );
 }
 

--- a/frontend/src/shell/AiModelsDiscover.tsx
+++ b/frontend/src/shell/AiModelsDiscover.tsx
@@ -215,13 +215,27 @@ function HubCard({
     const el = card.current;
     if (!el) return;
     let alive = true;
+    // Asked, or asking: one request per visit to the viewport, so a card that
+    // sits on screen while the answer arrives is not asked about twice. Cleared
+    // when the card leaves view, which is what lets a FAILED ask be retried —
+    // scroll away and back and the card tries again, rather than a single 429
+    // costing this repo its size for the rest of the page's life. A card whose
+    // ask succeeded stops observing entirely.
+    let asking = false;
     const io = new IntersectionObserver((entries) => {
-      if (!entries.some((e) => e.isIntersecting)) return;
-      // Fire once: the number cannot change while this page is open, and a
-      // card scrolled past twice must not be asked about twice.
-      io.disconnect();
+      if (!entries.some((e) => e.isIntersecting)) {
+        asking = false;
+        return;
+      }
+      if (asking) return;
+      asking = true;
       lookupTotalSize(model.id).then((bytes) => {
-        if (alive) setTotal(bytes);
+        if (!alive) return;
+        setTotal(bytes);
+        // An answer — a number, or the Hub having none — is now cached and
+        // cannot change while this page is open. Anything else was a failure
+        // that nobody remembered, so keep watching for another chance.
+        if (knownTotalSize(model.id) !== undefined) io.disconnect();
       });
     });
     io.observe(el);

--- a/frontend/src/shell/hubSize.test.ts
+++ b/frontend/src/shell/hubSize.test.ts
@@ -142,6 +142,41 @@ describe("lookupTotalSize", () => {
     expect(await lookupTotalSize("org/m", fetchSize)).toBeNull();
   });
 
+  it("does not remember a Hub-side failure as 'no number'", async () => {
+    // The server answers 200 with an `error` when the Hub call itself failed —
+    // a rate limit, an unreachable Hub — and deliberately does NOT cache that,
+    // so the next card can find out for itself. Caching it here would undo
+    // exactly that: one 429 and the repo shows a dash until the tab closes.
+    let calls = 0;
+    const fetchSize = async () => {
+      calls += 1;
+      return calls === 1
+        ? { usedStorage: null, error: "429 Too Many Requests" }
+        : { usedStorage: 4_619_599_193 };
+    };
+    expect(await lookupTotalSize("org/m", fetchSize)).toBeNull();
+    // Nothing was learned, so a card mounting later must not paint the failure
+    // as an answer — `undefined` is what tells the two apart.
+    expect(knownTotalSize("org/m")).toBeUndefined();
+    expect(await lookupTotalSize("org/m", fetchSize)).toBe(4_619_599_193);
+    expect(calls).toBe(2);
+    expect(knownTotalSize("org/m")).toBe(4_619_599_193);
+  });
+
+  it("does not leave a rejected lookup wedged as forever-pending", async () => {
+    // The in-flight map is what collapses concurrent asks. An id left in it
+    // after a rejection would hand every later caller the same dead promise.
+    let calls = 0;
+    const fetchSize = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("offline");
+      return { usedStorage: 7 };
+    };
+    expect(await lookupTotalSize("org/m", fetchSize)).toBeNull();
+    expect(await lookupTotalSize("org/m", fetchSize)).toBe(7);
+    expect(calls).toBe(2);
+  });
+
   it("tells one repo from another", async () => {
     const fetchSize = async (id: string) => ({ usedStorage: id === "org/a" ? 1 : 2 });
     expect(await lookupTotalSize("org/a", fetchSize)).toBe(1);

--- a/frontend/src/shell/hubSize.test.ts
+++ b/frontend/src/shell/hubSize.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { HubModel } from "@platform/lib/api";
+import {
+  _forgetTotalSizes,
+  hubSizeLabel,
+  hubSizeTitle,
+  knownTotalSize,
+  lookupTotalSize,
+} from "./hubSize";
+
+// The Discover tab shows two different measurements in one cell — the weights
+// the Hub's dtype map describes, and (when there is no dtype map) the Hub's
+// total for the whole repo. These tests are about telling them apart, and about
+// the traffic the second one is allowed to cost: one request per repo, ever.
+
+function row(extra: Partial<HubModel> = {}): HubModel {
+  return {
+    id: "org/m",
+    task: "text generation",
+    taskHelp: null,
+    pipelineTag: "text-generation",
+    capability: "text-generation",
+    gated: null,
+    library: null,
+    downloads: null,
+    likes: null,
+    updated: null,
+    params: null,
+    estimatedSize: null,
+    local: { state: "none" },
+    url: "https://huggingface.co/org/m",
+    ...extra,
+  };
+}
+
+describe("hubSizeLabel", () => {
+  it("shows the weights figure when the Hub published one", () => {
+    expect(hubSizeLabel(row({ estimatedSize: 16_000_000_000 }), null)).toBe("≈15 GB");
+  });
+
+  it("prefers the weights figure over a total, so a repo never changes measure", () => {
+    // A card with an estimate never asks for the fallback at all; if one ever
+    // arrived anyway, the free and more meaningful number still wins.
+    expect(hubSizeLabel(row({ estimatedSize: 16_000_000_000 }), 20_000_000_000)).toBe("≈15 GB");
+  });
+
+  it("falls back to the repo total for a repo with no dtype map", () => {
+    // The mflux repo from the complaint: no safetensors, and a dash here until
+    // this fallback existed. Same bytes the Hub's own page shows as 4.61 GB —
+    // it counts in decimal, `formatSize` in binary, which is the app's unit
+    // everywhere else and not a thing to special-case in one cell.
+    expect(hubSizeLabel(row(), 4_619_599_193)).toBe("≈4.3 GB");
+  });
+
+  it("is a dash while nothing is known", () => {
+    expect(hubSizeLabel(row(), null)).toBeNull();
+  });
+});
+
+describe("hubSizeTitle", () => {
+  it("says the weights figure is computed from parameter counts", () => {
+    const title = hubSizeTitle(row({ estimatedSize: 16_000_000_000 }), null);
+    expect(title).toContain("of weights");
+    expect(title).toContain("parameter counts");
+  });
+
+  it("does NOT claim parameter counts for the fallback total", () => {
+    // The whole reason this function takes the fallback: the total includes the
+    // tokenizer, the configs and every quantised copy the author shipped, so
+    // describing it as computed from parameter counts is a claim about work
+    // that never happened.
+    const title = hubSizeTitle(row(), 4_619_599_193);
+    expect(title).toContain("total for this repo");
+    expect(title).toContain("every file in it");
+    expect(title).not.toContain("parameter counts");
+  });
+
+  it("does not claim a size is impossible when nobody has looked yet", () => {
+    // The lookup is lazy, so this tooltip is what an unscrolled card shows. It
+    // used to say the size "can't be computed here", which stopped being true
+    // the moment a fallback existed.
+    const title = hubSizeTitle(row(), null);
+    expect(title).toContain("no safetensors metadata");
+    expect(title).not.toContain("can't be computed");
+  });
+});
+
+describe("lookupTotalSize", () => {
+  beforeEach(_forgetTotalSizes);
+
+  it("asks the server once and remembers the answer", async () => {
+    const asked: string[] = [];
+    const fetchSize = async (id: string) => {
+      asked.push(id);
+      return { usedStorage: 4_619_599_193 };
+    };
+    expect(await lookupTotalSize("org/m", fetchSize)).toBe(4_619_599_193);
+    expect(await lookupTotalSize("org/m", fetchSize)).toBe(4_619_599_193);
+    expect(asked).toEqual(["org/m"]);
+    // …and a card mounting later can paint the number immediately.
+    expect(knownTotalSize("org/m")).toBe(4_619_599_193);
+  });
+
+  it("collapses concurrent asks for the same repo into one request", async () => {
+    // React 18 runs an effect twice in strict mode and an IntersectionObserver
+    // can report the same card again before state settles. Either would be a
+    // second call to a third party for a number already on its way.
+    const asked: string[] = [];
+    let release: (v: { usedStorage: number | null }) => void = () => {};
+    const fetchSize = (id: string) => {
+      asked.push(id);
+      return new Promise<{ usedStorage: number | null }>((res) => {
+        release = res;
+      });
+    };
+    const a = lookupTotalSize("org/m", fetchSize);
+    const b = lookupTotalSize("org/m", fetchSize);
+    release({ usedStorage: 7 });
+    expect(await a).toBe(7);
+    expect(await b).toBe(7);
+    expect(asked).toEqual(["org/m"]);
+  });
+
+  it("remembers 'the Hub has no number for this one' as an answer", async () => {
+    // Null is a result, not a miss. Treating it as one would re-ask on every
+    // scroll for exactly the repos the Hub cannot measure.
+    let calls = 0;
+    const fetchSize = async () => {
+      calls += 1;
+      return { usedStorage: null };
+    };
+    expect(await lookupTotalSize("org/m", fetchSize)).toBeNull();
+    expect(await lookupTotalSize("org/m", fetchSize)).toBeNull();
+    expect(calls).toBe(1);
+    expect(knownTotalSize("org/m")).toBeNull();
+  });
+
+  it("keeps the dash rather than rejecting when the request fails", async () => {
+    const fetchSize = async () => {
+      throw new Error("offline");
+    };
+    expect(await lookupTotalSize("org/m", fetchSize)).toBeNull();
+  });
+
+  it("tells one repo from another", async () => {
+    const fetchSize = async (id: string) => ({ usedStorage: id === "org/a" ? 1 : 2 });
+    expect(await lookupTotalSize("org/a", fetchSize)).toBe(1);
+    expect(await lookupTotalSize("org/b", fetchSize)).toBe(2);
+  });
+
+  it("has nothing to say about a repo nobody has asked about", () => {
+    expect(knownTotalSize("org/never")).toBeUndefined();
+  });
+});

--- a/frontend/src/shell/hubSize.ts
+++ b/frontend/src/shell/hubSize.ts
@@ -63,10 +63,15 @@ export function hubSizeTitle(model: HubModel, total: number | null): string | un
   return "This repo publishes no safetensors metadata on the Hub, so there is no size to show yet.";
 }
 
-/** Totals already resolved, for the page's lifetime. Null is an ANSWER — the
+/** Totals already ANSWERED, for the page's lifetime. Null is an answer — the
  *  Hub does not measure every repo — so `has` is the question to ask, not
  *  truthiness. Re-sorting or re-filtering brings the same cards back into view,
- *  which must not cost a second round trip. */
+ *  which must not cost a second round trip.
+ *
+ *  A failed lookup is NOT an answer and never lands here: the server returns
+ *  200 with an `error` field on a Hub-side failure and deliberately does not
+ *  cache it, so caching it on this side would turn one 429 into a permanent
+ *  dash for that repo. */
 const resolved = new Map<string, number | null>();
 
 /** Lookups in flight. React 18 runs an effect twice in strict mode, and an
@@ -74,9 +79,11 @@ const resolved = new Map<string, number | null>();
  *  either would be a duplicate request to a third party. */
 const inFlight = new Map<string, Promise<number | null>>();
 
-/** The total already known for this repo, or `undefined` if nobody has asked.
- *  Lets a card render the right number on its very first paint rather than
- *  flashing a dash for a repo the page measured a scroll ago. */
+/** The total already known for this repo, or `undefined` if nobody has asked —
+ *  or if the asking failed, which is not something known. Lets a card render
+ *  the right number on its very first paint rather than flashing a dash for a
+ *  repo the page measured a scroll ago, and lets it tell "the Hub said no
+ *  number" (cached null) from "the ask did not get through" (undefined). */
 export function knownTotalSize(id: string): number | null | undefined {
   return resolved.has(id) ? (resolved.get(id) ?? null) : undefined;
 }
@@ -84,26 +91,38 @@ export function knownTotalSize(id: string): number | null | undefined {
 /** This repo's total bytes, asked once however many cards want it.
  *
  *  A failure resolves to null rather than rejecting: the card keeps its dash,
- *  and a size nobody asked out loud for is not worth a banner. Cached either
- *  way — a Hub that has no number for this repo will not have one a scroll
- *  later, and the server does not cache its own errors, so a genuine outage
- *  costs one attempt per card rather than one per scroll.
+ *  and a size nobody asked out loud for is not worth a banner. But it is NOT
+ *  remembered — an answer is remembered, a failure is only reported. The server
+ *  goes out of its way not to cache its own Hub errors so that the next card
+ *  can find out for itself; caching them here would undo exactly that, and a
+ *  transient 429 would read as "this repo has no size" until the tab closed.
+ *  Whether anything asks again is the caller's business (see `HubCard`); this
+ *  only promises not to stand in the way.
  */
 export function lookupTotalSize(
   id: string,
-  fetchSize: (id: string) => Promise<{ usedStorage: number | null }> = getHubModelSize,
+  fetchSize: (
+    id: string,
+  ) => Promise<{ usedStorage: number | null; error?: string }> = getHubModelSize,
 ): Promise<number | null> {
-  const known = resolved.get(id);
-  if (resolved.has(id)) return Promise.resolve(known ?? null);
+  if (resolved.has(id)) return Promise.resolve(resolved.get(id) ?? null);
   const running = inFlight.get(id);
   if (running) return running;
   const lookup = fetchSize(id)
-    .then((r) => (typeof r.usedStorage === "number" ? r.usedStorage : null))
-    .catch(() => null)
-    .then((bytes) => {
+    .then((r) => {
+      // 200 with an `error` is how the server reports a Hub-side failure — a
+      // rate limit, an unreachable Hub, a reply it could not read. It looks
+      // like "no number for this repo" and means something else entirely.
+      if (r.error) return null;
+      const bytes = typeof r.usedStorage === "number" ? r.usedStorage : null;
       resolved.set(id, bytes);
-      inFlight.delete(id);
       return bytes;
+    })
+    .catch(() => null)
+    // Whichever way it went, the id stops being in flight — a rejected lookup
+    // that stayed here would wedge the repo as forever pending.
+    .finally(() => {
+      inFlight.delete(id);
     });
   inFlight.set(id, lookup);
   return lookup;

--- a/frontend/src/shell/hubSize.ts
+++ b/frontend/src/shell/hubSize.ts
@@ -1,0 +1,116 @@
+// The number beside a search result's name: which figure it is, what it
+// measures, and how the second one gets asked for.
+//
+// There are TWO sizes on this page and they are not the same measurement.
+//
+//   * `estimatedSize` — the weights, recovered by the server from the dtype →
+//     parameter-count map the Hub publishes. Free: it rides the search reply.
+//   * `usedStorage` — the Hub's total for the whole repo: every file in it,
+//     tokenizer and configs and every quantised copy the author shipped. Costs
+//     ONE REQUEST PER REPO, because the Hub refuses to expand the field on its
+//     list endpoint (see `routers/hub_models.py`).
+//
+// The second exists because the first is often absent: a GGUF, mflux or
+// LoRA-only repo publishes no dtype map at all, so the card showed a dash while
+// the model's own page on the Hub showed a real total. It is a FALLBACK, asked
+// for only when there is no estimate and only for a card actually on screen —
+// a page of two dozen results must not become two dozen outbound calls on a
+// debounced keystroke.
+//
+// And because the two measure different things, the tooltip has to say WHICH
+// one it is showing. A total that includes three quantised copies described as
+// "computed from the parameter counts" would be a sentence about work that
+// never happened.
+//
+// Here rather than in the component for the reason `discoverView.ts` is: there
+// is no DOM harness in this repo by design, so the part with a rule in it lives
+// in a module that can be driven. What stays in `HubCard` is the
+// IntersectionObserver — the one piece that genuinely needs a DOM node.
+import type { HubModel } from "@platform/lib/api";
+import { getHubModelSize } from "@platform/lib/api";
+import { formatSize } from "@platform/lib/format";
+
+/** What the size cell reads, or null for the dash. `total` is the fallback,
+ *  once it has resolved; it is ignored when there is a real estimate, so a repo
+ *  that publishes weights metadata always shows the weights figure. */
+export function hubSizeLabel(model: HubModel, total: number | null): string | null {
+  if (model.estimatedSize) return `≈${formatSize(model.estimatedSize)}`;
+  if (total !== null) return `≈${formatSize(total)}`;
+  return null;
+}
+
+/** What that number MEASURES, on hover. Three states, because there are three
+ *  different true things to say — and the third has to stay true while a lazy
+ *  lookup simply has not fired yet, so it does not claim the size "can't be
+ *  computed" about a card nobody has scrolled to. */
+export function hubSizeTitle(model: HubModel, total: number | null): string | undefined {
+  if (model.estimatedSize) {
+    // The "≈" is doing real work: the bytes are recovered from the dtype →
+    // parameter-count map the Hub publishes, which is the weights and not the
+    // tokenizer, configs or extra formats sitting beside them.
+    return (
+      `≈${formatSize(model.estimatedSize)} of weights, computed from the parameter counts the Hub ` +
+      "publishes. Other files in the repo are not included."
+    );
+  }
+  if (total !== null) {
+    return (
+      `≈${formatSize(total)} — the Hub's total for this repo: every file in it, not just the ` +
+      "weights a load would read. This repo publishes no safetensors metadata, so there is no " +
+      "weights-only figure to show."
+    );
+  }
+  return "This repo publishes no safetensors metadata on the Hub, so there is no size to show yet.";
+}
+
+/** Totals already resolved, for the page's lifetime. Null is an ANSWER — the
+ *  Hub does not measure every repo — so `has` is the question to ask, not
+ *  truthiness. Re-sorting or re-filtering brings the same cards back into view,
+ *  which must not cost a second round trip. */
+const resolved = new Map<string, number | null>();
+
+/** Lookups in flight. React 18 runs an effect twice in strict mode, and an
+ *  IntersectionObserver can report the same card again before state settles;
+ *  either would be a duplicate request to a third party. */
+const inFlight = new Map<string, Promise<number | null>>();
+
+/** The total already known for this repo, or `undefined` if nobody has asked.
+ *  Lets a card render the right number on its very first paint rather than
+ *  flashing a dash for a repo the page measured a scroll ago. */
+export function knownTotalSize(id: string): number | null | undefined {
+  return resolved.has(id) ? (resolved.get(id) ?? null) : undefined;
+}
+
+/** This repo's total bytes, asked once however many cards want it.
+ *
+ *  A failure resolves to null rather than rejecting: the card keeps its dash,
+ *  and a size nobody asked out loud for is not worth a banner. Cached either
+ *  way — a Hub that has no number for this repo will not have one a scroll
+ *  later, and the server does not cache its own errors, so a genuine outage
+ *  costs one attempt per card rather than one per scroll.
+ */
+export function lookupTotalSize(
+  id: string,
+  fetchSize: (id: string) => Promise<{ usedStorage: number | null }> = getHubModelSize,
+): Promise<number | null> {
+  const known = resolved.get(id);
+  if (resolved.has(id)) return Promise.resolve(known ?? null);
+  const running = inFlight.get(id);
+  if (running) return running;
+  const lookup = fetchSize(id)
+    .then((r) => (typeof r.usedStorage === "number" ? r.usedStorage : null))
+    .catch(() => null)
+    .then((bytes) => {
+      resolved.set(id, bytes);
+      inFlight.delete(id);
+      return bytes;
+    });
+  inFlight.set(id, lookup);
+  return lookup;
+}
+
+/** Tests only: the caches outlive a component, which is the point of them. */
+export function _forgetTotalSizes(): void {
+  resolved.clear();
+  inFlight.clear();
+}

--- a/fused_render/ai/catalog.py
+++ b/fused_render/ai/catalog.py
@@ -311,6 +311,35 @@ SUGGESTIONS: dict[str, list[dict]] = {
     ],
     "diffusers-image": [
         {
+            "id": "tonera/FLUX.2-klein-4B-int8-diffusers",
+            "label": "FLUX.2 klein 4B (int8)",
+            # The whole repo, per the rule the entry below states: 8.22e9 bytes
+            # of `usedStorage` (2026-08-20 Hub metadata), and here that number
+            # IS the download — one repo, no component repo, and no skipped
+            # subfolder, because the quantization is already in the checkpoint.
+            "size_gb": 8.2,
+            # **No `_GGUF_RECIPES` row, and that is the point of this entry.**
+            # The repo is a full diffusers pipeline whose `transformer/config.json`
+            # carries `"quant_method": "torchao"`, so `from_pretrained` builds
+            # the quantized component itself and the ordinary no-recipe branch
+            # of `torch_image.load()` loads it unchanged. Its weights are a
+            # `.bin` rather than a `.safetensors` — torchao's tensor subclasses
+            # do not serialize to safetensors in this save — which needs no flag
+            # either: `use_safetensors` defaults to None, which ModelMixin reads
+            # as "prefer safetensors, allow pickle", and the fallback to
+            # `diffusion_pytorch_model.bin` is per COMPONENT, so the text
+            # encoder and VAE still come from their safetensors. Forcing
+            # `use_safetensors=False` would break those two instead.
+            #
+            # It leads the list, so it is what a bare `fused.ai.image()` starts:
+            # that is the one ordering rule
+            # (`test_every_suggestion_list_is_ordered_smallest_first`), and the
+            # smaller thing to fetch is the reason this entry exists at all.
+            "note": "Smallest Diffusers download here: one self-contained repo "
+                    "with an int8-quantized transformer, rather than the base "
+                    "pipeline plus a separate GGUF file.",
+        },
+        {
             "id": "black-forest-labs/FLUX.2-klein-4B",
             "label": "FLUX.2 klein 4B",
             # EVERYTHING the Download fetches, both repos: 8.23 of base

--- a/fused_render/ai/runners/diffusers_image/pyproject.toml
+++ b/fused_render/ai/runners/diffusers_image/pyproject.toml
@@ -73,6 +73,33 @@
 #   sentencepiece  the tokenizer format those text encoders use
 #   protobuf       sentencepiece's model format needs it at load time
 #   gguf           reads the quantized single-file transformer (see torch_image.py)
+#   torchao        reads the OTHER quantized transformer in `catalog.py` — the
+#                  int8 diffusers repo, which is not a GGUF swap but an ordinary
+#                  `from_pretrained` over a component whose `config.json`
+#                  carries `"quant_method": "torchao"`. diffusers turns that into
+#                  a `TorchAoConfig` itself; what it cannot do is import the
+#                  package, and `quantizers/torchao/torchao_quantizer.py` raises
+#                  `ImportError` without it. `>=0.15` is DIFFUSERS' OWN floor —
+#                  that same file refuses an older torchao by version number —
+#                  and it is also the first release whose
+#                  `Int8WeightOnlyConfig` carries the `granularity` field the
+#                  repo's config was serialized with, so the floor is the
+#                  library's requirement rather than a guess. `<1` rather than a
+#                  pre-1.0 minor ceiling, unlike `diffusers` above, because
+#                  nothing in `torch_image.py` calls torchao: diffusers does,
+#                  and it version-gates the calls it makes.
+#                  **It installs on every platform this app ships to** — PyPI
+#                  carries a manylinux x86_64 wheel and a `py3-none-any` wheel
+#                  beside it, which is what macOS and Windows resolve to — so
+#                  the wheels-only rule above holds in all three folders, and
+#                  torchao is named in all three because the repo it reads is
+#                  suggested to all three (one `catalog.py` list, aliased).
+#                  What is NOT claimed is speed. PyPI's is torchao's GENERIC
+#                  build; the CUDA and XPU builds live on its own indexes, which
+#                  none of these manifests uses, and no benchmark here says what
+#                  an int8 weight-only transformer costs per step on CUDA, ROCm,
+#                  MPS or CPU. So the `catalog.py` note promises a smaller
+#                  download and nothing about the clock.
 #   pillow         writes the PNG
 #   huggingface_hub downloads
 #   psutil         answers "how much memory is this costing"
@@ -88,6 +115,7 @@ dependencies = [
     "sentencepiece",
     "protobuf",
     "gguf",
+    "torchao>=0.15,<1",
     "pillow",
     "huggingface_hub",
     "psutil",

--- a/fused_render/ai/runners/diffusers_image_cuda/pyproject.toml
+++ b/fused_render/ai/runners/diffusers_image_cuda/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "sentencepiece",
     "protobuf",
     "gguf",
+    "torchao>=0.15,<1",
     "pillow",
     "huggingface_hub",
     "psutil",

--- a/fused_render/ai/runners/diffusers_image_rocm/pyproject.toml
+++ b/fused_render/ai/runners/diffusers_image_rocm/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "sentencepiece",
     "protobuf",
     "gguf",
+    "torchao>=0.15,<1",
     "pillow",
     "huggingface_hub",
     "psutil",

--- a/fused_render/server/routers/hub_models.py
+++ b/fused_render/server/routers/hub_models.py
@@ -75,6 +75,22 @@ count map, so the bytes are recovered by summing `count * bits / 8` — the same
 arithmetic the model card does locally (HF-17), and the same `≈`. A repo
 without safetensors metadata reports no size rather than a guessed one.
 
+**And when there is no safetensors metadata, `hub/size` is the second ask —
+one repo at a time, on purpose.** A GGUF, mflux or LoRA-only repo carries no
+dtype map, so the arithmetic above has nothing to work from and the card shows
+a dash, even though huggingface.co shows a real total on the model's own page.
+That total is `usedStorage`, and it exists ONLY on the per-repo detail endpoint:
+the list endpoint refuses `expand[]=usedStorage` with a 400 naming the fields it
+does accept, so there is no way to fold it into the search. Getting it for a
+page of results would therefore be one HTTP round trip PER ROW, on every
+debounced keystroke — exactly the traffic the cache above exists to avoid. So it
+is a separate route, and the page calls it lazily: only for a row that has no
+estimate, and only once that card has actually scrolled into view. It is also a
+DIFFERENT NUMBER and the page says so — the total of everything in the repo,
+not the weights — because a tooltip claiming "computed from parameter counts"
+over a figure that includes the tokenizer and three quantised copies would be a
+sentence about work that never happened.
+
 The TTL cache exists to be a good citizen: search-as-you-type would otherwise
 put one request per keystroke on a public API. Identical queries inside the
 window are answered from memory.
@@ -85,7 +101,7 @@ from __future__ import annotations
 import os
 import threading
 import time
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import quote, urlencode, urlsplit
 
 import httpx
 from fastapi import APIRouter, Body, Header
@@ -133,6 +149,10 @@ _SORTS = {
 }
 
 _MAX_LIMIT = 60
+
+# Longer than any real `org/name` and short enough that nothing hand-written
+# turns into a long URL this server goes and fetches.
+_MAX_ID_LEN = 200
 
 # An unfiltered query is filtered HERE, so the Hub has to be asked for more rows
 # than the page will show or a search for a common word would come back nearly
@@ -413,10 +433,14 @@ def _model_row(raw: dict, cache_dir: str, dirs: dict[str, str]) -> dict | None:
     }
 
 
-def _fetch(params: dict) -> tuple[list, str | None]:
-    """The Hub's model list for one query: (rows, error). Never raises — an
-    unreachable Hub is a sentence on the page, not a 500 from this server."""
-    url = f"{hub_endpoint()}/api/models?{urlencode(params, doseq=True)}"
+def _get(url: str):
+    """One authenticated GET at the Hub: (response, error). Never raises — an
+    unreachable Hub is a sentence on the page, not a 500 from this server.
+
+    Shared by the two outbound calls this module makes, so a rate limit or a
+    refused token reads the same whether the page was searching or asking one
+    repo how big it is.
+    """
     headers = {"Accept": "application/json"}
     token = _token()
     if token:
@@ -427,14 +451,22 @@ def _fetch(params: dict) -> tuple[list, str | None]:
     except httpx.HTTPError as e:
         # Offline, DNS, TLS, timeout — all the same to the person looking at the
         # page, and all worth naming rather than spinning forever.
-        return [], f"Could not reach {urlsplit(hub_endpoint()).netloc}: {e.__class__.__name__}"
+        return None, f"Could not reach {urlsplit(hub_endpoint()).netloc}: {e.__class__.__name__}"
     if response.status_code == 401 or response.status_code == 403:
-        return [], ("The Hub refused this request. A private or gated search needs a token — "
-                    "set HF_TOKEN, or log in with the Hugging Face CLI.")
+        return None, ("The Hub refused this request. A private or gated repo needs a token — "
+                      "set HF_TOKEN, or log in with the Hugging Face CLI.")
     if response.status_code == 429:
-        return [], "The Hub is rate-limiting this machine. Try again in a minute."
+        return None, "The Hub is rate-limiting this machine. Try again in a minute."
     if response.status_code >= 400:
-        return [], f"The Hub answered {response.status_code}."
+        return None, f"The Hub answered {response.status_code}."
+    return response, None
+
+
+def _fetch(params: dict) -> tuple[list, str | None]:
+    """The Hub's model list for one query: (rows, error)."""
+    response, error = _get(f"{hub_endpoint()}/api/models?{urlencode(params, doseq=True)}")
+    if error or response is None:
+        return [], error
     try:
         payload = response.json()
     except ValueError:
@@ -442,6 +474,37 @@ def _fetch(params: dict) -> tuple[list, str | None]:
     if not isinstance(payload, list):
         return [], "The Hub sent an unexpected reply."
     return payload, None
+
+
+def _fetch_used_storage(model_id: str) -> tuple[int | None, str | None]:
+    """One repo's total bytes on the Hub: (usedStorage, error).
+
+    The DETAIL endpoint, which answers with an object rather than the list
+    `_fetch` reads — and it is the only endpoint that will expand this field at
+    all (see the module docstring). The id is quoted into the PATH with its
+    slash intact and nothing else surviving, so a repo name carrying a `?`
+    cannot become a second query parameter.
+
+    Anything that is not a plain non-negative int is no answer: a string of
+    digits, a float, a `True`. This route's only job is the total, so a repo the
+    Hub does not measure reports None rather than falling back to the dtype map
+    the search already tried.
+    """
+    url = (f"{hub_endpoint()}/api/models/{quote(model_id, safe='/')}"
+           f"?{urlencode({'expand[]': 'usedStorage'})}")
+    response, error = _get(url)
+    if error or response is None:
+        return None, error
+    try:
+        payload = response.json()
+    except ValueError:
+        return None, "The Hub sent something that is not JSON."
+    if not isinstance(payload, dict):
+        return None, "The Hub sent an unexpected reply."
+    used = payload.get("usedStorage")
+    if isinstance(used, bool) or not isinstance(used, int) or used < 0:
+        return None, None
+    return used, None
 
 
 def _cached(key: tuple):
@@ -560,6 +623,53 @@ def api_hub_search(body: dict = Body(default={}), x_fused: str | None = Header(d
         "endpoint": hub_endpoint(),
         "authenticated": bool(_token()),
     }
+
+
+@router.post("/api/ai-models/hub/size")
+def api_hub_size(body: dict = Body(default={}), x_fused: str | None = Header(default=None)):
+    """One repo's TOTAL size on the Hub, for a card the dtype map could not
+    measure.
+
+    **Guarded POST for exactly the reason search is** — see `api_hub_search`:
+    the cost of this request is in the REQUEST, not the reply, because it leaves
+    the machine carrying the user's Hub token. Nothing about it being a "read"
+    changes that, so it takes the same shape rather than the rule acquiring a
+    second exception.
+
+    **One repo per call, and the page asks lazily.** The Hub only expands
+    `usedStorage` on the per-repo detail endpoint, so a page of two dozen
+    results is two dozen round trips — which is why this is not folded into
+    search and why the frontend calls it only for a row with no estimate whose
+    card has actually scrolled into view (see the module docstring).
+
+    The number is NOT the search's `estimatedSize` and must not be presented as
+    one: it is everything in the repo — tokenizer, configs, every quantised copy
+    the author published — rather than the weights a load would read.
+    """
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    model_id = body.get("id")
+    if not isinstance(model_id, str):
+        return _error("id must be a string", status=400)
+    model_id = model_id.strip()
+    # `org/name`, and nothing else becomes a request. The Hub's own shape, so a
+    # malformed id is a client bug rather than a URL this server goes and fetches.
+    parts = model_id.split("/")
+    if len(parts) != 2 or not all(parts) or len(model_id) > _MAX_ID_LEN:
+        return _error(f"{body.get('id')!r} is not a repo id of the form org/name", status=400)
+
+    key = ("size", hub_endpoint(), model_id, bool(_token()))
+    payload = _cached(key)
+    if payload is None:
+        used, error = _fetch_used_storage(model_id)
+        if error:
+            # Not a 5xx, and not cached: the request was fine, the far side was
+            # not, and the next card into view should find out for itself.
+            return {"id": model_id, "usedStorage": None, "error": error}
+        payload = {"usedStorage": used}
+        _store(key, payload)
+    return {"id": model_id, "usedStorage": payload["usedStorage"], "error": None}
 
 
 @router.get("/api/ai-models/hub/tasks")

--- a/fused_render/server/routers/hub_models.py
+++ b/fused_render/server/routers/hub_models.py
@@ -24,6 +24,15 @@ if
   is dropped too — we cannot promise something we cannot classify.
 * it is not `private`. There is no step an ordinary account can take to reach
   one, so a card for it could never be actioned by the person reading it.
+* its `library_name`, when it has one, is not a framework this app has no
+  runner for at all. The tag above says what a model is FOR and is blind to
+  what it is MADE OF, so a `text-to-image` repo of `.tflite` graphs passed it
+  and arrived with a Download button in front of a load that could only fail.
+  This is a NARROW test and stays narrow — see `_UNRUNNABLE_LIBRARIES`: it
+  names formats with no path through any runner under any circumstances, and
+  it is a denylist because the formats we DO read are open and
+  community-labelled (one FLUX.2 klein loads from four different values of
+  this field).
 
 **The constraint is "an engine here can run it", not "nothing further is asked
 of the user"** — that is D316's correction. Gated repos come BACK, carrying
@@ -208,6 +217,48 @@ _DTYPE_BITS = {
     "U64": 64, "I64": 64, "F64": 64,
 }
 
+# Hub `library_name` values NOTHING here can ever open, and the reason this is a
+# DENYLIST rather than an allowlist.
+#
+# The tag filter above asks "is this KIND of model runnable"; it cannot see the
+# FORMAT, so `litert-community/FLUX.2-klein-4B-LiteRT` — a `text-to-image` repo
+# of `.tflite` graphs — arrived with a Download button in front of a load that
+# could only fail. `grep -rn litert fused_render/` finds nothing, and no
+# quantization, platform or wheel would change that.
+#
+# An allowlist keyed to the libraries the runners are BUILT on (diffusers,
+# transformers, mlx) is the tempting version and it is wrong, because it is not
+# what the repos we load actually report. Read off the Hub, not guessed: the
+# FLUX.2 klein family alone loads today from `diffusers`
+# (black-forest-labs/FLUX.2-klein-4B), `ggml`
+# (unsloth/FLUX.2-klein-4B-GGUF, the recipe's quantized transformer),
+# `diffusion-single-file` (mlx-community/FLUX.2-Klein-4B-4bit, the one repo
+# `MFLUX_VARIANTS` names) and `mflux` (Runpod/FLUX.2-klein-4B-mflux-4bit) —
+# four values for one model — while Whisper adds `ctranslate2` and `mlx`. A
+# three-name allowlist would hide most of what works. The set of formats we
+# read is open and community-labelled; the set we provably cannot is small and
+# nameable, so the small one is the one written down.
+#
+# **What this claims and what it does not.** It claims only that the named
+# framework has no runner in this app AT ALL — not that a repo passing it will
+# load. It deliberately does NOT try to predict quantization, file layout or
+# anything host-specific: that is D316's line, and a diffusers-tagged repo with
+# a bespoke quantization still gets through and still fails, which is a
+# different and harder problem. When in doubt a value is LEFT OUT: a card that
+# should not be there is the status quo, and hiding a repo that would have
+# loaded is a regression this filter must not introduce.
+_UNRUNNABLE_LIBRARIES = frozenset({
+    # Graph formats for other runtimes entirely. No runner imports any of them.
+    "litert", "tflite", "coreml", "onnx", "openvino", "unity-sentis",
+    "keras", "tf-keras",
+    # Speech stacks that are not the three this app has: a `.nemo` archive is
+    # the case worth naming, since `parakeet-mlx` reads the MLX CONVERSION of
+    # one (`library_name: "mlx"`) and never the archive itself.
+    "nemo", "espnet", "speechbrain", "k2",
+    # Classical NLP toolkits, which publish under supported pipeline tags.
+    "spacy", "fasttext", "flair", "stanza", "allennlp", "sklearn", "paddlenlp",
+})
+
 _cache: dict[tuple, tuple[float, dict]] = {}
 _cache_lock = threading.Lock()
 
@@ -370,7 +421,7 @@ def _model_row(raw: dict, cache_dir: str, dirs: dict[str, str]) -> dict | None:
     """One Hub result, joined to the local cache — or None for a row this app
     has no business offering.
 
-    **Three ways to be dropped, and they are the search's whole contract**
+    **Four ways to be dropped, and they are the search's whole contract**
     (D313, narrowed by D316). A row that reaches the page comes with a Download
     button or with the one sentence that says what to do first, so every one of
     these is the difference between an actionable card and one that apologises:
@@ -383,6 +434,14 @@ def _model_row(raw: dict, cache_dir: str, dirs: dict[str, str]) -> dict | None:
       that can see it. There is no step an ordinary account can take to reach
       one: no licence to accept, no queue to join, so a card for it could never
       be actioned by the person reading it.
+    * a `library_name` in `_UNRUNNABLE_LIBRARIES` — the right KIND of model in
+      a format nothing here reads. The tag says what a repo is FOR and cannot
+      see what it is MADE OF, which is how a `.tflite` FLUX got a Download
+      button; see that set for why it is a denylist and, importantly, for the
+      much smaller thing it claims. A MISSING or non-string `library_name` is
+      not a drop: the Hub often does not set it, and silence about the format
+      is not evidence against it — only an explicit unrunnable value counts,
+      the same way `_gate` reads only what the Hub actually said.
 
     **`gated` is NOT a drop, and the distinction is the point** (D316). It was
     one, on the rule that every card must be downloadable — a rule drawn one
@@ -406,6 +465,9 @@ def _model_row(raw: dict, cache_dir: str, dirs: dict[str, str]) -> dict | None:
     capability = capability_for_task(task)
     if capability is None:
         return None
+    library = raw.get("library_name") if isinstance(raw.get("library_name"), str) else None
+    if library and library.lower() in _UNRUNNABLE_LIBRARIES:
+        return None
     safetensors = raw.get("safetensors")
     return {
         "id": model_id,
@@ -422,7 +484,9 @@ def _model_row(raw: dict, cache_dir: str, dirs: dict[str, str]) -> dict | None:
         # tests one field for "is there a gate and what kind". A missing key
         # would make "no gate" and "the Hub did not say" the same answer.
         "gated": _gate(raw.get("gated")),
-        "library": raw.get("library_name") if isinstance(raw.get("library_name"), str) else None,
+        # Whatever the Hub said, minus the values dropped above — so the badge
+        # on a card and the reason a card exists read off the same field.
+        "library": library,
         "downloads": raw.get("downloads") if isinstance(raw.get("downloads"), int) else None,
         "likes": raw.get("likes") if isinstance(raw.get("likes"), int) else None,
         "updated": raw.get("lastModified") if isinstance(raw.get("lastModified"), str) else None,

--- a/fused_render/server/routers/hub_models.py
+++ b/fused_render/server/routers/hub_models.py
@@ -1,5 +1,5 @@
-"""POST /api/ai-models/hub/search — models on the Hugging Face Hub that this
-machine can actually run, told apart from the ones already on this disk.
+"""/api/ai-models/hub/* — models on the Hugging Face Hub that this machine can
+actually run, told apart from the ones already on this disk.
 
 The AI Models page (§37) answers "what did I already download". This answers the
 other half — "what is there" — and the two are only useful *together*: the Hub
@@ -433,7 +433,7 @@ def _model_row(raw: dict, cache_dir: str, dirs: dict[str, str]) -> dict | None:
     }
 
 
-def _get(url: str):
+def _get(url: str) -> tuple[httpx.Response | None, str | None]:
     """One authenticated GET at the Hub: (response, error). Never raises — an
     unreachable Hub is a sentence on the page, not a 500 from this server.
 
@@ -657,7 +657,9 @@ def api_hub_size(body: dict = Body(default={}), x_fused: str | None = Header(def
     # malformed id is a client bug rather than a URL this server goes and fetches.
     parts = model_id.split("/")
     if len(parts) != 2 or not all(parts) or len(model_id) > _MAX_ID_LEN:
-        return _error(f"{body.get('id')!r} is not a repo id of the form org/name", status=400)
+        # Echoed back so a caller can see WHICH id was refused, truncated so a
+        # megabyte of junk in the body is not a megabyte of error message.
+        return _error(f"{model_id[:80]!r} is not a repo id of the form org/name", status=400)
 
     key = ("size", hub_endpoint(), model_id, bool(_token()))
     payload = _cached(key)

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -503,6 +503,7 @@ def test_image_generation_takes_MFLUX_on_apple_silicon_and_diffusers_elsewhere(
     # Switching also moves the suggestion list, since a repo belongs to a
     # backend: the MLX conversion is unloadable by diffusers and vice versa.
     assert [m["id"] for m in catalog.for_capability(registry.IMAGE_GENERATION)] == [
+        "tonera/FLUX.2-klein-4B-int8-diffusers",
         "black-forest-labs/FLUX.2-klein-4B"]
 
     # Windows and Linux never see the MLX row at all, preference or none.

--- a/tests/test_hub_models.py
+++ b/tests/test_hub_models.py
@@ -604,3 +604,157 @@ def test_the_task_glossary_stays_an_ordinary_read(client):
     so it keeps the unguarded GET every other read has (WF-5). The asymmetry is
     the point: what earns the guard is the outbound call, not the router."""
     assert client.get("/api/ai-models/hub/tasks").status_code == 200
+
+
+# -- the total-size fallback (hub/size) --------------------------------------
+#
+# A repo with no safetensors metadata — GGUF, mflux, a LoRA — has no size to
+# recover from a dtype map, and the search endpoint cannot ask for one: the
+# Hub's LIST endpoint refuses `expand[]=usedStorage` outright. The real total
+# comes from the per-repo DETAIL endpoint, one round trip each, which is why it
+# is its own route the page calls only for the cards it is actually showing.
+
+
+def _size(client, body=None):
+    """One size lookup. Guarded POST for the same reason search is: it leaves
+    the machine carrying the user's token."""
+    return client.post("/api/ai-models/hub/size", json=body or {},
+                       headers={"X-Fused": "1"})
+
+
+def _detail(payload, status=200, body=None):
+    """A stand-in `httpx.get` returning one canned per-repo detail answer — an
+    OBJECT, not the list the search endpoint gets."""
+    def fake(url, **kwargs):
+        fake.calls.append((url, kwargs))
+        content = json.dumps(payload).encode() if body is None else body
+        return httpx.Response(status, content=content,
+                              request=httpx.Request("GET", url))
+    fake.calls = []
+    return fake
+
+
+def test_the_total_size_comes_from_the_detail_endpoint(client, monkeypatch):
+    # The number the Hub's own model page shows for a repo with no safetensors:
+    # everything in it, not just the weights.
+    fake = _detail({"id": "Runpod/FLUX.2-klein-4B-mflux-4bit", "usedStorage": 4_619_599_193})
+    monkeypatch.setattr(httpx, "get", fake)
+    body = _size(client, {"id": "Runpod/FLUX.2-klein-4B-mflux-4bit"}).json()
+    assert body == {"id": "Runpod/FLUX.2-klein-4B-mflux-4bit",
+                    "usedStorage": 4_619_599_193, "error": None}
+    url = fake.calls[0][0]
+    assert url == ("https://huggingface.co/api/models/"
+                   "Runpod/FLUX.2-klein-4B-mflux-4bit?expand%5B%5D=usedStorage")
+
+
+def test_a_repo_the_hub_has_no_total_for_reports_none(client, monkeypatch):
+    # No guess and no fallback to the dtype map: this route's only job is the
+    # total, and a repo the Hub does not measure has none.
+    monkeypatch.setattr(httpx, "get", _detail({"id": "org/m"}))
+    assert _size(client, {"id": "org/m"}).json() == {
+        "id": "org/m", "usedStorage": None, "error": None}
+
+
+@pytest.mark.parametrize("value", ["4619599193", -1, 1.5, True, {}, None])
+def test_a_total_that_is_not_a_count_of_bytes_is_no_total(client, monkeypatch, value):
+    # A string of digits is not an int, and a negative is not a size. Either
+    # would reach the card as a number someone plans a download around.
+    monkeypatch.setattr(httpx, "get", _detail({"id": "org/m", "usedStorage": value}))
+    assert _size(client, {"id": "org/m"}).json()["usedStorage"] is None
+
+
+def test_the_id_is_quoted_into_the_path_not_concatenated(client, monkeypatch):
+    # `org/name` keeps its slash — it is the path — but nothing else does, so an
+    # id carrying a `?` cannot become a second query parameter.
+    fake = _detail({})
+    monkeypatch.setattr(httpx, "get", fake)
+    _size(client, {"id": "org/a b?expand[]=evil"})
+    url = fake.calls[0][0]
+    assert "/api/models/org/a%20b%3Fexpand%5B%5D%3Devil?" in url
+
+
+@pytest.mark.parametrize("bad", [
+    None, "", "   ", 7, ["org/m"], "nameonly", "org/name/extra", "/name", "org/",
+    "org/" + "n" * 300,
+])
+def test_a_malformed_id_is_refused_before_the_hub_is_asked(client, monkeypatch, bad):
+    fake = _detail({})
+    monkeypatch.setattr(httpx, "get", fake)
+    reply = _size(client, {"id": bad})
+    assert reply.status_code == 400 and reply.json()["error"]
+    assert not fake.calls, "a malformed id still cost an outbound request"
+
+
+def test_an_unreachable_hub_is_a_sentence_not_a_500_for_sizes(client, monkeypatch):
+    def boom(url, **kwargs):
+        raise httpx.ConnectError("no route to host")
+
+    monkeypatch.setattr(httpx, "get", boom)
+    body = _size(client, {"id": "org/m"}).json()
+    assert body["usedStorage"] is None and "huggingface.co" in body["error"]
+
+
+@pytest.mark.parametrize("status,needle", [
+    (403, "token"), (429, "rate-limiting"), (500, "500")])
+def test_an_unhappy_hub_explains_itself_for_sizes(client, monkeypatch, status, needle):
+    monkeypatch.setattr(httpx, "get", _detail(None, status=status))
+    body = _size(client, {"id": "org/m"}).json()
+    assert body["usedStorage"] is None and needle in body["error"]
+
+
+@pytest.mark.parametrize("raw", [b"<html>nope</html>", b'[{"not": "an object"}]'])
+def test_an_unexpected_detail_reply_does_not_reach_the_page(client, monkeypatch, raw):
+    # The detail endpoint answers with an object. A list is the LIST endpoint's
+    # shape, and reading one as a repo would be indexing blindly.
+    monkeypatch.setattr(httpx, "get", _detail(None, body=raw))
+    body = _size(client, {"id": "org/m"}).json()
+    assert body["usedStorage"] is None and body["error"]
+
+
+def test_the_same_repo_inside_the_window_is_asked_once(client, monkeypatch):
+    # One round trip per repo is the cost this route exists to bound; a card
+    # that scrolls back into view must not pay it again.
+    fake = _detail({"id": "org/m", "usedStorage": 123})
+    monkeypatch.setattr(httpx, "get", fake)
+    for _ in range(3):
+        assert _size(client, {"id": "org/m"}).json()["usedStorage"] == 123
+    assert len(fake.calls) == 1
+    _size(client, {"id": "org/other"})
+    assert len(fake.calls) == 2  # …a different repo is a different question
+
+
+def test_a_size_error_is_not_cached(client, monkeypatch):
+    monkeypatch.setattr(httpx, "get", _detail(None, status=500))
+    assert _size(client, {"id": "org/m"}).json()["error"]
+    monkeypatch.setattr(httpx, "get", _detail({"id": "org/m", "usedStorage": 9}))
+    assert _size(client, {"id": "org/m"}).json()["usedStorage"] == 9
+
+
+def test_the_size_lookup_does_not_collide_with_a_search_answer(client, hub_cache, monkeypatch):
+    # Both caches are the same dict, so the keys have to be told apart or a
+    # search would be answered with a size.
+    monkeypatch.setattr(httpx, "get", _reply([_hit("org/m")]))
+    assert _search(client).json()["models"][0]["id"] == "org/m"
+    monkeypatch.setattr(httpx, "get", _detail({"id": "org/m", "usedStorage": 5}))
+    assert _size(client, {"id": "org/m"}).json()["usedStorage"] == 5
+
+
+def test_the_size_lookup_sends_the_token_but_never_returns_it(client, monkeypatch):
+    fake = _detail({"id": "org/m", "usedStorage": 5})
+    monkeypatch.setenv("HF_TOKEN", "hf_secret")
+    monkeypatch.setattr(httpx, "get", fake)
+    body = _size(client, {"id": "org/m"}).json()
+    assert fake.calls[0][1]["headers"]["Authorization"] == "Bearer hf_secret"
+    assert "hf_secret" not in json.dumps(body)
+
+
+def test_the_size_lookup_is_a_guarded_post(client, monkeypatch):
+    # Same reasoning as search: the cost is in the REQUEST, which spends
+    # someone's credential and their rate limit on a third party.
+    fake = _detail({"id": "org/m", "usedStorage": 5})
+    monkeypatch.setattr(httpx, "get", fake)
+    blind = client.post("/api/ai-models/hub/size", json={"id": "org/m"})
+    assert blind.status_code == 403
+    assert not fake.calls, "a guarded size lookup still reached the Hub"
+    assert client.get("/api/ai-models/hub/size").status_code == 405
+    assert _size(client, {"id": "org/m"}).status_code == 200

--- a/tests/test_hub_models.py
+++ b/tests/test_hub_models.py
@@ -502,6 +502,62 @@ def test_an_ungated_result_says_so_rather_than_saying_nothing(client, hub_cache,
     assert [r["gated"] for r in _search(client).json()["models"]] == [None, None]
 
 
+def test_a_result_in_a_format_no_runner_reads_is_dropped(client, hub_cache, monkeypatch):
+    """The tag is right and the format is unreadable — the case the tag filter
+    cannot see.
+
+    `litert-community/FLUX.2-klein-4B-LiteRT` is the repo from the complaint: a
+    `text-to-image` model, so `capability_for_task` passes it, published as
+    `.tflite` graphs, which nothing in `runners/` imports under any
+    circumstances. The card offered a Download button and the load that followed
+    could only fail.
+    """
+    monkeypatch.setattr(httpx, "get", _reply([
+        {"id": "litert-community/FLUX.2-klein-4B-LiteRT",
+         "pipeline_tag": "text-to-image", "library_name": "litert"},
+        # A raw NeMo archive is the same shape of mistake in the audio column:
+        # `parakeet-mlx` reads the MLX CONVERSION of one, never the `.nemo`.
+        {"id": "nvidia/parakeet-tdt-0.6b-v3",
+         "pipeline_tag": "automatic-speech-recognition", "library_name": "nemo"},
+        _hit("org/known"),
+    ]))
+    assert [m["id"] for m in _search(client).json()["models"]] == ["org/known"]
+
+
+def test_a_result_with_no_library_name_is_kept(client, hub_cache, monkeypatch):
+    """An ABSENT library says nothing about the format, so it cannot be read as
+    "unsupported" — only a value naming a framework we have no runner for is."""
+    monkeypatch.setattr(httpx, "get", _reply([
+        _hit("org/unsaid"), _hit("org/null", library_name=None),
+        # Not a string, so not a value either: this must be as harmless as a
+        # missing key rather than a 500 in a `.lower()`.
+        _hit("org/weird", library_name=17),
+    ]))
+    assert [m["id"] for m in _search(client).json()["models"]] == [
+        "org/unsaid", "org/null", "org/weird"]
+
+
+@pytest.mark.parametrize("library", [
+    # Every one of these is a value a repo something here loads TODAY reports,
+    # read off the Hub rather than guessed — which is why this filter is a
+    # denylist. An allowlist of the libraries our runners are built on
+    # (diffusers, transformers, mlx) would have hidden five of these eight.
+    "diffusers",            # black-forest-labs/FLUX.2-klein-4B
+    "transformers",         # most text models
+    "mlx",                  # mlx-community/whisper-large-v3-turbo, …/Qwen3-8B-4bit
+    "mflux",                # Runpod/FLUX.2-klein-4B-mflux-4bit
+    "ggml",                 # unsloth/FLUX.2-klein-4B-GGUF, the recipe's transformer
+    "gguf",                 # the same repos' other spelling of it
+    "ctranslate2",          # Systran/faster-whisper-large-v3
+    "diffusion-single-file",  # mlx-community/FLUX.2-Klein-4B-4bit
+])
+def test_a_library_something_here_loads_is_not_dropped(client, hub_cache, monkeypatch, library):
+    monkeypatch.setattr(httpx, "get", _reply([_hit("org/fine", library_name=library)]))
+    models = _search(client).json()["models"]
+    assert [m["id"] for m in models] == ["org/fine"]
+    assert models[0]["library"] == library
+
+
 def test_asking_for_a_task_nothing_here_runs_is_refused(client, hub_cache, monkeypatch):
     # Not an empty grid: that reads as "the Hub has no summarization models"
     # rather than "this app does not run them", and the Hub is not the one being


### PR DESCRIPTION
## Summary

- Discover cards for a Hub repo with no `safetensors` metadata (GGUF, MLX/mflux, LoRA-only, etc.) always showed "—" for size, even though the Hub itself reports a real total via a `usedStorage` field. That field isn't available on the bulk search endpoint (confirmed via a live 400), only on the per-repo detail endpoint, so it's fetched lazily — one request per card, and only once the card actually scrolls into view — rather than eagerly for every search result. A follow-up fix (found by `/code-review`) makes sure a transient Hub-side failure (429, unreachable) is never cached as a permanent "no size" — only a genuine answer is remembered.
- Discover search results included repos in formats no runner in this app can load at all (e.g. `litert-community/FLUX.2-klein-4B-LiteRT`, `library_name: "litert"`), which showed a working-looking Download button that would fail at Load time. The existing filter only checked `pipeline_tag`, never `library_name`. Added a denylist of `library_name` values with categorically no runner path here (LiteRT/TFLite, ONNX, CoreML, OpenVINO, NeMo, and others) — deliberately a denylist, not an allowlist, since the app's own working repos already span four different `library_name` values (`diffusers`, `ggml`, `diffusion-single-file`, `mflux`) for one model family alone, so a naive allowlist would have hidden real, working results.
- Added a smaller diffusers-side FLUX.2 klein option: `tonera/FLUX.2-klein-4B-int8-diffusers` (~8.2GB, genuine `torchao` `Int8WeightOnlyConfig` quantization, verified against the actual pinned diffusers wheel's loading code — no `use_safetensors` workaround needed, and none added). Because it's smaller than the existing GGUF-recipe entry (10.8GB actual pull), it becomes the new default for a bare `fused.ai.image()` call, per the app's existing size-ordering convention — confirmed as the intended outcome rather than a side effect to work around.

None of these changes touch the existing "an engine here can run it" pipeline_tag filter — all three are additive fallbacks/guards/options.

## Visuals

```mermaid
flowchart TD
    A[Hub search result] --> B{pipeline_tag runnable?}
    B -->|no| X[dropped]
    B -->|yes| C{library_name in denylist?}
    C -->|yes, e.g. litert| X
    C -->|no| D{estimatedSize from safetensors?}
    D -->|yes| E[card shows size]
    D -->|no| F[card shows —]
    F --> G[card scrolls into view]
    G --> H[POST /api/ai-models/hub/size]
    H -->|real answer| E
    H -->|Hub error| F
```

## Usage

No new user-facing controls for the search-page fixes — both are transparent improvements to the existing AI Models → Discover page:
- Searching the Hub now silently omits results this app has no runner for.
- A result card with no safetensors-derived size fills in a real total size shortly after scrolling into view; a transient Hub error is retried instead of freezing as "—" forever.

The new catalog entry IS user-visible: it appears in AI Models → Discover's curated `diffusers-image` suggestions, and — being the smallest entry — is what a bare `fused.ai.image()` call downloads/loads by default going forward.

## Test Plan

- [x] Backend: `tests/test_hub_models.py` — 83 tests, covering the size endpoint (success, missing `usedStorage`, all Hub failure modes, id validation, URL quoting, caching/no-cache-on-error) and the library-format filter (litert/nemo dropped, missing/null `library_name` passes through, an 8-case regression guard over every `library_name` this app's existing runners actually use).
- [x] Frontend: `frontend/src/shell/hubSize.test.ts` (15 tests) covering the lazy-fetch cache/dedup/tooltip logic, including the error-vs-genuine-null distinction from the code-review fix. Full frontend suite 2004 passing, `tsc --noEmit` clean.
- [x] `tests/test_ai_runtime.py`, `tests/test_ai_diffusers_worker.py`, `tests/test_ai_models_api.py` — 418 passing, including the updated default-model assertion for the new catalog entry.
- [x] Full backend suite run three times (once per change) on this machine: `19 failed, 8537 passed, 143 skipped, 1 error` every time — same failure IDs as the pre-existing macOS-local baseline (`test_claude_health`, `templates/map` GDAL/true-color, `test_calls`, `test_ai_metrics`, a joblib_model import collision), no new failures from any of the three changes.
- [ ] Manual: open AI Models → Discover, search "FLUX.2 klein 4B", confirm `litert-community/FLUX.2-klein-4B-LiteRT` no longer appears and `tonera/FLUX.2-klein-4B-int8-diffusers` does; confirm a card with no safetensors size fills in a real size shortly after scrolling it into view.
- [ ] Manual (higher-risk, not verified here — no GPU/download in this sandbox): actually download and load `tonera/FLUX.2-klein-4B-int8-diffusers` end to end on a real machine to confirm the torchao-quantized transformer loads and generates.
