### PR TITLE
Canvas sync tests: stage both sides with the watcher paused (kills the merge_seq CI flake)

### DIFF
--- a/tests/test_canvases.py
+++ b/tests/test_canvases.py
@@ -6,6 +6,7 @@ invocations logged — so the tests exercise the real subprocess seam without a
 network or a fused install. The `fused login` credential store is pointed at a
 tmp file via FUSED_RENDER_FUSED_CREDENTIALS.
 """
+import contextlib
 import json
 import os
 import subprocess
@@ -1224,6 +1225,44 @@ def _manager(name="alpha"):
     return canvases_mod._syncs[name]
 
 
+@contextlib.contextmanager
+def _staged(name="alpha"):
+    """Stage a local edit AND a remote move without the watcher observing a
+    half-staged world.
+
+    Every "remote moved while the clone was dirty" test has to set up two sides
+    at once, and the remote side alone takes three separate writes (the bundle
+    files, then the manifest that is the change signal, sometimes a scenario
+    file too). The watcher is ticking through all of it, and the intermediate
+    state "clone dirty, remote NOT moved yet" is one the product handles
+    correctly and the test does not want: the debounced push fires, its
+    pre-push probe truthfully finds an unmoved remote, so there is nothing to
+    merge — and the push it then runs leaves the clone CLEAN, so when the
+    manifest finally lands the poll takes the clean-clone wholesale force pull.
+    `merge_seq` stays 0 for the rest of the test, because the remote never
+    moves again.
+
+    That is not a hypothetical. It is the flake that failed
+    test_sync_merges_remote_changes_while_dirty on every CI run of one branch
+    (push_seq 1, pull_seq 1, merge_seq 0), reproduced exactly by sleeping 0.8s
+    between the local edit and set_manifest. DEBOUNCE_S is 0.3s in these tests
+    and the staging is plain tmpdir I/O, so a 4-worker runner only has to stall
+    the test thread for a third of a second to get there.
+
+    Pausing is the fix rather than a longer DEBOUNCE_S: it is exact (no tick
+    can land mid-staging at any load) and costs no wall-clock. `pause()` also
+    waits out any op already in flight, and rebaseline=False is required — the
+    default would adopt the local edit we just staged as the clean sync point,
+    which is the very thing under test.
+    """
+    manager = _manager(name)
+    manager.pause()
+    try:
+        yield manager
+    finally:
+        manager.resume(rebaseline=False)
+
+
 def _watcher_diag(name="alpha"):
     """Why the watcher is not making progress, for a wait that timed out.
 
@@ -1322,9 +1361,10 @@ def test_sync_merges_remote_changes_while_dirty(harness, tmp_path, monkeypatch, 
     shims = _cloned_shim_harness(harness, tmp_path, monkeypatch)
     harness.client.post("/api/canvases/sync/start", json={"name": "alpha"}, headers=GUARD)
 
-    (harness.root / "alpha" / "a.py").write_text("a-local\n", encoding="utf-8")
-    shims.set_remote_files({**_BASE_FILES, "b.py": "b2-remote\n"})
-    shims.set_manifest("t2")
+    with _staged():  # see _staged: a tick mid-staging pushes instead of merging
+        (harness.root / "alpha" / "a.py").write_text("a-local\n", encoding="utf-8")
+        shims.set_remote_files({**_BASE_FILES, "b.py": "b2-remote\n"})
+        shims.set_manifest("t2")
 
     status = _wait_status(harness, lambda s: s["merge_seq"] >= 1 and s["push_seq"] >= 1)
     assert status and status["merge_seq"] >= 1 and status["push_seq"] >= 1, (
@@ -1351,9 +1391,10 @@ def test_sync_merge_keeps_local_delete(harness, tmp_path, monkeypatch, fake_agen
     shims = _cloned_shim_harness(harness, tmp_path, monkeypatch)
     harness.client.post("/api/canvases/sync/start", json={"name": "alpha"}, headers=GUARD)
 
-    (harness.root / "alpha" / "b.py").unlink()
-    shims.set_remote_files({**_BASE_FILES, "a.py": "a2-remote\n"})
-    shims.set_manifest("t2")
+    with _staged():  # see _staged: a tick mid-staging pushes instead of merging
+        (harness.root / "alpha" / "b.py").unlink()
+        shims.set_remote_files({**_BASE_FILES, "a.py": "a2-remote\n"})
+        shims.set_manifest("t2")
 
     status = _wait_status(harness, lambda s: s["merge_seq"] >= 1 and s["push_seq"] >= 1)
     assert status and status["merge_seq"] >= 1, status
@@ -1378,13 +1419,14 @@ def test_sync_merge_applies_remote_delete_when_untouched(harness, tmp_path, monk
     shims = _cloned_shim_harness(harness, tmp_path, monkeypatch)
     harness.client.post("/api/canvases/sync/start", json={"name": "alpha"}, headers=GUARD)
 
-    (harness.root / "alpha" / "canvas.toml").write_text(
-        'type = "canvas"\nlocal = true\n', encoding="utf-8"
-    )
-    remote = dict(_BASE_FILES)
-    del remote["b.py"]
-    shims.set_remote_files(remote)
-    shims.set_manifest("t2")
+    with _staged():  # see _staged: a tick mid-staging pushes instead of merging
+        (harness.root / "alpha" / "canvas.toml").write_text(
+            'type = "canvas"\nlocal = true\n', encoding="utf-8"
+        )
+        remote = dict(_BASE_FILES)
+        del remote["b.py"]
+        shims.set_remote_files(remote)
+        shims.set_manifest("t2")
 
     status = _wait_status(harness, lambda s: s["merge_seq"] >= 1 and s["push_seq"] >= 1)
     assert status and status["merge_seq"] >= 1, status
@@ -1563,10 +1605,11 @@ def test_sync_merge_rolls_back_when_it_breaks_validation(harness, tmp_path, monk
     shims = _cloned_shim_harness(harness, tmp_path, monkeypatch)
     harness.client.post("/api/canvases/sync/start", json={"name": "alpha"}, headers=GUARD)
 
-    (harness.root / "alpha" / "a.py").write_text("a-local\n", encoding="utf-8")
-    shims.set_remote_files({**_BASE_FILES, "b.py": "b2-remote\n"})
-    shims.set_manifest("t2")
-    harness.set_scenario({"pull_files": _BASE_FILES, "validate_fail": True})
+    with _staged():  # see _staged: a tick mid-staging pushes instead of merging
+        (harness.root / "alpha" / "a.py").write_text("a-local\n", encoding="utf-8")
+        shims.set_remote_files({**_BASE_FILES, "b.py": "b2-remote\n"})
+        shims.set_manifest("t2")
+        harness.set_scenario({"pull_files": _BASE_FILES, "validate_fail": True})
 
     status = _wait_status(
         harness, lambda s: s["merge_rollback_seq"] >= 1 and s["push_seq"] >= 1


### PR DESCRIPTION
## Summary

- Kills the `test_canvases.py` flake that has been reddening CI lanes on unrelated branches (and on `main`) — always the same xdist worker, always a `merge_seq`/`merge_rollback_seq` assertion. **No product code changed; the sync watcher was behaving correctly at every step.**
- Root cause is unsynchronized harness staging. The four "remote moved while the clone was dirty" tests dirty the clone and *then* move the fake remote in two-to-three separate writes (bundle files → the manifest that **is** the change signal → sometimes a scenario file), all while the watcher ticks. A tick inside that gap sees "clone dirty, remote not moved yet": the 0.3s debounced push fires, its pre-push probe truthfully finds nothing to merge, and the successful push leaves the clone **clean** — so when the manifest finally lands, the poll takes the clean-clone wholesale force pull. `merge_seq` stays 0 forever after, because the remote never moves again.
- Fix: a `_staged()` context manager that pauses the watcher across the staging block, with `resume(rebaseline=False)` so the staged local edit isn't blessed as the clean sync point. Chosen over simply raising `DEBOUNCE_S` because it is exact at any load and adds no wall-clock.
- Applied to the four tests with that shape. The two siblings that already set `DEBOUNCE_S = 30.0` are immune, and the two session-hold tests hold the push, so neither needed touching.

## Visuals

The failing interleaving — what a tick landing mid-staging produces (the CI signature is the red leaf: `push_seq 1, pull_seq 1, merge_seq 0`):

```mermaid
flowchart TD
    A[Test dirties the clone] --> B[Test starts staging the remote]
    B --> C{Watcher tick lands here?}
    C -->|"No (fast box)"| D[Manifest lands first]
    D --> E[Poll: remote moved + clone dirty]
    E --> F["Three-way merge<br/>merge_seq 1 — test passes"]
    C -->|"Yes (loaded worker)"| G["Debounced push;<br/>probe sees unmoved remote"]
    G --> H[Nothing merged, clone now clean]
    H --> I["Manifest lands; poll force-pulls<br/>merge_seq stuck at 0 — test fails"]
```

`_staged()` removes the `C` branch entirely: no tick can observe the half-staged world.

## Usage

Not user-invocable — test-harness only. Inside `tests/test_canvases.py`, any test that has to move both sides at once now wraps the setup:

```python
with _staged():  # see _staged: a tick mid-staging pushes instead of merging
    (harness.root / "alpha" / "a.py").write_text("a-local\n", encoding="utf-8")
    shims.set_remote_files({**_BASE_FILES, "b.py": "b2-remote\n"})
    shims.set_manifest("t2")
```

## Test Plan

- [x] `pytest tests/test_canvases.py` — 91 passed. Tests updated: `test_sync_merges_remote_changes_while_dirty`, `test_sync_merge_keeps_local_delete`, `test_sync_merge_applies_remote_delete_when_untouched`, `test_sync_merge_rolls_back_when_it_breaks_validation`.
- [x] **Failure reproduced before fixing.** A scratch copy of the test with `time.sleep(0.8)` between the local edit and `set_manifest("t2")` yields the exact CI status dict — `push_seq 1, pull_seq 1, merge_seq 0, merge_rollback_seq 0, echo_seq 0`, with `last_pull_at` after `last_push_at`.
- [x] **Fix proven stall-proof.** The same scratch test wrapped in `_staged()`, parameterized over stalls of 0.0s / 0.8s / 2.0s, reaches `merge_seq 1, pull_seq 0` in all three.
- [x] **Load soak.** Full file run 8× under 14 competing busy-loop processes on a 10-core box: 8 × 91 passed, one iteration stretching to 35s (real contention), zero failures.
- [x] Ruled out the tempting wrong theory: tick starvation alone does *not* cause this — with the remote already moved, a push that wins the race merges via its own pre-push guard (`merge_seq 1`) and the test still passes.
- [ ] Reviewer check: CI lanes on this PR go green, and the flake stops appearing on unrelated branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
