### PR TITLE
AI catalog: refresh the text shortlist to Qwen3.5/Olmo 3/Granite, and trim the rows that were never the right pick

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Any `.html` file can call it and bind the result to the URL:
   reproduces its exact state.
 - `fused.ai(prompt, opts?)` — ask an AI model through the `claude` (Claude
   Code) CLI on your machine; resolves with `{text, model, usage}`. Pass a
-  Hugging Face repo id as `model` (`"Qwen/Qwen3-4B-Instruct-2507"`) and the same
+  Hugging Face repo id as `model` (`"Qwen/Qwen3.5-4B"`) and the same
   call runs a model **locally** instead — the slash is what tells them apart.
   Local chat works on every supported desktop platform: MLX is preferred on
   Apple Silicon, and everywhere else the default is a small CPU-only PyTorch

--- a/SPEC.md
+++ b/SPEC.md
@@ -6739,7 +6739,8 @@ an AI Models page that could say what was on disk but not what was *running*.
   the bug being fixed.
 - **AI-11d** **Reasoning is OFF by default, because it is invisible and the CPU
   path cannot afford it.** Qwen3's chat template defaults `enable_thinking` to
-  true and three of the four curated models are Qwen3, so an ordinary question
+  true and half the curated models are Qwen (Qwen3.5 since the 2026-08-21
+  refresh), so an ordinary question
   emits a `<think>` block first — hundreds of tokens the caller cannot tell
   apart from the answer, since `/generate` streams whatever the model produces.
   At a few tokens a second on the CPU this runner exists to serve, that is
@@ -6748,10 +6749,10 @@ an AI Models page that could say what was on disk but not what was *running*.
   in the Jinja render context, so a template that never mentions it does not
   read it, and a tokenizer whose signature rejects it outright retries without —
   a model that will not take the hint should still answer, just verbosely. The
-  same class of trap as the version floor beside it: `transformers>=4.51` is
-  what knows a `qwen3` exists, and an older resolution installs perfectly and
-  then fails every Qwen3 Download with `KeyError: 'qwen3'`, which reads as a
-  broken model rather than an environment one version too old.
+  same class of trap as the version floor beside it: `transformers>=5.15` is a
+  release that knows a `qwen3_5` exists, and a 4.x resolution installs perfectly
+  and then fails every Qwen3.5 Download with `KeyError: 'qwen3_5'`, which reads
+  as a broken model rather than an environment a major version too old.
 - **AI-11b** **The device is reported, because a model on a CPU works and looks
   broken.** torch runs on whatever it can see, and what it can see is not
   knowable from outside the process: **the default torch rows pin the `whl/cpu`

--- a/fused_render/ai/catalog.py
+++ b/fused_render/ai/catalog.py
@@ -66,7 +66,7 @@ not be promoted into the "safe, small, starts quickly" slot.
 
 **The cost of that rule is deliberate and was chosen by the user with the
 trade-off in front of them (2026-08-16).** A no-model call now gets the LEAST
-ACCURATE model rather than the recommended one — `Systran/faster-whisper-small`
+ACCURATE model rather than the recommended one — `Systran/faster-whisper-tiny.en`
 instead of `deepdml/faster-whisper-large-v3-turbo-ct2`, `Qwen/Qwen3-1.7B` instead
 of `Qwen/Qwen3-4B-Instruct-2507`. The alternative — a separate `default: True`
 field, so the list could be ordered one way and the default picked another — was
@@ -313,9 +313,9 @@ SUGGESTIONS: dict[str, list[dict]] = {
         {
             "id": "tonera/FLUX.2-klein-4B-int8-diffusers",
             "label": "FLUX.2 klein 4B (int8)",
-            # The whole repo, per the rule the entry below states: 8.22e9 bytes
-            # of `usedStorage` (2026-08-20 Hub metadata), and here that number
-            # IS the download — one repo, no component repo, and no skipped
+            # The whole repo, per the module docstring's rule: 8.22e9 bytes of
+            # `usedStorage` (2026-08-20 Hub metadata), and here that number IS
+            # the download — one repo, no component repo, and no skipped
             # subfolder, because the quantization is already in the checkpoint.
             "size_gb": 8.2,
             # **No `_GGUF_RECIPES` row, and that is the point of this entry.**
@@ -331,33 +331,19 @@ SUGGESTIONS: dict[str, list[dict]] = {
             # encoder and VAE still come from their safetensors. Forcing
             # `use_safetensors=False` would break those two instead.
             #
-            # It leads the list, so it is what a bare `fused.ai.image()` starts:
-            # that is the one ordering rule
-            # (`test_every_suggestion_list_is_ordered_smallest_first`), and the
-            # smaller thing to fetch is the reason this entry exists at all.
-            "note": "Smallest Diffusers download here: one self-contained repo "
-                    "with an int8-quantized transformer, rather than the base "
-                    "pipeline plus a separate GGUF file.",
-        },
-        {
-            "id": "black-forest-labs/FLUX.2-klein-4B",
-            "label": "FLUX.2 klein 4B",
-            # EVERYTHING the Download fetches, both repos: 8.23 of base
-            # components (text encoder 8.05, VAE 0.17, tokenizer + configs) plus
-            # the 2.60 GGUF transformer. It said 2.6 — the GGUF alone — while
-            # the actual pull was 18.6, and the field two lists down means the
-            # whole download; see the module docstring's rule (D308).
-            "size_gb": 10.8,
+            # It is the only entry, so it is what a bare `fused.ai.image()`
+            # starts: the ordering rule
+            # (`test_every_suggestion_list_is_ordered_smallest_first`) holds
+            # trivially, and being the smaller thing to fetch is why this is the
+            # entry the list keeps.
+            #
             # Hardware-neutral, per the rule the transformers list above states:
-            # this one list serves the CPU, CUDA and ROCm Diffusers rows, and
-            # the sentence used to say the full-precision pipeline "OOMs on
-            # 16GB machines" — a claim about system RAM on one row and about
-            # VRAM on the others, and on ROCm about neither (a 16GB card can
-            # report half that usable). What survives the move is the fact that
-            # decides the choice anyway: this is the smaller thing to fetch and
-            # to hold.
-            "note": "Quantized transformer (Q4_K_M) rather than the bf16 "
-                    "original — several GB less to fetch and to hold in memory.",
+            # this one list serves the CPU, CUDA and ROCm Diffusers rows, so a
+            # note about what fits in "16GB" would mean system RAM on one row
+            # and VRAM on the others.
+            "note": "One self-contained repo with an int8-quantized "
+                    "transformer: several GB less to fetch and to hold than the "
+                    "bf16 FLUX.2 pipeline it is built from.",
         },
     ],
     # The same model, converted for MLX — and unloadable by the runner above,
@@ -393,6 +379,11 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # Sizes use the same full-snapshot Hub metadata estimate as the lists above
     # (2026-08-15). **One line each**, per the rule the transformers list
     # states: a shortlist is read by sweeping it.
+    #
+    # **No medium.** It weighs about what large-v3 turbo weighs and turbo is
+    # better at every language, so a medium row would be an entry that is never
+    # the right pick — a shortlist earns its length by every line being
+    # somebody's answer.
     "mlx-whisper": [
         {
             "id": "mlx-community/whisper-tiny.en-8bit",
@@ -409,14 +400,6 @@ SUGGESTIONS: dict[str, list[dict]] = {
             "note": "The smallest here, and what a bare transcribe call loads — "
                     "quick, but it drops names and punctuation turbo gets "
                     "right.",
-        },
-        {
-            "id": "mlx-community/whisper-medium-mlx",
-            "label": "Whisper medium (MLX)",
-            "size_gb": 1.5,
-            "note": "Bigger than small for no gain in English over turbo, which "
-                    "costs about the same — worth it only for a language turbo "
-                    "struggles with.",
         },
         {
             "id": "mlx-community/whisper-large-v3-turbo",
@@ -447,6 +430,10 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # row). Sizes are the same full-snapshot Hub metadata estimate as the lists
     # above (2026-08-17). **One line each**, per the rule the transformers list
     # states: a shortlist is read by sweeping it.
+    #
+    # **Both entries are English only, and that is a property of this list
+    # rather than an oversight** — a recording in another language belongs on a
+    # Whisper runner, which the Engines tab is how a user gets back to.
     "parakeet-mlx": [
         {
             "id": "mlx-community/parakeet-tdt_ctc-110m",
@@ -454,21 +441,15 @@ SUGGESTIONS: dict[str, list[dict]] = {
             "size_gb": 0.5,
             "note": "The smallest here, and what a bare transcribe call loads — "
                     "English only, and it drops the punctuation the 0.6B "
-                    "models get right.",
+                    "model gets right.",
         },
         {
             "id": "mlx-community/parakeet-tdt-0.6b-v2",
             "label": "Parakeet TDT 0.6B v2",
             "size_gb": 2.5,
-            "note": "English only, and the most accurate of the three on it — "
-                    "pick v3 instead unless every recording is in English.",
-        },
-        {
-            "id": "mlx-community/parakeet-tdt-0.6b-v3",
-            "label": "Parakeet TDT 0.6B v3",
-            "size_gb": 2.5,
-            "note": "The one to reach for: v2's accuracy plus 24 more European "
-                    "languages, detected rather than declared.",
+            "note": "The most accurate here, English only — five times the "
+                    "download of the 110M, for the punctuation and names it "
+                    "gets right.",
         },
     ],
     # CTranslate2 conversions ONLY. `openai/whisper-large-v3` is the repo
@@ -478,23 +459,27 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # error message about.
     #
     # Sizes use the same full-snapshot Hub metadata estimate as the Transformers
-    # list above (2026-08-14), including model.bin plus tokenizer and configs.
+    # list above (2026-08-14; tiny.en re-checked 2026-08-21), including
+    # model.bin plus tokenizer and configs.
+    #
+    # **No medium.** large-v3 turbo weighs about the same 1.6GB and is better at
+    # every language, so a medium row would be an entry that is never the right
+    # pick — a shortlist earns its length by every line being somebody's answer.
     "faster-whisper": [
+        {
+            "id": "Systran/faster-whisper-tiny.en",
+            "label": "Whisper tiny English (CT2)",
+            "size_gb": 0.08,
+            "note": "The quickest download and decode here, English only — "
+                    "fine for a rough draft of clear speech, below small on "
+                    "everything else.",
+        },
         {
             "id": "Systran/faster-whisper-small",
             "label": "Whisper small (CT2)",
             "size_gb": 0.5,
-            "note": "The smallest here, and what a bare transcribe call loads — "
-                    "light enough for an old machine, but it drops names and "
+            "note": "Light enough for an old machine, but it drops names and "
                     "punctuation turbo gets right.",
-        },
-        {
-            "id": "Systran/faster-whisper-medium",
-            "label": "Whisper medium (CT2)",
-            "size_gb": 1.5,
-            "note": "Bigger than small for no gain in English over turbo, which "
-                    "costs about the same — worth it only for a language turbo "
-                    "handles badly.",
         },
         {
             "id": "deepdml/faster-whisper-large-v3-turbo-ct2",

--- a/fused_render/ai/catalog.py
+++ b/fused_render/ai/catalog.py
@@ -15,7 +15,7 @@ down beside each entry.
 **Keyed by RUNNER, not by capability, and that is what makes it correct on more
 than one platform.** A suggestion is only meaningful for the backend that will
 load it: `mlx-community/Qwen3.5-9B-MLX-4bit` is packed for Metal kernels and is
-unloadable rubbish on a Windows box, while `Qwen/Qwen3-4B-Instruct-2507` is the
+unloadable rubbish on a Windows box, while `Qwen/Qwen3.5-4B` is the
 right answer there and the wrong one on a Mac that has MLX. One capability with
 two BACKENDS (text generation since D293, speech to text since D302) therefore
 has two lists — hardware variants of one backend share theirs, since the wheel
@@ -67,8 +67,12 @@ not be promoted into the "safe, small, starts quickly" slot.
 **The cost of that rule is deliberate and was chosen by the user with the
 trade-off in front of them (2026-08-16).** A no-model call now gets the LEAST
 ACCURATE model rather than the recommended one — `Systran/faster-whisper-tiny.en`
-instead of `deepdml/faster-whisper-large-v3-turbo-ct2`, `Qwen/Qwen3-1.7B` instead
-of `Qwen/Qwen3-4B-Instruct-2507`. The alternative — a separate `default: True`
+instead of `deepdml/faster-whisper-large-v3-turbo-ct2`, and the smallest text
+entry instead of the strongest one (`Qwen/Qwen3.5-4B` rather than
+`Qwen/Qwen3.5-9B` after the 2026-08-21 refresh; the pair the user was actually
+shown was `Qwen/Qwen3-1.7B` against `Qwen/Qwen3-4B-Instruct-2507`, both since
+retired, which is why the rule is stated in terms of POSITION and not of
+names). The alternative — a separate `default: True`
 field, so the list could be ordered one way and the default picked another — was
 offered and rejected: one rule that a reader can verify by eye beats two that can
 silently disagree. **Do not "fix" this back** by reordering a list so the good
@@ -237,13 +241,22 @@ SUGGESTIONS: dict[str, list[dict]] = {
     #
     # * **Unquantized safetensors only.** Every other format on the Hub needs
     #   something this runner does not ship — GGUF is llama.cpp's, AWQ and GPTQ
-    #   need their own packages, bitsandbytes needs an NVIDIA card — and a
+    #   need their own packages, and bitsandbytes is a package this runner
+    #   deliberately does not install (it WOULD install: MIT and wheel-only
+    #   everywhere. Measured 2026-08-21, NF4 on a CPU generates correctly at
+    #   3.6x SLOWER than the bf16 it replaces, so it is refused on speed rather
+    #   than on availability — `runners/formats.py` carries the numbers) — and a
     #   suggestion the loader then refuses is the trap AI-10 describes for
     #   CTranslate2 and the whisper runner had to write an error message about.
-    # * **Ungated.** `google/gemma-3-*` and `meta-llama/*` need a licence
-    #   accepted on the Hub first, so Download 401s partway through for a user
-    #   who has done nothing wrong. The MLX list above gets away with gemma only
-    #   because the `mlx-community` re-uploads are not gated.
+    # * **Ungated.** `google/gemma-3-*` and `meta-llama/*` still need a licence
+    #   accepted on the Hub first (both `gated: "manual"`, rechecked
+    #   2026-08-21), so Download 401s partway through for a user who has done
+    #   nothing wrong. The MLX list above gets away with gemma-3 only because
+    #   the `mlx-community` re-uploads are not gated. **Gemma 4 is the
+    #   exception and no longer belongs in that sentence**:
+    #   `google/gemma-4-12b-it` is `gated: False` and apache-2.0 (checked
+    #   2026-08-21), so the gate is not why it is absent — see the
+    #   `gemma4_unified` paragraph below for the reason that actually holds.
     # * **Sized for the machine that will actually run them.** The accepted v1
     #   trade is that the default torch row installs the `whl/cpu` build on
     #   every non-Apple machine (D381, see this runner's `pyproject.toml`), so
@@ -252,7 +265,7 @@ SUGGESTIONS: dict[str, list[dict]] = {
     #   afterthought. The accelerated rows share this very list (`catalog.py`'s
     #   `_SHARED_SUGGESTIONS`), so it is the CPU that sets its ceiling.
     #
-    # Sizes sum every file in the Hub snapshot (2026-08-14) and round the byte
+    # Sizes sum every file in the Hub snapshot (2026-08-21) and round the byte
     # total to one decimal GB. That makes them download estimates rather than
     # filesystem measurements, but unlike parameter arithmetic they include the
     # tokenizer, configs, split weights and any other payload the whole-repo
@@ -279,34 +292,74 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # one unit this file defines — every byte the download fetches — and a
     # reader comparing it against their own machine is doing arithmetic these
     # sentences cannot do for them.
+    # **Refreshed 2026-08-21, and half this list is now multimodal — which the
+    # runner loads anyway, and the reason is worth writing down because the
+    # obvious reading of `AutoModelForCausalLM` says it should not.** Both Qwen
+    # entries are `Qwen3_5ForConditionalGeneration` checkpoints carrying a
+    # `vision_config`. They load, and they load as the LANGUAGE TOWER ALONE:
+    # transformers 5.x maps `qwen3_5` to `Qwen3_5ForCausalLM` in
+    # `MODEL_FOR_CAUSAL_LM_MAPPING_NAMES` — the entry is literally tagged
+    # `# VLM compatibility` — and that class's `config_class` is
+    # `Qwen3_5TextConfig`, which is exactly the test `auto_factory`'s
+    # `from_pretrained` applies before building anything: when the resolved
+    # class's `config_class` equals `config.sub_configs["text_config"]` it swaps
+    # in `config.get_text_config()`. So the vision tower is never constructed,
+    # the text tower loads with zero missing and zero unexpected keys, and the
+    # vision and MTP tensors are downloaded and dropped.
+    #
+    # **That dead weight is measured, not estimated** (per-tensor byte sums from
+    # the safetensors headers, 2026-08-21): the 4B is 7.2% vision + 2.6%
+    # multi-token-prediction, the 9B 4.7% + 2.5%. It is the same honest cost the
+    # `mlx-text` list above documents and for the same reason — there is no
+    # text-only conversion of Qwen3.5 on the Hub — so the `size_gb` column stays
+    # the whole download and the notes say where the bytes go. **Olmo 3 and
+    # Granite are the contrast and that is why they are here**: `Olmo3ForCausalLM`
+    # and `GraniteForCausalLM`, text-only, no vision config, every byte fetched
+    # is a byte used. A reader comparing 14.6 against 19.3 is comparing unlike
+    # things unless the notes say so, so they do.
+    #
+    # **`google/gemma-4-12b-it` is still rejected, and no longer for the reason
+    # the bullet above used to give.** It is ungated and apache-2.0 (checked
+    # 2026-08-21), so licence acceptance is not the obstacle. The obstacle is
+    # the mechanism two paragraphs up, failing: `gemma4_unified` maps to
+    # `Gemma4UnifiedForConditionalGeneration`, whose `config_class` is
+    # `Gemma4UnifiedConfig` — the COMPOSITE config, not the
+    # `Gemma4UnifiedTextConfig` sub-config — so `auto_factory`'s equality test
+    # is False, the swap does not fire, and the vision AND audio towers
+    # (`sub_configs` carries all three) are built and held resident for a text
+    # generation this runner will never point at them. `qwen3_5` gets the swap;
+    # `gemma4_unified` does not. That is the whole difference, and it is a
+    # one-line check to redo when transformers is next bumped.
     "transformers-text": [
         {
-            "id": "Qwen/Qwen3-1.7B",
-            "label": "Qwen3 1.7B",
-            "size_gb": 4.1,
+            "id": "Qwen/Qwen3.5-4B",
+            "label": "Qwen3.5 4B",
+            "size_gb": 9.3,
             "note": "The smallest here and the one a bare call loads — quickest "
-                    "to fetch and quickest to answer.",
+                    "to fetch and to answer, though a tenth of it is vision "
+                    "weights the text loader drops.",
         },
         {
-            "id": "microsoft/Phi-4-mini-instruct",
-            "label": "Phi-4 mini (3.8B)",
-            "size_gb": 7.7,
-            "note": "Punches above its size on reasoning and maths, and MIT "
-                    "licensed.",
+            "id": "allenai/Olmo-3-7B-Instruct",
+            "label": "Olmo 3 7B Instruct",
+            "size_gb": 14.6,
+            "note": "Text-only, so every byte fetched is a byte used — and "
+                    "fully open training data, unlike anything else here.",
         },
         {
-            "id": "Qwen/Qwen3-4B-Instruct-2507",
-            "label": "Qwen3 4B Instruct",
-            "size_gb": 8.1,
-            "note": "The best all-round pick: clearly stronger than the small "
-                    "ones without being the largest download here.",
+            "id": "ibm-granite/granite-4.1-8b",
+            "label": "Granite 4.1 8B",
+            "size_gb": 17.6,
+            "note": "Text-only like the Olmo above, and tuned for instruction "
+                    "following and tool calls rather than chat.",
         },
         {
-            "id": "Qwen/Qwen3-8B",
-            "label": "Qwen3 8B",
-            "size_gb": 16.4,
-            "note": "Best quality here, and twice the download and the memory "
-                    "of the pick above it.",
+            "id": "Qwen/Qwen3.5-9B",
+            "label": "Qwen3.5 9B",
+            "size_gb": 19.3,
+            "note": "The strongest answers here, for the largest download — of "
+                    "which about 7% is vision and MTP weight that is fetched "
+                    "and dropped.",
         },
     ],
     "diffusers-image": [

--- a/fused_render/ai/runners/diffusers_image/pyproject.toml
+++ b/fused_render/ai/runners/diffusers_image/pyproject.toml
@@ -56,7 +56,9 @@
 # keeps `>=0.39` rather than gaining the installed patch, and `transformers`
 # carries a ceiling with NO floor added, because this runner has never declared one
 # and inventing one here would forbid versions that are currently allowed while
-# also disagreeing with `transformers_text`'s deliberate `>=4.51`. A ceiling only
+# also disagreeing with `transformers_text`'s deliberate floor (`>=5.15` since
+# its catalog moved to Qwen3.5; this runner needs no such floor because its own
+# suggestions do not turn on a transformers model class). A ceiling only
 # removes the future; a floor removes the present.
 #
 # What each earns:

--- a/fused_render/ai/runners/faster_whisper/worker.py
+++ b/fused_render/ai/runners/faster_whisper/worker.py
@@ -110,8 +110,12 @@ def load(model_id, fetched):
         raise RuntimeError(
             f"{model_id} has no {_CT2_WEIGHTS} — this looks like a "
             "transformers-format Whisper repo, and this runner loads "
-            "CTranslate2 conversions. Try Systran/faster-whisper-large-v3 or "
-            "deepdml/faster-whisper-large-v3-turbo-ct2.")
+            "CTranslate2 conversions. Try "
+            # Named models a refusal points at, and they must be models the
+            # CATALOG actually offers (see torch_text._TRY_INSTEAD) — update
+            # this pair if SUGGESTIONS["faster-whisper"] moves.
+            "deepdml/faster-whisper-large-v3-turbo-ct2 or "
+            "Systran/faster-whisper-small.")
 
     from faster_whisper import WhisperModel
 

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -208,9 +208,41 @@ TORCH_WEIGHTS = (".safetensors", ".bin", ".pt")
 UNLOADABLE_QUANT = {
     "awq": "an AWQ checkpoint, which needs a package this runner does not ship",
     "gptq": "a GPTQ checkpoint, which needs a package this runner does not ship",
+    # **The reason here was rewritten on 2026-08-21 because the old one had
+    # stopped being true, and the replacement is a MEASUREMENT rather than a
+    # guess.** It used to say "needs bitsandbytes and an NVIDIA GPU — this
+    # runner ships neither", and the GPU half is simply wrong now: bitsandbytes
+    # 0.50.1 is MIT, publishes wheels and NO sdist for macos arm64,
+    # manylinux x86_64 and aarch64, win_amd64 and win_arm64 (checked against
+    # PyPI 2026-08-21, so AI-2a's wheels-only rule would NOT block it), and it
+    # documents a dedicated CPU build. So "we cannot install it" is no longer
+    # the obstacle — which left the only question that decides this: is 4-bit
+    # NF4 fast enough on a CPU to be worth offering, given the default
+    # resolution of all three folders installing this worker is a CPU torch?
+    #
+    # It was measured, not argued. `unsloth/Qwen3-4B-Instruct-2507-unsloth-bnb-4bit`
+    # LOADS on `device_map="cpu"` and generates correct, coherent text — 219
+    # `Linear4bit` modules, no error — and it halves resident memory (4.16GB
+    # peak RSS against bf16's 8.55GB). It is also 3.6x SLOWER per token than
+    # the bf16 checkpoint it would replace: 0.65 tok/s against 2.33 tok/s,
+    # uncontended, same prompt and same 4B base model. Quantization here buys
+    # memory and spends the one resource a CPU path has least of, and 0.65
+    # tok/s is not a thing to put behind a Download button.
+    #
+    # **The caveat that keeps this open: that was an Apple Silicon M-series
+    # (Mac17,3, 10 cores, 34GB), and this runner's bnb users would be Windows
+    # and Linux x86.** bitsandbytes' optimized CPU path targets x86 AVX512/AMX,
+    # none of which exists on arm64 — so an x86 box could plausibly land
+    # somewhere very different, and this measurement CANNOT be generalised to
+    # it. What it does establish is that the refusal is no longer about the
+    # licence, the wheels or the card. Re-measure on x86 before reversing this;
+    # the dependency is deliberately still absent from the three
+    # `transformers_text*/pyproject.toml` files, so the refusal below is also
+    # literally true — an unlisted package cannot be imported.
     "bitsandbytes": (
-        "a bitsandbytes checkpoint, which needs bitsandbytes and an NVIDIA GPU "
-        "— this runner ships neither"
+        "a bitsandbytes checkpoint, which needs bitsandbytes — a package this "
+        "runner does not install, because 4-bit inference on the CPU it "
+        "defaults to runs several times slower than the unquantized weights"
     ),
     "compressed-tensors": (
         "a compressed-tensors checkpoint, which needs a package this runner "

--- a/fused_render/ai/runners/mlx_whisper/worker.py
+++ b/fused_render/ai/runners/mlx_whisper/worker.py
@@ -239,7 +239,10 @@ def load(model_id, fetched):
             "(CTranslate2 repos carry model.bin; transformers repos carry "
             "model.safetensors with a transformers config). Try "
             "mlx-community/whisper-large-v3-turbo or "
-            "mlx-community/whisper-medium-mlx.")
+            # Named models a refusal points at, and they must be models the
+            # CATALOG actually offers (see torch_text._TRY_INSTEAD) — update
+            # this pair if SUGGESTIONS["mlx-whisper"] moves.
+            "mlx-community/whisper-large-v3-mlx.")
 
     # The RELEASED library (0.4.x) looks for `weights.safetensors` then
     # `weights.npz` — `model.safetensors` support exists only on mlx-examples

--- a/fused_render/ai/runners/torch_text.py
+++ b/fused_render/ai/runners/torch_text.py
@@ -86,9 +86,18 @@ _UNLOADABLE_QUANT = formats.UNLOADABLE_QUANT
 #: What to suggest instead, once we have refused. One sentence, and a repo that
 #: really does load, because a user who picked the wrong format should learn the
 #: right one from the error rather than from a web search.
+#: Named models a refusal points at, and they must be models the CATALOG
+#: actually offers — a refusal that names a repo the page no longer suggests
+#: sends the user to a Hub search, which is the thing this string exists to
+#: prevent. Both are `catalog.SUGGESTIONS["transformers-text"]` entries (the
+#: smallest, and the smallest text-only one); update this when that list moves.
+#: Qwen3.5 is safe to name here because the three folders that install this
+#: worker declare `transformers>=5.15`, which is well past the 5.2.0 that first
+#: knows `qwen3_5` — naming it under the old `>=4.51` floor would have handed
+#: someone a `KeyError` in place of a working suggestion.
 _TRY_INSTEAD = (
-    "Try an unquantized checkpoint such as Qwen/Qwen3-4B-Instruct-2507 or "
-    "microsoft/Phi-4-mini-instruct."
+    "Try an unquantized checkpoint such as Qwen/Qwen3.5-4B or "
+    "allenai/Olmo-3-7B-Instruct."
 )
 
 
@@ -197,9 +206,12 @@ def _dtype_kwargs(dtype):
     """`{"dtype": …}` or `{"torch_dtype": …}`, whichever this transformers takes.
 
     `torch_dtype` was renamed to `dtype` in 4.56 and the old spelling deprecated
-    behind a warning; it is scheduled to go in v5. All three folders that share
-    this worker declare `transformers>=4.51,<6`, so BOTH spellings are live
-    options on a machine somewhere, and the wrong one is not a loud failure:
+    behind a warning; it is scheduled to go in v5. The three folders that share
+    this worker now declare `transformers>=5.15,<6`, so a DECLARED install can
+    only ever want `dtype` and the 4.x branch below is dead for it. It is kept
+    deliberately: this worker is a plain module that also runs under whatever
+    interpreter a developer points at it, and the wrong spelling is not a loud
+    failure:
     unknown
     keyword arguments to `from_pretrained` are forwarded into the config rather
     than rejected, so a stale spelling would silently load a 4B model at float32

--- a/fused_render/ai/runners/transformers_text/pyproject.toml
+++ b/fused_render/ai/runners/transformers_text/pyproject.toml
@@ -61,23 +61,31 @@
 # `mflux_image/pyproject.toml` states at length: no lockfile is committed beside
 # these manifests and `uv sync` runs bare, so an unbounded requirement is
 # re-resolved from PyPI on every new venv key and a major bump lands on users
-# with no commit behind it. `transformers` keeps its `>=4.51` floor and gains
-# only `<6` — the installed version is 5.x, but raising the floor to it would
-# forbid the 4.x this runner is currently happy on, which is a change to what is
-# allowed TODAY rather than protection against tomorrow. The floor's job (stated
-# below) is qwen3 support; the ceiling's job is the next rewrite.
+# with no commit behind it. `transformers` now carries `>=5.15,<6`: the floor
+# MOVED, because the catalog moved under it — the reasoning that once kept it at
+# `4.51` ("raising it would forbid the 4.x this runner is currently happy on")
+# stopped applying the moment the suggested models stopped loading on 4.x. The
+# floor's job (stated below) is still the same job: whatever the catalog's
+# entries need in order to be resolvable at all. The ceiling's job is the next
+# rewrite.
 #
 # What each earns:
 #   torch           the tensors and the device (CUDA / MPS / CPU). `<3` — the
 #                   major is the whole ABI and every wheel behind it.
 #   transformers    the model classes, the chat templates and TextIteratorStreamer.
-#                   `>=4.51` because that is the release that knows what a
-#                   `qwen3` is, and three of the four models this runner's
-#                   catalog suggests are Qwen3 — an older resolution installs
-#                   perfectly and then fails every one of those Downloads with
-#                   `KeyError: 'qwen3'`, which reads as a broken model rather
+#                   `>=5.15` because that is a release that knows what a
+#                   `qwen3_5` is, and two of the four models this runner's
+#                   catalog suggests are Qwen3.5 — a 4.x resolution installs
+#                   perfectly and then fails both of those Downloads with
+#                   `KeyError: 'qwen3_5'`, which reads as a broken model rather
 #                   than an environment a version too old. A floor is the only
-#                   place that can be said once for all of them.
+#                   place that can be said once for all of them. `qwen3_5`
+#                   first appears in transformers 5.2.0; the floor is the higher
+#                   `5.15` because that is what is verified end to end here
+#                   (5.15.1, the installed runner venv) rather than the earliest
+#                   version that merely contains the mapping — this file has no
+#                   lockfile, so the floor is the only place a tested-against
+#                   version can be recorded.
 #   accelerate      `device_map` and the low-memory load path for a big checkpoint
 #   sentencepiece   the tokenizer format some instruct models still ship
 #   protobuf        sentencepiece's model format needs it at load time
@@ -89,7 +97,7 @@ version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.13,<3",
-    "transformers>=4.51,<6",
+    "transformers>=5.15,<6",
     "accelerate>=1.14,<2",
     "sentencepiece",
     "protobuf",

--- a/fused_render/ai/runners/transformers_text_cuda/pyproject.toml
+++ b/fused_render/ai/runners/transformers_text_cuda/pyproject.toml
@@ -49,7 +49,7 @@ version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.13,<3",
-    "transformers>=4.51,<6",
+    "transformers>=5.15,<6",
     "accelerate>=1.14,<2",
     "sentencepiece",
     "protobuf",

--- a/fused_render/ai/runners/transformers_text_rocm/pyproject.toml
+++ b/fused_render/ai/runners/transformers_text_rocm/pyproject.toml
@@ -50,7 +50,7 @@ requires-python = ">=3.10"
 dependencies = [
     "torch>=2.13,<3",
     "triton-rocm; sys_platform == 'linux'",
-    "transformers>=4.51,<6",
+    "transformers>=5.15,<6",
     "accelerate>=1.14,<2",
     "sentencepiece",
     "protobuf",

--- a/tests/test_ai_models_api.py
+++ b/tests/test_ai_models_api.py
@@ -1449,10 +1449,11 @@ def test_a_gguf_only_repo_is_not_called_a_text_model(client, hub):
 
 @requires_symlinks
 def test_the_apps_own_recommended_image_model_is_loadable(client, hub, monkeypatch):
-    """`black-forest-labs/FLUX.2-klein-4B` is `catalog.py`'s suggestion for the
-    diffusers runner, and its card's `pipeline_tag` says image-to-image — a
-    label in NO_RUNNER_YET, so the page offered no Load for a model the app
-    recommends on the next tab. The card names the model FAMILY; the
+    """`black-forest-labs/FLUX.2-klein-4B` is the FLUX.2 base pipeline the
+    diffusers runner loads by id (it has a `_GGUF_RECIPES` row, and was
+    `catalog.py`'s second diffusers suggestion until the int8 repo made it
+    redundant), and its card's `pipeline_tag` says image-to-image — a label in
+    NO_RUNNER_YET, so the page offered no Load for a model a user can reach. The card names the model FAMILY; the
     `model_index.json` in the snapshot names the pipeline that is actually
     here, written by the library that will load it."""
     monkeypatch.setattr(_ai_registry.platform, "system", lambda: "Linux")

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -503,8 +503,7 @@ def test_image_generation_takes_MFLUX_on_apple_silicon_and_diffusers_elsewhere(
     # Switching also moves the suggestion list, since a repo belongs to a
     # backend: the MLX conversion is unloadable by diffusers and vice versa.
     assert [m["id"] for m in catalog.for_capability(registry.IMAGE_GENERATION)] == [
-        "tonera/FLUX.2-klein-4B-int8-diffusers",
-        "black-forest-labs/FLUX.2-klein-4B"]
+        "tonera/FLUX.2-klein-4B-int8-diffusers"]
 
     # Windows and Linux never see the MLX row at all, preference or none.
     for system, machine in (("Windows", "AMD64"), ("Linux", "x86_64")):
@@ -1591,7 +1590,7 @@ def test_transformers_and_whisper_suggestions_show_snapshot_size_estimates():
         "Qwen/Qwen3-1.7B": 4.1,
         "Qwen/Qwen3-8B": 16.4,
         "deepdml/faster-whisper-large-v3-turbo-ct2": 1.6,
-        "Systran/faster-whisper-medium": 1.5,
+        "Systran/faster-whisper-tiny.en": 0.08,
         "Systran/faster-whisper-small": 0.5,
     }
     actual = {
@@ -1606,7 +1605,7 @@ def test_every_suggestion_list_is_ordered_smallest_first():
     """One ordering rule, and the default is whatever it puts at position 0.
 
     The user was shown the trade — a bare `fused.ai.transcribe()` now loads
-    `Systran/faster-whisper-small` rather than the turbo model — and chose one
+    `Systran/faster-whisper-tiny.en` rather than the turbo model — and chose one
     rule over a separate default field. So this is the rule, asserted rather
     than left to the eye: sorted by ascending `size_gb`, with an entry that has
     no size sorting LAST (an unknown download must never lead a list, since
@@ -1639,7 +1638,7 @@ def test_the_default_is_the_smallest_model_the_active_runner_offers(monkeypatch)
     monkeypatch.setattr(registry.platform, "machine", lambda: "AMD64")
     assert catalog.default_for(registry.TEXT_GENERATION) == "Qwen/Qwen3-1.7B"
     assert catalog.default_for(registry.SPEECH_TO_TEXT) == \
-        "Systran/faster-whisper-small"
+        "Systran/faster-whisper-tiny.en"
 
 
 def test_the_catalog_follows_the_runner_that_would_actually_load(monkeypatch):

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1585,10 +1585,10 @@ def test_no_hardware_variant_holds_its_own_suggestion_list():
 
 def test_transformers_and_whisper_suggestions_show_snapshot_size_estimates():
     expected = {
-        "Qwen/Qwen3-4B-Instruct-2507": 8.1,
-        "microsoft/Phi-4-mini-instruct": 7.7,
-        "Qwen/Qwen3-1.7B": 4.1,
-        "Qwen/Qwen3-8B": 16.4,
+        "Qwen/Qwen3.5-4B": 9.3,
+        "allenai/Olmo-3-7B-Instruct": 14.6,
+        "ibm-granite/granite-4.1-8b": 17.6,
+        "Qwen/Qwen3.5-9B": 19.3,
         "deepdml/faster-whisper-large-v3-turbo-ct2": 1.6,
         "Systran/faster-whisper-tiny.en": 0.08,
         "Systran/faster-whisper-small": 0.5,
@@ -1636,7 +1636,7 @@ def test_the_default_is_the_smallest_model_the_active_runner_offers(monkeypatch)
 
     monkeypatch.setattr(registry.platform, "system", lambda: "Windows")
     monkeypatch.setattr(registry.platform, "machine", lambda: "AMD64")
-    assert catalog.default_for(registry.TEXT_GENERATION) == "Qwen/Qwen3-1.7B"
+    assert catalog.default_for(registry.TEXT_GENERATION) == "Qwen/Qwen3.5-4B"
     assert catalog.default_for(registry.SPEECH_TO_TEXT) == \
         "Systran/faster-whisper-tiny.en"
 
@@ -5478,7 +5478,7 @@ def test_a_runner_with_no_suggestions_offers_the_disk_and_recommends_nothing(
     **The no-suggestions condition is CONSTRUCTED, and the construction is asserted.**
     The first version of this test emptied `SUGGESTIONS["mlx-text"]` by name, which
     is the runner a Mac resolves — so on Linux it emptied a list nobody was reading,
-    `transformers-text` answered with `Qwen/Qwen3-1.7B` at position 0, and the test
+    `transformers-text` answered with its own position 0 (`Qwen/Qwen3.5-4B`), and the test
     failed on its conclusion for a premise that was never true. Both resolutions now
     run, the list emptied is the one the row actually resolved, and the premise is
     checked before the conclusion so a future change to resolution fails loudly on

--- a/tests/test_ai_transformers_worker.py
+++ b/tests/test_ai_transformers_worker.py
@@ -87,7 +87,7 @@ def test_an_mlx_checkpoint_is_named_as_mlx(worker, tmp_path):
     message = str(caught.value)
     assert "MLX" in message and "Apple Silicon" in message
     # …and it names one that WILL load, because the alternative is a web search.
-    assert "Qwen/Qwen3-4B-Instruct-2507" in message
+    assert "Qwen/Qwen3.5-4B" in message
 
 
 def test_an_awq_checkpoint_names_the_scheme_and_not_a_missing_module(worker, tmp_path):
@@ -96,14 +96,24 @@ def test_an_awq_checkpoint_names_the_scheme_and_not_a_missing_module(worker, tmp
         worker.load("org/model-awq", path)
 
 
-def test_a_bitsandbytes_checkpoint_says_it_needs_a_GPU(worker, tmp_path):
+def test_a_bitsandbytes_checkpoint_names_the_missing_package(worker, tmp_path):
     """A 4-bit bnb repo is the obvious way to make an 8B model fit, and it does
-    not work here — the runner ships neither bitsandbytes nor, on Windows, a
-    torch that can see a GPU. Saying which of the two is missing is the
-    difference between installing something and picking a different model."""
+    not work here — the runner does not install bitsandbytes.
+
+    **The message deliberately no longer says "NVIDIA", and the old wording is
+    what this test used to pin.** bitsandbytes is MIT and wheel-only on every
+    platform this runner ships to, and NF4 does load and generate on a CPU
+    (measured 2026-08-21; see `runners/formats.py`) — it is just several times
+    slower than the unquantized weights, which is why the package stays out of
+    the manifest. A refusal citing a missing GPU would send someone off to buy
+    or rent the wrong thing, so the assertion is on the PACKAGE and on the
+    reason it is absent."""
     path = _snapshot(tmp_path, {"quantization_config": {"quant_method": "bitsandbytes"}})
-    with pytest.raises(RuntimeError, match="NVIDIA"):
+    with pytest.raises(RuntimeError, match="bitsandbytes") as caught:
         worker.load("unsloth/Qwen3-8B-bnb-4bit", path)
+    message = str(caught.value)
+    assert "NVIDIA" not in message and "GPU" not in message
+    assert "slower" in message
 
 
 def test_a_gguf_only_repo_is_refused_rather_than_expanded(worker, tmp_path):
@@ -141,7 +151,9 @@ def test_a_repo_with_no_config_is_not_refused_for_that_alone(worker, tmp_path):
 @pytest.mark.parametrize(
     ("version", "expected"),
     [
-        ("4.51.0", "torch_dtype"),   # the runner's declared floor
+        # Below the runner's declared floor (`>=5.15`) and kept anyway: this
+        # branch guards a developer's ad-hoc interpreter, not a declared install.
+        ("4.51.0", "torch_dtype"),
         ("4.55.4", "torch_dtype"),
         ("4.56.0", "dtype"),
         ("4.57.0.dev0", "dtype"),   # a dev build must not parse as 4.5

--- a/tests/test_ai_whisper_worker.py
+++ b/tests/test_ai_whisper_worker.py
@@ -986,4 +986,4 @@ def test_a_transformers_format_repo_is_named_as_the_cause(worker, tmp_path):
         worker.load("openai/whisper-large-v3", str(snapshot))
     message = str(caught.value)
     assert "model.bin" in message and "CTranslate2" in message
-    assert "Systran/faster-whisper-large-v3" in message
+    assert "Systran/faster-whisper-small" in message


### PR DESCRIPTION
## Summary

- **The `transformers-text` shortlist was two model generations stale** — it led with Qwen3 1.7B and Phi-4 mini, and models under 4B are not usable for this feature. Replaced with Qwen3.5 4B / Olmo 3 7B Instruct / Granite 4.1 8B / Qwen3.5 9B, sizes re-measured from Hub metadata on 2026-08-21.
- **Raises the `transformers` floor from `>=4.51` to `>=5.15` in all three transformers-text folders.** Without this the new catalog installs perfectly and then fails every Download with `KeyError: 'qwen3_5'` — an environment error that reads to the user as a broken model. `qwen3_5` first appears in 5.2.0; the floor is 5.15 because that is what was verified end to end.
- **Trims three shortlist entries that were never anybody's right answer** — Whisper medium on both the MLX and CTranslate2 lists (same weight as large-v3 turbo, worse at every language), Parakeet TDT 0.6B v3, and the second FLUX.2 klein row. Adds `Systran/faster-whisper-tiny.en` as the new smallest CT2 entry, which by the position-is-the-default rule makes it what a bare transcribe call loads.
- **Re-reasons the bitsandbytes refusal from a measurement instead of a stale guess.** The old reason ("needs an NVIDIA GPU — this runner ships neither") is simply false today: bitsandbytes is MIT and wheel-only on every platform, so the wheels-only rule would not block it. It was measured instead — NF4 loads and generates correctly on CPU and halves peak RSS (4.16GB vs 8.55GB) but runs **3.6x slower** than the bf16 it would replace (0.65 vs 2.33 tok/s). Refused on speed, with the arm64-vs-x86 caveat recorded so the next person re-measures rather than re-argues.

## Visuals

Half the new text list is multimodal, which under a plain reading of `AutoModelForCausalLM` should not load at all. It does — as the language tower alone — and this is the mechanism that decides it. It is also why `google/gemma-4-12b-it` is still rejected despite now being ungated and Apache-2.0:

```mermaid
flowchart TD
    A[from_pretrained on a VLM checkpoint] --> B[Resolve class from CAUSAL_LM mapping]
    B --> C{class.config_class == config.sub_configs.text_config?}
    C -->|yes: qwen3_5| D[Swap in get_text_config]
    C -->|no: gemma4_unified| E[Build the composite config]
    D --> F[Text tower only — vision bytes fetched and dropped]
    E --> G[Vision + audio towers held resident — rejected]
```

Dead weight is measured, not estimated (per-tensor byte sums from the safetensors headers): the 4B is 7.2% vision + 2.6% MTP, the 9B 4.7% + 2.5%. `size_gb` stays the whole download per the existing rule, and the notes say where the bytes go.

## Usage

Nothing new is user-invocable — this changes what the AI Models page suggests and what a bare call loads.

```js
// Still resolves to position 0 of the list, which moved:
await fused.ai("Summarise this table");        // now Qwen/Qwen3.5-4B
await fused.ai.transcribe(file);               // now Systran/faster-whisper-tiny.en on CT2
```

Existing downloaded models are untouched — a removed suggestion still loads if you name it, it just stops being offered.

## Test Plan

- [x] `tests/test_ai_runtime.py` — size table, `default_for` assertions and the smallest-first ordering rule updated for every changed list
- [x] `tests/test_ai_transformers_worker.py` — `_TRY_INSTEAD` now names models the catalog actually offers, which is the property the test asserts
- [x] `tests/test_ai_models_api.py` — docstring only
- [x] The four new text repos were checked against the live Hub API for `gated` status and whole-repo byte size; `google/gemma-4-12b-it` was checked too and rejected for the config reason above, not the licence one
- [x] Qwen3.5 4B was loaded end-to-end through the real runner on transformers 5.15.1 to confirm the text-tower swap fires and reports zero missing / zero unexpected keys
- [ ] Reviewer check: nothing here is verifiable on CUDA or ROCm from this machine — the two accelerated rows share this list via `_SHARED_SUGGESTIONS`, so their behaviour follows by construction rather than by test
