### PR TITLE
Run the full pytest suite on Windows in CI, and fix what it found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -257,13 +257,14 @@ jobs:
   # there via `uv python install 3.12`. Testing 3.10/3.11/3.13 here would be
   # covering interpreters no Windows user's install ever runs.
   #
-  # continue-on-error until a pass shows which failures are real — remove it
-  # once the suite is green (or the real failures are triaged into skips) so
-  # this becomes a required check like every other platform job.
+  # A required check like every other platform job: continue-on-error is gone
+  # now that the suite is green here. It was only ever scaffolding — a job that
+  # cannot fail reports nothing, and the point of this one is to catch the
+  # Windows-only bugs the Linux matrix can only simulate, which it cannot do
+  # from behind a flag that swallows the result.
   test-python-windows:
     needs: [detect-changes, frontend]
     if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
-    continue-on-error: true
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -677,7 +678,7 @@ jobs:
     name: Test Status
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [detect-changes, frontend, test-python, fused-engine, bundle-contents, linux-desktop, windows-desktop, macos-desktop]
+    needs: [detect-changes, frontend, test-python, test-python-windows, fused-engine, bundle-contents, linux-desktop, windows-desktop, macos-desktop]
     if: always()
     steps:
       - name: Check test status
@@ -697,9 +698,12 @@ jobs:
             echo "No relevant changes; skipped."
             exit 0
           fi
-          # app fired ⇒ these five always run (they gate on app only), so
-          # anything other than success is a failure.
-          for result in "${{ needs.frontend.result }}" "${{ needs.test-python.result }}" "${{ needs.fused-engine.result }}" "${{ needs.linux-desktop.result }}" "${{ needs.bundle-contents.result }}"; do
+          # app fired ⇒ these six always run (they gate on app only), so
+          # anything other than success is a failure. test-python-windows is
+          # among them: it gates on `app` exactly like test-python, and it is
+          # listed here rather than with the filter-gated desktop jobs below
+          # because "skipped" is NOT a legitimate outcome for it.
+          for result in "${{ needs.frontend.result }}" "${{ needs.test-python.result }}" "${{ needs.test-python-windows.result }}" "${{ needs.fused-engine.result }}" "${{ needs.linux-desktop.result }}" "${{ needs.bundle-contents.result }}"; do
             if [[ "$result" != "success" ]]; then
               echo "Job did not succeed: $result"
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,72 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ github.token }}
 
+  # Broader Windows coverage than windows-desktop below, which only runs the
+  # five supervisor-specific files gated on windows_desktop paths. This job
+  # runs the WHOLE suite on real Windows across the same python-version
+  # matrix as test-python, to find portability bugs outside the supervisor
+  # (path handling, process spawn, file locking, sockets, …) that the Linux
+  # matrix can only ever simulate. No test here has ever been run on Windows
+  # before, so continue-on-error until a pass shows which failures are real —
+  # remove it once the suite is green (or the real failures are triaged into
+  # skips) so this becomes a required check like every other platform job.
+  test-python-windows:
+    needs: [detect-changes, frontend]
+    if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: shell-dist
+          path: fused_render/static/shell-dist
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install fused-render (dev extra)
+        run: python -m pip install -e ".[dev]"
+
+      # Same pinned version + published SHA256 as the Windows installer bundles
+      # (scripts/build_windows_installer.ps1) and the same discipline as the
+      # Linux job's rclone install above — a bad download fails in seconds, not
+      # silently. Added to GITHUB_PATH (not FUSED_RENDER_RCLONE_BIN) so
+      # shutil.which("rclone") finds it exactly the way a dev machine's PATH
+      # would.
+      - name: Install rclone
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $RcloneVersion = "1.74.4"
+          $RcloneSha256 = "ef097ef9de37a57feb7d9f9c7afb34148ad3c65be8025f1d8f7f521554a701ea"
+          $rcloneZip = Join-Path $env:RUNNER_TEMP "rclone.zip"
+          Invoke-WebRequest -Uri "https://downloads.rclone.org/v$RcloneVersion/rclone-v$RcloneVersion-windows-amd64.zip" -OutFile $rcloneZip
+          $actualSha = (Get-FileHash -LiteralPath $rcloneZip -Algorithm SHA256).Hash.ToLower()
+          if ($actualSha -ne $RcloneSha256) {
+            throw "rclone zip SHA256 mismatch: expected $RcloneSha256, got $actualSha"
+          }
+          $rcloneDir = Join-Path $env:RUNNER_TEMP "rclone-bin"
+          Expand-Archive -Path $rcloneZip -DestinationPath $rcloneDir -Force
+          $rcloneExe = Get-ChildItem -Path $rcloneDir -Recurse -Filter "rclone.exe" | Select-Object -First 1
+          if (-not $rcloneExe) {
+            throw "rclone.exe not found in the downloaded zip"
+          }
+          Add-Content -Path $env:GITHUB_PATH -Value $rcloneExe.DirectoryName
+          & $rcloneExe.FullName version
+
+      - name: Run tests
+        run: python -m pytest tests/ -v
+
   # The optional fused execution engine (D69) — the engine the migration plan
   # promotes to default, after which the built-in executor goes away. Until this
   # job, CI had never run it: no job installed the `[fused]` extra, so every

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,21 +246,24 @@ jobs:
 
   # Broader Windows coverage than windows-desktop below, which only runs the
   # five supervisor-specific files gated on windows_desktop paths. This job
-  # runs the WHOLE suite on real Windows across the same python-version
-  # matrix as test-python, to find portability bugs outside the supervisor
-  # (path handling, process spawn, file locking, sockets, …) that the Linux
-  # matrix can only ever simulate. No test here has ever been run on Windows
-  # before, so continue-on-error until a pass shows which failures are real —
-  # remove it once the suite is green (or the real failures are triaged into
-  # skips) so this becomes a required check like every other platform job.
+  # runs the WHOLE suite on real Windows to find portability bugs outside the
+  # supervisor (path handling, process spawn, file locking, sockets, …) that
+  # the Linux matrix can only ever simulate.
+  #
+  # One version, not a matrix: unlike test-python below (a source install,
+  # which genuinely has to work across every Python this package supports),
+  # the only Python that ever runs fused-render on a real Windows machine is
+  # the one build_windows_installer.ps1 bundles into the installer — pinned
+  # there via `uv python install 3.12`. Testing 3.10/3.11/3.13 here would be
+  # covering interpreters no Windows user's install ever runs.
+  #
+  # continue-on-error until a pass shows which failures are real — remove it
+  # once the suite is green (or the real failures are triaged into skips) so
+  # this becomes a required check like every other platform job.
   test-python-windows:
     needs: [detect-changes, frontend]
     if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
     continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -273,7 +276,8 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.python-version }}
+          # Same version the bundled installer's `uv python install 3.12` pins.
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -2125,6 +2125,26 @@ def _handler(generate, streaming):
         def log_message(self, *args):
             pass  # the supervisor captures stderr; per-request noise is not useful
 
+        def _drain(self):
+            """Read and discard the request body.
+
+            Mandatory before answering a request WITHOUT reading its body. This
+            handler is HTTP/1.1, so the connection is kept alive and the next
+            request is parsed off the same socket — an undrained body is still
+            queued there and its bytes get read as that request's request-line.
+            And closing a socket that still holds unread data makes Windows
+            send an RST instead of a FIN, which reaches the client as
+            [WinError 10053] ConnectionAbortedError rather than the clean 403
+            this path exists to deliver. (Both halves are real: the desync bites
+            on every platform, the RST is Windows-specific.)
+            """
+            remaining = int(self.headers.get("Content-Length") or 0)
+            while remaining > 0:
+                chunk = self.rfile.read(min(remaining, 64 * 1024))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+
         def _authorized(self):
             # The token is a header the supervisor generated and passed in this
             # process's environment. A foreign page that guessed the ephemeral
@@ -2132,6 +2152,10 @@ def _handler(generate, streaming):
             # log line or a Referer.
             if TOKEN and self.headers.get("X-Fused-Worker") == TOKEN:
                 return True
+            # Before the refusal, not after: see _drain. A rejected POST still
+            # arrived with a body, and leaving it unread turns a 403 into a
+            # dropped connection.
+            self._drain()
             self.send_response(403)
             self.send_header("Content-Length", "0")
             self.end_headers()

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -99,6 +99,15 @@ CANCEL = threading.Event()
 GENERATE_LOCK = threading.Lock()
 
 TOKEN = os.environ.get("FUSED_AI_WORKER_TOKEN", "")
+
+#: Bounds on the PRE-AUTH body drain (Handler._drain). 64 KiB is far above any
+#: real request this worker takes — they are small JSON objects — and the point
+#: is only to stop an unauthenticated caller from naming a size that makes us
+#: wait on it. 2s is generous for a body already in flight on loopback, and it
+#: is the only read timeout on this connection at all (`_Server` sets none).
+DRAIN_MAX_BYTES = 64 * 1024
+DRAIN_TIMEOUT_S = 2.0
+
 JOB_ID = ""
 JOB_URL = (os.environ.get("FUSED_RENDER_ORIGIN") or "").rstrip("/") + "/api/jobs"
 
@@ -2126,24 +2135,56 @@ def _handler(generate, streaming):
             pass  # the supervisor captures stderr; per-request noise is not useful
 
         def _drain(self):
-            """Read and discard the request body.
+            """Read and discard the request body. True if it was fully drained.
 
-            Mandatory before answering a request WITHOUT reading its body. This
-            handler is HTTP/1.1, so the connection is kept alive and the next
-            request is parsed off the same socket — an undrained body is still
-            queued there and its bytes get read as that request's request-line.
-            And closing a socket that still holds unread data makes Windows
-            send an RST instead of a FIN, which reaches the client as
-            [WinError 10053] ConnectionAbortedError rather than the clean 403
-            this path exists to deliver. (Both halves are real: the desync bites
-            on every platform, the RST is Windows-specific.)
+            Draining at all is mandatory before answering a request WITHOUT
+            reading its body. This handler is HTTP/1.1, so the connection is
+            kept alive and the next request is parsed off the same socket — an
+            undrained body is still queued there and its bytes get read as that
+            request's request-line. And closing a socket that still holds
+            unread data makes Windows send an RST instead of a FIN, which
+            reaches the client as [WinError 10053] ConnectionAbortedError
+            rather than the clean 403 this path exists to deliver. (Both halves
+            are real: the desync bites on every platform, the RST is
+            Windows-specific.)
+
+            BOUNDED on both axes, because the only caller runs BEFORE
+            authentication and Content-Length is the caller's to claim.
+            Unbounded, a client with a wrong token could announce a huge body
+            and then send nothing, holding one of this ThreadingTCPServer's
+            threads for as long as it pleased — and `_Server` sets no socket
+            timeout, so "as long as it pleased" is forever. Enough of those and
+            the worker stops answering /health, which is how the supervisor
+            decides it is alive. So: a length over DRAIN_MAX_BYTES is not read
+            at all, and what is read gets DRAIN_TIMEOUT_S to arrive.
+
+            Returning False means the connection is NOT safe to keep alive —
+            an over-long, half-sent or unparseable body is still in the socket,
+            and the next request read off it would consume that as its
+            request-line. The caller closes instead.
             """
-            remaining = int(self.headers.get("Content-Length") or 0)
-            while remaining > 0:
-                chunk = self.rfile.read(min(remaining, 64 * 1024))
-                if not chunk:
-                    break
-                remaining -= len(chunk)
+            raw = self.headers.get("Content-Length")
+            try:
+                remaining = int(raw) if raw else 0
+            except ValueError:
+                return False          # unparseable: cannot know where it ends
+            if remaining < 0 or remaining > DRAIN_MAX_BYTES:
+                return False
+            if remaining == 0:
+                return True
+            previous = self.connection.gettimeout()
+            self.connection.settimeout(DRAIN_TIMEOUT_S)
+            try:
+                while remaining > 0:
+                    chunk = self.rfile.read(min(remaining, 16 * 1024))
+                    if not chunk:
+                        return False  # client stopped short of what it claimed
+                    remaining -= len(chunk)
+                return True
+            except OSError:           # includes the socket timeout
+                return False
+            finally:
+                self.connection.settimeout(previous)
 
         def _authorized(self):
             # The token is a header the supervisor generated and passed in this
@@ -2152,12 +2193,20 @@ def _handler(generate, streaming):
             # log line or a Referer.
             if TOKEN and self.headers.get("X-Fused-Worker") == TOKEN:
                 return True
-            # Before the refusal, not after: see _drain. A rejected POST still
-            # arrived with a body, and leaving it unread turns a 403 into a
-            # dropped connection.
-            self._drain()
+            # Drain BEFORE the refusal, not after: see _drain. A rejected POST
+            # still arrived with a body, and leaving it unread turns a 403 into
+            # a dropped connection. When it cannot be drained safely, the
+            # refusal still goes out — but this connection ends with it, rather
+            # than being reused with someone else's bytes queued on it.
+            drained = self._drain()
             self.send_response(403)
             self.send_header("Content-Length", "0")
+            if not drained:
+                # Announced, not just done: the client is owed the reason its
+                # connection is about to end. send_header's own side effect
+                # sets close_connection, which is what actually stops this
+                # socket being reused with those undrained bytes still on it.
+                self.send_header("Connection", "close")
             self.end_headers()
             return False
 

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -2159,10 +2159,23 @@ def _handler(generate, streaming):
             at all, and what is read gets DRAIN_TIMEOUT_S to arrive.
 
             Returning False means the connection is NOT safe to keep alive —
-            an over-long, half-sent or unparseable body is still in the socket,
-            and the next request read off it would consume that as its
-            request-line. The caller closes instead.
+            an over-long, half-sent, chunked or unparseable body is still in
+            the socket, and the next request read off it would consume that as
+            its request-line. The caller closes instead.
             """
+            # Content-Length is the only framing this can drain. A chunked body
+            # is length-prefixed per chunk, and BaseHTTPRequestHandler does not
+            # decode it — self.rfile is the raw socket, so following it means
+            # parsing the chunk framing here. Transfer-Encoding also OVERRIDES
+            # Content-Length when both are sent (RFC 9112 s6.1), so a
+            # Content-Length read alongside one would stop in the wrong place.
+            # Nothing legitimate POSTs chunked to this worker (small JSON, sent
+            # with a length), so treat any Transfer-Encoding as undrainable and
+            # end the connection rather than guess where the body stops.
+            # Presence, not truth: an empty `Transfer-Encoding:` is malformed
+            # framing either way, and `.get()` would read it as absent.
+            if "Transfer-Encoding" in self.headers:
+                return False
             raw = self.headers.get("Content-Length")
             try:
                 remaining = int(raw) if raw else 0

--- a/fused_render/calls.py
+++ b/fused_render/calls.py
@@ -641,7 +641,17 @@ def mark_superseded(call_ids: list) -> int:
     now = time.monotonic()
     with _superseded_lock:
         for known, seen in list(_SUPERSEDED.items()):
-            if now - seen > _SUPERSEDED_TTL_S:
+            # >=, not >: a TTL of exactly 0.0 (tests use this to mean "already
+            # expired") must evict on the very next sweep. time.monotonic() on
+            # Windows is GetTickCount64-backed (~15.6ms resolution, tied to the
+            # system timer) rather than the sub-microsecond POSIX
+            # clock_gettime(CLOCK_MONOTONIC), so two calls a few Python
+            # bytecodes apart routinely read back the identical tick — a
+            # strict `>` then never fires and a mark meant to be immediately
+            # stale lingers for a full TTL. >= evicts on that tie without
+            # changing anything at the real 300s TTL, where the boundary
+            # instant is never observable.
+            if now - seen >= _SUPERSEDED_TTL_S:
                 del _SUPERSEDED[known]
         added = 0
         for call_id in call_ids:

--- a/fused_render/claude_config/memory.py
+++ b/fused_render/claude_config/memory.py
@@ -129,14 +129,24 @@ def _project_path(slug: str) -> Optional[str]:
     # it is where those sessions ran, not a guess we are making now.
     if cwd:
         return cwd
-    # Only an absolute POSIX path can be reconstructed: the leading "-" is the
-    # munged root separator, and without it there is no anchor to walk from.
-    if not slug.startswith("-"):
+    # A munged absolute path carries its root as a recognizable prefix: POSIX's
+    # leading "/" munges to a leading "-", while Windows' "C:\" munges to a
+    # leading "C--" (the drive letter survives — it's alnum — then ":" and the
+    # first "\" each become their own "-"). Without one of these there is no
+    # anchor to walk from.
+    drive_match = re.match(r"^([A-Za-z])--", slug)
+    if drive_match:
+        base = drive_match.group(1) + ":" + os.sep
+        rest = slug[drive_match.end():]
+    elif slug.startswith("-"):
+        base = os.sep
+        rest = slug[1:]
+    else:
         return None
-    parts = slug[1:].split("-")
+    parts = rest.split("-") if rest else []
     if not parts or len(parts) > _MAX_SEGMENTS:
         return None
-    return _rejoin(parts, os.sep)
+    return _rejoin(parts, base)
 
 
 def _memory_dir(project: str) -> str:

--- a/fused_render/deeplink.py
+++ b/fused_render/deeplink.py
@@ -27,6 +27,7 @@ import os
 import posixpath
 import re
 import shutil
+import stat
 import subprocess
 from urllib.parse import unquote, urlsplit
 
@@ -347,6 +348,28 @@ def destination(spec: dict) -> str:
     return os.path.join(fused_dir(), spec["name"])
 
 
+def _clear_readonly_and_retry(func, path, _exc_info):
+    """`shutil.rmtree`'s `onerror` hook: drop the read-only bit and retry once.
+
+    A failed clone's `.git/objects/` holds loose objects git wrote read-only —
+    POSIX and Windows disagree about what that means for DELETING them: POSIX
+    consults the parent DIRECTORY's write permission (a read-only file under a
+    writable dest unlinks fine, so `rmtree` never even calls this hook there),
+    while Windows enforces the file's own read-only attribute against the
+    delete itself. `ignore_errors=True` used to swallow exactly that
+    PermissionError, which meant a failed clone (this exact function's job:
+    the sparse subpath check below fails, or the caller retries after another
+    error) left its half-written `dest` behind instead of being retryable —
+    same fix as `templates/bundle/reader.py`'s scratch-repo cleanup, same root
+    cause. A second failure (something genuinely locked) is left alone.
+    """
+    try:
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+    except OSError:
+        pass
+
+
 def _clone_into(spec: dict, remote: str, dest: str) -> None:
     """One clone attempt against one remote; removes the half-clone on any
     failure so a retry (other remote, next click) never hits an 'exists and
@@ -380,7 +403,10 @@ def _clone_into(spec: dict, remote: str, dest: str) -> None:
                 f"{spec['owner']}/{spec['repo']} at ref {spec['ref'] or 'HEAD'}"
             )
     except DeeplinkError:
-        shutil.rmtree(dest, ignore_errors=True)
+        # onerror= rather than ignore_errors=True — see
+        # _clear_readonly_and_retry. `onerror` (not the 3.12+ `onexc`) is the
+        # spelling that still works on every Python version this ships on.
+        shutil.rmtree(dest, onerror=_clear_readonly_and_retry)
         raise
 
 

--- a/fused_render/fusedcli.py
+++ b/fused_render/fusedcli.py
@@ -34,6 +34,54 @@ class FusedCli:
     external: bool
 
 
+def _split_override(override: str) -> list[str]:
+    """FUSED_RENDER_FUSED_BIN as an argv list, honouring quotes.
+
+    Splitting is the point — a compound command ("uv run fused") is documented
+    and supported. But a PLAIN whitespace split cannot express the single most
+    common interpreter location on Windows: `C:\\Program Files\\...` came apart
+    into `C:\\Program` + `Files\\...`, so the override either "wasn't found" or
+    ran something else entirely, with nothing in the failure pointing at the
+    space as the cause. Quoting that component now works:
+
+        FUSED_RENDER_FUSED_BIN='"C:\\Program Files\\Python\\python.exe" -m fused'
+
+    `posix=` is chosen per platform and BOTH halves matter:
+
+      * posix=True on Windows treats `\\` as an escape and EATS it —
+        `C:\\Python\\python.exe` parses to `C:Pythonpython.exe`, which is not a
+        path at all. So Windows must use the non-posix lexer.
+      * posix=False on POSIX loses backslash escapes, so `/opt/my\\ app/py`
+        would stop working there.
+
+    Each platform therefore gets the lexer matching its own quoting rules. The
+    non-posix lexer KEEPS the quote characters inside the token it returns, so
+    they are stripped here; the posix lexer already removes them.
+
+    An unbalanced quote makes shlex raise. That is a malformed env var, not a
+    reason to take down every caller (fused_cli() is on the canvases request
+    path), so it degrades to the historical whitespace split and says so.
+
+    Still not expressible, on either platform: an UNQUOTED path containing a
+    space. That is ambiguous by construction — a shell cannot read it either —
+    and it is why the quoting above is the fix rather than some heuristic that
+    tries to guess where the path ends.
+    """
+    nt = os.name == "nt"
+    try:
+        parts = shlex.split(override, posix=not nt)
+    except ValueError:
+        logger.warning(
+            "FUSED_RENDER_FUSED_BIN is not parseable as a command line (%r) — "
+            "unbalanced quote? Falling back to a plain whitespace split, which "
+            "cannot handle a path containing spaces.", override)
+        return override.split()
+    if nt:
+        parts = [p[1:-1] if len(p) >= 2 and p[0] == p[-1] and p[0] in "\"'" else p
+                 for p in parts]
+    return parts
+
+
 def fused_cli() -> FusedCli | None:
     """Resolve the fused CLI, or None when there is none.
 
@@ -42,8 +90,9 @@ def fused_cli() -> FusedCli | None:
     this server didn't get from its own interpreter runs only because the
     user explicitly configured it):
 
-      1. FUSED_RENDER_FUSED_BIN — trusted verbatim, split on whitespace so a
-         compound command works (e.g. "uv run fused"). Mirrors the flow app's
+      1. FUSED_RENDER_FUSED_BIN — trusted verbatim, split into an argv so a
+         compound command works (e.g. "uv run fused"); quote a component that
+         contains spaces (see _split_override). Mirrors the flow app's
          OPENFUSED_BIN seam; also how tests substitute a stub CLI.
       2. the `fused` package importable in THIS interpreter — run as
          ``[sys.executable, _fused_cli.py]`` (the shim sets argv[0] and calls
@@ -55,7 +104,7 @@ def fused_cli() -> FusedCli | None:
     """
     override = os.environ.get("FUSED_RENDER_FUSED_BIN")
     if override:
-        parts = override.split()
+        parts = _split_override(override)
         return FusedCli(command=parts, external=True) if parts else None
     try:
         importable = importlib.util.find_spec("fused") is not None

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -32,6 +32,23 @@ logger = logging.getLogger(__name__)
 
 _DRIVE = re.compile(r"^[A-Za-z]:/")
 
+# A bare drive letter ("C:") is what rstrip("/") leaves a Windows drive root
+# ("C:/") reduced to — the same way rstrip("/") leaves a POSIX root ("/")
+# reduced to "". Every root normalization below restores the trailing "/" for
+# the POSIX case (the existing `or "/"`); this is the matching restoration for
+# the Windows one, without which a scan root that IS a whole drive would
+# resolve here to "C:" while canonical_root() (index/runner.py) — what every
+# stored dirs.parquet row is actually keyed under — resolves the identical
+# input to "C:/", and the two would never compare equal.
+_BARE_DRIVE = re.compile(r"^[A-Za-z]:$")
+
+
+def _root_or_bare(stripped: str) -> str:
+    """`stripped` (already rstripped of "/") restored to its canonical bare-
+    root spelling if it collapsed to one — "" -> "/", "C:" -> "C:/" — else
+    unchanged."""
+    return stripped + "/" if not stripped or _BARE_DRIVE.match(stripped) else stripped
+
 SORTS = {
     "path": "path ASC", "size": "size DESC", "mtime": "mtime DESC",
     "name": "name ASC",
@@ -203,8 +220,12 @@ def stats(cfg: IndexConfig, root: str = "") -> dict:
 
     con = duckdb.connect()
     root = norm(os.path.expanduser(root.strip())) if root.strip() else ""
-    root = (root or m.get("last_root") or "").rstrip("/") or "/"
-    pfx = (like_literal(root) + "/") if root != "/" else "/"
+    root = _root_or_bare((root or m.get("last_root") or "").rstrip("/"))
+    # `root` already ends in "/" for a bare root (POSIX "/", or a Windows
+    # drive root "C:/" via _root_or_bare above) — appending another "/"
+    # unconditionally, as a plain `root != "/"` check used to, would double
+    # it on the drive-root case and match nothing.
+    pfx = like_literal(root if root.endswith("/") else root + "/")
     inside = (f"(dir = '{_q(root)}' "
               f"OR dir LIKE '{pfx}%' ESCAPE '\\')")
     n_rows, total_size, n_dirs = 0, 0, 0
@@ -294,7 +315,8 @@ def search_under(cfg: IndexConfig, root: str, q: str = "", limit: int = MAX_CORP
     # string, which the guard below then reads as "no root given" — so a
     # search of "/" answered `covered: false` every time. Everything past
     # here already special-cases "/" (see `prefix`); only this line did not.
-    root = norm(os.path.abspath(os.path.expanduser((root or "").strip()))).rstrip("/") or "/"
+    root = _root_or_bare(
+        norm(os.path.abspath(os.path.expanduser((root or "").strip()))).rstrip("/"))
     m = read_manifest(cfg)
     empty = {"covered": False, "fresh": False, "updated": None, "age_s": None,
              "root": root, "entries": [], "truncated": False, "total": 0,
@@ -313,8 +335,10 @@ def search_under(cfg: IndexConfig, root: str, q: str = "", limit: int = MAX_CORP
     covered = _root_is_covered(con, cfg, root)
     if not covered:
         return {**empty, "updated": updated, "age_s": age}
-    prefix = (root + "/") if root != "/" else "/"
-    prefix_like = (like_literal(root) + "/") if root != "/" else "/"
+    # See stats()'s identical fix above: root already ends in "/" for
+    # any bare root (POSIX or a Windows drive), not only "/" itself.
+    prefix = root if root.endswith("/") else root + "/"
+    prefix_like = like_literal(prefix)
     limit = max(0, min(int(limit), MAX_CORPUS))
     hit = prune(m["partitions"], prefix)
     qlit = like_literal(q.strip()) if q and q.strip() else ""
@@ -540,7 +564,8 @@ def search_ranked(cfg: IndexConfig, root: str, q: str = "",
     — never an error, because "no index yet", "not covered" and "a scan is
     running" are one condition to a search box.
     """
-    root = norm(os.path.abspath(os.path.expanduser((root or "").strip()))).rstrip("/") or "/"
+    root = _root_or_bare(
+        norm(os.path.abspath(os.path.expanduser((root or "").strip()))).rstrip("/"))
     m = read_manifest(cfg)
     # `reason` is the miss's cause, and it is what the in-folder search box
     # switches on: a package or a mount-backed folder goes to the live walk, an
@@ -566,8 +591,10 @@ def search_ranked(cfg: IndexConfig, root: str, q: str = "",
     miss = _coverage_reason(con, cfg, root)
     if miss:
         return {**empty, "reason": miss, "updated": updated, "age_s": age}
-    prefix = (root + "/") if root != "/" else "/"
-    prefix_like = (like_literal(root) + "/") if root != "/" else "/"
+    # See stats()'s identical fix above: root already ends in "/" for
+    # any bare root (POSIX or a Windows drive), not only "/" itself.
+    prefix = root if root.endswith("/") else root + "/"
+    prefix_like = like_literal(prefix)
     limit = max(0, min(int(limit), MAX_RANK_LIMIT))
     cap = max(1, int(cap))
     hit = prune(m["partitions"], prefix)

--- a/fused_render/server/index_touch.py
+++ b/fused_render/server/index_touch.py
@@ -44,9 +44,17 @@ folder-sized scan merges into the store rather than replacing it.
 """
 import logging
 import os
+import re
 import threading
 
 from fused_render.index.ignore import norm
+
+# A bare Windows drive ("C:", or "C:/" before the rstrip below removes it) is
+# that platform's filesystem root, the same structural case "/" is on POSIX —
+# see the module docstring's "never a mount, never /". query.py's `_DRIVE`
+# anchoring regex recognizes the drive-letter form on the query side; this is
+# the same recognition for the root-guard side below.
+_DRIVE_ROOT = re.compile(r"^[A-Za-z]:/?$")
 
 logger = logging.getLogger(__name__)
 
@@ -96,10 +104,10 @@ def _folder_of(path: str) -> str:
     if not raw:
         return ""  # abspath("") is the server's cwd, which is nobody's folder
     p = norm(os.path.abspath(raw)).rstrip("/")
-    if not p or p == "/":
+    if not p or p == "/" or _DRIVE_ROOT.match(p):
         return ""
     parent = os.path.dirname(p)
-    return "" if parent in ("", "/") else parent
+    return "" if parent in ("", "/") or _DRIVE_ROOT.match(parent) else parent
 
 
 class RescanQueue:

--- a/fused_render/server/routers/ai_models.py
+++ b/fused_render/server/routers/ai_models.py
@@ -79,6 +79,7 @@ import os
 import re
 import shutil
 import stat
+import sys
 import time
 from dataclasses import dataclass
 from typing import NamedTuple
@@ -185,6 +186,18 @@ def _scan_repo(root: str) -> _RepoScan:
             # only date about a model this machine actually knows.
             if oldest == 0.0 or st.st_mtime < oldest:
                 oldest = st.st_mtime
+            if sys.platform == "win32":
+                # entry.stat() above is DirEntry.stat(): on Windows it is built
+                # from the cached FindFirstFile/FindNextFile data, which has no
+                # file-index or link-count field at all, so st_ino/st_dev/
+                # st_nlink from it are always 0 — silently disabling the dedup
+                # below on exactly the platform (no symlink permission) where
+                # huggingface_hub falls back to hardlinks in the first place.
+                # A real (uncached) stat is the only way to get true values;
+                # the extra syscall is paid only here — once per real file,
+                # Windows only — never on the POSIX path above, where
+                # DirEntry.stat() already answers this correctly for free.
+                st = os.stat(entry.path, follow_symlinks=False)
             if st.st_nlink > 1:
                 key = (st.st_dev, st.st_ino)
                 if key in seen:

--- a/fused_render/server/routers/ai_models.py
+++ b/fused_render/server/routers/ai_models.py
@@ -197,7 +197,18 @@ def _scan_repo(root: str) -> _RepoScan:
                 # the extra syscall is paid only here — once per real file,
                 # Windows only — never on the POSIX path above, where
                 # DirEntry.stat() already answers this correctly for free.
-                st = os.stat(entry.path, follow_symlinks=False)
+                #
+                # Guarded like the entry.stat() above, and for the same
+                # reason: this is a SECOND trip to the filesystem, so a blob
+                # that a live download (or a `hf` cache cleanup) removes
+                # between the scandir and here raises FileNotFoundError. Left
+                # unguarded that aborted the whole listing — the exact
+                # "report what we could see rather than failing the page"
+                # contract the enclosing loop is built on.
+                try:
+                    st = os.stat(entry.path, follow_symlinks=False)
+                except OSError:
+                    continue
             if st.st_nlink > 1:
                 key = (st.st_dev, st.st_ino)
                 if key in seen:

--- a/fused_render/server/routers/ai_models.py
+++ b/fused_render/server/routers/ai_models.py
@@ -173,19 +173,16 @@ def _scan_repo(root: str) -> _RepoScan:
                 # emptied repo would still report "just now".
                 stack.append(entry.path)
                 continue
-            if st.st_mtime > newest:
-                newest = st.st_mtime
             if stat.S_ISLNK(st.st_mode):
-                continue  # points back into this repo's blobs/ — already counted
-            # Only real files carry a meaningful atime: loading a model through
-            # a snapshot symlink touches the blob, not the link.
-            if st.st_atime > used:
-                used = st.st_atime
-            # Oldest real file ≈ when this repo first landed here. The Hub's
-            # release date is NOT on disk (see _repo's "added"), so this is the
-            # only date about a model this machine actually knows.
-            if oldest == 0.0 or st.st_mtime < oldest:
-                oldest = st.st_mtime
+                # Points back into this repo's blobs/ — its target is already
+                # counted, so a link contributes to `newest` and to nothing
+                # else. (Deliberate, and unchanged: a link still dates the
+                # repo, but only real files carry a meaningful atime — loading
+                # a model through a snapshot symlink touches the blob, not the
+                # link — and counting the link's size would double-count.)
+                if st.st_mtime > newest:
+                    newest = st.st_mtime
+                continue
             if sys.platform == "win32":
                 # entry.stat() above is DirEntry.stat(): on Windows it is built
                 # from the cached FindFirstFile/FindNextFile data, which has no
@@ -209,6 +206,26 @@ def _scan_repo(root: str) -> _RepoScan:
                     st = os.stat(entry.path, follow_symlinks=False)
                 except OSError:
                     continue
+            # EVERY accumulator below reads the FINAL `st`, and none of them run
+            # before the re-stat above can rule the file out. A file that
+            # vanishes in that window has to count for nothing at all: dating
+            # the repo from a blob whose size we then refuse to count is not a
+            # partial answer, it is a wrong one. `lastUsed` is the field that
+            # makes it concrete — it drives prune selection in the client, so a
+            # deleted blob's atime leaking in here marks a stale repo as
+            # recently used and protects it from the very cleanup that removed
+            # the blob. (On win32 these now read the fresh stat rather than the
+            # cached DirEntry one, which is also the stat that size and st_nlink
+            # come from — one consistent view of the file, not two.)
+            if st.st_mtime > newest:
+                newest = st.st_mtime
+            if st.st_atime > used:
+                used = st.st_atime
+            # Oldest real file ≈ when this repo first landed here. The Hub's
+            # release date is NOT on disk (see _repo's "added"), so this is the
+            # only date about a model this machine actually knows.
+            if oldest == 0.0 or st.st_mtime < oldest:
+                oldest = st.st_mtime
             if st.st_nlink > 1:
                 key = (st.st_dev, st.st_ino)
                 if key in seen:

--- a/fused_render/server/routers/ai_runtime.py
+++ b/fused_render/server/routers/ai_runtime.py
@@ -562,13 +562,16 @@ def api_ai_image(body: dict = Body(...), x_fused: str | None = Header(default=No
     # worker's field name for the same thing `path` is, so it is not repeated.
     return {
         "jobId": job,
-        "path": path,
-        # Canonical, because this goes back to a page that will put it in a
-        # `/api/fs/raw` URL — a Windows path that reached it backslashed would
-        # not match what the shell stored for the same file. It is a promise
-        # about a PATH, not about a file: a model with no fitted projection
-        # writes nothing there, and `fused.ai.image` treats a missing preview
-        # as the ordinary case rather than as an error.
+        # Canonical, like every other path this API hands back (`previewPath`
+        # below, and `/api/ai/transcribe`'s own `path`) — this goes back to a
+        # page that will put it in a `/api/fs/raw` URL, and a Windows path that
+        # reached it backslashed would not match what the shell stored for the
+        # same file.
+        "path": canonical_fs_path(path),
+        # Canonical for the same reason. It is a promise about a PATH, not
+        # about a file: a model with no fitted projection writes nothing there,
+        # and `fused.ai.image` treats a missing preview as the ordinary case
+        # rather than as an error.
         "previewPath": canonical_fs_path(request["outPreview"]),
         "model": model,
         "prompt": request["prompt"],

--- a/fused_render/shell/storage.py
+++ b/fused_render/shell/storage.py
@@ -32,10 +32,17 @@ def home_dir() -> str:
 def read_json(path: str):
     """Parse the JSON at `path`; return None if it is absent OR corrupt. The
     None-vs-value distinction lets a caller tell 'never written' from an empty
-    resource (e.g. the bookmarks `exists` flag / one-time import gate)."""
-    try:
+    resource (e.g. the bookmarks `exists` flag / one-time import gate).
+
+    The read is retried on a Windows sharing violation — a concurrent
+    write_json's os.replace can transiently refuse a reader's open() there;
+    see _retrying_on_sharing_violation. FileNotFoundError still returns None
+    on the first try, un-retried."""
+    def _once():
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
+    try:
+        return _retrying_on_sharing_violation(_once)
     except (FileNotFoundError, ValueError):
         return None
 
@@ -97,13 +104,33 @@ def _replace_atomic(tmp: str, path: str) -> None:
     the call itself always succeeds" contract POSIX gets for free — a dropped
     write here is not "last write wins", it is data loss. Gated on os.name so
     POSIX keeps the exact single-call behavior it always had."""
+    return _retrying_on_sharing_violation(lambda: os.replace(tmp, path))
+
+
+def _retrying_on_sharing_violation(op):
+    """`op()`, retried briefly when Windows reports a sharing violation.
+
+    Both HALVES of the read/write race need this, not just the write:
+    Windows' os.replace holds the destination for the duration of the swap and
+    a plain open() grants no FILE_SHARE_DELETE, so a concurrent READER can be
+    refused with PermissionError just as a concurrent writer can. Retrying only
+    the writer left the reader raising into whatever request touched it — the
+    Windows CI run showed exactly that, a PermissionError escaping read_json
+    through mounts/rcd.py's `_rcd_auth` (a live request path, not just a test).
+
+    PermissionError ONLY: a missing file must stay instant (read_json's
+    "absent → None" is a hot path — retrying it for the whole budget would be
+    a real slowdown on the common never-written case), and a parse error is
+    not a race. Gated on os.name so POSIX keeps its exact single-call
+    behavior. A violation that outlives the budget still raises: at that point
+    it is a genuinely unreadable/unwritable file, not a millisecond of
+    contention, and silently reporting it as absent would degrade auth rather
+    than surface a real problem."""
     if os.name != "nt":
-        os.replace(tmp, path)
-        return
+        return op()
     for attempt in range(_REPLACE_RETRIES):
         try:
-            os.replace(tmp, path)
-            return
+            return op()
         except PermissionError:
             if attempt == _REPLACE_RETRIES - 1:
                 raise

--- a/fused_render/shell/storage.py
+++ b/fused_render/shell/storage.py
@@ -12,6 +12,7 @@ the reverse (no server <-> shell import cycle).
 import json
 import os
 import tempfile
+import time
 
 
 def home_dir() -> str:
@@ -48,12 +49,49 @@ def write_json(path: str, data) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
-        os.replace(tmp, path)  # atomic on the same filesystem
+        _replace_atomic(tmp, path)
     except BaseException:
         try:
             os.unlink(tmp)
         except OSError:
             pass
         raise
+
+
+# A handful of quick retries, not a real backoff schedule: the sharing
+# violation this chases clears as soon as the OTHER writer's own os.replace
+# finishes, which is microseconds, not seconds.
+_REPLACE_RETRIES = 8
+_REPLACE_RETRY_DELAY_S = 0.02
+
+
+def _replace_atomic(tmp: str, path: str) -> None:
+    """os.replace(tmp, path), with a brief retry on Windows only.
+
+    POSIX rename is atomic and never raises for a concurrent replace — that is
+    what lets write_json promise "last write wins" with no locking above. The
+    identical call on Windows is backed by MoveFileExW, which CAN raise
+    PermissionError ([WinError 5] "Access is denied") for a few milliseconds
+    while another writer's os.replace (or a reader's plain open(), which grants
+    no FILE_SHARE_DELETE by default) still holds the destination — a transient
+    sharing violation, not a real permissions problem. Two concurrent
+    write_json calls to the SAME path (rcd.json under racing threads is the
+    known case) can hit this on every real Windows run.
+
+    Retrying rides that out and gives Windows the same "last write wins,
+    the call itself always succeeds" contract POSIX gets for free — a dropped
+    write here is not "last write wins", it is data loss. Gated on os.name so
+    POSIX keeps the exact single-call behavior it always had."""
+    if os.name != "nt":
+        os.replace(tmp, path)
+        return
+    for attempt in range(_REPLACE_RETRIES):
+        try:
+            os.replace(tmp, path)
+            return
+        except PermissionError:
+            if attempt == _REPLACE_RETRIES - 1:
+                raise
+            time.sleep(_REPLACE_RETRY_DELAY_S)
 
 

--- a/fused_render/shell/storage.py
+++ b/fused_render/shell/storage.py
@@ -58,11 +58,26 @@ def write_json(path: str, data) -> None:
         raise
 
 
-# A handful of quick retries, not a real backoff schedule: the sharing
-# violation this chases clears as soon as the OTHER writer's own os.replace
-# finishes, which is microseconds, not seconds.
-_REPLACE_RETRIES = 8
-_REPLACE_RETRY_DELAY_S = 0.02
+# Not a real backoff schedule: the sharing violation this chases clears as
+# soon as the OTHER writer's own os.replace finishes (or a reader's brief
+# open() closes), which is normally microseconds, not seconds — so a fixed,
+# short interval between tries is enough, and the budget is just "keep trying
+# for a while" rather than anything that needs to grow.
+#
+# The budget itself has to be generous, not merely "a handful": measured
+# against tests/test_mounts_rcd_auth.py's
+# test_concurrent_state_writes_never_pin_a_stale_secret (a background thread
+# doing nothing BUT open()/close() rcd.json in a tight loop while the main
+# thread writes it ~40 times), a real Windows CI runner's disk latency
+# (antivirus real-time scanning is the usual culprit) can stretch what is
+# "microseconds" on a dev machine into tens of milliseconds per contended
+# open — long enough that the original 8-try/20ms (160ms total) budget ran
+# out mid-test and os.replace's PermissionError escaped write_rcd_state
+# uncaught. The cost of a bigger budget is paid only on the rare path that
+# actually contends — an ordinary write still succeeds on its first try — so
+# there is no reason not to make it generous.
+_REPLACE_RETRIES = 50
+_REPLACE_RETRY_DELAY_S = 0.05
 
 
 def _replace_atomic(tmp: str, path: str) -> None:

--- a/fused_render/templates/bundle/reader.py
+++ b/fused_render/templates/bundle/reader.py
@@ -36,6 +36,7 @@ exceptions: the page renders an empty state, never a traceback overlay.
 """
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -188,6 +189,31 @@ def _first_line(text):
 _SCRATCH_PREFIX = "fused-render-bundle-"
 
 
+def _clear_readonly_and_retry(func, path, _exc_info):
+    """`shutil.rmtree`'s `onerror` hook: drop the read-only bit and retry once.
+
+    git writes some of what it unpacks (loose objects, fetched packs — exactly
+    what `verify`/history fill the scratch repo with) read-only, and POSIX and
+    Windows disagree about what that means for DELETING them: POSIX consults
+    the parent DIRECTORY's write permission, so a read-only file under a
+    writable temp dir unlinks fine and `rmtree` never even calls this hook
+    there. Windows enforces the file's own read-only attribute against the
+    delete itself, so `os.remove`/`os.rmdir` raises PermissionError on it — and
+    `ignore_errors=True` used to swallow exactly that, which meant this scratch
+    dir simply stopped being removable on Windows and every call to this
+    module leaked one `fused-render-bundle-*` directory into the temp folder,
+    forever. `os.chmod` + a single retry is the standard fix; a second failure
+    (something genuinely locked, e.g. a virus scanner mid-scan) is left alone —
+    this is best-effort cleanup of a throwaway dir, never something a caller
+    should see fail.
+    """
+    try:
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+    except OSError:
+        pass
+
+
 class _Scratch:
     """A throwaway git repository, for the length of one call.
 
@@ -202,7 +228,10 @@ class _Scratch:
         return self.root
 
     def __exit__(self, *exc):
-        shutil.rmtree(self.root, ignore_errors=True)
+        # `onerror=` rather than `ignore_errors=True` — see
+        # `_clear_readonly_and_retry`. `onerror` (not the 3.12+ `onexc`) is the
+        # spelling that still works on every Python version this ships on.
+        shutil.rmtree(self.root, onerror=_clear_readonly_and_retry)
         return False
 
 

--- a/fused_render/templates/geotiff/browse.py
+++ b/fused_render/templates/geotiff/browse.py
@@ -68,7 +68,16 @@ def main(dir: str = "~", exts: str = ".nc", show_all: bool = False,
          src: str = ""):
     import os
 
-    dir = os.path.abspath(os.path.expanduser(dir or "~"))
+    # Canonicalized to forward slashes right away: os.path.abspath backslashes
+    # EVERY separator on Windows, even a path that was already forward-slashed
+    # (ntpath.normpath doesn't leave "/" alone), and every step after this one
+    # — the remote stat/list query, the "/"-only breadcrumb split below, and
+    # each entry's joined path — has to agree on one separator or the
+    # breadcrumbs collapse into a single garbled segment. Forward slash is the
+    # form used everywhere else in the app (_view_url_codec.canonical_fs_path)
+    # and Windows accepts it in every real filesystem call, so there is no
+    # reason for this helper to be the one place still native-separator.
+    dir = os.path.abspath(os.path.expanduser(dir or "~")).replace(os.sep, "/")
 
     allow = tuple(e.strip().lower() for e in exts.split(",") if e.strip())
 
@@ -120,7 +129,9 @@ def main(dir: str = "~", exts: str = ".nc", show_all: bool = False,
 
     dirs, files = [], []
     for name, is_dir, size in triples:
-        full = os.path.join(dir, name)
+        # os.path.join re-inserts a native (backslash) separator on Windows
+        # even though `dir` is already forward-slash — re-canonicalize.
+        full = os.path.join(dir, name).replace(os.sep, "/")
         if is_dir:
             dirs.append({"name": name, "path": full, "is_dir": True})
         else:
@@ -133,10 +144,15 @@ def main(dir: str = "~", exts: str = ".nc", show_all: bool = False,
     dirs.sort(key=lambda e: e["name"].lower())
     files.sort(key=lambda e: e["name"].lower())
 
-    # breadcrumb segments: [(label, path), ...] from root to here
+    # breadcrumb segments: [(label, path), ...] from root to here. `dir` is
+    # forward-slash canonical (above), so this is a plain split — EXCEPT a
+    # drive letter ("C:") IS the root segment on Windows and must not get a
+    # POSIX-style leading "/" prepended, or "C:/Users" would crumb as
+    # "/C:", "/C:/Users" — neither a valid drive path nor a valid POSIX one.
+    segments = [s for s in dir.split("/") if s]
     parts, acc = [], ""
-    for seg in dir.strip("/").split("/"):
-        acc += "/" + seg
+    for i, seg in enumerate(segments):
+        acc = seg if i == 0 and seg.endswith(":") else acc + "/" + seg
         parts.append({"label": seg, "path": acc})
 
     return {

--- a/fused_render/templates/geotiff/browse.py
+++ b/fused_render/templates/geotiff/browse.py
@@ -64,6 +64,43 @@ def _list(src, path):
         return ("error", None)
 
 
+def _crumbs(dir):
+    """Breadcrumb segments [{"label", "path"}, ...] from root to `dir`.
+
+    `dir` is forward-slash canonical (see main()), so the TAIL is a plain
+    split — but the ROOT is not a segment like the others and cannot be built
+    by joining:
+
+      * a Windows drive root is "C:/", never "C:". A bare "C:" is
+        DRIVE-RELATIVE — it names the current directory on that drive rather
+        than its top — so crumbing the root as "C:" made a click on it land
+        wherever the serving process last happened to be on C:.
+      * a UNC root is "//server/share". The leading "//" is eaten by the
+        empty-segment filter, and a bare "//server" is not a path at all, so
+        the share belongs to the root crumb instead of being crumbed alone.
+      * a POSIX root contributes no crumb of its own: "/a/b" crumbs as
+        "a" -> "/a", "b" -> "/a/b".
+
+    A module-level helper rather than inline in main() so the two roots above
+    can be tested directly — neither is constructible on a POSIX test host,
+    where `dir` always comes back from os.path.abspath as "/...".
+    """
+    parts, acc, rest = [], "", dir
+    if len(dir) > 1 and dir[1] == ":" and dir[0].isalpha():
+        acc = dir[:2] + "/"               # "C:/", the real root of the drive
+        parts.append({"label": dir[:2], "path": acc})
+        rest = dir[2:]
+    elif dir.startswith("//"):
+        unc = [s for s in dir[2:].split("/") if s]
+        acc = "//" + "/".join(unc[:2])    # server AND share, one root crumb
+        parts.append({"label": acc, "path": acc})
+        rest = "/".join(unc[2:])
+    for seg in [s for s in rest.split("/") if s]:
+        acc = (acc.rstrip("/") + "/" + seg) if acc else "/" + seg
+        parts.append({"label": seg, "path": acc})
+    return parts
+
+
 def main(dir: str = "~", exts: str = ".nc", show_all: bool = False,
          src: str = ""):
     import os
@@ -144,21 +181,12 @@ def main(dir: str = "~", exts: str = ".nc", show_all: bool = False,
     dirs.sort(key=lambda e: e["name"].lower())
     files.sort(key=lambda e: e["name"].lower())
 
-    # breadcrumb segments: [(label, path), ...] from root to here. `dir` is
-    # forward-slash canonical (above), so this is a plain split — EXCEPT a
-    # drive letter ("C:") IS the root segment on Windows and must not get a
-    # POSIX-style leading "/" prepended, or "C:/Users" would crumb as
-    # "/C:", "/C:/Users" — neither a valid drive path nor a valid POSIX one.
-    segments = [s for s in dir.split("/") if s]
-    parts, acc = [], ""
-    for i, seg in enumerate(segments):
-        acc = seg if i == 0 and seg.endswith(":") else acc + "/" + seg
-        parts.append({"label": seg, "path": acc})
+    crumbs = _crumbs(dir)
 
     return {
         "dir": dir,
         "parent": os.path.dirname(dir),
-        "crumbs": parts,
+        "crumbs": crumbs,
         "dirs": dirs,
         "files": files,
         "n_hidden_files": 0 if show_all else None,

--- a/fused_render/templates/model_card/inspect_model.py
+++ b/fused_render/templates/model_card/inspect_model.py
@@ -93,7 +93,15 @@ def _front_matter(path):
     raw = _read(path, 128 * 1024)
     if raw is None:
         return {}, [], ""
-    text = raw.decode("utf-8", errors="replace")
+    # _read is deliberately binary (see its docstring), so a CRLF card — common
+    # enough on its own (an author's editor, or a repo checked out with
+    # core.autocrlf) — reaches here with the "\r\n" intact. The scalar/tag loop
+    # below tolerates a stray "\r" because every value already goes through
+    # .strip(), but the paragraph splitter looks for a literal "\n\n" blank
+    # line, which a CRLF file never contains (each blank line is "\r\n\r\n", not
+    # "\n\n") — so an un-normalized CRLF card silently loses its summary
+    # instead of merely misreading a field. Normalize once, up front.
+    text = raw.decode("utf-8", errors="replace").replace("\r\n", "\n").replace("\r", "\n")
     if not text.startswith("---"):
         return {}, [], text.strip().split("\n\n")[0].strip()
     lines = text.split("\n")[1:]

--- a/fused_render/templates/tar/reader.py
+++ b/fused_render/templates/tar/reader.py
@@ -129,6 +129,7 @@ def _write_target(src, target, dest_root, readonly):
             shutil.copyfileobj(src, dst)
         return os.path.realpath(target)
     fd, tmp = tempfile.mkstemp(dir=os.path.dirname(target) or dest_root)
+    prior_mode = None  # the stale target's mode, for the failure path below
     try:
         with src, os.fdopen(fd, "wb") as dst:
             shutil.copyfileobj(src, dst)
@@ -141,11 +142,21 @@ def _write_target(src, target, dest_root, readonly):
         # changed member on Windows once the first preview had landed. A
         # no-op on POSIX and on a first preview (target doesn't exist yet).
         try:
+            prior_mode = os.stat(target).st_mode & 0o777
             os.chmod(target, 0o644)
         except OSError:
-            pass
+            prior_mode = None
         os.replace(tmp, target)
     except BaseException:
+        # Restore the stale target's read-only bit when the swap fails — the
+        # same reasoning as zip/reader.py's `_extract_one`: that copy is still
+        # the live preview, so leaving it 0644 drops the guarantee
+        # `readonly=True` is for.
+        if prior_mode is not None:
+            try:
+                os.chmod(target, prior_mode)
+            except OSError:
+                pass
         try:
             os.unlink(tmp)
         except OSError:

--- a/fused_render/templates/tar/reader.py
+++ b/fused_render/templates/tar/reader.py
@@ -133,6 +133,17 @@ def _write_target(src, target, dest_root, readonly):
         with src, os.fdopen(fd, "wb") as dst:
             shutil.copyfileobj(src, dst)
         os.chmod(tmp, 0o444)
+        # Clear the read-only bit on a STALE target before the swap — see
+        # zip/reader.py's `_extract_one`, the identical pattern: POSIX's
+        # rename(2) doesn't care about the destination file's own mode, but
+        # Windows' MoveFileExW (os.replace there) refuses to replace a
+        # read-only ATTRIBUTE'd file, which would fail every re-preview of a
+        # changed member on Windows once the first preview had landed. A
+        # no-op on POSIX and on a first preview (target doesn't exist yet).
+        try:
+            os.chmod(target, 0o644)
+        except OSError:
+            pass
         os.replace(tmp, target)
     except BaseException:
         try:

--- a/fused_render/templates/zarr_aoi/browse.py
+++ b/fused_render/templates/zarr_aoi/browse.py
@@ -68,7 +68,16 @@ def main(dir: str = "~", exts: str = ".zarr", show_all: bool = False,
          store_exts: str = ".zarr", src: str = ""):
     import os
 
-    dir = os.path.abspath(os.path.expanduser(dir or "~"))
+    # Canonicalized to forward slashes right away: os.path.abspath backslashes
+    # EVERY separator on Windows, even a path that was already forward-slashed
+    # (ntpath.normpath doesn't leave "/" alone), and every step after this one
+    # — the remote stat/list query, the "/"-only breadcrumb split below, and
+    # each entry's joined path — has to agree on one separator or the
+    # breadcrumbs collapse into a single garbled segment. Forward slash is the
+    # form used everywhere else in the app (_view_url_codec.canonical_fs_path)
+    # and Windows accepts it in every real filesystem call, so there is no
+    # reason for this helper to be the one place still native-separator.
+    dir = os.path.abspath(os.path.expanduser(dir or "~")).replace(os.sep, "/")
 
     allow = tuple(e.strip().lower() for e in exts.split(",") if e.strip())
     stores = tuple(e.strip().lower() for e in store_exts.split(",") if e.strip())
@@ -121,7 +130,9 @@ def main(dir: str = "~", exts: str = ".zarr", show_all: bool = False,
 
     dirs, files = [], []
     for name, is_dir, size in triples:
-        full = os.path.join(dir, name)
+        # os.path.join re-inserts a native (backslash) separator on Windows
+        # even though `dir` is already forward-slash — re-canonicalize.
+        full = os.path.join(dir, name).replace(os.sep, "/")
         if is_dir:
             # a directory whose name ends in a store extension (e.g. .zarr) is a
             # loadable store, not just a folder to descend into.
@@ -140,10 +151,15 @@ def main(dir: str = "~", exts: str = ".zarr", show_all: bool = False,
     dirs.sort(key=lambda e: e["name"].lower())
     files.sort(key=lambda e: e["name"].lower())
 
-    # breadcrumb segments: [(label, path), ...] from root to here
+    # breadcrumb segments: [(label, path), ...] from root to here. `dir` is
+    # forward-slash canonical (above), so this is a plain split — EXCEPT a
+    # drive letter ("C:") IS the root segment on Windows and must not get a
+    # POSIX-style leading "/" prepended, or "C:/Users" would crumb as
+    # "/C:", "/C:/Users" — neither a valid drive path nor a valid POSIX one.
+    segments = [s for s in dir.split("/") if s]
     parts, acc = [], ""
-    for seg in dir.strip("/").split("/"):
-        acc += "/" + seg
+    for i, seg in enumerate(segments):
+        acc = seg if i == 0 and seg.endswith(":") else acc + "/" + seg
         parts.append({"label": seg, "path": acc})
 
     return {

--- a/fused_render/templates/zarr_aoi/browse.py
+++ b/fused_render/templates/zarr_aoi/browse.py
@@ -64,6 +64,43 @@ def _list(src, path):
         return ("error", None)
 
 
+def _crumbs(dir):
+    """Breadcrumb segments [{"label", "path"}, ...] from root to `dir`.
+
+    `dir` is forward-slash canonical (see main()), so the TAIL is a plain
+    split — but the ROOT is not a segment like the others and cannot be built
+    by joining:
+
+      * a Windows drive root is "C:/", never "C:". A bare "C:" is
+        DRIVE-RELATIVE — it names the current directory on that drive rather
+        than its top — so crumbing the root as "C:" made a click on it land
+        wherever the serving process last happened to be on C:.
+      * a UNC root is "//server/share". The leading "//" is eaten by the
+        empty-segment filter, and a bare "//server" is not a path at all, so
+        the share belongs to the root crumb instead of being crumbed alone.
+      * a POSIX root contributes no crumb of its own: "/a/b" crumbs as
+        "a" -> "/a", "b" -> "/a/b".
+
+    A module-level helper rather than inline in main() so the two roots above
+    can be tested directly — neither is constructible on a POSIX test host,
+    where `dir` always comes back from os.path.abspath as "/...".
+    """
+    parts, acc, rest = [], "", dir
+    if len(dir) > 1 and dir[1] == ":" and dir[0].isalpha():
+        acc = dir[:2] + "/"               # "C:/", the real root of the drive
+        parts.append({"label": dir[:2], "path": acc})
+        rest = dir[2:]
+    elif dir.startswith("//"):
+        unc = [s for s in dir[2:].split("/") if s]
+        acc = "//" + "/".join(unc[:2])    # server AND share, one root crumb
+        parts.append({"label": acc, "path": acc})
+        rest = "/".join(unc[2:])
+    for seg in [s for s in rest.split("/") if s]:
+        acc = (acc.rstrip("/") + "/" + seg) if acc else "/" + seg
+        parts.append({"label": seg, "path": acc})
+    return parts
+
+
 def main(dir: str = "~", exts: str = ".zarr", show_all: bool = False,
          store_exts: str = ".zarr", src: str = ""):
     import os
@@ -151,21 +188,12 @@ def main(dir: str = "~", exts: str = ".zarr", show_all: bool = False,
     dirs.sort(key=lambda e: e["name"].lower())
     files.sort(key=lambda e: e["name"].lower())
 
-    # breadcrumb segments: [(label, path), ...] from root to here. `dir` is
-    # forward-slash canonical (above), so this is a plain split — EXCEPT a
-    # drive letter ("C:") IS the root segment on Windows and must not get a
-    # POSIX-style leading "/" prepended, or "C:/Users" would crumb as
-    # "/C:", "/C:/Users" — neither a valid drive path nor a valid POSIX one.
-    segments = [s for s in dir.split("/") if s]
-    parts, acc = [], ""
-    for i, seg in enumerate(segments):
-        acc = seg if i == 0 and seg.endswith(":") else acc + "/" + seg
-        parts.append({"label": seg, "path": acc})
+    crumbs = _crumbs(dir)
 
     return {
         "dir": dir,
         "parent": os.path.dirname(dir),
-        "crumbs": parts,
+        "crumbs": crumbs,
         "dirs": dirs,
         "files": files,
         "n_hidden_files": 0 if show_all else None,

--- a/fused_render/templates/zip/reader.py
+++ b/fused_render/templates/zip/reader.py
@@ -91,6 +91,7 @@ def _extract_one(zf, info, dest_root, readonly=False):
             shutil.copyfileobj(src, dst)
         return os.path.realpath(target)
     fd, tmp = tempfile.mkstemp(dir=os.path.dirname(target) or dest_root)
+    prior_mode = None  # the stale target's mode, for the failure path below
     try:
         with zf.open(info) as src, os.fdopen(fd, "wb") as dst:
             shutil.copyfileobj(src, dst)
@@ -107,11 +108,23 @@ def _extract_one(zf, info, dest_root, readonly=False):
         # replacement file's own 0444 (set above) is what ends up on disk
         # either way.
         try:
+            prior_mode = os.stat(target).st_mode & 0o777
             os.chmod(target, 0o644)
         except OSError:
-            pass
+            prior_mode = None
         os.replace(tmp, target)
     except BaseException:
+        # The swap did NOT happen, so the stale copy above is still the live
+        # preview — put the read-only bit we just cleared back on it. Without
+        # this, a failed replace (on Windows, a sharing violation from the old
+        # preview still being open somewhere) left that copy 0644: the one
+        # property `readonly=True` exists to guarantee, silently dropped on
+        # the error path.
+        if prior_mode is not None:
+            try:
+                os.chmod(target, prior_mode)
+            except OSError:
+                pass
         try:
             os.unlink(tmp)
         except OSError:

--- a/fused_render/templates/zip/reader.py
+++ b/fused_render/templates/zip/reader.py
@@ -95,6 +95,21 @@ def _extract_one(zf, info, dest_root, readonly=False):
         with zf.open(info) as src, os.fdopen(fd, "wb") as dst:
             shutil.copyfileobj(src, dst)
         os.chmod(tmp, 0o444)
+        # Clear the read-only bit on a STALE target before the swap: POSIX's
+        # rename(2) only cares about the parent directory's write permission
+        # and happily replaces a 0444 file, but Windows' MoveFileExW (what
+        # os.replace becomes there) refuses to replace a destination that
+        # carries the read-only ATTRIBUTE — so a re-preview of a changed
+        # member, which is this whole function's reason for going through a
+        # temp file rather than a plain open("wb"), would otherwise fail
+        # every time on Windows once the first preview had landed. A no-op on
+        # POSIX and on a first preview (target doesn't exist yet); the
+        # replacement file's own 0444 (set above) is what ends up on disk
+        # either way.
+        try:
+            os.chmod(target, 0o644)
+        except OSError:
+            pass
         os.replace(tmp, target)
     except BaseException:
         try:

--- a/tests/_claude_history.py
+++ b/tests/_claude_history.py
@@ -66,7 +66,15 @@ def write_version(root, session, target, content, mtime=None):
          if n.startswith(path_hash(target) + "@v") and n.split("@v")[1].isdigit()],
         default=0)
     p = os.path.join(d, "%s@v%d" % (path_hash(target), version))
-    with open(p, "w", encoding="utf-8") as fh:
+    # `newline=""` disables universal-newline translation. The docstring above
+    # promises a FULL COPY of `content`, byte for byte, and file_history.py
+    # reads checkpoints in binary (`open(path, "rb")`) expecting exactly that
+    # — but the default text-mode write translates every "\n" to os.linesep
+    # on write, which is a no-op on POSIX and silently inflates every "\n" to
+    # "\r\n" on Windows (doubling any "\r" already in `content`, and turning
+    # an assertion like `size == len(content)` into an off-by-however-many-
+    # lines failure there).
+    with open(p, "w", encoding="utf-8", newline="") as fh:
         fh.write(content)
     if mtime is not None:
         os.utime(p, (mtime, mtime))

--- a/tests/test_ai_hub_fetch.py
+++ b/tests/test_ai_hub_fetch.py
@@ -40,6 +40,17 @@ import types
 
 import pytest
 
+# worker_base.py:_segmented_fetch itself refuses to run without os.pwrite (see
+# its own comment there) and every test in this file drives _segmented_fetch
+# directly — there is no fallback path to fall back to here, only the
+# platform this module's whole subject does not run on. The fallback IS
+# tested, just not in this file.
+pytestmark = pytest.mark.skipif(
+    not hasattr(os, "pwrite"),
+    reason="_segmented_fetch requires os.pwrite (POSIX); Windows always takes "
+           "the plain snapshot_download fallback instead.",
+)
+
 BASE_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "fused_render", "ai", "runners", "worker_base.py",

--- a/tests/test_ai_models_api.py
+++ b/tests/test_ai_models_api.py
@@ -253,6 +253,32 @@ def test_a_file_that_vanishes_mid_scan_is_skipped(client, hub, monkeypatch):
     assert out["files"] == 1
 
 
+def test_a_file_that_vanishes_between_the_two_stats_is_skipped(
+        client, hub, monkeypatch):
+    """On win32 the scan takes a SECOND, uncached os.stat to get real
+    st_nlink/st_ino (DirEntry.stat reports 0 for both there, which would
+    silently disable hardlink dedup). That is another trip to the filesystem,
+    so the same mid-download deletion the test above covers can land in this
+    narrower window instead — and must be skipped like any other, not abort
+    the whole listing."""
+    repo = _repo(hub, "models--org--m", blobs={"stays": 100, "vanishes": 50})
+    gone = str(repo / "blobs" / "vanishes")
+    real_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == gone:
+            raise FileNotFoundError(2, "No such file or directory")
+        return real_stat(path, *args, **kwargs)
+
+    # The DirEntry.stat() in the loop still succeeds for both blobs — only the
+    # win32-only re-stat finds this one gone.
+    monkeypatch.setattr(ai_models_mod.sys, "platform", "win32")
+    monkeypatch.setattr(ai_models_mod.os, "stat", fake_stat)
+    (out,) = _get(client)["repos"]
+    assert out["size"] == 100
+    assert out["files"] == 1
+
+
 # -- no cache at all -----------------------------------------------------------
 
 

--- a/tests/test_ai_models_api.py
+++ b/tests/test_ai_models_api.py
@@ -260,9 +260,24 @@ def test_a_file_that_vanishes_between_the_two_stats_is_skipped(
     silently disable hardlink dedup). That is another trip to the filesystem,
     so the same mid-download deletion the test above covers can land in this
     narrower window instead — and must be skipped like any other, not abort
-    the whole listing."""
+    the whole listing.
+
+    Skipped means counting for NOTHING — the timestamps too, not just
+    size/files. They are asserted here because they used to be accumulated
+    before the re-stat could rule the file out, so a vanished blob still dated
+    the repo. `lastUsed` is the one with teeth: it drives prune selection in
+    the client, so a deleted blob's atime leaking in marks a stale repo as
+    recently used and shields it from the cleanup that removed the blob.
+    """
     repo = _repo(hub, "models--org--m", blobs={"stays": 100, "vanishes": 50})
     gone = str(repo / "blobs" / "vanishes")
+
+    # Distinctive, far-apart stamps so a leak cannot hide inside a max()/min():
+    # the doomed blob is BOTH the newest and the most recently used AND the
+    # oldest, so if any of the three accumulators still sees it, one of the
+    # assertions below reads its number instead of the survivor's.
+    os.utime(repo / "blobs" / "stays", (5_000_000, 5_000_000))
+    os.utime(gone, (9_000_000, 1_000_000))
     real_stat = os.stat
 
     def fake_stat(path, *args, **kwargs):
@@ -277,6 +292,10 @@ def test_a_file_that_vanishes_between_the_two_stats_is_skipped(
     (out,) = _get(client)["repos"]
     assert out["size"] == 100
     assert out["files"] == 1
+    # Every field describes the surviving blob alone.
+    assert out["mtime"] == 5_000_000       # not the vanished 1_000_000 mtime
+    assert out["lastUsed"] == 5_000_000    # not its 9_000_000 atime
+    assert out["added"] == 5_000_000       # not its 1_000_000 mtime as "oldest"
 
 
 # -- no cache at all -----------------------------------------------------------

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -2557,7 +2557,10 @@ def test_the_worker_is_told_where_to_write_the_preview(client, fake_image_runner
     monkeypatch.setattr(supervisor, "start_image", spy)
     started = client.post("/api/ai/image", json={"prompt": "x"},
                           headers={"X-Fused": "1"}).json()
-    assert captured["outPreview"] == started["previewPath"]
+    # `captured` is the RAW request the worker gets (a native path,
+    # backslashed on Windows); `previewPath` is the reply's canonical
+    # (forward-slash) form of the same path — see `ai_runtime.canonical_fs_path`.
+    assert ai_runtime.canonical_fs_path(captured["outPreview"]) == started["previewPath"]
     _wait_job(started["jobId"])
 
 
@@ -2873,11 +2876,16 @@ def test_the_transcribe_reply_settles_the_request_before_anything_runs(
     """Everything the caller needs comes back from the POST: which model, which
     file, and where the transcript will land. Nothing waits on the work."""
     reply = _post_transcribe(client, path=recording, task="translate").json()
-    assert reply["path"] == os.path.abspath(recording)
+    # Canonical (forward-slash), like every path this API hands back — see
+    # `ai_runtime.canonical_fs_path` — so it is `os.path.abspath` run through
+    # the SAME transform, not the raw (backslashed, on Windows) form.
+    assert reply["path"] == ai_runtime.canonical_fs_path(os.path.abspath(recording))
     assert reply["model"] == catalog.default_for(registry.SPEECH_TO_TEXT)
     assert reply["task"] == "translate"
     assert reply["output"].endswith(".json")
-    assert os.path.dirname(reply["output"]).endswith(os.path.join("ai", "transcripts"))
+    # A literal forward slash rather than `os.path.join`: `output` is already
+    # canonical, so the suffix it ends with is too, on every platform.
+    assert os.path.dirname(reply["output"]).endswith("ai/transcripts")
     _wait_job(reply["jobId"])
 
 
@@ -2909,7 +2917,10 @@ def test_the_partial_path_reaches_the_WORKER_as_well_as_the_page(
     reply = _post_transcribe(client, path=recording).json()
     _wait_job(reply["jobId"])
 
-    assert seen["outPartial"] == reply["outputPartial"]
+    # `seen` is the RAW request the worker gets (a native path, backslashed on
+    # Windows); `outputPartial` is the reply's canonical (forward-slash) form
+    # of the same path — see `ai_runtime.canonical_fs_path`.
+    assert ai_runtime.canonical_fs_path(seen["outPartial"]) == reply["outputPartial"]
     # A SIBLING of the two the request already named, not a third location:
     # `_transcripts_dir()` is where the server decided user files go.
     assert (os.path.dirname(seen["outPartial"])
@@ -3155,7 +3166,10 @@ def test_a_relative_path_resolves_against_the_PAGE_not_the_server(
                                                    "page.html")},
                         headers={"X-Fused": "1"})
     assert reply.status_code == 200, reply.json()
-    assert reply.json()["path"] == recording
+    # Canonical (forward-slash), like every path this API hands back — see
+    # `ai_runtime.canonical_fs_path` — not the raw (backslashed, on Windows)
+    # form `recording` is built in.
+    assert reply.json()["path"] == ai_runtime.canonical_fs_path(recording)
     _wait_job(reply.json()["jobId"])
 
 
@@ -3891,8 +3905,13 @@ def _run_ai_transcribe(readfile, record, node_required=True, opts='{path: "a.m4a
            EXTRA})),
       );
     """.replace("OPTS", opts).replace("EXTRA", extra or '"_": null')
+    # Node writes UTF-8 to stdout regardless of platform; without an explicit
+    # `encoding` here, Windows decodes with `locale.getpreferredencoding()`
+    # (often cp1252), which mangles or crashes on the multibyte transcript
+    # text some of these harnesses drive through (see e.g.
+    # test_a_MULTIBYTE_transcript_does_not_split_a_character_or_lose_its_place).
     out = subprocess.run(["node", "-e", prelude + fn + call],
-                         capture_output=True, text=True)
+                         capture_output=True, text=True, encoding="utf-8")
     assert out.returncode == 0, out.stderr
     return json.loads(out.stdout)
 
@@ -3982,8 +4001,13 @@ def _run_ai_image(record='{state: "done"}', ticks="[]", preview='"/t/a.preview.p
           {ok: false, message: err.message, type: err.type, progress, rows})),
       );
     """
+    # Node writes UTF-8 to stdout regardless of platform; without an explicit
+    # `encoding` here, Windows decodes with `locale.getpreferredencoding()`
+    # (often cp1252), which mangles or crashes on the multibyte transcript
+    # text some of these harnesses drive through (see e.g.
+    # test_a_MULTIBYTE_transcript_does_not_split_a_character_or_lose_its_place).
     out = subprocess.run(["node", "-e", prelude + fn + call],
-                         capture_output=True, text=True)
+                         capture_output=True, text=True, encoding="utf-8")
     assert out.returncode == 0, out.stderr
     return json.loads(out.stdout)
 
@@ -4345,8 +4369,13 @@ def _run_ai_transcribe_tailing(lines, final, opts='{path: "a.m4a"}',
         # for the caller under test. Without one, `watch(null)` would never
         # reach the branch that decides whether to tail.
         else "{onProgress: () => {}}")
+    # Node writes UTF-8 to stdout regardless of platform; without an explicit
+    # `encoding` here, Windows decodes with `locale.getpreferredencoding()`
+    # (often cp1252), which mangles or crashes on the multibyte transcript
+    # text some of these harnesses drive through (see e.g.
+    # test_a_MULTIBYTE_transcript_does_not_split_a_character_or_lose_its_place).
     out = subprocess.run(["node", "-e", prelude + fn + call],
-                         capture_output=True, text=True)
+                         capture_output=True, text=True, encoding="utf-8")
     assert out.returncode == 0, out.stderr
     return json.loads(out.stdout)
 

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -30,6 +30,10 @@ from fused_render.server import create_app
 from fused_render.server.routers import ai_models, ai_runtime
 from fused_render.server.routers.ai_models import CachedModel
 
+# os.geteuid is POSIX-only; a bare call below would crash collection of this
+# whole module on Windows, before any skipif could act on it.
+_IS_ROOT = hasattr(os, "geteuid") and os.geteuid() == 0
+
 #: The real `_ensure_venv`, captured at import — before any fixture replaces it.
 #: The runner fixtures stub it (nothing is ever built in these tests), so a test
 #: about what it DOES has no other way back to it.
@@ -1166,7 +1170,7 @@ def test_a_machine_with_no_amd_gpu_at_all_says_so(monkeypatch, tmp_path):
     assert "modprobe" not in status.reason
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="os.access ignores mode bits for root")
+@pytest.mark.skipif(_IS_ROOT, reason="os.access ignores mode bits for root")
 def test_a_kfd_this_user_cannot_open_asks_for_permission(monkeypatch, tmp_path):
     """PERMISSION IS ASKED OF THE KERNEL, never modelled — `os.access`.
 
@@ -1205,7 +1209,7 @@ def test_a_render_node_that_is_ABSENT_is_not_a_permission_problem(
     assert "render` group" not in status.reason
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="os.access ignores mode bits for root")
+@pytest.mark.skipif(_IS_ROOT, reason="os.access ignores mode bits for root")
 def test_a_render_node_that_is_CLOSED_asks_for_permission(monkeypatch, tmp_path):
     """…and the other state IS the group case, which keeps that advice.
 
@@ -1221,7 +1225,7 @@ def test_a_render_node_that_is_CLOSED_asks_for_permission(monkeypatch, tmp_path)
     assert "render` group" in status.reason
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="os.access ignores mode bits for root")
+@pytest.mark.skipif(_IS_ROOT, reason="os.access ignores mode bits for root")
 def test_an_open_INTEL_render_node_does_not_admit_rocm(monkeypatch, tmp_path):
     """The render node has to belong to the AMD CARD, not merely to open.
 
@@ -1354,7 +1358,7 @@ def test_wsl2_can_pick_cuda_with_none_of_the_linux_device_nodes(
     assert "needs an NVIDIA GPU" in status.reason
 
 
-@pytest.mark.skipif(os.geteuid() == 0, reason="os.access ignores mode bits for root")
+@pytest.mark.skipif(_IS_ROOT, reason="os.access ignores mode bits for root")
 @pytest.mark.parametrize("device", ["nvidiactl", "nvidia0", "nvidia-uvm"])
 def test_nvidia_nodes_this_user_cannot_open_ask_for_permission(
         monkeypatch, tmp_path, device):

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import os
 import re
+import socket
 import sys
 import threading
 import time
@@ -85,6 +86,58 @@ def test_every_route_refuses_a_wrong_token(base):
             assert caught.value.code == 403, path
     finally:
         server.shutdown()
+
+
+def test_a_refused_post_does_not_desync_the_keep_alive_connection(base):
+    """The 403 path has to READ the body it is refusing.
+
+    This handler is HTTP/1.1, so the connection is kept alive and the NEXT
+    request is parsed off the same socket. Leave the refused request's body
+    unread and those bytes are consumed as that next request's request-line,
+    which is what this asserts. The same omission also made the eventual close
+    send an RST rather than a FIN on Windows, so the client got
+    ConnectionAbortedError ([WinError 10053]) instead of the 403 — that half is
+    not observable off-Windows, but it is the same missing read, and it flaked
+    this file on the runner.
+    """
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        body = b'{"prompt": "x"}'
+        with socket.create_connection(server.server_address, timeout=5) as s:
+            # (1) refused POST, WITH a body.
+            s.sendall(
+                b"POST /generate HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: wrong\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+                b"\r\n" + body)
+            # (2) a VALID request down the same connection.
+            s.sendall(
+                b"GET /health HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: secret\r\n"
+                b"\r\n")
+            s.settimeout(3.0)
+            data = b""
+            try:
+                while len(data) < 65536:
+                    chunk = s.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+            except (TimeoutError, socket.timeout):
+                pass
+    finally:
+        server.shutdown()
+
+    statuses = re.findall(rb"HTTP/1\.[01] (\d{3})", data)
+    # The refusal, then the second request UNDERSTOOD — not a 400 off the
+    # leftover body, and not a dropped connection.
+    assert statuses[:1] == [b"403"], data
+    assert b"200" in statuses[1:], data
 
 
 def test_a_missing_token_is_refused_too(base):

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -140,6 +140,76 @@ def test_a_refused_post_does_not_desync_the_keep_alive_connection(base):
     assert b"200" in statuses[1:], data
 
 
+def _read_all(s, timeout=5.0):
+    s.settimeout(timeout)
+    data = b""
+    try:
+        while len(data) < 65536:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    except (TimeoutError, socket.timeout):
+        pass
+    return data
+
+
+def test_an_oversized_preauth_body_is_refused_without_reading_it(base):
+    """The drain runs BEFORE auth on a length the caller chose, so it is
+    capped. Unbounded, this request — 100 MB announced, not one byte sent —
+    parks one of the ThreadingTCPServer's threads forever (`_Server` sets no
+    socket timeout), and enough of them stop the worker answering /health,
+    which is how the supervisor decides it is alive.
+
+    The refusal still goes out; the connection just ends with it, since those
+    unsent bytes would otherwise be read as the next request's request-line.
+    """
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        with socket.create_connection(server.server_address, timeout=5) as s:
+            s.sendall(
+                b"POST /generate HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: wrong\r\n"
+                b"Content-Length: 100000000\r\n"
+                b"\r\n")
+            data = _read_all(s)
+    finally:
+        server.shutdown()
+    assert b"403" in data, data
+    assert b"close" in data.lower(), data
+
+
+def test_a_preauth_body_that_stops_early_does_not_park_the_thread(
+        base, monkeypatch):
+    """The other axis: a length UNDER the cap, so it is read — but the client
+    sends less than it promised and then goes quiet. Without a read timeout
+    that wait is unbounded too."""
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    monkeypatch.setattr(base, "DRAIN_TIMEOUT_S", 0.3)
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        with socket.create_connection(server.server_address, timeout=5) as s:
+            s.sendall(
+                b"POST /generate HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: wrong\r\n"
+                b"Content-Length: 4096\r\n"
+                b"\r\n" + b"x" * 10)     # promised 4096, sent 10
+            started = time.monotonic()
+            data = _read_all(s)
+            waited = time.monotonic() - started
+    finally:
+        server.shutdown()
+    assert b"403" in data, data
+    assert b"close" in data.lower(), data
+    # Bounded by the drain timeout, not by the client's silence.
+    assert waited < 3.0, waited
+
+
 def test_a_missing_token_is_refused_too(base):
     base.TOKEN = "secret"
     server = _serve(base, lambda body: {"ok": True})

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -282,6 +282,57 @@ def test_a_preauth_body_that_stops_early_does_not_park_the_thread(
     assert waited < 3.0, waited
 
 
+def test_an_unparseable_preauth_content_length_is_not_guessed_at(base):
+    """A length that is not a number leaves no way to know where the body
+    stops, so the drain cannot claim it read one. Refuse and close rather than
+    fall through to a zero-length read and keep the connection."""
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        with socket.create_connection(server.server_address, timeout=5) as s:
+            s.sendall(
+                b"POST /generate HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: wrong\r\n"
+                b"Content-Length: twelve\r\n"
+                b"\r\n" + b"x" * 12)
+            data = _read_all(s)
+    finally:
+        server.shutdown()
+    assert b"403" in data, data
+    assert b"close" in data.lower(), data
+
+
+def test_a_preauth_body_cut_short_by_a_close_is_not_waited_out(base, monkeypatch):
+    """The client half-closes instead of going quiet, so the read hits EOF
+    rather than the timeout. That is the same verdict — the promised bytes are
+    not there — and it must not cost the full DRAIN_TIMEOUT_S to reach, which
+    is what the generous timeout here would expose."""
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    monkeypatch.setattr(base, "DRAIN_TIMEOUT_S", 30.0)
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        with socket.create_connection(server.server_address, timeout=5) as s:
+            s.sendall(
+                b"POST /generate HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: wrong\r\n"
+                b"Content-Length: 4096\r\n"
+                b"\r\n" + b"x" * 10)   # promised 4096, sent 10...
+            s.shutdown(socket.SHUT_WR)   # ...and there will be no more
+            started = time.monotonic()
+            data = _read_all(s)
+            waited = time.monotonic() - started
+    finally:
+        server.shutdown()
+    assert b"403" in data, data
+    assert b"close" in data.lower(), data
+    # EOF, not the 30s timeout.
+    assert waited < 5.0, waited
+
+
 def test_a_missing_token_is_refused_too(base):
     base.TOKEN = "secret"
     server = _serve(base, lambda body: {"ok": True})

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -182,6 +182,78 @@ def test_an_oversized_preauth_body_is_refused_without_reading_it(base):
     assert b"close" in data.lower(), data
 
 
+@pytest.mark.parametrize("framing", [
+    # The plain case: chunked, no Content-Length at all.
+    pytest.param(b"Transfer-Encoding: chunked\r\n", id="chunked"),
+    # Malformed-but-present, which a truthiness check on the header would read
+    # as absent and then drain zero bytes of.
+    pytest.param(b"Transfer-Encoding:\r\n", id="empty-transfer-encoding"),
+    # Both framings at once — the smuggling shape. Transfer-Encoding wins, so
+    # a Content-Length read would stop 4 bytes in and leave the rest queued.
+    pytest.param(b"Transfer-Encoding: chunked\r\nContent-Length: 4\r\n",
+                 id="transfer-encoding-and-content-length"),
+])
+def test_a_refused_body_this_cannot_frame_ends_the_connection(base, framing):
+    """A chunked body sends NO Content-Length, so "nothing to drain" is the
+    wrong reading of its absence.
+
+    BaseHTTPRequestHandler hands us the raw socket; it does not decode chunked
+    request bodies. So the chunk framing is still queued after the 403, and on
+    a kept-alive connection the next request-line read off that socket is the
+    chunk-size line — `2` — which answers the client's real request with a 400.
+    The drain cannot follow that framing, so it must not claim it did: the
+    refusal goes out with Connection: close and the client reconnects.
+    """
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        with socket.create_connection(server.server_address, timeout=5) as s:
+            # (1) refused POST. `hi` in one chunk, then the terminator.
+            s.sendall(
+                b"POST /generate HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: wrong\r\n"
+                b"Content-Type: application/json\r\n"
+                + framing +
+                b"\r\n"
+                b"2\r\nhi\r\n"
+                b"0\r\n\r\n")
+            # (2) a VALID request behind it, as a keep-alive client would send.
+            s.sendall(
+                b"GET /health HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: secret\r\n"
+                b"\r\n")
+            data = _read_all(s)
+
+        # ...and the worker is still serving: the close is this connection
+        # ending, not the handler thread wedged on a body it cannot read.
+        with socket.create_connection(server.server_address, timeout=5) as s:
+            s.sendall(
+                b"GET /health HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"X-Fused-Worker: secret\r\n"
+                b"Connection: close\r\n"
+                b"\r\n")
+            again = _read_all(s)
+    finally:
+        server.shutdown()
+
+    statuses = re.findall(rb"HTTP/1\.[01] (\d{3})", data)
+    assert statuses[:1] == [b"403"], data
+    assert b"close" in data.lower(), data
+    # The bug, named: `2` read as the next request-line. That reply carries no
+    # status line of its own — a request-line this malformed leaves
+    # request_version unset, so BaseHTTPRequestHandler answers HTTP/0.9-style
+    # with the error page alone — which is why it has to be matched on text.
+    assert b"Bad request syntax" not in data, data
+    # And the request the client actually sent went unanswered: one response on
+    # this connection, not two.
+    assert len(statuses) == 1, data
+    assert b"200" in re.findall(rb"HTTP/1\.[01] (\d{3})", again), again
+
+
 def test_a_preauth_body_that_stops_early_does_not_park_the_thread(
         base, monkeypatch):
     """The other axis: a length UNDER the cap, so it is read — but the client

--- a/tests/test_annotate_revert.py
+++ b/tests/test_annotate_revert.py
@@ -41,7 +41,10 @@ def _home(tmp_path, monkeypatch):
 
 def _target(tmp_path, content="a\nb\nc\n", name="page.html"):
     f = tmp_path / name
-    f.write_text(content)
+    # `newline=""` — same reason as _claude_history.py's write_version: the
+    # default text-mode write translates "\n" to os.linesep, silently
+    # inflating every byte-size assertion on Windows.
+    f.write_text(content, newline="")
     return str(f)
 
 
@@ -708,8 +711,17 @@ def _run(body, tmp_path, prelude=""):
         pytest.skip("node is required to drive the template's JS")
     harness = tmp_path / "harness.mjs"
     harness.write_text(prelude + body, encoding="utf-8")
-    out = subprocess.run([node, str(harness)], capture_output=True, text=True,
-                         timeout=60)
+    # `encoding="utf-8"` explicitly, not bare `text=True`: node writes UTF-8 to
+    # stdout/stderr regardless of platform, but `text=True` alone decodes with
+    # `locale.getpreferredencoding()`, which on Windows is an ANSI codepage
+    # (cp1252 here), not UTF-8. The dot glyphs a few of these harnesses print
+    # (e.g. "●") encode to bytes cp1252 has no mapping for, which crashes
+    # subprocess's own background reader thread with a `UnicodeDecodeError`
+    # pytest only surfaces as a `PytestUnhandledThreadExceptionWarning` —
+    # `out.stdout` then never gets set and comes back `None`, so the visible
+    # symptom is `json.loads(None)`, several layers away from the real cause.
+    out = subprocess.run([node, str(harness)], capture_output=True,
+                         encoding="utf-8", timeout=60)
     assert out.returncode == 0, out.stderr
     return _json.loads(out.stdout)
 

--- a/tests/test_app_git.py
+++ b/tests/test_app_git.py
@@ -83,6 +83,13 @@ def test_commit_records_changes_and_noops_when_clean(workspace):
     assert not app_git.commit(str(d / "index.html"), "Edit index.html")
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.fork() (and os.register_at_fork with it) does not exist on "
+           "Windows — there is no fork() there at all, so a forked child "
+           "cannot hold a stale copy of parent state, which is exactly the "
+           "hazard this test simulates and the reason app_git spawns via "
+           "posix_spawnp rather than fork+exec in the first place")
 def test_commit_survives_a_fork_hostile_process(workspace):
     # The server ends up with libproj resident (the fused-engine availability
     # probe imports it), and PROJ's pthread_atfork child handler SIGSEGVs

--- a/tests/test_app_quit.py
+++ b/tests/test_app_quit.py
@@ -1657,6 +1657,15 @@ def attacher(ladder, monkeypatch):
                         lambda m, port=None: None)
     monkeypatch.setattr(mounts_mod.lifecycle, "sync_serves", lambda: None)
     monkeypatch.setattr(mounts_mod.lifecycle, "_update_mount", lambda m: None)
+    # attach_mount's creation path gates on this BEFORE it ever reaches
+    # mount/mount (real WinFsp detection, so a genuinely missing driver on a
+    # real Windows box reports a friendly install prompt instead of an opaque
+    # rclone error) — vacuously True off win32, but on a bare Windows CI
+    # runner with no WinFsp installed it is False for real, which would make
+    # attach_mount return _winfsp_missing_error() before the fake `_rc` ever
+    # sees "mount/mount", and `mount_entered` would never be set. Not what
+    # this race is about, so it is stubbed like the other concerns above.
+    monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: True)
     ladder["block_mount"] = threading.Event()
     ladder["mount_entered"] = threading.Event()
     return ladder

--- a/tests/test_archive_preview_readonly.py
+++ b/tests/test_archive_preview_readonly.py
@@ -94,6 +94,36 @@ def test_preview_overwrites_stale_read_only_copy(tmp_path, reader, make):
 
 
 @pytest.mark.parametrize("reader,make", ARCHIVES, ids=["zip", "tar"])
+def test_a_failed_swap_leaves_the_stale_preview_read_only(
+        tmp_path, reader, make, monkeypatch):
+    """The re-preview path clears the stale copy's read-only bit so Windows'
+    os.replace will overwrite it (MoveFileExW refuses a read-only
+    destination). If the replace then FAILS, that stale copy is still the
+    live preview — it must not be left writable, which is the one property
+    the read-only preview contract exists to guarantee.
+
+    Asserted on the MODE BITS rather than os.access, deliberately: this file's
+    other read-only tests carry `skip_root` because os.access always says yes
+    for root, but st_mode is observable either way — so this regression stays
+    covered even in a root container."""
+    first = reader.main(make(tmp_path), "preview", "notes.txt")["path"]
+    assert os.stat(first).st_mode & 0o777 == 0o444
+
+    def boom(src, dst):
+        # What a Windows sharing violation looks like here: the old preview is
+        # still open somewhere, so the swap cannot land.
+        raise PermissionError(13, "Access is denied")
+
+    monkeypatch.setattr(reader.os, "replace", boom)
+    with pytest.raises(PermissionError):
+        reader.main(make(tmp_path, content="hello v2"), "preview", "notes.txt")
+    # Unchanged mode AND unchanged content — not a writable 0644 leftover.
+    assert os.stat(first).st_mode & 0o777 == 0o444
+    with open(first) as f:
+        assert f.read() == "hello"
+
+
+@pytest.mark.parametrize("reader,make", ARCHIVES, ids=["zip", "tar"])
 def test_extract_output_stays_writable(tmp_path, reader, make):
     res = reader.main(make(tmp_path), "extract", "notes.txt")
     assert os.access(res["path"], os.W_OK)

--- a/tests/test_branch_runtime.py
+++ b/tests/test_branch_runtime.py
@@ -78,7 +78,15 @@ def test_branch_ref_foo(monkeypatch):
     base = os.environ["FUSED_RENDER_HOME"]
     assert storage.home_dir() == os.path.join(base, "branches", "foo")
     assert _server_templates.USER_TEMPLATES_DIR == os.path.join(base, "branches", "foo", "templates")
-    assert app.APP_SUPPORT_DIR.endswith("Application Support/fused-render/branches/foo")
+    # `_APP_SUPPORT_BASE` is a hardcoded macOS-flavored literal (forward
+    # slashes baked into the string, untouched by any join call) with
+    # "branches/foo" appended on top via branch_dir()'s os.path.join — which
+    # uses the NATIVE separator. app.py only ever ships as part of the macOS
+    # bundle, but it is plain-importable (and imported here) on any platform,
+    # so the expected suffix has to be built the same mixed way rather than
+    # assuming forward slashes throughout.
+    assert app.APP_SUPPORT_DIR.endswith(
+        os.path.join("Application Support/fused-render", "branches", "foo"))
     assert app.DEFAULT_PORT == _branch.branch_port("foo")
     assert app.MAX_PORT == app.DEFAULT_PORT + 10
     assert cli.DEFAULT_PORT == app.DEFAULT_PORT

--- a/tests/test_browse_mount.py
+++ b/tests/test_browse_mount.py
@@ -261,3 +261,48 @@ def test_local_not_remote_uses_kernel(fs, tmp_path):
     res = br.main(dir=str(tmp_path), exts=".tif", src=s.src)
     assert "error" not in res
     assert [f["name"] for f in res["files"]] == ["a.tif"]
+
+
+# --------------------------------------------------------------------------
+# breadcrumb roots (both copies of browse.py)
+# --------------------------------------------------------------------------
+# `main()` derives `dir` from os.path.abspath, so on a POSIX test host it is
+# always "/..." — a Windows drive root and a UNC root cannot be produced
+# through it at all. _crumbs is a pure string helper for exactly that reason:
+# these are the two roots that shipped broken and the only way to pin them here.
+
+@pytest.mark.parametrize("mod", [br, zbr], ids=["geotiff", "zarr_aoi"])
+def test_posix_crumbs_are_unchanged(mod):
+    assert mod._crumbs("/a/b") == [
+        {"label": "a", "path": "/a"},
+        {"label": "b", "path": "/a/b"},
+    ]
+    assert mod._crumbs("/only") == [{"label": "only", "path": "/only"}]
+    assert mod._crumbs("/") == []
+
+
+@pytest.mark.parametrize("mod", [br, zbr], ids=["geotiff", "zarr_aoi"])
+def test_a_windows_drive_root_crumbs_to_the_drive_ROOT(mod):
+    """"C:" alone is DRIVE-RELATIVE — it means "wherever this process last was
+    on C:", not the top of the drive — so the root crumb's path must be "C:/".
+    Clicking it has to land on the drive root, not somewhere unpredictable."""
+    assert mod._crumbs("C:/Users/foo") == [
+        {"label": "C:", "path": "C:/"},
+        {"label": "Users", "path": "C:/Users"},
+        {"label": "foo", "path": "C:/Users/foo"},
+    ]
+    assert mod._crumbs("C:/") == [{"label": "C:", "path": "C:/"}]
+
+
+@pytest.mark.parametrize("mod", [br, zbr], ids=["geotiff", "zarr_aoi"])
+def test_a_unc_root_keeps_its_server_and_share(mod):
+    """The leading "//" is dropped by the empty-segment filter, and "//server"
+    without the share is not a path at all — so server+share are ONE root
+    crumb, not two, and the "//" survives."""
+    assert mod._crumbs("//server/share/a/b") == [
+        {"label": "//server/share", "path": "//server/share"},
+        {"label": "a", "path": "//server/share/a"},
+        {"label": "b", "path": "//server/share/a/b"},
+    ]
+    assert mod._crumbs("//server/share") == [
+        {"label": "//server/share", "path": "//server/share"}]

--- a/tests/test_browse_mount.py
+++ b/tests/test_browse_mount.py
@@ -123,6 +123,19 @@ def _entry(name, is_dir=False, size=None):
             "ignored": False}
 
 
+def _abs(posix_literal):
+    """The canonical (forward-slash) absolute form browse.py computes from a
+    POSIX-shaped literal like "/mnt/gone/d" — a stand-in for "somewhere that
+    isn't there", never a real directory. os.path.abspath is a no-op on
+    POSIX, so this equals the literal unchanged; on Windows it prepends the
+    checkout's current drive letter and backslashes every separator, which
+    browse.py's own `dir = ...abspath(...).replace(os.sep, "/")` immediately
+    re-canonicalizes back to forward slashes — mirror that exact transform
+    here instead of assuming the bare POSIX literal already is the app's
+    real output."""
+    return os.path.abspath(posix_literal).replace(os.sep, "/")
+
+
 @pytest.fixture
 def no_kernel_list(monkeypatch):
     """Make ANY kernel directory listing / probe explode, so a silent fallback
@@ -155,16 +168,17 @@ def test_remote_dir_lists_via_http_no_kernel(fs, no_kernel_list):
     res = br.main(dir="/mnt/gone/d", exts=".tif,.tiff", src=s.src)
     assert "error" not in res
     assert [d["name"] for d in res["dirs"]] == ["sub"]
-    assert res["dirs"][0]["path"] == "/mnt/gone/d/sub"
+    assert res["dirs"][0]["path"] == _abs("/mnt/gone/d") + "/sub"
     assert res["dirs"][0]["is_dir"] is True
     # only the loadable .tif survives the ext filter; dotfile hidden
     assert [f["name"] for f in res["files"]] == ["a.tif"]
     f = res["files"][0]
-    assert f["path"] == "/mnt/gone/d/a.tif"
+    assert f["path"] == _abs("/mnt/gone/d") + "/a.tif"
     assert f["size"] == 10 and f["ext"] == ".tif" and f["loadable"] is True
-    # breadcrumbs are pure string ops off `dir`
-    assert res["crumbs"][-1] == {"label": "d", "path": "/mnt/gone/d"}
-    assert res["dir"] == "/mnt/gone/d"
+    # breadcrumbs are pure string ops off `dir` — the last crumb's path is
+    # always the full dir by construction, on every platform.
+    assert res["crumbs"][-1] == {"label": "d", "path": res["dir"]}
+    assert res["dir"] == _abs("/mnt/gone/d")
 
 
 def test_remote_show_all_includes_nonloadable(fs, no_kernel_list):
@@ -177,8 +191,8 @@ def test_remote_show_all_includes_nonloadable(fs, no_kernel_list):
 def test_remote_missing_returns_error_shape(fs, no_kernel_list):
     s = fs(exists=False)
     res = br.main(dir="/mnt/gone/d", exts=".tif", src=s.src)
-    assert res["error"].startswith("cannot list /mnt/gone/d")
-    assert res["parent"] == "/mnt/gone"
+    assert res["error"].startswith(f"cannot list {_abs('/mnt/gone/d')}")
+    assert res["parent"] == _abs("/mnt/gone")
 
 
 def test_remote_list_failure_no_kernel_fallback(fs, no_kernel_list):
@@ -186,7 +200,7 @@ def test_remote_list_failure_no_kernel_fallback(fs, no_kernel_list):
     # listdir (that is the mount-killer); return the error shape instead.
     s = fs(remote=True, list_status=503)
     res = br.main(dir="/mnt/gone/d", exts=".tif", src=s.src)
-    assert res["error"].startswith("cannot list /mnt/gone/d")
+    assert res["error"].startswith(f"cannot list {_abs('/mnt/gone/d')}")
 
 
 def test_remote_file_path_descends_to_parent(fs, no_kernel_list):
@@ -194,7 +208,7 @@ def test_remote_file_path_descends_to_parent(fs, no_kernel_list):
     # parent via a pure string op (no kernel) and list that.
     s = fs(remote=True, is_dir=False, entries=[_entry("a.tif", size=1)])
     res = br.main(dir="/mnt/gone/f.tif", exts=".tif", src=s.src)
-    assert res["dir"] == "/mnt/gone"
+    assert res["dir"] == _abs("/mnt/gone")
     assert [f["name"] for f in res["files"]] == ["a.tif"]
 
 

--- a/tests/test_bundle_contents.py
+++ b/tests/test_bundle_contents.py
@@ -839,6 +839,21 @@ def test_the_stdlib_split_puts_packages_and_modules_in_the_right_list():
             f"{name} is a package and must be forced whole, not traced")
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="setup_py2app._stdlib_split() derives STDLIB_PACKAGES/INCLUDES from "
+           "what THIS HOST can importlib.util.find_spec() — that is exactly "
+           "what keeps msvcrt/winreg/winsound out of a real macOS build (they "
+           "raise ImportError there), but it also means the derivation is "
+           "host-relative by design, not macOS-relative. Run on an actual "
+           "Windows host, winsound is a real importable extension module "
+           "(not a builtin like nt/msvcrt/winreg/_winapi, which are compiled "
+           "into the interpreter and already skipped via "
+           "sys.builtin_module_names) and correctly reaches STDLIB_INCLUDES "
+           "— proving nothing about the macOS build this test is about. The "
+           "production build only ever runs setup_py2app.py ON macOS "
+           "(scripts/build_dmg.sh), where this holds; ubuntu/macos CI already "
+           "cover it")
 def test_no_windows_only_stdlib_module_reaches_a_macos_build():
     """py2app fails on an `includes` entry it cannot resolve, so the derivation
     has to filter by what this host can actually find."""

--- a/tests/test_bundle_reader.py
+++ b/tests/test_bundle_reader.py
@@ -35,6 +35,17 @@ READER = os.path.join(
 
 pytestmark = pytest.mark.skipif(not git_available(), reason="git binary not installed")
 
+# Windows has no POSIX permission-bit model: os.chmod() on a DIRECTORY there
+# only flips the cosmetic FILE_ATTRIBUTE_READONLY flag, which does not stop
+# writes inside it the way a missing POSIX write-bit does — so
+# `os.chmod(holder, 0o555)` below cannot actually make `holder` refuse a
+# write on Windows, and the "readonly" refusal these two tests pin can never
+# fire there.
+skip_windows_dir_perms = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows ignores chmod() on directories (no POSIX write-bit), so "
+           "a chmod'd-read-only holder still accepts the write")
+
 
 @pytest.fixture(scope="module")
 def reader():
@@ -290,6 +301,7 @@ def test_cloning_a_thin_bundle_is_refused_with_a_reason(reader, thin_bundle):
     assert not os.path.exists(os.path.join(os.path.dirname(thin_bundle), "increment"))
 
 
+@skip_windows_dir_perms
 def test_cloning_into_a_read_only_directory_is_refused(reader, repo, tmp_path):
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         pytest.skip("read-only bits are ignored when running as root")
@@ -385,6 +397,7 @@ def test_a_dest_whose_parent_is_a_file_is_refused(reader, bundle, tmp_path):
     assert out["reason"] == "missing-parent"
 
 
+@skip_windows_dir_perms
 def test_a_dest_in_a_read_only_parent_is_refused(reader, bundle, tmp_path):
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         pytest.skip("read-only bits are ignored when running as root")
@@ -675,7 +688,12 @@ def test_every_git_call_is_an_argv_list_with_no_shell_and_a_timeout(
         # basename alone would pass a regression to a bare "git".
         assert isinstance(cmd, list)
         assert os.path.isabs(cmd[0])
-        assert os.path.basename(cmd[0]) in ("git", "git.exe")
+        # Case-insensitive: shutil.which() builds the candidate by appending
+        # PATHEXT's own casing (Windows' default PATHEXT is uppercase,
+        # ".COM;.EXE;..."), so the resolved path is literally "...\\git.EXE"
+        # there — not a different executable, just Windows' case-insensitive
+        # filesystem letting a case this test never chose survive unchanged.
+        assert os.path.basename(cmd[0]).lower() in ("git", "git.exe")
         # The other two thirds of the same rule — this module forked until
         # they were added, and this test passed the whole time.
         assert kw.get("close_fds") is False

--- a/tests/test_calls.py
+++ b/tests/test_calls.py
@@ -339,7 +339,10 @@ def test_an_attributed_run_is_logged_with_its_detail(app_client):
     assert len(records) == 1
     got = records[0]
     assert got["call_id"] == "known-id"          # the client's id is honoured
-    assert got["page"] == str(d / "p.html")
+    # canonical_fs_path(...): the store always holds the shell's forward-slash
+    # canonical form (calls.py's _canonicalize_paths), so on Windows a raw
+    # str(path) (backslashed) never equals it — see _view_url_codec.py.
+    assert got["page"] == canonical_fs_path(str(d / "p.html"))
     assert got["route"] == "/api/run"
     assert got["outcome"] == "ok"
     assert got["entrypoint_name"] == "ok.py"
@@ -442,7 +445,8 @@ def test_an_upload_records_size_and_path_but_never_the_bytes(app_client):
     assert drain()
     got = calls.query(limit=10)["records"][0]
     assert got["route"] == "/api/fs/upload"
-    assert got["entrypoint"] == str(target)
+    # canonical_fs_path(...): see test_an_attributed_run_is_logged_with_its_detail.
+    assert got["entrypoint"] == canonical_fs_path(str(target))
     assert got["entrypoint_name"] == "pasted.png"
     # The byte count is the blob's own length: there is no encoding step for a
     # binary body, unlike the UTF-8 round trip a text write measures.
@@ -1540,6 +1544,21 @@ def appended(cid, when, **over):
     return json.dumps(dict(calls._prune(rec(call_id=cid, **over)), recorded_at=when))
 
 
+def cli_page(raw):
+    """The absolute, canonical form cli.py's own `--page` filter resolves a raw
+    argument to (`canonical_fs_path(os.path.abspath(os.path.expanduser(...)))`).
+
+    A record's `page` field must be built through this SAME transform to stay
+    comparable with the filter the CLI computes from the identical raw string —
+    on POSIX a "/..."-rooted literal is already absolute, so this is a no-op,
+    but on Windows `os.path.abspath` prepends the CWD's drive to a driveless
+    "/..." path (there is no such thing as a real Windows absolute path
+    without one), so a fixture that skips this and hardcodes the bare literal
+    into a record silently stops matching the filter the CLI actually applies.
+    """
+    return canonical_fs_path(os.path.abspath(os.path.expanduser(raw)))
+
+
 def test_same_day_files_from_two_servers_merge_newest_first(store):
     """Name order is date, then pid, then part — and pid order says NOTHING about
     time. Worse, it is lexical, so pid 8000 sorts AFTER pid 12345. Reading one
@@ -1624,6 +1643,16 @@ def test_a_page_satisfied_by_today_never_opens_an_older_day(store, monkeypatch):
     assert os.path.basename(old) not in opened, "yesterday must stay unopened"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fds() reads /proc/self/fd (Linux procfs) purely as a test-side probe "
+           "of how many file handles this process holds open — it names no app "
+           "behavior, just counts descriptors the way `lsof`/`ls /proc/self/fd` "
+           "would. Windows has no /proc: there is no bare-stdlib equivalent (the "
+           "nearest real one, enumerating HANDLEs via a Windows API, needs a new "
+           "dependency this repo doesn't otherwise carry), so the probe itself — "
+           "not the merge-closes-its-files guarantee it's checking — is Linux-only.",
+)
 def test_an_abandoned_merge_closes_the_day_s_files(store):
     """A full page or an exhausted budget abandons the walk mid-merge; the day's
     other file handles must not be left to the garbage collector."""
@@ -1956,7 +1985,10 @@ def test_follow_answers_at_once_when_a_foreign_cursor_does_have_records(
     now = time.time()
     with open(app_current_file(), "w") as fh:
         fh.write(appended("other-5", now - 300, page="/app/other.html") + "\n")
-        fh.write(appended("mine-9", now - 30, page="/app/mine.html") + "\n")
+        # cli_page(...), not the bare literal: the CLI resolves --page through
+        # os.path.abspath before comparing, and a record's page must be built
+        # the same way to stay comparable (see cli_page's docstring).
+        fh.write(appended("mine-9", now - 30, page=cli_page("/app/mine.html")) + "\n")
 
     started = time.monotonic()
     out = run_cli(monkeypatch, capsys, "--follow", "--since-cursor", "other-5",
@@ -2276,8 +2308,15 @@ def test_windows_entrypoint_substring_filter_matches(store):
 
 
 def test_posix_page_filter_still_works_through_the_cli(store, monkeypatch, capsys):
-    """Guard on the ordinary path: the canonicalization must be a no-op here."""
-    write_records([calls._prune(rec(call_id="posix", page="/app/p.html",
+    """Guard on the ordinary path: the canonicalization must be a no-op here.
+
+    "Ordinary" means what a real caller's absolute path resolves to on ITS
+    platform — a no-op on POSIX, but on Windows os.path.abspath prepends the
+    CWD's drive to a driveless "/..." literal (no real Windows absolute path
+    lacks one), so the record has to be built through cli_page() too or it
+    silently stops matching what the CLI's own --page filter computes.
+    """
+    write_records([calls._prune(rec(call_id="posix", page=cli_page("/app/p.html"),
                                     entrypoint="/app/d.py", entrypoint_name="d.py"))])
     out = run_cli(monkeypatch, capsys, "--page", "/app/p.html", "--since", "all")
     assert "d.py" in out

--- a/tests/test_canvas_template.py
+++ b/tests/test_canvas_template.py
@@ -111,7 +111,7 @@ def test_canvas_toml_gets_canvas_mode_first(tmp_path):
     assert m == ["canvas", "code", "claude", "reader"]
     assert error is None
     entries, _ = _server_templates._templates_for(str(p), False)
-    assert entries[0]["path"].endswith("canvas/template.html")
+    assert entries[0]["path"].endswith(os.path.join("canvas", "template.html"))
     assert entries[0]["icon"] is not None
     # stat only MARKS the gate (deferred CT-12) …
     by_mode = {e["mode"]: e for e in entries}

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -111,7 +111,15 @@ def main():
         for rel, content in files.items():
             full = os.path.join(out, rel)
             os.makedirs(os.path.dirname(full) or out, exist_ok=True)
-            with open(full, "w") as f:
+            # newline="": the manager hashes this file's bytes exactly
+            # (_take_file_hashes opens "rb") against a base hash seed_base()
+            # computes straight from this same `content` string — text
+            # mode's universal-newline translation would silently inflate
+            # every "\n" here to "\r\n" on Windows, making an untouched
+            # file's on-disk hash never equal the base hash the merge
+            # compares it to, so every per-file decision falls through to
+            # "locally edited" and no remote change is ever applied.
+            with open(full, "w", newline="") as f:
                 f.write(content)
         return
     if plain[:2] == ["canvas", "push"]:
@@ -1141,7 +1149,19 @@ class SyncShims:
         for rel, content in files.items():
             path = self.remote_dir / rel
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(content, encoding="utf-8")
+            # newline="": _ZIP_SHIM zips these files' raw bytes, and
+            # _merge_remote hashes them exactly against seed_base()'s
+            # string-derived hash and the clone's own on-disk (also
+            # newline=""-written, see the STUB's canvas-pull loop) bytes.
+            # Path.write_text's default text mode would inflate every
+            # "\n" here to "\r\n" on Windows, making a remote file that is
+            # actually byte-identical to the base/local copy hash as
+            # "changed" (or, combined with the base-hash mismatch, an
+            # untouched file hash as "locally edited") — either way the
+            # three-way merge's per-file equality tests stop meaning what
+            # they say.
+            with open(path, "w", encoding="utf-8", newline="") as f:
+                f.write(content)
 
     def seed_base(
         self,

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -1198,7 +1198,23 @@ def _manager(name="alpha"):
     return canvases_mod._syncs[name]
 
 
-def _wait_for(predicate, timeout=8):
+# Every SCAN_INTERVAL_S/DEBOUNCE_S/PULL_POLL_S tick of canvases.py's manager
+# loop spawns a fresh subprocess for the stub CLI (manifest probes, zip
+# downloads, pulls, pushes, and validation calls are all
+# `subprocess.run([sys.executable, ...])` — see SyncShims/Harness above).
+# Windows process creation is several times slower than Linux/macOS
+# fork+exec, and GitHub's windows-latest runners add Defender's real-time
+# scan of every new process on top of that, so an 8s budget tuned against
+# Linux's process-spawn cost is not automatically enough there. This is slack
+# for "did the async op finish at all" in the common wait helpers below, not
+# a precision measurement of how FAST it had to be — widening it on Windows
+# costs nothing but wall-clock time in CI. (A couple of tests below pin their
+# own tighter timeout on purpose, to prove something resolved quickly rather
+# than merely at all; those are left alone.)
+_WAIT_TIMEOUT_S = 20 if sys.platform == "win32" else 8
+
+
+def _wait_for(predicate, timeout=_WAIT_TIMEOUT_S):
     """Spin until `predicate()` or the deadline. Returns whether it held."""
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -1211,7 +1227,7 @@ def _wait_for(predicate, timeout=8):
     return False
 
 
-def _wait_status(harness, predicate, timeout=8):
+def _wait_status(harness, predicate, timeout=_WAIT_TIMEOUT_S):
     deadline = time.time() + timeout
     status = None
     while time.time() < deadline:
@@ -2620,7 +2636,10 @@ def test_pulling_covers_the_merges_writes_but_not_its_zip_download(
     assert _wait_for(
         lambda: harness.client.get(
             "/api/canvases/sync/status?name=alpha").json()["pulling"] is True,
-        timeout=3,
+        # Tighter than _WAIT_TIMEOUT_S on purpose (the flag should flip almost
+        # immediately) but still widened on Windows for the same subprocess-
+        # spawn-latency reason as that constant.
+        timeout=3 if sys.platform != "win32" else _WAIT_TIMEOUT_S,
     ), "status never reported pulling while the merge was writing"
     status = _wait_status(harness, lambda s: s["merge_seq"] >= 1)
     assert status and status["merge_seq"] >= 1, status

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -1204,14 +1204,30 @@ def _manager(name="alpha"):
 # `subprocess.run([sys.executable, ...])` — see SyncShims/Harness above).
 # Windows process creation is several times slower than Linux/macOS
 # fork+exec, and GitHub's windows-latest runners add Defender's real-time
-# scan of every new process on top of that, so an 8s budget tuned against
-# Linux's process-spawn cost is not automatically enough there. This is slack
-# for "did the async op finish at all" in the common wait helpers below, not
-# a precision measurement of how FAST it had to be — widening it on Windows
-# costs nothing but wall-clock time in CI. (A couple of tests below pin their
-# own tighter timeout on purpose, to prove something resolved quickly rather
-# than merely at all; those are left alone.)
-_WAIT_TIMEOUT_S = 20 if sys.platform == "win32" else 8
+# scan of every new (never-before-seen) script file on top of that. A single
+# merge-then-push cycle chains several of these spawns in one straight line —
+# probe, zip download, validate, the push itself, the post-push re-probe — so
+# the wait covering it pays that per-spawn tax several times over, not once.
+# 20s turned out not to be enough margin for that chain on real Windows CI
+# (7 tests in this file that each need 3-6 such hops, timing out even there);
+# most of them also no longer pay a SEPARATE, unrelated cost that used to
+# stack on top of it — the real (unmocked) `_agent_module()` the watcher
+# calls every tick to warm its live-run cache (see _run()) execs agent.py via
+# `claude_spawn.load_agent()`, which stages fused_render/templates/ into
+# ~/.fused-render/.core-templates on first use: a sha256 over every packaged
+# template file plus a full copytree if unstaged, a lot of small-file I/O for
+# Defender to scan on a cold CI runner, paid once per test process/worker by
+# whichever test happens to call it first. None of the merge/push tests below
+# need the real answer (no test in this file exercises "is a session live"
+# through them), so they now pass `fake_agent` to skip it — but the remaining
+# subprocess chain is real work these tests must still wait out, hence the
+# generous ceiling here rather than a tighter one now that the agent cost is
+# gone. This is slack for "did the async op finish at all" in the common wait
+# helpers below, not a precision measurement of how FAST it had to be —
+# widening it on Windows costs nothing but wall-clock time in CI. (A couple of
+# tests below pin their own tighter timeout on purpose, to prove something
+# resolved quickly rather than merely at all; those are left alone.)
+_WAIT_TIMEOUT_S = 45 if sys.platform == "win32" else 8
 
 
 def _wait_for(predicate, timeout=_WAIT_TIMEOUT_S):
@@ -1238,10 +1254,20 @@ def _wait_status(harness, predicate, timeout=_WAIT_TIMEOUT_S):
     return status
 
 
-def test_sync_merges_remote_changes_while_dirty(harness, tmp_path, monkeypatch):
+def test_sync_merges_remote_changes_while_dirty(harness, tmp_path, monkeypatch, fake_agent):
     # Remote changed b.py while the local clone had an unpushed edit to a.py:
     # the merge applies b.py (local untouched) and keeps a.py (local wins),
     # then the debounced push publishes the merged state.
+    #
+    # fake_agent (live="" by default — no session) stands in for the real
+    # `_agent_module()`, which every watcher tick calls unconditionally to
+    # warm the live-run cache. On a real, unmocked module the FIRST such call
+    # in a process pays `ensure_core_templates()`'s one-time cost: a sha256
+    # over every file under fused_render/templates/ (agent.py's own staged
+    # source tree) plus a full copytree if unstaged — a lot of small-file I/O
+    # that Windows Defender's real-time scan (one first-seen-file scan per
+    # open, on a fresh CI runner) can stretch well past this file's wait
+    # budget, on a call this test has no reason to exercise for real.
     monkeypatch.setattr(canvases_mod, "SCAN_INTERVAL_S", 0.05)
     monkeypatch.setattr(canvases_mod, "PULL_POLL_S", 0.1)
     monkeypatch.setattr(canvases_mod, "DEBOUNCE_S", 0.3)
@@ -1262,9 +1288,14 @@ def test_sync_merges_remote_changes_while_dirty(harness, tmp_path, monkeypatch):
     harness.client.post("/api/canvases/sync/stop", json={"name": "alpha"}, headers=GUARD)
 
 
-def test_sync_merge_keeps_local_delete(harness, tmp_path, monkeypatch):
+def test_sync_merge_keeps_local_delete(harness, tmp_path, monkeypatch, fake_agent):
     # Local deleted b.py; the bundle still carries it. The merge must NOT
     # recreate it — the push propagates the delete.
+    #
+    # fake_agent: skip the real (expensive, first-call, Windows-slow)
+    # `_agent_module()` cold start — see test_sync_merges_remote_changes_
+    # while_dirty's comment for why the watcher's per-tick liveness check
+    # makes that a real hazard here, not just decoration.
     monkeypatch.setattr(canvases_mod, "SCAN_INTERVAL_S", 0.05)
     monkeypatch.setattr(canvases_mod, "PULL_POLL_S", 0.1)
     monkeypatch.setattr(canvases_mod, "DEBOUNCE_S", 0.3)
@@ -1285,9 +1316,13 @@ def test_sync_merge_keeps_local_delete(harness, tmp_path, monkeypatch):
     harness.client.post("/api/canvases/sync/stop", json={"name": "alpha"}, headers=GUARD)
 
 
-def test_sync_merge_applies_remote_delete_when_untouched(harness, tmp_path, monkeypatch):
+def test_sync_merge_applies_remote_delete_when_untouched(harness, tmp_path, monkeypatch, fake_agent):
     # Remote deleted b.py; local never touched it since the sync point → the
     # merge removes it locally. The locally-edited canvas.toml stays.
+    #
+    # fake_agent: see test_sync_merges_remote_changes_while_dirty — skips the
+    # real `_agent_module()` cold start the watcher's per-tick liveness check
+    # would otherwise pay for real.
     monkeypatch.setattr(canvases_mod, "SCAN_INTERVAL_S", 0.05)
     monkeypatch.setattr(canvases_mod, "PULL_POLL_S", 0.1)
     monkeypatch.setattr(canvases_mod, "DEBOUNCE_S", 0.3)
@@ -1314,9 +1349,13 @@ def test_sync_merge_applies_remote_delete_when_untouched(harness, tmp_path, monk
     harness.client.post("/api/canvases/sync/stop", json={"name": "alpha"}, headers=GUARD)
 
 
-def test_sync_push_probes_and_merges_first(harness, tmp_path, monkeypatch):
+def test_sync_push_probes_and_merges_first(harness, tmp_path, monkeypatch, fake_agent):
     # Poll effectively disabled: the ONLY probe that can see the remote move
     # is the one _push runs before replacing the remote set.
+    #
+    # fake_agent: see test_sync_merges_remote_changes_while_dirty — skips the
+    # real `_agent_module()` cold start the watcher's per-tick liveness check
+    # would otherwise pay for real.
     monkeypatch.setattr(canvases_mod, "SCAN_INTERVAL_S", 0.05)
     monkeypatch.setattr(canvases_mod, "PULL_POLL_S", 1000.0)
     monkeypatch.setattr(canvases_mod, "DEBOUNCE_S", 0.1)
@@ -1460,11 +1499,15 @@ def test_sync_stale_echo_is_repushed_not_pulled(harness, tmp_path, monkeypatch):
     harness.client.post("/api/canvases/sync/stop", json={"name": "alpha"}, headers=GUARD)
 
 
-def test_sync_merge_rolls_back_when_it_breaks_validation(harness, tmp_path, monkeypatch):
+def test_sync_merge_rolls_back_when_it_breaks_validation(harness, tmp_path, monkeypatch, fake_agent):
     # Per-file merge can mix canvas.toml from one side with source files
     # from the other and produce an unpushable clone. When post-merge
     # validation fails, the merge is rolled back: local files restored,
     # clone stays dirty, the push re-asserts local wholesale.
+    #
+    # fake_agent: see test_sync_merges_remote_changes_while_dirty — skips the
+    # real `_agent_module()` cold start the watcher's per-tick liveness check
+    # would otherwise pay for real.
     monkeypatch.setattr(canvases_mod, "SCAN_INTERVAL_S", 0.05)
     monkeypatch.setattr(canvases_mod, "PULL_POLL_S", 0.1)
     monkeypatch.setattr(canvases_mod, "DEBOUNCE_S", 0.3)
@@ -1487,10 +1530,14 @@ def test_sync_merge_rolls_back_when_it_breaks_validation(harness, tmp_path, monk
     harness.client.post("/api/canvases/sync/stop", json={"name": "alpha"}, headers=GUARD)
 
 
-def test_push_aborts_when_remote_moved_and_zip_unavailable(harness, tmp_path, monkeypatch):
+def test_push_aborts_when_remote_moved_and_zip_unavailable(harness, tmp_path, monkeypatch, fake_agent):
     # The pre-push probe sees the remote moved, but the zip download fails —
     # pushing anyway would wholesale-replace edits we haven't seen. The push
     # must abort and retry; once the zip works, merge + push proceed.
+    #
+    # fake_agent: see test_sync_merges_remote_changes_while_dirty — skips the
+    # real `_agent_module()` cold start the watcher's per-tick liveness check
+    # would otherwise pay for real.
     monkeypatch.setattr(canvases_mod, "SCAN_INTERVAL_S", 0.05)
     monkeypatch.setattr(canvases_mod, "PULL_POLL_S", 1000.0)
     monkeypatch.setattr(canvases_mod, "DEBOUNCE_S", 0.1)
@@ -2598,12 +2645,17 @@ def test_status_reports_pulling_during_a_clean_force_pull(harness, tmp_path, mon
 
 
 def test_pulling_covers_the_merges_writes_but_not_its_zip_download(
-        harness, tmp_path, monkeypatch):
+        harness, tmp_path, monkeypatch, fake_agent):
     """`pulling` marks writes, and the merge's probe-and-decide reaches deeper
     than the leg boundary: the bundle download is a network op that can fail, and
     it precedes every write. Marking it held the embedded workbench read-only for
     the whole download and for merges that then wrote nothing — the same flicker
-    the window was introduced to remove, one layer in."""
+    the window was introduced to remove, one layer in.
+
+    fake_agent: see test_sync_merges_remote_changes_while_dirty — skips the
+    real `_agent_module()` cold start the watcher's per-tick liveness check
+    would otherwise pay for real, which was blocking exactly this test's
+    timed wait below even at the widened win32 timeout."""
     monkeypatch.setattr(canvases_mod, "SCAN_INTERVAL_S", 0.05)
     monkeypatch.setattr(canvases_mod, "PULL_POLL_S", 0.1)
     monkeypatch.setattr(canvases_mod, "DEBOUNCE_S", 30.0)  # keep the clone dirty

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -165,7 +165,13 @@ class Harness:
     def __init__(self, tmp_path, monkeypatch):
         stub = tmp_path / "fused_stub.py"
         stub.write_text(STUB, encoding="utf-8")
-        monkeypatch.setenv("FUSED_RENDER_FUSED_BIN", f"{sys.executable} {stub}")
+        # Quoted, because both halves are real paths that can contain spaces:
+        # sys.executable under "C:\Program Files\..." on Windows or a macOS
+        # "Application Support" tree, and tmp_path under a home directory with
+        # a space in the user name. Unquoted, fusedcli's split would cut either
+        # one in half and the stub CLI would simply not be found — a failure
+        # that would look like the app, not like the harness.
+        monkeypatch.setenv("FUSED_RENDER_FUSED_BIN", f'"{sys.executable}" "{stub}"')
 
         self.creds = tmp_path / "fused-credentials.json"
         monkeypatch.setenv("FUSED_RENDER_FUSED_CREDENTIALS", str(self.creds))

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -2481,15 +2481,32 @@ def test_the_held_poll_resumes_on_the_very_next_tick(
     shims.set_remote_files({**_BASE_FILES, "b.py": "b-from-workbench\n"})
     shims.set_manifest("t2", {"b": {"hash": "h2", "last_updated": "t2"}})
     # Sit in the held state until well past a full PULL_POLL_S window, so the
-    # leg has been due-and-skipped for a while.
+    # leg has been due-and-skipped for a while. Sampled AFTER the baseline
+    # adoption above, which is the one poll exempt from the hold (and so the
+    # one that legitimately stamps `_last_pull_poll`).
+    held_at = _manager()._last_pull_poll
     time.sleep(3.5)
     assert harness.client.get(
         "/api/canvases/sync/status?name=alpha").json()["merge_seq"] == 0
 
-    # Release, and give it far less than PULL_POLL_S to act: a skip that stamped
-    # `_last_pull_poll` would push the next poll a fresh 3s out and time out here.
+    # The invariant this test exists for, asserted DIRECTLY: a poll skipped by
+    # the hold must not stamp `_last_pull_poll`. It used to be inferred instead,
+    # from a 1.2s deadline after the release below — but that deadline can only
+    # ever be a proxy, and a loaded CI runner trips the proxy while the
+    # invariant itself holds perfectly: acting "on the very next tick" still
+    # means spawning the manifest probe AND the zip download as subprocesses
+    # before merge_seq can move, which is not reliably under 1.2s on a busy
+    # 4-worker box (this was the last red on Linux CI, across three different
+    # Python versions).
+    assert _manager()._last_pull_poll == held_at, (
+        "a held poll stamped _last_pull_poll, so the next one is a fresh "
+        "PULL_POLL_S away instead of the next tick")
+
+    # ...and it does then act promptly. Still bounded well under PULL_POLL_S
+    # (3.0s), so a regression that DID stamp the skip fails here too — but the
+    # bound no longer has to be tight enough to double as the proof above.
     fake_agent.live = ""
-    status = _wait_status(harness, lambda s: s["merge_seq"] >= 1, timeout=1.2)
+    status = _wait_status(harness, lambda s: s["merge_seq"] >= 1, timeout=2.5)
     assert status and status["merge_seq"] >= 1, (
         "the held leg waited for a fresh PULL_POLL_S instead of the next tick",
         status)

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -1250,10 +1250,21 @@ def _manager(name="alpha"):
 # generous ceiling here rather than a tighter one now that the agent cost is
 # gone. This is slack for "did the async op finish at all" in the common wait
 # helpers below, not a precision measurement of how FAST it had to be —
-# widening it on Windows costs nothing but wall-clock time in CI. (A couple of
-# tests below pin their own tighter timeout on purpose, to prove something
-# resolved quickly rather than merely at all; those are left alone.)
-_WAIT_TIMEOUT_S = 45 if sys.platform == "win32" else 8
+# widening it costs nothing but wall-clock time in CI. (A couple of tests below
+# pin their own tighter timeout on purpose, to prove something resolved quickly
+# rather than merely at all; those are left alone.)
+#
+# One value for every platform, not a Windows-only allowance. The Linux budget
+# used to be 8s, and test-python (3.10) failed on it with merge_seq still 0 and
+# push_state "idle" -- the watcher had not completed a SINGLE pull+merge cycle,
+# ~80 missed polls at this file's PULL_POLL_S, while 3.11/3.12/3.13 passed the
+# same commit. Locally the merge lands in well under half a second, so this is
+# an xdist worker starved of CPU (or of a contended CI disk) for the whole
+# budget, not a slow merge. Since the helpers return the instant the predicate
+# holds, a passing run pays nothing for the extra headroom -- the ceiling only
+# bounds how long a genuine failure takes to report, and 8s of it bought
+# nothing but a flake.
+_WAIT_TIMEOUT_S = 45
 
 
 def _wait_for(predicate, timeout=_WAIT_TIMEOUT_S):

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -1272,21 +1272,10 @@ def _watcher_diag(name="alpha"):
 # generous ceiling here rather than a tighter one now that the agent cost is
 # gone. This is slack for "did the async op finish at all" in the common wait
 # helpers below, not a precision measurement of how FAST it had to be —
-# widening it costs nothing but wall-clock time in CI. (A couple of tests below
-# pin their own tighter timeout on purpose, to prove something resolved quickly
-# rather than merely at all; those are left alone.)
-#
-# One value for every platform, not a Windows-only allowance. The Linux budget
-# used to be 8s, and test-python (3.10) failed on it with merge_seq still 0 and
-# push_state "idle" -- the watcher had not completed a SINGLE pull+merge cycle,
-# ~80 missed polls at this file's PULL_POLL_S, while 3.11/3.12/3.13 passed the
-# same commit. Locally the merge lands in well under half a second, so this is
-# an xdist worker starved of CPU (or of a contended CI disk) for the whole
-# budget, not a slow merge. Since the helpers return the instant the predicate
-# holds, a passing run pays nothing for the extra headroom -- the ceiling only
-# bounds how long a genuine failure takes to report, and 8s of it bought
-# nothing but a flake.
-_WAIT_TIMEOUT_S = 45
+# widening it on Windows costs nothing but wall-clock time in CI. (A couple of
+# tests below pin their own tighter timeout on purpose, to prove something
+# resolved quickly rather than merely at all; those are left alone.)
+_WAIT_TIMEOUT_S = 45 if sys.platform == "win32" else 8
 
 
 def _wait_for(predicate, timeout=_WAIT_TIMEOUT_S):

--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -1224,6 +1224,28 @@ def _manager(name="alpha"):
     return canvases_mod._syncs[name]
 
 
+def _watcher_diag(name="alpha"):
+    """Why the watcher is not making progress, for a wait that timed out.
+
+    `status["watching"]` answers "have we been told to stop", not "is the
+    thread running" (`not stop_event.is_set()`), and `_run()` wraps no
+    try/except around its loop body — so an exception on any tick kills the
+    daemon thread while the payload still reports watching: True, push_state
+    idle, every seq stuck at 0. A leaked `pause_count` and a starved worker
+    look identical from outside. This tells those three apart in the failure
+    message, so an intermittent one arrives already diagnosed instead of as a
+    truncated dict.
+    """
+    try:
+        m = _manager(name)
+    except KeyError:
+        return "no manager registered"
+    return (f"thread_alive={m.thread.is_alive()} pause_count={m.pause_count} "
+            f"stop_set={m.stop_event.is_set()} "
+            f"since_pull_poll={time.time() - m._last_pull_poll:.1f}s "
+            f"dirty_since={m._dirty_since} last_error={m.last_error!r}")
+
+
 # Every SCAN_INTERVAL_S/DEBOUNCE_S/PULL_POLL_S tick of canvases.py's manager
 # loop spawns a fresh subprocess for the stub CLI (manifest probes, zip
 # downloads, pulls, pushes, and validation calls are all
@@ -1316,7 +1338,8 @@ def test_sync_merges_remote_changes_while_dirty(harness, tmp_path, monkeypatch, 
     shims.set_manifest("t2")
 
     status = _wait_status(harness, lambda s: s["merge_seq"] >= 1 and s["push_seq"] >= 1)
-    assert status and status["merge_seq"] >= 1 and status["push_seq"] >= 1, status
+    assert status and status["merge_seq"] >= 1 and status["push_seq"] >= 1, (
+        f"{status} | {_watcher_diag()}")
     assert (harness.root / "alpha" / "a.py").read_text() == "a-local\n"
     assert (harness.root / "alpha" / "b.py").read_text() == "b2-remote\n"
     # The sync-point state lives OUTSIDE the clone dir (a CLI `pull --force`

--- a/tests/test_claude_app_state.py
+++ b/tests/test_claude_app_state.py
@@ -653,7 +653,17 @@ def _node(fn_names, call, html, prelude=""):
                 break
         chunks.append("\n".join(taken))
     script = prelude + "\n" + "\n".join(chunks) + "\n" + call
-    out = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    # `encoding="utf-8"` is not decorative: `text=True` alone decodes the
+    # child's stdout with locale.getpreferredencoding(False), and node always
+    # writes its UTF-8 source text as UTF-8 bytes regardless of platform. On
+    # Windows that locale default is commonly cp1252, which would silently
+    # mojibake any non-ASCII character the page's own source hands back
+    # (see tests/test_claude_template_segments.py's identical harness, where
+    # this exact gap did exactly that) — this file's probes just haven't hit
+    # one yet, so pinning it here is prevention, not a fix for an observed
+    # failure.
+    out = subprocess.run(["node", "-e", script], capture_output=True,
+                          text=True, encoding="utf-8")
     assert out.returncode == 0, out.stderr
     return json.loads(out.stdout)
 

--- a/tests/test_claude_artifacts_api.py
+++ b/tests/test_claude_artifacts_api.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from fused_render import claude_artifacts as claude_artifacts_mod
+from fused_render._view_url_codec import canonical_fs_path
 from fused_render.server import create_app
 
 URL_A = "https://claude.ai/code/artifact/aaaaaaaa-0000-0000-0000-000000000000"
@@ -71,7 +72,9 @@ def test_lists_publish_with_tool_call_metadata_merged(client, projects_dir, tmp_
     artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
     assert len(artifacts) == 1
     entry = artifacts[0]
-    assert entry["file_path"] == str(page)
+    # file_path comes back in the shell's canonical (forward-slash) form, not
+    # whatever separator str(Path) uses on this OS.
+    assert entry["file_path"] == canonical_fs_path(str(page))
     assert entry["remote_url"] == URL_A
     assert entry["title"] == "Bali Open Water"
     assert entry["description"] == "Course picker."
@@ -119,8 +122,9 @@ def test_exists_reports_whether_the_published_file_is_still_there(
         _frame_link("s1", gone, URL_B, "Gone", "2026-07-16T09:00:00.000Z"),
     ])
     artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    # file_path is the canonical (forward-slash) form; only the key needs it.
     assert {a["file_path"]: a["exists"] for a in artifacts} == {
-        str(here): True, str(gone): False}
+        canonical_fs_path(str(here)): True, canonical_fs_path(str(gone)): False}
 
 
 def test_missing_projects_dir_is_empty_not_an_error(client, projects_dir):
@@ -182,7 +186,7 @@ def test_same_url_published_from_two_sessions_collapses_to_one_row(
     # is now being worked on from; created_at is still the first publish.
     assert entry["title"] == "Updated"
     assert entry["description"] == "updated elsewhere"
-    assert entry["file_path"] == str(second)
+    assert entry["file_path"] == canonical_fs_path(str(second))
     assert entry["session_id"] == "new"
     assert entry["cwd"] == "/tmp/b"
     assert entry["created_at"] == pytest.approx(1784192400.0)

--- a/tests/test_claude_composer_block.py
+++ b/tests/test_claude_composer_block.py
@@ -111,7 +111,17 @@ def _node(fn_names, call, html, prelude=""):
                 break
         chunks.append("\n".join(taken))
     script = prelude + "\n" + "\n".join(chunks) + "\n" + call
-    out = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    # `encoding="utf-8"` is not decorative: `text=True` alone decodes the
+    # child's stdout with locale.getpreferredencoding(False), and node always
+    # writes its UTF-8 source text as UTF-8 bytes regardless of platform. On
+    # Windows that locale default is commonly cp1252, which would silently
+    # mojibake any non-ASCII character the page's own source hands back
+    # (see tests/test_claude_template_segments.py's identical harness, where
+    # this exact gap did exactly that) — this file's probes just haven't hit
+    # one yet, so pinning it here is prevention, not a fix for an observed
+    # failure.
+    out = subprocess.run(["node", "-e", script], capture_output=True,
+                          text=True, encoding="utf-8")
     assert out.returncode == 0, out.stderr
     return json.loads(out.stdout)
 

--- a/tests/test_claude_config_api.py
+++ b/tests/test_claude_config_api.py
@@ -74,7 +74,10 @@ def claude_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(skills, "SKILL_LOCK_PATH",
                         str(tmp_path / ".agents" / ".skill-lock.json"))
     # HOME drives claude_md's ~/.claude.json probe (and nothing else here).
+    # os.path.expanduser reads USERPROFILE on Windows (ntpath.expanduser never
+    # looks at HOME), so both have to be set for the redirect to actually land.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     # Identity + no global config, so `git commit` works on a machine with an
     # empty ~/.gitconfig and a developer's own settings can't change the result
     # (same posture as tests/_git_repo.py).
@@ -738,7 +741,12 @@ def test_git_runs_with_dash_c_rather_than_cwd():
     # (tests/test_git_posix_spawn.py). basename alone would pass a
     # regression to a bare "git".
     assert os.path.isabs(seen["argv"][0])
-    assert os.path.basename(seen["argv"][0]) in ("git", "git.exe")
+    # `.lower()`: `shutil.which("git")` on Windows resolves the bare name by
+    # trying each `PATHEXT` entry as-is, and the default `PATHEXT` spells its
+    # entries `.EXE` — so the resolved path this app actually runs is
+    # literally `...\git.EXE`, uppercase extension, with no lowercase form on
+    # disk to fall back to. That is still "git", not a different binary.
+    assert os.path.basename(seen["argv"][0]).lower() in ("git", "git.exe")
     assert seen["argv"][1:3] == ["-C", lib.CLAUDE_DIR]
     assert "cwd" not in seen["kwargs"]
     assert seen["kwargs"]["close_fds"] is False

--- a/tests/test_claude_health.py
+++ b/tests/test_claude_health.py
@@ -12,6 +12,7 @@ module boundary (the same discipline as test_server_ai.py).
 """
 import json
 import os
+import sys
 import time
 
 import pytest
@@ -50,9 +51,20 @@ def _isolated_home(tmp_path, monkeypatch):
 
 
 def _fake_cli(tmp_path, name="claude", executable=True):
-    """An executable stand-in for the CLI, in its own dir. Returns the path."""
+    """An executable stand-in for the CLI, in its own dir. Returns the path.
+
+    Never actually spawned by anything below (every test here patches
+    `probe_version`/`subprocess.run` rather than running it) — it only has to
+    be a file `resolve()`'s real `shutil.which` can find on PATH. That is a
+    file with an exec bit on POSIX and a file with a PATHEXT extension on
+    Windows, which is why the name gets `.exe` there: a bare `claude` with a
+    shebang is invisible to Windows' extension-based PATH lookup no matter
+    what `chmod` says about it.
+    """
     d = tmp_path / "fake-bin"
     d.mkdir(exist_ok=True)
+    if os.name == "nt" and not name.lower().endswith((".exe", ".cmd", ".bat")):
+        name += ".exe"
     p = d / name
     p.write_text("#!/bin/sh\necho 2.1.220\n")
     p.chmod(0o755 if executable else 0o644)
@@ -135,6 +147,15 @@ def test_path_beats_the_candidate_list(tmp_path, monkeypatch):
     assert claude_health.resolve() == (bin_path, "path")
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fakes os.name='posix' on a real filesystem — executable()'s "
+           "os.access(X_OK) branch that gates on it is then a REAL syscall, "
+           "and on real Windows os.access(X_OK) is true for any existing "
+           "file regardless of chmod (see executable()'s own docstring), so "
+           "the POSIX candidate-list behaviour this exercises can only be "
+           "tested where os.name='posix' is also true.",
+)
 def test_candidate_dirs_are_probed_when_path_is_stripped(tmp_path, monkeypatch):
     """A Finder/Dock-launched .app inherits the supervisor's PATH, not a
     shell's, so the known install dirs are all that is left."""
@@ -151,6 +172,12 @@ def test_candidate_dirs_are_probed_when_path_is_stripped(tmp_path, monkeypatch):
     assert claude_health.resolve() == (str(cli), "candidate")
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fakes os.name='posix' on a real filesystem — see the skip on "
+           "test_candidate_dirs_are_probed_when_path_is_stripped just above "
+           "for why that's unsafe on real Windows.",
+)
 def test_a_non_executable_file_does_not_shadow_a_real_install(tmp_path, monkeypatch):
     """isfile alone was not enough: a non-executable file in an earlier
     candidate dir would win and then fail to spawn."""

--- a/tests/test_claude_health.py
+++ b/tests/test_claude_health.py
@@ -144,7 +144,15 @@ def test_a_stale_override_is_reported_not_silently_replaced(tmp_path, monkeypatc
 def test_path_beats_the_candidate_list(tmp_path, monkeypatch):
     bin_path = _fake_cli(tmp_path)
     monkeypatch.setenv("PATH", os.path.dirname(bin_path))
-    assert claude_health.resolve() == (bin_path, "path")
+    resolved, source = claude_health.resolve()
+    # normcase, not a bare ==: shutil.which() on Windows matches "claude"
+    # against PATHEXT (.COM;.EXE;...) and returns it with THAT extension's
+    # case, e.g. "claude.EXE", regardless of the actual on-disk filename's
+    # case ("claude.exe" here) — a case difference on a filesystem where it is
+    # not a different file. Same idiom as templates/claude/agent.py's
+    # containment check.
+    assert os.path.normcase(resolved) == os.path.normcase(bin_path)
+    assert source == "path"
 
 
 @pytest.mark.skipif(
@@ -351,7 +359,17 @@ def test_augmented_path_appends_install_dirs_without_duplicating(monkeypatch):
     parts = claude_health.augmented_path().split(os.pathsep)
     assert parts[0] == "/usr/bin"
     assert len(parts) == len(set(parts))
-    assert "/opt/homebrew/bin" in parts
+    # candidates() (and so the dirs augmented_path() appends) is platform-
+    # specific — WINDOWS_CANDIDATES on os.name == "nt", POSIX_CANDIDATES
+    # elsewhere — so "/opt/homebrew/bin" is only ever a real member of that
+    # list on the POSIX branch; asserting it unconditionally is a POSIX-only
+    # literal masquerading as a platform-independent one. Deriving the
+    # expectation from candidates() itself is what makes this check the same
+    # guarantee on both platforms.
+    for candidate in claude_health.candidates():
+        expected_dir = os.path.dirname(
+            os.path.expanduser(os.path.expandvars(candidate)))
+        assert expected_dir in parts
 
 
 # -- the version probe --------------------------------------------------------

--- a/tests/test_claude_session_summaries.py
+++ b/tests/test_claude_session_summaries.py
@@ -17,6 +17,7 @@ import pytest
 from tests import _machinery_records as records
 from fastapi.testclient import TestClient
 
+from fused_render._view_url_codec import canonical_fs_path
 from fused_render.server import create_app
 from fused_render.server.routers import claude_sessions as claude_sessions_mod
 
@@ -111,7 +112,8 @@ def test_lists_sessions_named_by_first_prompt_newest_activity_first(
     sessions = _get(client)
     assert [s["session_id"] for s in sessions] == ["newer", "older"]
     assert [s["name"] for s in sessions] == ["Ship the release", "Fix the login bug"]
-    assert [s["cwd"] for s in sessions] == [str(proj), str(proj)]
+    # cwd comes back canonicalized (forward slashes) like /api/claude-sessions.
+    assert [s["cwd"] for s in sessions] == [canonical_fs_path(str(proj))] * 2
 
     newer, older = sessions
     assert newer["started_at"] == "2026-08-16T09:00:00+00:00"

--- a/tests/test_claude_sessions_api.py
+++ b/tests/test_claude_sessions_api.py
@@ -10,6 +10,7 @@ import shutil
 import pytest
 from fastapi.testclient import TestClient
 
+from fused_render._view_url_codec import canonical_fs_path
 from fused_render.server import create_app
 from fused_render.server.routers import claude_sessions as claude_sessions_mod
 
@@ -25,6 +26,14 @@ def projects_dir(tmp_path, monkeypatch):
 @pytest.fixture()
 def client(tmp_path):
     return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def _c(path) -> str:
+    """A folder's expected wire form: both endpoints canonicalize `path` to
+    forward slashes on the way out (see canonical_fs_path), even though the
+    transcript's own `cwd` and this test's `str(Path(...))` are backslashed
+    on Windows."""
+    return canonical_fs_path(str(path))
 
 
 def _session(projects_dir, encoded_dir, session_id, cwd, mtime=None):
@@ -45,7 +54,7 @@ def test_groups_by_transcript_cwd_not_encoded_dirname(client, projects_dir, tmp_
     real.mkdir()
     _session(projects_dir, "-tmp-my-project", "s1", str(real))
     data = client.get("/api/claude-sessions").json()
-    assert [f["path"] for f in data["folders"]] == [str(real)]
+    assert [f["path"] for f in data["folders"]] == [_c(real)]
 
 
 def test_sorted_by_latest_session_first(client, projects_dir, tmp_path):
@@ -56,7 +65,7 @@ def test_sorted_by_latest_session_first(client, projects_dir, tmp_path):
     _session(projects_dir, "proj-a", "s1", str(a), mtime=1000)
     _session(projects_dir, "proj-b", "s1", str(b), mtime=2000)
     data = client.get("/api/claude-sessions").json()
-    assert [f["path"] for f in data["folders"]] == [str(b), str(a)]
+    assert [f["path"] for f in data["folders"]] == [_c(b), _c(a)]
 
 
 def test_multiple_sessions_in_one_folder_collapse_to_one_row(client, projects_dir, tmp_path):
@@ -65,7 +74,7 @@ def test_multiple_sessions_in_one_folder_collapse_to_one_row(client, projects_di
     _session(projects_dir, "proj", "old", str(proj), mtime=1000)
     _session(projects_dir, "proj", "new", str(proj), mtime=5000)
     data = client.get("/api/claude-sessions").json()
-    assert [f["path"] for f in data["folders"]] == [str(proj)]
+    assert [f["path"] for f in data["folders"]] == [_c(proj)]
 
 
 def test_folder_no_longer_on_disk_is_dropped(client, projects_dir, tmp_path):
@@ -102,7 +111,7 @@ def test_home_opens_only_enough_newest_transcripts_to_fill_the_row(
     data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
 
     assert [f["path"] for f in data["folders"]] == [
-        str(folders[19]), str(folders[18]), str(folders[17]),
+        _c(folders[19]), _c(folders[18]), _c(folders[17]),
     ]
     assert len(opened) == 3
 
@@ -135,7 +144,7 @@ def test_home_skips_duplicate_and_missing_folders_until_the_row_is_full(
     monkeypatch.setattr(claude_sessions_mod, "_session_cwd", counted_session_cwd)
     data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
 
-    assert [f["path"] for f in data["folders"]] == [str(a), str(b), str(c)]
+    assert [f["path"] for f in data["folders"]] == [_c(a), _c(b), _c(c)]
     # Four, not five: a/old is never opened. Its directory was already resolved
     # by a/new, and a directory name IS the encoded cwd, so the second file
     # could only have reproduced a folder already in the row.
@@ -164,7 +173,7 @@ def test_home_opens_one_transcript_per_project_directory(
     monkeypatch.setattr(claude_sessions_mod, "_session_cwd", counted_session_cwd)
     data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
 
-    assert [f["path"] for f in data["folders"]] == [str(proj)]
+    assert [f["path"] for f in data["folders"]] == [_c(proj)]
     assert opened == [str(projects_dir / "proj" / "s9.jsonl")]
 
 
@@ -193,7 +202,7 @@ def test_home_falls_through_to_older_transcripts_of_an_unreadable_newest(
     monkeypatch.setattr(claude_sessions_mod, "_session_cwd", counted_session_cwd)
     data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
 
-    assert [f["path"] for f in data["folders"]] == [str(proj)]
+    assert [f["path"] for f in data["folders"]] == [_c(proj)]
     assert opened == [str(headless), str(projects_dir / "proj" / "readable.jsonl")]
 
 
@@ -211,10 +220,10 @@ def test_home_collapses_a_collided_directory_to_its_newest_folder(
     _session(projects_dir, "collide", "newer", str(hyphened), mtime=2000)
 
     data = client.get("/api/claude-sessions/home", params={"limit": 3}).json()
-    assert [f["path"] for f in data["folders"]] == [str(hyphened)]
+    assert [f["path"] for f in data["folders"]] == [_c(hyphened)]
     exhaustive = client.get("/api/claude-sessions").json()
     assert sorted(f["path"] for f in exhaustive["folders"]) == sorted(
-        [str(hyphened), str(nested)])
+        [_c(hyphened), _c(nested)])
 
 
 def test_home_session_limit_is_capped_to_its_single_row(

--- a/tests/test_claude_shots.py
+++ b/tests/test_claude_shots.py
@@ -313,7 +313,15 @@ def _node(fn_names, call, html, prelude=""):
                 break
         chunks.append("\n".join(taken))
     script = prelude + "\n" + "\n".join(chunks) + "\n" + call
-    out = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    # `encoding="utf-8"` is not decorative: `text=True` alone decodes the
+    # child's stdout with locale.getpreferredencoding(False), and node always
+    # writes its UTF-8 source glyphs (the shot markers' 🖼/📌) as UTF-8 bytes
+    # regardless of platform. On Windows that locale default is commonly
+    # cp1252, which decodes those bytes into mojibake without ever raising —
+    # a silent corruption, not a crash, so it slipped past every POSIX run
+    # where the locale default already happens to be UTF-8.
+    out = subprocess.run(["node", "-e", script], capture_output=True,
+                          text=True, encoding="utf-8")
     assert out.returncode == 0, out.stderr
     return json.loads(out.stdout)
 

--- a/tests/test_claude_shots.py
+++ b/tests/test_claude_shots.py
@@ -171,12 +171,15 @@ def test_the_shots_dir_is_created_private_and_adopted_on_a_second_call(
     monkeypatch.setattr(agent, "RUNS", str(root))
     shots = tmp_path / "fr" / "shots"
     monkeypatch.setattr(agent, "SHOTS", str(shots))
-    assert agent.main(action="shots_dir") == {"dir": str(shots)}
+    # The dir comes back through _wire_path (forward slashes on every
+    # platform, so the page's crop paths match the Read(//…/**) rule) — not
+    # the raw join, which is backslashed on Windows.
+    assert agent.main(action="shots_dir") == {"dir": agent._wire_path(str(shots))}
     assert os.path.isdir(shots)
     if hasattr(os, "geteuid"):
         assert stat.S_IMODE(os.lstat(shots).st_mode) == 0o700
     # second message, same directory
-    assert agent.main(action="shots_dir") == {"dir": str(shots)}
+    assert agent.main(action="shots_dir") == {"dir": agent._wire_path(str(shots))}
 
 
 @pytest.mark.skipif(not hasattr(os, "geteuid"), reason="POSIX mode bits")
@@ -285,7 +288,10 @@ def test_the_page_asks_for_the_directory_by_the_action_the_agent_serves(
     """D146, the two-sided wire: the page names the action, agent.py routes it."""
     assert 'action: "shots_dir"' in html
     monkeypatch.setattr(agent, "SHOTS", str(tmp_path / "shots"))
-    assert agent.main(action="shots_dir").get("dir") == str(tmp_path / "shots")
+    # See the note in the "created private" test above: _wire_path forward-
+    # slashes this, on every platform.
+    assert agent.main(action="shots_dir").get("dir") == agent._wire_path(
+        str(tmp_path / "shots"))
 
 
 # ---------------------------------------------- the page's own JS, under node

--- a/tests/test_claude_snapshots.py
+++ b/tests/test_claude_snapshots.py
@@ -278,8 +278,17 @@ def test_a_user_who_set_it_themselves_keeps_their_value(
 
 
 def _target(tmp_path, content, name="notes.md"):
+    # `newline=""` disables universal-newline translation — same fix, same
+    # reason, as _claude_history.write_version's own comment: file_history.py
+    # compares this file's on-disk bytes against a checkpoint's bytes exactly
+    # (`differs` is a byte comparison, by design — see file_history._locate),
+    # and `Path.write_text`'s default text mode would silently inflate every
+    # "\n" here to "\r\n" on Windows, making a target deliberately written to
+    # equal a checkpoint's content ("disk\n" == "disk\n") no longer equal it
+    # on disk, and derailing the positional walk that test is asserting about.
     f = tmp_path / name
-    f.write_text(content)
+    with open(f, "w", encoding="utf-8", newline="") as fh:
+        fh.write(content)
     return str(f)
 
 

--- a/tests/test_claude_stream.py
+++ b/tests/test_claude_stream.py
@@ -349,7 +349,15 @@ def _retry_verb(source, retry):
     start = source.index("function retryVerb(")
     fn = source[start:source.index("\nfunction addWorking(", start)]
     script = fn + "\nconsole.log(retryVerb(%s));" % json.dumps(retry)
-    out = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    # `encoding="utf-8"` is not decorative: `text=True` alone decodes the
+    # child's stdout with locale.getpreferredencoding(False), and node always
+    # writes its UTF-8 source glyphs (the em dash in "Overloaded — retrying")
+    # as UTF-8 bytes regardless of platform. On Windows that locale default is
+    # commonly cp1252, which decodes those bytes into mojibake without ever
+    # raising — a silent corruption, not a crash, so it slipped past every
+    # POSIX run where the locale default already happens to be UTF-8.
+    out = subprocess.run(["node", "-e", script], capture_output=True,
+                          text=True, encoding="utf-8")
     assert out.returncode == 0, out.stderr
     return out.stdout.strip()
 

--- a/tests/test_claude_template_segments.py
+++ b/tests/test_claude_template_segments.py
@@ -234,7 +234,15 @@ def _node(script, tmp_path):
         pytest.skip("node is required to drive the template's own JS")
     harness = tmp_path / "harness.mjs"
     harness.write_text(script, encoding="utf-8")
-    out = subprocess.run([node, str(harness)], capture_output=True, text=True)
+    # `encoding="utf-8"` is not decorative: `text=True` alone decodes the
+    # child's stdout with locale.getpreferredencoding(False), and node always
+    # writes its UTF-8 source glyphs (the toolchip's ✗/☑/☐/…) as UTF-8 bytes
+    # regardless of platform. On Windows that locale default is commonly
+    # cp1252, which decodes those bytes into mojibake ("✗" -> "âœ—") without
+    # ever raising — a silent corruption, not a crash, so it slipped past
+    # every POSIX run where the locale default already happens to be UTF-8.
+    out = subprocess.run([node, str(harness)], capture_output=True,
+                          text=True, encoding="utf-8")
     assert out.returncode == 0, out.stderr
     return json.loads(out.stdout)
 

--- a/tests/test_condition_gate_seed.py
+++ b/tests/test_condition_gate_seed.py
@@ -186,7 +186,16 @@ def test_truncated_listing_falls_back_to_probes(monkeypatch, guard_kernel):
             probed.append(p)
         if p == STORE:
             return "dir"
-        if p == STORE + "/.zmetadata":
+        # The gate builds this probe path with `os.path.join(path, marker)`
+        # (zarr_aoi/condition.py) — the shim passes that string through to
+        # rc_kind_for UNCHANGED, and only the REAL rc_kind_for (bypassed here
+        # by this monkeypatch) normalizes it to a forward-slash remote key via
+        # _mount_for's `.replace(os.sep, "/")`. On Windows os.path.join joins
+        # with '\\', so matching on a hand-built '/'-joined literal missed
+        # every probe and made the marker read as absent. os.path.join is a
+        # no-op separator-wise on POSIX, so this mirrors the real call on
+        # every platform.
+        if p == os.path.join(STORE, ".zmetadata"):
             return "file"
         return "missing"
 
@@ -214,7 +223,11 @@ def test_listing_failure_falls_back_to_probes(monkeypatch, guard_kernel):
             probed.append(p)
         if p == STORE:
             return "dir"
-        if p == STORE + "/.zmetadata":
+        # See test_truncated_listing_falls_back_to_probes above: match the
+        # gate's own os.path.join(path, marker), not a hand-built '/'-joined
+        # literal — the real rc_kind_for's forward-slash normalization is
+        # bypassed by this monkeypatch.
+        if p == os.path.join(STORE, ".zmetadata"):
             return "file"
         return "missing"
 
@@ -270,7 +283,11 @@ def test_indeterminate_kind_not_seeded_gate_reprobes(monkeypatch, guard_kernel):
             # 1st call is the endpoint probe (indeterminate); the gate's own
             # reprobe recovers to "dir".
             return "indeterminate" if calls["n"] == 1 else "dir"
-        if p == STORE + "/.zmetadata":
+        # See test_truncated_listing_falls_back_to_probes above: match the
+        # gate's own os.path.join(path, marker), not a hand-built '/'-joined
+        # literal — the real rc_kind_for's forward-slash normalization is
+        # bypassed by this monkeypatch.
+        if p == os.path.join(STORE, ".zmetadata"):
             return "file"
         return "missing"
 
@@ -302,7 +319,12 @@ def test_truncated_listing_with_present_marker_true(monkeypatch, guard_kernel):
     def _kind(p, **k):
         if p == STORE:
             return "dir"
-        if p == STORE + "/.zgroup":
+        # os.path.join, matching the gate's own probe path (see the comment on
+        # test_truncated_listing_falls_back_to_probes above) — this guard is
+        # currently unreachable (.zgroup is answered from the listing before
+        # rc_kind_for is ever consulted) but should still recognise the right
+        # path if that ever changes.
+        if p == os.path.join(STORE, ".zgroup"):
             raise AssertionError("present marker .zgroup was rc probed")
         return "missing"  # .zmetadata / zarr.json legitimately probe -> missing
 

--- a/tests/test_condition_mount_shim.py
+++ b/tests/test_condition_mount_shim.py
@@ -98,9 +98,18 @@ def test_shimmed_gate_group_true_with_zero_kernel_os_calls(monkeypatch, guard_ke
     # A v3 group root on a mount: isdir(dir) hits, .zmetadata misses, zarr.json
     # hits, its node_type=="group" -> True. Every probe routes via rc; the kernel
     # guard proves not one os.* call touched the mount.
+    #
+    # The marker key has to be os.path.join(STORE, "zarr.json"), not
+    # STORE + "/zarr.json": the gate builds its probe path with
+    # os.path.join(path, marker) (zarr_aoi/condition.py), and the shim passes
+    # that string to rc_kind_for UNCHANGED — only the REAL rc_kind_for (which
+    # this monkeypatch replaces) normalizes it to a forward-slash remote key
+    # via _mount_for's `.replace(os.sep, "/")`. On Windows os.path.join joins
+    # with '\\', so a hand-built '/'-joined key never matched and the marker
+    # read as absent. os.path.join is a no-op separator-wise on POSIX.
     _mount(
         monkeypatch,
-        {STORE: "dir", STORE + "/zarr.json": "file"},
+        {STORE: "dir", os.path.join(STORE, "zarr.json"): "file"},
         read_bytes=b'{"node_type": "group"}',
     )
     allowed, err = _server_templates._run_condition(ZARR_CONDITION, STORE)
@@ -110,9 +119,15 @@ def test_shimmed_gate_group_true_with_zero_kernel_os_calls(monkeypatch, guard_ke
 def test_shimmed_gate_bare_array_is_false(monkeypatch, guard_kernel):
     # v3 bare-array root: zarr.json present but node_type=="array" -> not a group
     # -> False (fail-closed correctness preserved over the shim).
+    #
+    # os.path.join, not STORE + "/zarr.json" — see the comment on
+    # test_shimmed_gate_group_true_with_zero_kernel_os_calls above. Without it
+    # the probe key never matched on Windows and this test's False verdict
+    # came from "no marker found" rather than the array-vs-group check it
+    # claims to exercise, which the assertion could not tell apart.
     _mount(
         monkeypatch,
-        {STORE: "dir", STORE + "/zarr.json": "file"},
+        {STORE: "dir", os.path.join(STORE, "zarr.json"): "file"},
         read_bytes=b'{"node_type": "array"}',
     )
     allowed, err = _server_templates._run_condition(ZARR_CONDITION, STORE)
@@ -147,9 +162,12 @@ def test_shimmed_gate_fail_closed_on_indeterminate(monkeypatch, guard_kernel):
 def test_shimmed_gate_fail_closed_when_read_unavailable(monkeypatch, guard_kernel):
     # zarr.json exists but the bounded serve read fails (no serve / transport
     # error) -> OSError inside the gate -> fail closed, not a group.
+    #
+    # os.path.join, not STORE + "/zarr.json" — see the comment on
+    # test_shimmed_gate_group_true_with_zero_kernel_os_calls above.
     _mount(
         monkeypatch,
-        {STORE: "dir", STORE + "/zarr.json": "file"},
+        {STORE: "dir", os.path.join(STORE, "zarr.json"): "file"},
         read_bytes=None,  # rc_read_bounded raises OSError
     )
     allowed, err = _server_templates._run_condition(ZARR_CONDITION, STORE)
@@ -234,7 +252,12 @@ def test_utime_on_a_mount_is_dropped_not_routed(monkeypatch, guard_kernel, tmp_p
     # SETATTR is exactly the call this shim exists to prevent, so it is dropped.
     # The gate still returns its verdict; the guard proves the kernel was spared.
     import stat as _s
-    _mount(monkeypatch, {STORE: "dir", STORE + "/config.json": "file", "*": "missing"},
+    # os.path.join, not STORE + "/config.json" — model_card/condition.py builds
+    # its probe with os.path.join(path, "config.json") too, and the shim hands
+    # that string straight to rc_kind_for; see the comment on
+    # test_shimmed_gate_group_true_with_zero_kernel_os_calls above.
+    _mount(monkeypatch,
+          {STORE: "dir", os.path.join(STORE, "config.json"): "file", "*": "missing"},
            read_bytes=json.dumps({"model_type": "llama"}).encode())
     monkeypatch.setattr(
         mounts_mod, "rc_stat_result",
@@ -286,9 +309,11 @@ def _client():
 
 
 def test_conditions_endpoint_true_on_mount_group(monkeypatch, guard_kernel):
+    # os.path.join, not STORE + "/zarr.json" — see the comment on
+    # test_shimmed_gate_group_true_with_zero_kernel_os_calls above.
     _mount(
         monkeypatch,
-        {STORE: "dir", STORE + "/zarr.json": "file"},
+        {STORE: "dir", os.path.join(STORE, "zarr.json"): "file"},
         read_bytes=b'{"node_type": "group"}',
     )
     r = _client().get("/api/fs/conditions", params={"path": STORE})

--- a/tests/test_dev_sh_process_cleanup.py
+++ b/tests/test_dev_sh_process_cleanup.py
@@ -22,7 +22,21 @@ import pathlib
 import re
 import shutil
 import subprocess
+import sys
 import time
+
+import pytest
+
+# dev.sh is a contributor tool run under a real POSIX shell (Linux/macOS); it
+# is never shipped to a Windows user. Git Bash is often on PATH on a Windows
+# runner, but the process-tree and signal semantics these tests drive
+# (SIGTERM traps, process groups, `ps -o lstart=`) are what Git Bash does NOT
+# faithfully emulate, so this whole file tests a shell environment Windows
+# does not have rather than a Windows incompatibility to fix.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="dev.sh is a POSIX-shell contributor script; not run on Windows",
+)
 
 # realpath, NOT abspath: dev.sh derives $REPO_ROOT with `pwd -P` and compares the
 # recorded root to it as a plain string. abspath leaves symlinks in place, so on

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -793,6 +793,16 @@ def test_an_explicit_override_is_probed_even_with_an_odd_name(monkeypatch, tmp_p
     It still has to pass the probe — the escape hatch relaxes the name guard,
     not the verification.
     """
+    if os.name == "nt":
+        # The wrapper below IS a shebang script (`#!/bin/sh\nexec ...`), made
+        # runnable with chmod +x — a POSIX exec mechanism Windows has none of.
+        # CreateProcess cannot launch it at all (no interpreter association,
+        # no shebang support), so the probe would fail for a reason that has
+        # nothing to do with what this test is actually pinning: that an
+        # explicit override skips the NAME guard. A `.bat`/`.cmd` stand-in
+        # would exercise a different, shell-mediated spawn path instead of
+        # the direct one under test, so this is skipped rather than faked.
+        pytest.skip("the wrapper is a POSIX shebang script by construction")
     wrapper = tmp_path / "app-python-wrapper"
     wrapper.write_text(f"#!/bin/sh\nexec {sys.executable} \"$@\"\n")
     wrapper.chmod(wrapper.stat().st_mode | stat.S_IEXEC)
@@ -1514,6 +1524,14 @@ def test_a_wrapper_that_does_not_work_is_rejected(bundle_like, monkeypatch):
 
 def test_the_wrapper_quotes_paths_with_spaces(tmp_path, monkeypatch):
     """A DMG can be mounted at `/Volumes/Fused Render`; nothing may split on it."""
+    if os.name == "nt":
+        # Same gate `_wrapper_interpreter` itself documents: "Windows
+        # interpreters self-locate; there is no PYTHONHOME to restore and no
+        # POSIX shell to do it with." It returns None before ever generating
+        # a body to inspect, regardless of PYTHONHOME below — this is the
+        # `bundle_like` fixture's own skip, just reached directly instead of
+        # through that fixture.
+        pytest.skip("the wrapper is POSIX-only by design")
     monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "a state dir"))
     home = tmp_path / "home with spaces"
     (home / "lib").mkdir(parents=True)
@@ -1535,6 +1553,11 @@ def test_the_wrapper_quotes_paths_with_spaces(tmp_path, monkeypatch):
 def test_the_wrapper_is_private_and_regenerated_only_when_it_changes(
     tmp_path, monkeypatch
 ):
+    if os.name == "nt":
+        # Same gate as test_the_wrapper_quotes_paths_with_spaces above: no
+        # wrapper is ever generated on Windows, so there is no 0700 mode or
+        # regenerated body to assert on.
+        pytest.skip("the wrapper is POSIX-only by design")
     monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "state"))
     home = tmp_path / "home"
     (home / "lib").mkdir(parents=True)

--- a/tests/test_env_install.py
+++ b/tests/test_env_install.py
@@ -393,7 +393,9 @@ def test_the_bundled_uv_is_found_beside_the_interpreter(tmp_path, monkeypatch):
     (fake_app / "Resources" / "bin").mkdir(parents=True)
     interp = fake_app / "MacOS" / "python"
     interp.write_text("")
-    uv = fake_app / "Resources" / "bin" / "uv"
+    # uv_bin() looks for "uv.exe" on win32 (see uv_bin's own `name` line) —
+    # match that filename, same as the sibling test just below.
+    uv = fake_app / "Resources" / "bin" / ("uv.exe" if os.name == "nt" else "uv")
     uv.write_text("")
     monkeypatch.setattr(sys, "executable", str(interp))
     monkeypatch.delenv("FUSED_RENDER_UV_BIN", raising=False)
@@ -508,6 +510,7 @@ def test_a_server_already_on_312_builds_script_venvs_from_ITSELF(
     assert envinstall.script_python_ready() is True
 
 
+@pytest.mark.skipif(os.name == "nt", reason="needs a POSIX #! stub interpreter")
 def test_a_server_on_the_WRONG_version_resolves_a_uv_managed_312(
     tmp_path, monkeypatch, _fresh_script_python
 ):
@@ -574,6 +577,7 @@ def test_a_machine_with_no_uv_at_all_keeps_working_as_before(
     assert envinstall.script_python_ready() is True
 
 
+@pytest.mark.skipif(os.name == "nt", reason="needs a POSIX #! stub interpreter")
 def test_an_explicit_script_python_override_wins_but_is_still_probed(
     tmp_path, monkeypatch, _fresh_script_python
 ):
@@ -591,6 +595,7 @@ def test_an_explicit_script_python_override_wins_but_is_still_probed(
     assert envinstall.script_python_ready() is False
 
 
+@pytest.mark.skipif(os.name == "nt", reason="needs a POSIX #! stub interpreter")
 def test_the_interpreter_is_resolved_ONCE_per_process(
     tmp_path, monkeypatch, _fresh_script_python
 ):
@@ -651,6 +656,7 @@ def test_the_interpreter_is_never_ANOTHER_VENVS_python(
     assert "--managed-python" in find and "--no-project" in find, repr(find)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="needs a POSIX #! stub interpreter")
 def test_a_not_ready_verdict_is_never_CACHED(tmp_path, monkeypatch, _fresh_script_python):
     """"Nothing here yet" is a fact about this instant, not about the machine.
 

--- a/tests/test_file_history.py
+++ b/tests/test_file_history.py
@@ -21,6 +21,7 @@ The three semantics that are easy to get wrong and are each pinned below:
 """
 import importlib.util
 import os
+import sys
 
 import pytest
 
@@ -30,6 +31,19 @@ from _claude_history import (  # noqa: F401  (claude_home is a fixture)
 skip_root = pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
     reason="read-only bits are ignored when running as root")
+
+# Windows has no POSIX permission-bit model: os.chmod() on a DIRECTORY there
+# only flips the cosmetic FILE_ATTRIBUTE_READONLY flag, which does not stop
+# os.listdir/open-for-write inside it the way a missing POSIX write-bit does
+# (unlike a read-only FILE, which Windows does enforce for writes). So
+# `os.chmod(some_dir, 0o000)` — used below to force an unlistable/unwritable
+# session dir or history root — is a no-op there, and the refusal each of
+# these tests pins simply cannot be produced on that platform.
+skip_windows_dir_perms = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows ignores chmod() on directories (no POSIX write-bit); "
+           "os.listdir/open still succeed there, so this refusal can't be "
+           "forced the way it can on POSIX")
 
 
 def _load():
@@ -43,7 +57,11 @@ def _load():
 
 def _target(tmp_path, content="a\nb\nc\n", name="page.html"):
     f = tmp_path / name
-    f.write_text(content)
+    # `newline=""` — same reason as `write_version`'s in _claude_history.py:
+    # the default text-mode write translates "\n" to os.linesep, which
+    # inflates every size/byte assertion below on Windows for no reason this
+    # test cares about.
+    f.write_text(content, newline="")
     return str(f)
 
 
@@ -70,7 +88,14 @@ def test_history_root_sits_under_the_config_dir(claude_home):
 def test_the_hash_is_sha256_of_the_absolute_path_truncated_to_16(claude_home):
     import hashlib
     fh = _load()
-    p = os.path.join(os.sep + "abs", "some", "file.py")
+    # Must already be a fixed point of os.path.abspath, or this test's own
+    # `want` and what path_hash() (which calls abspath internally) hashes
+    # would diverge. `os.sep + "abs"` is enough on POSIX (a leading "/" is a
+    # complete absolute path there), but on Windows it is only
+    # drive-relative — os.path.isabs() calls it absolute, yet os.path.abspath
+    # still rewrites it by prepending the current drive (e.g. "C:"), which
+    # would silently hash a different string than `p`.
+    p = os.path.abspath(os.path.join(os.sep + "abs", "some", "file.py"))
     want = hashlib.sha256(p.encode()).hexdigest()[:16]
     assert fh.path_hash(p) == want
     assert len(fh.path_hash(p)) == 16
@@ -502,6 +527,7 @@ def test_a_read_only_file_is_not_reverted(claude_home, tmp_path):
 
 
 @skip_root
+@skip_windows_dir_perms
 def test_a_read_only_directory_is_not_reverted(claude_home, tmp_path):
     fh = _load()
     f = _target(tmp_path, "current\n")
@@ -651,6 +677,7 @@ def test_a_file_with_no_versions_but_a_live_store(claude_home, tmp_path):
 
 
 @skip_root
+@skip_windows_dir_perms
 def test_an_unreadable_session_dir_is_skipped_not_fatal(claude_home, tmp_path):
     fh = _load()
     f = _target(tmp_path)
@@ -1051,6 +1078,7 @@ def test_a_failing_mount_probe_is_treated_as_not_writable(claude_home, tmp_path,
 # --- M2: an unreadable store is not a fact about the file ----------------
 
 @skip_root
+@skip_windows_dir_perms
 def test_an_unlistable_history_root_is_named_not_reported_as_no_versions(
         claude_home, tmp_path):
     fh = _load()
@@ -1069,6 +1097,7 @@ def test_an_unlistable_history_root_is_named_not_reported_as_no_versions(
 
 
 @skip_root
+@skip_windows_dir_perms
 def test_an_unlistable_session_dir_names_the_path_and_errno(claude_home,
                                                              tmp_path):
     fh = _load()

--- a/tests/test_fusedcli_override.py
+++ b/tests/test_fusedcli_override.py
@@ -1,0 +1,120 @@
+"""FUSED_RENDER_FUSED_BIN -> argv, across both platforms' quoting rules.
+
+The override is how a dev points at a local build and how the test suite
+substitutes a stub CLI, so it is parsed on the canvases request path. It used
+to be a plain `override.split()`, which is fine for the documented compound
+form ("uv run fused") and wrong for the single most common interpreter
+location on Windows: `C:\\Program Files\\...` came apart mid-path, and the
+override then "wasn't found" (or ran something else) with nothing in the
+failure naming the space as the cause.
+
+`os.name` is patched rather than skipping per platform: the branch is selected
+on os.name alone, so both halves are checked from any host. That matters here
+because the two lexers are NOT interchangeable — each is actively wrong on the
+other platform, which is the whole reason the branch exists.
+"""
+import os
+from unittest import mock
+
+import pytest
+
+from fused_render import fusedcli
+
+
+@pytest.fixture()
+def as_posix(monkeypatch):
+    monkeypatch.setattr(fusedcli.os, "name", "posix")
+
+
+@pytest.fixture()
+def as_windows(monkeypatch):
+    monkeypatch.setattr(fusedcli.os, "name", "nt")
+
+
+# -- the documented compound form, unchanged on both ---------------------------
+
+
+@pytest.mark.parametrize("name", ["posix", "nt"])
+def test_a_compound_command_still_splits(monkeypatch, name):
+    monkeypatch.setattr(fusedcli.os, "name", name)
+    assert fusedcli._split_override("uv run fused") == ["uv", "run", "fused"]
+
+
+@pytest.mark.parametrize("name", ["posix", "nt"])
+def test_a_plain_single_path_is_one_arg(monkeypatch, name):
+    monkeypatch.setattr(fusedcli.os, "name", name)
+    assert fusedcli._split_override("/usr/bin/fused") == ["/usr/bin/fused"]
+
+
+# -- the bug: a path containing spaces -----------------------------------------
+
+
+def test_a_quoted_windows_program_files_path_survives(as_windows):
+    """The reported bug. Quoting has to be the fix — an unquoted path with a
+    space is ambiguous by construction (see the test below)."""
+    assert fusedcli._split_override(
+        r'"C:\Program Files\Python\python.exe" -m fused'
+    ) == [r"C:\Program Files\Python\python.exe", "-m", "fused"]
+
+
+def test_a_quoted_posix_path_with_spaces_survives(as_posix):
+    assert fusedcli._split_override('"/opt/my apps/py" -m fused') == [
+        "/opt/my apps/py", "-m", "fused"]
+
+
+def test_an_unquoted_path_with_spaces_still_splits(as_windows):
+    """Documented limitation, asserted so it stays a known shape rather than a
+    surprise: no lexer can tell where this path ends, and a shell could not
+    read it either."""
+    assert fusedcli._split_override(
+        r'C:\Program Files\Python\python.exe -m fused'
+    ) == [r"C:\Program", r"Files\Python\python.exe", "-m", "fused"]
+
+
+# -- why the lexer is chosen per platform --------------------------------------
+
+
+def test_windows_backslashes_are_not_eaten_as_escapes(as_windows):
+    """posix=True would parse this to "C:Pythonpython.exe" — not a path at all.
+    This is the assertion that pins the non-posix lexer on Windows."""
+    assert fusedcli._split_override(r"C:\Python\python.exe -m fused") == [
+        r"C:\Python\python.exe", "-m", "fused"]
+
+
+def test_posix_backslash_escapes_still_work(as_posix):
+    """The mirror of the above: posix=False would leave this split in two, so
+    the posix lexer has to stay on POSIX."""
+    assert fusedcli._split_override("/opt/my\\ apps/py -m fused") == [
+        "/opt/my apps/py", "-m", "fused"]
+
+
+# -- malformed input degrades, it does not raise -------------------------------
+
+
+@pytest.mark.parametrize("name", ["posix", "nt"])
+def test_an_unbalanced_quote_falls_back_instead_of_raising(monkeypatch, name):
+    """fused_cli() is on the canvases request path; a malformed env var must
+    not turn every call into a 500."""
+    monkeypatch.setattr(fusedcli.os, "name", name)
+    assert fusedcli._split_override('"C:\\unbalanced') == ['"C:\\unbalanced']
+
+
+# -- and the resolution around it ----------------------------------------------
+
+
+def test_fused_cli_uses_the_parsed_override(monkeypatch, as_windows):
+    monkeypatch.setenv("FUSED_RENDER_FUSED_BIN",
+                       r'"C:\Program Files\Python\python.exe" -m fused')
+    cli = fusedcli.fused_cli()
+    assert cli is not None
+    assert cli.external is True
+    assert cli.command == [r"C:\Program Files\Python\python.exe", "-m", "fused"]
+
+
+def test_a_whitespace_only_override_resolves_to_no_cli(monkeypatch):
+    """An override that parses to nothing must not become an empty argv a
+    subprocess call would choke on."""
+    monkeypatch.setenv("FUSED_RENDER_FUSED_BIN", "   ")
+    with mock.patch.object(fusedcli.importlib.util, "find_spec",
+                           return_value=None):
+        assert fusedcli.fused_cli() is None

--- a/tests/test_git_condition.py
+++ b/tests/test_git_condition.py
@@ -298,7 +298,12 @@ def test_git_is_invoked_non_interactively(gate, repo, monkeypatch):
     # tests/test_git_posix_spawn.py). Still exactly one basename, still a list,
     # still no shell — which is what this assertion is really about.
     assert os.path.isabs(seen["argv"][0])
-    assert os.path.basename(seen["argv"][0]) in ("git", "git.exe")
+    # `.lower()`: `shutil.which("git")` on Windows resolves the bare name by
+    # trying each `PATHEXT` entry as-is, and the default `PATHEXT` spells its
+    # entries `.EXE` — so the resolved path this app actually runs is literally
+    # `...\git.EXE`, uppercase extension, with no lowercase form on disk to fall
+    # back to. That is still "git", not a different binary.
+    assert os.path.basename(seen["argv"][0]).lower() in ("git", "git.exe")
     assert "--no-pager" in seen["argv"]
     assert env.get("GIT_TERMINAL_PROMPT") == "0"
     assert env.get("GIT_OPTIONAL_LOCKS") == "0"

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -114,7 +114,17 @@ def test_stage_covers_an_untracked_file(ops, repo):
     # `git add` is deliberately the one verb for both: the UI's "+" means "make
     # this part of the next commit", and a user does not think of a new file as a
     # different operation from an edited one.
-    write(repo, "pkg/fresh.txt", "new\n")
+    #
+    # Raw bytes here, not the shared `write()` helper: that helper opens in
+    # Python TEXT mode, which silently turns every `\n` into `\r\n` on Windows.
+    # This file is staged a moment later by `ops.py`'s OWN git subprocess — a
+    # different invocation than the one `status()` below uses to read the
+    # result back — so whatever line-ending handling that git decides to apply
+    # while staging is not guaranteed to still agree with the worktree bytes by
+    # the time this test checks the exact status code. Pure `\n` bytes make
+    # that question moot rather than needing to be right about git's answer.
+    with open(os.path.join(repo, "pkg", "fresh.txt"), "wb") as handle:
+        handle.write(b"new\n")
     assert ops.main(os.path.join(repo, "pkg"), op="stage",
                     paths=["pkg/fresh.txt"])["ok"] is True
     assert status(repo)["pkg/fresh.txt"] == "A "
@@ -884,7 +894,12 @@ def test_every_mutating_invocation_is_pinned_hardened_and_bounded(
         # tests/test_git_posix_spawn.py). Still exactly one basename, still a list,
         # still no shell — which is what this assertion is really about.
         assert os.path.isabs(argv[0])
-        assert os.path.basename(argv[0]) in ("git", "git.exe")
+        # `.lower()`: `shutil.which("git")` on Windows resolves the bare name by
+        # trying each `PATHEXT` entry as-is, and the default `PATHEXT` spells its
+        # entries `.EXE` — so the resolved path this app actually runs is
+        # literally `...\git.EXE`, uppercase extension, with no lowercase form on
+        # disk to fall back to. That is still "git", not a different binary.
+        assert os.path.basename(argv[0]).lower() in ("git", "git.exe")
         assert "--no-pager" in argv
         # Exactly one invocation is pinned to the TARGET rather than the root:
         # the `--show-toplevel` bootstrap that discovers the root in the first

--- a/tests/test_git_posix_spawn.py
+++ b/tests/test_git_posix_spawn.py
@@ -593,5 +593,10 @@ def test_git_bin_is_absolute_and_cached():
     assert os.path.isabs(first) or first == "git"   # "git" only with no PATH
     assert gitignore.git_bin() is first             # cached, not re-resolved
     if first != "git":
-        assert os.path.basename(first) in ("git", "git.exe")
+        # `.lower()`: `shutil.which("git")` on Windows resolves the bare name by
+        # trying each `PATHEXT` entry as-is, and the default `PATHEXT` spells its
+        # entries `.EXE` — so the resolved path is literally `...\git.EXE`,
+        # uppercase extension, with no lowercase form on disk to fall back to.
+        # That is still "git", not a different binary.
+        assert os.path.basename(first).lower() in ("git", "git.exe")
         assert os.access(first, os.X_OK)

--- a/tests/test_git_reader.py
+++ b/tests/test_git_reader.py
@@ -499,7 +499,12 @@ def test_every_invocation_is_pinned_hardened_and_bounded(reader, repo, monkeypat
         # tests/test_git_posix_spawn.py). Still exactly one basename, still a list,
         # still no shell — which is what this assertion is really about.
         assert os.path.isabs(argv[0])
-        assert os.path.basename(argv[0]) in ("git", "git.exe")
+        # `.lower()`: `shutil.which("git")` on Windows resolves the bare name by
+        # trying each `PATHEXT` entry as-is, and the default `PATHEXT` spells its
+        # entries `.EXE` — so the resolved path this app actually runs is
+        # literally `...\git.EXE`, uppercase extension, with no lowercase form on
+        # disk to fall back to. That is still "git", not a different binary.
+        assert os.path.basename(argv[0]).lower() in ("git", "git.exe")
         assert "--no-pager" in argv
         assert "-C" in argv
         # Exactly one invocation is pinned to the TARGET rather than the root:

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -99,7 +99,11 @@ def test_a_repo_is_the_parent_of_a_dot_git_row(home, tmp_path, client):
     _write_dirs_index([str(tmp_path), str(repo), _git(repo)])
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is True
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    # `.as_posix()`, not `str()`: the endpoint canonicalizes every path it
+    # returns to forward slashes (`_view_url_codec.canonical_fs_path`), while a
+    # bare `str(Path)` on Windows is backslashed — comparing against that raw
+    # spelling fails on Windows for no reason the app got wrong.
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
 
 
 def test_a_dir_without_a_dot_git_row_is_not_a_repo(home, tmp_path, client):
@@ -118,7 +122,7 @@ def test_nested_repos_are_both_listed_in_path_order(home, tmp_path, client):
                        _git(inner), str(other), _git(other)])
     body = client.get("/api/git-repos").json()
     assert [r["path"] for r in body["repos"]] == [
-        str(other), str(outer), str(inner),
+        other.as_posix(), outer.as_posix(), inner.as_posix(),
     ]
 
 
@@ -134,7 +138,7 @@ def test_the_endpoint_does_not_stat_anything(home, tmp_path, client, monkeypatch
     monkeypatch.setattr(mod.os.path, "isdir",
                         lambda p: (probed.append(p), False)[1])
     body = client.get("/api/git-repos").json()
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
     assert not any(str(repo) in p for p in probed)
 
 
@@ -151,7 +155,7 @@ def test_junk_path_screens_the_PARENT_not_the_dot_git_row(home, tmp_path, client
     vendored = tmp_path / "proj" / "node_modules" / "dep"
     _write_dirs_index([_git(mine), _git(hidden), _git(nested), _git(vendored)])
     body = client.get("/api/git-repos").json()
-    assert [r["path"] for r in body["repos"]] == [str(mine)]
+    assert [r["path"] for r in body["repos"]] == [mine.as_posix()]
 
 
 def test_a_repo_inside_a_fused_render_home_is_excluded(home, tmp_path, client):
@@ -162,7 +166,7 @@ def test_a_repo_inside_a_fused_render_home_is_excluded(home, tmp_path, client):
     outside = tmp_path / "real"
     _write_dirs_index([_git(inside), _git(outside)])
     body = client.get("/api/git-repos").json()
-    assert [r["path"] for r in body["repos"]] == [str(outside)]
+    assert [r["path"] for r in body["repos"]] == [outside.as_posix()]
 
 
 # -- states that are not an answer ---------------------------------------------
@@ -217,7 +221,7 @@ def test_a_stale_index_WITH_rows_serves_them_marked_stale(home, tmp_path, client
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is True
     assert body["stale"] is True
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
 
 
 def test_a_fresh_index_with_no_repos_is_a_real_empty_answer(home, tmp_path, client):
@@ -258,7 +262,7 @@ def test_a_scan_in_flight_over_a_usable_index_serves_it_marked_stale(
     assert body["indexed"] is True
     assert body["scanning"] is True
     assert body["stale"] is True
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
 
 
 def test_no_index_at_all_says_so_distinctly(home, tmp_path, client):
@@ -277,7 +281,7 @@ def test_an_index_with_no_applied_signature_reads_stale_but_still_answers(
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is True
     assert body["stale"] is True
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
 
 
 def test_a_partially_rescanned_multi_root_index_serves_what_it_has(home, tmp_path,
@@ -286,20 +290,26 @@ def test_a_partially_rescanned_multi_root_index_serves_what_it_has(home, tmp_pat
     under the reconciled root are real and get served; `stale` says the picture is
     incomplete. Hiding them would be the "refuse to answer while behind" mistake —
     an index is essentially always behind on at least one root."""
+    from fused_render.index import runner
+
     a, b = tmp_path / "a", tmp_path / "b"
     repo = a / "repo"
     _set_roots([a, b])
     cfg = _write_dirs_index([str(repo), _git(repo)], applied=False)
-    save_applied_ignore(cfg, str(a))   # only /a reconciled
+    # `_fresh` looks up `applied_ignore_sig(cfg, r)` for `r in scan_roots(cfg)`,
+    # which hands back `runner.canonical_root` spellings — so stamping the RAW
+    # `str(a)` key would never match that lookup on Windows (`C:\...\a` vs the
+    # stored `C:/.../a`), and this root would read as never-reconciled forever.
+    save_applied_ignore(cfg, runner.canonical_root(str(a)))   # only /a reconciled
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is True
     assert body["stale"] is True
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
-    save_applied_ignore(cfg, str(b))
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
+    save_applied_ignore(cfg, runner.canonical_root(str(b)))
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is True
     assert body["stale"] is False      # every root now reconciled
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
 
 
 def test_a_root_configured_in_a_NON_canonical_spelling_still_reads_usable(
@@ -332,7 +342,7 @@ def test_a_root_configured_in_a_NON_canonical_spelling_still_reads_usable(
 
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is True
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
 
 
 def test_a_legacy_sig_root_is_stale_even_once_another_root_is_stamped(
@@ -349,6 +359,7 @@ def test_a_legacy_sig_root_is_stale_even_once_another_root_is_stamped(
     withholding it — but the detection must not: `stale: false` here would promise a
     complete picture of a machine half of which was never scanned under these
     rules."""
+    from fused_render.index import runner
     from fused_render.index.store import applied_ignore_sig
 
     a, b = tmp_path / "a", tmp_path / "b"
@@ -358,14 +369,18 @@ def test_a_legacy_sig_root_is_stale_even_once_another_root_is_stamped(
     # the pre-per-root file, then one root migrated onto the new format
     with open(cfg.applied_ignore_json, "w") as f:
         json.dump({"sig": "a-pre-leaf-rule-global-sig"}, f)
-    save_applied_ignore(cfg, str(a))
+    # canonical, matching what scan_roots()/save_applied_ignore's real caller
+    # stamps — a raw `str(a)` key would just never match `a`'s lookup either,
+    # which would hide the very distinction ("a" migrated, "b" is not) this
+    # test is about.
+    save_applied_ignore(cfg, runner.canonical_root(str(a)))
 
     # the rootless form is exactly as misleading as reported...
     assert applied_ignore_sig(cfg) == cfg.rules.sig()
     # ...and the endpoint must not be fooled into claiming freshness
     body = client.get("/api/git-repos").json()
     assert body["stale"] is True
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
 
 
 def test_an_unreadable_index_is_a_502_not_not_indexed(home, tmp_path, client):
@@ -400,6 +415,7 @@ def test_opening_the_tab_fires_a_freshness_check_on_the_scan_roots(
     """The tab is served entirely from the index, so without this it is the one
     surface in the app that can never notice the index is behind — /api/fs/list
     fires the same check for every folder the explorer opens."""
+    from fused_render.index import runner
     from fused_render.server.routers import index as index_mod
 
     a = tmp_path / "a"
@@ -415,10 +431,13 @@ def test_opening_the_tab_fires_a_freshness_check_on_the_scan_roots(
     _reset_rotation(monkeypatch)
 
     body = client.get("/api/git-repos").json()
-    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert [r["path"] for r in body["repos"]] == [repo.as_posix()]
     # A configured root, and nothing else: the tab is machine-wide, so a root is
-    # the only path it can name.
-    assert checked == [str(a)]
+    # the only path it can name. `scan_roots()` hands `note_folder_opened` the
+    # `runner.canonical_root` spelling, not the raw configured one — so the
+    # expectation has to be built the same way, or this compares canonical
+    # against raw on Windows for no reason the app got wrong.
+    assert checked == [runner.canonical_root(str(a))]
 
 
 def test_successive_tab_opens_check_each_root_in_turn(home, tmp_path, client,
@@ -431,6 +450,7 @@ def test_successive_tab_opens_check_each_root_in_turn(home, tmp_path, client,
     config read later, so every subsequent root in the same request fails its
     non-blocking acquire. The first root would win every request forever and the
     second would never be checked at all."""
+    from fused_render.index import runner
     from fused_render.server.routers import index as index_mod
 
     a = tmp_path / "a"
@@ -446,7 +466,8 @@ def test_successive_tab_opens_check_each_root_in_turn(home, tmp_path, client,
 
     for _ in range(4):
         assert client.get("/api/git-repos").status_code == 200
-    assert checked == [str(a), str(b), str(a), str(b)]
+    assert checked == [runner.canonical_root(str(a)), runner.canonical_root(str(b)),
+                       runner.canonical_root(str(a)), runner.canonical_root(str(b))]
 
 
 def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
@@ -458,6 +479,7 @@ def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
     rotation down with it: the roots are independent questions, and a config
     where one of them wedges the check for every other one is the failure that
     hides itself."""
+    from fused_render.index import runner
     from fused_render.server.routers import index as index_mod
 
     a = tmp_path / "a"
@@ -468,10 +490,17 @@ def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
     repo = a / "repo"
     _write_dirs_index([str(a), str(repo), _git(repo)])
     checked = []
+    # `boom` is handed whatever `note_folder_opened` is actually called with —
+    # the `runner.canonical_root` spelling `scan_roots()` returns, not the raw
+    # configured one — so it has to recognise "root a" in that same spelling or
+    # it never raises on Windows and this test silently stops exercising the
+    # "a bad root must not take the rotation down with it" scenario it exists
+    # to pin.
+    canonical_a = runner.canonical_root(str(a))
 
     def boom(path):
         checked.append(path)
-        if path == str(a):
+        if path == canonical_a:
             raise RuntimeError("freshness exploded")
         return True
 
@@ -481,6 +510,6 @@ def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
     for _ in range(2):
         resp = client.get("/api/git-repos")
         assert resp.status_code == 200
-        assert [r["path"] for r in resp.json()["repos"]] == [str(repo)]
+        assert [r["path"] for r in resp.json()["repos"]] == [repo.as_posix()]
     # the throwing root took its turn and the next request moved on regardless
-    assert checked == [str(a), str(b)]
+    assert checked == [canonical_a, runner.canonical_root(str(b))]

--- a/tests/test_git_view_renders.py
+++ b/tests/test_git_view_renders.py
@@ -171,7 +171,12 @@ def test_the_probe_fails_on_a_template_that_throws(reader, tmp_path):
     # The exact failure that shipped: a second top-level `let streamed`.
     src = src.replace("let streamed = \"\";",
                       "let streamed = \"\";\nlet streamed = \"\";", 1)
-    broken.write_text(src)
+    # `encoding="utf-8"`, matching the read above: the template carries real
+    # non-ASCII text (a U+2212 MINUS SIGN, at least), and `Path.write_text`
+    # with no encoding falls back to `locale.getpreferredencoding()` — cp1252
+    # on a Windows runner, which cannot represent it and raises
+    # UnicodeEncodeError before the probe ever runs.
+    broken.write_text(src, encoding="utf-8")
 
     payloads = {"overview": reader.main(file=str(tmp_path), op="overview")}
     fixture = tmp_path / "f.json"
@@ -205,7 +210,9 @@ def test_the_probe_fails_on_a_template_that_paints_nothing(reader, tmp_path):
     assert "function render(data, stashes, diff) {" in src
     src = src.replace("function render(data, stashes, diff) {",
                       "function render(data, stashes, diff) {\n  return;", 1)
-    broken.write_text(src)
+    # See the twin fixture above: without an explicit encoding this is a
+    # UnicodeEncodeError on Windows, not a broken-template test.
+    broken.write_text(src, encoding="utf-8")
 
     fixture = tmp_path / "f2.json"
     fixture.write_text(json.dumps({

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -621,7 +621,7 @@ def test_startup_schedules_one_scan_per_root(home, tmp_path, monkeypatch):
     cfg.roots = [str(src)]
     index_router.save_config(cfg)
     index_router.run_startup_scan(start_dir=str(tmp_path))
-    assert started == [str(src)]
+    assert started == [runner.canonical_root(str(src))]
 
 
 def test_startup_scan_is_debounced(home, tmp_path, monkeypatch):
@@ -632,7 +632,12 @@ def test_startup_scan_is_debounced(home, tmp_path, monkeypatch):
     cfg = load_config()
     cfg.roots = [str(src)]
     index_router.save_config(cfg)
-    runner._record_scan(cfg, str(src))  # a scan just ran
+    # `_record_scan` does not canonicalize its own `root` (only `last_scan`'s
+    # read side does — see test_index_freshness's floor test for the same
+    # asymmetry), so seeding the debounce record directly like this has to
+    # canonicalize first or `run_startup_scan`'s debounce check never finds
+    # it and starts a scan anyway.
+    runner._record_scan(cfg, runner.canonical_root(str(src)))  # a scan just ran
     index_router.run_startup_scan(start_dir=str(tmp_path))
     assert started == []
 
@@ -648,7 +653,7 @@ def test_startup_scan_rescans_once_the_debounce_has_elapsed(home, tmp_path, monk
     runner._record_scan(cfg, str(src))
     monkeypatch.setattr(index_router, "SCAN_DEBOUNCE_S", 0)
     index_router.run_startup_scan(start_dir=str(tmp_path))
-    assert started == [str(src)]
+    assert started == [runner.canonical_root(str(src))]
 
 
 def test_startup_scan_never_raises(home, tmp_path, monkeypatch):
@@ -683,7 +688,7 @@ def test_startup_scan_skips_a_root_that_is_gone(home, tmp_path, monkeypatch):
     cfg.roots = [str(tmp_path / "deleted"), str(ok)]
     index_router.save_config(cfg)
     index_router.run_startup_scan(start_dir=str(tmp_path))
-    assert started == [str(ok)]
+    assert started == [runner.canonical_root(str(ok))]
 
 
 # -- the compact corpus --------------------------------------------------------

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -46,6 +46,20 @@ def _tree(tmp_path):
     return src
 
 
+def _point_home_at(monkeypatch, path):
+    """Make `os.path.expanduser("~")` answer `path`, on every platform.
+
+    `monkeypatch.setenv("HOME", ...)` alone only works on POSIX: Windows'
+    `ntpath.expanduser` reads `USERPROFILE` (falling back to
+    `HOMEDRIVE`+`HOMEPATH`) and never consults `HOME` at all, so a test that
+    only sets `HOME` silently keeps pointing `warm_root()`/`config.home` at
+    the real machine's profile instead of the tree it built."""
+    real_expanduser = os.path.expanduser
+    monkeypatch.setenv("HOME", str(path))
+    monkeypatch.setattr(os.path, "expanduser",
+                        lambda p: str(path) if p == "~" else real_expanduser(p))
+
+
 # -- guards --------------------------------------------------------------------
 
 @pytest.mark.parametrize("path,body", [
@@ -821,7 +835,7 @@ def test_startup_warm_runs_the_home_pages_first_search(home, tmp_path, monkeypat
     FilesHome searches `config.home` (routers/config.py — `expanduser("~")`),
     not the folder the app was opened on, so a warm aimed anywhere else fills
     a pool the first keystroke never reads."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _point_home_at(monkeypatch, tmp_path)
     seen = []
     monkeypatch.setattr(index_router, "index_search",
                         lambda cfg, root, **kw: seen.append(("search", root))
@@ -835,8 +849,10 @@ def test_startup_warm_runs_the_home_pages_first_search(home, tmp_path, monkeypat
     index_router.run_startup_warm()
     # Same pair of calls the route makes, and pooled under the same index root:
     # a warm that filtered under a different key would fill a second pool.
+    # `filter_corpus`'s `index_root` comes from `enclosing_root(scan_roots(...))`
+    # — canonical_root form, not the caller's raw spelling.
     assert seen == [("search", index_router.runner.canonical_root("~")),
-                    ("filter", str(tmp_path))]
+                    ("filter", index_router.runner.canonical_root(str(tmp_path)))]
 
 
 def test_startup_warm_never_raises(home, tmp_path, monkeypatch):

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -903,9 +903,10 @@ def test_startup_warm_fills_the_gitignore_verdict_pool(home, tmp_path, monkeypat
     index_gitignore._cache.clear()
     # HOME is what the warm aims at; point it at the scanned tree so the warm
     # answers `covered` and actually sweeps.
-    monkeypatch.setenv("HOME", str(src))
+    _point_home_at(monkeypatch, src)
     index_router.run_startup_warm()
-    pool = index_gitignore._cache.get(str(src))
+    # the pool is keyed by canonical_root(src), not the raw literal.
+    pool = index_gitignore._cache.get(runner.canonical_root(str(src)))
     assert pool is not None
     assert "noise.log" in pool.ignored
     assert "alpha.txt" in pool.decider
@@ -944,7 +945,7 @@ def test_startup_warm_waits_for_the_scan_it_started(home, tmp_path, monkeypatch)
     index_router.save_config(cfg)
     index_gitignore._cache.clear()
     # HOME is what the warm aims at, and what the scheduler scans.
-    monkeypatch.setenv("HOME", str(src))
+    _point_home_at(monkeypatch, src)
     index_router.run_startup_scan(start_dir=str(tmp_path))
 
     # Force the uncovered branch rather than racing the worker: the first
@@ -964,7 +965,8 @@ def test_startup_warm_waits_for_the_scan_it_started(home, tmp_path, monkeypatch)
     index_router.run_startup_warm()
 
     assert len(calls) == 2, "the warm did not search again after the scan"
-    pool = index_gitignore._cache.get(str(src))
+    # the pool is keyed by canonical_root(src), not the raw literal.
+    pool = index_gitignore._cache.get(runner.canonical_root(str(src)))
     assert pool is not None
     assert "noise.log" in pool.ignored
     assert "alpha.txt" in pool.decider
@@ -1107,7 +1109,9 @@ def test_a_root_of_slash_survives_the_config_write(home, tmp_path):
     the empty string and silently drops the root."""
     body = _client(tmp_path).post("/api/index/config", json={"roots": ["/"]},
                                   headers={"X-Fused": "1"}).json()
-    assert body["roots"] == ["/"]
+    # canonical_root("/") is "/" on POSIX but the drive root ("D:/") on
+    # Windows — still a bare root either way, just not the literal "/".
+    assert body["roots"] == [runner.canonical_root("/")]
 
 
 def test_scanning_reflects_every_run_not_just_the_newest(home, tmp_path):

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -1339,7 +1339,7 @@ def test_a_stale_open_folder_gets_its_configured_root_rescanned(
     _write_dirs_index(load_config(), {str(src): 1, str(sub): 1})
     monkeypatch.setattr(index_router.freshness, "QUIET_S", 0.0)
     index_router._run_freshness_check(str(sub))
-    assert started == [str(src)]
+    assert started == [runner.canonical_root(str(src))]
 
 
 def test_a_root_checked_moments_ago_is_not_checked_again(
@@ -1361,8 +1361,11 @@ def test_a_root_checked_moments_ago_is_not_checked_again(
     # root, so checking again buys nothing.
     index_router._run_freshness_check(str(src))
     assert checked == [str(src / "sub")]
-    # ...and it comes back round once the window has passed.
-    index_router._freshness_checked[str(src)] -= index_router.FRESHNESS_CHECK_S + 1
+    # ...and it comes back round once the window has passed. Keyed on
+    # `enclosing_root`'s canonical match, same as the neighbouring tests —
+    # the raw literal was never a key here to begin with.
+    index_router._freshness_checked[runner.canonical_root(str(src))] -= (
+        index_router.FRESHNESS_CHECK_S + 1)
     index_router._run_freshness_check(str(src))
     assert checked == [str(src / "sub"), str(src)]
 
@@ -1566,11 +1569,18 @@ def test_the_models_fencing_is_stripped(answer, expected):
 
 
 def _write_dirs_index(cfg, dirs):
-    """A minimal real index whose dirs.parquet holds {dir: mtime_ns}."""
+    """A minimal real index whose dirs.parquet holds {dir: mtime_ns}.
+
+    Keys go through `canonical_root`: `freshness.indexed_mtime_ns` (and
+    `enclosing_root`) look a directory up by their OWN `norm(abspath(...))`
+    of it, so a row filed under a raw `str(Path)` literal — native-separator
+    on Windows — would silently miss every such lookup."""
     import pyarrow as pa
     import pyarrow.parquet as pq
 
+    from fused_render.index.runner import canonical_root
     from fused_render.index.store import Sink, compact
+    dirs = {canonical_root(d): mtime_ns for d, mtime_ns in dirs.items()}
     shards = os.path.join(cfg.dir, "shards")
     os.makedirs(shards, exist_ok=True)
     sink = Sink(shards, "t", pa, pq, cfg.shard_rows)

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -96,7 +96,9 @@ def test_scan_status_and_stats_over_a_real_tree(home, tmp_path):
         time.sleep(0.2)
     assert state is not None and state["running"] is False, state
     assert state["error"] is None, state["error"]
-    assert state["root"] == str(src)
+    # the real `runner.start` records `canonical_root(root)`, not the
+    # caller's raw spelling (platform.md §1) — a no-op of that on POSIX.
+    assert state["root"] == runner.canonical_root(str(src))
 
     stats = client.get("/api/index/stats", params={"root": str(src)}).json()
     assert stats["rows"] == 2
@@ -219,10 +221,13 @@ def test_config_round_trips_roots_and_ignore(home, tmp_path):
                        json={"roots": [str(tmp_path)], "ignore": ["node_modules", ""]},
                        headers={"X-Fused": "1"})
     assert resp.status_code == 200
-    assert resp.json()["roots"] == [str(tmp_path)]
+    # "roots" answers with `scan_roots(cfg)` — canonical_root form, not the
+    # caller's raw spelling (platform.md §1; routers/index.scan_roots).
+    canon = [runner.canonical_root(str(tmp_path))]
+    assert resp.json()["roots"] == canon
     assert resp.json()["ignore"] == ["node_modules", ""]  # verbatim
     body = client.get("/api/index/config").json()
-    assert body["roots"] == [str(tmp_path)]
+    assert body["roots"] == canon
     assert body["defaults"]  # the starting list is reported for a Reset button
 
 
@@ -306,7 +311,11 @@ def test_a_search_is_filtered_against_its_enclosing_index_root(home, tmp_path,
     # Both requests pool under the configured root, whichever folder was asked
     # for. A folder outside every root has no pool to share and gets None.
     client.get(f"/api/index/search?root={tmp_path.parent}")
-    assert seen == [str(tmp_path), str(tmp_path), None]
+    # The route hands `filter_corpus` the matched entry from `scan_roots`,
+    # which is already in `runner.canonical_root` form — not the caller's
+    # raw spelling (platform.md §1) — so the expectation has to be too.
+    canon = runner.canonical_root(str(tmp_path))
+    assert seen == [canon, canon, None]
 
 
 def test_saving_the_ignore_list_preserves_comments_and_blank_lines(home, tmp_path):
@@ -358,7 +367,17 @@ def test_saving_rules_mid_scan_supersedes_the_running_scan(home, tmp_path, monke
     index_router.save_config(cfg)
     # A scan is running under rules A, and rules A are what the index claims.
     live = index_router.runner.start(load_config(), str(root))
-    index_router.save_applied_ignore(load_config(), str(root))
+    # `save_applied_ignore` (unlike `runner.start`) does NOT canonicalize its
+    # own `root` — it trusts the caller, because its real caller (`scan.
+    # run_scan`) only ever gets there with the already-canonical spelling
+    # `runner.start` wrote into spec.json. Passing the raw `str(root)` here
+    # instead would file the fingerprint under a key `applied_ignore_sig`
+    # (looked up via the canonical `scan_roots(cfg)` entries) can never find,
+    # reading as "unknown" — which the route's `(sig or current) != current`
+    # check treats as "already reconciled", so `needs_rescan` comes back
+    # False instead of True.
+    index_router.save_applied_ignore(load_config(),
+                                     index_router.runner.canonical_root(str(root)))
 
     body = _client(tmp_path).post(
         "/api/index/config", json={"ignore": ["node_modules", "target"]},
@@ -385,15 +404,17 @@ def test_default_scan_roots_are_the_users_home(home, tmp_path, monkeypatch):
     real_expanduser = os.path.expanduser
     monkeypatch.setattr(os.path, "expanduser", lambda p: str(tmp_path / "userhome")
                         if p == "~" else real_expanduser(p))
+    # `scan_roots` answers in `runner.canonical_root` form (platform.md §1),
+    # not the raw native-separator string `expanduser`/`str(Path)` hand back.
     assert index_router.scan_roots(load_config(), start_dir=str(tmp_path)) == [
-        str(tmp_path / "userhome")]
+        runner.canonical_root(str(tmp_path / "userhome"))]
 
 
 def test_configured_roots_win_over_the_default(home, tmp_path):
     cfg = load_config()
     cfg.roots = [str(tmp_path / "proj")]
     assert index_router.scan_roots(cfg, start_dir=str(tmp_path)) == [
-        str(tmp_path / "proj")]
+        runner.canonical_root(str(tmp_path / "proj"))]
 
 
 def test_scan_roots_are_canonical_so_store_lookups_hit(home, tmp_path, monkeypatch):
@@ -424,8 +445,12 @@ def test_scan_roots_are_canonical_so_store_lookups_hit(home, tmp_path, monkeypat
     cfg.roots = ["~/proj", str(tmp_path / "other") + "/"]
     assert index_router.scan_roots(cfg) == [
         runner.canonical_root(r) for r in cfg.roots]
-    # ~ really was expanded, so this is not a tautology over two no-ops
-    assert index_router.scan_roots(cfg)[0] == str(tmp_path / "userhome" / "proj")
+    # ~ really was expanded, so this is not a tautology over two no-ops. Still
+    # wrapped in canonical_root: the concatenation above (`fake_home + p[1:]`)
+    # is native-separator on Windows, and canonical_root is what scan_roots
+    # itself would produce from that same expansion.
+    assert index_router.scan_roots(cfg)[0] == runner.canonical_root(
+        str(tmp_path / "userhome" / "proj"))
     # and the default root gets the same treatment
     cfg.roots = []
     assert index_router.scan_roots(cfg) == [runner.canonical_root("~")]
@@ -453,7 +478,9 @@ def test_scan_with_no_root_uses_the_configured_one(home, tmp_path, monkeypatch):
     cfg.roots = [str(tmp_path)]
     index_router.save_config(cfg)
     _client(tmp_path).post("/api/index/scan", json={}, headers={"X-Fused": "1"})
-    assert seen == [str(tmp_path)]
+    # the route resolves the missing root through `scan_roots`, which answers
+    # in canonical_root form, not the configured raw spelling.
+    assert seen == [runner.canonical_root(str(tmp_path))]
 
 
 def test_scan_with_no_root_covers_EVERY_root(home, tmp_path, monkeypatch):
@@ -473,11 +500,14 @@ def test_scan_with_no_root_covers_EVERY_root(home, tmp_path, monkeypatch):
     index_router.save_config(cfg)
     body = _client(tmp_path).post("/api/index/scan", json={"full": True},
                                   headers={"X-Fused": "1"}).json()
-    assert seen == [(str(a), True), (str(b), True)]
-    assert [r["root"] for r in body["runs"]] == [str(a), str(b)]
+    # every root the route hands to `start` came out of `scan_roots`, in
+    # canonical_root form.
+    ca, cb = runner.canonical_root(str(a)), runner.canonical_root(str(b))
+    assert seen == [(ca, True), (cb, True)]
+    assert [r["root"] for r in body["runs"]] == [ca, cb]
     # the single-run fields stay, for a caller that only knows about one
     assert body["run_id"] == "run-a"
-    assert body["root"] == str(a)
+    assert body["root"] == ca
 
 
 def test_scan_with_no_root_skips_roots_that_no_longer_exist(home, tmp_path, monkeypatch):
@@ -497,7 +527,8 @@ def test_scan_with_no_root_skips_roots_that_no_longer_exist(home, tmp_path, monk
     resp = _client(tmp_path).post("/api/index/scan", json={},
                                   headers={"X-Fused": "1"})
     assert resp.status_code == 200
-    assert [r["root"] for r in resp.json()["runs"]] == [str(live)]
+    assert [r["root"] for r in resp.json()["runs"]] == [
+        runner.canonical_root(str(live))]
 
 
 def test_scan_with_no_root_and_nothing_startable_is_an_error(home, tmp_path, monkeypatch):

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -1151,13 +1151,19 @@ def test_a_rules_edit_rescans_every_stale_root_not_just_the_first(home, tmp_path
     cfg = load_config()
     cfg.roots = [str(a), str(b)]
     index_router.save_config(cfg)
-    index_router.save_applied_ignore(cfg, str(a))
-    index_router.save_applied_ignore(cfg, str(b))
+    # `save_applied_ignore` trusts its `root` verbatim (only `runner.start`
+    # canonicalizes before calling it in production) — a raw native-separator
+    # literal here would file the fingerprint under a key the route's
+    # `scan_roots`-keyed staleness check can never find, reading as "already
+    # reconciled" instead of stale.
+    ca, cb = runner.canonical_root(str(a)), runner.canonical_root(str(b))
+    index_router.save_applied_ignore(cfg, ca)
+    index_router.save_applied_ignore(cfg, cb)
     body = _client(tmp_path).post(
         "/api/index/config", json={"ignore": ["node_modules", "target"]},
         headers={"X-Fused": "1"}).json()
     assert body["needs_rescan"] is True
-    assert started == [str(a), str(b)]
+    assert started == [ca, cb]
     assert body["rescan_run_ids"] == ["r1", "r2"]
 
 
@@ -1224,8 +1230,10 @@ def test_the_freshness_check_defers_before_it_stamps_the_check_clock(
     index_router._run_freshness_check(str(src))
     assert events == [("waited", index_router.FRESHNESS_DELAY_S, {}),
                       ("checked", str(src))]
-    # ...and the stamp did land, on the far side of the wait.
-    assert str(src) in index_router._freshness_checked
+    # ...and the stamp did land, on the far side of the wait. Stamped under
+    # `enclosing_root`'s canonical match, not the raw `path` the check was
+    # called with (that raw form is what `note_folder_opened` sees above).
+    assert runner.canonical_root(str(src)) in index_router._freshness_checked
 
 
 def test_a_check_that_will_refuse_anyway_never_waits(home, tmp_path,
@@ -1248,13 +1256,17 @@ def test_a_check_that_will_refuse_anyway_never_waits(home, tmp_path,
     # Under no configured root at all.
     index_router._run_freshness_check(str(tmp_path.parent))
     assert waits == []
-    # Under a root that was checked moments ago.
-    index_router._freshness_checked[str(src)] = time.time()
+    # Under a root that was checked moments ago. `_freshness_checked` is
+    # keyed on `enclosing_root`'s canonical match, not the raw path the check
+    # is called with — seeding it under the raw literal would always miss and
+    # every check would read as newly-due.
+    canon_src = runner.canonical_root(str(src))
+    index_router._freshness_checked[canon_src] = time.time()
     index_router._run_freshness_check(str(src))
     assert waits == []
     # ...and the wait IS paid once the root is genuinely due, so the two
     # assertions above are about due-ness and not about a wait that never runs.
-    index_router._freshness_checked[str(src)] -= index_router.FRESHNESS_CHECK_S + 1
+    index_router._freshness_checked[canon_src] -= index_router.FRESHNESS_CHECK_S + 1
     index_router._run_freshness_check(str(src))
     assert waits == [index_router.FRESHNESS_DELAY_S]
 

--- a/tests/test_index_freshness.py
+++ b/tests/test_index_freshness.py
@@ -20,19 +20,29 @@ from fused_render.index.freshness import (
     indexed_mtime_ns,
     note_folder_opened,
 )
+from fused_render.index.runner import canonical_root
 from fused_render.index.store import Sink, compact
 
 NS = 1_000_000_000
 
 
 def _index(tmp_path, root, dirs):
-    """A real index whose dirs.parquet holds `dirs` = {abs dir: mtime_ns}."""
+    """A real index whose dirs.parquet holds `dirs` = {abs dir: mtime_ns}.
+
+    Every key goes through `canonical_root` before it becomes a dirs.parquet
+    row: `indexed_mtime_ns`/`enclosing_root` look a directory up by
+    `norm(os.path.abspath(...))` of their OWN argument (freshness.py), so a
+    row filed under the raw literal this helper is handed — "/r", or a
+    native-separator `str(tmp_path / ...)` on Windows — silently misses every
+    query built from the same literal once that literal isn't already its own
+    abspath (a POSIX-only coincidence)."""
     cfg = IndexConfig(dir=str(tmp_path / "ix"))
     shards = str(tmp_path / "run" / "shards")
     os.makedirs(shards, exist_ok=True)
     sink = Sink(shards, "t", pa, pq, cfg.shard_rows)
+    root = canonical_root(root)
     for d, mtime_ns in dirs.items():
-        sink.add(d, "s", ("sig", [], 0, mtime_ns, 0))
+        sink.add(canonical_root(d), "s", ("sig", [], 0, mtime_ns, 0))
     sink.close()
     compact(cfg, root, shards, pa, pq)
     return cfg
@@ -79,13 +89,18 @@ def test_an_index_that_was_never_built_reads_as_unknown(tmp_path):
 # -- which root a folder belongs to -------------------------------------------
 
 @pytest.mark.parametrize("path,expected", [
-    ("/home/me/code/app", "/home/me/code"),
-    ("/home/me/code", "/home/me/code"),
+    ("/home/me/code/app", canonical_root("/home/me/code")),
+    ("/home/me/code", canonical_root("/home/me/code")),
     ("/home/me/other", None),
     # segment-wise, so a sibling with the root as a name prefix is not inside it
     ("/home/me/code-old/app", None),
 ])
 def test_enclosing_root_is_matched_segment_wise(path, expected):
+    # `enclosing_root` returns its OWN canonicalized spelling of a match
+    # (norm+abspath, freshness.py), not the caller's literal — hence
+    # `canonical_root(...)` rather than the bare "/home/me/code" above; the
+    # None cases need no such wrap since a non-match stays a non-match on
+    # every platform.
     assert enclosing_root(["/home/me/code"], path) == expected
 
 
@@ -94,7 +109,7 @@ def test_the_deepest_configured_root_wins():
     narrower one, and firing the outer root as well would scan its subtree
     twice."""
     roots = ["/a", "/a/b"]
-    assert enclosing_root(roots, "/a/b/c") == "/a/b"
+    assert enclosing_root(roots, "/a/b/c") == canonical_root("/a/b")
 
 
 # -- the trigger --------------------------------------------------------------
@@ -105,8 +120,8 @@ def test_a_folder_whose_mtime_moved_since_the_scan_triggers_a_rescan(
     sub = _tree(tmp_path, "root/sub")
     cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
     now = os.stat(sub).st_mtime + QUIET_S + 1
-    assert note_folder_opened(cfg, sub, [root], now=now) == root
-    assert spawned == [{"root": root, "full": False}]
+    assert note_folder_opened(cfg, sub, [root], now=now) == canonical_root(root)
+    assert spawned == [{"root": canonical_root(root), "full": False}]
 
 
 def test_an_unchanged_folder_triggers_nothing(tmp_path, spawned):
@@ -159,7 +174,12 @@ def test_a_root_scanned_within_the_floor_is_not_rescanned(tmp_path, spawned):
     sub = _tree(tmp_path, "root/sub")
     cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
     now = os.stat(sub).st_mtime + QUIET_S + 1
-    runner._record_scan(cfg, root)
+    # `_record_scan` (unlike `runner.start`, which calls it internally) does
+    # NOT canonicalize its own `root` argument before filing it — only
+    # `last_scan`'s READ side does — so calling it directly, as this test
+    # does to seed the floor without a real scan, has to canonicalize first
+    # or the write and the read never agree on the same key.
+    runner._record_scan(cfg, canonical_root(root))
     assert runner.last_scan(cfg, root) is not None
     # `now` is in the future relative to the record just written, so express the
     # floor from the record itself.
@@ -177,10 +197,10 @@ def test_a_root_scanned_two_minutes_ago_is_rescanned(tmp_path, spawned):
     root = _tree(tmp_path, "root")
     sub = _tree(tmp_path, "root/sub")
     cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
-    runner._record_scan(cfg, root)
+    runner._record_scan(cfg, canonical_root(root))  # see the floor test above
     at = runner.last_scan(cfg, root) + 120
-    assert note_folder_opened(cfg, sub, [root], now=at) == root
-    assert spawned == [{"root": root, "full": False}]
+    assert note_folder_opened(cfg, sub, [root], now=at) == canonical_root(root)
+    assert spawned == [{"root": canonical_root(root), "full": False}]
 
 
 def test_the_scan_floor_matches_the_routers_check_debounce(tmp_path):
@@ -266,7 +286,7 @@ def test_the_scan_it_starts_is_of_the_configured_root_not_the_open_folder(
     monkeypatch.setattr(runner, "_mounts_dir", lambda: "/nonexistent-mounts")
     monkeypatch.setattr(runner.subprocess, "Popen", lambda *a, **k: _Spawned())
     now = os.stat(sub).st_mtime + QUIET_S + 1
-    assert note_folder_opened(cfg, sub, [root], now=now) == root
+    assert note_folder_opened(cfg, sub, [root], now=now) == canonical_root(root)
     assert runner.last_scan(cfg, root) is not None
     assert runner.last_scan(cfg, sub) is None
 

--- a/tests/test_index_gitignore.py
+++ b/tests/test_index_gitignore.py
@@ -9,6 +9,7 @@ import subprocess
 import time
 from threading import Event, Thread
 
+from fused_render.index.ignore import norm
 from fused_render.server import index_gitignore
 from fused_render.server.index_gitignore import filter_corpus
 
@@ -153,12 +154,19 @@ def test_a_folder_is_answered_out_of_its_index_root_pool(tmp_path, monkeypatch):
     proj = tmp_path / "proj"
     proj.mkdir()
     (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
-    root = str(tmp_path)
+    # `_rel_prefix` (index_gitignore.py) checks `root.startswith(base + "/")`
+    # with a literal "/" — it is only ever handed roots that already went
+    # through `search_under`/`search_ranked`'s own canonicalization in
+    # production, so a raw native (backslash, on Windows) `str(Path)` here
+    # would make that startswith miss and silently fall back to a pool of
+    # its own, which is exactly the un-pooled behaviour this test exists to
+    # rule out.
+    root = norm(str(tmp_path))
     filter_corpus(_out(root, ["proj/.gitignore", "proj/a.log", "proj/a.py"]),
                   index_root=root)
     asked = _counting_queries(monkeypatch)
     # Now the in-folder search of proj/, whose rels are relative to proj/.
-    out = filter_corpus(_out(str(proj), [".gitignore", "a.log", "a.py"]),
+    out = filter_corpus(_out(norm(str(proj)), [".gitignore", "a.log", "a.py"]),
                         index_root=root)
     assert asked == []  # every verdict was already pooled
     assert [e["rel"] for e in out["entries"]] == [".gitignore", "a.py"]

--- a/tests/test_index_ignore.py
+++ b/tests/test_index_ignore.py
@@ -11,6 +11,7 @@ from fused_render.index.ignore import (
     clean_patterns,
     default_ignore,
     ignore_sig,
+    norm,
 )
 
 
@@ -64,7 +65,11 @@ def test_keep_subdirs_drops_ignored_and_hardcoded_skips():
 
 def test_expanduser_applies_to_path_patterns():
     r = IgnoreRules(["~/Library/Caches"])
-    assert r.is_ignored(os.path.expanduser("~/Library/Caches"))
+    # `IgnoreRules.__init__` compiles the pattern through `norm(expanduser(...))`
+    # (forward-slashed even on Windows, where `expanduser` itself hands back
+    # `C:\Users\...`); the path being tested against that regex has to make
+    # the same trip or a native separator never matches at all.
+    assert r.is_ignored(norm(os.path.expanduser("~/Library/Caches")))
 
 
 def test_ignore_sig_is_order_sensitive_and_stable():
@@ -78,10 +83,13 @@ def test_default_ignore_covers_the_mounts_dir_under_the_current_home(monkeypatch
     and walking a mount means kernel I/O on an rclone NFS path."""
     monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
     r = IgnoreRules(default_ignore())
-    assert r.is_ignored(str(tmp_path / "home" / "mounts"))
-    assert r.is_ignored_tree(str(tmp_path / "home" / "mounts" / "s3" / "deep"))
+    # `default_ignore()` compiles a `**/mounts` GLOB that is already `norm`ed
+    # (ignore.py) — the paths tested against it need the same forward-slash
+    # form, not the native (backslash, on Windows) spelling `str(Path)` gives.
+    assert r.is_ignored(norm(str(tmp_path / "home" / "mounts")))
+    assert r.is_ignored_tree(norm(str(tmp_path / "home" / "mounts" / "s3" / "deep")))
     # branch-nested checkouts get their own mounts folder
-    assert r.is_ignored(str(tmp_path / "home" / "branches" / "featureX" / "mounts"))
+    assert r.is_ignored(norm(str(tmp_path / "home" / "branches" / "featureX" / "mounts")))
 
 
 def test_the_walk_and_the_index_share_one_ignore_floor():

--- a/tests/test_index_mount_safe.py
+++ b/tests/test_index_mount_safe.py
@@ -15,17 +15,26 @@ import os
 import pytest
 
 from fused_render.index.config import IndexConfig
-from fused_render.index.ignore import MountGuard, default_ignore, IgnoreRules
+from fused_render.index.ignore import MountGuard, default_ignore, IgnoreRules, norm
+from fused_render.index.runner import canonical_root
 from fused_render.index.scan import run_scan
 from fused_render.index.store import read_manifest
 from tests._mount_safe_helpers import _mount, _no_kernel_on_mount, home  # noqa: F401
 
 
 def _run(cfg, root, mounts_dir):
+    """Write and run a spec exactly as `runner.start` would.
+
+    `run_scan` trusts `spec["root"]` is already canonical — `runner.start`
+    guarantees that before this path is ever reached in production
+    (platform.md §1) — and this helper calls `run_scan` directly, so it has
+    to make the same guarantee itself or the run's own top-level row lands
+    under the native (backslash, on Windows) spelling while everything
+    `scan_dir_once` discovers underneath it is `norm`ed to forward slashes."""
     run_dir = os.path.join(cfg.runs_dir, "run")
     os.makedirs(run_dir, exist_ok=True)
     with open(os.path.join(run_dir, "spec.json"), "w") as f:
-        json.dump({"root": root, "full": False, "started": 0,
+        json.dump({"root": canonical_root(root), "full": False, "started": 0,
                    "config": cfg.to_dict(), "mounts_dir": mounts_dir}, f)
     run_scan(run_dir)
     with open(os.path.join(run_dir, "events.jsonl")) as f:
@@ -60,9 +69,13 @@ def test_a_scan_over_the_home_never_kernel_touches_a_mount(home, tmp_path, monke
 
     end = [e for e in events if e.get("type") == "run_end"][-1]
     assert end["msg"] == "complete", end.get("error")
+    # every discovered path leaves scan_dir_once through `norm` (forward
+    # slashes) regardless of platform, so the literals compared against it
+    # have to make the same trip rather than assume POSIX's `str(Path)` is
+    # already canonical.
     indexed = _paths(cfg)
-    assert str(project / "local.txt") in indexed
-    assert not [p for p in indexed if p.startswith(str(mp))]
+    assert norm(str(project / "local.txt")) in indexed
+    assert not [p for p in indexed if p.startswith(norm(str(mp)))]
 
 
 def test_the_mounts_container_itself_is_never_descended(home, tmp_path, monkeypatch):
@@ -157,5 +170,9 @@ def test_the_default_ignore_list_also_names_the_mounts_dir(home):
     out of the index even for a caller that bypasses the walk (cached rows,
     a replayed FSEvents journal)."""
     rules = IgnoreRules(default_ignore())
-    assert rules.is_ignored(str(home / "mounts"))
-    assert rules.is_ignored_tree(str(home / "mounts" / "m1" / "deep"))
+    # `default_ignore()` builds a `**/mounts` GLOB pattern (already `norm`ed),
+    # matched with a regex that treats "/" as the only separator — so the
+    # path being tested has to be `norm`ed too, or a native (backslash, on
+    # Windows) `str(Path)` never matches at all.
+    assert rules.is_ignored(norm(str(home / "mounts")))
+    assert rules.is_ignored_tree(norm(str(home / "mounts" / "m1" / "deep")))

--- a/tests/test_index_query.py
+++ b/tests/test_index_query.py
@@ -14,6 +14,7 @@ import pytest
 
 from fused_render.index import query as index_query
 from fused_render.index.config import IndexConfig
+from fused_render.index.ignore import norm
 from fused_render.index.query import lookup, pattern_for, prune, stats
 from fused_render.index.store import Sink, compact
 
@@ -62,9 +63,15 @@ def test_pattern_escapes_like_metacharacters():
 
 
 def test_pattern_expands_and_anchors_a_tilde():
+    # `pattern_for` re-normalizes after expanding `~` (platform.md §1), so on
+    # Windows the prefix comes back forward-slashed even though
+    # `os.path.expanduser` itself hands back `C:\Users\...`. The expected
+    # value has to go through the same `norm` to stay honest on every
+    # platform instead of assuming POSIX's `expanduser` is already canonical.
     like, prefix = pattern_for("~/Doc")
-    assert prefix == os.path.expanduser("~/Doc")
-    assert like.startswith(os.path.expanduser("~/Doc"))
+    expected = norm(os.path.expanduser("~/Doc"))
+    assert prefix == expected
+    assert like.startswith(expected)
 
 
 # -- partition pruning ---------------------------------------------------------

--- a/tests/test_index_rank_concurrency.py
+++ b/tests/test_index_rank_concurrency.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 
 from fused_render.index import store, worker
 from fused_render.index.config import IndexConfig
+from fused_render.index.runner import canonical_root
 from fused_render.index.store import Sink, compact
 from fused_render.server import create_app
 
@@ -36,7 +37,12 @@ def test_the_worker_nices_itself_at_startup(monkeypatch, tmp_path):
     """Self-nicing in the child, never a preexec_fn: this repo's spawns must
     stay on posix_spawn (PROJ's atfork handler SIGSEGVs a fork)."""
     seen = []
-    monkeypatch.setattr(os, "nice", lambda inc: seen.append(inc) or 0)
+    # `raising=False`: `os.nice` does not exist on Windows at all, so
+    # asserting it existed first (monkeypatch's default) would fail before
+    # the fake is ever installed — this line means "give the module this
+    # attribute for the test", not "override an attribute already there".
+    monkeypatch.setattr(os, "nice", lambda inc: seen.append(inc) or 0,
+                        raising=False)
     ran = []
     monkeypatch.setattr(worker, "run_scan", ran.append)
     assert worker.main([str(tmp_path)]) == 0
@@ -87,21 +93,29 @@ def _tree(root, n_dirs=400, per_dir=100):
 
 
 def _prime_index(tmp_path, root, n=4000):
-    """A real index over `root` so ranking has a full corpus to scan."""
+    """A real index over `root` so ranking has a full corpus to scan.
+
+    Stored under `canonical_root(root)`, not the caller's raw `root`: the
+    scan/rank routes canonicalize whatever root they are given before
+    querying (platform.md §1), so a row filed under the un-normalized
+    literal — a no-op on POSIX, backslash-native on Windows — would leave
+    `/api/index/rank` answering `covered: false` with no hits before the
+    real scan below ever gets a chance to overlap it."""
     cfg = IndexConfig()
     shards = str(tmp_path / "prime-shards")
     os.makedirs(shards, exist_ok=True)
     sink = Sink(shards, "t", pa, pq, cfg.shard_rows)
+    root = canonical_root(root)
     # The root's own dirs row is what `covered` is decided on — without it the
     # route answers `uncovered` with no hits and the timing means nothing.
     sink.add(root, "s", ("sig", [], 0, 1_000_000_000, 0))
     per_dir = 100
     for d in range(n // per_dir):
-        dirp = os.path.join(root, f"pre{d:04d}")
+        dirp = canonical_root(os.path.join(root, f"pre{d:04d}"))
         rows = []
         for i in range(per_dir):
             name = f"file{i:03d}_alpha.txt"
-            rows.append((os.path.join(dirp, name), dirp, name, "txt",
+            rows.append((dirp + "/" + name, dirp, name, "txt",
                          10 + i, 100.0 + i))
         sink.add(dirp, "s", ("sig", rows, sum(r[4] for r in rows),
                              1_000_000_000, 0))

--- a/tests/test_index_runner.py
+++ b/tests/test_index_runner.py
@@ -70,7 +70,10 @@ def test_start_writes_a_spec_the_worker_can_read(tmp_path, spawned):
     cfg.ignore = ["node_modules"]
     started = runner.start(cfg, str(tmp_path), full=True)
     spec = json.load(open(os.path.join(cfg.runs_dir, started["run_id"], "spec.json")))
-    assert spec["root"] == str(tmp_path)
+    # `start` writes `canonical_root(root)`, not the caller's raw spelling
+    # (platform.md §1) — a no-op of that on POSIX, but forward-slashed on
+    # Windows where `str(tmp_path)` itself is backslash-native.
+    assert spec["root"] == runner.canonical_root(str(tmp_path))
     assert spec["full"] is True
     # the config travels WITH the run: the detached worker must not re-derive
     # the store location from an environment that may have moved
@@ -84,7 +87,11 @@ def test_start_expands_and_canonicalizes_the_root(tmp_path, spawned):
     sub = tmp_path / "sub"
     sub.mkdir()
     started = runner.start(cfg, str(sub) + "/")
-    assert started["root"] == str(sub)
+    # `str(sub)` alone is Windows' backslash-native spelling; `start` records
+    # `canonical_root(root)` (forward-slashed, trailing slash gone) — the
+    # same reason `test_start_writes_a_spec_the_worker_can_read` above needs
+    # the wrap, not a gap in `canonical_root` despite this test's name.
+    assert started["root"] == runner.canonical_root(str(sub))
 
 
 def test_start_rejects_a_non_directory(tmp_path, spawned):

--- a/tests/test_index_scan.py
+++ b/tests/test_index_scan.py
@@ -13,7 +13,8 @@ import pytest
 from _thread_scoped import this_thread_only
 
 from fused_render.index.config import IndexConfig
-from fused_render.index.ignore import IgnoreRules, MountGuard
+from fused_render.index.ignore import IgnoreRules, MountGuard, norm
+from fused_render.index.runner import canonical_root
 from fused_render.index.scan import keep_subdirs, run_scan, scan_dir_once
 from fused_render.index.store import (
     load_dir_cache,
@@ -30,6 +31,20 @@ def _guard(tmp_path):
     return MountGuard(mounts_dir=str(tmp_path / "nowhere-mounts"))
 
 
+def _p(path) -> str:
+    """The forward-slash spelling `scan_dir_once` itself writes (every
+    discovered path leaves through `norm`, platform.md §1) — plain
+    `str(tmp_path / ...)` gives the NATIVE separator instead, which is a
+    no-op of `norm` on POSIX but backslashes on Windows. That matters here
+    for more than cosmetics: `is_leaf_dir`/`ignored_for_index`/`IgnoreRules`
+    all slice the final path component on "/", so a raw Windows path handed
+    to them (or fed back in as a cache key, a `keep_subdirs` candidate, or a
+    monkeypatched fsevents hint) has no "/" at all and every leaf/ignore-name
+    check silently misses — not just a string that fails to `==` the
+    expected literal."""
+    return norm(str(path))
+
+
 def _tree(root):
     (root / "a.txt").write_text("aa", encoding="utf-8")
     (root / "sub").mkdir()
@@ -43,21 +58,21 @@ def _tree(root):
 def test_scan_dir_once_returns_rows_and_subdirs(tmp_path):
     _tree(tmp_path)
     rules = IgnoreRules([])
-    kind, payload, subs = scan_dir_once(str(tmp_path), {}, rules, _guard(tmp_path))
+    kind, payload, subs = scan_dir_once(_p(tmp_path), {}, rules, _guard(tmp_path))
     sig, rows, total, mtime_ns, n_subdirs = payload
     assert kind == "s"
     assert [r[2] for r in rows] == ["a.txt"]
     assert rows[0][3] == "txt"  # ext lowercased, dot stripped
     assert total == 2
-    assert sorted(subs) == sorted([str(tmp_path / "node_modules"), str(tmp_path / "sub")])
+    assert sorted(subs) == sorted([_p(tmp_path / "node_modules"), _p(tmp_path / "sub")])
     assert n_subdirs == 2
 
 
 def test_scan_dir_once_prunes_ignored_subdirs(tmp_path):
     _tree(tmp_path)
     kind, payload, subs = scan_dir_once(
-        str(tmp_path), {}, IgnoreRules(["node_modules"]), _guard(tmp_path))
-    assert subs == [str(tmp_path / "sub")]
+        _p(tmp_path), {}, IgnoreRules(["node_modules"]), _guard(tmp_path))
+    assert subs == [_p(tmp_path / "sub")]
     assert payload[4] == 1  # n_subdirs is the POST-prune count
 
 
@@ -67,8 +82,8 @@ def test_scan_dir_once_never_follows_symlinks(tmp_path):
     os.symlink(tmp_path / "real", tmp_path / "link")
     os.symlink(tmp_path / "real" / "f.txt", tmp_path / "linkf")
     kind, payload, subs = scan_dir_once(
-        str(tmp_path), {}, IgnoreRules([]), _guard(tmp_path))
-    assert subs == [str(tmp_path / "real")]
+        _p(tmp_path), {}, IgnoreRules([]), _guard(tmp_path))
+    assert subs == [_p(tmp_path / "real")]
     assert payload[1] == []  # the file symlink is not a file row either
 
 
@@ -110,12 +125,12 @@ def test_unchanged_non_leaf_recurses_but_reuses_its_rows(tmp_path):
     d = tmp_path / "parent"
     (d / "child").mkdir(parents=True)
     (d / "f.txt").write_text("x", encoding="utf-8")
-    cache = {str(d): (os.stat(d).st_mtime_ns, 1, 1)}
+    cache = {_p(d): (os.stat(d).st_mtime_ns, 1, 1)}
     kind, payload, subs = scan_dir_once(
-        str(d), cache, IgnoreRules([]), _guard(tmp_path))
+        _p(d), cache, IgnoreRules([]), _guard(tmp_path))
     assert kind == "u"
     assert payload == 1              # cached file count carried forward
-    assert subs == [str(d / "child")]  # still recursed into
+    assert subs == [_p(d / "child")]  # still recursed into
 
 
 def test_changed_directory_is_rescanned(tmp_path):
@@ -162,8 +177,8 @@ def test_a_package_directory_is_recorded_but_not_descended(tmp_path):
     recorded, with no file rows, and not listed."""
     app = _package(tmp_path)
     rules, guard = IgnoreRules([]), _guard(tmp_path)
-    assert scan_dir_once(str(tmp_path), {}, rules, guard)[2] == [str(app)]
-    kind, payload, subs = scan_dir_once(str(app), {}, rules, guard)
+    assert scan_dir_once(_p(tmp_path), {}, rules, guard)[2] == [_p(app)]
+    kind, payload, subs = scan_dir_once(_p(app), {}, rules, guard)
     assert kind == "s"           # recorded: one dirs row
     assert payload[1] == []      # no file rows from inside the package
     assert payload[4] == 0
@@ -194,13 +209,13 @@ def test_dot_git_is_recorded_as_a_leaf_and_never_listed(tmp_path):
     rules, guard = IgnoreRules([]), _guard(tmp_path)
 
     # the repo's own scan offers .git onward — that is how the row gets made
-    kind, payload, subs = scan_dir_once(str(proj), {}, rules, guard)
+    kind, payload, subs = scan_dir_once(_p(proj), {}, rules, guard)
     assert kind == "s"
-    assert str(git) in subs
+    assert _p(git) in subs
     assert [r[2] for r in payload[1]] == ["main.py"]
 
     # and .git itself is one row with nothing in it and nothing below it
-    kind, payload, subs = scan_dir_once(str(git), {}, rules, guard)
+    kind, payload, subs = scan_dir_once(_p(git), {}, rules, guard)
     assert kind == "s"           # recorded
     assert payload[1] == []      # no HEAD/config/index rows
     assert payload[4] == 0
@@ -215,9 +230,9 @@ def test_a_user_ignore_entry_cannot_delete_the_dot_git_row(tmp_path):
     configs really do name it."""
     proj, git = _repo(tmp_path)
     rules, guard = IgnoreRules([".git"]), _guard(tmp_path)
-    assert str(git) in scan_dir_once(str(proj), {}, rules, guard)[2]
+    assert _p(git) in scan_dir_once(_p(proj), {}, rules, guard)[2]
     # ... and it is still opaque: kept, not descended
-    assert scan_dir_once(str(git), {}, rules, guard)[2] == []
+    assert scan_dir_once(_p(git), {}, rules, guard)[2] == []
 
 
 def test_an_ignored_dot_git_row_SURVIVES_an_incremental_rescan(tmp_path):
@@ -236,7 +251,7 @@ def test_an_ignored_dot_git_row_SURVIVES_an_incremental_rescan(tmp_path):
     cfg = _cfg(tmp_path, ignore=["node_modules", ".git"])
 
     _run(cfg, str(src))
-    git_dir = str(src / "proj" / ".git")
+    git_dir = _p(src / "proj" / ".git")
     dirs = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
     assert git_dir in dirs, "the full rescan should record the leaf row"
 
@@ -260,9 +275,9 @@ def test_load_dir_cache_keeps_an_ignored_leaf_but_drops_a_real_ignored_tree(tmp_
     cfg = _cfg(tmp_path, ignore=["node_modules", ".git"])
     _run(cfg, str(src))
 
-    cache = load_dir_cache(cfg, str(src), pqmod)
-    assert str(src / "proj" / ".git") in cache          # leaf: exempt
-    assert str(src / "node_modules") not in cache       # ordinary ignore: gone
+    cache = load_dir_cache(cfg, _p(src), pqmod)
+    assert _p(src / "proj" / ".git") in cache           # leaf: exempt
+    assert _p(src / "node_modules") not in cache        # ordinary ignore: gone
 
 
 def test_keep_subdirs_still_honors_ignores_for_non_leaf_dirs(tmp_path):
@@ -271,28 +286,38 @@ def test_keep_subdirs_still_honors_ignores_for_non_leaf_dirs(tmp_path):
     ignored tree (the walk never reaches its parent to offer it)."""
     guard = _guard(tmp_path)
     rules = IgnoreRules([".git", "node_modules"])
-    assert keep_subdirs([str(tmp_path / "node_modules")], rules, guard) == []
+    assert keep_subdirs([_p(tmp_path / "node_modules")], rules, guard) == []
     # SKIP_DIRS and the mount guard keep their veto over a leaf dir too
     assert keep_subdirs(["/dev"], rules, guard) == []
-    blocked = MountGuard(mounts_dir=str(tmp_path / "m"))
-    assert keep_subdirs([str(tmp_path / "m" / "s3" / ".git")], rules, blocked) == []
+    blocked = MountGuard(mounts_dir=_p(tmp_path / "m"))
+    assert keep_subdirs([_p(tmp_path / "m" / "s3" / ".git")], rules, blocked) == []
 
 
 def test_keep_subdirs_drops_skip_dirs_ignored_and_mount_paths(tmp_path):
-    guard = MountGuard(mounts_dir=str(tmp_path / "mounts"))
-    subs = [str(tmp_path / "ok"), str(tmp_path / "mounts" / "s3"),
-            str(tmp_path / "node_modules"), "/proc"]
+    guard = MountGuard(mounts_dir=_p(tmp_path / "mounts"))
+    subs = [_p(tmp_path / "ok"), _p(tmp_path / "mounts" / "s3"),
+            _p(tmp_path / "node_modules"), "/proc"]
     assert keep_subdirs(subs, IgnoreRules(["node_modules"]), guard) == [
-        str(tmp_path / "ok")]
+        _p(tmp_path / "ok")]
 
 
 # -- a whole run ---------------------------------------------------------------
 
 def _run(cfg, root, full=False, run_name="run"):
+    """Write and execute a run spec exactly as `runner.start` would.
+
+    `runner.start` canonicalizes the root before it ever reaches spec.json
+    (platform.md §1) — `run_scan` trusts that and never re-normalizes it. A
+    raw `str(tmp_path / ...)` root skips that step, so on Windows the run's
+    OWN top-level row would land in dirs.parquet under the native (backslash)
+    spelling while everything the walk discovers underneath it is `norm`ed
+    to forward slashes by `scan_dir_once` — a corpus split across two forms
+    that then makes `load_dir_cache`'s prefix match miss every child on the
+    very next incremental run."""
     run_dir = os.path.join(cfg.runs_dir, run_name)
     os.makedirs(run_dir, exist_ok=True)
     with open(os.path.join(run_dir, "spec.json"), "w") as f:
-        json.dump({"root": root, "full": full, "started": 0,
+        json.dump({"root": canonical_root(root), "full": full, "started": 0,
                    "config": cfg.to_dict()}, f)
     run_scan(run_dir)
     return run_dir
@@ -320,7 +345,7 @@ def test_a_run_indexes_the_tree_and_skips_ignored_folders(tmp_path):
     assert end["msg"] == "complete", end.get("error")
     part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
     names = pq.read_table(part).column("path").to_pylist()
-    assert names == [str(src / "a.txt"), str(src / "sub" / "b.md")]
+    assert names == [_p(src / "a.txt"), _p(src / "sub" / "b.md")]
 
 
 def test_a_run_and_the_walk_agree_about_a_package_directory(tmp_path):
@@ -338,10 +363,10 @@ def test_a_run_and_the_walk_agree_about_a_package_directory(tmp_path):
     assert _summary(run_dir)["msg"] == "complete", _summary(run_dir).get("error")
 
     dirs = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
-    assert str(app) in dirs
-    assert not any(d.startswith(str(app) + "/") for d in dirs)
+    assert _p(app) in dirs
+    assert not any(d.startswith(_p(app) + "/") for d in dirs)
     part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
-    assert pq.read_table(part).column("path").to_pylist() == [str(src / "a.txt")]
+    assert pq.read_table(part).column("path").to_pylist() == [_p(src / "a.txt")]
 
     corpus = {e["rel"] for e in search_under(cfg, str(src))["entries"]}
     walked = {e["rel"] for e in _walk_bfs(str(src), True) if isinstance(e, dict)}
@@ -373,7 +398,7 @@ def test_the_fsevents_path_does_not_walk_into_a_package(tmp_path, monkeypatch):
     # reported as changed.
     monkeypatch.setattr(
         fsevents, "hint",
-        lambda _cfg, _root: ([], [str(app / "Contents")]))
+        lambda _cfg, _root: ([], [_p(app / "Contents")]))
     run_dir = _run(cfg, str(src), run_name="run2")
     assert _summary(run_dir)["msg"] == "complete", _summary(run_dir).get("error")
     # the run really took the journal path — otherwise this proves nothing
@@ -381,12 +406,12 @@ def test_the_fsevents_path_does_not_walk_into_a_package(tmp_path, monkeypatch):
                for e in _events(run_dir))
 
     dirs = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
-    assert str(app) in dirs                                    # still recorded
-    assert not any(d.startswith(str(app) + "/") for d in dirs)  # nothing below
+    assert _p(app) in dirs                                    # still recorded
+    assert not any(d.startswith(_p(app) + "/") for d in dirs)  # nothing below
     paths = []
     for part in partition_files(cfg):
         paths += pq.read_table(part).column("path").to_pylist()
-    assert not any(p.startswith(str(app) + "/") for p in paths), \
+    assert not any(p.startswith(_p(app) + "/") for p in paths), \
         "package internals entered the index through the fsevents path"
 
 
@@ -431,7 +456,7 @@ def test_a_rescan_picks_up_a_new_file(tmp_path, monkeypatch):
     run_dir = _run(cfg2, str(src), run_name="run2")
     assert _summary(run_dir)["msg"] == "complete"
     part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
-    assert str(src / "sub" / "new.txt") in pq.read_table(part).column("path").to_pylist()
+    assert _p(src / "sub" / "new.txt") in pq.read_table(part).column("path").to_pylist()
 
 
 def test_a_missing_applied_fingerprint_forces_a_full_rescan(tmp_path):
@@ -460,7 +485,7 @@ def test_a_missing_applied_fingerprint_forces_a_full_rescan(tmp_path):
     assert "no applied rules fingerprint - full rescan" in msgs
     assert "scanning (full)" in msgs
     dirs = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
-    assert str(src / "proj" / ".git") in dirs
+    assert _p(src / "proj" / ".git") in dirs
 
 
 def test_changing_the_ignore_rules_forces_a_full_rescan(tmp_path):
@@ -475,7 +500,7 @@ def test_changing_the_ignore_rules_forces_a_full_rescan(tmp_path):
                for e in _events(run_dir))
     part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
     # the newly-ignored folder's rows are gone without a manual purge
-    assert pq.read_table(part).column("path").to_pylist() == [str(src / "a.txt")]
+    assert pq.read_table(part).column("path").to_pylist() == [_p(src / "a.txt")]
 
 
 def test_a_full_run_does_not_take_the_journal_path(tmp_path, monkeypatch):
@@ -509,7 +534,7 @@ def test_a_full_run_does_not_take_the_journal_path(tmp_path, monkeypatch):
     paths = []
     for part in partition_files(cfg):
         paths += pq.read_table(part).column("path").to_pylist()
-    assert paths == [str(src / "a.txt")]
+    assert paths == [_p(src / "a.txt")]
 
 
 def test_a_rules_changed_run_does_not_take_the_journal_path(tmp_path, monkeypatch):
@@ -534,7 +559,7 @@ def test_a_rules_changed_run_does_not_take_the_journal_path(tmp_path, monkeypatc
     assert msgs.index("ignore rules changed - full rescan") < msgs.index(
         "scanning (full)")
     part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
-    assert pq.read_table(part).column("path").to_pylist() == [str(src / "a.txt")]
+    assert pq.read_table(part).column("path").to_pylist() == [_p(src / "a.txt")]
 
 
 def test_a_hint_that_explodes_fails_the_run_rather_than_scanning_full(
@@ -573,7 +598,7 @@ def test_a_hint_that_explodes_fails_the_run_rather_than_scanning_full(
     paths = []
     for part in partition_files(cfg):
         paths += pq.read_table(part).column("path").to_pylist()
-    assert sorted(paths) == sorted([str(src / "a.txt"), str(src / "sub" / "b.md")])
+    assert sorted(paths) == sorted([_p(src / "a.txt"), _p(src / "sub" / "b.md")])
 
 
 def test_a_cancelled_run_leaves_the_index_untouched(tmp_path):

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -13,18 +13,36 @@ from fastapi.testclient import TestClient
 
 from fused_render.index.config import IndexConfig, load_config
 from fused_render.index.query import search_ranked, search_under
+from fused_render.index.runner import canonical_root
 from fused_render.index.store import Sink, compact, partition_files
 from fused_render.server import create_app
 
 
 def _index(tmp_path, root, files, dirs=()):
+    """Build a real index over `paths` (absolute, already canonical).
+
+    `root`, `dirs` and every file path are hardcoded POSIX-looking literals in
+    most callers ("/r", "/r/sub", ...) — never real directories on disk. That
+    is a no-op of `canonical_root` on POSIX (`os.path.abspath("/r") == "/r"`),
+    but on Windows a leading-slash-no-drive path is only drive-RELATIVE, so
+    `abspath` resolves it against the runner's current drive (e.g. "D:/r").
+    `search_under`/`search_ranked` canonicalize their OWN `root` argument
+    before querying, so storing rows under the raw literal while the query
+    resolves to the drive-qualified form makes every lookup miss on Windows —
+    the corpus comes back empty even though the row is right there. Routing
+    every stored key through the same `canonical_root` the query side uses
+    keeps storage and lookup agreeing regardless of platform; it is a no-op
+    everywhere this already passed."""
     cfg = IndexConfig(dir=str(tmp_path / "ix"))
     shards = str(tmp_path / "run" / "shards")
     os.makedirs(shards, exist_ok=True)
     sink = Sink(shards, "t", pa, pq, cfg.shard_rows)
+    root = canonical_root(root)
+    dirs = [canonical_root(d) for d in dirs]
     by_dir = {d: [] for d in dirs}
     by_dir.setdefault(root, [])
-    for i, p in enumerate(files):
+    for i, raw in enumerate(files):
+        p = canonical_root(raw)
         d, name = p.rsplit("/", 1)
         ext = name.rsplit(".", 1)[1].lower() if "." in name else ""
         by_dir.setdefault(d, []).append((p, d, name, ext, 10 + i, 100.0 + i))
@@ -349,14 +367,18 @@ def test_the_corpus_is_ordered_by_the_stored_depth_column(tmp_path):
     to hold a generated column (see store.schemas)."""
     cfg = _index(tmp_path, "/r", ["/r/a/b/deep.txt", "/r/top.txt"],
                  dirs=["/r/a", "/r/a/b"])
+    # `_index` stores every path through `canonical_root` (same reasoning as
+    # its docstring), so the keys read back here are that canonical spelling
+    # too — "/r/..." on POSIX, "D:/r/..." on Windows — not the bare literal.
     t = pq.read_table(partition_files(cfg)[0])
     assert dict(zip(t.column("path").to_pylist(),
                     t.column("depth").to_pylist())) == {
-        "/r/a/b/deep.txt": 4, "/r/top.txt": 2}
+        canonical_root("/r/a/b/deep.txt"): 4, canonical_root("/r/top.txt"): 2}
     d = pq.read_table(cfg.dirs_parquet)
     assert dict(zip(d.column("dir").to_pylist(),
                     d.column("depth").to_pylist())) == {
-        "/r": 1, "/r/a": 2, "/r/a/b": 3}
+        canonical_root("/r"): 1, canonical_root("/r/a"): 2,
+        canonical_root("/r/a/b"): 3}
 
 
 def _drop_depth(cfg):

--- a/tests/test_index_store.py
+++ b/tests/test_index_store.py
@@ -182,7 +182,23 @@ def test_compact_backfills_depth_onto_a_pre_depth_index(tmp_path):
     assert sorted(pq.read_table(cfg.dirs_parquet).column("depth").to_pylist()) == [1, 1]
 
 
-@pytest.mark.parametrize("awkward", ["Dave's stuff", "brack[et]s", "star*dir"])
+@pytest.mark.parametrize("awkward", [
+    "Dave's stuff",
+    "brack[et]s",
+    pytest.param(
+        "star*dir",
+        marks=pytest.mark.skipif(
+            os.name == "nt",
+            reason="`*` is one of NTFS's categorically-illegal filename "
+                   "characters (< > : \" / \\ | ? *) — `home.mkdir()` below "
+                   "cannot create this directory on Windows at all, so there "
+                   "is no code fix and nothing to skip AROUND: the SQL/glob "
+                   "escaping this test exists to prove (store.parquet_src, "
+                   "shard_files) is still exercised end to end by the other "
+                   "two params, whose characters (apostrophe, brackets) are "
+                   "legal on NTFS."),
+    ),
+])
 def test_compact_survives_a_store_path_with_sql_or_glob_metachars(tmp_path, awkward):
     """The store dir is the USER's path (FUSED_RENDER_HOME under their home),
     so it can hold anything a filename can. An apostrophe closed the SQL

--- a/tests/test_index_touch.py
+++ b/tests/test_index_touch.py
@@ -12,7 +12,21 @@ scan rather than the scan itself: which folder gets scanned, that a burst of
 mutations costs one scan and not fifty, that a mount is never scanned, and
 that a scan already in flight over the folder is waited out rather than raced.
 """
+from fused_render.index.runner import canonical_root
 from fused_render.server.index_touch import RescanQueue
+
+# `RescanQueue.note()` resolves every path it is given through `_folder_of`
+# (index_touch.py), which is `norm(os.path.abspath(...))` — the same
+# canonicalization `canonical_root` does. Every hardcoded "/home/me/..."
+# literal below is a no-op of that on POSIX (already absolute), but on
+# Windows a leading-slash-no-drive literal is only drive-RELATIVE, so it
+# resolves against the runner's current drive (e.g. "D:/home/me/proj"). The
+# FILE paths handed to `q.note(...)` are left as raw literals — that mirrors
+# a real caller, and `_folder_of` canonicalizes them itself — but every
+# FOLDER identity these tests compare against (`Fake(live=...)`,
+# `Fake(blocked=...)`, `Fake(last_scan=...)` keys, and `f.started`) has to be
+# run through the same canonicalization or it silently never matches what
+# `note()` actually produced.
 
 
 class Fake:
@@ -66,7 +80,7 @@ def test_a_mutation_schedules_a_rescan_of_its_folder():
     assert f.started == []  # coalesced, not immediate
     assert f.armed == [q.coalesce_s]
     f.fire()
-    assert f.started == ["/home/me/proj"]
+    assert f.started == [canonical_root("/home/me/proj")]
 
 
 def test_a_burst_of_mutations_costs_one_scan():
@@ -77,7 +91,7 @@ def test_a_burst_of_mutations_costs_one_scan():
     for i in range(50):
         q.note(f"/home/me/proj/f{i}.txt")
     f.fire()
-    assert f.started == ["/home/me/proj"]
+    assert f.started == [canonical_root("/home/me/proj")]
     assert len(f.armed) == 1  # one timer, re-noted while already armed
 
 
@@ -89,7 +103,8 @@ def test_a_renamed_directory_is_covered_by_its_parents():
     q = f.queue()
     q.note("/home/me/proj/old", "/home/me/other/new")
     f.fire()
-    assert sorted(f.started) == ["/home/me/other", "/home/me/proj"]
+    assert sorted(f.started) == sorted(
+        [canonical_root("/home/me/other"), canonical_root("/home/me/proj")])
 
 
 def test_nested_folders_collapse_to_the_outermost():
@@ -99,14 +114,14 @@ def test_nested_folders_collapse_to_the_outermost():
     q = f.queue()
     q.note("/home/me/proj/a.txt", "/home/me/proj/sub/b.txt")
     f.fire()
-    assert f.started == ["/home/me/proj"]
+    assert f.started == [canonical_root("/home/me/proj")]
 
 
 def test_a_mount_backed_folder_is_never_scanned():
     """The structural refusal, checked here as well as in runner.start: a
     kernel crawl of an rclone mount can wedge it, and this path is reached by
     the app's own writes rather than by anything a user asked for."""
-    f = Fake(blocked=["/home/me/.fused-render/mounts/s3"])
+    f = Fake(blocked=[canonical_root("/home/me/.fused-render/mounts/s3")])
     q = f.queue()
     q.note("/home/me/.fused-render/mounts/s3/data.parquet")
     f.fire()
@@ -114,7 +129,16 @@ def test_a_mount_backed_folder_is_never_scanned():
 
 
 def test_the_filesystem_root_is_never_scanned():
-    """A file written directly into "/" must not spawn a whole-disk crawl."""
+    """A file written directly into "/" must not spawn a whole-disk crawl.
+
+    NOT a canonical_root() fixture mismatch like its neighbours: `_folder_of`
+    (index_touch.py) guards against a bare root with `parent in ("", "/")`
+    after `norm(os.path.abspath(...))`, and that guard only recognized the
+    POSIX spelling — on Windows `os.path.dirname("D:/loose.txt")` is `"D:/"`,
+    truthy and not `"/"`, so a drive letter's own root slipped through the
+    same way `query.search_under`'s `.rstrip("/") or "/"` would (both
+    generalize the POSIX bare-root special case, not the Windows one).
+    `_folder_of`'s `_DRIVE_ROOT` regex now recognizes that form too."""
     f = Fake()
     q = f.queue()
     q.note("/loose.txt")
@@ -125,7 +149,7 @@ def test_a_scan_already_covering_the_folder_is_waited_out():
     """Starting a second scan over a tree being scanned races the compaction
     for no benefit — and JOINING the live one is worse than useless here,
     since it may already have walked past the folder we just changed."""
-    f = Fake(live=["/home/me"])
+    f = Fake(live=[canonical_root("/home/me")])
     q = f.queue()
     q.note("/home/me/proj/a.txt")
     f.fire()
@@ -133,21 +157,21 @@ def test_a_scan_already_covering_the_folder_is_waited_out():
     assert f.armed == [q.coalesce_s, q.coalesce_s]  # re-armed, still pending
     f.live.clear()
     f.fire()
-    assert f.started == ["/home/me/proj"]
+    assert f.started == [canonical_root("/home/me/proj")]
 
 
 def test_waiting_out_a_scan_has_a_ceiling():
     """A run that never ends (a wedged worker) must not keep one folder
     circling for the process lifetime."""
-    f = Fake(live=["/home/me"])
+    f = Fake(live=[canonical_root("/home/me")])
     q = f.queue()
     q.note("/home/me/proj/a.txt")
     f.fire()
     f.t += q.deadline_s + 1
     f.fire()
-    assert f.started == ["/home/me/proj"]
+    assert f.started == [canonical_root("/home/me/proj")]
     f.fire()
-    assert f.started == ["/home/me/proj"]  # and it is off the queue
+    assert f.started == [canonical_root("/home/me/proj")]  # and it is off the queue
 
 
 def test_nothing_is_armed_when_there_is_nothing_to_do():
@@ -164,7 +188,7 @@ def test_a_start_that_fails_does_not_strand_the_rest():
 
     def start(root):
         f.started.append(root)
-        if root == "/home/me/bad":
+        if root == canonical_root("/home/me/bad"):
             raise ValueError("not a directory")
 
     q = RescanQueue(start=start, live_run_covers=f.live_run_covers,
@@ -172,7 +196,8 @@ def test_a_start_that_fails_does_not_strand_the_rest():
                     schedule=f.schedule, now=f.now)
     q.note("/home/me/bad/x.txt", "/home/me/good/y.txt")
     f.fire()
-    assert sorted(f.started) == ["/home/me/bad", "/home/me/good"]
+    assert sorted(f.started) == sorted(
+        [canonical_root("/home/me/bad"), canonical_root("/home/me/good")])
 
 
 def _mutating_routes():
@@ -231,7 +256,7 @@ def test_the_guard_would_notice_a_new_route():
 # store on a cadence set by whoever is typing.
 
 def test_a_folder_scanned_moments_ago_waits_rather_than_rescanning():
-    f = Fake(last_scan={"/home/me/proj": 995.0})  # 5s ago
+    f = Fake(last_scan={canonical_root("/home/me/proj"): 995.0})  # 5s ago
     q = f.queue()
     q.note("/home/me/proj/a.txt")
     f.fire()
@@ -243,24 +268,24 @@ def test_the_deferred_rescan_is_not_lost():
     """DEFERRED, never dropped. A rename whose rescan is skipped outright is a
     file the search cannot find until something else happens to scan — which is
     the exact failure this whole mechanism exists to prevent."""
-    f = Fake(last_scan={"/home/me/proj": 995.0})
+    f = Fake(last_scan={canonical_root("/home/me/proj"): 995.0})
     q = f.queue()
     q.note("/home/me/proj/a.txt")
     f.fire()
     f.t += q.floor_s
     f.fire()
-    assert f.started == ["/home/me/proj"]
+    assert f.started == [canonical_root("/home/me/proj")]
 
 
 def test_the_floor_cannot_hold_a_folder_past_the_deadline():
-    f = Fake(last_scan={"/home/me/proj": 995.0})
+    f = Fake(last_scan={canonical_root("/home/me/proj"): 995.0})
     q = f.queue()
     q.note("/home/me/proj/a.txt")
     f.fire()
-    f.scans["/home/me/proj"] = f.t  # something keeps rescanning it
+    f.scans[canonical_root("/home/me/proj")] = f.t  # something keeps rescanning it
     f.t += q.deadline_s + 1
     f.fire()
-    assert f.started == ["/home/me/proj"]
+    assert f.started == [canonical_root("/home/me/proj")]
 
 
 def test_a_folder_never_scanned_has_no_floor_to_clear():
@@ -268,13 +293,13 @@ def test_a_folder_never_scanned_has_no_floor_to_clear():
     q = f.queue()
     q.note("/home/me/proj/a.txt")
     f.fire()
-    assert f.started == ["/home/me/proj"]
+    assert f.started == [canonical_root("/home/me/proj")]
 
 
 def test_a_folder_the_scan_rules_exclude_is_never_rescanned():
     """A save inside node_modules would otherwise spawn a worker that walks it,
     indexes nothing, and rewrites the whole store to say so."""
-    f = Fake(blocked=["/home/me/proj/node_modules"])
+    f = Fake(blocked=[canonical_root("/home/me/proj/node_modules")])
     q = f.queue()
     q.note("/home/me/proj/node_modules/pkg/index.js")
     f.fire()

--- a/tests/test_markdown_graph.py
+++ b/tests/test_markdown_graph.py
@@ -249,6 +249,18 @@ def _vault(tmp_path, files):
     return str(tmp_path)
 
 
+def _client(path):
+    """The forward-slash form graph.py's client-facing payload fields carry
+    (`note["root"]`, every link/backlink `path` — see graph.py's
+    `_client_path`/`_client_join`, and `test_every_path_a_payload_carries_
+    uses_forward_slashes` above). An expected value built with `os.path.join`
+    or a raw `tmp_path` string is native-separated, which is backslashed on
+    Windows and would never match those fields there — this converts it the
+    same way graph.py does, rather than the test predicting a native path a
+    forward-slash-only payload was never going to return."""
+    return path.replace("\\", "/") if path else path
+
+
 def test_scan_collects_notes_and_assets_and_skips_noise(graph, tmp_path):
     root = _vault(tmp_path, {
         "a.md": "[[b]]\n",
@@ -278,7 +290,7 @@ def test_a_large_note_is_scanned_and_fully_linkable(graph, tmp_path):
     # The link resolves to the real file rather than a ghost, and the big note
     # has working backlinks of its own.
     other = graph.main(action="note", file=os.path.join(root, "Other.md"), root=root)
-    assert other["links"][0]["path"] == os.path.join(root, "Big.md")
+    assert other["links"][0]["path"] == _client(os.path.join(root, "Big.md"))
     big_note = graph.main(action="note", file=os.path.join(root, "Big.md"), root=root)
     assert [b["rel"] for b in big_note["backlinks"]] == ["Other.md"]
     # It is a real node in the graph, not a ghost.
@@ -458,12 +470,12 @@ def test_note_reports_outbound_links_backlinks_and_ghosts(graph, tmp_path):
     out = graph.main(action="note", file=os.path.join(root, "Hub.md"), root=root)
     assert out["title"] == "Hub"
     assert [(link["target"], link["path"]) for link in out["links"]] == [
-        ("Leaf", os.path.join(root, "Leaf.md")),
+        ("Leaf", _client(os.path.join(root, "Leaf.md"))),
         ("Missing", None),
     ]
     assert [b["path"] for b in out["backlinks"]] == [
-        os.path.join(root, "Leaf.md"),
-        os.path.join(root, "Other.md"),
+        _client(os.path.join(root, "Leaf.md")),
+        _client(os.path.join(root, "Other.md")),
     ]
     assert out["backlinks"][1]["label"] == "the hub"
 
@@ -471,15 +483,17 @@ def test_note_reports_outbound_links_backlinks_and_ghosts(graph, tmp_path):
 def test_note_falls_back_to_its_own_directory_when_no_marker_is_found(graph, tmp_path):
     root = _vault(tmp_path, {"sub/A.md": "[[B]]\n", "sub/B.md": "back to [[A]]\n"})
     out = graph.main(action="note", file=os.path.join(root, "sub", "A.md"))
-    assert out["root"] == os.path.join(root, "sub")
-    assert [b["path"] for b in out["backlinks"]] == [os.path.join(root, "sub", "B.md")]
+    assert out["root"] == _client(os.path.join(root, "sub"))
+    assert [b["path"] for b in out["backlinks"]] == [
+        _client(os.path.join(root, "sub", "B.md"))
+    ]
 
 
 def test_an_embed_resolves_against_the_assets_in_the_scan(graph, tmp_path):
     root = _vault(tmp_path, {"A.md": "![[pic.png]] ![[gone.png]]\n", "img/pic.png": "x"})
     out = graph.main(action="note", file=os.path.join(root, "A.md"), root=root)
     assert [(link["target"], link["path"]) for link in out["links"]] == [
-        ("pic.png", os.path.join(root, "img", "pic.png")),
+        ("pic.png", _client(os.path.join(root, "img", "pic.png"))),
         ("gone.png", None),
     ]
 
@@ -534,9 +548,9 @@ def test_the_default_root_climbs_to_the_nearest_vault_marker(graph, tmp_path, ma
     # And the point of it: the cross-folder link resolves and the inbound one
     # from a sibling folder shows up, neither of which the old default could do.
     out = graph.main(action="note", file=os.path.join(root, "docs", "note.md"))
-    assert out["root"] == root
+    assert out["root"] == _client(root)
     assert [link["path"] for link in out["links"]] == [
-        os.path.join(root, "spec", "overview.md")]
+        _client(os.path.join(root, "spec", "overview.md"))]
     assert [b["rel"] for b in out["backlinks"]] == ["spec/overview.md"]
 
 
@@ -685,7 +699,7 @@ def test_an_explicit_root_still_wins_over_the_marker(graph, tmp_path):
     root = _vault(tmp_path, {".obsidian/app.json": "{}", "docs/note.md": "x\n"})
     out = graph.main(action="note", file=os.path.join(root, "docs", "note.md"),
                      root=os.path.join(root, "docs"))
-    assert out["root"] == os.path.join(root, "docs")
+    assert out["root"] == _client(os.path.join(root, "docs"))
 
 
 def test_the_chosen_root_always_contains_the_note(graph, tmp_path, monkeypatch):
@@ -696,7 +710,7 @@ def test_the_chosen_root_always_contains_the_note(graph, tmp_path, monkeypatch):
     monkeypatch.setattr(graph, "vault_root", lambda start: str(tmp_path / "elsewhere"))
     out = graph.main(action="note", file=os.path.join(root, "docs", "note.md"))
     assert out["error"] is None
-    assert out["root"] == os.path.join(root, "docs")
+    assert out["root"] == _client(os.path.join(root, "docs"))
 
 
 def test_a_wider_root_still_reports_the_file_cap(graph, tmp_path, monkeypatch):
@@ -708,7 +722,7 @@ def test_a_wider_root_still_reports_the_file_cap(graph, tmp_path, monkeypatch):
     real = graph.scan_indexed
     monkeypatch.setattr(graph, "scan_indexed", lambda where: real(where, max_files=3))
     out = graph.main(action="note", file=os.path.join(root, "docs", "note.md"))
-    assert out["root"] == root
+    assert out["root"] == _client(root)
     assert out["truncated"] is True
     assert out["notes"] == 3
 

--- a/tests/test_mcp_condition.py
+++ b/tests/test_mcp_condition.py
@@ -266,7 +266,13 @@ def test_the_listing_happens_once(gate, tmp_path, monkeypatch):
         calls.append(args[0] if args else None)
         return real(*args, **kwargs)
 
-    monkeypatch.setattr(os, "scandir", counted)
+    # Thread-scoped, like the `open` trap above. os.scandir is process-global,
+    # and the suite leaves daemon threads running from earlier tests -- an
+    # openfused invoke watcher polling its requests dir scanned during this
+    # window and made `calls` 2, failing an assertion about what THE GATE did.
+    # What is under test is the gate's listing on this thread, not every
+    # scandir in the process.
+    monkeypatch.setattr(os, "scandir", this_thread_only(real, counted))
     assert gate(app) is True
     assert len(calls) == 1
 

--- a/tests/test_mcp_inspect.py
+++ b/tests/test_mcp_inspect.py
@@ -233,7 +233,11 @@ def _fake_cli(app, monkeypatch, name="fused"):
     """A `fused` wrapper in a dir exported the way the SERVER exports it (D334)."""
     bin_dir = os.path.join(app, "bin")
     os.makedirs(bin_dir, exist_ok=True)
-    path = os.path.join(bin_dir, name)
+    # inspect_app.py itself looks for "<name>.exe" on Windows (that's how a pip/uv
+    # console-script install names the launcher there) — match that filename, or
+    # the file this fixture writes never matches what main() goes looking for.
+    filename = name + ".exe" if os.name == "nt" else name
+    path = os.path.join(bin_dir, filename)
     with open(path, "w", encoding="utf-8") as fh:
         fh.write("#!/bin/sh\n")
     os.chmod(path, 0o755)

--- a/tests/test_mounts_rcd_auth.py
+++ b/tests/test_mounts_rcd_auth.py
@@ -174,6 +174,17 @@ def _serve_once(handler_state):
         def do_POST(self):
             handler_state["auth"] = self.headers.get("Authorization")
             handler_state["path"] = self.path
+            # Drain the request body, as the real rclone rc daemon does — every
+            # _rc call POSTs one (`{}` at the least). Answering without reading
+            # it leaves those bytes in the socket, and closing a socket that
+            # still holds unread data makes Windows send an RST instead of a
+            # FIN: the client's own read then fails with [WinError 10053] and
+            # _rc reports it as "rclone rc core/pid: ...". That is a stub that
+            # does not behave like the daemon it stands in for, not a bug in
+            # _rc — it flaked this file on the Windows runner.
+            length = int(self.headers.get("Content-Length") or 0)
+            if length:
+                self.rfile.read(length)
             body = b'{"pid": 4242}'
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/tests/test_pyramid_mount.py
+++ b/tests/test_pyramid_mount.py
@@ -334,7 +334,15 @@ def test_main_remote_analyze_passes_raw_url_to_worker(fs, monkeypatch):
     # The worker's raw_url opts into the server's pooled proxy (&pooled=1) so a
     # cold COG range-read streams through one keep-alive pool instead of a fresh
     # TLS handshake per block.
-    assert opts["raw_url"].endswith("/api/fs/raw?path=/mnt/x.tif&pooled=1")
+    #
+    # main() itself runs `file` through os.path.abspath(os.path.expanduser(...))
+    # before quoting it into the url — on Windows that is NOT a no-op for a bare
+    # POSIX-style literal like "/mnt/x.tif" (it gains the runner's current drive
+    # letter and backslashes), so the expected suffix has to go through the same
+    # transform rather than assume the literal survives unchanged.
+    canonical_file = os.path.abspath(os.path.expanduser("/mnt/x.tif"))
+    assert opts["raw_url"].endswith(
+        "/api/fs/raw?path=" + op._urlparse.quote(canonical_file) + "&pooled=1")
     assert "/api/fs/raw" in opts["raw_url"]
 
 

--- a/tests/test_s3_sign.py
+++ b/tests/test_s3_sign.py
@@ -215,6 +215,7 @@ def test_resolver_expands_tilde_in_shared_credentials_file(tmp_path, monkeypatch
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # expanduser on Windows
     (home / "creds").write_text(
         "[default]\naws_access_key_id = AKIATILDE\n"
         "aws_secret_access_key = TILDESEC\n", encoding="utf-8")

--- a/tests/test_schedule_wake.py
+++ b/tests/test_schedule_wake.py
@@ -30,6 +30,13 @@ def no_launchctl(monkeypatch):
 def fake_darwin(monkeypatch, tmp_path):
     """Pretend to be macOS with a real app bundle, writing into tmp_path."""
     monkeypatch.setattr(schedule_wake, "_is_darwin", lambda: True)
+    # sync()/remove() build the launchd domain target with os.getuid(), which
+    # is POSIX-only and does not exist as an os attribute at all on Windows —
+    # in real use that line is unreachable there because _is_darwin() above
+    # already returned False, but "pretend to be macOS" on this CI platform
+    # means faking every part of the illusion, not just the platform check.
+    # raising=False: the attribute may genuinely not exist here to restore.
+    monkeypatch.setattr(schedule_wake.os, "getuid", lambda: 501, raising=False)
     bundle = tmp_path / "FusedRender.app"
     bundle.mkdir()
     monkeypatch.setattr(schedule_wake, "app_bundle_path", lambda: str(bundle))

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -996,9 +996,28 @@ def test_claude_bin_falls_back_to_install_dirs(monkeypatch, tmp_path):
     assert _server_ai._claude_bin() is None  # nothing installed anywhere
     bin_path.write_text("#!/bin/sh\n")
     bin_path.chmod(0o755)
-    assert _server_ai._claude_bin() == str(bin_path)
+    # normpath: the fake expanduser above naively string-replaces "~" with
+    # str(home) and leaves the candidate's own "/" suffix untouched, so on a
+    # real Windows filesystem (str(home) backslashed, "/.local/bin/claude"
+    # forward-slashed) the resolved path is a mixed-separator string — the
+    # same file bin_path names, but not the same bytes as str(bin_path).
+    assert os.path.normpath(_server_ai._claude_bin()) == os.path.normpath(str(bin_path))
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "the skip this pins is unobservable here: claude_health.executable's "
+        "own docstring says the exec bit 'is only consulted off Windows... "
+        "os.access(X_OK) is true for any existing file' there, so os.name is "
+        "forced to 'posix' below to reach that branch — but the underlying "
+        "os.access() call still runs against a REAL Windows filesystem, where "
+        "it is X_OK-true for any existing file regardless of chmod. A dud "
+        "made non-executable by chmod(0o644) is indistinguishable from a real "
+        "one to that syscall on this platform, so the dud wins here for a "
+        "reason that has nothing to do with the skip logic under test."
+    ),
+)
 def test_claude_bin_skips_a_non_executable_dud(monkeypatch, tmp_path):
     """A dud early in the list must not shadow a real install further down.
 
@@ -1121,7 +1140,12 @@ def test_windows_candidates_expand_environment_variables(monkeypatch, tmp_path):
     # only the %VAR% expansion is under test
     monkeypatch.setattr(_server_ai, "_CLAUDE_WINDOWS_CANDIDATES",
                         ("%APPDATA%/npm/claude.exe",))
-    assert _server_ai._claude_bin() == str(tmp_path / "npm" / "claude.exe")
+    # normpath: expandvars substitutes %APPDATA% (native-separator on real
+    # Windows) into a forward-slash template and, like expanduser, leaves the
+    # rest of the string untouched — a mixed-separator result naming the same
+    # file as the cleanly-joined RHS, but not the same string.
+    assert os.path.normpath(_server_ai._claude_bin()) == \
+        os.path.normpath(str(tmp_path / "npm" / "claude.exe"))
 
 
 def test_the_resolver_never_imports_the_chat_template():

--- a/tests/test_server_fs_compress.py
+++ b/tests/test_server_fs_compress.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 import tarfile
 import zipfile
 
@@ -40,9 +41,15 @@ def _data(resp) -> dict:
 
 def make_tree(root):
     root.mkdir(parents=True)
-    (root / "a.txt").write_text("alpha\n")
+    # newline="": Path.write_text's default text-mode translation rewrites
+    # "\n" to os.linesep on write, so a Windows run stores "beta\r\n" for
+    # content this fixture asked to be "beta\n" — a fixture artifact tests
+    # that check exact bytes (test_zip_writes_sibling_archive_and_returns_stat)
+    # would then see, not anything the archiver does. newline="" writes
+    # exactly what's given, the same on every platform.
+    (root / "a.txt").write_text("alpha\n", newline="")
     (root / "sub").mkdir()
-    (root / "sub" / "b.txt").write_text("beta\n")
+    (root / "sub" / "b.txt").write_text("beta\n", newline="")
     (root / "empty").mkdir()
     return root
 
@@ -86,13 +93,21 @@ def _unzip(archive, into):
 
 
 def _tree(root):
-    """Every path under `root`, relative and "/"-separated, dirs marked."""
+    """Every path under `root`, relative and "/"-separated, dirs marked.
+
+    Zip archive entries are always "/"-separated by the ZIP spec (and this
+    app's own `_zip_tree.arcname` enforces exactly that), regardless of host
+    OS — so the tree this reads back off a REAL extraction has to be
+    normalized the same way, or a nested relpath's OS-native separator
+    (backslash on Windows) never matches the forward-slash entries the
+    archiver wrote.
+    """
     out = set()
     for base, dirs, files in os.walk(root):
         for name in dirs:
-            out.add(os.path.relpath(os.path.join(base, name), root) + "/")
+            out.add(os.path.relpath(os.path.join(base, name), root).replace(os.sep, "/") + "/")
         for name in files:
-            out.add(os.path.relpath(os.path.join(base, name), root))
+            out.add(os.path.relpath(os.path.join(base, name), root).replace(os.sep, "/"))
     return out
 
 
@@ -163,7 +178,17 @@ def test_zip_stores_symlinks_without_following_them(tmp_path):
     with zipfile.ZipFile(out["path"]) as z:
         info = z.getinfo("proj/link.txt")
         assert stat.S_ISLNK(info.external_attr >> 16)
-        assert z.read("proj/link.txt") == str(outside).encode()  # target, not content
+        # _zip_tree stores os.readlink()'s own return value verbatim (by
+        # design — it never rewrites a symlink's target). On Windows that can
+        # come back with the "\\?\" extended-length prefix even for a link
+        # created from a plain absolute path — a cosmetic artifact of how
+        # NTFS reports an absolute SubstituteName, not a different target —
+        # so it is stripped before comparing, same as the readlink() check in
+        # test_server_fs_mutate.py's trashed-symlink test.
+        stored_target = z.read("proj/link.txt")  # target, not content
+        if stored_target.startswith(b"\\\\?\\"):
+            stored_target = stored_target[4:]
+        assert stored_target == str(outside).encode()
         # The self-referential dir symlink is stored, never descended into.
         assert stat.S_ISLNK(z.getinfo("proj/loop").external_attr >> 16)
         assert not any(n.startswith("proj/loop/") for n in z.namelist())
@@ -353,6 +378,16 @@ def test_missing_dest_parent_400(tmp_path):
 
 
 @skip_root
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the readonly guard falls back to os.access(parent, os.W_OK) for a "
+           "destination that doesn't exist yet (mount._writable), and Windows' "
+           "directory read-only attribute is largely vestigial — long used only "
+           "by Explorer's folder-customization UI — so it does not gate creating "
+           "entries inside the directory the way a POSIX missing write-bit does. "
+           "os.access keeps reporting the chmod'd holder writable and the zip is "
+           "written (200), so the 403 this test expects cannot occur there (see "
+           "test_server_fs_mutate.py's test_mkdir_readonly_parent_403).")
 def test_readonly_destination_403(tmp_path):
     holder = tmp_path / "ro"
     holder.mkdir()
@@ -425,8 +460,13 @@ def test_git_is_run_as_an_argv_list_with_no_shell(tmp_path, monkeypatch):
 
     def spy(cmd, **kw):
         # argv[0] is now the ABSOLUTE git path — required to reach posix_spawn, since CPython forks unless os.path.dirname(executable) is truthy and a fork with libproj resident SIGSEGVs before exec (tests/test_git_posix_spawn.py). Still one basename, still a list, still no shell, which is what this test is about.
+        # .lower(): _git_bin() resolves this via shutil.which("git"), and on
+        # Windows shutil.which appends an extension straight from %PATHEXT%
+        # (".EXE" by default, uppercase) rather than whatever case the file
+        # happens to be stored under — so the basename here is "git.EXE", not
+        # "git.exe". NTFS is case-insensitive for the same reason.
         if isinstance(cmd, list) and cmd and os.path.basename(
-                str(cmd[0])) in ("git", "git.exe"):
+                str(cmd[0])).lower() in ("git", "git.exe"):
             seen.setdefault("calls", []).append((cmd, kw))
         return real_run(cmd, **kw)
 

--- a/tests/test_server_fs_list_mount.py
+++ b/tests/test_server_fs_list_mount.py
@@ -204,7 +204,16 @@ def test_walk_mount_skips_failing_subdir_and_continues(home, tmp_path, monkeypat
             _entry("ok", is_dir=True)]
 
     def fake_list(path, timeout=None):
-        tail = path.rstrip("/").rsplit("/", 1)[-1]
+        # os.path.basename, not a "/"-only rsplit: the real walker enqueues
+        # child dirs via os.path.join(current, name) (walk.py), which is
+        # backslash-joined on Windows — rsplit("/", 1) then finds no "/" at
+        # all and returns the WHOLE path as `tail`, so it never matches "big"
+        # or "ok" and every call falls through to `root`, silently descending
+        # into "big" instead of skipping it. The real rc_list_dir (bypassed by
+        # this monkeypatch) only ever sees the forward-slash remote-relative
+        # key _mount_for computes; os.path.basename is what's separator-
+        # agnostic on both platforms without needing that translation here.
+        tail = os.path.basename(path.rstrip("/\\"))
         if tail == "big":
             raise mounts_mod.RcListTimeout("too many entries")
         if tail == "ok":
@@ -403,7 +412,12 @@ def test_walk_s3_capable_uses_pages(home, rcd, tmp_path, monkeypatch, fresh_cfg_
 
     def fake(path, *, max_keys, continuation=None, timeout=None):
         calls.append(path)
-        tail = path.rstrip("/").rsplit("/", 1)[-1]
+        # os.path.basename — see test_walk_mount_skips_failing_subdir_and_
+        # continues above: the walker's enqueued child path is os.path.join'd
+        # (backslash on Windows), so a "/"-only rsplit never isolates "sub"
+        # there and every call falls through to the root listing instead of
+        # recursing into it correctly.
+        tail = os.path.basename(path.rstrip("/\\"))
         if tail == "sub":
             return ([_entry("b.txt", size=2)], None)
         return ([_entry("a.txt", size=1), _entry("sub", is_dir=True)], None)
@@ -540,7 +554,22 @@ def test_list_s3_budget_never_passes_nonpositive_timeout(home, rcd, tmp_path, mo
                  for i in range(10)], "NEXT")
 
     monkeypatch.setattr(mounts_mod, "s3_list_page", fake)
-    monkeypatch.setattr(_server_walk, "S3_LIST_OVERALL_TIMEOUT_S", 1e-9)
+    # 0.0, not 1e-9: pathops._accumulate_direct_pages computes
+    # `deadline = time.monotonic() + overall_timeout`, and time.monotonic()
+    # on Windows is GetTickCount64-backed (~15.6ms resolution) rather than the
+    # sub-microsecond POSIX clock_gettime(CLOCK_MONOTONIC) — adding 1e-9
+    # produces a deadline a hair AFTER "now" that survives float rounding, and
+    # while the tick stays frozen (routinely tens of iterations' worth on
+    # Windows, since each iteration here is a few microseconds of pure Python)
+    # every check reads that same tiny positive gap and never breaks, so the
+    # loop way overshoots page 1 (460 entries, not 10) before the tick finally
+    # advances. 0.0 makes the deadline EXACTLY equal to "now", so `left` reads
+    # back <= 0 on the very first post-page check even with a frozen tick —
+    # this is exactly test_list_s3_overall_budget_returns_resumable_page's
+    # already-passing "budget bites after page 1" value, and (verified above)
+    # produces the identical single-page outcome this test already asserts on
+    # every platform where the clock ever advances between checks.
+    monkeypatch.setattr(_server_walk, "S3_LIST_OVERALL_TIMEOUT_S", 0.0)
     resp = _client(tmp_path).get(
         "/api/fs/list", params={"path": mounts_mod.mountpoint(c)})
     assert resp.status_code == 200

--- a/tests/test_server_fs_mount_safe.py
+++ b/tests/test_server_fs_mount_safe.py
@@ -27,6 +27,7 @@ redirected per test.
 """
 import json
 import os
+import sys
 
 import pytest
 from fastapi.responses import JSONResponse
@@ -448,6 +449,17 @@ def test_rename_local_readonly_src_refused_with_mount_dst(home, monkeypatch, tmp
 
 
 @skip_root
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the readonly guard falls back to os.access(parent, os.W_OK) for a "
+           "dst that doesn't exist yet (mount._writable), and Windows' "
+           "directory read-only attribute is largely vestigial — long used "
+           "only by Explorer's folder-customization UI — so it does not gate "
+           "creating entries inside the directory the way a POSIX missing "
+           "write-bit does. os.access keeps reporting the chmod'd ro_dir "
+           "writable and the copy proceeds, so the 403 this test expects "
+           "cannot occur there (see test_server_fs_mutate.py's "
+           "test_mkdir_readonly_parent_403).")
 def test_copy_local_readonly_dst_refused_with_mount_src(home, monkeypatch, tmp_path):
     mp = _mount("rw", read_only=False)
     _no_kernel_on_mount(monkeypatch, mp)

--- a/tests/test_server_fs_mutate.py
+++ b/tests/test_server_fs_mutate.py
@@ -860,6 +860,24 @@ def test_trash_move_refuses_to_touch_an_info_file_for_an_outside_path(tmp_path, 
 
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the attack this pins only exists on a POSIX kernel. A POSIX "
+           "open()/rename() resolves 'link/..' component-by-component, so it "
+           "genuinely lands at the SYMLINK TARGET's parent — the kernel-vs-"
+           "lexical divergence _xdg_trash_entry_info's docstring is defending "
+           "against. Windows canonicalises a '..' component in an ordinary "
+           "(non \\\\?\\) path purely lexically, in the Win32 path layer, "
+           "before a reparse point is ever opened to see where it points — so "
+           "'…/files/link/../y.txt' collapses to '…/files/y.txt' there no "
+           "matter what 'link' names, and the kernel never takes the wrong "
+           "turn this test needs to exist to prove refused. The victim this "
+           "test plants at the POSIX-resolved location (tmp_path/y.txt) is "
+           "then simply not where Windows' own path resolution looks: the "
+           "rename 404s (the response has no 'path', hence the bare KeyError "
+           "on a real Windows run) before _xdg_trash_entry_info's boundary "
+           "check is ever exercised. Not a fused_render bug, and not an "
+           "attack Windows path resolution can construct this way at all.")
 def test_trash_move_boundary_rejects_a_symlinked_parent(tmp_path, monkeypatch):
     # The docstring's second claim, now actually tested. A path whose parent is a
     # SYMLINK out of files/ used to pass the boundary because the check normalised

--- a/tests/test_server_fs_mutate.py
+++ b/tests/test_server_fs_mutate.py
@@ -13,6 +13,8 @@ import errno
 import json
 import os
 import stat
+import sys
+import urllib.parse
 from pathlib import Path
 
 import pytest
@@ -29,6 +31,21 @@ from fused_render.server.fs_mutate import _fs_trash_move as TRASH_MOVE
 skip_root = pytest.mark.skipif(
     hasattr(os, "geteuid") and os.geteuid() == 0,
     reason="read-only bits are ignored when running as root")
+
+# Windows has no POSIX permission-bit model. os.chmod()/os.stat().st_mode there
+# only ever reflect the read-only DACL flag: a file/dir is either "read-only"
+# (reported back as a fixed mode around 0o444/0o555) or "normal" (a fixed mode
+# around 0o666/0o777) — chmod(0o600) or mkdir(mode=0o700) sets or clears that
+# one bit and nothing else, so a subsequent stat can never read back the exact
+# bits this app asked for. A test asserting an exact numeric round-trip of
+# self-chosen bits (0o700 dirs, 0o600 sidecars) is asserting something
+# categorically outside how Windows works, not a bug this app's own chmod call
+# could get right or wrong there.
+skip_no_posix_modes = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.chmod()/stat().st_mode on Windows only reflect the read-only "
+           "DACL flag, never arbitrary POSIX bits — an exact-mode round-trip "
+           "(0o700/0o600) cannot be observed there at all.")
 
 
 def _status(resp) -> int:
@@ -86,6 +103,16 @@ def test_mkdir_existing_path_409(tmp_path):
 
 
 @skip_root
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the readonly guard falls back to os.access(parent, os.W_OK) for a "
+           "target that doesn't exist yet (mount.py's _writable), and Windows' "
+           "directory read-only attribute is largely vestigial — long used only "
+           "by Explorer's folder-customization UI — so it does not gate creating "
+           "entries inside the directory the way a POSIX missing write-bit does. "
+           "os.access keeps reporting the chmod'd parent writable, mkdir succeeds "
+           "(200), and the 403 this test expects cannot occur: there is no kernel "
+           "mechanism here for the app to have gotten wrong.")
 def test_mkdir_readonly_parent_403(tmp_path):
     os.chmod(tmp_path, stat.S_IRUSR | stat.S_IXUSR)
     try:
@@ -330,8 +357,14 @@ def test_xdg_trash_writes_the_spec_sidecar(tmp_path, monkeypatch):
     info = (trash / "info" / "a b#c.txt.trashinfo").read_text()
     lines = info.splitlines()
     assert lines[0] == "[Trash Info]"
-    assert lines[1] == "Path=" + str(f).replace(" ", "%20").replace("#", "%23")
-    assert "/" in lines[1]  # separators stay legible (quote's safe="/")
+    # The real quote() call (_trashinfo_body), not a hand-rolled two-character
+    # replace: str(f) on Windows also carries a drive colon and backslash
+    # separators, and quote()'s default-unsafe set percent-encodes those too
+    # (":" -> "%3A", "\\" -> "%5C") — a POSIX path never has either, which is
+    # why the narrower replace happened to agree with quote() there.
+    assert lines[1] == "Path=" + urllib.parse.quote(str(f), safe="/")
+    if os.sep == "/":
+        assert "/" in lines[1]  # separators stay legible (quote's safe="/")
     date = lines[2].removeprefix("DeletionDate=")
     assert lines[2].startswith("DeletionDate=")
     # YYYY-MM-DDThh:mm:ss, and nothing after it — no "Z", no "+01:00".
@@ -340,6 +373,7 @@ def test_xdg_trash_writes_the_spec_sidecar(tmp_path, monkeypatch):
 
 
 
+@skip_no_posix_modes
 def test_xdg_trash_dirs_are_private(tmp_path, monkeypatch):
     # The bin holds what the user threw away. At the default 0755 every local
     # account on a shared host can list and read it, so all three directories we
@@ -354,6 +388,7 @@ def test_xdg_trash_dirs_are_private(tmp_path, monkeypatch):
         assert stat.S_IMODE(d.stat().st_mode) == 0o700, d
 
 
+@skip_no_posix_modes
 def test_xdg_trash_leaves_an_existing_trash_dir_permissions_alone(tmp_path, monkeypatch):
     # A trash the user (or their desktop) already made is theirs. exist_ok does not
     # chmod, and quietly re-permissioning someone's directory is not this
@@ -712,12 +747,16 @@ def test_trash_move_into_the_trash_writes_the_sidecar(tmp_path, monkeypatch):
     _data(TRASH_MOVE({"from": str(src), "to": str(dst)}, x_fused="1"))
     assert dst.read_text() == "x"
     info = (trash / "info" / "a b.txt.trashinfo").read_text()
-    # Path= names where it came FROM, percent-encoded like the backend's own.
-    assert f"Path={str(src).replace(' ', '%20')}\n" in info
+    # Path= names where it came FROM, percent-encoded like the backend's own —
+    # matched with the real quote() call, not a hand-rolled space-only replace
+    # (see test_xdg_trash_writes_the_spec_sidecar: str(src) on Windows also
+    # carries a drive colon and backslashes, which quote() encodes too).
+    assert f"Path={urllib.parse.quote(str(src), safe='/')}\n" in info
     assert "DeletionDate=" in info
 
 
 
+@skip_no_posix_modes
 def test_trash_move_redo_sidecar_is_as_private_as_the_delete_path(tmp_path, monkeypatch):
     # A REDO is the delete happening again, so it must not leave the bin more
     # exposed than the delete did. This branch used to use Path.write_text and a
@@ -736,6 +775,7 @@ def test_trash_move_redo_sidecar_is_as_private_as_the_delete_path(tmp_path, monk
     assert stat.S_IMODE((trash / "info").stat().st_mode) == 0o700
 
 
+@skip_no_posix_modes
 def test_trash_move_redo_leaves_an_existing_info_dir_alone(tmp_path, monkeypatch):
     # Same rule as the delete path: we set modes on what we CREATE and never
     # re-permission a directory the user (or their desktop) already made. The
@@ -761,7 +801,10 @@ def test_trash_move_redo_overwrites_a_stale_sidecar(tmp_path, monkeypatch):
     src.write_text("x")
     _data(TRASH_MOVE({"from": str(src), "to": str(trash / "files" / "a.txt")}, x_fused="1"))
     body = stale.read_text()
-    assert f"Path={src}\n" in body
+    # quote(), not the bare f-string: see test_xdg_trash_writes_the_spec_sidecar
+    # — on Windows str(src) itself needs percent-encoding (drive colon,
+    # backslash separators), which `_trashinfo_body` applies via quote().
+    assert f"Path={urllib.parse.quote(str(src), safe='/')}\n" in body
     assert "entirely-and-much-longer" not in body  # truncated, not left trailing
 
 
@@ -826,7 +869,14 @@ def test_trash_move_boundary_rejects_a_symlinked_parent(tmp_path, monkeypatch):
     trash = _xdg_trash_root(monkeypatch, tmp_path)
     outside = tmp_path / "outside"
     outside.mkdir()
-    (trash / "files" / "link").symlink_to(outside)
+    # target_is_directory=True: on Windows symlink_to defaults to a FILE-type
+    # reparse point, and a file-type link to a directory does not resolve
+    # `link/..` through it the way this test's attack path needs — the kernel
+    # never gets the chance to take the wrong turn the test is trying to prove
+    # is refused. POSIX symlinks are type-agnostic, so this is a no-op there
+    # (matches the equivalent link in test_delete_symlink_to_dir_removes_link_
+    # not_target above).
+    (trash / "files" / "link").symlink_to(outside, target_is_directory=True)
     victim = trash / "info" / "y.txt.trashinfo"
     victim.write_text("[Trash Info]\n")
     # The file must sit where the KERNEL resolves the attack path, or the rename
@@ -860,7 +910,15 @@ def test_trash_move_still_recognises_a_trashed_SYMLINK_as_an_entry(tmp_path, mon
     dst = tmp_path / "link.txt"
     _data(TRASH_MOVE({"from": str(entry), "to": str(dst)}, x_fused="1"))
     assert dst.is_symlink()   # the LINK came home, not a copy of its target
-    assert os.readlink(dst) == str(target)
+    # Windows can report the reparse point's target with the "\\?\"
+    # extended-length prefix even though it was created from a plain absolute
+    # path — a cosmetic artifact of how NTFS stores/returns an absolute
+    # SubstituteName, not a different target. Stripped before comparing so
+    # the assertion is still about WHICH file the link names.
+    got_target = os.readlink(dst)
+    if got_target.startswith("\\\\?\\"):
+        got_target = got_target[4:]
+    assert got_target == str(target)
     assert not info.exists()  # and its sidecar went with it
     assert target.read_text() == "payload"  # the target was never touched
     # NOTE a DANGLING trashed link cannot be restored this way, and not because of

--- a/tests/test_server_fs_write.py
+++ b/tests/test_server_fs_write.py
@@ -14,6 +14,7 @@ templates render read-only mode up front.
 import json
 import os
 import stat
+import sys
 
 import pytest
 from fastapi.responses import JSONResponse
@@ -70,6 +71,16 @@ def test_stat_writable_false_for_readonly_file(readonly):
 
 
 @skip_root
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="`writable` on a directory comes from os.access(path, os.W_OK) "
+           "(mount._writable), and Windows' directory read-only attribute is "
+           "largely vestigial — long used only by Explorer's folder-"
+           "customization UI, not access control — so os.access keeps "
+           "reporting a chmod'd-read-only DIRECTORY as writable there. The "
+           "sibling file case (test_stat_writable_false_for_readonly_file) is "
+           "unaffected: Windows' read-only attribute IS honoured for files, "
+           "just not for directories.")
 def test_stat_writable_on_directory(tmp_path):
     assert _data(STAT(str(tmp_path)))["writable"] is True
     os.chmod(tmp_path, stat.S_IRUSR | stat.S_IXUSR)

--- a/tests/test_server_walk.py
+++ b/tests/test_server_walk.py
@@ -259,7 +259,24 @@ def test_walk_stream_same_entries_as_plain(tmp_path):
     plain = client.get("/api/fs/walk", params={"path": str(tmp_path)}).json()
     lines = _stream_lines(client, str(tmp_path))
     streamed = [e for line in lines if "entries" in line for e in line["entries"]]
-    assert streamed == plain["entries"]  # same content, same (BFS) order
+    # Same content, same (BFS) order, and — mtime aside — same values. These are
+    # two INDEPENDENT requests (that is the point: confirming the streamed and
+    # plain responses agree), each running its OWN full call to _walk_bfs a
+    # moment apart; both go through the exact same generator, so there is no
+    # code path here that could disagree about what a directory's mtime is.
+    # What CAN legitimately differ by a sub-millisecond amount between two live
+    # re-stats of the same just-created directory is the filesystem's own
+    # metadata write-back settling — on a real Windows/NTFS runner a `sub` dir
+    # whose creation is still being committed when the first request's
+    # FindNextFile-backed DirEntry.stat() captures it can read back a mtime a
+    # fraction of a millisecond earlier than the second request's, moments
+    # later, does. That is filesystem timing noise between two reads, not a
+    # disagreement to pin exactly.
+    assert [{**e, "mtime": None} for e in streamed] \
+        == [{**e, "mtime": None} for e in plain["entries"]]
+    assert len(streamed) == len(plain["entries"])
+    for s, p in zip(streamed, plain["entries"]):
+        assert abs(s["mtime"] - p["mtime"]) < 0.01
 
 
 def test_walk_stream_truncation(tmp_path, monkeypatch):

--- a/tests/test_shell_bookmarks.py
+++ b/tests/test_shell_bookmarks.py
@@ -414,8 +414,13 @@ def test_migration_leaves_unique_tree_unwritten(tmp_path, monkeypatch):
 
 def _view_url(path, search=""):
     # Encode each segment like the frontend's urlForFsPath (lib/router.ts) —
-    # mirrors test_shell_recents.py's helper of the same name.
-    encoded = "/".join(quote(s, safe="") for s in str(path).lstrip("/").split("/"))
+    # mirrors test_shell_recents.py's helper of the same name. str(path) is
+    # OS-native (backslash-separated on Windows) — normalize to the shell's
+    # canonical forward-slash form FIRST (same as _view_url_codec's
+    # canonical_fs_path), or a Windows drive path collapses to one un-split,
+    # garbage-encoded segment instead of the real path segments.
+    posix = str(path).replace("\\", "/")
+    encoded = "/".join(quote(s, safe="") for s in posix.lstrip("/").split("/"))
     return "/view/" + encoded + search
 
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -310,7 +310,11 @@ def test_mountpoint_derives_from_branch_aware_home(home):
     c = mounts_mod.add_mount("data", "remote:bucket")
     mp = mounts_mod.mountpoint(c)
     assert mp.startswith(str(home))
-    assert mp.endswith("/mounts/data")
+    # mounts_dir() deliberately os.path.normpath's — a mountpoint has to
+    # string-match what rcd itself reports, which is OS-native (backslashed
+    # on Windows), unlike the rest of the app's forward-slash canonical form
+    # (store.py's mounts_dir docstring). So the suffix is OS-native too.
+    assert mp.endswith(mounts_mod.os.path.join("mounts", "data"))
 
 
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -36,6 +36,21 @@ def _warm_https_opener():
         _u._opener = _u.build_opener()
 
 
+@pytest.fixture(autouse=True)
+def _winfsp_present_by_default(monkeypatch):
+    """Assume WinFsp is installed unless a test says otherwise.
+
+    `_winfsp_available()` is vacuously True off win32 — which is what let every
+    generic (not-about-WinFsp) test in this file run unpatched as long as CI
+    was Linux/macOS only. Running for real on win32 makes that vacuous default
+    into a real filesystem probe against a driver DLL this CI runner does not
+    have installed, so it has to be stated explicitly instead of inherited for
+    free. The handful of tests that exercise the missing-driver path set their
+    own `monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: False)`
+    afterwards, which wins over this one."""
+    monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: True)
+
+
 @pytest.fixture()
 def home(tmp_path, monkeypatch):
     home = tmp_path / "home"

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -3090,22 +3090,47 @@ def _make_mount(home, rcd, name="data", remote="remote:bucket", served=True):
 # test in this file ever runs the real predicate; these must, or the swallowed
 # OSError (the whole bug) stays invisible.
 def _wedge(monkeypatch, mp, *, also_mounted=None):
-    """Make `mp` stat like a mount whose backend process is gone. Restores the
-    genuine os.path.ismount (optionally OR'd with the stub rcd's mount table, so
-    a remount later in the same test can still be seen) and fails lstat/stat on
-    `mp` alone. Returns a {"v": True} flag a test flips to un-wedge the path
-    once its umount has "succeeded"."""
-    # Bound before patching: os.path IS posixpath, so a lambda that referenced
-    # posixpath.ismount by attribute would call the patched name — itself.
-    real_ismount = posixpath.ismount
+    """Make `mp` stat like a mount whose backend process is gone: ismount
+    answers deterministically, and lstat/stat on `mp` alone raise ENOTCONN.
+    Returns a {"v": True} flag a test flips to un-wedge the path once its
+    umount has "succeeded".
+
+    ismount is ANSWERED HERE rather than delegated to the real
+    posixpath.ismount, which is what this used to do. That delegation made the
+    fixture depend on the host filesystem, and it misfires on a Windows runner:
+    posixpath decides "mountpoint" by comparing a path's (st_dev, st_ino)
+    against its parent's and returning True when the inodes match, and Windows
+    reports st_ino as 0 for these paths — 0 == 0, so an ORDINARY TEMP DIRECTORY
+    came back True. That single wrong answer is the whole of both Windows
+    failures this file had: the healthy-path assertion in
+    test_mount_wedged_false_for_missing_and_healthy_paths, and the
+    post-umount "still mounted" check in
+    test_reconnect_force_unmounts_enotconn_mount_that_ismount_cannot_see.
+    (Verifiable off-Windows: force st_ino to 0 for a dir and its parent, and
+    posixpath.ismount calls it a mountpoint.)
+
+    The three answers below are the scenario's own definition, so they are
+    stated instead of derived:
+      * the wedged path is NOT a mountpoint to ismount — that is the very
+        thing being modeled, "a mount ismount cannot see", and
+        test_mount_wedged_detects_enotconn asserts it directly;
+      * a path in `also_mounted` IS one, so a remount later in the same test
+        is visible (that is what the stub rcd's table is passed in for);
+      * nothing else is — these tests only ever hand it tmp_path dirs.
+    On POSIX this is the same set of answers the real predicate already gave,
+    so the Linux suite is unaffected; it just no longer asks the host.
+    """
     # The wedge being modeled is the POSIX FUSE one (ENOTCONN stats); pin the
     # platform so _mount_wedged's win32 branch never bypasses these mocks.
     monkeypatch.setattr(mounts_mod.sys, "platform", "linux")
-    monkeypatch.setattr(
-        mounts_mod.os.path, "ismount",
-        real_ismount if also_mounted is None
-        else lambda p: real_ismount(p) or p in also_mounted)
     wedged = {"v": True}
+
+    def fake_ismount(p):
+        if wedged["v"] and p == mp:
+            return False
+        return also_mounted is not None and p in also_mounted
+
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", fake_ismount)
 
     def stub(real):
         def probe(path, *a, **kw):
@@ -3120,6 +3145,50 @@ def _wedge(monkeypatch, mp, *, also_mounted=None):
     monkeypatch.setattr(mounts_mod.os, "lstat", stub(_os.lstat))
     monkeypatch.setattr(mounts_mod.os, "stat", stub(_os.stat))
     return wedged
+
+
+def test_the_wedge_fixture_never_asks_the_host_what_a_mountpoint_is(
+        tmp_path, monkeypatch):
+    """Regression guard for both Windows failures this file used to have.
+
+    `_wedge` used to delegate to the real posixpath.ismount, which decides
+    "mountpoint" by comparing a path's (st_dev, st_ino) with its parent's and
+    saying yes when the inodes match. Windows reports st_ino as 0 for these
+    paths, so 0 == 0 made an ORDINARY TEMP DIR answer True — which is the
+    entire cause of the two failures (the healthy-path assertion below, and
+    reconnect's post-umount "still mounted" check).
+
+    Reproduced off-Windows by forcing st_ino to 0, since that zero is the whole
+    of the platform difference: under the old fixture these assertions fail
+    here exactly as they did on the runner, and under the current one they hold
+    because ismount is answered from the scenario instead of the filesystem.
+    """
+    healthy = str(tmp_path / "plain")
+    _os.makedirs(healthy)
+    wedged_path = str(tmp_path / "mnt")
+    _os.makedirs(wedged_path, exist_ok=True)
+
+    real_lstat = _os.lstat
+
+    class _ZeroIno:
+        """A stat_result whose st_ino is 0, as Windows reports it here."""
+
+        def __init__(self, s):
+            self._s = s
+
+        st_ino = 0
+
+        def __getattr__(self, name):
+            return getattr(self._s, name)
+
+    monkeypatch.setattr(_os, "lstat", lambda p, *a, **k: _ZeroIno(real_lstat(p)))
+
+    _wedge(monkeypatch, wedged_path)
+    # A plain directory is not a mount, whatever the host's inodes say.
+    assert mounts_mod.os.path.ismount(healthy) is False
+    assert mounts_mod._is_mounted(healthy) is False
+    # And the wedged path stays invisible to ismount — the modeled scenario.
+    assert mounts_mod.os.path.ismount(wedged_path) is False
 
 
 def test_mount_wedged_detects_enotconn(tmp_path, monkeypatch):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -5003,7 +5003,12 @@ def test_no_session_token_remote_keeps_default_link_ttl(home, rcd, fresh_upstrea
     before = time.monotonic()
     mounts_mod.upstream_url_for(f)
     _url, expiry = mounts_mod._upstream_links[("remote:bucket", "a.parquet")]
-    assert expiry - before > mounts_mod._SESSION_TOKEN_LINK_TTL_S
+    # >=, not >: probe.py computes expiry as its OWN time.monotonic() call
+    # plus the TTL, and that call can land on the same coarse tick as
+    # `before` above (Windows' time.monotonic() is GetTickCount64-backed,
+    # ~15.6ms resolution) — the real guarantee is "at least the TTL", not
+    # "strictly more than it".
+    assert expiry - before >= mounts_mod._SESSION_TOKEN_LINK_TTL_S
 
 
 def test_fs_raw_redirects_cold_native_range_reads(client, home, rcd, fresh_upstream):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -4994,21 +4994,42 @@ def test_env_session_token_remote_gets_short_link_ttl(home, rcd, fresh_upstream,
     assert 240 < expiry - before < mounts_mod._SESSION_TOKEN_LINK_TTL_S + 60
 
 
-def test_no_session_token_remote_keeps_default_link_ttl(home, rcd, fresh_upstream):
+def test_no_session_token_remote_keeps_default_link_ttl(
+        home, rcd, fresh_upstream, monkeypatch):
     import os
 
+    # config/get MUST be stubbed for this test to test its own name. Without
+    # it `_rc` raises, `_remote_config` returns None, and `_link_ttl` takes its
+    # documented "cannot rule out a session token" clamp — the SAME 300s this
+    # test exists to prove is NOT used. It passed anyway for as long as it has
+    # existed, on nothing but float noise: the old `> _SESSION_TOKEN_LINK_TTL_S`
+    # saw (now + 300.0) - now land at 300.00009 on Linux and 299.99999999999977
+    # on Windows, so the identical wrong behaviour passed on one platform and
+    # failed on the other.
+    #
+    # Static keys and no AWS_SESSION_TOKEN: a remote whose credentials
+    # genuinely carry no STS token, which is the case the default ttl is for.
+    monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
+    rcd.responses["config/get"] = {"type": "s3", "access_key_id": "AK",
+                                   "secret_access_key": "SK"}
     rcd.responses["operations/publiclink"] = {"url": "https://signed.example/x?sig=1"}
     c = mounts_mod.add_mount("data", "remote:bucket")
     f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
     before = time.monotonic()
     mounts_mod.upstream_url_for(f)
     _url, expiry = mounts_mod._upstream_links[("remote:bucket", "a.parquet")]
-    # >=, not >: probe.py computes expiry as its OWN time.monotonic() call
-    # plus the TTL, and that call can land on the same coarse tick as
-    # `before` above (Windows' time.monotonic() is GetTickCount64-backed,
-    # ~15.6ms resolution) — the real guarantee is "at least the TTL", not
-    # "strictly more than it".
-    assert expiry - before >= mounts_mod._SESSION_TOKEN_LINK_TTL_S
+    # Pinned against the DEFAULT ttl itself, not merely "> the clamp". The
+    # weaker form is what this line used to be, and it is a trap: the failure
+    # mode in practice is the clamp being applied when it should not be, and
+    # `> clamp` / `>= clamp` both let a run that took the clamp slip through on
+    # nothing but floating-point noise ((now + 300.0) - now lands a few ULPs
+    # either side of 300.0 at monotonic values in the thousands, so the same
+    # wrong behaviour passes or fails at random).
+    #
+    # abs=1.0 absorbs the tick between probe.py's own time.monotonic() and
+    # `before` here; the two ttls are 1800 vs 300, so no tolerance this small
+    # can confuse them.
+    assert expiry - before == pytest.approx(mounts_mod._LINK_TTL_S, abs=1.0)
 
 
 def test_fs_raw_redirects_cold_native_range_reads(client, home, rcd, fresh_upstream):

--- a/tests/test_shell_recents.py
+++ b/tests/test_shell_recents.py
@@ -26,7 +26,12 @@ def _client(tmp_path, monkeypatch):
 
 def _view_url(path, search=""):
     # Encode each segment like the frontend's urlForFsPath (lib/router.ts).
-    encoded = "/".join(quote(s, safe="") for s in str(path).lstrip("/").split("/"))
+    # str(path) is OS-native (backslash-separated on Windows) — normalize to
+    # the shell's canonical forward-slash form FIRST, same as
+    # _view_url_codec.canonical_fs_path, or a Windows drive path collapses to
+    # one un-split, garbage-encoded segment instead of the real path segments.
+    posix = str(path).replace("\\", "/")
+    encoded = "/".join(quote(s, safe="") for s in posix.lstrip("/").split("/"))
     return "/view/" + encoded + search
 
 

--- a/tests/test_shell_storage_retry.py
+++ b/tests/test_shell_storage_retry.py
@@ -1,0 +1,136 @@
+"""storage.read_json / write_json under Windows sharing violations.
+
+POSIX rename(2) is atomic and never refuses a concurrent replace, and a
+concurrent open() for read is never refused either — which is what lets
+storage.write_json promise "last write wins" with no locking above it (D3).
+Windows gives neither for free: os.replace is backed by MoveFileExW, which
+holds the destination for the duration of the swap, and a plain open() grants
+no FILE_SHARE_DELETE — so a writer AND a reader can each be refused with a
+transient PermissionError ([WinError 5] / [Errno 13]) for a few milliseconds.
+
+Both halves are covered here because only fixing the writer left the reader
+raising into live requests: the Windows CI run surfaced a PermissionError out
+of read_json via shell/mounts/rcd.py's `_rcd_auth`, which is a request path.
+
+`os.name` is patched rather than skipping off-Windows: the retry is gated on
+os.name alone, so this pins the real branch on any host.
+"""
+import json
+import os
+
+import pytest
+
+from fused_render.shell import storage
+
+
+@pytest.fixture()
+def no_sleep(monkeypatch):
+    """The retry's own delay, removed — these tests assert the retry COUNT,
+    and the real budget would otherwise spend seconds sleeping."""
+    monkeypatch.setattr(storage.time, "sleep", lambda _s: None)
+
+
+@pytest.fixture()
+def as_windows(monkeypatch):
+    monkeypatch.setattr(storage.os, "name", "nt")
+
+
+def test_read_json_rides_out_a_transient_sharing_violation(
+        tmp_path, monkeypatch, as_windows, no_sleep):
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({"secret": "v2"}), encoding="utf-8")
+    real_open, calls = open, []
+
+    def flaky_open(*a, **kw):
+        calls.append(1)
+        if len(calls) < 3:            # refused twice, then the writer lets go
+            raise PermissionError(13, "Permission denied")
+        return real_open(*a, **kw)
+
+    monkeypatch.setattr("builtins.open", flaky_open)
+    assert storage.read_json(str(path)) == {"secret": "v2"}
+    assert len(calls) == 3
+
+
+def test_a_missing_file_is_answered_at_once_and_never_retried(
+        tmp_path, monkeypatch, as_windows, no_sleep):
+    """read_json's "absent -> None" is a hot path (the bookmarks `exists`
+    flag, the one-time import gate). Retrying it would spend the whole budget
+    on the commonest case, so only PermissionError is retried."""
+    calls = []
+    real_open = open
+
+    def counting_open(*a, **kw):
+        calls.append(1)
+        return real_open(*a, **kw)
+
+    monkeypatch.setattr("builtins.open", counting_open)
+    assert storage.read_json(str(tmp_path / "never-written.json")) is None
+    assert len(calls) == 1
+
+
+def test_a_corrupt_file_is_still_none_and_not_retried(
+        tmp_path, monkeypatch, as_windows, no_sleep):
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    calls = []
+    real_open = open
+
+    def counting_open(*a, **kw):
+        calls.append(1)
+        return real_open(*a, **kw)
+
+    monkeypatch.setattr("builtins.open", counting_open)
+    assert storage.read_json(str(path)) is None
+    assert len(calls) == 1
+
+
+def test_a_violation_that_outlives_the_budget_still_raises(
+        tmp_path, monkeypatch, as_windows, no_sleep):
+    """A file that is genuinely unreadable is not a millisecond of contention.
+    Reporting it as None would silently degrade whatever read it (mount auth,
+    say) instead of surfacing a real problem."""
+    path = tmp_path / "state.json"
+    path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        "builtins.open",
+        lambda *a, **kw: (_ for _ in ()).throw(PermissionError(13, "denied")))
+    with pytest.raises(PermissionError):
+        storage.read_json(str(path))
+
+
+def test_write_json_rides_out_a_transient_sharing_violation(
+        tmp_path, monkeypatch, as_windows, no_sleep):
+    path = tmp_path / "state.json"
+    real_replace, calls = os.replace, []
+
+    def flaky_replace(src, dst):
+        calls.append(1)
+        if len(calls) < 3:
+            raise PermissionError(13, "Access is denied")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(storage.os, "replace", flaky_replace)
+    storage.write_json(str(path), {"secret": "v3"})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"secret": "v3"}
+    assert len(calls) == 3
+
+
+def test_posix_keeps_its_exact_single_call_behaviour(tmp_path, monkeypatch):
+    """The retry must not change POSIX at all: one call, no sleep import in
+    the hot path, and a PermissionError propagating immediately."""
+    monkeypatch.setattr(storage.os, "name", "posix")
+    monkeypatch.setattr(
+        storage.time, "sleep",
+        lambda _s: pytest.fail("POSIX must never sleep-and-retry"))
+    path = tmp_path / "state.json"
+    calls = []
+    real_replace = os.replace
+
+    def counting_replace(src, dst):
+        calls.append(1)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(storage.os, "replace", counting_replace)
+    storage.write_json(str(path), {"a": 1})
+    assert len(calls) == 1

--- a/tests/test_supervisor_linux_integration.py
+++ b/tests/test_supervisor_linux_integration.py
@@ -71,7 +71,11 @@ def test_first_install_writes_files_and_pokes_databases(env):
 
     # .desktop entry: absolute quoted AppImage Exec with the URL field code.
     desktop = env.desktop_file.read_text()
-    assert f"Exec={env.appimage} %u" in desktop
+    # Via _exec_quote rather than the assumption "no quoting needed": a real
+    # tmp_path is a native path, and on Windows that always contains the
+    # backslash separator, itself an _EXEC_RESERVED char — even though this
+    # Linux-only integration path never runs on a real Windows install.
+    assert f"Exec={integration.startup._exec_quote(str(env.appimage))} %u" in desktop
     assert "MimeType=" in desktop and desktop.rstrip().endswith("x-scheme-handler/fused-render;")
     assert f"Icon={env.icon_file}" in desktop
 
@@ -134,7 +138,7 @@ def test_reintegrates_when_appimage_moves(env, tmp_path):
     moved.write_text("#!/bin/sh\n")
     integration.integrate(env.paths, appimage=moved, icon_source=env.icon_src)
     assert env.tool_calls != []
-    assert f"Exec={moved} %u" in env.desktop_file.read_text()
+    assert f"Exec={integration.startup._exec_quote(str(moved))} %u" in env.desktop_file.read_text()
     assert json.loads(env.stamp_file.read_text())["appimage"] == str(moved)
 
 
@@ -264,7 +268,17 @@ def test_deintegrate_swallows_tool_failures(env, monkeypatch):
 
 
 def _exec_line(appimage: str) -> str:
-    entry = integration._desktop_entry(Path(appimage), "fused-render")
+    # Deliberately NOT wrapped in Path(appimage): _desktop_entry only ever
+    # calls str() on it, and these are POSIX-style literals standing in for a
+    # hypothetical AppImage location (AppImages/.desktop files are Linux-only,
+    # so no such path is ever native-Windows in reality). Routing a literal
+    # through Path() would let the host OS's path flavour reinterpret it —
+    # on Windows, `Path("/opt/Fu\\sed.AppImage")` parses the embedded "\\" as
+    # a directory separator instead of the literal character under test, and
+    # str() back out renders every "/" as "\\" too, corrupting the very
+    # escaping behaviour being pinned here. Passing the plain string keeps
+    # these tests pure-string checks of _exec_quote, exactly as intended.
+    entry = integration._desktop_entry(appimage, "fused-render")
     (line,) = [ln for ln in entry.splitlines() if ln.startswith("Exec=")]
     return line
 

--- a/tests/test_supervisor_linux_paths.py
+++ b/tests/test_supervisor_linux_paths.py
@@ -5,6 +5,7 @@ selection) with no Linux kernel dependency, so they run on macOS too. The
 dialogs themselves are gate-tested manually (docs/LINUX_DESKTOP_SPEC.md).
 """
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,7 @@ def test_state_is_the_flat_dotdir_shared_with_cli(monkeypatch, tmp_path):
     # XDG_CACHE_HOME (disposable, out of backup scope) and runtime stays on
     # XDG_RUNTIME_DIR (tmpfs, 0700, socket-safe).
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Path.home()'s expanduser on Windows
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
     p = paths_mod.DesktopPaths.discover_linux()
@@ -80,6 +82,7 @@ def test_xdg_data_home_no_longer_affects_the_root(monkeypatch, tmp_path):
     # The move off ~/.local/share means XDG_DATA_HOME must NOT steer the state
     # root anymore — it only ever governed the old XDG-data layout.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Path.home()'s expanduser on Windows
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
     p = paths_mod.DesktopPaths.discover_linux()
     root = tmp_path / ".fused-render"
@@ -91,6 +94,7 @@ def test_xdg_data_home_no_longer_affects_the_root(monkeypatch, tmp_path):
 def test_cache_and_runtime_fallbacks_when_xdg_unset(monkeypatch, tmp_path):
     _clear_xdg(monkeypatch)
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Path.home()'s expanduser on Windows
     p = paths_mod.DesktopPaths.discover_linux()
     root = tmp_path / ".fused-render"
     assert p.root == root
@@ -186,7 +190,12 @@ def test_payload_tools_share_one_dir(monkeypatch, tmp_path):
     tools = tmp_path / "tools"
     env = paths_mod.DesktopPaths.discover_linux().child_environment("i", "t", tools)
     assert env["FUSED_RENDER_DUCKDB_EXTENSION_DIR"] == str(tools / "duckdb_extensions")
-    assert env["FUSED_RENDER_RCLONE_BIN"] == str(tools / "rclone")
+    # child_environment names the binary "rclone.exe" on win32 (it's bundled
+    # that way), "rclone" everywhere else — match that rather than assume the
+    # POSIX name, since this test's whole point is the shared tools_dir, not
+    # the platform-specific filename.
+    rclone_name = "rclone.exe" if sys.platform == "win32" else "rclone"
+    assert env["FUSED_RENDER_RCLONE_BIN"] == str(tools / rclone_name)
     assert env["PATH"].split(os.pathsep)[0] == str(tools)
 
 

--- a/tests/test_supervisor_linux_startup.py
+++ b/tests/test_supervisor_linux_startup.py
@@ -40,15 +40,30 @@ def _autostart_exec(monkeypatch, tmp_path, appimage):
 def test_autostart_entry_double_quotes_spaced_launcher(monkeypatch, tmp_path):
     appimage = tmp_path / "Fused Render.AppImage"
     appimage.write_text("#!/bin/sh\n")
+    # The exact escaping algorithm (space -> double-quoted, no other reserved
+    # chars) is already pinned with a literal input by test_exec_quote_* above;
+    # what this test adds is that set_enabled() actually feeds the REAL
+    # resolved launcher through that same _exec_quote, so the expectation is
+    # built the same way rather than assumed. That distinction matters on
+    # Windows: tmp_path is a native WindowsPath there, and its backslash
+    # separators are themselves an _EXEC_RESERVED character, so a hardcoded
+    # "just double-quoted, nothing escaped inside" literal would be wrong for
+    # a real Windows path even though this Linux-only module never runs there.
     assert _autostart_exec(monkeypatch, tmp_path, appimage) == (
-        f'Exec="{appimage}" --startup'
+        f"Exec={startup._exec_quote(str(appimage))} --startup"
     )
 
 
 def test_autostart_entry_plain_launcher_unquoted(monkeypatch, tmp_path):
     appimage = tmp_path / "FusedRender.AppImage"
     appimage.write_text("#!/bin/sh\n")
-    assert _autostart_exec(monkeypatch, tmp_path, appimage) == f"Exec={appimage} --startup"
+    # See the comment above: same reasoning, "unquoted" only actually holds
+    # when the real launcher path has no reserved character, which every
+    # POSIX tmp_path satisfies but no Windows one can (it always contains
+    # backslash separators).
+    assert _autostart_exec(monkeypatch, tmp_path, appimage) == (
+        f"Exec={startup._exec_quote(str(appimage))} --startup"
+    )
 
 
 # ---- refresh_autostart: self-heal the autostart Exec= after an AppImage move --
@@ -69,7 +84,11 @@ def test_refresh_autostart_rewrites_stale_exec_path(monkeypatch, tmp_path):
     old = tmp_path / "FusedRender.AppImage"
     old.write_text("#!/bin/sh\n")
     desktop = _enable_autostart(monkeypatch, tmp_path, old)
-    assert f"Exec={old} --startup" in desktop.read_text()
+    # Built via _exec_quote rather than assumed unquoted, same reasoning as
+    # the two tests above: a real tmp_path is a native path, and on Windows
+    # that's never free of _EXEC_RESERVED characters (the backslash
+    # separator), even though this Linux-only module never runs there for real.
+    assert f"Exec={startup._exec_quote(str(old))} --startup" in desktop.read_text()
 
     # The AppImage moved: $APPIMAGE now points at the new location.
     moved = tmp_path / "moved" / "FusedRender.AppImage"
@@ -79,7 +98,7 @@ def test_refresh_autostart_rewrites_stale_exec_path(monkeypatch, tmp_path):
 
     startup.refresh_autostart()
 
-    assert f"Exec={moved} --startup" in desktop.read_text()
+    assert f"Exec={startup._exec_quote(str(moved))} --startup" in desktop.read_text()
 
 
 def test_refresh_autostart_is_noop_when_entry_already_matches(monkeypatch, tmp_path):

--- a/tests/test_supervisor_linux_tree.py
+++ b/tests/test_supervisor_linux_tree.py
@@ -12,7 +12,6 @@ process that holds an exclusive lock on a shared file is alive; once the kernel
 releases that lock (because the process died), the test can take it — this works
 identically across pid namespaces because the mount namespace is shared.
 """
-import fcntl
 import os
 import shutil
 import signal
@@ -22,6 +21,12 @@ import time
 from pathlib import Path
 
 import pytest
+
+# importorskip, not a bare `import fcntl`: fcntl is POSIX-only, and a bare
+# import blows up at COLLECTION time on Windows, before the pytestmark below
+# ever gets a chance to skip the module (mirrors tests/test_supervisor_job.py's
+# `pytest.importorskip("win32job")` for the same reason on the other platform).
+fcntl = pytest.importorskip("fcntl")
 
 pytestmark = pytest.mark.skipif(
     not sys.platform.startswith("linux"),

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -215,8 +215,10 @@ def test_a_chat_opened_on_a_file_targets_that_file(
     ])
 
     task = _tasks(client)[0]
-    assert task["target"] == str(file)
-    assert task["project"] == str(proj)
+    # The API canonicalizes project/target (tasks.py: canonical_fs_path) — a
+    # forward-slash form, unlike the raw native-separator str(Path) on Windows.
+    assert task["target"] == tasks_mod.canonical_fs_path(str(file))
+    assert task["project"] == tasks_mod.canonical_fs_path(str(proj))
     assert task["messages"][0]["body"] == "make the wave faster"
 
 
@@ -231,8 +233,8 @@ def test_a_pane_file_that_is_gone_falls_back_to_the_folder(
     ])
 
     task = _tasks(client)[0]
-    assert task["target"] == str(proj)
-    assert task["project"] == str(proj)
+    assert task["target"] == tasks_mod.canonical_fs_path(str(proj))
+    assert task["project"] == tasks_mod.canonical_fs_path(str(proj))
 
 
 def test_a_scheduled_entry_target_beats_the_pane_file(
@@ -254,7 +256,7 @@ def test_a_scheduled_entry_target_beats_the_pane_file(
     ])
 
     task = _tasks(client)[0]
-    assert task["target"] == str(proj / "report.py")
+    assert task["target"] == tasks_mod.canonical_fs_path(str(proj / "report.py"))
 
 
 def test_sidebar_pulse_is_the_compact_projection_of_the_task_rows(
@@ -551,8 +553,8 @@ def test_a_pending_scheduled_message_is_a_task_with_no_session(client,
     assert task["task_id"] == "TASK-001"
     # A task on a FILE belongs to the folder (§2) — files and folders do not get
     # separate session pools — and keeps the file as its displayed target.
-    assert task["project"] == str(target.parent)
-    assert task["target"] == str(target)
+    assert task["project"] == tasks_mod.canonical_fs_path(str(target.parent))
+    assert task["target"] == tasks_mod.canonical_fs_path(str(target))
     assert task["status"] == "upcoming"
     assert task["message_count"] == 1
     message = task["messages"][0]

--- a/tests/test_tasks_store.py
+++ b/tests/test_tasks_store.py
@@ -386,6 +386,14 @@ def test_concurrent_marks_all_survive(state_dir):
     """Two writers, one file. Without the read-modify-write inside the lock the
     second would persist a snapshot taken before the first's change and silently
     drop it."""
+    if tasks_store.fcntl is None:
+        # `_update`'s own comment says it: "Windows falls back to no
+        # inter-process lock" — not a bug this sweep introduced, the same
+        # accepted posture as claude_sessions.api_claude_session_triage. With
+        # no lock at all, two threads racing the read-modify-write WILL drop
+        # one side's marks; that is not this test's bug to catch, since the
+        # code never promised otherwise there.
+        pytest.skip("no lock on this platform (tasks_store._update, by design)")
     errors = []
 
     def mark(prefix):
@@ -411,6 +419,12 @@ def test_concurrent_marks_all_survive(state_dir):
 def test_concurrent_allocations_do_not_collide(state_dir):
     """Two listings racing to number the same project must not hand out one
     number twice."""
+    if tasks_store.fcntl is None:
+        # Same reasoning as test_concurrent_marks_all_survive above: with no
+        # lock on this platform, two threads can read the same "next number"
+        # and both allocate it — an accepted gap, not a regression to catch.
+        pytest.skip("no lock on this platform (tasks_store._update, by design)")
+
     def allocate(prefix):
         for n in range(10):
             tasks_store.ensure_ids([(f"{prefix}{n}", "/p", float(n))])

--- a/tests/test_template_appenv.py
+++ b/tests/test_template_appenv.py
@@ -271,7 +271,12 @@ def test_the_bundled_uv_is_on_the_path_every_child_inherits(home, tmp_path, monk
     monkeypatch.setenv("PATH", str(empty))
 
     server.export_app_env()
-    assert shutil.which("uv") == str(uv)
+    # normcase, not a bare ==: shutil.which() on Windows matches "uv" against
+    # PATHEXT (.COM;.EXE;...) and returns cmd + THAT extension's case, e.g.
+    # "uv.EXE", regardless of the actual on-disk filename's case ("uv.exe"
+    # here) — a case difference on a filesystem where it is not a different
+    # file. Same idiom as templates/claude/agent.py's containment check.
+    assert os.path.normcase(shutil.which("uv")) == os.path.normcase(str(uv))
 
 
 def test_ro_mounts_env_tracks_a_store_write(home, monkeypatch):

--- a/tests/test_template_listing_mount.py
+++ b/tests/test_template_listing_mount.py
@@ -284,9 +284,25 @@ def pathfs():
 _DIR = "/definitely/not/here/on/disk/mnt-dir"
 
 
-def test_map_discover_remote_file_descends_to_parent(pathfs):
+def _abs_dir_and_file(name):
+    """The (directory, file) pair every one of these readers actually queries
+    the fake fs/stat+list server with — NOT the raw `_DIR` literal.
+
+    Each reader's own first line is `path = os.path.abspath(...)`, so on POSIX
+    this is a no-op and `_DIR` round-trips unchanged, but on Windows abspath
+    prepends the checkout's current drive letter and swaps in backslashes
+    (`D:\\definitely\\...`) before the path ever reaches `_stat`/`_list_remote`.
+    `_PathFakeFS` matches the query path by exact string, so the fake server's
+    `dir_path`/`file_path` — and any assertion against the reader's returned
+    dir/path field — have to be built through that SAME abspath, exactly like
+    `test_map_discover_remote_file_descends_to_parent` below already does.
+    """
     directory = os.path.abspath(_DIR)
-    file_path = os.path.join(directory, "scene.nitf")
+    return directory, os.path.join(directory, name)
+
+
+def test_map_discover_remote_file_descends_to_parent(pathfs):
+    directory, file_path = _abs_dir_and_file("scene.nitf")
     server = pathfs(
         directory,
         [_ent("sub", is_dir=True), _ent("scene.nitf", size=10)],
@@ -302,50 +318,55 @@ def test_map_discover_remote_file_descends_to_parent(pathfs):
 
 
 def test_excel_listdir_remote_file_descends_to_parent(pathfs):
-    fp = _DIR + "/book.xlsx"
-    s = pathfs(_DIR, [_ent("sub", is_dir=True), _ent("book.xlsx", size=10)], fp)
+    directory, fp = _abs_dir_and_file("book.xlsx")
+    s = pathfs(directory, [_ent("sub", is_dir=True), _ent("book.xlsx", size=10)], fp)
     res = excel._listdir(fp, origin=s.src)
     assert "error" not in res
-    assert res["path"] == _DIR
+    # excel._listdir forward-slashes its own abspath'd `path` before returning
+    # it (D99-style "/"-only crumb/join contract) — canonicalize the same way.
+    assert res["path"] == directory.replace(os.sep, "/")
     assert res["dirs"] == ["sub"]
     assert [f["name"] for f in res["files"]] == ["book.xlsx"]
 
 
 def test_docs_listdir_remote_file_descends_to_parent(pathfs):
-    fp = _DIR + "/report.docx"
-    s = pathfs(_DIR, [_ent("sub", is_dir=True), _ent("report.docx")], fp)
+    directory, fp = _abs_dir_and_file("report.docx")
+    s = pathfs(directory, [_ent("sub", is_dir=True), _ent("report.docx")], fp)
     res = docs.main(action="listdir", path=fp, src=s.src)
-    assert res["path"] == _DIR
+    assert res["path"] == directory.replace(os.sep, "/")
     assert res["dirs"] == ["sub"]
     assert res["files"] == ["report.docx"]
 
 
 def test_latex_browse_remote_file_descends_to_parent(pathfs):
-    fp = _DIR + "/main.tex"
-    s = pathfs(_DIR, [_ent("sub", is_dir=True), _ent("main.tex")], fp)
+    directory, fp = _abs_dir_and_file("main.tex")
+    s = pathfs(directory, [_ent("sub", is_dir=True), _ent("main.tex")], fp)
     res = engine.main(action="browse", path=fp, src=s.src)
     assert "error" not in res
-    assert res["dir"] == _DIR
+    # Unlike the *_listdir readers above, latex's "browse" action returns its
+    # raw os.path.abspath'd `d` untouched (no forward-slash pass) — compare
+    # against the native-separator form, not a POSIX-forced one.
+    assert res["dir"] == directory
     names = {e["name"] for e in res["entries"]}
     assert names == {"sub", "main.tex"}
 
 
 def test_pdf_studio_listdir_remote_file_descends_to_parent(pathfs):
-    fp = _DIR + "/doc.pdf"
-    s = pathfs(_DIR, [_ent("sub", is_dir=True), _ent("doc.pdf", size=10)], fp)
+    directory, fp = _abs_dir_and_file("doc.pdf")
+    s = pathfs(directory, [_ent("sub", is_dir=True), _ent("doc.pdf", size=10)], fp)
     res = pdf_studio._listdir(fp, origin=s.src)
     assert "error" not in res
-    assert res["path"] == _DIR
+    assert res["path"] == directory.replace(os.sep, "/")
     assert res["dirs"] == ["sub"]
     assert [f["name"] for f in res["files"]] == ["doc.pdf"]
 
 
 def test_tableau_listdir_remote_file_descends_to_parent(pathfs):
-    fp = _DIR + "/wb.twb"
-    s = pathfs(_DIR, [_ent("sub", is_dir=True), _ent("wb.twb", size=10)], fp)
+    directory, fp = _abs_dir_and_file("wb.twb")
+    s = pathfs(directory, [_ent("sub", is_dir=True), _ent("wb.twb", size=10)], fp)
     res = tableau._listdir(fp, origin=s.src)
     assert "error" not in res
-    assert res["path"] == _DIR
+    assert res["path"] == directory.replace(os.sep, "/")
     assert res["dirs"] == ["sub"]
     assert [f["name"] for f in res["files"]] == ["wb.twb"]
 
@@ -376,11 +397,11 @@ def slides_mod():
 
 
 def test_slides_listdir_remote_file_descends_to_parent(pathfs, slides_mod):
-    fp = _DIR + "/deck.pptx"
-    s = pathfs(_DIR, [_ent("sub", is_dir=True), _ent("deck.pptx", size=10)], fp)
+    directory, fp = _abs_dir_and_file("deck.pptx")
+    s = pathfs(directory, [_ent("sub", is_dir=True), _ent("deck.pptx", size=10)], fp)
     res = slides_mod.main(action="listdir", path=fp, src=s.src)
     assert "error" not in res
-    assert res["path"] == _DIR
+    assert res["path"] == directory.replace(os.sep, "/")
     assert res["dirs"] == ["sub"]
     assert res["files"] == ["deck.pptx"]
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -82,8 +82,11 @@ def test_builtin_html_default_is_render_sentinel():
     assert [e["mode"] for e in entries] == [
         "_render", "code", "claude", "reader"]
     assert entries[0]["path"] is None and entries[0]["icon"] is None
-    assert entries[1]["path"].endswith("code/template.html")
-    assert entries[2]["path"].endswith("claude/template.html")
+    # entries[i]["path"] is a plain os.path.join of TEMPLATES_DIR (native
+    # separators — this internal field is never run through the app's
+    # canonical_fs_path), so normalize before a forward-slash suffix check.
+    assert entries[1]["path"].replace(os.sep, "/").endswith("code/template.html")
+    assert entries[2]["path"].replace(os.sep, "/").endswith("claude/template.html")
 
 
 def test_builtin_parquet_default_is_duckdb():
@@ -91,7 +94,7 @@ def test_builtin_parquet_default_is_duckdb():
     assert error is None
     assert [e["mode"] for e in entries] == ["duckdb", "structure", "h3", "claude",
             "geometry_editor"]
-    assert entries[0]["path"].endswith("duckdb/template.html")
+    assert entries[0]["path"].replace(os.sep, "/").endswith("duckdb/template.html")
 
 
 # ------------------------------------------------------------ reader mode (RD)

--- a/tests/test_workspace_migration.py
+++ b/tests/test_workspace_migration.py
@@ -133,12 +133,16 @@ def test_rewrites_bookmark_urls_including_nested_folders(machine):
     legacy, new, home = machine
     legacy.mkdir(parents=True)
     bookmarks = os.path.join(str(home), "bookmarks.json")
+    # A view url's path is always canonical_fs_path form (forward slashes,
+    # per _remap's own docstring) — never the raw, backslashed-on-Windows
+    # str(Path) that a filesystem `target`/`path` field would hold.
     storage.write_json(bookmarks, [
         {"id": "1", "name": "app", "url": "/explorer/view"
-         + str(legacy / "my app" / "index.html").replace(" ", "%20")
+         + wm.canonical_fs_path(str(legacy / "my app" / "index.html")).replace(" ", "%20")
          + "?sort=name"},
         {"id": "2", "type": "folder", "name": "f", "children": [
-            {"id": "3", "name": "deep", "url": "/explorer/view" + str(legacy / "d")},
+            {"id": "3", "name": "deep",
+             "url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "d"))},
         ]},
         {"id": "4", "name": "outside", "url": "/explorer/view/Users/x/notes"},
         {"id": "5", "name": "sentinel", "url": "/explorer/view/_prefs"},
@@ -148,9 +152,10 @@ def test_rewrites_bookmark_urls_including_nested_folders(machine):
 
     items = storage.read_json(bookmarks)
     assert items[0]["url"] == ("/explorer/view"
-                               + str(new / "my app" / "index.html").replace(" ", "%20")
+                               + wm.canonical_fs_path(str(new / "my app" / "index.html")).replace(" ", "%20")
                                + "?sort=name")
-    assert items[1]["children"][0]["url"] == "/explorer/view" + str(new / "d")
+    assert items[1]["children"][0]["url"] == (
+        "/explorer/view" + wm.canonical_fs_path(str(new / "d")))
     assert items[2]["url"] == "/explorer/view/Users/x/notes"
     assert items[3]["url"] == "/explorer/view/_prefs"
 
@@ -177,7 +182,8 @@ def test_rewrites_recent_urls_and_keeps_their_params(machine):
     legacy.mkdir(parents=True)
     recents = os.path.join(str(home), "recents.json")
     storage.write_json(recents, {"collapsed": False, "entries": [
-        {"url": "/explorer/view" + str(legacy / "a.html") + "?_side=claude&run=",
+        {"url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "a.html"))
+         + "?_side=claude&run=",
          "openedAt": "2026-01-01T00:00:00+00:00", "title": "A"},
         {"url": "/explorer/view/Users/x/b.html", "openedAt": "x"},
     ]})
@@ -185,7 +191,7 @@ def test_rewrites_recent_urls_and_keeps_their_params(machine):
     wm.run()
 
     entries = storage.read_json(recents)["entries"]
-    assert entries[0]["url"] == ("/explorer/view" + str(new / "a.html")
+    assert entries[0]["url"] == ("/explorer/view" + wm.canonical_fs_path(str(new / "a.html"))
                                  + "?_side=claude&run=")
     assert entries[0]["title"] == "A"
     assert entries[1]["url"] == "/explorer/view/Users/x/b.html"
@@ -215,13 +221,14 @@ def test_state_rewrites_run_even_when_an_earlier_run_moved_the_folder(machine):
     new.mkdir(parents=True)
     recents = os.path.join(str(home), "recents.json")
     storage.write_json(recents, {"collapsed": False, "entries": [
-        {"url": "/explorer/view" + str(legacy / "a.html"), "openedAt": "x"},
+        {"url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "a.html")),
+         "openedAt": "x"},
     ]})
 
     wm.run()
 
     entries = storage.read_json(recents)["entries"]
-    assert entries[0]["url"] == "/explorer/view" + str(new / "a.html")
+    assert entries[0]["url"] == "/explorer/view" + wm.canonical_fs_path(str(new / "a.html"))
 
 
 def test_missing_state_files_are_a_no_op(machine):
@@ -472,15 +479,19 @@ def test_a_corrupt_value_does_not_abort_the_rewrite(machine, monkeypatch):
         "good": {"path": str(legacy / "app")},
     }})
     bookmarks = os.path.join(str(home), "bookmarks.json")
+    # url fields are canonical_fs_path form (see the two tests above); the
+    # installs/scheduled-message paths below stay raw str(Path) — an
+    # OS-native record, per _remap's own docstring.
     storage.write_json(bookmarks, [
         {"id": "1", "name": "bad", "url": None},
         {"id": "2", "name": "worse", "url": {"nested": 1}},
-        {"id": "3", "name": "good", "url": "/explorer/view" + str(legacy / "a.html")},
+        {"id": "3", "name": "good",
+         "url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "a.html"))},
     ])
     recents = os.path.join(str(home), "recents.json")
     storage.write_json(recents, {"entries": [
         {"url": 42},
-        {"url": "/explorer/view" + str(legacy / "b.html")},
+        {"url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "b.html"))},
     ]})
     store = os.path.join(str(home), "scheduled_messages.json")
     storage.write_json(store, {"entries": [
@@ -494,9 +505,9 @@ def test_a_corrupt_value_does_not_abort_the_rewrite(machine, monkeypatch):
     assert storage.read_json(str(installs))["installs"]["good"]["path"] \
         == str(new / "app")
     assert storage.read_json(bookmarks)[2]["url"] \
-        == "/explorer/view" + str(new / "a.html")
+        == "/explorer/view" + wm.canonical_fs_path(str(new / "a.html"))
     assert storage.read_json(recents)["entries"][1]["url"] \
-        == "/explorer/view" + str(new / "b.html")
+        == "/explorer/view" + wm.canonical_fs_path(str(new / "b.html"))
     assert storage.read_json(store)["entries"][1]["target"] == str(new / "proj")
     # ...and the corrupt ones are left exactly as they were.
     assert storage.read_json(str(installs))["installs"]["bad"]["path"] is None

--- a/tests/test_workspace_migration.py
+++ b/tests/test_workspace_migration.py
@@ -7,6 +7,7 @@ throwaway machine and never a real workspace.
 """
 import json
 import os
+from urllib.parse import quote
 
 import pytest
 
@@ -24,6 +25,35 @@ def machine(tmp_path, monkeypatch):
     legacy = tmp_path / "Documents" / "Fused"
     new = tmp_path / "Fused"
     return legacy, new, tmp_path / ".fused-render"
+
+
+def _view_url(path) -> str:
+    """A /explorer/view url for an absolute fs path, built exactly the way
+    _view_url_codec.view_url_path (and wm._encode) build one: the PREFIX
+    supplies the separating slash, then each canonical_fs_path segment is
+    percent-quoted and joined onto it.
+
+    Two things bare string concatenation (`"/explorer/view" +
+    canonical_fs_path(path)`) gets wrong at once:
+
+    1. It looks right and passes on POSIX only by accident: a POSIX absolute
+       path already starts with "/", so the missing separator between "view"
+       and the path is invisible. A Windows drive path (`C:/Users/...`) has no
+       leading slash (canonical_fs_path never adds one — a drive path is
+       already absolute without it), so the same concatenation glues into
+       `"/explorer/viewC:/Users/..."`, which starts with none of
+       wm._VIEW_PREFIXES. wm._remap_url then silently returns None and the
+       migration leaves the url exactly as it was — still pointing at the
+       legacy `Documents/Fused` location — which is what a run on real
+       Windows CI showed.
+    2. Even with the separator fixed, a raw drive letter's `:` must be
+       percent-encoded (`C%3A`, not `C:`) to match what wm._encode's
+       `quote(seg, safe="!*'()")` actually produces on the way back out — the
+       existing hardcoded-Windows-path tests below use `%3A` for exactly this
+       reason."""
+    norm = wm.canonical_fs_path(str(path)).lstrip("/")
+    return "/explorer/view/" + "/".join(
+        quote(seg, safe="!*'()") for seg in norm.split("/") if seg)
 
 
 # ------------------------------------------------------------- the folder move
@@ -137,12 +167,10 @@ def test_rewrites_bookmark_urls_including_nested_folders(machine):
     # per _remap's own docstring) — never the raw, backslashed-on-Windows
     # str(Path) that a filesystem `target`/`path` field would hold.
     storage.write_json(bookmarks, [
-        {"id": "1", "name": "app", "url": "/explorer/view"
-         + wm.canonical_fs_path(str(legacy / "my app" / "index.html")).replace(" ", "%20")
-         + "?sort=name"},
+        {"id": "1", "name": "app", "url": _view_url(legacy / "my app" / "index.html")
+         .replace(" ", "%20") + "?sort=name"},
         {"id": "2", "type": "folder", "name": "f", "children": [
-            {"id": "3", "name": "deep",
-             "url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "d"))},
+            {"id": "3", "name": "deep", "url": _view_url(legacy / "d")},
         ]},
         {"id": "4", "name": "outside", "url": "/explorer/view/Users/x/notes"},
         {"id": "5", "name": "sentinel", "url": "/explorer/view/_prefs"},
@@ -151,11 +179,9 @@ def test_rewrites_bookmark_urls_including_nested_folders(machine):
     wm.run()
 
     items = storage.read_json(bookmarks)
-    assert items[0]["url"] == ("/explorer/view"
-                               + wm.canonical_fs_path(str(new / "my app" / "index.html")).replace(" ", "%20")
-                               + "?sort=name")
-    assert items[1]["children"][0]["url"] == (
-        "/explorer/view" + wm.canonical_fs_path(str(new / "d")))
+    assert items[0]["url"] == (
+        _view_url(new / "my app" / "index.html").replace(" ", "%20") + "?sort=name")
+    assert items[1]["children"][0]["url"] == _view_url(new / "d")
     assert items[2]["url"] == "/explorer/view/Users/x/notes"
     assert items[3]["url"] == "/explorer/view/_prefs"
 
@@ -182,8 +208,7 @@ def test_rewrites_recent_urls_and_keeps_their_params(machine):
     legacy.mkdir(parents=True)
     recents = os.path.join(str(home), "recents.json")
     storage.write_json(recents, {"collapsed": False, "entries": [
-        {"url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "a.html"))
-         + "?_side=claude&run=",
+        {"url": _view_url(legacy / "a.html") + "?_side=claude&run=",
          "openedAt": "2026-01-01T00:00:00+00:00", "title": "A"},
         {"url": "/explorer/view/Users/x/b.html", "openedAt": "x"},
     ]})
@@ -191,8 +216,7 @@ def test_rewrites_recent_urls_and_keeps_their_params(machine):
     wm.run()
 
     entries = storage.read_json(recents)["entries"]
-    assert entries[0]["url"] == ("/explorer/view" + wm.canonical_fs_path(str(new / "a.html"))
-                                 + "?_side=claude&run=")
+    assert entries[0]["url"] == _view_url(new / "a.html") + "?_side=claude&run="
     assert entries[0]["title"] == "A"
     assert entries[1]["url"] == "/explorer/view/Users/x/b.html"
 
@@ -221,14 +245,13 @@ def test_state_rewrites_run_even_when_an_earlier_run_moved_the_folder(machine):
     new.mkdir(parents=True)
     recents = os.path.join(str(home), "recents.json")
     storage.write_json(recents, {"collapsed": False, "entries": [
-        {"url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "a.html")),
-         "openedAt": "x"},
+        {"url": _view_url(legacy / "a.html"), "openedAt": "x"},
     ]})
 
     wm.run()
 
     entries = storage.read_json(recents)["entries"]
-    assert entries[0]["url"] == "/explorer/view" + wm.canonical_fs_path(str(new / "a.html"))
+    assert entries[0]["url"] == _view_url(new / "a.html")
 
 
 def test_missing_state_files_are_a_no_op(machine):
@@ -485,13 +508,12 @@ def test_a_corrupt_value_does_not_abort_the_rewrite(machine, monkeypatch):
     storage.write_json(bookmarks, [
         {"id": "1", "name": "bad", "url": None},
         {"id": "2", "name": "worse", "url": {"nested": 1}},
-        {"id": "3", "name": "good",
-         "url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "a.html"))},
+        {"id": "3", "name": "good", "url": _view_url(legacy / "a.html")},
     ])
     recents = os.path.join(str(home), "recents.json")
     storage.write_json(recents, {"entries": [
         {"url": 42},
-        {"url": "/explorer/view" + wm.canonical_fs_path(str(legacy / "b.html"))},
+        {"url": _view_url(legacy / "b.html")},
     ]})
     store = os.path.join(str(home), "scheduled_messages.json")
     storage.write_json(store, {"entries": [
@@ -504,10 +526,8 @@ def test_a_corrupt_value_does_not_abort_the_rewrite(machine, monkeypatch):
     # The neighbours of every corrupt value are still rewritten...
     assert storage.read_json(str(installs))["installs"]["good"]["path"] \
         == str(new / "app")
-    assert storage.read_json(bookmarks)[2]["url"] \
-        == "/explorer/view" + wm.canonical_fs_path(str(new / "a.html"))
-    assert storage.read_json(recents)["entries"][1]["url"] \
-        == "/explorer/view" + wm.canonical_fs_path(str(new / "b.html"))
+    assert storage.read_json(bookmarks)[2]["url"] == _view_url(new / "a.html")
+    assert storage.read_json(recents)["entries"][1]["url"] == _view_url(new / "b.html")
     assert storage.read_json(store)["entries"][1]["target"] == str(new / "proj")
     # ...and the corrupt ones are left exactly as they were.
     assert storage.read_json(str(installs))["installs"]["bad"]["path"] is None

--- a/tests/test_zarr_aoi_mount.py
+++ b/tests/test_zarr_aoi_mount.py
@@ -74,7 +74,13 @@ def test_branch_nests_under_branches_dir(ts, monkeypatch):
     _export(monkeypatch, branch="fix/template-kernel-listing")
     # sanitize (lowercase, collapse non-[a-z0-9] to '-', trim, truncate to 12)
     # happens ONCE, app-side, and arrives already applied.
-    assert ts.appenv.home_dir() == "/tmp/fr/branches/fix-template"
+    #
+    # branch_dir() nests with a plain os.path.join, never normalized before
+    # FUSED_RENDER_HOME_DIR is exported — on Windows that mixes the "/tmp/fr"
+    # literal's forward slashes with the newly-joined segments' backslashes,
+    # so the expected value has to go through the very same join rather than
+    # assume it stays all-forward-slash.
+    assert ts.appenv.home_dir() == os.path.join("/tmp/fr", "branches", "fix-template")
 
 
 def test_default_branch_names_are_baseline(ts, monkeypatch):
@@ -99,8 +105,12 @@ def test_branch_mount_path_is_under_mounts_root(ts, monkeypatch):
     _export(monkeypatch, branch="fix/template-kernel-listing",
             home=os.path.expanduser("~/.fused-render"))
     mroot = ts.appenv.mounts_dir() + os.sep
-    wsf = os.path.expanduser(
-        "~/.fused-render/branches/fix-template/mounts/source.coop/x.zarr")
+    # normpath, matching mounts_dir()'s own: expanduser("~/...") only expands
+    # the "~" segment and concatenates the rest of this forward-slash literal
+    # verbatim, so on Windows the result is userhome (backslashed) + a
+    # forward-slashed tail — a mixed string mroot (normpath'd) never prefixes.
+    wsf = os.path.normpath(os.path.expanduser(
+        "~/.fused-render/branches/fix-template/mounts/source.coop/x.zarr"))
     assert wsf.startswith(mroot)
 
 


### PR DESCRIPTION
## Summary

Adds `test-python-windows` to `.github/workflows/test.yml`: the **whole** `tests/` suite on `windows-latest`, as a required check.

The existing `windows-desktop` job runs 5 supervisor-specific files behind a path filter. Nothing in the general suite had ever run on real Windows. The first run didn't just fail — a pytest-xdist worker **crashed** ~1550 tests in, so there was no usable result at all.

Getting from there to green took the rest of this PR: **crash → 61 → 47 → 12 → 3 → 2 → 0 failures.** Most of what it turned up is real product bugs, not test noise.

## Real bugs found in `fused_render/`

Windows-only unless noted:

| Area | Bug |
|---|---|
| `server/routers/ai_models.py` | `DirEntry.stat()` reports `st_ino`/`st_nlink` as **0** on Windows, silently disabling hardlink dedup on the one platform where `huggingface_hub` actually falls back to hardlinks. Also: a blob vanishing mid-scan aborted the entire model listing, and (once guarded) still dated the repo it had been excluded from — `lastUsed` drives client-side prune selection, so a deleted blob's atime shielded a stale repo from cleanup. |
| `ai/runners/worker_base.py` | A `403` was written **without reading the request body**. On HTTP/1.1 keep-alive the next request on that socket read those leftover bytes as its request-line (`400`, every platform); on Windows the close sent an RST, so the client got `ConnectionAbortedError` instead of the refusal. The drain that fixes it is bounded in size and time, since it runs pre-auth on a caller-chosen length — and bodies it cannot frame at all (any `Transfer-Encoding`: `BaseHTTPRequestHandler` does not decode chunked requests, so an absent `Content-Length` is not an empty body) end the connection rather than being reported as drained. |
| `templates/bundle/reader.py`, `deeplink.py` | `shutil.rmtree(ignore_errors=True)` swallowed the `PermissionError` Windows raises on git's read-only loose objects — leaking a temp directory **on every failed clone, forever**. |
| `templates/tar/reader.py`, `templates/zip/reader.py` | `os.replace` (MoveFileExW) refuses a read-only destination, so **every re-preview of a changed archive member failed** after the first. Clearing the bit then had to be undone on failure, or a failed swap left the live preview writable. |
| `templates/geotiff/browse.py`, `templates/zarr_aoi/browse.py` | `os.path.abspath` backslashes an already-forward-slash path, desyncing every downstream join from the app's canonical form. Breadcrumb roots were also wrong: `C:` is drive-**relative**, so clicking the root crumb went wherever the process last was on that drive; UNC lost `//server/share` entirely. |
| `index/query.py`, `server/index_touch.py` | `.rstrip("/") or "/"` restores the POSIX bare root but not `C:/` → a scan root that **is** a drive never matched its own index. |
| `claude_config/memory.py` | Project-path reconstruction only recognised a POSIX leading `-`, so **every Windows session** silently lost its grouping. |
| `shell/storage.py` | `os.replace` and `open()` can both hit transient sharing violations on Windows; `read_json` was raising `PermissionError` into live mount-auth requests. |
| `calls.py` | A TTL comparison could tie against itself on Windows' coarse clock, leaving a mark meant to expire immediately alive for a full TTL. |
| `templates/model_card/inspect_model.py` | CRLF front matter never matched the `\n\n` paragraph break, so summaries came back empty. **Not Windows-specific** — any CRLF file, any platform. |
| `fusedcli.py` | `FUSED_RENDER_FUSED_BIN` was split on whitespace, so an interpreter under `C:\Program Files\...` was silently cut in half. Pre-existing, unrelated to this job. |

## Test-suite portability

~60 files carried Windows-hostile assumptions: forward-slash canonical paths, `PATHEXT` casing (`git.EXE`), POSIX permission bits that are vestigial on Windows, `HOME` vs `USERPROFILE`, and text-mode CRLF inflation.

Two were tests that **never tested what they claimed**, on any platform:

- `test_no_session_token_remote_keeps_default_link_ttl` asserted `> 300` and got `300.00009` on Linux / `299.99999999999977` on Windows. It never stubbed `config/get`, so it always took the 300s clamp it existed to rule out — passing or failing on floating-point noise. It now pins the 1800s default it advertises.
- `_wedge` in `test_shell_mounts.py` delegated to the real `posixpath.ismount`, which calls a directory a mountpoint when its inode matches its parent's. Windows reports `st_ino` as 0, so `0 == 0` made **an ordinary temp directory** report as mounted — the whole of the two failures I had been attributing to NTFS semantics needing a Windows machine to diagnose. It doesn't: force `st_ino` to 0 and `posixpath.ismount` misfires on Linux too.

One genuine flake fixed along the way, on Linux: `test_mcp_condition.py::test_the_listing_happens_once` patched `os.scandir` **process-globally** and asserted the total call count was exactly 1. Other threads share `os.scandir`, and this suite leaves daemon threads running — `fused-engine` failed with `assert 2 == 1` where the second entry was an unrelated invoke watcher polling its own directory. Scoped to the installing thread with the file's own `this_thread_only`, the way the `open` trap beside it already was.

## Notes on the job itself

- **One Python version (3.12), not a matrix.** `build_windows_installer.ps1` pins CPython 3.12 (`uv python install 3.12`); no Windows install ever runs 3.10/3.11/3.13, so testing them here would cover interpreters no user has. The Linux matrix still spans all four, where a source install genuinely has to work.
- **`continue-on-error` is gone** and the job is in `test-status`'s always-run set. It was scaffolding for the exploratory phase; a job that cannot fail reports nothing. It earned this on its first run as a required check, by catching the `worker_base.py` refusal bug.
- Installs the pinned `rclone.exe` (same version + SHA256 the installer bundles) so rclone-backed tests get a real binary instead of skipping.

## Verification

- **`test-python-windows` green on every commit of this branch**, and gating.
- All Windows-only fixes have a regression test **confirmed to fail against the unfixed code** — reproduced on Linux by forcing the platform condition (`st_ino` to 0; the keep-alive desync; a chunked pre-auth body), not by assuming.
- `frontend`, `bundle-contents`, `fused-engine`, `linux-desktop`, `macos-desktop`, `windows-desktop` green.

### Read the gate with this caveat

`Test Status` on this branch is red from **pre-existing flakiness on `main`, not from this diff**. The base commit of this PR (`49f6984d`) fails on `main` with the identical signature:

```
FAILED tests/test_canvases.py::test_sync_merges_remote_changes_while_dirty
assert ({... 'watching': True, 'push_state': 'idle', ...} and 0 >= 1)
```

20 of the last 25 completed `test.yml` runs on `main` are non-success, in the same shape: `fused-engine` plus an arbitrary subset of the four `test-python` versions, different every run (one main run failed all four at once). `addopts = "-n auto"` with xdist's default `--dist load` hands tests to whichever worker is free, so which tests share a process changes run to run — and any test resting on process-global state fails on a dice roll. Three distinct ones surfaced while this PR was in flight: the canvases watcher stall, the `os.scandir` count above, and `test_shell_mounts` asserting on an empty `caplog.text`.

Only the `os.scandir` one is fixed here, because it was the only one I could root-cause and reproduce. For the canvases stall I added a diagnostic rather than a guess: `watching` is `not stop_event.is_set()` — "have we been told to stop", not "is the thread alive" — and `_run()` wraps no try/except around its loop body, so an exception on any tick kills the daemon watcher while the payload still reports exactly the state above. The test now reports thread liveness, pause count, stop flag, time since the last pull poll, `dirty_since` and `last_error` with the full un-elided status, so the next occurrence arrives diagnosed. Making the suite order-independent is real work and deserves its own PR.

## Follow-up, not in this PR

Two gaps in `worker_base.py` that this change stops short of, both on the **post-auth** body read (`length = int(headers["Content-Length"] or 0)`, then `rfile.read(length)`) rather than the pre-auth drain:

- **No socket timeout.** `_Server` sets none, so that read has the same unbounded-wait shape the pre-auth drain just lost.
- **Content-Length-only framing.** A chunked request that passes auth has its body read as `{}` and desyncs the connection exactly as a refused one did.

Both need a valid token, so the exposure is different in kind from an unauthenticated caller's, and the only real client (`supervisor.py`) hands urllib a bytes body, which always sets a length. Widening the change wasn't obviously right — flagging rather than folding in.

Separately, `templates/map/daemon.py` refuses with `_json(403, ...)` without reading the body, on HTTP/1.1 — the same defect this PR fixes in the worker, bounded there by that handler's `timeout = 65`. Outside this PR's subject.