### PR TITLE
Playground review fixes: a watch that can tell a dropped poll from a finished job

### DIFF
--- a/frontend/src/apps/ai_models/discover/DiscoverTab.tsx
+++ b/frontend/src/apps/ai_models/discover/DiscoverTab.tsx
@@ -53,6 +53,7 @@ import {
   type HubTask,
 } from "@platform/lib/api";
 import { refreshAiRuntime } from "@apps/ai_models/lib/aiRuntime";
+import { tabHref } from "@apps/ai_models/routes";
 import { ModelProgress } from "@apps/ai_models/shared/ModelProgress";
 import type { Job } from "@platform/lib/jobs";
 import { formatParams, timeAgo } from "@platform/lib/format";
@@ -83,6 +84,15 @@ const SORTS: { value: HubSort; label: string; title: string }[] = [
   { value: "updated", label: "Updated", title: "Changed most recently" },
   { value: "created", label: "New", title: "Published most recently" },
 ];
+
+
+/** Where a Try button goes: the playground, this model selected, and none of
+ *  Discover's own query string carried across. The Local tab's RepoCard has
+ *  the same one-liner — both exist so the bare `/ai-models` prefix is never
+ *  hand-spelled here. */
+function tryHref(id: string): string {
+  return tabHref("playground", "?model=" + encodeURIComponent(id));
+}
 
 function count(n: number | null): string | null {
   if (n === null || n === undefined) return null;
@@ -317,13 +327,13 @@ function HubCard({
           {have && model.capability && (
             <a
               className="am-card-explore-link"
-              href={`/ai-models?model=${encodeURIComponent(model.id)}`}
+              href={tryHref(model.id)}
               title={`Try ${model.id} in the Playground`}
               onClick={(e) => {
                 if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)
                   return;
                 e.preventDefault();
-                navigateUrl(`/ai-models?model=${encodeURIComponent(model.id)}`);
+                navigateUrl(tryHref(model.id));
               }}
             >
               Try
@@ -495,13 +505,13 @@ function Suggested({
                     {group.available && (
                       <a
                         className="am-card-explore-link"
-                        href={`/ai-models?model=${encodeURIComponent(m.id)}`}
+                        href={tryHref(m.id)}
                         title={`Try ${m.label} in the Playground`}
                         onClick={(e) => {
                           if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)
                             return;
                           e.preventDefault();
-                          navigateUrl(`/ai-models?model=${encodeURIComponent(m.id)}`);
+                          navigateUrl(tryHref(m.id));
                         }}
                       >
                         Try

--- a/frontend/src/apps/ai_models/lib/params.test.ts
+++ b/frontend/src/apps/ai_models/lib/params.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+
+// params.ts imports router.ts for `replaceSearch`, and router.ts reads
+// `location` at module scope; bun has no DOM. Same shim as router.test.ts.
+// Nothing below touches it — every case hands the codec its own search string.
+(globalThis as { location?: unknown }).location ??= {
+  pathname: "/ai-models/playground",
+  search: "",
+  href: "http://localhost/ai-models/playground",
+};
+(globalThis as { history?: unknown }).history ??= {
+  state: null,
+  pushState() {},
+  replaceState() {},
+};
+(globalThis as { window?: unknown }).window ??= {
+  dispatchEvent() {},
+  addEventListener() {},
+  removeEventListener() {},
+};
+
+// A dynamic import, not a static one: static imports hoist ABOVE the shim
+// above and router.ts would read `location` before it exists (chat-params.test
+// takes the same route for the same reason).
+const { numParam, readParam } = await import("./params");
+
+// Every case drives the `search` argument rather than a real `location` — the
+// same reason `tabHref` takes one (routes.ts): these are codecs, and a codec
+// that can only be tested inside a browser is not being tested.
+
+test("a missing or empty param keeps the fallback", () => {
+  expect(numParam("temp", 0.7, 0, 2, "")).toBe(0.7);
+  expect(numParam("temp", 0.7, 0, 2, "?temp=")).toBe(0.7);
+  // `Number("")` is 0 — a temperature nobody chose, and the reason the
+  // emptiness check exists at all.
+  expect(numParam("temp", 0.7, 0, 2, "?temp=%20%20")).toBe(0.7);
+});
+
+test("a non-numeric param keeps the fallback", () => {
+  expect(numParam("temp", 0.7, 0, 2, "?temp=hot")).toBe(0.7);
+  expect(numParam("maxtok", 1024, 1, 32768, "?maxtok=NaN")).toBe(1024);
+  expect(numParam("maxtok", 1024, 1, 32768, "?maxtok=Infinity")).toBe(1024);
+});
+
+test("an in-range param is taken as written", () => {
+  expect(numParam("temp", 0.7, 0, 2, "?temp=1.4")).toBe(1.4);
+  expect(numParam("maxtok", 1024, 1, 32768, "?maxtok=1")).toBe(1);
+  expect(numParam("maxtok", 1024, 1, 32768, "?maxtok=32768")).toBe(32768);
+});
+
+test("an out-of-range param CLAMPS, because the server would refuse it", () => {
+  // The load-bearing case. `_sampling_problem` (server/ai.py) REJECTS rather
+  // than clamps, so a hand-edited or stale link used to seed the rail with a
+  // value that made every single message 400 — a link that opens a chat which
+  // can never send. Clamping on the way in is what keeps that link usable.
+  expect(numParam("temp", 0.7, 0, 2, "?temp=5")).toBe(2);
+  expect(numParam("temp", 0.7, 0, 2, "?temp=-1")).toBe(0);
+  expect(numParam("topp", 0.95, 0, 1, "?topp=9")).toBe(1);
+  expect(numParam("maxtok", 1024, 1, 32768, "?maxtok=0")).toBe(1);
+  expect(numParam("maxtok", 1024, 1, 32768, "?maxtok=999999")).toBe(32768);
+});
+
+test("bounds are optional and absent ones do not clamp", () => {
+  expect(numParam("seed", 0, undefined, undefined, "?seed=99999999")).toBe(99999999);
+  expect(numParam("guidance", 1, 0, undefined, "?guidance=100")).toBe(100);
+  expect(numParam("guidance", 1, 0, undefined, "?guidance=-3")).toBe(0);
+});
+
+test("readParam takes the search it is handed", () => {
+  expect(readParam("model", "?model=a%2Fb")).toBe("a/b");
+  expect(readParam("cap", "?model=x")).toBe(null);
+});

--- a/frontend/src/apps/ai_models/lib/params.ts
+++ b/frontend/src/apps/ai_models/lib/params.ts
@@ -12,18 +12,37 @@
 // — the page shell reads `?cap=` through the same door (see routes.ts).
 import { replaceSearch } from "@platform/lib/router";
 
-/** Read one query param off the CURRENT url. */
-export function readParam(key: string): string | null {
-  return new URLSearchParams(location.search).get(key);
+/** Read one query param off the CURRENT url. The second argument exists so
+ *  tests can drive this without a `location`, the same three-argument trick
+ *  `tabHref` takes in routes.ts and for the same reason. */
+export function readParam(key: string, search: string = location.search): string | null {
+  return new URLSearchParams(search).get(key);
 }
 
 /** A numeric param, defensively: a shared link is exactly where a malformed or
- *  empty value arrives, and `Number("")` is 0 — a temperature nobody chose. */
-export function numParam(key: string, fallback: number): number {
-  const raw = readParam(key);
+ *  empty value arrives, and `Number("")` is 0 — a temperature nobody chose.
+ *
+ *  `min`/`max` CLAMP rather than reject, and passing them is not optional
+ *  politeness wherever the server validates the same number. The sampling
+ *  route REFUSES an out-of-range value (`_sampling_problem`, server/ai.py)
+ *  instead of clamping it, so `?temp=5` used to seed the rail with 5 and then
+ *  400 on every single message — a link that opens a permanently broken chat.
+ *  The rail's own number input already clamps to the same bounds; this closes
+ *  the door the URL left open. */
+export function numParam(
+  key: string,
+  fallback: number,
+  min?: number,
+  max?: number,
+  search?: string,
+): number {
+  const raw = readParam(key, search ?? location.search);
   if (raw === null || raw.trim() === "") return fallback;
   const value = Number(raw);
-  return Number.isFinite(value) ? value : fallback;
+  if (!Number.isFinite(value)) return fallback;
+  if (min !== undefined && value < min) return min;
+  if (max !== undefined && value > max) return max;
+  return value;
 }
 
 /** Rewrite query params in place — null deletes. `replaceSearch`, not

--- a/frontend/src/apps/ai_models/playground/ChatStage.tsx
+++ b/frontend/src/apps/ai_models/playground/ChatStage.tsx
@@ -30,6 +30,15 @@ import { numParam, readParam, writeParams } from "@apps/ai_models/lib/params";
 // a slider cannot ask for a value the request would 400 on. 1024 max tokens is
 // also the WORKER's own default — the slider states the truth of a bare call.
 const DEFAULTS = { temperature: 0.7, top_p: 0.95, max_tokens: 1024 };
+// The server's `_SAMPLING` bounds, restated because it REJECTS an out-of-range
+// value rather than clamping it — so a hand-edited or stale link has to be
+// clamped on the way IN, or every message on that link 400s. Keep in step with
+// server/ai.py; the rail's sliders already carry the same numbers.
+const LIMITS = {
+  temperature: [0, 2],
+  top_p: [0, 1],
+  max_tokens: [1, 32768],
+} as const;
 
 // A standing system prompt by default, not a blank: small local models drift
 // into rambling or page-long <think> blocks without one, and the person this
@@ -95,9 +104,13 @@ export function ChatStage({
   const [streaming, setStreaming] = useState(false);
   const [railOpen, setRailOpen] = useState(false);
 
-  const [temperature, setTemperature] = useState(() => numParam("temp", DEFAULTS.temperature));
-  const [topP, setTopP] = useState(() => numParam("topp", DEFAULTS.top_p));
-  const [maxTokens, setMaxTokens] = useState(() => numParam("maxtok", DEFAULTS.max_tokens));
+  const [temperature, setTemperature] = useState(() =>
+    numParam("temp", DEFAULTS.temperature, ...LIMITS.temperature),
+  );
+  const [topP, setTopP] = useState(() => numParam("topp", DEFAULTS.top_p, ...LIMITS.top_p));
+  const [maxTokens, setMaxTokens] = useState(() =>
+    numParam("maxtok", DEFAULTS.max_tokens, ...LIMITS.max_tokens),
+  );
   // `??`, not `||`: an EMPTY `system=` param is the user having cleared the
   // default on purpose, and must stay cleared on reload.
   const [system, setSystem] = useState(() => readParam("system") ?? DEFAULT_SYSTEM);
@@ -195,9 +208,13 @@ export function ChatStage({
             : "Downloading the model — the first message pays for this once…",
         );
         if (e.jobId) {
-          await watchJob(e.jobId, controller.signal, (job) =>
+          const outcome = await watchJob(e.jobId, controller.signal, (job) =>
             setStatus(job.detail || "Loading the model…"),
           );
+          // Someone stopped the load from the Activity panel. Retrying would
+          // just earn a second 409 and surface it as a stream error, so say
+          // what actually happened.
+          if (outcome.state === "cancelled") throw new Error("the model load was cancelled");
         }
         setStatus(null);
         result = await run();
@@ -374,8 +391,8 @@ export function ChatStage({
           <RailSlider
             label="Temperature"
             hint="Lower is focused and repeatable; higher is varied and creative."
-            min={0}
-            max={2}
+            min={LIMITS.temperature[0]}
+            max={LIMITS.temperature[1]}
             step={0.05}
             value={temperature}
             fallback={DEFAULTS.temperature}
@@ -384,8 +401,8 @@ export function ChatStage({
           <RailSlider
             label="Top-p"
             hint="How much of the probability mass the model may sample from."
-            min={0}
-            max={1}
+            min={LIMITS.top_p[0]}
+            max={LIMITS.top_p[1]}
             step={0.01}
             value={topP}
             fallback={DEFAULTS.top_p}
@@ -394,8 +411,8 @@ export function ChatStage({
           <RailSlider
             label="Max tokens"
             hint="The longest reply allowed. One token is roughly ¾ of a word."
-            min={1}
-            max={32768}
+            min={LIMITS.max_tokens[0]}
+            max={LIMITS.max_tokens[1]}
             step={1}
             value={maxTokens}
             fallback={DEFAULTS.max_tokens}

--- a/frontend/src/apps/ai_models/playground/EmbedStage.tsx
+++ b/frontend/src/apps/ai_models/playground/EmbedStage.tsx
@@ -84,9 +84,12 @@ export function EmbedStage({ model, downloaded }: { model: string; downloaded: b
             : "Downloading the model — the first run pays for this once…",
         );
         if (e.jobId) {
-          await watchJob(e.jobId, controller.signal, (job) =>
+          const outcome = await watchJob(e.jobId, controller.signal, (job) =>
             setStatus(job.detail || "Loading the model…"),
           );
+          // Stopped from the Activity panel — asking again only earns a second
+          // 409 (the same reasoning as the chat stage's dance).
+          if (outcome.state === "cancelled") throw new Error("the model load was cancelled");
         }
         setStatus(null);
         result = await ask();

--- a/frontend/src/apps/ai_models/playground/ImageStage.tsx
+++ b/frontend/src/apps/ai_models/playground/ImageStage.tsx
@@ -32,6 +32,11 @@ const SERVER_STEPS = 28;
 // guidance-distilled (FLUX.2 klein bakes the prompt-following in — CFG on top
 // only slows it down and overcooks the colours).
 const DEFAULTS = { width: 512, height: 512, guidance: 1.0 };
+// The rail's slider bounds, in one place so a URL value and a dragged value
+// cannot disagree about what the control's scale is.
+const SIZE_RANGE = [256, 2048] as const;
+const STEPS_RANGE = [1, 100] as const;
+const GUIDANCE_RANGE = [0, 20] as const;
 
 // Multiple-of-16 pairs on the same small-by-default footing as DEFAULTS.
 // The chip writes this pair into the same `w`/`h` params the custom sliders
@@ -69,10 +74,16 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
       : null;
 
   const [prompt, setPrompt] = useState(() => readParam("prompt") ?? "");
-  const [width, setWidth] = useState(() => numParam("w", DEFAULTS.width));
-  const [height, setHeight] = useState(() => numParam("h", DEFAULTS.height));
-  const [steps, setSteps] = useState(() => numParam("steps", modelSteps));
-  const [guidance, setGuidance] = useState(() => numParam("guidance", DEFAULTS.guidance));
+  // Clamped to the rail's own ranges. The image route SETTLES what it is sent
+  // rather than refusing it, so a wild number here is not the 400 the chat
+  // stage risks — but a slider pinned off its own scale by a URL is still a
+  // control that lies about what will run.
+  const [width, setWidth] = useState(() => numParam("w", DEFAULTS.width, ...SIZE_RANGE));
+  const [height, setHeight] = useState(() => numParam("h", DEFAULTS.height, ...SIZE_RANGE));
+  const [steps, setSteps] = useState(() => numParam("steps", modelSteps, ...STEPS_RANGE));
+  const [guidance, setGuidance] = useState(() =>
+    numParam("guidance", DEFAULTS.guidance, ...GUIDANCE_RANGE),
+  );
   const [seed, setSeed] = useState<string>(() => readParam("seed") ?? "");
   const [railOpen, setRailOpen] = useState(false);
   const [run, setRun] = useState<Run | null>(null);
@@ -98,11 +109,17 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
   const abortRef = useRef<AbortController | null>(null);
   useEffect(() => () => abortRef.current?.abort(), []);
 
+  // Keyed on the STARTED reply, not on `run`: the watch's onTick rewrites
+  // `run` every poll (a fresh `{...r, job}`), so an effect keyed on the whole
+  // object was torn down and rebuilt each second and the 1500ms timer never
+  // lived long enough to fire once — the live preview never advanced. Same
+  // shape TranscribeStage uses for its partial-transcript tail.
+  const rendering = run && !run.done ? run.started : null;
   useEffect(() => {
-    if (!run || run.done) return;
+    if (!rendering) return;
     const timer = window.setInterval(() => setPreviewTick((n) => n + 1), 1500);
     return () => window.clearInterval(timer);
-  }, [run]);
+  }, [rendering]);
 
   const aspect = ASPECTS.find((a) => a.width === width && a.height === height)?.value ?? null;
   const speed = speedChips?.find((c) => c.steps === steps)?.value ?? null;
@@ -114,6 +131,13 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
     setError(null);
     setPreviewLive(false);
     try {
+      // Published BEFORE the first await: unmounting while this POST is in
+      // flight used to leave the ref null, so the cleanup aborted nothing and
+      // the watch below polled /api/jobs once a second from a dead component
+      // for the whole render. watchJob checks the signal on entry, so an abort
+      // that lands during the POST throws AbortError straight out.
+      const controller = new AbortController();
+      abortRef.current = controller;
       const started = await startImage({
         prompt: wanted,
         model,
@@ -127,12 +151,17 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
         ...(seed.trim() !== "" ? { seed: Number(seed) } : {}),
       });
       setRun({ started, job: null, done: false });
-      const controller = new AbortController();
-      abortRef.current = controller;
       try {
-        await watchJob(started.jobId, controller.signal, (job) =>
+        const outcome = await watchJob(started.jobId, controller.signal, (job) =>
           setRun((r) => (r && r.started.jobId === started.jobId ? { ...r, job } : r)),
         );
+        // Stop was pressed. The worker died before writing the output, so
+        // marking this done would render an <img> at a path that holds
+        // nothing and file the dead render in the gallery strip.
+        if (outcome.state === "cancelled") {
+          setRun(null);
+          return;
+        }
         setRun((r) => (r && r.started.jobId === started.jobId ? { ...r, done: true } : r));
         setGallery((g) => [started, ...g.filter((i) => i.jobId !== started.jobId)].slice(0, 12));
       } catch (e) {
@@ -299,8 +328,8 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
             <RailSlider
               label="Width"
               hint="Snapped to a multiple of 16 by the server."
-              min={256}
-              max={2048}
+              min={SIZE_RANGE[0]}
+              max={SIZE_RANGE[1]}
               step={16}
               value={width}
               fallback={DEFAULTS.width}
@@ -309,8 +338,8 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
             <RailSlider
               label="Height"
               hint="Bigger is slower and needs more memory."
-              min={256}
-              max={2048}
+              min={SIZE_RANGE[0]}
+              max={SIZE_RANGE[1]}
               step={16}
               value={height}
               fallback={DEFAULTS.height}
@@ -336,8 +365,8 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
                 ? "This model is distilled for few steps — more is slower, rarely better."
                 : "Denoising passes — more is slower and usually cleaner."
             }
-            min={1}
-            max={100}
+            min={STEPS_RANGE[0]}
+            max={STEPS_RANGE[1]}
             step={1}
             value={steps}
             fallback={modelSteps}
@@ -346,8 +375,8 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
           <RailSlider
             label="Guidance"
             hint="How literally the prompt is followed. Distilled models want 1; raise it only for classic models. Very high looks overcooked."
-            min={0}
-            max={20}
+            min={GUIDANCE_RANGE[0]}
+            max={GUIDANCE_RANGE[1]}
             step={0.5}
             value={guidance}
             fallback={DEFAULTS.guidance}

--- a/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
+++ b/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
@@ -169,7 +169,9 @@ export default function PlaygroundTab() {
     if (!row || row.available) return null;
     // The reason comes off the catalog and is a server sentence that may or
     // may not be punctuated; this line puts another one after it.
-    const reason = row.reason?.trim() || "it is not available on this machine";
+    // The fallback must not restate the lead-in — "X is not available here —
+    // it is not available on this machine" says nothing twice.
+    const reason = row.reason?.trim() || "no engine for it is installed.";
     return { row, reason: /[.!?]$/.test(reason) ? reason : reason + "." };
   }, [capabilities, asked, askedCap]);
 

--- a/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
+++ b/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
@@ -137,20 +137,40 @@ export default function PlaygroundTab() {
   // `model` always wins, and an unknown cap value falls through silently.
   const askedCap = useMemo(() => readParam("cap"), [urlVersion]);
   const selected = useMemo(() => {
-    for (const row of capabilities) {
+    // Only a row the SIDEBAR ACTUALLY DRAWS is selectable. An unavailable
+    // capability renders its reason in place of its model buttons (HF-8), so
+    // selecting into one lit up nothing, and the first Send died on a raw
+    // engine error while the real explanation sat one group away, unread.
+    const usable = capabilities.filter((r) => r.available && r.models.length);
+    for (const row of usable) {
       const hit = row.models.find((m) => m.id === asked);
       if (hit) return { row, model: hit };
     }
-    const rows = [
-      ...capabilities.filter((r) => r.capability === askedCap),
-      ...capabilities,
-    ];
+    const rows = [...usable.filter((r) => r.capability === askedCap), ...usable];
     for (const row of rows) {
       const fallback =
         row.models.find((m) => m.id === row.default) ?? row.models[0];
       if (fallback) return { row, model: fallback };
     }
     return null;
+  }, [capabilities, asked, askedCap]);
+
+  // What the URL asked for, when this machine cannot give it. Home's strip is
+  // the STATIC `PLAYGROUND_GROUPS` list, not the catalog, so every machine
+  // shows a "Search by meaning" card whether or not it has an embeddings
+  // engine — and answering that click by silently opening a chat box is a
+  // worse answer than naming the reason. Same for a `?model=` link to a model
+  // whose capability is ruled out here.
+  const blockedAsk = useMemo(() => {
+    if (!asked && !askedCap) return null;
+    const row =
+      capabilities.find((r) => r.models.some((m) => m.id === asked)) ??
+      capabilities.find((r) => r.capability === askedCap);
+    if (!row || row.available) return null;
+    // The reason comes off the catalog and is a server sentence that may or
+    // may not be punctuated; this line puts another one after it.
+    const reason = row.reason?.trim() || "it is not available on this machine";
+    return { row, reason: /[.!?]$/.test(reason) ? reason : reason + "." };
   }, [capabilities, asked, askedCap]);
 
   const select = (id: string) => {
@@ -333,9 +353,20 @@ export default function PlaygroundTab() {
 
       <div className="pg-stage">
         {actionError && <ErrorBanner>{actionError}</ErrorBanner>}
+        {blockedAsk && selected && (
+          // Not an ErrorBanner: nothing failed and nothing the user did is
+          // wrong — the link simply named a task this machine cannot run, and
+          // the stage below is the substitute, said out loud.
+          <p className="pg-blocked-ask">
+            {groupLabel(blockedAsk.row.capability)} is not available here — {blockedAsk.reason}{" "}
+            Showing {groupLabel(selected.row.capability)} instead.
+          </p>
+        )}
         {!selected ? (
           <p className="cc-empty">
-            No models to try yet — the Discover tab is where a first one comes from.
+            {blockedAsk
+              ? `${groupLabel(blockedAsk.row.capability)} is not available here — ${blockedAsk.reason}`
+              : "No models to try yet — the Discover tab is where a first one comes from."}
           </p>
         ) : (
           <>

--- a/frontend/src/apps/ai_models/playground/TranscribeStage.tsx
+++ b/frontend/src/apps/ai_models/playground/TranscribeStage.tsx
@@ -78,6 +78,12 @@ export function TranscribeStage({ model }: { model: string }) {
   }, [task, language, vad, words, source]);
 
   const abortRef = useRef<AbortController | null>(null);
+  // `land()` awaits the config, the mkdir and the upload before it starts a
+  // job at all, so an unmount inside that window runs the cleanup below while
+  // the continuation is still queued — it would then start a watch against a
+  // controller the cleanup has already come and gone for, leaking a 1/s poll
+  // from a dead component. The flag is what the continuation checks.
+  const aliveRef = useRef(true);
   const recorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const meterRef = useRef<{ ctx: AudioContext; raf: number } | null>(null);
@@ -93,6 +99,7 @@ export function TranscribeStage({ model }: { model: string }) {
 
   useEffect(
     () => () => {
+      aliveRef.current = false;
       abortRef.current?.abort();
       recorderRef.current?.stream.getTracks().forEach((t) => t.stop());
       stopMeter();
@@ -128,6 +135,12 @@ export function TranscribeStage({ model }: { model: string }) {
   }, [running]);
 
   const transcribePath = async (path: string) => {
+    if (!aliveRef.current) return;
+    // Published BEFORE the first await, for the same reason ImageStage does
+    // it: an unmount during this POST used to leave the ref null, so nothing
+    // aborted the watch that the continuation went on to start.
+    const controller = new AbortController();
+    abortRef.current = controller;
     const started = await startTranscribe({
       path,
       model,
@@ -138,14 +151,20 @@ export function TranscribeStage({ model }: { model: string }) {
     });
     setSegments([]);
     setPhase({ step: "running", started, job: null });
-    const controller = new AbortController();
-    abortRef.current = controller;
     try {
-      await watchJob(started.jobId, controller.signal, (job) =>
+      const outcome = await watchJob(started.jobId, controller.signal, (job) =>
         setPhase((p) =>
           p.step === "running" && p.started.jobId === started.jobId ? { ...p, job } : p,
         ),
       );
+      // Stop was pressed. Falling through would read back two artefacts that
+      // were never written and then report "the transcript could not be read
+      // back — it is saved in the transcripts folder", which is a lie about a
+      // run the user themselves killed.
+      if (outcome.state === "cancelled") {
+        setPhase({ step: "idle" });
+        return;
+      }
     } catch (e) {
       if ((e as Error).name === "AbortError") return;
       setError((e as Error).message);

--- a/frontend/src/apps/ai_models/playground/TranscribeStage.tsx
+++ b/frontend/src/apps/ai_models/playground/TranscribeStage.tsx
@@ -97,15 +97,20 @@ export function TranscribeStage({ model }: { model: string }) {
     setLevel(0);
   };
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // Set on the way IN as well as cleared on the way out. The app does not
+    // mount under StrictMode today, but its dev double-mount reuses the same
+    // instance and its refs — a flag only ever cleared would latch false on
+    // the simulated unmount and kill transcription for the rest of the
+    // session. Two other modules here already guard that double invocation.
+    aliveRef.current = true;
+    return () => {
       aliveRef.current = false;
       abortRef.current?.abort();
       recorderRef.current?.stream.getTracks().forEach((t) => t.stop());
       stopMeter();
-    },
-    [],
-  );
+    };
+  }, []);
 
   // The elapsed counter while recording — the second half of "it hears me".
   useEffect(() => {

--- a/frontend/src/apps/ai_models/playground/client.test.ts
+++ b/frontend/src/apps/ai_models/playground/client.test.ts
@@ -1,0 +1,154 @@
+// watchJob's contract, which is three-way and was being read as two.
+//
+// The bug these encode: a FAILED poll left `row` undefined and fell into the
+// "the row vanished" return, so one flaky `/api/jobs` read resolved the watch
+// as an ordinary finish — the image stage rendered a file the worker had not
+// written yet, the transcribe stage read back a transcript that was not there,
+// and the chat stage retried into a second 409. None of that is visible in a
+// manual smoke, because the happy path never drops a poll.
+import { expect, test } from "bun:test";
+
+// client.ts reaches api.ts/router.ts, which read `location` at module scope;
+// bun has no DOM. Same shim as router.test.ts.
+(globalThis as { location?: unknown }).location ??= {
+  pathname: "/ai-models/playground",
+  search: "",
+  href: "http://localhost/ai-models/playground",
+  origin: "http://localhost",
+};
+(globalThis as { history?: unknown }).history ??= {
+  state: null,
+  pushState() {},
+  replaceState() {},
+};
+(globalThis as { window?: unknown }).window ??= {
+  dispatchEvent() {},
+  addEventListener() {},
+  removeEventListener() {},
+};
+
+// Dynamic, so the shim above is in place before the module graph evaluates.
+const { watchJob } = await import("./client");
+import type { Job } from "@platform/lib/jobs";
+
+const JOB: Job = {
+  id: "j1",
+  title: "Rendering",
+  detail: "",
+  kind: "task",
+  state: "running",
+  done: null,
+  total: null,
+  unit: "",
+  message: "",
+  page: "",
+  owner: "server",
+  cancellable: true,
+  cancel_requested: false,
+  started_at: 0,
+  updated_at: 0,
+  finished_at: null,
+  stalled: false,
+};
+
+/** Drive one watch over a scripted sequence of polls. A string entry is a
+ *  state for job j1, `"absent"` is a snapshot without the row, and an Error is
+ *  a transport failure. The 1s sleep is stubbed out so a multi-tick scenario
+ *  costs nothing. */
+async function watch(script: (string | Error)[], signal = new AbortController().signal) {
+  const realFetch = globalThis.fetch;
+  const realSetTimeout = globalThis.setTimeout;
+  let at = 0;
+  const seen: string[] = [];
+  (globalThis as { fetch: unknown }).fetch = async () => {
+    const step = script[Math.min(at++, script.length - 1)];
+    if (step instanceof Error) throw step;
+    return {
+      ok: true,
+      json: async () => ({
+        jobs: step === "absent" ? [] : [{ ...JOB, state: step }],
+        now: 0,
+      }),
+    };
+  };
+  (globalThis as { setTimeout: unknown }).setTimeout = (fn: () => void) => realSetTimeout(fn, 0);
+  try {
+    return { outcome: await watchJob("j1", signal, (job) => seen.push(job.state)), seen, at };
+  } finally {
+    globalThis.fetch = realFetch;
+    globalThis.setTimeout = realSetTimeout;
+  }
+}
+
+test("a terminal row resolves done, carrying the row", async () => {
+  const { outcome, seen } = await watch(["running", "done"]);
+  expect(outcome).toEqual({ state: "done", job: { ...JOB, state: "done" } });
+  // onTick fires for every poll that read a row, the running one included —
+  // that is what draws the progress bar.
+  expect(seen).toEqual(["running", "done"]);
+});
+
+test("a cancelled row is NOT a finished one", async () => {
+  // The distinction the callers need: no artefact was written, so the image
+  // stage must not render the output path and the transcribe stage must not
+  // claim a saved transcript.
+  const { outcome } = await watch(["running", "cancelled"]);
+  expect(outcome.state).toBe("cancelled");
+});
+
+test("a vanished row resolves gone", async () => {
+  // FINISHED_TTL_S is 30s against a 1s poll, so this is the manager retiring a
+  // row we took too long to read — the ordinary end of a finished load.
+  const { outcome } = await watch(["absent"]);
+  expect(outcome).toEqual({ state: "gone" });
+});
+
+test("an error row throws its own message", async () => {
+  const realFetch = globalThis.fetch;
+  (globalThis as { fetch: unknown }).fetch = async () => ({
+    ok: true,
+    json: async () => ({ jobs: [{ ...JOB, state: "error", message: "out of memory" }], now: 0 }),
+  });
+  try {
+    await expect(watchJob("j1", new AbortController().signal)).rejects.toThrow("out of memory");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("a failed poll is retried, NOT read as a vanished row", async () => {
+  // The regression. Before the fix this resolved `null` on the first throw and
+  // every caller treated that as success.
+  const { outcome, at } = await watch([
+    new Error("network"),
+    "running",
+    new Error("network"),
+    "done",
+  ]);
+  expect(outcome.state).toBe("done");
+  expect(at).toBe(4);
+});
+
+test("a run of failed polls eventually gives up instead of hanging", async () => {
+  // Without a cap, a dead server is a spinner that never resolves and never
+  // errors — the failure the retry loop would otherwise trade the old bug for.
+  const script = Array.from({ length: 40 }, () => new Error("network"));
+  await expect(watch(script)).rejects.toThrow(/lost contact/);
+});
+
+test("a poll run that recovers resets the failure count", async () => {
+  const script: (string | Error)[] = [];
+  for (let round = 0; round < 5; round++) {
+    for (let i = 0; i < 9; i++) script.push(new Error("network"));
+    script.push("running");
+  }
+  script.push("done");
+  const { outcome } = await watch(script);
+  expect(outcome.state).toBe("done");
+});
+
+test("an already-aborted signal throws before the first poll", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await expect(watch(["done"], controller.signal)).rejects.toThrow(/abort/i);
+});

--- a/frontend/src/apps/ai_models/playground/client.ts
+++ b/frontend/src/apps/ai_models/playground/client.ts
@@ -136,31 +136,63 @@ export function cancelGeneration(capability?: string): Promise<{ cancelled: bool
   return postJson<{ cancelled: boolean }>("/api/ai/cancel", capability ? { capability } : {});
 }
 
-/** Watch one job row until it leaves "running". Resolves with the terminal
- *  row; a row that VANISHES resolves null (the manager retired it — for a
- *  finished load that is the ordinary end). Rejects only on an error state,
- *  with the row's own message. */
+/** How many polls in a row may fail before the watch gives up. A blip while
+ *  the server is busy is ordinary and the next tick asks again; ten seconds of
+ *  silence is an outage, and a watch that polls a dead server forever is a
+ *  spinner nobody can dismiss. The throw lands in each caller's own catch. */
+const MAX_POLL_FAILURES = 10;
+
+/** Why a watch ended. Three outcomes, not two, because the callers genuinely
+ *  need to tell them apart and a `Job | null` cannot say it:
+ *
+ *  - `done`      — the row reached a terminal non-error state. The artefact,
+ *                  if the job makes one, is on disk.
+ *  - `cancelled` — somebody stopped it. NO artefact was written, so a caller
+ *                  must not render an output path or claim a saved file.
+ *  - `gone`      — the row vanished between polls. `FINISHED_TTL_S` is 30s
+ *                  against a 1s poll, so this is the manager retiring a row we
+ *                  simply took too long to read; treat it as `done` unless the
+ *                  caller can check the artefact itself.
+ *
+ *  A FAILED poll is none of these and never ends the watch — that conflation
+ *  is what made a single flaky `/api/jobs` read resolve as success. Rejects on
+ *  an error state (with the row's own message), on abort, and after
+ *  `MAX_POLL_FAILURES` consecutive failures. */
+export type WatchOutcome =
+  | { state: "done"; job: Job }
+  | { state: "cancelled"; job: Job }
+  | { state: "gone" };
+
 export async function watchJob(
   jobId: string,
   signal: AbortSignal,
   onTick?: (job: Job) => void,
-): Promise<Job | null> {
+): Promise<WatchOutcome> {
+  let failures = 0;
   for (;;) {
     if (signal.aborted) throw new DOMException("aborted", "AbortError");
     let row: Job | undefined;
     try {
       const snapshot = await fetchJobs(signal);
+      failures = 0;
       row = snapshot.jobs.find((j) => j.id === jobId);
       if (row && onTick) onTick(row);
+      // Read, and the row is not there: the manager retired it.
+      if (!row) return { state: "gone" };
+      if (row.state !== "running") {
+        if (row.state === "error") throw new Error(row.message || "the job failed");
+        return { state: row.state === "cancelled" ? "cancelled" : "done", job: row };
+      }
     } catch (e) {
       if ((e as Error).name === "AbortError") throw e;
+      // A terminal row throws its own message out of the try — that is the
+      // job failing, not the poll, and it must not be retried.
+      if (row) throw e;
+      if (++failures >= MAX_POLL_FAILURES) {
+        throw new Error("lost contact with the job list while waiting for this to finish");
+      }
       // One failed poll is not news; the next tick asks again.
     }
-    if (row && row.state !== "running") {
-      if (row.state === "error") throw new Error(row.message || "the job failed");
-      return row;
-    }
-    if (!row) return null;
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 }

--- a/frontend/src/styles/ai-playground.css
+++ b/frontend/src/styles/ai-playground.css
@@ -1257,3 +1257,13 @@
     max-width: 88%;
   }
 }
+
+/* The URL asked for a capability this machine cannot run, and the stage below
+ * is the substitute. Quiet, not alarming: nothing failed, and the sidebar is
+ * already showing the same reason against the group that is out. */
+.pg-blocked-ask {
+  margin: 0 0 10px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--fg-muted);
+}


### PR DESCRIPTION
## What

Seven findings from a code review of #732, all in the new playground code. #732 is merged, so this lands on `main` rather than stacking.

The root of the first three is one contract. `watchJob` resolved `Job | null`, and *two different things* arrived as `null`: the row vanished, and the poll threw. Every call site read that as "finished".

## The findings

**1. A dropped poll resolved the watch as success** — `client.ts`. The catch left `row` undefined and fell into the `if (!row) return null` below it, so the comment there ("the next tick asks again") was false. One transient `/api/jobs` failure mid-run meant the image stage rendered a file the worker had not written, the transcribe stage read back a transcript that was not there, and the chat stage retried its generation into a second 409.

`watchJob` now resolves a three-way `WatchOutcome` — `done` / `cancelled` / `gone` — and a failed poll ends nothing. A consecutive-failure cap (10) throws, so the fix does not trade the old bug for a watch that polls a dead server forever and shows a spinner nobody can dismiss.

**2. The live image preview never worked** — `ImageStage.tsx`. The preview-poll effect was keyed on `[run]`, but the watch's `onTick` writes a fresh `{...r, job}` every ~1s poll. The 1500 ms interval was torn down each second and never survived to fire, so `previewTick` never incremented and the `<img>` src never changed — for every render, on every machine. Now keyed on the started reply, the shape `TranscribeStage` already used for its partial-transcript tail.

**3. Stop reported success** — `ImageStage.tsx`, `TranscribeStage.tsx`. `watchJob` resolves rather than rejects for a cancelled job and neither caller checked. Pressing Stop flipped the run to done, rendered an `<img>` at an output path the killed worker never wrote, and filed the dead render in the session gallery. Transcription said "the transcript could not be read back — it is saved in the transcripts folder", which is untrue of a run the user killed.

**4. `?cap=` could select a model that isn't in the sidebar** — `PlaygroundTab.tsx`. The fallback iterated capability rows without filtering on `available`, but the sidebar renders model buttons only `{row.available && …}`. On a machine missing an engine, a Home card selected a model that appeared nowhere, highlighted nothing, and died on the first Send with a raw engine error while the real reason sat one group away.

Selection now only considers rows the sidebar actually draws. Home's strip is the **static** `PLAYGROUND_GROUPS` list, not the catalog, so every machine shows a "Search by meaning" card whether or not it has an embeddings engine — silently opening a chat box in answer to that click is a worse answer than naming the reason, so the stage now says which task was asked for, why it is out, and what it swapped in.

**5. A URL could seed a permanently-broken chat** — `lib/params.ts`. `numParam` guarded NaN but not range, while the sampling route *rejects* rather than clamps (`_sampling_problem`, `server/ai.py`). `?temp=5` or `?maxtok=0` initialised the rail with that value and 400'd every message. It clamps now, to the server's own `_SAMPLING` bounds; the image stage clamps to its rail ranges (that route settles what it is sent, but a slider pinned off its own scale still lies about what will run). Both stages' sliders read the same constants, so a URL value and a dragged value cannot disagree.

**6. A watch could outlive its component** — `ImageStage.tsx`, `TranscribeStage.tsx`. `abortRef.current = controller` was assigned *after* the first `await`. Leave the tab while that POST is in flight and the unmount cleanup saw a null ref; the continuation then started a watch with a controller nothing would ever abort, leaking a 1/s poll from a dead component for the job's whole duration — the opposite of both files' "only the WATCH stops on unmount" comment. `TranscribeStage` also carries an alive flag, because `land()` awaits the config, the mkdir and the upload before it reaches a job at all, so the same leak had a second door.

**7. Two Try links spelled a URL the app replaces** — `DiscoverTab.tsx`. They hardcoded the bare `/ai-models?model=` prefix and only reached the playground because `App.tsx` rewrites it at render time. They go through `tabHref` now, like `RepoCard`'s.

## Tests

#732 deferred tests. Findings 1 and 2 are both invisible to the manual smoke it left pending — 2 always, 1 only under a flaky poll — so the two pieces that can be tested without a DOM now are:

- `client.test.ts` — `watchJob`'s outcomes, including the dropped-poll regression (it resolved `null` before, which every caller read as success) and the give-up cap. The 1s sleep is stubbed, so multi-tick scenarios are free.
- `params.test.ts` — `numParam`'s clamping, fallbacks, and optional bounds.

`readParam`/`numParam` take an optional search string, the same argument `tabHref` takes and for the same reason: a codec that can only be tested inside a browser is not being tested.

`tsc`, boundaries, `bun test` (2113 pass), and `vite build` all pass.

## Notes

- No DECISIONS row: these are corrections to a shape that is days old, and the reasoning that would go in a row is at the code — `watchJob`'s three outcomes are documented where a future caller will read them.
- Finding 4's notice is new user-visible copy; worth a look on a machine that is actually missing an engine.
- Still owed from #732 and not addressed here: SPEC/DECISIONS rows for the playground, the Local tab's cache walk on mount, and stage params lingering in the URL across tab switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
