### PR TITLE
Claude template: collision-driven composer fitting (no width breakpoints)

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -9869,18 +9869,42 @@ const footEl = document.getElementById("footnote");
 // What the row needs on ONE line, summed by hand. NOT scrollWidth: on a flex row
 // it is floored at clientWidth, and this row also wraps, so an overflowing row
 // quietly gets taller and reports no overflow at all — the exact failure that made
-// this invisible to CSS. The spacer is skipped because it is slack and not
-// content (flex-basis 0 while the row fits, the line break once it does not).
+// this invisible to CSS.
+//
+// TWO THINGS THE SUM HAS TO GET EXACTLY RIGHT, and the first version got both
+// slightly wrong — enough to leave a ~6px band at every stage boundary where the
+// row had already wrapped (Schedule and Send fell to a second line) while this
+// function still reported that it fit (Akshil, 2026-08-20):
+//
+//   1. SEATS vs CONTENT are different questions. The spacer contributes no WIDTH
+//      (flex-basis 0 while the row fits, the line break once it does not) but it
+//      is a flex item like any other, so the browser puts a `gap` on each side of
+//      it. Skipping it from the gap count under-charged the row by exactly one
+//      gap. Every child that is laid out at all takes a seat here; only its width
+//      is conditional. `display: none` is the one thing with no seat — the
+//      screenshot button whenever there is no pane to photograph — and it is
+//      asked of the computed style rather than inferred from a zero offsetWidth,
+//      which cannot tell "not laid out" from "laid out at zero width".
+//
+//   2. SUB-PIXELS count, because the browser's own wrap decision is made in
+//      them. offsetWidth is rounded to an integer, so a row of seven controls
+//      could be under-read by several pixels at exactly the widths where a few
+//      pixels is the whole question. getBoundingClientRect is the fractional
+//      reading, and margins (which offsetWidth never included) come off the
+//      computed style so a later layout tweak cannot silently reopen this gap.
 function composerRowNeed(row) {
   const cs = getComputedStyle(row);
   let need = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
-  let kids = 0;
+  let seats = 0;
   for (const c of row.children) {
-    if (c.classList.contains("spacer") || !c.offsetWidth) continue;  // hidden child, no seat
-    need += c.offsetWidth;
-    kids += 1;
+    const s = getComputedStyle(c);
+    if (s.display === "none") continue;   // not laid out: no width, and no gap either
+    seats += 1;
+    if (c.classList.contains("spacer")) continue;   // a seat, but slack rather than content
+    need += c.getBoundingClientRect().width +
+      (parseFloat(s.marginLeft) || 0) + (parseFloat(s.marginRight) || 0);
   }
-  if (kids > 1) need += (parseFloat(cs.columnGap) || 0) * (kids - 1);
+  if (seats > 1) need += (parseFloat(cs.columnGap) || 0) * (seats - 1);
   return need;
 }
 

--- a/tests/test_claude_narrow.py
+++ b/tests/test_claude_narrow.py
@@ -273,6 +273,34 @@ def test_the_control_row_compacts_and_folds_but_never_at_a_width(html):
         "the row adapts by measuring, never inside a breakpoint"
 
 
+def test_the_rows_need_counts_every_seat_and_reads_sub_pixels(html):
+    """The two ways a hand-summed need can come out SHORT, both of which left a
+    ~6px band at every stage boundary where the row had already wrapped — Schedule
+    and Send on a second line — while the sum still said it fit (Akshil,
+    2026-08-20, narrowing the right sidebar):
+
+      * the SPACER is a flex item, so the browser puts a `gap` on each side of it.
+        It contributes no width, but skipping it from the gap count under-charged
+        the row by exactly one gap — 6px, the width of the failing band.
+      * offsetWidth is an INTEGER. The browser decides the wrap in sub-pixels, so
+        a row of seven controls could be under-read by several pixels at exactly
+        the widths where a few pixels is the whole question.
+
+    A seat is anything laid out at all, asked of the computed `display` — a zero
+    offsetWidth cannot tell "not laid out" from "laid out at zero width"."""
+    need = _fn(html, "function composerRowNeed(row)")
+    assert "getBoundingClientRect().width" in need, \
+        "the wrap is decided in sub-pixels, so the need has to be read in them"
+    assert "offsetWidth" not in need, "offsetWidth rounds; the need must not"
+    assert 'display === "none"' in need, \
+        "only a child that is not laid out loses its seat — and its gap with it"
+    # the spacer keeps its seat (and so its gaps) and only skips the width sum:
+    # the `continue` for it comes AFTER the seat is counted.
+    assert need.index("seats += 1") < need.index('classList.contains("spacer")'), \
+        "the spacer is a seat that pays gaps; only its width is slack"
+    assert "seats - 1" in need, "n seats, n-1 gaps"
+
+
 def test_the_approvals_pill_shortens_and_the_menu_does_not(html):
     """Approvals is the row's only long label ("ask every time" beside "fable" and
     "medium"), so it is the only one with a short form — and the short forms are


### PR DESCRIPTION
## Bug

Narrowing the right sidebar with the claude template open, the composer's **calendar (Schedule)** and **Send** buttons wrapped onto a second line at certain in-between widths.

`fitComposerRow` (PR #685) already measures rather than using breakpoints — but its `composerRowNeed` sum under-read the row by ~6px, so every stage of the ladder (`none → compact → tight → stack`) engaged one gap too late. The row had already wrapped while the sum still said it fit.

**Failing widths found before the fix** (sweep at 1px steps, 240–560px, standalone template):

| composer | widths | stage the row was in |
|---|---|---|
| home card | 419–424 | `none` (compact not yet engaged) |
| home card | 357–362 | `compact` (tight not yet engaged) |
| chat | 411–416 | `none` |
| chat | 349–354 | `compact` |

24 failing widths / 642 sampled. Each band is exactly 6px wide — one `column-gap`.

At w=424 the probe read `need = 341`, `box = 346`: five controls at 317px + **four** gaps at 6px. The row actually has **six** laid-out items, so the browser charged **five** gaps — 347px, which does not fit in 346.

## Approach

Still collision detection, no width thresholds — the sum just has to be the one the browser makes. Two under-reads in `composerRowNeed`:

1. **The spacer is a seat.** It contributes no width (flex-basis 0 while the row fits, the line break once it does not) but it *is* a flex item, so the browser puts a `gap` on each side of it. It was skipped entirely — width and seat — costing exactly one gap. It now keeps its seat and only its width stays slack. A seat is anything laid out at all, asked of the computed `display`; a zero `offsetWidth` cannot tell "not laid out" (the screenshot button with no pane) from "laid out at zero width".

2. **Sub-pixels count.** `offsetWidth` rounds to an integer while the browser decides the wrap in fractions — a row of seven controls could be under-read by several pixels at exactly the widths where a few pixels is the whole question. Widths now come from `getBoundingClientRect().width`, plus margins off the computed style so a later layout tweak cannot silently reopen the gap.

The calendar and Send buttons were already inside the measured set (they are row children); what was missing was the gap the spacer between them and the pills pays for.

**No visual change to the stages** — `.compact`, `.tight`, `.stack` are untouched. Only *when* they engage moved, by 6px each.

## Sweep evidence (after)

Script-asserted single line at **every** width 240→560px in 1px steps, across four configurations (home / chat composer × screenshot button hidden / shown), by comparing the rounded vertical midpoints of every laid-out row child:

```
{"failCount":0,"total":1284}
```

`cmux browser errors list` → **No browser errors**.

Stage ladder still engages in order and reaches every stage:

```
home       none@560  compact@424  compact+tight@362
chat+shot  none@560  compact@454  compact+tight@392
```

`compact` now engages at 424 — the exact width the row used to wrap at.

## Tests

- `tests/test_claude_narrow.py` — **16 passed**, including a new `test_the_rows_need_counts_every_seat_and_reads_sub_pixels` pinning both halves of the fix.
- All composer-touching template tests (13 files) — **526 passed, 0 failed**.
- Full suite — **8503 passed, 9 failed**; 8 of those reproduce unchanged on `origin/main` (`test_claude_health`, `test_ai_metrics`, `test_calls` — environment-dependent on a local claude binary) and the 9th (`test_schedule_api`) passes in isolation, an ordering flake. **0 fails attributable to this change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)