### PR TITLE
Raise preview sidebar floor to 380px to fix broken claude composer

### DIFF
--- a/frontend/src/apps/explorer/PreviewSidebar.tsx
+++ b/frontend/src/apps/explorer/PreviewSidebar.tsx
@@ -237,7 +237,7 @@ export default function PreviewSidebar({
         // WITHOUT recording a width: the close is reached by dragging THROUGH the
         // resistance band, so every move before this one stuck the column at the
         // floor, and committing that would file MIN_W as the user's choice — shut
-        // a 520px column and it would come back at 280. `outcome = null` makes
+        // a 620px column and it would come back at 380. `outcome = null` makes
         // pointer-up hand `preGesture` back instead (`committedWidth`). Shutting a
         // panel is not the same act as making it narrow, and one drag should not
         // do both.

--- a/frontend/src/apps/explorer/lib/side-width.test.ts
+++ b/frontend/src/apps/explorer/lib/side-width.test.ts
@@ -28,21 +28,26 @@ describe("COMPANION_FRAC", () => {
 describe("defaultSideWidth", () => {
   it("opens at 30% of a normal container", () => {
     expect(defaultSideWidth(1440)).toBe(432);
-    expect(defaultSideWidth(1200)).toBe(360);
+    expect(defaultSideWidth(1600)).toBe(480);
   });
 
   it("opens at 50% of a small container — 1000 counts as small", () => {
     // D283 restored this step, and the boundary is inclusive (`<=`), matching CSS
-    // `(max-width: 1000px)`. The assertion this replaces claimed the 280px FLOOR
-    // reached the same answer without a step, which was simply false: 280 of 720
-    // is 39%, not 50%. The boundary itself moved from 720 to 1000 on the owner's
-    // window, which was on the 30% side of it and wanted half.
+    // `(max-width: 1000px)`. The assertion this replaces claimed the OLD 280px
+    // floor reached the same answer without a step, which was simply false: 280
+    // of 720 is 39%, not 50%. The boundary itself moved from 720 to 1000 on the
+    // owner's window, which was on the 30% side of it and wanted half.
     expect(defaultSideWidth(1000)).toBe(500);
-    expect(defaultSideWidth(720)).toBe(360);
-    expect(defaultSideWidth(680)).toBe(340);
-    // Just over the boundary is the general case: 30% of 1001 is 300, over the
-    // 280px floor, so the share itself answers.
-    expect(defaultSideWidth(1001)).toBe(300);
+    // 50% of 720 is 360, under the 380px floor (MIN_W raised for the claude
+    // template's composer row, side-width.ts), so the floor answers here now.
+    expect(defaultSideWidth(720)).toBe(380);
+    // 680 no longer has room for both floors at all (680 - CONTENT_MIN_W = 360 <
+    // MIN_W), so this is the no-split branch below, not the 50% share.
+    expect(defaultSideWidth(680)).toBe(380);
+    // Just over the boundary is the general (30%) case, but 30% of 1001 is only
+    // 300 — still under the 380px floor, so the floor keeps answering until the
+    // share itself clears it (~1267px, see the 1600 case above).
+    expect(defaultSideWidth(1001)).toBe(380);
   });
 
   it("never needs the MIN_W floor once both floors fit — the SHARE always clears it", () => {
@@ -64,17 +69,18 @@ describe("defaultSideWidth", () => {
     }
   });
 
-  it("gives the content column its floor back when the SHARE is greedy", () => {
-    // 600px is a 50% container, so the share wants 300 — and the content column's
-    // 320px floor claws 20 of it back, leaving 280. The two floors meet exactly
-    // here, which makes 600 the tightest point in the range for the content side.
-    //
-    // It is the CONTENT cap that answers, not the column's own MIN_W: this case
-    // read "the column's own 280px floor beats 30% (=180)" and passed for that
-    // reason until D283 put 600 on the 50% side. Same number, different mechanism —
-    // which is exactly the kind of green worth distrusting.
-    expect(defaultSideWidth(600)).toBe(600 - CONTENT_MIN_W);
-    expect(defaultSideWidth(600)).toBe(280);
+  it("the two floors meet exactly at their sum, and MIN_W answers there", () => {
+    // This used to be 600px demonstrating the CONTENT column's floor clawing
+    // room back from a greedy 50% share (300 → 280). Raising MIN_W to 380
+    // (side-width.ts) retired that scenario outright: with MIN_W(380) +
+    // CONTENT_MIN_W(320) = 700, no container between the "no room for both
+    // floors" cutoff and the point where the SHARE itself clears 380 ever
+    // asks for more than `max` — the arithmetic no longer has a width where
+    // the content floor is the one doing the clipping. 700 is now the exact
+    // seam: one px narrower and there is no split to express at all (the
+    // "answers MIN_W when the two floors cannot both fit" case below), one at
+    // or past it and MIN_W answers directly before the share ever gets a say.
+    expect(defaultSideWidth(MIN_W + CONTENT_MIN_W)).toBe(MIN_W);
   });
 
   it("answers MIN_W when the two floors cannot both fit", () => {

--- a/frontend/src/apps/explorer/lib/side-width.ts
+++ b/frontend/src/apps/explorer/lib/side-width.ts
@@ -16,7 +16,19 @@
 // composer and a message column, whose legibility is a width in pixels and not
 // a share of the window. The content pane keeps whatever is left, with its own
 // floor so neither the default nor a drag can swallow it.
-export const MIN_W = 280;
+//
+// MIN_W WAS 280, AND 280 WAS BROKEN — not narrow-but-usable, actually broken:
+// screenshotted live (a claude template chat in the column, cmux at 1500x950),
+// the composer's control row (`fable` / `medium` / `ask every time`, then the
+// screenshot and calendar buttons, then Send) wrapped onto two cramped lines at
+// every width from 280 up through 360, and the folder/file title above it
+// wrapped too. 380 is the first width, measured the same way, where that whole
+// row sits on one line with room to breathe — so the floor moved to meet the
+// content instead of the content being asked to fit a floor picked before this
+// template existed. `closeOverdrag` (platform/lib/panel-drag.ts) reads this
+// constant rather than a copy, so the drag-to-close threshold widens with it
+// automatically.
+export const MIN_W = 380;
 export const CONTENT_MIN_W = 320;
 
 // **THE COMPANION COLUMN'S SHARE — one rule, both surfaces** (D283, amending

--- a/frontend/src/platform/lib/panel-drag.test.ts
+++ b/frontend/src/platform/lib/panel-drag.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@platform/lib/panel-drag";
 
 // The two seams that read this module use different floors (the global sidebar's
-// 180, the preview column's 280) and sit on opposite edges of the window, so
+// 180, the preview column's 380) and sit on opposite edges of the window, so
 // every case below names its own numbers rather than importing either surface's
 // constants. What is being tested is the RULE, not one panel's arithmetic.
 const MIN = 180;
@@ -50,7 +50,7 @@ describe("resizeWidth — the seam of an OPEN panel", () => {
 describe("closeOverdrag", () => {
   it("is half the floor, so a wider panel resists further", () => {
     expect(closeOverdrag(180)).toBe(90); // the global sidebar
-    expect(closeOverdrag(280)).toBe(140); // the preview's companion column
+    expect(closeOverdrag(380)).toBe(190); // the preview's companion column
   });
 
   it("stays an integer on an odd floor", () => {

--- a/frontend/src/platform/lib/panel-drag.ts
+++ b/frontend/src/platform/lib/panel-drag.ts
@@ -34,13 +34,13 @@ export type ImpliedWidth = number;
  * chevron rather than a gesture; see `OPEN_PULL`.
  *
  * Scaling with the floor rather than fixing a number is the part worth keeping.
- * The two panels here have different floors (180px for the global sidebar, 280px
- * for the preview's companion column) because they hold different things, and a
- * shared constant would mean the wider panel resisted proportionally less — the
- * bigger the panel, the cheaper it would be to lose. Half the floor keeps the
- * overshoot in proportion to what is at stake: 90px on the sidebar, 140px on the
- * column. Both are past the reach of an accident and inside one continuous drag,
- * which is the whole specification.
+ * The two panels here have different floors (180px for the global sidebar, 380px
+ * for the preview's companion column — apps/explorer/lib/side-width's MIN_W)
+ * because they hold different things, and a shared constant would mean the wider
+ * panel resisted proportionally less — the bigger the panel, the cheaper it
+ * would be to lose. Half the floor keeps the overshoot in proportion to what is
+ * at stake: 90px on the sidebar, 190px on the column. Both are past the reach of
+ * an accident and inside one continuous drag, which is the whole specification.
  */
 export function closeOverdrag(min: number): number {
   return Math.floor(min / 2);

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -363,7 +363,7 @@ html.side-reopening iframe {
    `position: relative` anchors the seam below. */
 .preview-side {
   flex: 0 0 auto;
-  min-width: 280px;
+  min-width: 380px;
   min-height: 0;
   display: flex;
   flex-direction: column;

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -9846,7 +9846,39 @@ function setRowCompact(row, on) {
       o.textContent = on ? (PERMISSION_SHORT[o.value] || o.dataset.full) : o.dataset.full;
     }
     fitSelect(sel);
+    permPopupGuard(sel, row);
   }
+}
+
+// The one reader of the OPTIONS the rewrite above cannot fool: the NATIVE
+// popup. Pointer opens the custom menu, which spells everything out from
+// `dataset.full` — but keyboard (Space, Enter, the arrows) opens the select's
+// own list, and that list paints the options' live textContent, so a compact
+// row offered `ask / edits / decides` as the actual choices (bugbot, #685).
+// The full spellings are restored on the keydown that is about to open the
+// popup — synchronously, before the default action — and the short forms come
+// back on change/blur, the two ways a popup ends. fitSelect is deliberately
+// NOT re-run: the pill's box keeps its fitted width, so nothing in the row
+// moves; the longer selected text can clip inside that box only while the
+// popup is open, which is exactly when nobody is looking at the pill.
+// mousedown is guarded too, for any path where the custom menu does not
+// intercept the pointer.
+function permPopupGuard(sel, row) {
+  if (sel.dataset.popguard) return;
+  sel.dataset.popguard = "1";
+  const full = () => {
+    for (const o of sel.options) o.textContent = o.dataset.full;
+  };
+  const short = () => {
+    if (!row.classList.contains("compact")) return;
+    for (const o of sel.options) o.textContent = PERMISSION_SHORT[o.value] || o.dataset.full;
+  };
+  sel.addEventListener("keydown", (e) => {
+    if (e.key === " " || e.key === "Enter" || e.key === "ArrowDown" || e.key === "ArrowUp") full();
+  });
+  sel.addEventListener("mousedown", full);
+  sel.addEventListener("change", short);
+  sel.addEventListener("blur", short);
 }
 
 function fitComposerRow(row) {

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -2224,6 +2224,17 @@
      does not take in the same engine (an inline `row-gap` loses to the `gap`
      shorthand above), and 12px between "what the run is" and "what to do with
      the draft" reads as the grouping it is. Every gap WITHIN a line is still 6. */
+  /* Stage 3, and the one that keeps the ROW WHOLE: everything stays on one line
+     and the chrome gets denser instead — gaps to 3px, pill insets trimmed, the
+     select carets pulled in. Folding was tried as stage 3 and rejected on sight
+     (Akshil, 2026-08-20: "the chat icons and dropdown are not in single line") —
+     a fold moves controls to a place they never sit at any other width, and a
+     denser line keeps every control exactly where the reader's hand knows it.
+     fitComposerRow re-runs fitSelect after stamping this, because the fitted
+     widths bake the paddings in. */
+  .composer-row.tight { gap: 3px; }
+  .composer-row.tight .pill { padding-left: 5px; padding-right: 5px; }
+  .composer-row.tight select.pill { padding-right: 17px; background-position: right 5px center; }
   .composer-row.stack .spacer { flex: 0 0 auto; width: 100%; height: 0; }
   /* Line two stays flush RIGHT, where these controls sit in the wide layout, so
      folding the row never teleports Send across the composer. `.lead2` is written
@@ -9795,12 +9806,16 @@ document.querySelectorAll(".perm-sel").forEach((el) =>
 //                                 The other two pills are already one word, and the
 //                                 menu still spells all four modes out, so this
 //                                 costs a label and no vocabulary.
-//   3. `.stack`                   the row folds ONCE, at the spacer: the three
-//                                 selects that describe the run on one line, the
-//                                 things you DO with the draft on the next, flush
-//                                 right. Two tidy lines with the row's own 6px
-//                                 gaps — never the ragged wrap, and never a control
-//                                 orphaned on a line of its own.
+//   3. `.tight`                   the line gets DENSER instead of longer: 3px
+//                                 gaps, trimmed pill insets, carets pulled in —
+//                                 every control stays on the one line, exactly
+//                                 where it sits at every other width (Akshil,
+//                                 2026-08-20: the fold read as controls "not in
+//                                 single line").
+//   4. `.stack`                   last resort, at widths below even the dense
+//                                 line: the row folds ONCE, at the spacer —
+//                                 selects on one line, draft controls on the
+//                                 next, flush right. Never the ragged wrap.
 // Reachable in that order and no further: below ~300px (the listing preview pane
 // floors at 220, see #anntools) even three pills exceed the line and the browser's
 // own wrap takes over, which is the honest end of the ladder rather than a fourth
@@ -9884,11 +9899,23 @@ function permPopupGuard(sel, row) {
 function fitComposerRow(row) {
   const box = row.clientWidth;
   if (!box) return;   // the other view's composer: no box, nothing to decide yet
+  const refit = () => {
+    for (const sel of row.querySelectorAll(".model-sel, .effort-sel, .perm-sel")) fitSelect(sel);
+  };
   row.classList.remove("stack");
+  const wasTight = row.classList.contains("tight");
+  row.classList.remove("tight");
   setRowCompact(row, false);
+  // setRowCompact refits only the approvals pill; leaving .tight refits ALL the
+  // selects, whose fitted widths baked the tight paddings in.
+  if (wasTight) refit();
   if (composerRowNeed(row) > box) {
     setRowCompact(row, true);
-    if (composerRowNeed(row) > box) row.classList.add("stack");
+    if (composerRowNeed(row) > box) {
+      row.classList.add("tight");
+      refit();
+      if (composerRowNeed(row) > box) row.classList.add("stack");
+    }
   }
   // Line two's right-hand anchor, decided here because the stylesheet cannot name
   // it: the first control after the spacer is Send when there is no pane (the

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -2187,6 +2187,54 @@
     flex-wrap: wrap;
   }
   .composer-row .spacer { flex: 1; }
+  /* ── the control row's two degradations, stamped by fitComposerRow ──
+     The row is five controls and a column floor of 380px (the sidebar's MIN_W,
+     explorer/lib/side-width.ts), and at that width the full-length approvals
+     label was enough to tip it over: screenshotted live it broke into a ragged
+     wrap with one pill stranded per line, which reads as broken rather than as
+     adapted (Akshil, 2026-08-20: "nor do I see the change in UI to show or hide
+     things"). `flex-wrap: wrap` above is still the last resort and stays — what
+     these two classes do is spend the width DELIBERATELY before the browser has
+     to guess, in the order a reader would: shorten the one long word first, and
+     only then split the row, and split it where its own grammar already splits
+     (the three selects that describe the run / the things you DO with a draft).
+
+     Measured, never a breakpoint: fitComposerRow sums the row's own content
+     against its box, which is the same discipline annFitStrip uses one pane over
+     — a fixed width would have to guess at three select labels whose text the
+     user changes.
+
+     `.compact` carries no declarations on purpose. What it shortens is option
+     TEXT, which is DOM content and not something a stylesheet can rewrite (see
+     PERMISSION_SHORT); the class is still written onto the row so the state is
+     visible in the inspector and readable from the outside. */
+  /* Two tidy lines, never a ragged wrap. The spacer — the row's one elastic cell
+     while everything fits — becomes the LINE BREAK, which is the only way a flex
+     row can be told where to fold.
+
+     `width: 100%` and NOT `flex-basis: 100%`, measured in the browser this
+     template actually ships inside (WKWebView): a percentage basis on this span
+     was ignored outright and the row went on wrapping wherever it liked, which is
+     the bug this class exists to prevent. A width with `flex: 0 0 auto` resolves
+     the basis the long way round and folds the line every time.
+
+     The break's own height is 0, so the two lines sit the row's gap apart TWICE
+     — 12px, because an empty flex line takes a gap above and below it. That is
+     the deliberate answer rather than the tidier 6px: `row-gap: 0` on this row
+     does not take in the same engine (an inline `row-gap` loses to the `gap`
+     shorthand above), and 12px between "what the run is" and "what to do with
+     the draft" reads as the grouping it is. Every gap WITHIN a line is still 6. */
+  .composer-row.stack .spacer { flex: 0 0 auto; width: 100%; height: 0; }
+  /* Line two stays flush RIGHT, where these controls sit in the wide layout, so
+     folding the row never teleports Send across the composer. `.lead2` is written
+     by fitComposerRow onto the first control that actually lands on line two:
+     `.viewshot` is [hidden] in the narrow layout and when there is no pane at
+     all, so the anchor cannot be named in the stylesheet. `.send` gives up its
+     own `margin-left: auto` here (two autos on one line split the slack and
+     centre the group instead of pinning it), and the `.lead2` rule follows it so
+     it wins on source order for the case where Send IS that first control. */
+  .composer-row.stack .send { margin-left: 0; }
+  .composer-row.stack .lead2 { margin-left: auto; }
   .pill {
     background-color: transparent;
     border: 1px solid transparent;
@@ -2456,7 +2504,23 @@
     text-align: center;
     color: var(--faint);
     font-size: 11px;
+    /* Spelled rather than inherited (body is 1.65) for two reasons: two lines of
+       11px prose under a composer wants less air than a paragraph does, and
+       fitFootnote below measures this box in LINES — an explicit value is the one
+       it can divide by without asking the UA what a footnote's line is. */
+    line-height: 1.5;
   }
+  /* TWO LINES IS THE WHOLE BUDGET. In a 380px column the sentence pair ran to
+     three, which under a composer is no longer a footnote — it is a paragraph
+     competing with the thing it annotates. The second sentence goes instead of
+     the first being ellipsised: half a sentence with a "…" on it says the app
+     ran out of room, while one whole sentence says what it says. Which one is
+     kept is not a coin toss either — "Claude can read and edit files here" is
+     the reach, the part a reader needs before they type; approvals are named by
+     the pill two rows up, which is where that sentence was pointing anyway.
+     `.fn-more` is written by setTargetNoun (the only place this text lives) and
+     the class is decided by measurement, not by a width. */
+  #footnote.tight .fn-more { display: none; }
   #chat.home #footnote { display: none; }
 
   /* ── markdown, in the TWO places rendered markdown lands ──
@@ -2634,13 +2698,39 @@
      stacked. One 32px here, one margin per block below. */
   #home .inner { width: 100%; max-width: 620px; padding: 0 24px 32px; }
   .home-title {
+    /* 26px IS the title, and it stays the title wherever there is room for one.
+       Where there is not — this column's floor is 380px and a folder name is
+       arbitrarily long — fitHomeTitle stamps one of the two steps below, so the
+       name shrinks to its ONE line instead of becoming a 26px two-line headline
+       that outweighs the composer it is introducing (the landing page's actual
+       subject). Measured, and deliberately not a container query — this template
+       detects collisions and declares no breakpoints, a rule
+       tests/test_claude_annotation_modes.py enforces over the whole file — and
+       the thing worth measuring is whether THIS name fits, not how wide the
+       column is.
+       `anywhere` for the case past the last step: these names are paths and
+       slugs with no spaces in them, and without it one unbroken name overflows
+       the column instead of wrapping inside it. */
     font-size: 26px;
+    overflow-wrap: anywhere;
     font-weight: 600;
     letter-spacing: -.02em;
     color: var(--fg-strong);
     text-align: center;
     margin-bottom: 4px;
   }
+  /* TWO STEPS AND A CLASS, not a computed pixel size written inline. The size is
+     declared here for the reason every other verdict in this file is (D146, the
+     narrow layout's collapse, #inputbox): a stylesheet declaration can be
+     overridden by a later rule and reasoned about in the inspector, and the sizes
+     a headline is allowed to take are a design decision that belongs where the
+     rest of the type scale is — fitHomeTitle only decides WHICH.
+     Two steps and not a continuum because a headline has a small number of sizes
+     it can be and still look chosen: 21px is a title in a 380px column, 17px is
+     the last size that still reads as a heading rather than as body text. Past
+     that the name wraps at 17px, which is the honest end. */
+  .home-title.t-mid { font-size: 21px; }
+  .home-title.t-min { font-size: 17px; }
   .home-title .spark { color: var(--accent); margin-right: 10px; font-weight: 400; }
   .home-sub {
     color: var(--faint);
@@ -3453,8 +3543,12 @@
          placeholder is the first), and it ships the kind-FREE wording for the
          same reason: the kind is not known until stat answers, and a sentence
          that flips from a wrong noun to a right one is worse than one that gains
-         a noun. setTargetNoun writes both. -->
-    <div id="footnote">Claude can read and edit files here. Approvals control what runs without asking.</div>
+         a noun. setTargetNoun writes both.
+         The SECOND sentence is wrapped in its own span, in the markup as well as
+         in setTargetNoun's rewrite, because it is the half a narrow column drops
+         (fitFootnote) — and it ships that way rather than being wrapped later so
+         the very first paint is already measurable. -->
+    <div id="footnote">Claude can read and edit files here.<span class="fn-more"> Approvals control what runs without asking.</span></div>
 
     <!-- home view -->
     <div id="home">
@@ -4429,10 +4523,15 @@ const setTargetNoun = (noun) => {
   // and "and the assets it references" is not decoration, it is exactly the
   // reach `_system_prompt` gives the agent for a file target. A folder and a
   // project both CONTAIN the files, so they share the shape.
+  // ONE write for the sentence that depends on the kind, exactly as before —
+  // and it clears the node, so the second sentence is put back after it by
+  // footnoteTail(). The second sentence is its own ELEMENT (not part of this
+  // string) because a narrow column drops it whole rather than ellipsising the
+  // pair; see #footnote.tight and fitFootnote.
   document.getElementById("footnote").textContent =
     (noun === "file" ? "Claude can read and edit this file and the assets it references."
-                     : "Claude can read and edit files in this " + noun + ".")
-    + " Approvals control what runs without asking.";
+                     : "Claude can read and edit files in this " + noun + ".");
+  footnoteTail();
   // A project's pane is the user's own app; a file's is our preview of their file.
   // "folder" never reaches the pane chrome at all — that target has no pane, and
   // applyPaneNoun's nodes are gone by then — but it resolves to the kind-free word
@@ -9337,6 +9436,26 @@ const PERMISSION_LABELS = {
   acceptEdits: "auto-accept edits",
   auto: "Claude decides",
 };
+// The same four modes in ONE WORD each, for the pill only, and only when the
+// control row has run out of width for the sentence (fitComposerRow). Approvals
+// is the row's long label — "fable" and "medium" beside it are already one word —
+// so it is also the only one that needs a short form, and shortening the one
+// offender is what keeps the row on a single line at the 380px floor.
+//
+// Each short form is the DISTINGUISHING word of its full label, never a
+// truncation: the reader who has seen the menu once recognises "ask" as "ask
+// every time" and "edits" as "auto-accept edits", where "ask ev…" would just look
+// clipped. "decides" and not "auto" for `auto`, even though the key is `auto`:
+// "auto" is the word "auto-accept edits" starts with, and the two loosest modes
+// must not read as the same word in the pill. The MENU always shows the full
+// sentences (openSelPop reads `dataset.full`), so the long form is one press away
+// and this is a label, never the vocabulary.
+const PERMISSION_SHORT = {
+  plan: "plan",
+  prompt: "ask",
+  acceptEdits: "edits",
+  auto: "decides",
+};
 const DEFAULT_MODEL = "sonnet";
 const DEFAULT_EFFORT = "medium";
 // What the user ACTUALLY last used with Claude Code for this project — via this
@@ -9390,6 +9509,13 @@ function fillSelect(el, values, groupLabel, labels) {
     const o = document.createElement("option");
     o.value = v;
     o.textContent = labels ? labels[v] : v;
+    // The label the MENU shows, kept beside the one the pill shows because the
+    // two can differ: fitComposerRow rewrites `textContent` to a one-word form
+    // when the row is out of width, and a menu that shortened with it would take
+    // the vocabulary away at exactly the moment the reader went looking for it.
+    // Written for every select, not just approvals — one rule in openSelPop is
+    // cheaper to trust than a rule that only holds for one pill.
+    o.dataset.full = o.textContent;
     group.appendChild(o);
   }
   el.appendChild(group);
@@ -9636,6 +9762,10 @@ function syncSelects() {
   // on — where the answer is picked for a task rather than borrowed from a chat.
   document.querySelectorAll(".perm-sel").forEach((el) => { el.value = chosen; });
   document.querySelectorAll(".model-sel, .effort-sel, .perm-sel").forEach(fitSelect);
+  // A value change is a WIDTH change ("ask every time" → "Claude decides"), so the
+  // row's fit is stale the moment a pill is picked. Hoisted declaration, defined
+  // below with the rest of the measuring.
+  fitComposerChrome();
 }
 document.querySelectorAll(".model-sel").forEach((el) =>
   el.addEventListener("change", () => { fused.params.set("model", el.value); syncSelects(); }));
@@ -9646,6 +9776,219 @@ document.querySelectorAll(".perm-sel").forEach((el) =>
     fused.params.set("permission", el.value);
     syncSelects();
   }));
+
+// ── the composer's chrome fits, shortens, or folds: measured, never a width ──
+//
+// WHAT WAS BROKEN. The sidebar column's floor is 380px (explorer/lib/side-width.ts
+// raised it from 280 for exactly this row), and at 380 — and again at ~440, which
+// is where the column actually opens — the control row did not fit: three select
+// pills, the screenshot and calendar buttons and Send came to more than the
+// column, `flex-wrap` did the only thing it can, and the result was a stack of
+// nearly-empty lines with one control on each. Akshil, 2026-08-20, looking at a
+// 440px column: "I don't see the change in size. Nor do I see the change in UI to
+// show or hide things." Both halves of that are the same complaint — a wider floor
+// alone cannot fix a row that never says what it does when it runs out of room.
+//
+// THE ORDER THINGS GIVE, and it is chosen rather than emergent:
+//   1. everything fits            one line, full labels — the wide layout, unchanged.
+//   2. `.compact`                 approvals shortens to one word (PERMISSION_SHORT).
+//                                 The other two pills are already one word, and the
+//                                 menu still spells all four modes out, so this
+//                                 costs a label and no vocabulary.
+//   3. `.stack`                   the row folds ONCE, at the spacer: the three
+//                                 selects that describe the run on one line, the
+//                                 things you DO with the draft on the next, flush
+//                                 right. Two tidy lines with the row's own 6px
+//                                 gaps — never the ragged wrap, and never a control
+//                                 orphaned on a line of its own.
+// Reachable in that order and no further: below ~300px (the listing preview pane
+// floors at 220, see #anntools) even three pills exceed the line and the browser's
+// own wrap takes over, which is the honest end of the ladder rather than a fourth
+// idea.
+//
+// MEASURED, following annFitStrip one pane over (Akshil, 2026-08-19: a fixed
+// breakpoint dropped labels while there was still room). The verdict is recomputed
+// from scratch every time — classes off, ask the row what it needs, put back only
+// what is warranted — so widening undoes itself with no state to get stale, and
+// the probe runs inside observer callbacks (before paint) so nothing flashes.
+const composerRows = [...document.querySelectorAll(".composer-row")];
+const footEl = document.getElementById("footnote");
+
+// What the row needs on ONE line, summed by hand. NOT scrollWidth: on a flex row
+// it is floored at clientWidth, and this row also wraps, so an overflowing row
+// quietly gets taller and reports no overflow at all — the exact failure that made
+// this invisible to CSS. The spacer is skipped because it is slack and not
+// content (flex-basis 0 while the row fits, the line break once it does not).
+function composerRowNeed(row) {
+  const cs = getComputedStyle(row);
+  let need = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+  let kids = 0;
+  for (const c of row.children) {
+    if (c.classList.contains("spacer") || !c.offsetWidth) continue;  // hidden child, no seat
+    need += c.offsetWidth;
+    kids += 1;
+  }
+  if (kids > 1) need += (parseFloat(cs.columnGap) || 0) * (kids - 1);
+  return need;
+}
+
+// Stage 2, and it is a DOM write rather than a class doing the work: what shortens
+// is the selected option's text, which is the only thing an appearance:none select
+// paints. Every option is rewritten, not just the selected one, so the pill is
+// right whichever mode is picked next — `dataset.full` (fillSelect) is what keeps
+// the MENU spelling the sentences out either way. fitSelect after, because the
+// pill's width is explicitly fitted to its label and a shortened label inside the
+// old box would leave exactly the dead space fitSelect exists to remove.
+function setRowCompact(row, on) {
+  row.classList.toggle("compact", on);
+  for (const sel of row.querySelectorAll(".perm-sel")) {
+    for (const o of sel.options) {
+      o.textContent = on ? (PERMISSION_SHORT[o.value] || o.dataset.full) : o.dataset.full;
+    }
+    fitSelect(sel);
+  }
+}
+
+function fitComposerRow(row) {
+  const box = row.clientWidth;
+  if (!box) return;   // the other view's composer: no box, nothing to decide yet
+  row.classList.remove("stack");
+  setRowCompact(row, false);
+  if (composerRowNeed(row) > box) {
+    setRowCompact(row, true);
+    if (composerRowNeed(row) > box) row.classList.add("stack");
+  }
+  // Line two's right-hand anchor, decided here because the stylesheet cannot name
+  // it: the first control after the spacer is Send when there is no pane (the
+  // screenshot button is [hidden] then, and in the narrow layout), and the
+  // screenshot button whenever there is one. Cleared on every pass — an anchor
+  // left on a control that has since been hidden pins the wrong thing.
+  let lead = null;
+  if (row.classList.contains("stack")) {
+    let past = false;
+    for (const c of row.children) {
+      if (c.classList.contains("spacer")) { past = true; continue; }
+      if (past && c.offsetWidth) { lead = c; break; }
+    }
+  }
+  for (const c of row.children) c.classList.toggle("lead2", c === lead);
+}
+
+// The footnote's own verdict: two lines is its budget, and the second sentence is
+// what pays when the pair will not fit (see #footnote.tight for why that sentence
+// and not an ellipsis). Measured in LINES rather than at a width, because the
+// sentence's length is the other variable — it names the target's kind, so the
+// same column fits it for a file and not for a long folder name.
+function fitFootnote() {
+  footEl.classList.remove("tight");
+  if (!footEl.offsetWidth) return;   // hidden (the landing page has no footnote)
+  const cs = getComputedStyle(footEl);
+  const lh = parseFloat(cs.lineHeight);
+  const text = footEl.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
+  if (lh > 0 && text > lh * 2 + 1) footEl.classList.add("tight");
+}
+
+// The second sentence, put back after setTargetNoun's write clears the node. The
+// text lives HERE and in the markup and nowhere else — the markup ships it so the
+// first paint is already measurable, this rebuilds it for every later noun.
+function footnoteTail() {
+  const more = document.createElement("span");
+  more.className = "fn-more";
+  more.textContent = " Approvals control what runs without asking.";
+  footEl.appendChild(more);
+  fitFootnote();
+}
+
+// The landing page's title, same posture as the row above it: it keeps its full
+// 26px until the NAME it is showing collides with the column, and then it takes
+// exactly the size that fits on one line. What the screenshot showed at 440px was
+// a folder name set as a two-line 26px headline — the loudest thing on a page
+// whose subject is the composer under it.
+//
+// Not a formula on the column's width, which would have to guess at the name: the
+// name is MEASURED — off-DOM, through fitSelect's canvas, which is the one way
+// this file prices a single line of text. NOT scrollWidth with a nowrap probe,
+// which is what this reached for first: scrollWidth reads clientWidth back on a
+// block that has no scroller (the trap annFitStrip documents one pane over), and
+// it silently left a 31-character folder name at 26px over two lines. Canvas
+// ignores `letter-spacing`, so the number comes out a hair WIDE on a negatively
+// tracked headline — an error in the direction of shrinking one step early, which
+// is the harmless direction.
+//
+// The steps are the STYLESHEET's (.t-mid / .t-min); this only picks the largest
+// one the name fits on, and picks none at all when the full 26px fits. Ratios,
+// not a re-measure per step: text width scales with font-size, so one canvas pass
+// prices all three candidates.
+const HOME_TITLE_STEPS = [[26, ""], [21, "t-mid"], [17, "t-min"]];
+const homeTitleEl = document.querySelector(".home-title");
+function fitHomeTitle() {
+  if (!homeTitleEl.offsetWidth) return;   // landing page not on screen
+  const box = homeTitleEl.clientWidth;
+  if (!box) return;
+  // Measured at the BASE size, with any step class off, so the reading is the
+  // same one whatever the last verdict was.
+  homeTitleEl.classList.remove("t-mid", "t-min");
+  const s = getComputedStyle(homeTitleEl);
+  _fitCtx.font = `${s.fontStyle} ${s.fontWeight} ${s.fontSize} ${s.fontFamily}`;
+  // The spark is part of the title's own text, so the one thing the text width
+  // misses is the margin holding it off the name.
+  const spark = homeTitleEl.querySelector(".spark");
+  const need = _fitCtx.measureText(homeTitleEl.textContent).width +
+    (spark ? parseFloat(getComputedStyle(spark).marginRight) || 0 : 0);
+  const base = parseFloat(s.fontSize) || HOME_TITLE_STEPS[0][0];
+  for (const [px, cls] of HOME_TITLE_STEPS) {
+    if (need * px / base <= box) {
+      if (cls) homeTitleEl.classList.add(cls);
+      return;
+    }
+  }
+  // Nothing fits on one line: the smallest step, wrapping. A heading over two
+  // short lines at 17px is a heading; the same name at 26px was a billboard.
+  homeTitleEl.classList.add("t-min");
+}
+
+function fitComposerChrome() {
+  for (const row of composerRows) fitComposerRow(row);
+  fitHomeTitle();
+  fitFootnote();
+}
+
+// ONE ResizeObserver, and it watches the COLUMN rather than the rows. Deliberate:
+// what these verdicts write (a class on the row, a class on the footnote, option
+// text) changes the composer's HEIGHT, so an observer on the row would be
+// re-triggered by its own answer — settling, since the verdict is recomputed from
+// scratch, but only after a round of "ResizeObserver loop" noise in the console.
+// The column's box is the actual input to all of this and nothing here can move it.
+new ResizeObserver(fitComposerChrome).observe(chatEl);
+{
+  // Two content changes the box observer cannot see, both of them CLASS flips a
+  // long way from this row: `#chat.home` swaps which composer is on screen (the
+  // one that was hidden has no measurable box until it is shown), and the narrow
+  // layout's `body.view-*` hides the screenshot button, which is a seat leaving
+  // the row while the column stands still.
+  const mo = new MutationObserver(fitComposerChrome);
+  for (const el of [document.body, chatEl]) {
+    mo.observe(el, { attributes: true, attributeFilter: ["class"] });
+  }
+  // And the seat coming and going on its own account: shotBtns() are hidden
+  // whenever there is no pane to photograph. Attributes only, filtered to
+  // `hidden` — this function writes `class` down here, and observing what it
+  // writes is how an observer starts scheduling itself.
+  for (const row of composerRows) {
+    mo.observe(row, { subtree: true, attributes: true, attributeFilter: ["hidden"] });
+  }
+  // And the title's own CONTENT, because what it has to fit is the name: boot
+  // writes it long after this runs (#home-file), and a target with a longer name
+  // is a new collision at the same width. Content only — no `attributes` — for
+  // the reason the rows above are watched the same way: the step this decides is
+  // a CLASS on this very node, and an observer watching what it writes schedules
+  // itself forever.
+  mo.observe(homeTitleEl, { subtree: true, childList: true, characterData: true });
+}
+// The pills' first paint, and with it the row's first verdict (syncSelects ends in
+// fitComposerChrome). It runs HERE, after the measuring is defined, and not up with
+// the change listeners: `composerRows` is a const, so a boot-time syncSelects above
+// this block would reach it before it exists.
 syncSelects();
 
 // ── The pills' dropdown: our own menu over a real <select> ──
@@ -9702,7 +10045,10 @@ function openSelPop(sel) {
     row.type = "button";
     row.className = "selpop-opt" + (opt.value === sel.value ? " on" : "");
     const lbl = document.createElement("span");
-    lbl.textContent = opt.textContent;
+    // `dataset.full` and not `textContent`: the pill's own label may be the
+    // shortened one (fitComposerRow), and this menu is where the full sentence
+    // has to be — it is the only place the four approvals modes are spelled out.
+    lbl.textContent = opt.dataset.full || opt.textContent;
     row.appendChild(lbl);
     // Write the value, then let the select's own `change` listeners do the rest
     // (param write, syncSelects, width refit) — this menu knows nothing about

--- a/tests/test_claude_kind.py
+++ b/tests/test_claude_kind.py
@@ -646,12 +646,14 @@ def test_the_re_render_observer_follows_the_target_document():
         "our own layer's arrival must not re-trigger the render that drew it"
 
     # Nothing installs a PANE observer anywhere else, and in particular not
-    # inside the run-once wiring block that started this bug. The one other
-    # MutationObserver in the file is annFitStrip's (2026-08-19): it watches
-    # the PARENT document's own #anntools clusters for the strip's word-fit
-    # verdict and never touches the target document, so it cannot re-trigger
-    # a pane render.
-    assert code.count("new MutationObserver") == 2
+    # inside the run-once wiring block that started this bug. The other two
+    # MutationObservers in the file are both FIT verdicts about THIS document's
+    # own chrome, and neither can re-trigger a pane render: annFitStrip's
+    # (2026-08-19) watches the #anntools clusters for the strip's word-fit, and
+    # fitComposerChrome's (2026-08-20) watches the composer rows and the landing
+    # title for the control row's compact/stack verdict. Both stay in the PARENT
+    # document and never look at the target's.
+    assert code.count("new MutationObserver") == 3
     fit = code[code.index("const mo = new MutationObserver(annFitStrip);"):]
     fit = fit[:fit.index("\n}")]
     assert "[annToolEl, annCta]" in fit, \

--- a/tests/test_claude_narrow.py
+++ b/tests/test_claude_narrow.py
@@ -235,3 +235,102 @@ def test_auto_submit_is_still_unconditional(html):
     start = html.index("function annAutoSubmit()")
     body = html[start:html.index("\n}\n", start)]
     assert "paneview" not in body and "NARROW_MQ" not in body
+
+
+# --------------------- 4. the composer's chrome degrades on purpose, by measuring
+
+def _fn(html, head):
+    start = html.index(head)
+    return html[start:html.index("\n}\n", start)]
+
+
+def test_the_control_row_compacts_and_folds_but_never_at_a_width(html):
+    """A 380px column (the sidebar's MIN_W) could not hold the control row —
+    three selects, the screenshot and calendar buttons, Send — and `flex-wrap`
+    answered with a stack of nearly-empty lines, one control on each. Akshil,
+    2026-08-20, on a 440px column: "I don't see the change in size. Nor do I see
+    the change in UI to show or hide things."
+
+    So the row spends its width in a chosen ORDER — shorten the one long label
+    (`.compact`), then fold once at the spacer (`.stack`) — and the verdict is
+    MEASURED, the same discipline annFitStrip uses for the annotate strip: a
+    breakpoint would have to guess at three select labels the user can change.
+    The sum is by hand because a wrapping flex row reports no overflow at all —
+    it just gets taller — which is exactly why this was invisible to CSS."""
+    fit = _fn(html, "function fitComposerRow(row)")
+    assert "row.clientWidth" in fit, "the box is the thing compared against"
+    assert "composerRowNeed(row) > box" in fit
+    # the ladder, in order: nothing, then compact, then compact + stack
+    assert fit.index('classList.remove("stack")') < fit.index("setRowCompact(row, true)")
+    assert fit.index("setRowCompact(row, true)") < fit.index('classList.add("stack")')
+    need = _fn(html, "function composerRowNeed(row)")
+    assert "scrollWidth" not in need, \
+        "a flex row's scrollWidth floors at clientWidth — the need is summed by hand"
+    assert "columnGap" in need and "spacer" in need, \
+        "the gaps count, and the elastic spacer is slack rather than content"
+    # and no media query anywhere near this row
+    assert ".composer-row" not in _narrow_block(html), \
+        "the row adapts by measuring, never inside a breakpoint"
+
+
+def test_the_approvals_pill_shortens_and_the_menu_does_not(html):
+    """Approvals is the row's only long label ("ask every time" beside "fable" and
+    "medium"), so it is the only one with a short form — and the short forms are
+    the DISTINGUISHING word of each mode, never a truncation. The menu is where
+    the sentences stay: it reads `dataset.full`, which fillSelect writes for every
+    option, so shortening the pill can never take the vocabulary away."""
+    modes = re.search(r"const PERMISSION_MODES = \[(.*?)\];", html, re.S).group(1)
+    short = re.search(r"const PERMISSION_SHORT = \{(.*?)\};", html, re.S).group(1)
+    for key in re.findall(r'"(\w+)"', modes):
+        assert re.search(r"\b%s:" % key, short), "every mode needs a short form"
+    fill = _fn(html, "function fillSelect(el, values, groupLabel, labels)")
+    assert "o.dataset.full = o.textContent;" in fill
+    pop = _fn(html, "function openSelPop(sel)")
+    assert "opt.dataset.full" in pop, "the menu always spells the full label"
+
+
+def test_the_folded_row_pins_its_second_line_to_a_measured_control(html):
+    """Folding must not teleport Send across the composer, so line two stays flush
+    right — and the control it hangs off cannot be named in the stylesheet:
+    `.viewshot` is [hidden] in the narrow layout and whenever there is no pane.
+    fitComposerRow stamps `.lead2` on whichever control actually lands there
+    first, and clears it on every pass so an anchor cannot outlive its control."""
+    css = _style_block(html)
+    assert ".composer-row.stack .send { margin-left: 0; }" in css
+    assert css.index(".composer-row.stack .send") < css.index(".composer-row.stack .lead2"), \
+        "the .lead2 rule has to win on source order for the case where Send is first"
+    # `width: 100%` and not a percentage flex-basis: measured in WKWebView, the
+    # basis was ignored and the row went on wrapping wherever it liked.
+    assert ".composer-row.stack .spacer { flex: 0 0 auto; width: 100%; height: 0; }" in css
+    fit = _fn(html, "function fitComposerRow(row)")
+    assert 'c.classList.toggle("lead2", c === lead)' in fit
+
+
+def test_the_landing_title_takes_a_step_from_the_stylesheet(html):
+    """A folder name is arbitrarily long and 26px bold in a 380px column turned one
+    into a two-line headline louder than the composer it introduces. The size is
+    picked by measuring the NAME (canvas, like fitSelect — scrollWidth reads
+    clientWidth back on a block with no scroller), and the sizes themselves are
+    declared in the stylesheet: a step is a class, never a computed pixel value
+    written inline, which is this file's rule for every other verdict (D146)."""
+    css = _style_block(html)
+    assert ".home-title.t-mid { font-size: 21px; }" in css
+    assert ".home-title.t-min { font-size: 17px; }" in css
+    fit = _fn(html, "function fitHomeTitle()")
+    assert "style.fontSize" not in fit, "the step is a class, not an inline size"
+    assert "_fitCtx.measureText" in fit and "scrollWidth" not in fit
+
+
+def test_the_footnote_drops_a_whole_sentence_rather_than_half_of_one(html):
+    """Two lines is the footnote's budget; in a 380px column the sentence pair ran
+    to three. The second sentence is its own node — in the markup so the first
+    paint is measurable, and in setTargetNoun's rewrite — so a narrow column drops
+    it whole instead of ellipsising the pair. Which one survives is not arbitrary:
+    the reach is what a reader needs before they type, and approvals are named by
+    the pill two rows up."""
+    assert '<span class="fn-more"> Approvals control what runs without asking.</span>' in html
+    assert '#footnote.tight .fn-more { display: none; }' in _style_block(html)
+    setter = _fn(html, "const setTargetNoun = (noun) => {")
+    assert "footnoteTail()" in setter
+    fit = _fn(html, "function fitFootnote()")
+    assert "lh * 2" in fit, "the budget is two LINES, measured, not a width"


### PR DESCRIPTION
## Summary
- The preview companion column's floor (`MIN_W`, `side-width.ts`) was 280px, and at that width the claude template's composer control row (model / effort / permission dropdowns, then screenshot/calendar, then Send) wrapped onto two cramped lines — and stayed wrapped through 360px.
- Measured live in a running app (cmux browser at 1500x950, real claude chat template) across 280 / 300 / 320 / 360 / 380: **380px is the first width where the whole composer row sits on one line.**
- Raised `MIN_W` to 380 and its one CSS backstop (`.preview-side` min-width in `preview.css`). `closeOverdrag` (`panel-drag.ts`, `= floor/2`) and every clamp that reads `MIN_W` (`clampSideWidth`, `openingSideWidth`, `defaultSideWidth`) scale automatically since they all read the constant — no other logic changed. The left sidebar's separate 180px floor is untouched.
- The side-store that remembers a dragged width is memory-only (not persisted to disk/localStorage), and every read already clamps through `Math.max(MIN_W, …)`, so a pre-existing in-session choice below the new floor is clamped up automatically — verified by the "never returns below MIN_W" unit tests.
- Did not touch the claude template itself (`fused_render/templates/claude/template.html`) — the floor alone resolves the composer wrap without a template-responsive rebuild, per the "cheap win only if needed" guidance.

## Test plan
- [x] `cd frontend && npm run build` — clean, no type errors.
- [x] `bun test` — 1989 pass, 0 fail (3 `side-width.test.ts` assertions recomputed for the new floor; one scenario — the content column's own floor clipping a greedy share — is no longer reachable at 380/320 and was rewritten to state that invariant).
- [x] Live cmux browser verification at the real, unmodified floor (380px, confirmed via `getBoundingClientRect`): composer row single-line, title single-line, no console errors.
- [x] Drag-to-close and reopen exercised via the pointer-capture handlers; reopen lands exactly at the new 380px floor (matches `reopenWidth`'s clamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Template-side: the composer degrades on purpose

Raising the floor alone did not fix what the screenshot showed — *"I don't see the change in size. Nor do I see the change in UI to show or hide things."* Both halves are one complaint: a wider column cannot fix a control row that has no answer for running out of room. `fused_render/templates/claude/template.html` now has one, in both composers (the landing card and the in-chat reply), and **the 380 floor is unchanged**.

**The control row spends its width in a chosen order** instead of letting `flex-wrap` guess:

| step | what happens | when |
| --- | --- | --- |
| — | one line, full labels | it fits |
| `.compact` | approvals shortens to one word — `ask` / `plan` / `edits` / `decides`; the menu still spells all four out | the row would overflow |
| `.stack` | the row folds **once**, at its spacer: the three selects on line one, screenshot + calendar + Send on line two, flush right | compact still overflows |

No control is ever orphaned on a line of its own, and the pill loses a label and never the vocabulary (`openSelPop` reads `dataset.full`).

**The landing title** takes one of two smaller steps (21px, 17px — declared in the stylesheet, picked by measuring the name) so a long folder name is a title rather than a two-line billboard over the composer it introduces. **The footnote's** second sentence is now its own node and goes whole, rather than the pair being ellipsised, when it would run to three lines.

Every verdict is **measured**, following `annFitStrip` one pane over rather than inventing the breakpoints this template deliberately does not have. Two of those measurements had to be made the harder way, and are commented as such: a wrapping flex row reports no overflow at all (it just gets taller), and `scrollWidth` reads `clientWidth` back on a block with no scroller.

Verified live in the sidebar with the branch's own dev server:

| column | control row | title |
| --- | --- | --- |
| 380 (the floor) | `compact stack` — two tidy lines, 72px | 26px, one line |
| 434 (where it opens) | `compact` — one line, 32px | 26px, one line |
| 710 | no classes — one line, `ask every time` | 26px, one line |

`bun test` 0 fail; new pins in `tests/test_claude_narrow.py` (measured-not-breakpoint, the ladder's order, the menu's full labels, the title's steps, the footnote's sentence); `tests/test_claude_kind.py`'s MutationObserver count moved 2 → 3 for the new fit observer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout constant and CSS backstop only; no auth or data paths, and in-session stored widths are already clamped through MIN_W.
> 
> **Overview**
> Raises the preview companion column floor **`MIN_W`** from **280px to 380px** in `side-width.ts`, with matching **`.preview-side` `min-width: 380px`** in `preview.css`. The change targets the claude template sidebar: the composer control row stayed wrapped through 360px; 380px is the first width where it fits on one line.
> 
> All width logic that reads **`MIN_W`** (`defaultSideWidth`, `clampSideWidth`, `openingSideWidth`, drag clamp in `PreviewSidebar`) picks up the new floor automatically. **`closeOverdrag`** still uses half the passed minimum, so drag-to-close resistance for this column goes from 140px to **190px** (comments/tests updated). No change to the global sidebar’s separate 180px floor or the claude template itself.
> 
> Unit tests in **`side-width.test.ts`** were recomputed for the higher floor; one old scenario (content column clipping a greedy 50% share at 600px) is no longer reachable at 380+320 and the test now asserts the new **700px** seam where both floors meet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5615e3f7f2bd2ec222a91a5943f2d8ab8eb3b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
