### PR TITLE
Fix main CI: isolate test_appfile's shell home (demo-<hash> leaking into /apps listings)

### DIFF
--- a/tests/test_appfile.py
+++ b/tests/test_appfile.py
@@ -16,6 +16,18 @@ from fused_render._view_url_codec import embed_url_path, view_url_path
 MARKER = '<meta charset="utf-8" />\n<meta name="fused-app" />'
 
 
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path, monkeypatch):
+    """Per-test shell home, the same way test_registered_apps.py does it.
+
+    conftest allocates ONE FUSED_RENDER_HOME per process, so without this the
+    AF-8 route test's `/render` of an extracted app writes a `linked` entry for
+    `<tmp>/cache/demo-<hash>` into a registered_apps.json shared with every
+    later test on the same xdist worker — where it surfaced as a phantom
+    `demo-<hash>` card in other modules' /api/apps listing assertions."""
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+
+
 def make_app(tmp_path, name="demo"):
     d = tmp_path / name
     d.mkdir()


### PR DESCRIPTION
## The breakage

Since #681 merged, main's own `test` workflow is red on every Python version + fused-engine — but only in full-suite xdist runs; each failing test passes alone:

- `tests/test_apps_api.py::test_an_unreadable_project_dir_is_skipped_at_any_uid`
- `tests/test_apps_api.py::test_any_top_level_folder_is_a_tag_no_registry`
- `tests/test_apps_api.py::test_entry_match_is_non_recursive`
- `tests/test_apps_api.py::test_hidden_dirs_and_hidden_htmls_are_skipped`

Signature: a `demo-<hex>` directory, hash differing per run, appearing in other tests' `/api/apps` listings under the `linked` tag.

## The leak mechanism

1. `tests/conftest.py` allocates **one** `FUSED_RENDER_HOME` per *process* (a module-level `mkdtemp`), not per test. Under xdist that means one shared shell home per worker.
2. #681's route test `test_routes_export_and_gateless_open` isolates `appfile.appfiles_root` (to `tmp_path/cache`) but not the shell home. Its final AF-8 step does `client.get("/render", path=extracted["entry"])`.
3. By D301, rendering a marked page in a folder **outside** the workspace *is* registration: it writes `{"path": "<tmp>/cache/demo-<16hex>", ...}` into `registered_apps.json` — under the shared home.
4. `registered_apps` entries merge into the `/apps` hub under the reserved virtual tag `linked`. So every later `test_apps_api` test on that worker — the ones that don't use the `recents_home` fixture — got an extra phantom card, hence `['demo-…', 'ok'] == ['ok']` and `'linked' == 'whatever-i-want'`.

The tmp dir is long gone by then, but `registered_apps` skips only unreadable *targets* lazily, and the listing assertions had already seen it.

## The fix

An autouse per-test `FUSED_RENDER_HOME` fixture in `tests/test_appfile.py` — byte-for-byte the pattern `tests/test_registered_apps.py` already uses for the very same store. Isolation only; no #681 assertion weakened or removed.

## Evidence

Reproduced deterministically without xdist by ordering the two files together:

```
$ pytest tests/test_appfile.py tests/test_apps_api.py -p no:randomly -q   # before
4 failed, 69 passed
$ pytest tests/test_appfile.py tests/test_apps_api.py -p no:randomly -q   # after
73 passed
```

Full suite, twice, `-n auto`: `8471 passed`, previously-failing tests green both times. The only reds are pre-existing local-environment failures (`test_claude_health.py`, `test_ai_metrics.py::test_a_missing_claude_binary_is_counted`, `test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`) — verified identical on unmodified `origin/main` in the same worktree, caused by a real `claude` binary on this machine.

`bun test`: `2004 pass, 0 fail`. `npm run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)