### PR TITLE
AI catalog: refresh both text shortlists — four families on llama.cpp, a 0.7GB first model on both

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -7121,7 +7121,7 @@ an AI Models page that could say what was on disk but not what was *running*.
   of which attempt succeeded, not a name for which backend served it, since
   the bound API cannot distinguish Vulkan from Metal.
 - **AI-11g** **Any Hub repo with a loadable root-level GGUF resolves, not
-  only the 4 curated filenames in `formats.GGUF_RECIPES`** (D412).
+  only the 5 curated filenames in `formats.GGUF_RECIPES`** (D412).
   `formats.pick_gguf_file()` ranks an arbitrary repo's own file listing —
   excluding subdirectories, multi-part shards, and auxiliary weights
   (`mmproj`/`mtp`/`draft`/`projector`, widened past one observed file to a

--- a/SPEC.md
+++ b/SPEC.md
@@ -7121,7 +7121,7 @@ an AI Models page that could say what was on disk but not what was *running*.
   of which attempt succeeded, not a name for which backend served it, since
   the bound API cannot distinguish Vulkan from Metal.
 - **AI-11g** **Any Hub repo with a loadable root-level GGUF resolves, not
-  only the 5 curated filenames in `formats.GGUF_RECIPES`** (D412).
+  only the 4 curated filenames in `formats.GGUF_RECIPES`** (D412).
   `formats.pick_gguf_file()` ranks an arbitrary repo's own file listing —
   excluding subdirectories, multi-part shards, and auxiliary weights
   (`mmproj`/`mtp`/`draft`/`projector`, widened past one observed file to a

--- a/fused_render/ai/catalog.py
+++ b/fused_render/ai/catalog.py
@@ -211,6 +211,34 @@ SUGGESTIONS: dict[str, list[dict]] = {
             "note": "The best all-round pick: strong on reasoning and code, and "
                     "comfortable on 16GB.",
         },
+        # The only MIXTURE-OF-EXPERTS row in this file, and it is here because
+        # the router changes what a size means: 8B of weights resident, ~1B of
+        # them multiplied per token, so it answers at roughly the speed of the
+        # 1.2B at the head of this list while knowing what an 8B knows. That
+        # is a different axis from every other row, which is why it earns a
+        # line 0.35GB from the Gemma below rather than duplicating it.
+        #
+        # **Nothing special is needed to load it, and that is worth stating
+        # because it is easy to assume otherwise.** MoE experts are ordinary
+        # tensors in the checkpoint; what is conditional is the COMPUTE, which
+        # the router does inside the model. There is no "load only the active
+        # experts" mode to miss — the whole 4.9GB is fetched and resident, and
+        # the win is arithmetic per token, not bytes.
+        #
+        # `LiquidAI/`, not `mlx-community/`: the publisher's own conversion is
+        # the only one (checked 2026-08-21), which is the same reason the
+        # prism-ml Bonsai row below is not an `mlx-community` id either.
+        # Mechanism-checked like the LFM2.5 row at position 0 and NOT loaded,
+        # for the same reason — `model_type` is `lfm2_moe`, and 0.31.3's wheel
+        # ships `lfm2_moe.py`, read out of it.
+        {
+            "id": "LiquidAI/LFM2.5-8B-A1B-MLX-4bit",
+            "label": "LFM2.5 8B-A1B (MLX 4-bit)",
+            "size_gb": 4.9,
+            "note": "8B of knowledge answering at about a 1B's speed — a "
+                    "mixture of experts, so only a fraction of it runs per "
+                    "token.",
+        },
         {
             "id": "mlx-community/gemma-4-e4b-it-4bit",
             "label": "Gemma 4 E4B (4-bit)",
@@ -302,22 +330,29 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # documents for `gemma4_unified`, so every entry ADDED here was loaded
     # through `llamacpp_text/.venv`'s own `llama_cpp.Llama` and asked for a
     # token before it went in (2026-08-21, llama-cpp-python 0.3.29): LFM2.5
-    # 1.2B (`lfm2`), Qwen3.5 4B Q4_K_M (`qwen35`) and Gemma 4 E4B (`gemma4`)
-    # each answered. The 27B row carries over from the previous shortlist
+    # 1.2B (`lfm2`), Qwen3.5 4B Q4_K_M (`qwen35`), Gemma 4 E4B (`gemma4`) and
+    # LFM2.5 8B-A1B (`lfm2moe`) each answered. The 27B row carries over from the previous shortlist
     # UNCHANGED and was not re-loaded for this refresh — 13GB to re-verify a
     # file that was already shipping. Redo the loads when the pin in
     # `llamacpp_text/pyproject.toml` moves; an arch name in the table is a
     # necessary condition, never a sufficient one.
     #
-    # **Four families, and that is a REQUIREMENT of the list rather than a
-    # coincidence of what was newest.** This list was five Qwen entries over
-    # three Qwen repos: two of them the same 4B at two quantizations, two of
-    # them the same 9B. A shortlist whose every row shares a tokenizer, a
-    # training mix and a failure mode gives a user nothing to try when the
-    # first answer is bad — "measure it against a model you already trust" is
-    # advice the MLX list can give because it has Gemma beside Qwen, and this
-    # one could not. Each row here is a different family: LFM2.5 (Liquid),
-    # Qwen3.5, Gemma 4, Qwen3.8 at the top end.
+    # **Three publishers over five rows, and that is a REQUIREMENT of the list
+    # rather than a coincidence of what was newest.** This list was five Qwen
+    # entries over three Qwen repos: two of them the same 4B at two
+    # quantizations, two of them the same 9B. A shortlist whose every row
+    # shares a tokenizer, a training mix and a failure mode gives a user
+    # nothing to try when the first answer is bad — "measure it against a
+    # model you already trust" is advice the MLX list can give because it has
+    # Gemma beside Qwen, and this one could not. Now: Liquid, Qwen and Google.
+    #
+    # **Liquid appears twice, and the second one is not a duplicate.** The
+    # 1.2B at position 0 and the 8B-A1B below it are a dense model and a
+    # mixture of experts — the same publisher, and nothing else in common that
+    # matters to a picker. Where a repeated Qwen 4B at two quantizations gave
+    # a reader one choice wearing two labels, these two answer different
+    # questions ("the smallest thing that works" and "8B answers at 1B
+    # speed"), which is the test a row has to pass to be here.
     #
     # **And that requirement is load-bearing precisely BECAUSE of D416.** Since
     # the transformers family was withdrawn, this list is what a bare "auto"
@@ -398,14 +433,39 @@ SUGGESTIONS: dict[str, list[dict]] = {
                     "above handles badly — it answers above its size class "
                     "for the download.",
         },
+        # The mixture-of-experts row, and it matters MORE here than its MLX
+        # twin does: this list's default build has no GPU, and a router that
+        # multiplies ~1B of an 8B model per token is the one architecture that
+        # turns a CPU into a reasonable place to run an 8B at all. Nothing in
+        # the runner has to know — MoE experts are ordinary tensors, only the
+        # COMPUTE is conditional, and llama.cpp does that inside the graph.
+        #
+        # **What we CANNOT do for it is placement**, and that is a binding
+        # limit rather than an oversight: llama.cpp's `--n-cpu-moe` (keep the
+        # expert tensors on the CPU, put attention on the GPU) is backed by
+        # `llama_model_params.tensor_buft_overrides`, which llama-cpp-python
+        # 0.3.29 exposes in the ctypes struct and NOT as a `Llama.__init__`
+        # keyword — checked against the installed signature, which offers only
+        # `n_gpu_layers`, `split_mode`, `main_gpu` and `tensor_split`. So on
+        # the Vulkan build this row is offloaded by whole layers like any
+        # dense model, leaving the trick unused. On the CPU build, which is
+        # what most machines resolve to, there is nothing left on the table.
+        {
+            "id": "LFM2.5-8B-A1B-Q4_K_M.gguf",
+            "label": "LFM2.5 8B-A1B (Q4_K_M)",
+            "size_gb": 5.2,
+            "note": "8B of knowledge answering at about a 1B's speed — a "
+                    "mixture of experts, so only a fraction of it runs per "
+                    "token.",
+        },
         {
             "id": "Qwen3.8-27B-UD-Q3_K_XL.gguf",
             "label": "Qwen3.8 27B (UD-Q3_K_XL)",
             "size_gb": 13.1,
             "note": "The newest and largest model here, quantized hard to fit "
-                    "the download — expect a bigger quality hit than the Gemma "
-                    "above, and a laptop GPU to run it mostly or entirely on "
-                    "the CPU rather than resident in VRAM.",
+                    "the download — expect a bigger quality hit than the "
+                    "LFM2.5 8B-A1B above, and a laptop GPU to run it mostly "
+                    "or entirely on the CPU rather than resident in VRAM.",
         },
     ],
     "diffusers-image": [

--- a/fused_render/ai/catalog.py
+++ b/fused_render/ai/catalog.py
@@ -120,8 +120,11 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # Refreshed 2026-08-16, and the refresh brought one fact this list has not
     # had to state before.
     #
-    # **EVERY CURRENT CHECKPOINT HERE IS MULTIMODAL, AND HALF OF IT IS DEAD
-    # WEIGHT.** Qwen3.5, Qwen3.6 and gemma-4 all ship as
+    # **EVERY QWEN AND GEMMA CHECKPOINT HERE IS MULTIMODAL, AND HALF OF IT IS
+    # DEAD WEIGHT** — the LFM2.5 entry at position 0 is the exception, and it
+    # is the first entry this list has ever had that pays none of this cost:
+    # `Lfm2ForCausalLM`, no `vision_config`, every byte fetched is a byte the
+    # language model uses. Qwen3.5, Qwen3.6 and gemma-4 all ship as
     # `…ForConditionalGeneration` with a `vision_config` (gemma-4 adds an
     # `audio_config`), and mlx-lm loads the LANGUAGE TOWER and nothing else —
     # the vision and audio weights sit in the snapshot, downloaded and unused,
@@ -167,20 +170,39 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # supported." The `e4b`/`e2b` siblings below are `gemma4` and do load.
     # Recheck when mlx-lm is next bumped.
     #
-    # Ordered SMALLEST FIRST, like every list in this file, which means the 1.8GB
-    # 2B leads and is what a no-model chat call loads — see the module docstring
-    # for why that trade was taken deliberately. Sizes are the whole-snapshot Hub
-    # byte sum on 2026-08-16 (D295), and every entry is ungated. **One line
-    # each**, and each note names the entry it compares itself to rather than
-    # saying "above"/"below", so a future size correction that moves a row does
-    # not quietly falsify the prose.
+    # Ordered SMALLEST FIRST, like every list in this file, which means the
+    # 0.7GB LFM2.5 1.2B leads and is what a no-model chat call loads — see the
+    # module docstring for why that trade was taken deliberately. Sizes are the
+    # whole-snapshot Hub byte sum on 2026-08-16 (D295), the LFM2.5 row's
+    # re-measured on 2026-08-21, and every entry is ungated. **One line each**,
+    # and each note names the entry it compares itself to rather than saying
+    # "above"/"below", so a future size correction that moves a row does not
+    # quietly falsify the prose.
     "mlx-text": [
+        # Position 0, replacing `mlx-community/Qwen3.5-2B-MLX-4bit` (1.7GB),
+        # and it is a straight win rather than a trade: 2.6x less to fetch,
+        # text-only where the Qwen 2B spent part of that on a vision tower
+        # mlx-lm drops, and the same model the `llamacpp-text` list leads with
+        # — so the two platforms now start a bare `fused.ai()` on the SAME
+        # model rather than on two different compromises.
+        #
+        # **Loadable by the mechanism, not by a load** — this repo could not
+        # be tried here, because MLX does not install off Apple Silicon and
+        # the refresh that added it was done on Linux. What WAS checked is the
+        # exact resolution step the `gemma4_unified` paragraph above turns on:
+        # `model_type` is `lfm2`, mlx-lm resolves a checkpoint by importing
+        # `mlx_lm.models.<model_type>`, and 0.31.3's wheel ships `lfm2.py`
+        # (read out of the published wheel, not assumed). Its `quantization`
+        # block is a plain uniform `{group_size: 64, bits: 4, mode: affine}`
+        # with no `quant_method`, so `formats.unloadable_quant` passes it the
+        # same way it passes every other row here. Someone on a Mac should
+        # still load it once.
         {
-            "id": "mlx-community/Qwen3.5-2B-MLX-4bit",
-            "label": "Qwen3.5 2B (MLX 4-bit)",
-            "size_gb": 1.8,
-            "note": "The smallest here and the one a bare call loads — weaker "
-                    "than the rest, and it runs anywhere MLX does.",
+            "id": "mlx-community/LFM2.5-1.2B-Instruct-4bit",
+            "label": "LFM2.5 1.2B Instruct (MLX 4-bit)",
+            "size_gb": 0.7,
+            "note": "The smallest here and the one a bare call loads — quick "
+                    "to fetch and to answer, and weaker than every other row.",
         },
         {
             "id": "mlx-community/Qwen3.5-4B-OptiQ-4bit",
@@ -337,9 +359,9 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # experience than a 0.7GB one that answers immediately, and LFM2.5 is not a
     # small transformer — Liquid's hybrid short-convolution stack is built for
     # CPU decode, which is the case this engine actually defaults into. The
-    # `mlx-text` list above already leads with a 2B for the same reason, so
-    # this makes the two platforms agree rather than inventing an exception.
-    # Every OTHER row here obeys the rule.
+    # `mlx-text` list above leads with the SAME model for the same reason, so
+    # the two platforms now start a no-model call on one model rather than on
+    # two different compromises. Every OTHER row here obeys the rule.
     #
     # **One line each** and hardware-neutral, per `SUGGESTIONS`' own rules:
     # this list

--- a/fused_render/ai/catalog.py
+++ b/fused_render/ai/catalog.py
@@ -271,32 +271,75 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # load — the same limitation `formats.COMPONENT_REPOS`'s repos already
     # have, for the same reason.
     #
-    # **`gguf.architecture = "qwen35"` on every entry here, which is worth
-    # spelling out because it is the whole reason this list can offer
-    # CURRENT-GENERATION Qwen at all.** llama.cpp converts and runs the TEXT
-    # TOWER of the `Qwen3_5ForConditionalGeneration` family — the same
+    # **Every entry's `general.architecture` is checked against
+    # `formats.GGUF_TEXT_ARCHITECTURES` BEFORE it is listed, and then the file
+    # is actually LOADED.** The metadata check is cheap and catches the wrong
+    # class of model; it does not prove that the June 2026 llama.cpp this
+    # runner vendors can build an August 2026 checkpoint of a family whose
+    # NAME it knows. That gap is exactly the trap the `mlx-text` list above
+    # documents for `gemma4_unified`, so every entry ADDED here was loaded
+    # through `llamacpp_text/.venv`'s own `llama_cpp.Llama` and asked for a
+    # token before it went in (2026-08-21, llama-cpp-python 0.3.29): LFM2.5
+    # 1.2B (`lfm2`), Qwen3.5 4B Q4_K_M (`qwen35`) and Gemma 4 E4B (`gemma4`)
+    # each answered. The 27B row carries over from the previous shortlist
+    # UNCHANGED and was not re-loaded for this refresh — 13GB to re-verify a
+    # file that was already shipping. Redo the loads when the pin in
+    # `llamacpp_text/pyproject.toml` moves; an arch name in the table is a
+    # necessary condition, never a sufficient one.
+    #
+    # **Four families, and that is a REQUIREMENT of the list rather than a
+    # coincidence of what was newest.** This list was five Qwen entries over
+    # three Qwen repos: two of them the same 4B at two quantizations, two of
+    # them the same 9B. A shortlist whose every row shares a tokenizer, a
+    # training mix and a failure mode gives a user nothing to try when the
+    # first answer is bad — "measure it against a model you already trust" is
+    # advice the MLX list can give because it has Gemma beside Qwen, and this
+    # one could not. Each row here is a different family: LFM2.5 (Liquid),
+    # Qwen3.5, Gemma 4, Qwen3.8 at the top end.
+    #
+    # **And that requirement is load-bearing precisely BECAUSE of D416.** Since
+    # the transformers family was withdrawn, this list is what a bare "auto"
+    # reaches on Windows and Linux rather than an opt-in a user had to go
+    # looking for — so these four entries are no longer an alternative
+    # shortlist beside a safetensors one, they are the whole of what text
+    # generation suggests on those platforms. A monoculture was a thin
+    # shortlist when it was the second list; it is the only list now.
+    #
+    # **The Qwen entries are still current-generation, which is the thing that
+    # made the old monoculture defensible.** llama.cpp converts and runs the
+    # TEXT TOWER of the `Qwen3_5ForConditionalGeneration` family — the same
     # language model the removed `transformers-text` list served in full bf16
     # precision, at 19.3GB for the 9B (D416) — so a machine too small for that
-    # download can still run the same model's answers at a fraction of the
-    # size, not a smaller model wearing the same name. Since D416 this list is
-    # also what a bare "auto" reaches on Windows and Linux rather than an opt-in
-    # a user had to find, which raises what these five entries have to be: they
-    # are no longer an alternative shortlist beside a safetensors one, they are
-    # the whole of what text generation suggests on those platforms.
+    # download still runs the same model's answers at a fraction of the size,
+    # not a smaller model wearing the same name.
     #
     # Sizes verified against the Hub's `?blobs=true` metadata on 2026-08-21,
     # summing ONLY the one GGUF file `download_file` fetches (never the whole
-    # repo) plus nothing else — these unsloth repos ship no external
-    # tokenizer/config files at their root, so there is no second download to
-    # add in (see `runners/llama_text.py`). Every file checked is a single
+    # repo) plus nothing else — a GGUF carries its own vocabulary, config and
+    # chat template inside the one file, so there is no second download to add
+    # in whatever else sits beside it in the repo (the LFM2.5 repo ships a
+    # `leap/` directory of runtime manifests and the gemma repo a `config.json`
+    # and an `MTP/` folder; none of it is fetched, see
+    # `runners/llama_text.py`). Every file checked is a single
     # root-level `.gguf`, not a `-00001-of-0000N` shard — `download_file` takes
     # one filename, so a sharded tier would have been silently unloadable and
     # was excluded before it could ship (the 27B repo's own BF16 tier IS
     # sharded, which is one reason its shortlist entry is the aggressively
     # quantized UD-Q3_K_XL rather than anything closer to full precision).
-    # Every repo checked `gated: false`. **No sub-4B entries** — the user's own
-    # standing rule that a text model under 4B parameters is not worth using,
-    # and every model here is a Qwen3.5-or-newer 4B, 9B or 27B.
+    # Every repo checked `gated: false`.
+    #
+    # **The "no text model under 4B" rule is deliberately broken at position 0,
+    # and only there.** That rule was written against 2025-era 1-3B models and
+    # it is the right default still — but position 0 is not a recommendation,
+    # it is what a bare `fused.ai()` loads on a machine whose owner never
+    # opened this page, and on the CPU wheel that is most non-Apple machines.
+    # A 2.7GB download that answers at a few tokens a second is a worse first
+    # experience than a 0.7GB one that answers immediately, and LFM2.5 is not a
+    # small transformer — Liquid's hybrid short-convolution stack is built for
+    # CPU decode, which is the case this engine actually defaults into. The
+    # `mlx-text` list above already leads with a 2B for the same reason, so
+    # this makes the two platforms agree rather than inventing an exception.
+    # Every OTHER row here obeys the rule.
     #
     # **One line each** and hardware-neutral, per `SUGGESTIONS`' own rules:
     # this list
@@ -304,48 +347,41 @@ SUGGESTIONS: dict[str, list[dict]] = {
     # `llamacpp-text-vulkan` to this same key), so a note naming one build's
     # device would be wrong on the other.
     "llamacpp-text": [
+        # The two Q8_0 rows this list used to carry (the 4B at 4.5GB and the 9B
+        # at 9.5GB) are gone, and not for length: Q8_0 is roughly twice
+        # Q4_K_M's arithmetic per token for a quality gain that is small next
+        # to moving up a size class, and this engine's default build has no
+        # GPU to hide that behind. A row that is never the right pick fails
+        # this file's own "every line is somebody's answer" test.
         {
-            "id": "Qwen3.5-4B-Q5_K_M.gguf",
-            "label": "Qwen3.5 4B (Q5_K_M)",
-            "size_gb": 3.1,
-            "note": "The smallest here and the one a bare call loads — Qwen3.5 "
-                    "4B (Q8_0) below is the same model at higher fidelity for "
-                    "1.3GB more.",
+            "id": "LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
+            "label": "LFM2.5 1.2B Instruct (Q4_K_M)",
+            "size_gb": 0.7,
+            "note": "The smallest here and the one a bare call loads — a "
+                    "hybrid architecture built for CPU decode, so it answers "
+                    "immediately where a 4B thinks.",
         },
         {
-            "id": "Qwen3.5-4B-Q8_0.gguf",
-            "label": "Qwen3.5 4B (Q8_0)",
-            "size_gb": 4.5,
-            "note": "The same 4B near full precision, for a third more "
-                    "download than Q5_K_M above.",
+            "id": "Qwen3.5-4B-Q4_K_M.gguf",
+            "label": "Qwen3.5 4B (Q4_K_M)",
+            "size_gb": 2.7,
+            "note": "The first row here strong enough for real work: current-"
+                    "gen Qwen, and a fifth of the unquantized 4B's download.",
         },
         {
-            "id": "Qwen3.5-9B-Q4_K_M.gguf",
-            "label": "Qwen3.5 9B (Q4_K_M)",
-            "size_gb": 5.7,
-            # Named the removed `transformers-text` engine until D416. A note
-            # citing an engine the page no longer lists is a dead reference the
-            # reader cannot resolve, so the comparison is to the FORMAT — which
-            # is the fact that actually earns the entry, and is true whatever
-            # engines happen to be registered.
-            "note": "Current-gen Qwen at under a third of what the same 9B "
-                    "weighs unquantized — the strongest pick here for the "
-                    "size.",
-        },
-        {
-            "id": "Qwen3.5-9B-Q8_0.gguf",
-            "label": "Qwen3.5 9B (Q8_0)",
-            "size_gb": 9.5,
-            "note": "The 9B at higher fidelity than Q4_K_M above, for nearly "
-                    "double the download — bigger than most laptop GPUs' "
-                    "VRAM, so expect a slower partial or CPU load there.",
+            "id": "gemma-4-E4B-it-Q4_K_M.gguf",
+            "label": "Gemma 4 E4B (Q4_K_M)",
+            "size_gb": 5.0,
+            "note": "A second family, worth trying on a prompt the Qwen 4B "
+                    "above handles badly — it answers above its size class "
+                    "for the download.",
         },
         {
             "id": "Qwen3.8-27B-UD-Q3_K_XL.gguf",
             "label": "Qwen3.8 27B (UD-Q3_K_XL)",
             "size_gb": 13.1,
             "note": "The newest and largest model here, quantized hard to fit "
-                    "the download — expect a bigger quality hit than the 9B "
+                    "the download — expect a bigger quality hit than the Gemma "
                     "above, and a laptop GPU to run it mostly or entirely on "
                     "the CPU rather than resident in VRAM.",
         },

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -463,6 +463,10 @@ GGUF_RECIPES = {
         "repo": "unsloth/gemma-4-E4B-it-GGUF",
         "file": "gemma-4-E4B-it-Q4_K_M.gguf",
     },
+    "LFM2.5-8B-A1B-Q4_K_M.gguf": {
+        "repo": "LiquidAI/LFM2.5-8B-A1B-GGUF",
+        "file": "LFM2.5-8B-A1B-Q4_K_M.gguf",
+    },
     "Qwen3.8-27B-UD-Q3_K_XL.gguf": {
         "repo": "unsloth/Qwen3.8-27B-GGUF",
         "file": "Qwen3.8-27B-UD-Q3_K_XL.gguf",
@@ -649,7 +653,7 @@ def pick_gguf_file(filenames) -> str | None:
 
     **This is the whole of Piece 1** (D412): given ANY Hub repo's file
     listing, decide which single `.gguf` a bare repo id resolves to, the same
-    question `GGUF_RECIPES` answers by hand for 4 curated filenames. Three
+    question `GGUF_RECIPES` answers by hand for 5 curated filenames. Three
     passes:
 
     1. Exclude by SHAPE — a subdirectory entry (`BF16/model.gguf`, sidesteps

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -444,22 +444,24 @@ def gguf_block_count(path: str) -> int | None:
 #: fetched it, `llama_text._resolve_model_id`, for the id shape the page's
 #: cache scan hands back). `test_ai_formats.py` asserts every id here also
 #: appears in `catalog.SUGGESTIONS["llamacpp-text"]`, so the two cannot drift.
+#:
+#: **`unsloth` is not a rule, and this table stopped pretending it was.** The
+#: shortlist's smallest entry comes out of `LiquidAI/…`, the publisher's own
+#: repo, because that is where LFM2.5 is published — nothing here reads the
+#: owner, and a curated `(repo, file)` pair is as loadable from one namespace
+#: as another.
 GGUF_RECIPES = {
-    "Qwen3.5-4B-Q5_K_M.gguf": {
+    "LFM2.5-1.2B-Instruct-Q4_K_M.gguf": {
+        "repo": "LiquidAI/LFM2.5-1.2B-Instruct-GGUF",
+        "file": "LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
+    },
+    "Qwen3.5-4B-Q4_K_M.gguf": {
         "repo": "unsloth/Qwen3.5-4B-GGUF",
-        "file": "Qwen3.5-4B-Q5_K_M.gguf",
+        "file": "Qwen3.5-4B-Q4_K_M.gguf",
     },
-    "Qwen3.5-4B-Q8_0.gguf": {
-        "repo": "unsloth/Qwen3.5-4B-GGUF",
-        "file": "Qwen3.5-4B-Q8_0.gguf",
-    },
-    "Qwen3.5-9B-Q4_K_M.gguf": {
-        "repo": "unsloth/Qwen3.5-9B-GGUF",
-        "file": "Qwen3.5-9B-Q4_K_M.gguf",
-    },
-    "Qwen3.5-9B-Q8_0.gguf": {
-        "repo": "unsloth/Qwen3.5-9B-GGUF",
-        "file": "Qwen3.5-9B-Q8_0.gguf",
+    "gemma-4-E4B-it-Q4_K_M.gguf": {
+        "repo": "unsloth/gemma-4-E4B-it-GGUF",
+        "file": "gemma-4-E4B-it-Q4_K_M.gguf",
     },
     "Qwen3.8-27B-UD-Q3_K_XL.gguf": {
         "repo": "unsloth/Qwen3.8-27B-GGUF",
@@ -647,7 +649,7 @@ def pick_gguf_file(filenames) -> str | None:
 
     **This is the whole of Piece 1** (D412): given ANY Hub repo's file
     listing, decide which single `.gguf` a bare repo id resolves to, the same
-    question `GGUF_RECIPES` answers by hand for 5 curated filenames. Three
+    question `GGUF_RECIPES` answers by hand for 4 curated filenames. Three
     passes:
 
     1. Exclude by SHAPE — a subdirectory entry (`BF16/model.gguf`, sidesteps

--- a/fused_render/ai/runners/llama_text.py
+++ b/fused_render/ai/runners/llama_text.py
@@ -65,20 +65,26 @@ name a component swapped into an otherwise ordinary pipeline, not a whole
 model a bare id could mean, so no picker generalizes them the way this one
 generalizes `GGUF_RECIPES`.
 
-**No external tokenizer/config download, and that is a fact about THESE
-repos, not a general rule.** unsloth's GGUF conversions — the ones
-`formats.GGUF_RECIPES` curates — ship no `tokenizer_config.json` or
-`config.json` at their root: checked directly against the Hub API on
-2026-08-21, the only non-GGUF files in `unsloth/Qwen3.5-4B-GGUF` and
-`unsloth/Qwen3.5-9B-GGUF` are `.gitattributes`, `README.md` and an imatrix
-calibration file, none of them a tokenizer. That is not an oversight on
-unsloth's part — it is the point of the GGUF format: the vocabulary, the
-architecture and (since llama.cpp's chat template support landed) the chat
-template all live inside the ONE file's own key-value metadata, which is
-exactly what `llama_cpp.Llama` reads at load time into `.metadata`. So
-`download()` fetches exactly one file (`worker_base.download_file`) and
-nothing else — there is no `download_snapshot(..., allow_patterns=…)` call
-here, because there is nothing at those repos' roots for it to fetch.
+**No external tokenizer/config download, and the reason is the FORMAT rather
+than the repos.** The vocabulary, the architecture and (since llama.cpp's
+chat template support landed) the chat template all live inside the ONE
+file's own key-value metadata, which is exactly what `llama_cpp.Llama` reads
+at load time into `.metadata`. So `download()` fetches exactly one file
+(`worker_base.download_file`) and nothing else — there is no
+`download_snapshot(..., allow_patterns=…)` call here, because a GGUF needs no
+companion.
+
+**This used to be argued the other way round — "those repos happen to ship
+nothing but GGUFs" — and that argument expired.** It was true of the three
+unsloth Qwen repos the table curated on 2026-08-21, whose only non-GGUF files
+were `.gitattributes`, `README.md` and an imatrix calibration file. The
+shortlist has since gained repos where it is plainly false:
+`unsloth/gemma-4-E4B-it-GGUF` carries a root `config.json` and an `MTP/`
+folder, and `LiquidAI/LFM2.5-1.2B-Instruct-GGUF` a `leap/` directory of
+runtime manifests. None of it is fetched and none of it is missed, which is
+the proof that the format was always doing the work. Stating it as a property
+of the repos would have made a correct implementation look like a lucky one,
+and would have argued against curating either of them.
 
 Five things are true of this runner and of no other text runner here, and all
 five are llama.cpp's doing. Three of them are stated as contrasts with the

--- a/fused_render/server/ai.py
+++ b/fused_render/server/ai.py
@@ -109,7 +109,7 @@ _AI_BIN_ENV = claude_health.BIN_ENV
 # **The seam gained a second shape (D411) and this is the one place it has to
 # be spelled out, because it is genuinely not a slash-shaped id.**
 # `llamacpp-text`'s curated ids (`formats.GGUF_RECIPES`) are the GGUF's own
-# FILENAME, never a repo id — `"Qwen3.5-4B-Q5_K_M.gguf"` has no `/` at all —
+# FILENAME, never a repo id — `"Qwen3.5-4B-Q4_K_M.gguf"` has no `/` at all —
 # because a GGUF repo commonly ships two dozen quantizations of one model and
 # the filename is what tells them apart (see `llama_text.py`'s own docstring).
 # `"/" in model` alone therefore sent every curated llamacpp id down the

--- a/skills/fused-render-ai/SKILL.md
+++ b/skills/fused-render-ai/SKILL.md
@@ -428,7 +428,7 @@ First failing = `ai_unavailable`, not your bug. `X-Fused: 1` is required on ever
 - **Rendering only `catalog()`'s curated entries** → the model the user just downloaded is missing from your picker. Render every entry; mark them.
 - **Assuming a capability's runner from the platform** → every capability has more than one and a user preference can pick any. Read `active` from `fused.ai.models.list()`.
 - **Hard-coding a repo id, or carrying one between engines** → formats are backend-specific; a repo that works on one engine is an unusable download on the other.
-- **Assuming a model id is always `org/name`** → `llamacpp-text`'s curated ids are the GGUF's own filename (`Qwen3.5-4B-Q5_K_M.gguf`, no slash). Splitting on `/` or building a Hub URL from `id` breaks on one; treat it as opaque.
+- **Assuming a model id is always `org/name`** → `llamacpp-text`'s curated ids are the GGUF's own filename (`Qwen3.5-4B-Q4_K_M.gguf`, no slash). Splitting on `/` or building a Hub URL from `id` breaks on one; treat it as opaque.
 
 **Images**
 

--- a/tests/test_ai_llamacpp_worker.py
+++ b/tests/test_ai_llamacpp_worker.py
@@ -97,8 +97,8 @@ def test_download_fetches_exactly_the_one_curated_file(worker):
     """No snapshot call, and no second repo — `worker_base.download_file` is
     the whole of it (see the module docstring on why there is no external
     tokenizer/config fetch for these repos)."""
-    path = worker.download("Qwen3.5-9B-Q4_K_M.gguf")
-    assert path == "/blobs/unsloth/Qwen3.5-9B-GGUF/Qwen3.5-9B-Q4_K_M.gguf"
+    path = worker.download("gemma-4-E4B-it-Q4_K_M.gguf")
+    assert path == "/blobs/unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf"
 
 
 def test_download_resolves_an_uncurated_repo_via_the_picker(worker, monkeypatch):
@@ -176,16 +176,16 @@ def test_load_refuses_an_uncurated_repo_with_nothing_loadable_before_importing_l
 
 
 def test_a_repo_id_resolves_to_its_already_cached_recipe(worker):
-    """The regression code review found: `unsloth/Qwen3.5-9B-GGUF` downloaded
-    through the filename id `Qwen3.5-9B-Q4_K_M.gguf` is what the AI Models
+    """The regression code review found: `unsloth/gemma-4-E4B-it-GGUF` downloaded
+    through the filename id `gemma-4-E4B-it-Q4_K_M.gguf` is what the AI Models
     page then offers a Load button for UNDER ITS REPO ID (the local cache is
     keyed by repo, not by this table's filenames) — and before this fix that
     second Load died with the "not curated" refusal for the exact model a
     user just fetched through this engine."""
     worker.worker_base.cached_files.add(
-        ("unsloth/Qwen3.5-9B-GGUF", "Qwen3.5-9B-Q4_K_M.gguf"))
-    path = worker.download("unsloth/Qwen3.5-9B-GGUF")
-    assert path == "/blobs/unsloth/Qwen3.5-9B-GGUF/Qwen3.5-9B-Q4_K_M.gguf"
+        ("unsloth/gemma-4-E4B-it-GGUF", "gemma-4-E4B-it-Q4_K_M.gguf"))
+    path = worker.download("unsloth/gemma-4-E4B-it-GGUF")
+    assert path == "/blobs/unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf"
 
 
 def test_a_repo_id_with_exactly_one_recipe_resolves_even_cold(worker):
@@ -196,13 +196,28 @@ def test_a_repo_id_with_exactly_one_recipe_resolves_even_cold(worker):
                     "Qwen3.8-27B-UD-Q3_K_XL.gguf")
 
 
-def test_a_repo_id_with_two_recipes_and_nothing_cached_is_refused_by_name(worker):
-    """`unsloth/Qwen3.5-4B-GGUF` curates TWO quantizations
-    (Q5_K_M and Q8_0) — with neither on disk yet, a bare repo id is genuinely
-    ambiguous, and guessing would risk a multi-gigabyte download of the wrong
-    one rather than a `FileNotFoundError`."""
+def test_a_repo_id_with_two_recipes_and_nothing_cached_is_refused_by_name(
+        worker, monkeypatch):
+    """Two curated quantizations of ONE repo, with neither on disk yet: the
+    bare repo id is genuinely ambiguous, and guessing would risk a
+    multi-gigabyte download of the wrong one rather than a `FileNotFoundError`.
+
+    The recipe table is PATCHED rather than read, and that is the point. The
+    shipped shortlist happens to curate exactly one quantization per repo
+    today — it curated two of the Qwen 4B until the 2026-08-21 refresh — so a
+    test that reached into the real table for its ambiguous pair would go
+    quietly vacuous the moment the curation stopped supplying one, which is
+    precisely what happened. This branch of `_resolve_model_id` must keep
+    working for the day a repo gains a second entry again.
+    """
+    monkeypatch.setattr(worker, "_GGUF_RECIPES", {
+        "Model-Q4_K_M.gguf": {"repo": "org/Model-GGUF",
+                              "file": "Model-Q4_K_M.gguf"},
+        "Model-Q8_0.gguf": {"repo": "org/Model-GGUF",
+                            "file": "Model-Q8_0.gguf"},
+    })
     with pytest.raises(RuntimeError, match="ambiguous"):
-        worker.download("unsloth/Qwen3.5-4B-GGUF")
+        worker.download("org/Model-GGUF")
 
 
 def test_load_also_resolves_a_repo_id_the_same_way(worker, monkeypatch):
@@ -563,7 +578,7 @@ def test_load_reports_cpu_when_the_build_has_no_gpu_backend_at_all(worker, monke
     — no retry loop to enter, since there is no smaller candidate than CPU."""
     fake = _fake_llama_cpp(monkeypatch, gpu_offload=False)
 
-    worker.load("Qwen3.5-9B-Q4_K_M.gguf", "/blobs/model.gguf")
+    worker.load("gemma-4-E4B-it-Q4_K_M.gguf", "/blobs/model.gguf")
     assert worker.worker_base.recorded == {"device": "cpu"}
     assert worker._loaded["llm"].kwargs["model_path"] == "/blobs/model.gguf"
     assert fake.calls == [0]
@@ -578,7 +593,7 @@ def test_load_offloads_to_the_gpu_when_the_build_supports_it(worker, monkeypatch
     layers" sentinel) succeeds outright."""
     fake = _fake_llama_cpp(monkeypatch, gpu_offload=True)
 
-    worker.load("Qwen3.5-9B-Q4_K_M.gguf", "/blobs/model.gguf")
+    worker.load("gemma-4-E4B-it-Q4_K_M.gguf", "/blobs/model.gguf")
     assert fake.calls == [-1]
     assert worker._loaded["llm"].kwargs["n_gpu_layers"] == -1
     assert worker.worker_base.recorded == {"device": "gpu"}
@@ -593,7 +608,7 @@ def test_load_backs_off_to_cpu_when_full_offload_does_not_fit(worker, monkeypatc
     an OOM'd Load" policy in its plainest form."""
     fake = _fake_llama_cpp(monkeypatch, gpu_offload=True, fail_for={-1})
 
-    worker.load("Qwen3.5-9B-Q4_K_M.gguf", "/blobs/model.gguf")
+    worker.load("gemma-4-E4B-it-Q4_K_M.gguf", "/blobs/model.gguf")
     assert fake.calls == [-1, 0]
     assert worker.worker_base.recorded == {"device": "cpu"}
 
@@ -625,7 +640,7 @@ def test_load_reports_partial_offload_when_fewer_than_all_layers_fit(
 
     fake = _fake_llama_cpp(monkeypatch, gpu_offload=True, fail_for={32})
 
-    worker.load("Qwen3.5-9B-Q4_K_M.gguf", str(gguf_path))
+    worker.load("gemma-4-E4B-it-Q4_K_M.gguf", str(gguf_path))
     # 32 (all) fails, the next step in the schedule (2/3 of 32 = 21) succeeds.
     assert fake.calls == [32, 21]
     assert worker.worker_base.recorded == {"device": "gpu (partial)"}
@@ -638,7 +653,7 @@ def test_load_does_not_swallow_a_failure_no_smaller_offload_can_fix(worker, monk
     fake = _fake_llama_cpp(monkeypatch, gpu_offload=True, fail_for={-1, 0})
 
     with pytest.raises(ValueError, match="Failed to load model"):
-        worker.load("Qwen3.5-9B-Q4_K_M.gguf", "/blobs/model.gguf")
+        worker.load("gemma-4-E4B-it-Q4_K_M.gguf", "/blobs/model.gguf")
     assert fake.calls == [-1, 0]
 
 

--- a/tests/test_ai_metrics.py
+++ b/tests/test_ai_metrics.py
@@ -408,7 +408,7 @@ def test_the_local_tier_records_its_generated_tokens(monkeypatch):
 def test_a_curated_llamacpp_filename_id_dispatches_local_not_to_claude(monkeypatch):
     """The bug this pins: `llamacpp-text`'s curated ids are the GGUF's own
     FILENAME (`formats.GGUF_RECIPES`), never a repo id, so
-    `"Qwen3.5-4B-Q5_K_M.gguf"` has no `/` at all. `"/" in model` alone sent
+    `"Qwen3.5-4B-Q4_K_M.gguf"` has no `/` at all. `"/" in model` alone sent
     it down the CLAUDE path as an unrecognised alias — a bug shipped with
     `llamacpp-text` itself (D411), found and fixed while auditing the
     fused-render-ai skill for what this branch invalidated (D412). If this
@@ -416,11 +416,11 @@ def test_a_curated_llamacpp_filename_id_dispatches_local_not_to_claude(monkeypat
     not silently."""
     _local(monkeypatch, [{"type": "done", "ok": True, "tokens": 5, "seconds": 0.2}])
     resp = asyncio.run(_server_ai._ai_relay(
-        {"prompt": "hi", "model": "Qwen3.5-4B-Q5_K_M.gguf"}))
+        {"prompt": "hi", "model": "Qwen3.5-4B-Q4_K_M.gguf"}))
     assert resp.status_code == 200
 
     row, = ai_metrics.snapshot(5)["models"]
-    assert (row["model"], row["tier"]) == ("Qwen3.5-4B-Q5_K_M.gguf", "local")
+    assert (row["model"], row["tier"]) == ("Qwen3.5-4B-Q4_K_M.gguf", "local")
 
 
 def test_the_local_tier_records_a_streamed_completion(monkeypatch):

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1924,7 +1924,7 @@ def test_the_default_is_the_smallest_model_the_active_runner_offers(monkeypatch)
     monkeypatch.setattr(registry.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(registry.platform, "machine", lambda: "arm64")
     assert catalog.default_for(registry.TEXT_GENERATION) == \
-        "mlx-community/Qwen3.5-2B-MLX-4bit"
+        "mlx-community/LFM2.5-1.2B-Instruct-4bit"
     # tiny.en is English-only, and it still leads: the one-rule trade above was
     # chosen with its cost in view, and an entry is added to the list because
     # it is worth OFFERING, not because it should be default-proof.

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1885,6 +1885,7 @@ def test_llamacpp_and_whisper_suggestions_show_snapshot_size_estimates():
         "LFM2.5-1.2B-Instruct-Q4_K_M.gguf": 0.7,
         "Qwen3.5-4B-Q4_K_M.gguf": 2.7,
         "gemma-4-E4B-it-Q4_K_M.gguf": 5.0,
+        "LFM2.5-8B-A1B-Q4_K_M.gguf": 5.2,
         "Qwen3.8-27B-UD-Q3_K_XL.gguf": 13.1,
         "deepdml/faster-whisper-large-v3-turbo-ct2": 1.6,
         "Systran/faster-whisper-tiny.en": 0.08,
@@ -1969,7 +1970,14 @@ def test_the_catalog_follows_the_runner_that_would_actually_load(monkeypatch):
     text = next(row for row in catalog.describe()
                 if row["capability"] == registry.TEXT_GENERATION)
     assert text["runner"] == "mlx-text"
-    assert all(m["id"].startswith(("mlx-community/", "prism-ml/")) for m in text["models"])
+    # The namespace set is a PROXY for "these are MLX conversions", and it
+    # grows: `prism-ml/` was added with the Bonsai row and `LiquidAI/` with the
+    # 8B-A1B, both because no `mlx-community/` conversion of them exists. What
+    # the assertion is really pinning is the Windows half above — that the two
+    # lists are disjoint — so a new publisher belongs here rather than being a
+    # reason to weaken it.
+    assert all(m["id"].startswith(("mlx-community/", "prism-ml/", "LiquidAI/"))
+               for m in text["models"])
 
 
 def test_the_cpu_warning_reaches_the_page(monkeypatch):

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1876,12 +1876,15 @@ def test_llamacpp_and_whisper_suggestions_show_snapshot_size_estimates():
     9.3 to 19.3GB — and now reads `llamacpp-text`, whose figures are the single
     GGUF file each id resolves to. That the numbers are a quarter to a third of
     what they replaced is the measurement D416 rests on, sitting here as data.
+
+    The llamacpp figures moved again with the four-family refresh, and the one
+    worth reading twice is position 0: 0.7GB, against the 9.3GB a bare call
+    fetched two changes ago.
     """
     expected = {
-        "Qwen3.5-4B-Q5_K_M.gguf": 3.1,
-        "Qwen3.5-4B-Q8_0.gguf": 4.5,
-        "Qwen3.5-9B-Q4_K_M.gguf": 5.7,
-        "Qwen3.5-9B-Q8_0.gguf": 9.5,
+        "LFM2.5-1.2B-Instruct-Q4_K_M.gguf": 0.7,
+        "Qwen3.5-4B-Q4_K_M.gguf": 2.7,
+        "gemma-4-E4B-it-Q4_K_M.gguf": 5.0,
         "Qwen3.8-27B-UD-Q3_K_XL.gguf": 13.1,
         "deepdml/faster-whisper-large-v3-turbo-ct2": 1.6,
         "Systran/faster-whisper-tiny.en": 0.08,
@@ -1930,7 +1933,8 @@ def test_the_default_is_the_smallest_model_the_active_runner_offers(monkeypatch)
 
     monkeypatch.setattr(registry.platform, "system", lambda: "Windows")
     monkeypatch.setattr(registry.platform, "machine", lambda: "AMD64")
-    assert catalog.default_for(registry.TEXT_GENERATION) == "Qwen3.5-4B-Q5_K_M.gguf"
+    assert catalog.default_for(registry.TEXT_GENERATION) == \
+        "LFM2.5-1.2B-Instruct-Q4_K_M.gguf"
     assert catalog.default_for(registry.SPEECH_TO_TEXT) == \
         "Systran/faster-whisper-tiny.en"
 
@@ -6452,11 +6456,11 @@ def test_a_llamacpp_curated_id_is_marked_downloaded_and_not_duplicated(
     monkeypatch.setattr(registry.platform, "machine", lambda: "x86_64")
     _prefer(monkeypatch, registry.TEXT_GENERATION, "llamacpp-text")
 
-    entry_id = "Qwen3.5-9B-Q4_K_M.gguf"
+    entry_id = "gemma-4-E4B-it-Q4_K_M.gguf"
     recipe = formats.GGUF_RECIPES[entry_id]
     repo = _cached_repo(hub, recipe["repo"], files=(recipe["file"],))
     (repo / "snapshots" / "c0ffee" / recipe["file"]).write_bytes(
-        _gguf_bytes("qwen35"))
+        _gguf_bytes("gemma4"))
 
     row = _catalog(client)[registry.TEXT_GENERATION]
     curated_match = next(m for m in row["models"] if m["id"] == entry_id)
@@ -6468,16 +6472,38 @@ def test_a_llamacpp_curated_id_is_marked_downloaded_and_not_duplicated(
 
 def test_a_llamacpp_curated_id_with_a_sibling_quant_not_downloaded_is_told_apart(
         client, hub, monkeypatch):
-    """`unsloth/Qwen3.5-4B-GGUF` curates TWO catalog entries (Q5_K_M and
-    Q8_0) — downloading one must not mark the OTHER "downloaded" too, since
-    `CachedModel.files` is checked per FILE, not per repo."""
+    """Two curated entries sharing ONE repo: downloading one must not mark the
+    OTHER "downloaded" too, since `CachedModel.files` is checked per FILE, not
+    per repo.
+
+    The pair is SYNTHESISED — appended to the shortlist and the recipe table
+    for the duration of this test — rather than taken from the shipped
+    curation. It used to be the real Qwen 4B's Q5_K_M and Q8_0 rows; the
+    2026-08-21 refresh left exactly one quantization per repo, which would
+    have turned this guard vacuous rather than red. The per-file rule has to
+    hold for the day a repo carries two entries again, so the test supplies
+    that day itself.
+    """
     monkeypatch.setattr(registry.platform, "system", lambda: "Linux")
     monkeypatch.setattr(registry.platform, "machine", lambda: "x86_64")
     _prefer(monkeypatch, registry.TEXT_GENERATION, "llamacpp-text")
 
-    downloaded_id = "Qwen3.5-4B-Q5_K_M.gguf"
-    other_id = "Qwen3.5-4B-Q8_0.gguf"
-    recipe = formats.GGUF_RECIPES[downloaded_id]
+    downloaded_id = "Model-Q4_K_M.gguf"
+    other_id = "Model-Q8_0.gguf"
+    recipes = dict(formats.GGUF_RECIPES)
+    for name in (downloaded_id, other_id):
+        recipes[name] = {"repo": "org/Model-GGUF", "file": name}
+    monkeypatch.setattr(formats, "GGUF_RECIPES", recipes)
+    monkeypatch.setitem(
+        catalog.SUGGESTIONS, "llamacpp-text",
+        catalog.SUGGESTIONS["llamacpp-text"] + [
+            {"id": downloaded_id, "label": "Model (Q4_K_M)", "size_gb": 1.0,
+             "note": "synthetic"},
+            {"id": other_id, "label": "Model (Q8_0)", "size_gb": 2.0,
+             "note": "synthetic"},
+        ])
+
+    recipe = recipes[downloaded_id]
     repo = _cached_repo(hub, recipe["repo"], files=(recipe["file"],))
     (repo / "snapshots" / "c0ffee" / recipe["file"]).write_bytes(
         _gguf_bytes("qwen35"))

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -294,9 +294,9 @@ def _stream(body):
 @pytest.mark.parametrize("model,expected", [
     ("mlx-community/Qwen3-8B-4bit", True),   # a Hugging Face repo id
     ("unsloth/Qwen3.5-4B-GGUF", True),       # ditto, an uncurated GGUF repo (D412)
-    ("Qwen3.5-4B-Q5_K_M.gguf", True),        # a curated llamacpp-text FILENAME id
-    ("Qwen3.5-9B-Q4_K_M.gguf", True),
-    ("QWEN3.5-4B-Q5_K_M.GGUF", True),        # case-insensitive, like the extension check it mirrors
+    ("Qwen3.5-4B-Q4_K_M.gguf", True),        # a curated llamacpp-text FILENAME id
+    ("LFM2.5-1.2B-Instruct-Q4_K_M.gguf", True),
+    ("QWEN3.5-4B-Q4_K_M.GGUF", True),        # case-insensitive, like the extension check it mirrors
     ("opus", False),
     ("sonnet", False),
     ("claude-haiku-4-5-20251001", False),


### PR DESCRIPTION
## Summary

`catalog.SUGGESTIONS["llamacpp-text"]` was five entries over three repos, **all Qwen** — two of them the same 4B at two quantizations, two of them the same 9B. A shortlist whose every row shares a tokenizer, a training mix and a failure mode gives a user nothing to try when the first answer is bad; "measure it against a model you already trust" is advice the `mlx-text` list can give because it has Gemma beside Qwen, and this one could not.

Four rows now, four families, smallest first:

| # | id | size | arch | family |
|---|---|---|---|---|
| 0 | `LFM2.5-1.2B-Instruct-Q4_K_M.gguf` | **0.7 GB** | `lfm2` | LiquidAI |
| 1 | `Qwen3.5-4B-Q4_K_M.gguf` | 2.7 GB | `qwen35` | Qwen |
| 2 | `gemma-4-E4B-it-Q4_K_M.gguf` | 5.0 GB | `gemma4` | Google |
| 3 | `Qwen3.8-27B-UD-Q3_K_XL.gguf` | 13.1 GB | `qwen35` | Qwen *(unchanged)* |

**The default drops 3.1 GB → 0.7 GB.** Position 0 is not a recommendation — it is what a bare `fused.ai()` loads, on the CPU wheel, on a machine whose owner never opened the AI Models page. LFM2.5 1.2B breaks the "no text model under 4B" rule for that slot and only that slot: Liquid's hybrid short-convolution stack is built for CPU decode, which is exactly the case this engine defaults into, and a 0.7 GB model that answers immediately is a better first experience than a 2.7 GB one that thinks. `mlx-text` already leads with a 2B, so this makes the two platforms agree rather than inventing an exception. Every other row still obeys the rule.

The two **Q8_0** rows are dropped — roughly twice Q4_K_M's arithmetic per token for a gain that is small next to moving up a size class, with no GPU in the default build to hide it behind. A row that is never the right pick fails this file's own "every line is somebody's answer" test.

## Visual

```mermaid
graph LR
    subgraph before["before · 3 repos, 1 family"]
        B0["Qwen3.5-4B Q5_K_M · 3.1 GB ← default"]
        B1["Qwen3.5-4B Q8_0 · 4.5 GB"]
        B2["Qwen3.5-9B Q4_K_M · 5.7 GB"]
        B3["Qwen3.5-9B Q8_0 · 9.5 GB"]
        B4["Qwen3.8-27B UD-Q3_K_XL · 13.1 GB"]
    end

    subgraph after["after · 4 repos, 4 families"]
        A0["LFM2.5-1.2B Q4_K_M · 0.7 GB ← default"]
        A1["Qwen3.5-4B Q4_K_M · 2.7 GB"]
        A2["gemma-4-E4B-it Q4_K_M · 5.0 GB"]
        A3["Qwen3.8-27B UD-Q3_K_XL · 13.1 GB"]
    end

    B0 -.->|"quant down"| A1
    B1 -.->|dropped| X["Q8_0: 2x the compute<br/>for a small gain"]
    B3 -.->|dropped| X
    B2 -.->|"replaced by a<br/>second family"| A2
    B4 --> A3

    style A0 fill:#efe,stroke:#6a6
    style X fill:#fee,stroke:#c66
```

## Verification

**Every added entry was actually loaded**, not just arch-checked. An architecture appearing in `formats.GGUF_TEXT_ARCHITECTURES` proves the vendored llama.cpp *knows the name*; it does not prove a June 2026 build constructs an August 2026 checkpoint of that family. That gap is exactly the trap `catalog.py` already documents for `gemma4_unified` on mlx-lm, so each new row went through `llamacpp_text/.venv`'s own `llama_cpp.Llama` (0.3.29) and was asked for a token:

```
LOAD-OK LiquidAI/LFM2.5-1.2B-Instruct-GGUF -> 'OK'
LOAD-OK unsloth/Qwen3.5-4B-GGUF            -> 'OK'   (Q4_K_M)
LOAD-OK unsloth/gemma-4-E4B-it-GGUF        -> 'OK'
```

The 27B row carries over unchanged and was **not** re-loaded — 13 GB to re-verify a file that was already shipping. The docstring says so rather than implying otherwise.

Sizes are the Hub's `?blobs=true` byte total for the one file `download_file` fetches, 2026-08-21. Every repo `gated: false`, every file a single unsharded root-level `.gguf`.

## Prose the refresh falsified

Two claims would have been left silently wrong, so both are rewritten:

- `llama_text.py` argued "no external tokenizer/config download" as a fact about **unsloth's repos** ("there is nothing at those repos' roots for it to fetch"). `unsloth/gemma-4-E4B-it-GGUF` ships a root `config.json` and an `MTP/` folder; `LiquidAI/LFM2.5-1.2B-Instruct-GGUF` a `leap/` directory. Neither is fetched and neither is missed — which is the proof the **format** was always doing the work. Stated the old way, it would have argued against curating either repo.
- `formats.GGUF_RECIPES` implied an unsloth-only namespace. Nothing reads the owner; the note now says so.

`SPEC.md` AI-11g's "the 5 curated filenames" becomes 4.

## Test changes

Two tests depended on the curation *happening* to put two quantizations in one repo, which it no longer does:

- `test_a_repo_id_with_two_recipes_and_nothing_cached_is_refused_by_name`
- `test_a_llamacpp_curated_id_with_a_sibling_quant_not_downloaded_is_told_apart`

Both now **synthesise** that pair (monkeypatching `_GGUF_RECIPES` / `GGUF_RECIPES` + `catalog.SUGGESTIONS`) instead of reading it out of the shipped list. The ambiguous-repo-id and per-file-downloaded rules must keep working for the day a repo carries two entries again — and a test that reaches into the curation for its fixture goes quietly *vacuous* rather than red when the curation stops supplying one, which is precisely what happened here.

## Test plan

- [x] `pytest tests/test_ai_formats.py tests/test_ai_llamacpp_worker.py tests/test_ai_runtime.py tests/test_ai_models_api.py tests/test_server_ai.py tests/test_ai_metrics.py tests/test_hub_models.py tests/test_ai_runner_deps.py tests/test_ai_worker_base.py tests/test_shell_prefs.py` — **917 passed**, 1 failure
- [x] `bun run test` (frontend) — **2080 passed, 0 failed**
- [x] Real loads of all three new entries (above)
- [x] Stale-id sweep: the `Q5_K_M`/`Q8_0` examples in `server/ai.py`, `SKILL.md`, `test_ai_metrics.py` and `test_server_ai.py` now name ids that are actually curated

**One pre-existing failure**, verified against `origin/main` in a clean worktree and unrelated to this PR: `tests/test_ai_metrics.py::test_a_missing_claude_binary_is_counted` counts `ai_error` where it expects `ai_unavailable`.

## Not in this PR

- ~~The `transformers-text` withdrawal (#727).~~ **Merged while this PR was open, and rebased onto.** That makes this list the default text shortlist on Windows and Linux rather than an opt-in a user had to go find — which is what makes the 0.7 GB position-0 entry matter, and is now argued in the catalog docstring rather than left implicit. The rebase also picked up main's `test_llamacpp_and_whisper_suggestions_show_snapshot_size_estimates` (which pins every `size_gb` by value) and its `default_for` assertion; both now read the new four.
- MoE offload (`--n-cpu-moe` / `tensor_buft_overrides`) is unreachable through llama-cpp-python 0.3.29's `Llama.__init__`, so no MoE entry is curated here yet.

---

## Second commit: the MLX list gets the same first model

**MLX supported quantized models all along** — every row in `mlx-text` is already a 4-bit, 2-bit, or OptiQ mixed-precision conversion, so there was nothing to add on that axis. What was wrong was which model *led* the list.

Position 0 moves from `mlx-community/Qwen3.5-2B-MLX-4bit` (1.7 GB) to `mlx-community/LFM2.5-1.2B-Instruct-4bit` (**0.7 GB**). It is a straight win, not a trade:

- **2.6× less to fetch** for a model of comparable class.
- **Text-only.** The list's own opening paragraph complains that every checkpoint it carries is `…ForConditionalGeneration` with a `vision_config` that mlx-lm downloads and drops — part of that old 1.7 GB was exactly that dead weight. This is `Lfm2ForCausalLM` with no vision config: the first row in the list that pays none of it. (The `-OptiQ-4bit` 2B is worse here, not better — 2.26 GB, of which `optiq/optiq_vision.safetensors` is 0.66 GB of pure vision.)
- **The same model `llamacpp-text` now leads with**, so a bare `fused.ai()` starts on one model across platforms instead of two different compromises.

### Verified by mechanism, not by a load

MLX does not install off Apple Silicon and this refresh was done on Linux, so unlike the three llama.cpp entries this one could **not** be loaded. The comment in the catalog says so plainly rather than implying parity. What *was* checked is the exact resolution step the list's own `gemma4_unified` paragraph turns on:

- `model_type` is `lfm2`; mlx-lm resolves a checkpoint by importing `mlx_lm.models.<model_type>`, and **0.31.3's published wheel ships `lfm2.py`** — read out of the wheel, not assumed. (The pin is `mlx-lm>=0.31,<0.32`.)
- `quantization` is a plain uniform `{group_size: 64, bits: 4, mode: affine}` with no `quant_method`, so `formats.unloadable_quant` passes it exactly as it passes every other row.

Someone on a Mac should still load it once before this ships.

`test_the_default_is_the_smallest_model_the_active_runner_offers` now asserts the new id on the Darwin/arm64 branch as well as the Windows one — both platforms' no-model default is pinned by test.

---

## Third commit: a mixture-of-experts row on both lists

`LFM2.5-8B-A1B` joins both shortlists — **5.2 GB** as `LFM2.5-8B-A1B-Q4_K_M.gguf`, **4.9 GB** as `LiquidAI/LFM2.5-8B-A1B-MLX-4bit`. 8B of weights, ~1B of them multiplied per token, so it answers at roughly the speed of the 1.2B leading each list while knowing what an 8B knows. That is a different axis from every other row, which is why it earns a line rather than duplicating the Gemma sitting 0.2 GB away.

### Neither runner needed a change, and the comments say why

"MoE support" sounds like it should need something, so both rows state that it doesn't: **experts are ordinary tensors in the checkpoint; what is conditional is the compute**, and llama.cpp and mlx-lm both do that inside the graph. There is no "load only the active experts" mode being missed — the whole file is fetched and resident, and the win is arithmetic per token, not bytes.

### What we *cannot* do is placement — written down, not discovered later

llama.cpp's `--n-cpu-moe` (expert tensors on the CPU, attention on the GPU) is backed by `llama_model_params.tensor_buft_overrides`, which llama-cpp-python 0.3.29 exposes **in the ctypes struct but not as a `Llama.__init__` keyword** — checked against the installed signature, which offers only `n_gpu_layers`, `split_mode`, `main_gpu`, `tensor_split`. So on the Vulkan build this row is offloaded by whole layers like a dense model, leaving the trick unused. On the **CPU build — what most machines resolve to — nothing is left on the table**, which is why the row is worth having now rather than after that work. Reaching the override needs ctypes and interacts with `_offload_schedule`'s try-and-back-off probe; that belongs in its own change with its own decision record.

Verification asymmetry, again stated in the code: the **GGUF was loaded** (0.3.29, answered a prompt — it is a reasoning model, so it opened with `<think>`). The MLX twin was mechanism-checked only: `model_type` is `lfm2_moe`, and 0.31.3's wheel ships `lfm2_moe.py`.

One test moved: `test_the_catalog_follows_the_runner_that_would_actually_load` asserted every MLX id starts with `mlx-community/` or `prism-ml/`. `LiquidAI/` joins them, with a comment that the namespace set is a **proxy** for "these are MLX conversions" and grows whenever a model has no mlx-community conversion (`prism-ml/` was added for the same reason) — the Windows half of that test is the invariant actually being pinned.

### Final shape

| | llama.cpp | MLX |
|---|---|---|
| 0 | LFM2.5 1.2B · 0.7 GB | LFM2.5 1.2B · 0.7 GB |
| 1 | Qwen3.5 4B · 2.7 GB | Qwen3.5 4B OptiQ · 4.0 GB |
| 2 | Gemma 4 E4B · 5.0 GB | **LFM2.5 8B-A1B · 4.9 GB** |
| 3 | **LFM2.5 8B-A1B · 5.2 GB** | Gemma 4 E4B · 5.2 GB |
| 4 | Qwen3.8 27B · 13.1 GB | Bonsai 27B · 6.1 GB, then Qwen 9B / 27B / 27B |

## CI

`test-python (3.10)` went red once on `tests/test_ai_worker_base.py::test_a_bars_own_n_is_updated_under_the_same_lock_as_the_ticker` — a threading race (`499 == 500`, "a concurrent update to .n was lost outside the lock"). It did **not** reproduce: the re-run of the identical commit is green on 3.10 along with 3.11/3.12/3.13, and this branch touches neither `worker_base.py` nor that test file. So it is flakiness in that test, not a 3.10-only locking bug and not this PR — but a test that loses a lock race once in a while is still worth its own issue, since the next person to hit it will also stop and investigate. See also #704, which proposes dropping 3.10 from the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
