### PR TITLE
Sidebar: move the version out of the brand row onto Settings

### DIFF
--- a/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
+++ b/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
@@ -1,5 +1,5 @@
-// Shared sidebar chassis: brand row (logo + owner-supplied title + version),
-// draggable width, collapse strip, and the resize handle. Owns NO body — each
+// Shared sidebar chassis: brand row (logo + owner-supplied title), draggable
+// width, collapse strip, and the resize handle. Owns NO body — each
 // sub-app (and the shell itself) renders its own sidebar by composing this
 // frame with its own sections, so the platform stays ignorant of bookmarks,
 // recents, and app lists. Width/collapsed state is shared across all owners
@@ -59,8 +59,6 @@ export interface SidebarRailItem {
 export interface SidebarFrameProps {
   /** Brand text next to the cube mark — names the owning context. */
   title: string;
-  /** Version chip after the title — shown only by the shell ("Render"). */
-  version?: string;
   /** Where the brand click lands; the front door of the owning app. */
   homeHref?: string;
   /** Section icons for the collapsed rail. Optional — a sidebar without them
@@ -116,7 +114,7 @@ export function NavItem({
   );
 }
 
-export function SidebarFrame({ title, version, homeHref = "/apps", rail, children }: SidebarFrameProps) {
+export function SidebarFrame({ title, homeHref = "/apps", rail, children }: SidebarFrameProps) {
   // Sidebar chrome: draggable width + collapsed flag, persisted once per
   // gesture (drag end / toggle), not per mousemove. The state lives in the
   // shared store (platform/lib/sidebarstate) rather than here so that a
@@ -354,7 +352,6 @@ export function SidebarFrame({ title, version, homeHref = "/apps", rail, childre
           </span>{" "}
           <span className="brand-title">{title}</span>
         </a>
-        {version && <span className="brand-version">v{version}</span>}
         <button
           type="button"
           className="icon-btn sidebar-collapse-btn"

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -124,6 +124,7 @@ function PreferencesTrigger({
   open,
   dot,
   active,
+  trailing,
   onToggle,
 }: {
   open: boolean;
@@ -131,6 +132,9 @@ function PreferencesTrigger({
   /** The current route is one of the menu's destinations — the trigger is
       the only sidebar chrome that can show it. */
   active: boolean;
+  /** Trailing-edge content, same slot NavItem gives Tasks its count — this
+      row's is the version chip. */
+  trailing?: React.ReactNode;
   onToggle: (el: HTMLElement) => void;
 }) {
   return (
@@ -146,6 +150,7 @@ function PreferencesTrigger({
         {dot}
       </span>{" "}
       Settings
+      {trailing && <span className="sidebar-item-trail">{trailing}</span>}
     </button>
   );
 }
@@ -441,7 +446,7 @@ export default function GlobalSidebar({ config }: { config: Config }) {
 
   return (
     <>
-      <SidebarFrame title="Render" version={config.version} homeHref="/home" rail={rail}>
+      <SidebarFrame title="Render" homeHref="/home" rail={rail}>
         <div className="sidebar-section sidebar-group">
           <NavItem
             href="/home"
@@ -475,10 +480,24 @@ export default function GlobalSidebar({ config }: { config: Config }) {
         <BookmarksSection />
         <div className="sidebar-section sidebar-settings">
           <UpdateBadge />
+          {/* The version rides the Settings row's trailing edge rather than the
+              brand row it used to sit in. Two reasons it moved: the brand row is
+              one click target for Home, so a version glued to the title read as
+              part of the app's NAME; and it competed for the line the title
+              ellipsises on when the sidebar is dragged narrow. Down here it is
+              what it is — a footnote about this install, in the same trailing
+              slot the Tasks row states its count in. */}
           <PreferencesTrigger
             open={prefsPos !== null}
             dot={triggerDot}
             active={prefsActive}
+            trailing={
+              config.version ? (
+                <span className="version-chip" title={`Fused Render v${config.version}`}>
+                  v{config.version}
+                </span>
+              ) : undefined
+            }
             onToggle={togglePrefsMenu}
           />
         </div>

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -220,8 +220,7 @@ a.sidebar-rail-btn {
 }
 
 /* Title truncates when the sidebar is dragged narrow (min 180px) so the
-   brand row never overflows; logo, version and collapse button keep their
-   size and the version stays visible beside the ellipsis. */
+   brand row never overflows; logo and collapse button keep their size. */
 .sidebar-brand .brand-title {
   min-width: 0;
   overflow: hidden;
@@ -229,12 +228,27 @@ a.sidebar-rail-btn {
   white-space: nowrap;
 }
 
-/* Package version after the name — smaller and muted grey. */
-.sidebar-brand .brand-version {
-  font-size: 10.5px;
-  font-weight: 500;
+/* The version chip, on the Settings row's trailing edge (shell/GlobalSidebar):
+   a small outlined pill, quiet on purpose — it is a fact about the install, not
+   a control, so it must not out-shout the row it rides on. Background is a tint
+   wash rather than --bg-alt (the recipe .fh-index-chip uses), because the
+   sidebar IS --bg-alt and the chip would be an invisible ring on its own color.
+   Monospace + tabular figures so the pill doesn't change width when a digit
+   does. */
+.version-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(var(--tint), 0.05);
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 9.5px;
+  line-height: 14px;
+  letter-spacing: 0.01em;
+  font-variant-numeric: tabular-nums;
   color: var(--fg-muted);
-  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .sidebar-section {


### PR DESCRIPTION
The version string sat next to the brand title, inside the link that goes Home. Two problems with that spot: glued to the name it read as part of the name (`Render v0.4.43` as one label), and it shared the one line the title ellipsises on when the sidebar is dragged down to its 180px floor.

It now rides the **Settings** row's trailing edge, in the same slot the Tasks row states its count in (`.sidebar-item-trail`), drawn as a small outlined pill.

Details worth knowing:

- The chip's fill is `rgba(var(--tint), 0.05)` rather than `--bg-alt` — the recipe `.fh-index-chip` uses — because the sidebar itself is `--bg-alt` and the chip would have been an invisible ring on its own color. Monospace + tabular figures so the pill doesn't change width when a digit does.
- The `version` prop leaves `SidebarFrame` with it. The frame knows nothing about a Settings row, so the shell that owns that row now owns the chip; `.sidebar-brand .brand-version` is deleted rather than orphaned.
- The collapsed rail is unchanged — the brand row never rendered there, so there was no version to move.

No DECISIONS row: this is a placement change that the diff already states.

## Test plan

- `npm run build` in `frontend/` (boundaries + `tsc --noEmit` + vite) passes.
- Visually confirmed in the running shell: the chip renders right-aligned on the Settings row, reading `v0.4.43`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)