### PR TITLE
Calendar popover: a repeating task's pill is the clicked DAY, rolled up

### DIFF
--- a/frontend/src/shell/ScheduleCalendar.tsx
+++ b/frontend/src/shell/ScheduleCalendar.tsx
@@ -612,29 +612,40 @@ function ChipPopover({
   // words, and the full reasoning is on that function: a ONE-OFF's pill is its
   // task's status (taskColumn + failed, exactly what the List's row and the
   // Board's card hand StatusIcon); a REPEATING task's pill answers for the
-  // clicked OCCURRENCE — In Progress while THIS DAY works (`liveToday`, the
-  // chip's own reading; `liveNow` would say In Progress on every day of a rule
-  // whose run is live somewhere else), Upcoming for a projected or not-yet-run
-  // day, and a past day's own outcome (Done/Failed) from the newest real run
-  // among the rows drawn right below it (Akshil, 2026-08-19: a rule's
+  // clicked DAY — In Progress while THIS DAY works (`liveToday`, the chip's own
+  // reading; `liveNow` would say In Progress on every day of a rule whose run
+  // is live somewhere else), Upcoming for a day still ahead or a today that
+  // still owes runs, and the day's ROLLED-UP outcome (any failure -> Failed,
+  // else Done) once the day is finished (Akshil, 2026-08-19: a rule's
   // task-level column is nearly always "upcoming", which made the pill useless
   // on the one view that is about days).
+  //
+  // A DAY, NOT THE NEWEST ROW (Akshil, 2026-08-20, raised twice). The first cut
+  // read the newest real row on the day — and the newest row on TODAY is
+  // tonight's last promise, so an hourly rule that had already run nine times
+  // wore "Upcoming" over a day of finished work. `chip.time` (which day was
+  // clicked) and a live `now` are what let dayPill tell the three cases apart.
   //
   // AND ALWAYS SOLID (Akshil, 2026-08-19). The pill used to inherit the clicked
   // chip's dashes through `chip.projected`; the dashes are a DAY-scoped drawing
   // ("nothing written down yet") and stay on the grid's ghost chips and the
-  // ghost rings on the occurrence rows — never on a status word.
+  // ghost rings on the occurrence rows — never on a status word. `chip.projected`
+  // has left the pill's inputs entirely: dayPill asks the CALENDAR whether the
+  // day is ahead of us, which is the fact that was being approximated.
   const recurring = Boolean(chip.recurring || repeat);
   // What the pill (word and shimmer alike) means by "running": the clicked
   // day's occurrences for a rule, the task itself for a one-off — so the pill
   // and the chip it was opened from can never disagree about the same day.
   const pillLive = recurring ? liveToday : liveNow;
-  const pill = useMemo(
-    () => popoverPill(task, recurring, chip.projected, pillLive, today),
-    [task, recurring, chip.projected, pillLive, today],
-  );
 
   const nowSec = Math.floor(Date.now() / 1000);
+  // One `now` for the whole render, and it is a dependency rather than a call
+  // inside the memo: the panel re-renders on every poll, so the pill re-decides
+  // as the day moves past its last slot without needing a clock of its own.
+  const pill = useMemo(
+    () => popoverPill(task, recurring, pillLive, today, chip.time, new Date(nowSec * 1000)),
+    [task, recurring, pillLive, today, chip.time, nowSec],
+  );
 
   const row = (m: TaskMessage, sameDayRow: boolean) => {
     const status = runStatus(m, taskMessageTone(m));

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -67,6 +67,7 @@ import {
   openMessageHref,
   openThreadIntent,
   opensElsewhere,
+  dayPill,
   popoverPill,
   parseLaneChoices,
   parseListMemory,
@@ -6375,12 +6376,113 @@ describe("isRunningIn", () => {
 });
 
 // ---- the popover header's pill --------------------------------------------------
-// Akshil, 2026-08-19: a one-off's pill is its task; a REPEATING task's pill is
-// the clicked OCCURRENCE — In Progress while it works, Upcoming for a future or
-// projected day, a past day's own outcome otherwise. And never dashed: solid in
+// Akshil, 2026-08-19 / 2026-08-20: a one-off's pill is its task; a REPEATING
+// task's pill is the clicked DAY, rolled up — In Progress while that day works,
+// Upcoming while it is ahead or still owes runs, and its own outcome (any
+// failure -> Failed, else Done) once it is finished. And never dashed: solid in
 // every state, because the pill is a word about status, not a drawing of a day.
+describe("dayPill", () => {
+  const at = (iso: string) => Math.floor(Date.parse(iso) / 1000);
+  const day = new Date("2026-08-15T00:00:00");
+  const ran = (iso: string, over: Partial<TaskMessage> = {}) =>
+    msg({
+      message_id: `MSG-${iso}`, at: at(iso), ran_at: at(iso),
+      state: "sent", turn: "done", ...over,
+    });
+  const promise = (iso: string) =>
+    msg({ message_id: `GHOST-${iso}`, at: at(iso), ran_at: 0, state: "pending" });
+
+  it("a day that is OVER and went clean is Done", () => {
+    const out = dayPill(
+      [ran("2026-08-15T09:00:00"), ran("2026-08-15T23:00:00")],
+      day,
+      new Date("2026-08-17T08:00:00"),
+      false,
+    );
+    expect(out).toMatchObject({ label: "Done", column: "done", failed: false });
+  });
+
+  it("one broken run makes the whole past day Failed, wherever it sits", () => {
+    // Buried under clean runs on either side: a failure is the thing you have
+    // to see, and green siblings must not hide it.
+    const rows = [
+      ran("2026-08-15T09:00:00"),
+      ran("2026-08-15T14:00:00", { state: "error" }),
+      ran("2026-08-15T20:00:00"),
+    ];
+    const now = new Date("2026-08-17T08:00:00");
+    expect(dayPill(rows, day, now, false).label).toBe("Failed");
+    // Order of the hand-over must not matter — this is a rollup, not a "newest".
+    expect(dayPill([...rows].reverse(), day, now, false).label).toBe("Failed");
+  });
+
+  it("a day still AHEAD is Upcoming, whatever it holds", () => {
+    const now = new Date("2026-08-13T12:00:00");
+    expect(dayPill([promise("2026-08-15T09:00:00")], day, now, false).label).toBe("Upcoming");
+    expect(dayPill([], day, now, false).label).toBe("Upcoming");
+  });
+
+  it("a run in flight beats every rollup", () => {
+    const now = new Date("2026-08-15T10:30:00");
+    const rows = [ran("2026-08-15T09:00:00", { state: "error" })];
+    // via the caller's isRunningIn reading of THIS day...
+    expect(dayPill(rows, day, now, true).label).toBe("In Progress");
+    // ...and via a row that is mid-send on its own account.
+    const sending = msg({
+      message_id: "M9", at: at("2026-08-15T10:00:00"), state: "sending",
+    });
+    expect(dayPill([...rows, sending], day, now, false).label).toBe("In Progress");
+  });
+
+  it("TODAY mid-day is Upcoming — some runs done, more still owed", () => {
+    // THE BUG, from the other side (Akshil, 2026-08-20): this used to read the
+    // NEWEST row, which on today is tonight's promise, so a day whose runs had
+    // already happened still said Upcoming. It says Upcoming here for the right
+    // reason — the day is not finished — and stops the moment the last slot is
+    // behind us (the case below).
+    const rows = [
+      ran("2026-08-15T09:00:00"),
+      ran("2026-08-15T10:00:00"),
+      promise("2026-08-15T11:00:00"),
+      promise("2026-08-15T23:00:00"),
+    ];
+    expect(dayPill(rows, day, new Date("2026-08-15T10:30:00"), false).label).toBe("Upcoming");
+  });
+
+  it("TODAY after its last slot settles into the day's outcome", () => {
+    const clean = [ran("2026-08-15T09:00:00"), ran("2026-08-15T23:00:00")];
+    expect(dayPill(clean, day, new Date("2026-08-15T23:30:00"), false).label).toBe("Done");
+    const broke = [ran("2026-08-15T09:00:00", { state: "error" }), ran("2026-08-15T23:00:00")];
+    expect(dayPill(broke, day, new Date("2026-08-15T23:30:00"), false).label).toBe("Failed");
+  });
+
+  it("a past day whose slots never ran is Archive, never Upcoming", () => {
+    // Past ghosts (`missed` + template_id) are the rows a closed app leaves
+    // behind. They are not outcomes, so neither rollup arm claims them — and
+    // calling the day Upcoming afterwards is the original bug in a new hat.
+    const skipped = msg({
+      message_id: "GHOST-2026-08-15T09:00:00", at: at("2026-08-15T09:00:00"),
+      ran_at: 0, state: "missed", template_id: "ENT-1",
+    });
+    expect(dayPill([skipped], day, new Date("2026-08-17T08:00:00"), false).label).toBe("Archive");
+  });
+
+  it("is solid in every state — a status is a word, not a drawing of a day", () => {
+    const now = new Date("2026-08-17T08:00:00");
+    for (const p of [
+      dayPill([promise("2026-08-15T09:00:00")], day, new Date("2026-08-13T00:00:00"), false),
+      dayPill([ran("2026-08-15T09:00:00", { state: "error" })], day, now, false),
+      dayPill([ran("2026-08-15T09:00:00")], day, now, true),
+    ]) {
+      expect(p.projected).toBe(false);
+    }
+  });
+});
+
 describe("popoverPill", () => {
   const at = (iso: string) => Math.floor(Date.parse(iso) / 1000);
+  const day = new Date("2026-08-15T00:00:00");
+  const later = new Date("2026-08-17T08:00:00");
   const done = msg({
     message_id: "MSG-001", at: at("2026-08-15T09:00:00"),
     ran_at: at("2026-08-15T09:00:00"), state: "sent", turn: "done",
@@ -6389,50 +6491,28 @@ describe("popoverPill", () => {
     message_id: "MSG-002", at: at("2026-08-15T14:00:00"),
     ran_at: at("2026-08-15T14:00:00"), state: "error", turn: "done",
   });
-  const ghost = msg({
-    message_id: "GHOST-2026-08-20T09:00:00",
-    at: at("2026-08-20T09:00:00"), ran_at: 0, state: "pending",
-  });
 
   it("a ONE-OFF keeps saying what the List's row and the Board's card say", () => {
     const t = task({ status: "done", failed: false });
-    expect(popoverPill(t, false, false, false, t.messages)).toMatchObject({
+    expect(popoverPill(t, false, false, t.messages, day, later)).toMatchObject({
       label: "Done", column: "done",
     });
     // failed folds into the column, exactly as StatusIcon reads it...
     const f = task({ status: "done", failed: true });
-    expect(popoverPill(f, false, false, false, f.messages).label).toBe("Failed");
+    expect(popoverPill(f, false, false, f.messages, day, later).label).toBe("Failed");
     // ...and the day's contents cannot move a one-off's word: it IS its task.
-    expect(popoverPill(t, false, false, false, [broke]).label).toBe("Done");
+    expect(popoverPill(t, false, false, [broke], day, later).label).toBe("Done");
   });
 
-  it("a REPEATING task answers for the clicked day, not for the rule", () => {
+  it("a REPEATING task hands the whole question to dayPill", () => {
     // The rule's task-level column is upcoming — the next run always is — which
     // is exactly why the task-level word was useless on a grid about days.
     const rule = task({ status: "upcoming", messages: [done, broke] });
-    // A past day whose NEWEST real run broke: Failed, matching the top row
-    // below — order of the hand-over must not matter.
-    expect(popoverPill(rule, true, false, false, [done, broke]).label).toBe("Failed");
-    expect(popoverPill(rule, true, false, false, [broke, done]).label).toBe("Failed");
-    // A day that ended clean: Done.
-    expect(popoverPill(rule, true, false, false, [done]).label).toBe("Done");
-    // A projected day is cron arithmetic: Upcoming — and so is a day holding
-    // nothing but ghosts, whichever of the two flags arrives first.
-    expect(popoverPill(rule, true, true, false, [ghost]).label).toBe("Upcoming");
-    expect(popoverPill(rule, true, false, false, [ghost]).label).toBe("Upcoming");
-    // Working right now beats everything: the pill is the shimmer's seat.
-    expect(popoverPill(rule, true, false, true, [done, broke]).label).toBe("In Progress");
-  });
-
-  it("is solid in every state — projected never reaches the pill", () => {
-    const rule = task({ status: "upcoming", messages: [done] });
-    for (const p of [
-      popoverPill(rule, true, true, false, [ghost]),
-      popoverPill(rule, true, false, false, [done, broke]),
-      popoverPill(task({ status: "upcoming" }), false, true, false, []),
-    ]) {
-      expect(p.projected).toBe(false);
-    }
+    expect(popoverPill(rule, true, false, [done, broke], day, later)).toEqual(
+      dayPill([done, broke], day, later, false),
+    );
+    expect(popoverPill(rule, true, false, [done, broke], day, later).label).toBe("Failed");
+    expect(popoverPill(rule, true, true, [done], day, later).label).toBe("In Progress");
   });
 
   it("is what the popover actually renders, shimmer seat and all", () => {
@@ -6443,11 +6523,16 @@ describe("popoverPill", () => {
     // whose run was live somewhere else. One-offs keep the task-level fact.
     expect(CAL).toContain("const liveToday = isRunningIn(task, chip.messages);");
     expect(CAL).toContain("const pillLive = recurring ? liveToday : liveNow;");
-    // The pill comes from this function, over the day's own rows...
-    expect(CAL).toContain("popoverPill(task, recurring, chip.projected, pillLive, today)");
+    // The pill comes from this function, over the day's own rows, and it is
+    // told WHICH day was clicked and WHEN now is — the two facts the day
+    // rollup turns on, and the two the newest-row reading did without.
+    expect(CAL).toContain(
+      "popoverPill(task, recurring, pillLive, today, chip.time, new Date(nowSec * 1000))",
+    );
     // ...the running day's pill carries the shimmer class...
     expect(CAL).toContain('pillLive ? " is-running" : ""');
-    // ...and the dashes can no longer reach it.
+    // ...and neither the dashes nor the chip's projected flag can reach it.
     expect(CAL).not.toContain('pill.projected ? " is-projected"');
+    expect(CAL).not.toContain("popoverPill(task, recurring, chip.projected");
   });
 });

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -36,10 +36,11 @@
 // the server), and every key is a time the server itself sent.
 import type { Task, TaskMessage, TaskPulseTask } from "@platform/lib/api";
 import {
+  addDays,
   BOARD_COLUMNS,
   explorerUrl,
   isProjected,
-  runStatus,
+  startOfDay,
   taskStatus,
   turnPhase,
 } from "./schedule-lib";
@@ -2775,48 +2776,132 @@ export function isRunningIn(task: Task, messages: TaskMessage[]): boolean {
 }
 
 /**
+ * ONE DAY OF A REPEATING TASK, as one of the app's five words (Akshil,
+ * 2026-08-20, raised twice).
+ *
+ * A repeating task has NO SINGLE TRUTHFUL STATUS, and that is the whole reason
+ * this function exists rather than some reading of the task. An hourly rule is
+ * simultaneously finished (09:00), working (10:00) and promised (11:00 through
+ * 23:00), so any one word about the RULE is wrong about most of it — which is
+ * how the popover came to say "Upcoming" over a day whose runs had all already
+ * happened. The clicked chip is not the rule: it is the rule ON ONE DAY, and a
+ * day IS a thing a single word can be true of. So the pill answers for the day.
+ *
+ * THE RULE, and it is deliberately three cases about TIME before it is anything
+ * about messages, because the day's position relative to now is what decides
+ * which question is even askable:
+ *
+ *   - A DAY STILL AHEAD -> Upcoming. Nothing on it has happened by definition;
+ *     whatever rows it holds are cron arithmetic or promises, and both are the
+ *     same word.
+ *   - TODAY, with runs still owed -> Upcoming (or In Progress if one is
+ *     actually going). This is the case the old newest-run reading got wrong in
+ *     the other direction too: the newest row on today is the 23:00 slot, so a
+ *     day that had already run nine times read as a pure promise. "Owed" is
+ *     asked of the slot's TIME, not of its row's kind, so a materialized
+ *     pending and a ghost count the same — they are both the day saying it is
+ *     not finished.
+ *   - A DAY THAT IS OVER, or today after its last slot -> the day's OUTCOME,
+ *     rolled up: any failure makes the day Failed (one broken run is the thing
+ *     you need to see, and burying it under nine green ones is how a rule
+ *     silently rots), otherwise anything that ran makes it Done.
+ *
+ * IN PROGRESS OUTRANKS ALL OF IT. `live` is the caller's isRunningIn reading of
+ * this same day — the exact list the grid chip shimmers by — and a run in
+ * flight is a fact about right now that no rollup should be allowed to
+ * overwrite. A row whose own tone is `in_progress` (a `sending` message the
+ * task-level reading has not caught up with) counts the same way.
+ *
+ * THE FALLBACK IS "ARCHIVE", NOT "UPCOMING", and it is the case worth being
+ * explicit about: a past day can hold nothing but slots that went by unrun —
+ * past ghosts (`missed` + template_id) that the rule skipped while the app was
+ * closed, or pendings nobody ever marked. Those are not outcomes, so the two
+ * rollup arms above pass over them; calling the day Upcoming afterwards is the
+ * original bug wearing a different hat. `archived` is already this app's word
+ * for a recurring slot that was due and did not run — it is what
+ * `messageTone` files those rows under and what greys their rings in the
+ * thread right below the pill — so the day inherits it rather than inventing a
+ * sixth state.
+ *
+ * Pure, and every input is an argument (`now` included) so the six cases above
+ * are six unit tests rather than six clock settings.
+ */
+export function dayPill(
+  occurrences: TaskMessage[],
+  day: Date,
+  now: Date,
+  live: boolean,
+): RunStatus {
+  if (live) return taskStatus("in_progress", false);
+
+  const start = startOfDay(day).getTime();
+  const end = startOfDay(addDays(day, 1)).getTime();
+  const at = now.getTime();
+  if (at < start) return taskStatus("upcoming", false);
+
+  const tones = occurrences.map((m) => messageTone(m));
+  if (tones.some((t) => t.column === "in_progress")) {
+    return taskStatus("in_progress", false);
+  }
+
+  // Does the day still owe a run? Only askable while the day is running; after
+  // midnight every slot is behind us and an unrun one is a fact, not a promise.
+  const nowSec = Math.floor(at / 1000);
+  const owed =
+    at < end &&
+    occurrences.some((m, i) => m.at > nowSec && tones[i].column === "upcoming");
+  if (owed) return taskStatus("upcoming", false);
+
+  if (tones.some((t) => t.failed)) return taskStatus("done", true);
+  if (tones.some((t) => t.column === "done")) return taskStatus("done", false);
+  if (tones.some((t) => t.column === "archived")) return taskStatus("archived", false);
+  // Nothing written down and nothing owed: an empty day, which in practice only
+  // happens before the rule's first slot. Upcoming is the honest word for it.
+  return taskStatus("upcoming", false);
+}
+
+/**
  * The calendar popover header's PILL, in the app's five words (Akshil,
- * 2026-08-19).
+ * 2026-08-19; day-scoped since 2026-08-20).
  *
  * Two different nouns, depending on what kind of task was clicked:
  *
  * A ONE-OFF is its task — one run, so "the task's status" and "this
  * occurrence's status" are the same fact, and the pill keeps saying exactly
  * what the List's row and the Board's card say: `taskStatus(taskColumn, failed)`.
+ * Untouched by the day rule below, and it should be: a one-off has exactly one
+ * day, so rolling it up could only ever restate the task.
  *
  * A REPEATING task is a rule, and a rule's task-level column is nearly always
  * `upcoming` — the next run is always scheduled — which made the pill useless
  * on the one grid that is ABOUT individual days: click last Tuesday's failed
- * run and the pill said "Upcoming". So for a recurring task the pill answers
- * for the clicked OCCURRENCE instead:
+ * run and the pill said "Upcoming". So a recurring task's pill is `dayPill`
+ * over THE CLICKED CHIP'S OWN DAY, whose reasoning lives on that function.
  *
- *   - actually working right now  -> In Progress (`live`, the isRunningIn
- *     reading the chip's own shimmer uses — same rule, same moment);
- *   - a projected/future day      -> Upcoming (cron arithmetic, or a
- *     materialized run that has not gone yet — runStatus says Upcoming for
- *     those too, so both future arms land on the same word);
- *   - a past day                  -> that day's outcome, from the NEWEST real
- *     run on the day (`runStatus` + `messageTone`, the exact pair the thread
- *     rows under the pill are painted with, so the pill can never disagree
- *     with the top row it summarizes). Ghost rows are cron math, never an
- *     outcome, and are filtered before "newest" is asked.
+ * WHY THIS GREW A `day` AND A `now`. The first cut of this (PR #645) answered
+ * from the NEWEST real row on the day, which is right for a day that is over
+ * and wrong for every day that is not: the newest row on today is tonight's
+ * 23:00 promise, so a rule that had already run nine times today wore
+ * "Upcoming", and a past day whose rows were never marked wore it too. "Newest"
+ * was standing in for a verdict; the verdict needed to know where the day sits
+ * relative to now, so now it is told.
  *
  * Always SOLID: whatever the word, the pill never inherits the projected
- * chip's dashes — a status is a word, not a drawing of a day.
+ * chip's dashes — a status is a word, not a drawing of a day. `projected` is
+ * therefore not an argument any more either: it was the last thing reaching in
+ * from the chip's DRAWING, and dayPill decides future-ness from the calendar
+ * rather than from whether anything was written down.
  */
 export function popoverPill(
   task: Task,
   recurring: boolean,
-  projected: boolean,
   live: boolean,
   dayMessages: TaskMessage[],
+  day: Date,
+  now: Date,
 ): RunStatus {
   if (!recurring) return taskStatus(taskColumn(task), task.failed);
-  if (live) return taskStatus("in_progress", false);
-  const real = dayMessages.filter((m) => !isProjected(m));
-  if (projected || real.length === 0) return taskStatus("upcoming", false);
-  const newest = real.reduce((a, b) => (b.at > a.at ? b : a));
-  return runStatus(newest, messageTone(newest));
+  return dayPill(dayMessages, day, now, live);
 }
 
 // ---- the sidebar's two-number summary of this page ----------------------------


### PR DESCRIPTION
## The problem (Akshil, 2026-08-20, raised twice)

Calendar view, a repeating task (hourly "bhi"). Click a chip on a PAST day — or today's chip after some runs have already happened — and the popover said **Upcoming**. The chip is that day's iteration; its 10:00 run already ran.

The root of it: a repeating task template has **no single truthful status**. An hourly rule is finished at 09:00, working at 10:00, and promised until 23:00 all at once. PR #645 already moved the pill off the task and onto the occurrence, but it answered from the NEWEST real row on the day — and the newest row on *today* is tonight's last promise, so a day of finished work read as a pure promise. A past day whose slots were never marked read the same way, because none of its rows were real.

## The rule now

One pure function, `tasks-lib.dayPill(occurrences, day, now, live)` — three cases about **time** before anything about messages, because where the day sits relative to now decides which question is even askable:

| the clicked day | pill |
| --- | --- |
| still ahead | Upcoming |
| today, runs still owed | Upcoming |
| any day, a run in flight | In Progress |
| over (or today past its last slot), all clean | Done |
| over, **any** run failed | Failed |
| over, nothing ever ran | Archive |

"Owed" is asked of the slot's **time**, not its row's kind, so a materialized pending and a cron ghost count the same — both are the day saying it is not finished.

**In Progress outranks the rollup**, still day-scoped via `pillLive` (the same `isRunningIn` reading the grid chip shimmers by), so one live run cannot light every day of a rule.

**Archive, not Upcoming, is the fallback** for a past day whose slots all went by unrun. Those are not outcomes, so neither rollup arm claims them — and calling such a day Upcoming is the original bug in a new hat. `archived` is already this app's word for a recurring slot that was due and did not run: it is what `messageTone` files those rows under and what greys their rings in the thread right below the pill.

**One-offs are untouched.** A one-off has exactly one day, so rolling it up could only restate the task; its pill stays `taskStatus(taskColumn, failed)` — the same word the List's row and the Board's card say.

**Chips are left alone.** `schedule-lib.dayTone` already tints each chip from a rollup of that day's own messages, so the grid was never wrong here — only the pill was.

`projected` leaves `popoverPill`'s inputs: `dayPill` asks the calendar whether the day is ahead of us, which is the fact that flag was approximating. `day` and `now` arrive in its place.

## Files

- `frontend/src/shell/tasks-lib.ts` — new `dayPill`; `popoverPill` delegates to it for recurring tasks
- `frontend/src/shell/ScheduleCalendar.tsx` — passes `chip.time` and a live `now`
- `frontend/src/shell/tasks-lib.test.ts` — the six cases as unit tests, plus the Archive fallback and solidity

## Verification

- `npm run build` — clean (boundaries, tsc, vite)
- `bun test` — **2011 pass, 0 fail**
- Live (dev server on :2456, hourly rule anchored two days back):
  - **yesterday (Wed 19 Aug), 24 slots, none ran → "Archive"** — on main this said "Upcoming"
  - today, runs still owed → "Upcoming"
  - a future day → "Upcoming"
  - no console errors


Done/Failed are covered by unit tests rather than live: producing them needs real Claude runs behind the chip.

**Note:** main's CI is red from #681 (`test_apps_api`) — inherited, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
