### PR TITLE
AI download: chunk queue for the tail, hf byte counters for the fallback bar

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -5693,6 +5693,29 @@ an AI Models page that could say what was on disk but not what was *running*.
   segments write out of order, so the file is created at its final size and
   filled sparsely, and `st_size` would report a 4.6GB download as complete before
   a byte had arrived.
+
+  **On the FALLBACK path — `snapshot_download`/`hf_hub_download`, not our own
+  segmented fetch — the disk walk alone is not enough either (D405).** `hf_xet`
+  ships in every runner venv and every mlx-community repo is Xet-backed, and Xet
+  delivers bytes in BURSTS: measured on a 481MB repo, `bytes_on_disk` sat on one
+  number for 6 seconds, then jumped ~90MB, then landed the last ~45% all at once
+  on completion. Scaled to a 4.6GB model that reads as "stuck at 98%" for a
+  minute of a perfectly healthy download. `_HubByteTicker` is a `tqdm_class`
+  passed to hf's own downloader that reads its BYTE bars directly — but the
+  outer "Fetching N files" bar hf also hands a `tqdm_class` is the same trap
+  one level further in, since it has no `unit` at all and reporting its
+  per-file `.update(1)` as bytes reproduces the "10 / 11 B" bug this section
+  already fixed once; `unit == "B"` is what tells the two apart. Xet also hands
+  back TWO byte bars — network TRANSFER and disk RECONSTRUCTION — covering
+  close to the same total, so they are tracked separately and the counter
+  reports whichever is FURTHER ALONG rather than their sum, which can read past
+  100%. The tick reports `max(hub counter, disk walk)`, never less than either,
+  and keeps ticking once a second regardless of which is moving — the tick
+  itself is the heartbeat (AI-5h), not whichever number happens to be live. An
+  hf version that reports differently, or ignores `tqdm_class` outright, is
+  silently indistinguishable from a counter that has not started yet: either
+  way the tick falls back to exactly the disk-walk-only number, because a
+  progress refinement must never be able to fail or freeze a download.
 - **AI-5c** **The port handshake file is per BRING-UP, never per capability.**
   Two workers for one capability really do overlap — an eviction's replacement
   starts while the old one is still being killed, a Download runs beside a Load —
@@ -5807,16 +5830,34 @@ an AI Models page that could say what was on disk but not what was *running*.
   by a token-holding user fail over to the slow path (the token is whatever
   `huggingface_hub.get_token()` finds in the worker — hf's own store, written by
   the Preferences login button or by a `hf auth login`; nothing is injected into
-  the worker's environment, §20/PF-1f, D402) — up to
-  **4 `Range` segments per file** with **segments across all files** as
-  the units of work in one pool capped at **8 connections** — the single number
-  that bounds how many sockets a download opens, which a pool per file would
-  multiply out. Segments share one fd and write with `os.pwrite`, and per-segment
-  offsets go to a sidecar in the order that makes them true: snapshot the
-  cursors, **fsync the data, then write the sidecar** — a recorded byte is always
-  a durable byte, so a resume never skips one that was still in flight. The
-  partial file is `<blob>.fusedpart`, deliberately **not** hf's `.incomplete`: hf
-  resumes one of those by seeking to its length, ours are written out of order,
+  the worker's environment, §20/PF-1f, D402) — a file at or above the
+  segment floor is split into **fixed `CHUNK_BYTES` (32MB) pieces**, with
+  **chunks across all files** as the units of work in one pool capped at **8
+  connections** (D404) — the single number that bounds how many sockets a
+  download opens, which a pool per file would multiply out. Fixed size rather
+  than the earlier `size / N` equal shares (capped at 4 per file) is what
+  fixed the download's TAIL: four equal shares finish at four different real
+  speeds, and once the fast three are done there is nothing left to hand the
+  slow one, which measured as a 481MB model's last quarter running 80% longer
+  than its first and a 4.6GB model crawling from ~90% to 100% for over a
+  minute. Fixed-size chunks turn a big file into MANY units of work in the
+  shared queue, so an idle worker pulls the NEXT chunk instead of finding
+  nothing assigned to it — a slow connection then delays only its own current
+  32MB, never the tail of the whole download. Chunks share one fd per file and
+  write with `os.pwrite`, and per-segment offsets go to a sidecar in the order
+  that makes them true: snapshot the cursors, **fsync the data, then write the
+  sidecar** — a recorded byte is always a durable byte, so a resume never
+  skips one that was still in flight. **The sidecar carries its own version
+  number** (`SIDECAR_VERSION`), because the chunk queue changed what a segment
+  list MEANS — fixed pieces rather than equal shares — so a sidecar written
+  before this existed can have the right etag and size and a self-consistent
+  layout while describing boundaries this build derives differently for the
+  same file, which is exactly the input shape that turns a resume into a
+  silently wrong blob rather than a loudly failed one. Any sidecar whose
+  version does not match, missing included, is discarded exactly like no
+  sidecar at all. The partial file is `<blob>.fusedpart`, deliberately **not**
+  hf's `.incomplete`: hf resumes one of those by seeking to its length, ours
+  are written out of order,
   and handing it one would produce a silently corrupt blob. Resume demands that
   etag and size still agree and that the recorded LAYOUT is the one resumed with;
   anything that does not agree starts clean, never a guess. **The range probe is

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -953,10 +953,26 @@ class _FileFetch:
         have us skip bytes that were never fetched, and the result is a blob of
         exactly the right length that is silently wrong. The layout itself is
         checked in `_restore`, against the segments derived from this answer.
+
+        **`isinstance(state, dict)` is checked explicitly, not left to fall out
+        of a `KeyError`.** A sidecar whose JSON parses but is not an object — a
+        truncated write that still happens to be valid JSON on its own, like a
+        bare `2` or a list — has no `.get`, and `state["etag"]` on such a value
+        raises `TypeError`, not `KeyError`; both were already caught here, so
+        this was harmless before the version check was added. `state.get(...)`
+        on a non-dict raises `AttributeError`, which was NOT in the tuple below
+        — so a malformed sidecar stopped reading as "no sidecar" for this one
+        file and instead escaped `plan()` entirely, taking the whole repo into
+        the fallback and `_clear_parts` deleting every OTHER file's progress
+        along with it. Checking the shape up front says directly what every
+        line below it assumes, rather than relying on whichever accessor
+        happens to be first to notice.
         """
         try:
             with open(self.sidecar) as handle:
                 state = json.load(handle)
+            if not isinstance(state, dict):
+                return None
             if state.get("version") != SIDECAR_VERSION:
                 return None
             if state["etag"] != self.meta["etag"] or state["size"] != self.size:

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -421,6 +421,30 @@ SEGMENT_MIN_BYTES = 32 * 1024 * 1024
 #: shared queue: a worker that finishes early pulls the next chunk rather than
 #: finding nothing assigned to it, so a slow connection only ever delays its
 #: own current 32MB, never the tail of the whole download.
+#:
+#: **Two costs this accepts, deliberately, both raised in review and both
+#: judged worth it rather than left unexamined.**
+#:
+#: (1) A 4.6GB shard is now ~144 requests instead of 4 — 144 TCP/TLS
+#: handshakes rather than 4, since `urllib` opens a fresh connection per
+#: `_open` call. Against a 32MB transfer per chunk that overhead is a small
+#: percentage, and it buys the one property size/N could not have at any
+#: chunk count: MORE units of work than `MAX_CONNECTIONS`, which is what
+#: makes stealing possible at all. A pool with only as many items as workers
+#: — four shares on eight connections — can never exhibit the failure this
+#: fixes, no matter how the four are sized.
+#:
+#: (2) `work` is built file-by-file (`_segmented_fetch`), so with one file's
+#: chunk count at or above `MAX_CONNECTIONS`, all 8 connections work that ONE
+#: file before the next file's chunks start — files finish roughly in
+#: submission order rather than interleaved. That is a scheduling preference,
+#: not a correctness gap: the cap still holds, nothing waits on a connection
+#: sitting idle, and a multi-file repo still finishes strictly faster than
+#: before this change. Round-robining chunks ACROSS files instead would
+#: trade "finishes files one at a time" for "every file creeps up together",
+#: which is not obviously better and was not what the tail bug asked for —
+#: left as a real option for whoever next has a reason to prefer it, not
+#: implemented speculatively here.
 CHUNK_BYTES = 32 * 1024 * 1024
 #: Across everything — the ONE number that bounds how many sockets a download
 #: opens. A pool per file would multiply the caps together.
@@ -1275,7 +1299,26 @@ def _resolve(repo_id, filenames, revision):
 
 def _run_segment(fetch, seg):
     """One unit of work in the pool: fill a segment, and finalise if it was the
-    last one its file was waiting on."""
+    last one its file was waiting on.
+
+    **`force=True` on every completion, so a 4.6GB shard now forces ~144
+    sidecar fsyncs instead of 4 — raised in review and judged not worth
+    changing yet.** The data most of that fsync flushes is already clean:
+    `_drain`'s own periodic `flush()` (no `force`) runs throughout the
+    segment on the same 1-second cadence regardless of chunk size, so a
+    completed 32MB chunk typically has little UNFLUSHED data behind it and
+    this call's real job is durably recording the LAST partial tick — the
+    bytes written since that periodic flush last fired, which on a fast link
+    can be most of the chunk. If this ever shows up in profiling on real
+    storage, the change to make is dropping `force` here entirely and
+    letting the periodic flush alone catch a finished segment: correctness
+    would not regress (a segment whose completion lands between two
+    periodic ticks just resumes as its last-recorded, slightly earlier
+    offset — a bigger but still bounded re-fetch, not a corrupt one), only
+    resume-efficiency would give up a little in exchange for far fewer
+    forced fsyncs. Not made speculatively because nothing here has measured
+    it as a real cost.
+    """
     try:
         try:
             fetch.run(seg)

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -405,12 +405,35 @@ def resident_bytes():
 #: Below this a file is fetched whole: splitting a 200KB config across four
 #: sockets costs four round trips to save nothing.
 SEGMENT_MIN_BYTES = 32 * 1024 * 1024
-#: Per file. Past a handful the Hub's per-connection throughput is the limit
-#: rather than the connection count, and each one is another socket to retry.
-MAX_SEGMENTS_PER_FILE = 4
+#: The size of one unit of work once a file IS being split. A separate
+#: constant from `SEGMENT_MIN_BYTES` on purpose, even though the two start out
+#: equal: one decides whether to split a file at all, the other decides how
+#: big each piece is once splitting happens, and nothing says a future tuning
+#: pass changes them together.
+#:
+#: **Fixed size, not `size / N` — this is the fix for the download's tail.**
+#: A big shard used to become a handful of EQUAL shares (see the retired
+#: `MAX_SEGMENTS_PER_FILE` below): four connections at four different real
+#: speeds finish at four different times, and once the fast three are done
+#: there is nothing left to hand them — the slowest share runs out the clock
+#: alone, which measured as a 4.6GB model crawling from ~90% to 100% for over
+#: a minute. Fixed-size chunks make a big file into MANY units of work in one
+#: shared queue: a worker that finishes early pulls the next chunk rather than
+#: finding nothing assigned to it, so a slow connection only ever delays its
+#: own current 32MB, never the tail of the whole download.
+CHUNK_BYTES = 32 * 1024 * 1024
 #: Across everything — the ONE number that bounds how many sockets a download
 #: opens. A pool per file would multiply the caps together.
 MAX_CONNECTIONS = 8
+#: RETIRED, deliberately left named rather than silently deleted: this used to
+#: cap a single file at 4 equal shares, back when segments were `size / N`.
+#: With fixed-size `CHUNK_BYTES` chunks pulled from one GLOBAL queue, a big
+#: file simply produces more chunks — that is the whole fix above — and
+#: `MAX_CONNECTIONS` is what already bounds how many run at once, so a second,
+#: per-file cap would only recreate the tail this redesign removes: capping a
+#: 4.6GB shard at 4 chunks again puts it back on 4 static shares. Nothing
+#: reads this constant; it stays as a marker for why the number is gone.
+_RETIRED_MAX_SEGMENTS_PER_FILE = 4
 #: Deliberately NOT hf's `.incomplete`. hf resumes one of those by seeking to
 #: its current length; our segments write out of order, so a partial file of
 #: length N does not mean the first N bytes are there, and handing hf one of
@@ -429,6 +452,21 @@ FLUSH_EVERY_S = 1.0
 #: `snapshot_download` default, which is what keeps the fast path and the
 #: fallback on one revision of a model.
 DEFAULT_REVISION = "main"
+
+#: The sidecar's own format number. Bumped whenever what a sidecar MEANS
+#: changes shape — the chunk queue is exactly such a change: a segment used to
+#: be one of `size / N` equal shares, and is now one of many fixed-size
+#: `CHUNK_BYTES` pieces, so a sidecar an older build left behind describes
+#: boundaries this build would derive differently for the same file. Identity
+#: (etag, size) still matches such a sidecar, and the layout even often looks
+#: internally consistent — which is exactly the shape of input that turns a
+#: resume into a silently wrong blob rather than an obviously failed one, so
+#: it cannot be left to the layout check to notice. Anything read back with a
+#: different number, MISSING included — every sidecar written before this
+#: field existed reads as missing — is treated exactly like no sidecar at all:
+#: the safe reading, since a fresh download from a clean chunk plan is always
+#: correct, merely slower than a resume would have been.
+SIDECAR_VERSION = 2
 
 _CONTENT_RANGE = re.compile(r"/(\d+)\s*$")
 _RANGE_START = re.compile(r"^bytes\s+(\d+)-")
@@ -740,19 +778,35 @@ def _sparse_ok(folder):
     return blocks is not None and blocks * 512 < SPARSE_PROBE_BYTES // 2
 
 
-def _segment_count(size):
+def _chunks(size):
+    """Split [0, size) into fixed `CHUNK_BYTES` pieces. `done` is the cursor.
+
+    Below `SEGMENT_MIN_BYTES` the file is one piece covering the whole thing —
+    unchanged from before the chunk queue, and still the right answer: there
+    is nothing to gain from splitting a file too small to matter.
+
+    At or above it, every piece but the last is exactly `CHUNK_BYTES` — fixed
+    size, not `size / N`. A fixed size is what turns a big file into MANY
+    units of work rather than a HANDFUL: the whole point, since a queue with
+    only as many items as connections gives a slow one nothing to hand off
+    once its faster siblings finish (see `CHUNK_BYTES`'s own comment). A
+    30-shard repo and a single 4.6GB shard both resolve to plans a worker can
+    keep pulling from until the file is actually done.
+
+    Deterministic in `size` alone — no `count` argument, unlike the equal-share
+    split this replaced — which is what lets a resume regenerate the exact
+    same boundaries a previous run planned without having to persist the
+    piece count anywhere but the sidecar's own `segments` list.
+    """
     if size < SEGMENT_MIN_BYTES:
-        return 1
-    return min(MAX_SEGMENTS_PER_FILE, -(-size // SEGMENT_MIN_BYTES))
-
-
-def _segments(size, count):
-    """Split [0, size) into `count` contiguous ranges. `done` is the cursor."""
-    span = size // count
-    return [{"start": i * span,
-             "end": size - 1 if i == count - 1 else (i + 1) * span - 1,
-             "done": 0}
-            for i in range(count)]
+        return [{"start": 0, "end": size - 1, "done": 0}]
+    pieces = []
+    start = 0
+    while start < size:
+        end = min(start + CHUNK_BYTES, size) - 1
+        pieces.append({"start": start, "end": end, "done": 0})
+        start = end + 1
+    return pieces
 
 
 def _seg_complete(seg):
@@ -827,7 +881,12 @@ class _FileFetch:
             # refuses, and the refusal takes down the whole repo — the fallback
             # then deleting this file's sidecar along with every OTHER file's
             # progress. Restarting this one file whole is strictly cheaper.
-            self.segments = _segments(self.size, len(saved))
+            #
+            # `_chunks` is deterministic in `size` alone, so the layout it
+            # derives here is the SAME plan a fresh download would make —
+            # `_restore` below is what checks that the saved offsets actually
+            # fit onto it.
+            self.segments = _chunks(self.size)
             if not self._restore(saved):
                 saved = None
             elif len(saved) > 1 and _probe_host(self.meta["location"],
@@ -836,15 +895,19 @@ class _FileFetch:
                 saved = None
         if saved is None:
             # …and once the sidecar is out, its layout goes with it. Kept, it
-            # would split a download that starts from zero by a number that
+            # would split a download that starts from zero by a plan that
             # described a file we just deleted: one connection for a 4.6GB
             # shard, or dozens for a small one.
-            count = _segment_count(self.size)
-            if count > 1 and _probe_host(self.meta["location"],
-                                         self._cdn_token(),
-                                         self.probes) is not True:
-                count = 1
-            self.segments = _segments(self.size, count)
+            self.segments = _chunks(self.size)
+            if len(self.segments) > 1 and _probe_host(self.meta["location"],
+                                                       self._cdn_token(),
+                                                       self.probes) is not True:
+                # No confirmed range support: one connection for the whole
+                # file rather than the chunk plan `_chunks` would otherwise
+                # hand out, for the same reason `_whole_body` refuses a 200 at
+                # a non-zero offset — every chunk past the first would be
+                # handed byte 0.
+                self.segments = [{"start": 0, "end": self.size - 1, "done": 0}]
             _remove(self.part)
             _remove(self.sidecar)
         self.fd = os.open(self.part, os.O_RDWR | os.O_CREAT, 0o644)
@@ -874,7 +937,18 @@ class _FileFetch:
     def _saved(self):
         """The segments a previous run recorded for THIS file, or None.
 
-        Identity first — etag, size, and a part file still as long as it was —
+        **Version first, before identity even gets a look-in.** The chunk
+        queue changed what a segment list MEANS — fixed `CHUNK_BYTES` pieces
+        rather than `size / N` equal shares — so a sidecar an older build
+        wrote can have the right etag, the right size, and a layout that still
+        passes the shape check in `_restore`, while every offset in it means a
+        different byte than this build would derive for the same file. Etag
+        and size agreeing says nothing about that; only the version does. A
+        missing `version` — every sidecar written before this field existed —
+        reads as a mismatch by construction, since `state.get` returns `None`
+        and `None != SIDECAR_VERSION`.
+
+        Identity next — etag, size, and a part file still as long as it was —
         because a sidecar belonging to a different revision of the file would
         have us skip bytes that were never fetched, and the result is a blob of
         exactly the right length that is silently wrong. The layout itself is
@@ -883,6 +957,8 @@ class _FileFetch:
         try:
             with open(self.sidecar) as handle:
                 state = json.load(handle)
+            if state.get("version") != SIDECAR_VERSION:
+                return None
             if state["etag"] != self.meta["etag"] or state["size"] != self.size:
                 return None
             saved = state["segments"]
@@ -931,7 +1007,8 @@ class _FileFetch:
             if not force and now - self.flushed < FLUSH_EVERY_S:
                 return
             self.flushed = now
-            state = {"etag": self.meta["etag"], "size": self.size,
+            state = {"version": SIDECAR_VERSION, "etag": self.meta["etag"],
+                     "size": self.size,
                      "segments": [dict(seg) for seg in self.segments]}
         with self.flush_lock:
             if self.fd is not None:

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -1504,9 +1504,17 @@ class _HubByteTicker:
         subclass, deliberately: hf's own `_create_progress_bar` hands a
         non-tqdm `cls` straight through as `cls(**kwargs)`, with none of
         tqdm's `disable`/`name` machinery grafted on, which this needs
-        exactly as little of. The only things read back off an instance are
-        `.n` and `.total` (hf's own aggregation helpers check both with
-        `getattr`/`hasattr`); the only thing called on it is `.update`.
+        exactly as little of. Read back off an instance: `.n`, `.total` (hf's
+        own aggregation helpers check both with `getattr`/`hasattr`) and
+        `.format_dict` — verified against the real huggingface_hub installed
+        in the runner venvs (1.27.0, 1.28.0): `_AggregatedTqdm.set_postfix_str`
+        forwards to `_set_aggregate_rate_postfix`, which does
+        `bar.format_dict.get("rate")` on OUR bar, called by
+        `XetDownloadProgressReporter.update_progress` on the first non-zero
+        byte increment. Missing it is not a cosmetic gap: it is an
+        `AttributeError` raised from inside the download, on every
+        Xet-backed repo — which is every mlx-community one — the moment the
+        first byte lands. Called: `.update`, `.set_postfix_str`.
         """
         ticker = self
 
@@ -1517,11 +1525,26 @@ class _HubByteTicker:
                 self._is_bytes = kwargs.get("unit") == "B"
                 self._reconstruct = "reconstruct" in (kwargs.get("desc") or "").lower()
 
+            @property
+            def format_dict(self):
+                # hf reads only `rate` off this (see the docstring above); `n`
+                # and `total` are included too since real tqdm's own
+                # `format_dict` carries them and a future caller reading
+                # either would otherwise hit the same missing-attribute crash
+                # this property exists to stop. `rate` is genuinely unknown —
+                # this class does no timing of its own — and `None` is what
+                # `_format_speed_postfix` already renders as "???B/s".
+                return {"rate": None, "n": self.n, "total": self.total}
+
             def update(self, n=1):
                 if not self._is_bytes or not n:
                     return
-                self.n += n
                 with ticker._lock:
+                    # `self.n` too, not just the ticker's own counters: it is
+                    # what `format_dict` above reports back to hf, and a
+                    # bar's own count has to agree with what it told the
+                    # ticker it saw.
+                    self.n += n
                     if self._reconstruct:
                         ticker._reconstruct += int(n)
                     else:

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -1425,15 +1425,137 @@ def _fallback(model_id, error):
     _clear_parts(repo_folder(model_id))
 
 
+class _HubByteTicker:
+    """A `tqdm_class` for hf's OWN downloaders, and the counter it writes into.
+
+    The fallback path's bar used to be driven only by the disk walk, and
+    `hf_xet` (installed in every runner venv; every mlx-community repo is
+    Xet-backed) delivers bytes in BURSTS rather than a steady trickle:
+    measured on a 481MB repo, `bytes_on_disk` sat on one number for 6 seconds,
+    then jumped ~90MB, then landed the final ~45% all at once on completion.
+    Scaled to a 4.6GB model that is a bar parked on one number for a MINUTE
+    while the download is perfectly healthy — the "stuck at 98%" report. hf
+    knows the true count the whole time; this reads it through the one seam
+    hf exposes for exactly that, and the disk walk stays as the heartbeat and
+    the fallback for whatever this cannot read.
+
+    **The outer bar is a file counter, and reporting it as bytes is the
+    original AI-5b trap one level further in.** `snapshot_download` hands its
+    `tqdm_class` to THREE distinct bars: one wrapping `hf_thread_map` over the
+    file list — `desc="Fetching N files"`, no `unit` at all, one `.update(1)`
+    per file — and two created directly for BYTES, `unit="B"`, one per
+    conceptual stream (`_create_progress_bar` in hf's own `_snapshot_download`
+    and `_xet_progress_reporting`). `unit == "B"` is what tells them apart:
+    when `unit` is absent it is the file counter, which is exactly how "10 /
+    11 B" happened before — the same bug this feature exists to fix,
+    reappearing one seam further in.
+
+    **Two byte streams, not one, and they must not be SUMMED.** hf's Xet path
+    reports network TRANSFER (`desc` containing "downloading bytes") and disk
+    RECONSTRUCTION (`desc` containing "reconstruct") separately — both cover
+    close to the same total under dedup/compression, so adding them can read
+    past 100% of a file that is not yet done. `bytes_on_disk` means "landed on
+    disk", which is what the reconstruction stream already means, so ticks
+    into the "reconstruct" bucket and the "transfer" bucket are kept apart and
+    the counter reports whichever is FURTHER ALONG — never their sum. A plain
+    `http_get` download (no Xet) hands back exactly one bar, whose `desc` is a
+    filename and matches neither keyword; it lands in the transfer bucket,
+    which is exactly the bytes it wrote, so the two-bucket split costs nothing
+    on that path.
+
+    `seen` is False until some byte bar reports ANYTHING, which is what lets
+    the caller tell "no usable counter" (an hf version that reports
+    differently, or ignores `tqdm_class` altogether, or a fetch that never
+    goes near hf's downloaders at all) from "the counter says zero because
+    nothing has landed yet" — the two must not be confused, or a slow start
+    would look like this feature having failed rather than a download that is
+    merely early.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._transfer = 0
+        self._reconstruct = 0
+        self.seen = False
+
+    @property
+    def value(self):
+        with self._lock:
+            return max(self._transfer, self._reconstruct)
+
+    def bar(self):
+        """A tqdm-COMPATIBLE class bound to this ticker — not a `tqdm`
+        subclass, deliberately: hf's own `_create_progress_bar` hands a
+        non-tqdm `cls` straight through as `cls(**kwargs)`, with none of
+        tqdm's `disable`/`name` machinery grafted on, which this needs
+        exactly as little of. The only things read back off an instance are
+        `.n` and `.total` (hf's own aggregation helpers check both with
+        `getattr`/`hasattr`); the only thing called on it is `.update`.
+        """
+        ticker = self
+
+        class _Bar:
+            def __init__(self, *_args, **kwargs):
+                self.n = kwargs.get("initial") or 0
+                self.total = kwargs.get("total")
+                self._is_bytes = kwargs.get("unit") == "B"
+                self._reconstruct = "reconstruct" in (kwargs.get("desc") or "").lower()
+
+            def update(self, n=1):
+                if not self._is_bytes or not n:
+                    return
+                self.n += n
+                with ticker._lock:
+                    if self._reconstruct:
+                        ticker._reconstruct += int(n)
+                    else:
+                        ticker._transfer += int(n)
+                    ticker.seen = True
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc_info):
+                return False
+
+            def close(self):
+                pass
+
+            def refresh(self):
+                pass
+
+            def set_postfix_str(self, *_args, **_kwargs):
+                pass
+
+            def set_description(self, *_args, **_kwargs):
+                pass
+
+        return _Bar
+
+
 def fetch_with_progress(model_id, call, total=None, detail="Fetching weights…",
-                        job=None, row=None):
-    """Run `call()` on a thread, reporting bytes-on-disk once a second.
+                        job=None, row=None, counter=None):
+    """Run `call()` on a thread, reporting progress once a second.
 
     `call` is whatever huggingface_hub function actually fetches — a whole
     snapshot for one runner, a single GGUF file for another — and this is the
     part neither of them should write twice: the poll is the progress AND the
     heartbeat, without which a long single-file download reports nothing for
-    minutes and the manager calls the row abandoned.
+    minutes and the manager calls the row abandoned. The ONE-SECOND TICK is
+    unconditional regardless of what drives `done` below it — the tick itself
+    is the heartbeat (AI-5h), and a fetch that happens to have a live byte
+    counter must keep beating exactly as often as one that does not.
+
+    `counter`, when given, is a `_HubByteTicker` whose `tqdm_class` `call` was
+    built to pass to hf's own downloader. Once it has `seen` anything, `done`
+    is `max(counter.value, bytes_on_disk(folder))` rather than the disk walk
+    alone — never less than either, so a counter that stalls while the disk
+    still advances (or the reverse) cannot make the bar go backwards. Before
+    it has seen anything — no counter at all, an hf version that reports
+    differently, a `tqdm_class` silently ignored — this degrades to exactly
+    the disk-walk-only behaviour from before it existed. See `_HubByteTicker`
+    for why a byte counter existing at all used to be exactly the AI-5b trap
+    ("10 / 11 B") one level further in.
 
     **`job`/`row` exist because not every fetch belongs to a download job.** A
     runner that pulls a component model DURING a request — the speech detector,
@@ -1478,13 +1600,28 @@ def fetch_with_progress(model_id, call, total=None, detail="Fetching weights…"
         total = repo_total_bytes(model_id)
     identity = {**(row or {}), "kind": "download", "unit": "bytes"}
 
+    def measured():
+        """Bytes done right now, from whichever source is actually moving.
+
+        `bytes_on_disk` always runs — it is the heartbeat's OWN measurement
+        too, and the fallback the moment `counter` cannot answer. `counter`,
+        once it has `seen` anything, can only raise the reported number: a
+        burst that lands on disk between two of hf's own ticks is still real
+        progress, and `max` is what keeps either source's silence from
+        hiding the other's advance.
+        """
+        disk = bytes_on_disk(folder)
+        if counter is not None and counter.seen:
+            return counter.value if disk is None else max(disk, counter.value)
+        return disk
+
     def tick(**fields):
         """One progress report that can carry a ✕ back. See the docstring."""
         report_or_cancel(job=job, **identity, state="running", **fields)
         if job is not None and CANCEL.is_set():
             raise Cancelled()
 
-    tick(detail=detail, done=_capped(bytes_on_disk(folder), total), total=total)
+    tick(detail=detail, done=_capped(measured(), total), total=total)
 
     result = {}
 
@@ -1502,15 +1639,14 @@ def fetch_with_progress(model_id, call, total=None, detail="Fetching weights…"
             # Finished during the join. Ticking now would be the late-cancel
             # the docstring refuses — the bytes are already on the disk.
             break
-        tick(done=_capped(bytes_on_disk(folder), total), total=total,
-             detail=detail)
+        tick(done=_capped(measured(), total), total=total, detail=detail)
     if "error" in result:
         raise result["error"]
-    # Land on the total rather than on the last walk: the snapshot symlinks are
-    # not counted, so a finished repo measures slightly under its own size and a
-    # bar that stopped at 98% reads as a download that gave up.
+    # Land on the total rather than on the last measurement: the snapshot
+    # symlinks are not counted, so a finished repo measures slightly under its
+    # own size and a bar that stopped at 98% reads as a download that gave up.
     report(job=job, **identity, state="running",
-           done=total or bytes_on_disk(folder), total=total)
+           done=total or measured(), total=total)
     return result["value"]
 
 
@@ -2045,9 +2181,16 @@ def download_snapshot(model_id, allow_patterns=None, ignore_patterns=None, **kwa
                    "ignore_patterns": ignore_patterns}
         if revision:
             options["revision"] = revision
+        # Ours unless `kwargs` already names one — a caller that passed its
+        # own `tqdm_class` gets it back unmolested, and `counter` simply never
+        # sees anything (`measured` in `fetch_with_progress` degrades to the
+        # disk walk on its own; see `_HubByteTicker`).
+        ticker = _HubByteTicker()
+        options.setdefault("tqdm_class", ticker.bar())
         options.update(kwargs)
         return fetch_with_progress(
-            model_id, lambda: snapshot_download(model_id, **options), total=total)
+            model_id, lambda: snapshot_download(model_id, **options), total=total,
+            counter=ticker)
 
     if kwargs or files is None or not sha:
         # An extra argument changes WHAT is fetched — `allow_patterns`, a
@@ -2127,10 +2270,12 @@ def download_file(repo_id, filename, detail=None, job=None, row=None):
     def hub():
         from huggingface_hub import hf_hub_download
 
+        ticker = _HubByteTicker()
         return fetch_with_progress(
             repo_id,
-            lambda: hf_hub_download(repo_id=repo_id, filename=filename),
-            total=total, detail=detail, job=job, row=row)
+            lambda: hf_hub_download(repo_id=repo_id, filename=filename,
+                                    tqdm_class=ticker.bar()),
+            total=total, detail=detail, job=job, row=row, counter=ticker)
 
     if not sha:
         return hub()

--- a/tests/test_ai_hub_fetch.py
+++ b/tests/test_ai_hub_fetch.py
@@ -1279,6 +1279,33 @@ def test_download_file_falls_back_like_the_snapshot_does(base, monkeypatch, tmp_
     assert base.download_file("org/m", "q4.gguf") == "/cache/blobs/gguf"
 
 
+def test_download_files_fallback_wires_a_byte_counter_through(base, monkeypatch,
+                                                               tmp_path, payload):
+    """`download_file`'s own `hub()`, not just `download_snapshot`'s: each call
+    site builds its own `_HubByteTicker` and has to hand hf's downloader the
+    matching `tqdm_class`, or the fallback bar is back to disk-walk-only."""
+    _wire(base, monkeypatch, tmp_path, "http://unused/weights", len(payload))
+    monkeypatch.setattr(base, "report", lambda job=None, **fields: None)
+    seen_bars = []
+
+    def hf_hub_download(repo_id=None, filename=None, tqdm_class=None, **kwargs):
+        if tqdm_class is not None:
+            bar = tqdm_class(desc=f"{filename}: reconstructing file",
+                             total=len(payload), unit="B")
+            bar.update(len(payload))
+            seen_bars.append(bar)
+        return "/cache/blobs/gguf"
+
+    _fake_hub(monkeypatch, hf_hub_download=hf_hub_download,
+              HfApi=lambda: types.SimpleNamespace(
+                  model_info=lambda *a, **k: types.SimpleNamespace(siblings=[])))
+    monkeypatch.setattr(base, "_repo_files", lambda *a, **k: (
+        _ for _ in ()).throw(RuntimeError("no listing")))
+
+    assert base.download_file("org/m", "q4.gguf") == "/cache/blobs/gguf"
+    assert len(seen_bars) == 1, "download_file's fallback did not pass tqdm_class"
+
+
 @pytest.mark.parametrize("call", ["snapshot", "file"])
 def test_a_cancel_is_never_swallowed_into_a_fallback(base, monkeypatch, tmp_path,
                                                      call):

--- a/tests/test_ai_hub_fetch.py
+++ b/tests/test_ai_hub_fetch.py
@@ -36,6 +36,7 @@ import json
 import os
 import socketserver
 import threading
+import time
 import types
 
 import pytest
@@ -117,7 +118,14 @@ def _start_server(payload, **flags):
              "ranges": True, "lie_after_probe": False, "clamp": False,
              "budget": None, "unauthorized": 0, "unauthorized_on": (),
              "break_first": 0, "break_bytes": 0, "chunk_cap": None,
-             "probe_fail_first": 0}
+             "probe_fail_first": 0,
+             # `hold_first_real`: the FIRST real (non-probe) request blocks
+             # entirely — no status line, no bytes — until `state["release"]`
+             # is set. Models one connection stalled mid-flight, for a test
+             # that needs to observe OTHER chunks being asked for while one is
+             # still open, not merely infer it from timing.
+             "hold_first_real": False, "release": threading.Event(),
+             "_held": False}
     state.update(flags)
 
     class Handler(http.server.BaseHTTPRequestHandler):
@@ -129,7 +137,7 @@ def _start_server(payload, **flags):
         def do_GET(self):
             header = self.headers.get("Range")
             probe = header == "bytes=0-0"
-            failed_probe = expired = False  # bound on every branch, not just one
+            failed_probe = expired = hold = False  # bound on every branch
             with state["lock"]:
                 state["log"].append(header)
                 state["requests"].append({
@@ -144,6 +152,12 @@ def _start_server(payload, **flags):
                                or state["real"] in state["unauthorized_on"])
                     if state["unauthorized"] > 0:
                         state["unauthorized"] -= 1
+                    if state["hold_first_real"] and not state["_held"]:
+                        state["_held"] = True
+                        hold = True
+
+            if hold:
+                state["release"].wait(timeout=10.0)
 
             if failed_probe:
                 self.send_response(503)
@@ -231,12 +245,22 @@ def payload():
 
 
 def _wire(base, monkeypatch, tmp_path, url, size, etag="e7ag", commit="c0m",
-          segment_min=20_000):
-    """Point worker_base at the local server and a throwaway cache folder."""
+          segment_min=20_000, chunk_bytes=50_000):
+    """Point worker_base at the local server and a throwaway cache folder.
+
+    `chunk_bytes` stands in for the real `CHUNK_BYTES` (32MB), the same way
+    `segment_min` stands in for `SEGMENT_MIN_BYTES`: the 200_000-byte `payload`
+    fixture has to split several ways without downloading real megabytes. The
+    default, 50_000, divides the fixture into exactly four equal chunks — the
+    same four offsets `MAX_SEGMENTS_PER_FILE` used to produce — so the many
+    existing assertions on `[0, 50_000, 100_000, 150_000]` keep meaning what
+    they said even though nothing under test caps the chunk COUNT any more.
+    """
     folder = str(tmp_path / "models--org--m")
     monkeypatch.setattr(base, "repo_folder",
                         lambda model_id, repo_type="model": folder)
     monkeypatch.setattr(base, "SEGMENT_MIN_BYTES", segment_min)
+    monkeypatch.setattr(base, "CHUNK_BYTES", chunk_bytes)
     monkeypatch.setattr(base, "_hub_file_meta", lambda repo, name, revision: {
         "url": url, "location": url, "etag": etag, "commit": commit, "size": size})
     return folder
@@ -728,9 +752,10 @@ def test_a_rejected_sidecar_does_not_keep_its_layout(base, monkeypatch, tmp_path
     with open(os.path.join(blobs, "e7ag.fusedpart.json"), "w") as handle:
         # Two segments, but not the two this size would produce: identity holds,
         # so it survives as far as the layout check, which rejects it.
-        json.dump({"etag": "e7ag", "size": len(payload), "segments": [
-            {"start": 0, "end": 10, "done": 0},
-            {"start": 11, "end": len(payload) - 1, "done": 0}]}, handle)
+        json.dump({"version": base.SIDECAR_VERSION, "etag": "e7ag",
+                  "size": len(payload), "segments": [
+                      {"start": 0, "end": 10, "done": 0},
+                      {"start": 11, "end": len(payload) - 1, "done": 0}]}, handle)
 
     snapshot = base._segmented_fetch("org/m", ["model.safetensors"], "c0m")
 
@@ -850,7 +875,7 @@ def test_a_sidecar_that_does_not_match_is_thrown_away(base, monkeypatch, tmp_pat
     with open(os.path.join(blobs, "e7ag.fusedpart"), "wb") as handle:
         handle.write(b"\xff" * len(payload))
     span = len(payload) // 4
-    state = {"etag": "e7ag", "size": len(payload),
+    state = {"version": base.SIDECAR_VERSION, "etag": "e7ag", "size": len(payload),
              "segments": [{"start": i * span, "end": (i + 1) * span - 1,
                            "done": span} for i in range(4)]}
     state[wrong] = {"etag": "an-older-revision", "size": len(payload) + 1,
@@ -861,6 +886,126 @@ def test_a_sidecar_that_does_not_match_is_thrown_away(base, monkeypatch, tmp_pat
     snapshot = base._segmented_fetch("org/m", ["model.safetensors"], "c0m")
 
     assert open(os.path.join(snapshot, "model.safetensors"), "rb").read() == payload
+
+
+def test_a_sidecar_from_before_the_chunk_queue_is_discarded_not_misread(
+        base, monkeypatch, tmp_path, payload):
+    """The chunk queue changed the shape of a resume: segments used to be
+    `size / MAX_SEGMENTS_PER_FILE` equal shares, and are now fixed-size chunks
+    pulled from a queue. A sidecar an OLDER build left behind describes the old
+    shape — same field names, different boundaries — and reading it as the new
+    shape would silently misplace every cursor: bytes recorded as landed at one
+    offset are really the offset a four-way split put there, and resuming
+    "into" them writes the file wrong under a correct-looking etag and size.
+
+    So the sidecar carries an explicit `version`, and anything that is not
+    today's number is treated exactly like no sidecar at all — the safe
+    reading, since size/etag still match and nothing else marks it as stale.
+    This one has no `version` key at all, which is what every sidecar written
+    before this existed looks like.
+    """
+    url, state = _start_server(payload)
+    folder = _wire(base, monkeypatch, tmp_path, url, len(payload))
+    blobs = os.path.join(folder, "blobs")
+    os.makedirs(blobs)
+    with open(os.path.join(blobs, "e7ag.fusedpart"), "wb") as handle:
+        handle.write(b"\0" * len(payload))
+    with open(os.path.join(blobs, "e7ag.fusedpart.json"), "w") as handle:
+        # The OLD shape: two equal size/2 shares, no `version` key at all.
+        half = len(payload) // 2
+        json.dump({"etag": "e7ag", "size": len(payload), "segments": [
+            {"start": 0, "end": half - 1, "done": half},
+            {"start": half, "end": len(payload) - 1, "done": half}]}, handle)
+
+    snapshot = base._segmented_fetch("org/m", ["model.safetensors"], "c0m")
+
+    assert open(os.path.join(snapshot, "model.safetensors"), "rb").read() == payload
+    # A fresh, fixed-size-chunk download — not a resume into the old layout's
+    # offsets, which this asserts by seeing every chunk boundary asked for.
+    assert _offsets(state["log"]) == [0, 50_000, 100_000, 150_000]
+
+
+def test_a_sidecar_from_a_future_version_is_also_discarded(base, monkeypatch,
+                                                            tmp_path, payload):
+    """Not just missing — ANY version that is not today's number, because a
+    format can change again and a stale reader must not guess that a number it
+    does not recognise is close enough."""
+    url, _state = _start_server(payload)
+    folder = _wire(base, monkeypatch, tmp_path, url, len(payload))
+    blobs = os.path.join(folder, "blobs")
+    os.makedirs(blobs)
+    with open(os.path.join(blobs, "e7ag.fusedpart"), "wb") as handle:
+        handle.write(b"\0" * len(payload))
+    with open(os.path.join(blobs, "e7ag.fusedpart.json"), "w") as handle:
+        json.dump({"version": base.SIDECAR_VERSION + 1, "etag": "e7ag",
+                  "size": len(payload), "segments": [
+                      {"start": 0, "end": len(payload) - 1, "done": len(payload)}]},
+                  handle)
+
+    snapshot = base._segmented_fetch("org/m", ["model.safetensors"], "c0m")
+
+    assert open(os.path.join(snapshot, "model.safetensors"), "rb").read() == payload
+
+
+def test_a_large_file_splits_into_many_fixed_size_chunks_not_four(
+        base, monkeypatch, tmp_path):
+    """`MAX_SEGMENTS_PER_FILE` capped a file at 4 segments so that a static
+    size/N split never opened more than 4 sockets for one file — a number that
+    stopped meaning anything once segments became fixed-size chunks pulled from
+    a GLOBAL queue capped by `MAX_CONNECTIONS`. A file many times a chunk must
+    still produce many chunks: that is what lets a worker that finishes early
+    pull the NEXT chunk instead of finding nothing left to steal.
+    """
+    payload_size = 900_000  # 18 chunks at the 50_000-byte test chunk size
+    url, state = _start_server(b"\0" * payload_size)
+    _wire(base, monkeypatch, tmp_path, url, payload_size)
+
+    base._segmented_fetch("org/m", ["model.safetensors"], "c0m")
+
+    assert len(_ranges(state["log"])) == 18, (
+        "a big file was still capped at a handful of segments")
+
+
+def test_a_slow_chunk_does_not_block_other_chunks_from_starting(base, monkeypatch,
+                                                                tmp_path):
+    """The mechanism behind the tail fix: workers pull the NEXT chunk off a
+    shared queue rather than each owning a fixed share for the whole download.
+
+    One connection is held open — mid-body, past its headers — while the pool
+    has `MAX_CONNECTIONS - 1` other workers free. If chunks were still static
+    per-worker shares, those workers would have nothing else queued once their
+    own share was assigned; with a queue many chunks deep, they keep pulling
+    and finishing the REST of the file while the slow one is still in flight.
+    Asserted on ORDER, not on wall-clock: every other chunk's request has to
+    reach the server before the held one is allowed to finish, which a
+    time-based assertion could only ever suggest and this proves directly.
+    """
+    payload_size = 900_000  # 18 chunks at the 50_000-byte test chunk size
+    url, state = _start_server(b"\0" * payload_size, hold_first_real=True)
+    _wire(base, monkeypatch, tmp_path, url, payload_size)
+    monkeypatch.setattr(base, "MAX_CONNECTIONS", 8)
+
+    thread = threading.Thread(
+        target=base._segmented_fetch, args=("org/m", ["model.safetensors"], "c0m"))
+    thread.start()
+    try:
+        deadline = time.monotonic() + 5.0
+        while not state["_held"] and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert state["_held"], "no request ever reached the server"
+
+        # The other 17 chunks are asked for while the first sits open with no
+        # response at all — only possible if a free worker pulls the NEXT
+        # queued chunk instead of finding nothing left assigned to it, which
+        # is exactly the property a static size/N split does not have.
+        deadline = time.monotonic() + 5.0
+        while len(_ranges(state["log"])) < 18 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert len(_ranges(state["log"])) == 18, (
+            "the rest of the file waited on the one held-open chunk")
+    finally:
+        state["release"].set()
+        thread.join(timeout=5.0)
 
 
 # -- the cache layout is the Hub's, not ours ------------------------------------

--- a/tests/test_ai_hub_fetch.py
+++ b/tests/test_ai_hub_fetch.py
@@ -947,6 +947,39 @@ def test_a_sidecar_from_a_future_version_is_also_discarded(base, monkeypatch,
     assert open(os.path.join(snapshot, "model.safetensors"), "rb").read() == payload
 
 
+@pytest.mark.parametrize("content", ["2", "[1, 2, 3]", '"just a string"'])
+def test_a_sidecar_that_is_not_an_OBJECT_is_thrown_away_not_fatal(
+        base, monkeypatch, tmp_path, payload, content):
+    """A sidecar whose JSON parses but is not a dict — a truncated write that
+    still happens to be valid JSON on its own — used to hit `state["etag"]`
+    and raise `TypeError`, caught by the same tuple as everything else here:
+    "no sidecar", one file restarts clean. `state.get("version")` runs BEFORE
+    that check now, and `.get` on a non-dict raises `AttributeError` instead —
+    which was NOT in the tuple, so this escaped `_saved` and `plan()` entirely,
+    turning a clean one-file restart into a whole-repo fallback that deletes
+    every OTHER file's progress via `_clear_parts`. This must still resolve
+    quietly to a fresh download of the one affected file, on the segmented
+    path — never a repo-wide fallback.
+    """
+    url, state = _start_server(payload)
+    folder = _wire(base, monkeypatch, tmp_path, url, len(payload))
+    blobs = os.path.join(folder, "blobs")
+    os.makedirs(blobs)
+    with open(os.path.join(blobs, "e7ag.fusedpart"), "wb") as handle:
+        handle.write(b"\0" * len(payload))
+    with open(os.path.join(blobs, "e7ag.fusedpart.json"), "w") as handle:
+        handle.write(content)
+
+    snapshot = base._segmented_fetch("org/m", ["model.safetensors"], "c0m")
+
+    assert open(os.path.join(snapshot, "model.safetensors"), "rb").read() == payload
+    # Fresh, fixed-size-chunk download — the segmented path, not the fallback:
+    # a repo-wide `_Unsegmentable`/fallback would never touch this server at
+    # all, since `_fake_hub`/`_wire` only wires the real server for the fast
+    # path.
+    assert _offsets(state["log"]) == [0, 50_000, 100_000, 150_000]
+
+
 def test_a_large_file_splits_into_many_fixed_size_chunks_not_four(
         base, monkeypatch, tmp_path):
     """`MAX_SEGMENTS_PER_FILE` capped a file at 4 segments so that a static

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -649,6 +649,131 @@ def test_fetch_with_progress_re_raises_on_the_calling_thread(base, monkeypatch):
         base.fetch_with_progress("org/m", boom, total=None)
 
 
+# -- driving the fallback bar from hf's OWN byte counters (AI-5b, xet bursts) ----
+#
+# `snapshot_download`/`hf_hub_download` on the fallback path used to be measured
+# purely by the disk walk, and `hf_xet` (installed in every runner venv; every
+# mlx-community repo is Xet-backed) delivers bytes in BURSTS — the walk sees one
+# number for many seconds and then a huge jump, which on a multi-GB model reads
+# as "stuck at 98%" even though the download is healthy. `_HubByteTicker` is the
+# `tqdm_class` that reads hf's own counters instead.
+
+
+def _bytes_bar(ticker, desc, **extra):
+    """One instance of `ticker.bar()`, shaped like what hf's own downloader
+    would construct — `unit="B"` is the whole of what marks a byte bar."""
+    return ticker.bar()(desc=desc, total=extra.pop("total", 0), unit="B", **extra)
+
+
+def test_a_hub_byte_counter_drives_done_while_the_disk_walk_is_stuck(
+        base, monkeypatch):
+    """The exact shape of the bug: `bytes_on_disk` frozen (the xet burst gap)
+    while hf's own reconstruction bar is moving underneath it."""
+    ticks = []
+    monkeypatch.setattr(base, "repo_folder", lambda model_id, repo_type="model": "/repo")
+    monkeypatch.setattr(base, "bytes_on_disk", lambda folder: 0)  # frozen
+    monkeypatch.setattr(base, "report",
+                        lambda job=None, **fields: ticks.append(fields) or None)
+    ticker = base._HubByteTicker()
+
+    def call():
+        bar = _bytes_bar(ticker, "Reconstructing (incomplete total...)", total=1024)
+        bar.update(400)
+        time.sleep(1.2)  # past the one-second tick, so a mid-flight poll sees it
+        return "/snap"
+
+    result = base.fetch_with_progress("org/m", call, total=1024, counter=ticker)
+
+    assert result == "/snap"
+    assert any(tick["done"] == 400 for tick in ticks), ticks
+    assert ticker.seen is True
+
+
+def test_the_outer_FILE_counter_is_never_read_as_bytes(base, monkeypatch):
+    """The trap this whole class exists to avoid one level further in: the
+    "Fetching N files" bar has no `unit`, and reporting its `.update(1)` per
+    file as bytes is how a 4.6GB pull once read "10 / 11 B"."""
+    monkeypatch.setattr(base, "repo_folder", lambda model_id, repo_type="model": "/repo")
+    monkeypatch.setattr(base, "bytes_on_disk", lambda folder: 0)
+    monkeypatch.setattr(base, "report", lambda job=None, **fields: None)
+    ticker = base._HubByteTicker()
+
+    Bar = ticker.bar()
+    file_counter = Bar(desc="Fetching 11 files", total=11)  # no `unit` at all
+    for _ in range(11):
+        file_counter.update(1)
+
+    assert ticker.seen is False, "the file counter was read as a byte counter"
+    assert ticker.value == 0
+
+
+def test_transfer_and_reconstruct_bars_are_not_summed(base, monkeypatch):
+    """hf's Xet path hands back TWO byte bars covering close to the same total
+    — network transfer and disk reconstruction. Summing them can read past
+    100% of a file that has not finished; the counter reports whichever
+    stream is FURTHER ALONG instead."""
+    ticker = base._HubByteTicker()
+    transfer = _bytes_bar(ticker, "Downloading bytes", total=1000)
+    reconstruct = _bytes_bar(ticker, "Reconstructing (incomplete total...)",
+                             total=1000)
+
+    transfer.update(600)
+    reconstruct.update(200)
+
+    assert ticker.value == 600, "the two streams were added instead of maxed"
+
+    reconstruct.update(500)
+    assert ticker.value == 700
+
+
+def test_a_missing_or_ignored_counter_falls_back_to_the_disk_walk(base, monkeypatch):
+    """An hf version that reports differently, or ignores `tqdm_class`
+    outright, must degrade SILENTLY to exactly today's behaviour — a progress
+    refinement must never be able to fail or freeze a download."""
+    ticks = []
+    disk = {"value": 0}
+    monkeypatch.setattr(base, "repo_folder", lambda model_id, repo_type="model": "/repo")
+    monkeypatch.setattr(base, "bytes_on_disk", lambda folder: disk["value"])
+    monkeypatch.setattr(base, "report",
+                        lambda job=None, **fields: ticks.append(fields) or None)
+    ticker = base._HubByteTicker()  # never touched by `call`
+
+    def call():
+        disk["value"] = 512
+        time.sleep(1.2)
+        return "/snap"
+
+    base.fetch_with_progress("org/m", call, total=1024, counter=ticker)
+
+    assert ticker.seen is False
+    assert any(tick["done"] == 512 for tick in ticks), ticks
+
+
+def test_reported_progress_never_goes_backwards(base, monkeypatch):
+    """`done` is `max(counter, disk)` at every tick, specifically so a counter
+    that stalls while the disk keeps moving — or the reverse — cannot make an
+    already-reported number look like it un-happened."""
+    ticks = []
+    disk = {"value": 900}  # AHEAD of the counter from the very first tick
+    monkeypatch.setattr(base, "repo_folder", lambda model_id, repo_type="model": "/repo")
+    monkeypatch.setattr(base, "bytes_on_disk", lambda folder: disk["value"])
+    monkeypatch.setattr(base, "report",
+                        lambda job=None, **fields: ticks.append(fields) or None)
+    ticker = base._HubByteTicker()
+
+    def call():
+        bar = _bytes_bar(ticker, "Reconstructing (incomplete total...)", total=1024)
+        bar.update(100)  # behind the disk walk's 900
+        time.sleep(1.2)
+        return "/snap"
+
+    base.fetch_with_progress("org/m", call, total=1024, counter=ticker)
+
+    dones = [tick["done"] for tick in ticks]
+    assert dones == sorted(dones), dones
+    assert 900 in dones, "the disk walk's lead was thrown away for the counter's number"
+
+
 # -- a fetch that happens inside a REQUEST, on a row with a live ✕ ---------------
 #
 # These fetches used to own a model-load row, whose ✕ the supervisor answers by
@@ -1346,6 +1471,36 @@ def test_the_FALLBACK_records_the_commit_hf_actually_landed(base, monkeypatch,
     base.download_snapshot("u/x")
 
     assert asked == {"revision": COMMIT}, asked
+
+
+def test_download_snapshots_fallback_wires_a_byte_counter_through(
+        base, monkeypatch, tmp_path):
+    """The fallback call site — not just `fetch_with_progress` in isolation —
+    has to actually HAND hf's downloader the `tqdm_class` that drives it."""
+    folder = _cache_folder(tmp_path)
+    snapshot = _snapshot_dir(tmp_path, "config.json")
+    hub = _LocalHub(cached=[], snapshot=snapshot)
+    seen_bars = []
+
+    def spy(model_id, allow_patterns=None, ignore_patterns=None,
+            local_files_only=False, revision=None, tqdm_class=None, **kw):
+        if not local_files_only and tqdm_class is not None:
+            bar = tqdm_class(desc="Reconstructing (incomplete total...)",
+                             total=7, unit="B")
+            bar.update(7)
+            seen_bars.append(bar)
+        return snapshot
+
+    hub.snapshot_download = spy
+    _local_hub(monkeypatch, base, hub, folder=folder)
+    monkeypatch.setattr(base, "_repo_files",
+                        lambda *a, **kw: (COMMIT, [("config.json", 7)]))
+    monkeypatch.setattr(base, "_segmented_fetch", _raiser(RuntimeError("no ranges")))
+    monkeypatch.setattr(base, "report", lambda job=None, **fields: None)
+
+    base.download_snapshot("u/x")
+
+    assert len(seen_bars) == 1, "the fallback did not pass its own tqdm_class through"
 
 
 def test_a_TORN_record_left_by_a_crashed_write_is_not_read_as_a_record(

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -726,6 +726,59 @@ def test_transfer_and_reconstruct_bars_are_not_summed(base, monkeypatch):
     assert ticker.value == 700
 
 
+def _set_aggregate_rate_postfix(bar):
+    """The exact call shape hf's `_xet_progress_reporting._set_aggregate_rate_postfix`
+    makes against a bar it was handed — verified against the real
+    huggingface_hub installed in the runner venvs (1.27.0, 1.28.0). Not a
+    stand-in for that function: this IS what it does, reduced to the one
+    line that crashed, so a future signature drift on hf's side is caught
+    here rather than by a user's first Xet-backed download."""
+    bar.set_postfix_str(str(bar.format_dict.get("rate")), refresh=False)
+
+
+def test_a_bar_survives_the_rate_postfix_call_hf_makes_on_it(base, monkeypatch):
+    """The HIGH finding: `XetDownloadProgressReporter.update_progress` calls
+    `_AggregatedTqdm.set_postfix_str`, which forwards to
+    `_set_aggregate_rate_postfix(transfer_progress_or_reconstruct_progress)`
+    — and those bars are OUR `_Bar` instances, made through
+    `_create_progress_bar(cls=tqdm_class)`. That function does
+    `bar.format_dict.get("rate")`, which raised `AttributeError` on the
+    first non-zero byte of every Xet-backed download (every mlx-community
+    repo) before `_Bar` grew a `format_dict`. The existing tests never
+    caught it because they only ever call `.update()` on a fake bar, never
+    one of hf's own helper functions — this one does, deliberately.
+    """
+    ticker = base._HubByteTicker()
+    bar = _bytes_bar(ticker, "Reconstructing (incomplete total...)", total=1000)
+    bar.update(100)
+
+    _set_aggregate_rate_postfix(bar)  # must not raise AttributeError
+
+    assert bar.format_dict["rate"] is None
+    assert bar.format_dict["n"] == 100
+    assert bar.format_dict["total"] == 1000
+
+
+def test_a_bars_own_n_is_updated_under_the_same_lock_as_the_ticker(base):
+    """`self.n += n` used to run OUTSIDE `ticker._lock`, racing the read
+    `format_dict` (and hf's own `_update_transfer_bar`/`_finish_transfer_bar`,
+    which read `.n` back to size hf's display) does on the same attribute.
+    Concurrent per-file threads funnel into ONE shared bar via
+    `_AggregatedTqdm`, exactly like `ticker._transfer`/`ticker._reconstruct`
+    do — so `.n` needs the same protection those already have, not a
+    separate unlocked increment beside them."""
+    ticker = base._HubByteTicker()
+    bar = _bytes_bar(ticker, "Reconstructing (incomplete total...)", total=100_000)
+    threads = [threading.Thread(target=bar.update, args=(1,)) for _ in range(500)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert bar.n == 500, "a concurrent update to .n was lost outside the lock"
+    assert ticker.value == 500
+
+
 def test_a_missing_or_ignored_counter_falls_back_to_the_disk_walk(base, monkeypatch):
     """An hf version that reports differently, or ignores `tqdm_class`
     outright, must degrade SILENTLY to exactly today's behaviour — a progress


### PR DESCRIPTION
## Summary

Two measured causes of a model download that reads as stuck, both in `worker_base.py`:

- **The download's tail ran on one connection.** A big shard was split into a handful of *equal* shares (`size / N`, capped at 4), so four connections at four real-world speeds finished at four different times and the slowest ran out the clock alone with nothing left to hand the idle workers. Measured anonymously against the Hub: `whisper-tiny.en-8bit`'s two equal 20MB halves took 17.2s vs 9.9s, and `whisper-small-mlx`'s four 120MB quarters took 22.3 / 16.5 / 15.3 / 12.4s — on a 4.6GB model that is over a minute crawling from ~90% to 100%. Now every file at or above `SEGMENT_MIN_BYTES` becomes many fixed 32MB chunks in the one `MAX_CONNECTIONS`-capped queue, so a worker that finishes early pulls the next chunk and a slow connection only ever delays its own 32MB.
- **The fallback bar froze for many seconds at a time.** Progress on the `snapshot_download` path was measured only by walking the repo folder, and `hf_xet` (installed in every runner venv; every mlx-community repo is Xet-backed) lands bytes in bursts — measured on a 481MB repo, `bytes_on_disk` sat on one number for 6 seconds, jumped ~90MB, then landed the final ~45% at once. Scaled to 4.6GB that is a bar parked on one number for a minute while the download is healthy. hf knows the true count throughout, so we now read it through `tqdm_class` and report `max(hf counter, bytes on disk)`.
- **Resume state is versioned.** A chunk plan means something different from an equal-share plan, so a sidecar left by an older build — same etag, same size, a layout that still passes the shape check — could have resumed into a silently wrong blob. `SIDECAR_VERSION` is checked before identity; a mismatch (a missing field included) reads as no sidecar at all.
- SPEC AI-5i rewritten for the chunk queue and sidecar versioning (D402); AI-5b extended for the fallback counters (D403).

## Visuals

How one large file's work is planned and consumed. The delta is the middle row: many fixed chunks in a shared queue instead of a few equal shares nailed to a connection.

```mermaid
flowchart TD
    F["One 4.6GB shard"] --> P{"size >= 32MB?"}
    P -->|no| W["Fetch whole, one connection"]
    P -->|yes| C["Fixed 32MB chunks"]
    C --> Q["Shared queue, cap 8 sockets"]
    Q --> R["Worker pulls next chunk when free"]
    R --> D["pwrite at offset, sidecar v2"]
```

Progress reporting, both paths:

```mermaid
flowchart TD
    T["Tick every 1s, unconditional"] --> M{"hf counter seen bytes?"}
    M -->|yes| X["max(counter, disk walk)"]
    M -->|no| K["Disk walk only, as before"]
    X --> RW["Report to download row"]
    K --> RW
```

## Usage

Not user-invocable — it changes how any model download behaves. To see it, download a suggested model from the AI Models page and watch the bar: it should advance smoothly to 100% instead of crawling or parking near the end. `CHUNK_BYTES`, `SEGMENT_MIN_BYTES` and `MAX_CONNECTIONS` remain the tuning knobs; `MAX_SEGMENTS_PER_FILE` is retired and left named as `_RETIRED_MAX_SEGMENTS_PER_FILE` with the reason it no longer applies.

## Test Plan

- [x] `pytest tests/test_ai_hub_fetch.py tests/test_ai_worker_base.py -q` → 123 passed (116 before; +7 new, 2 existing sidecar tests updated for versioning), run repeatedly and stable
- [x] New: chunk-count regression; a held-open connection proving a file's remaining chunks are still pulled and fetched; sidecar rejection for an old (unversioned) and a future version; hf byte counters driving `done`; a missing/unusable counter degrading to the disk walk; reported progress never decreasing
- [x] Byte-bar behaviour verified against the real `huggingface_hub` 1.28 source (`_snapshot_download.py`, `_xet_progress_reporting.py`, `utils/tqdm.py`) — the file-counter bar has no `unit`, the byte bars use `unit="B"`, and Xet reports transfer and reconstruct separately, so they are `max()`'d rather than summed
- [ ] **Not verified: a real network download against either fix.** Work-stealing is exercised through a controlled fake HTTP server, not real network jitter, and the hf/Xet interaction is verified by reading hf's source rather than by a live pull. Worth one manual 4.6GB download (FLUX.2-Klein) before trusting the tail fix in the field.
- [ ] Reviewer check: `tests/test_ai_runtime.py` shows ~111 fixture errors in a fresh worktree (`React shell not built`, `shell-dist/` absent) — pre-existing and unrelated, but confirm against CI rather than a local run
