### PR TITLE
Collapse the ranked search's check-ignore sweep to a single oracle

### DIFF
--- a/fused_render/server/index_gitignore.py
+++ b/fused_render/server/index_gitignore.py
@@ -66,10 +66,36 @@ walk takes the same posture when git is missing):
 
   * root inside a repo -> ONE oracle at the repo toplevel; `git -C toplevel
     check-ignore` cascades every nested .gitignore below it by itself.
-  * root outside any repo -> an oracle at each corpus directory that holds a
-    `.gitignore`, the OUTERMOST marker claiming each entry; the oracle's
-    work-tree graft cascades the nested ones below it. A repo whose rules
-    live only in .git/info/exclude (no .gitignore anywhere) goes unfiltered.
+  * root outside any repo -> the OUTERMOST marker claiming each entry, one
+    graft per entry's marker set — UNLESS the caller supplied `oracle_rels`
+    (see `filter_corpus`), in which case every entry decided under some
+    marker is answered by ONE oracle grafted at `root` itself instead of one
+    per marker. That collapse is only sound because `oracle_rels` came from
+    somewhere that already enumerated every `.gitignore` UNDER `root` — a
+    marker this module could not otherwise see is impossible by
+    construction, so a single graft at `root` cascades exactly the same
+    rules a graft at each individual marker would have, no more and no less.
+    Grafted at `root` and nowhere wider: a caller's `root` can itself be a
+    narrower folder than the configured scan root (an in-folder rank
+    search), and `oracle_rels` is only ever complete for what lies UNDER
+    `root` — a graft any higher could cascade a plain `.gitignore` between
+    `root` and the wider root that neither this discovery nor the live walk
+    (which computes its own repo boundary from the browsed folder, never
+    from a wider ancestor) would ever have honored. That would be
+    over-filtering, the one direction this module refuses to move in.
+
+    One behavioural difference IS real and deliberate: a marker directory
+    that is ITSELF a git repository (has its own `.git`) used to get its own
+    plain `git -C` oracle in the per-marker path, which incidentally reads
+    that repo's `.git/info/exclude` too. A `root`-grafted oracle is a
+    synthetic work-tree (no real `.git` at `root`), so it never reads any
+    nested repo's `info/exclude` the way a per-marker oracle rooted AT that
+    nested repo did. This can only ever show a file that used to be hidden,
+    never the reverse — the same direction as the header's other admission
+    that a repo whose rules live only in `.git/info/exclude` (no
+    `.gitignore` anywhere) goes unfiltered; consolidation just makes that
+    admission true uniformly instead of true only for a root that happens
+    to have no `.gitignore` of its own.
 
 Mount-backed roots never get here: the index refuses to scan them, so they
 are never `covered` — no check-ignore (kernel I/O) can be aimed at a mount.
@@ -325,7 +351,14 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list,
 
     _sweep_t0 = time.monotonic()
     try:
-        fresh = _ignored(root, entries, top, deciders, want)
+        # `oracle_rels is not None` is the WHOLE gate: it means the caller
+        # (index/query.py, for the ranked search) enumerated every
+        # `.gitignore` under `root` from the index itself, not from this
+        # possibly-narrowed payload — see the module header and
+        # `_ignored`'s `consolidate` parameter for why that is what makes
+        # collapsing to one oracle safe.
+        fresh = _ignored(root, entries, top, deciders, want,
+                         consolidate=oracle_rels is not None)
     finally:
         with _cache_lock:
             if _inflight.get(base) is mine:
@@ -574,8 +607,20 @@ def _deciders(root: str, entries: list, prefix: str,
     return None, out
 
 
-def _ignored(root: str, entries: list, top, deciders: list, want: set) -> set:
-    """The indexes in `want` that git calls ignored."""
+def _ignored(root: str, entries: list, top, deciders: list, want: set,
+            consolidate: bool = False) -> set:
+    """The indexes in `want` that git calls ignored.
+
+    `consolidate` is `_pooled_verdicts`'s translation of "the caller supplied
+    `oracle_rels`" — see the module header. When true, every index in `want`
+    is already known (via `_deciders`) to sit under SOME outermost marker at
+    or below `root`, so ONE oracle grafted at `root` cascades every one of
+    those markers in a single co-process. Grafted at `root` specifically, not
+    at whatever wider index root `filter_corpus` is pooling under: `root` is
+    the only thing `oracle_rels` is proven complete for, and a graft any
+    higher could cascade a `.gitignore` between `root` and that wider root
+    that nothing here ever discovered — over-filtering, which this module
+    does not do."""
     if top is not None:
         base = os.path.relpath(root, top).replace(os.sep, "/")
         prefix = "" if base in (".", "") else base + "/"
@@ -584,6 +629,19 @@ def _ignored(root: str, entries: list, top, deciders: list, want: set) -> set:
         idxs = sorted(want)
         queries = [prefix + entries[i]["rel"] for i in idxs]
         oracle = _IgnoreOracle(top)
+        try:
+            verdicts = oracle.ignored(queries)
+        finally:
+            oracle.close()
+        if not verdicts:
+            return set()
+        return {i for i, q in zip(idxs, queries) if q in verdicts}
+    if not want:
+        return set()
+    if consolidate:
+        idxs = sorted(want)
+        queries = [entries[i]["rel"] for i in idxs]
+        oracle = _IgnoreOracle(root)
         try:
             verdicts = oracle.ignored(queries)
         finally:

--- a/tests/test_index_gitignore.py
+++ b/tests/test_index_gitignore.py
@@ -78,9 +78,9 @@ def _counting_queries(monkeypatch):
     asked = []
     real = index_gitignore._ignored
 
-    def counting(root, entries, top, deciders, want):
+    def counting(root, entries, top, deciders, want, **kwargs):
         asked.append(sorted(entries[i]["rel"] for i in want))
-        return real(root, entries, top, deciders, want)
+        return real(root, entries, top, deciders, want, **kwargs)
 
     monkeypatch.setattr(index_gitignore, "_ignored", counting)
     return asked
@@ -678,3 +678,131 @@ def test_debug_logs_a_wait_on_someone_elses_inflight_sweep(tmp_path,
         filter_corpus(_out(root, rels), index_root=root)
     first.join(timeout=30)
     assert any("in-flight sweep" in r.message for r in caplog.records)
+
+
+# -- consolidation: one oracle instead of one per marker, ONLY when the -------
+# -- caller proved its marker discovery complete (`oracle_rels`) -------------
+
+def _counting_oracles(monkeypatch):
+    """Every root `_IgnoreOracle` was actually constructed with, one entry per
+    check-ignore co-process spawned — real oracles underneath, just counted."""
+    real = index_gitignore._IgnoreOracle
+    roots = []
+
+    class Counting(real):
+        def __init__(self, repo_root):
+            roots.append(repo_root)
+            super().__init__(repo_root)
+
+    monkeypatch.setattr(index_gitignore, "_IgnoreOracle", Counting)
+    return roots
+
+
+def test_supplied_oracle_rels_consolidate_to_one_oracle_at_root(
+        tmp_path, monkeypatch):
+    """The whole point of the fix: a caller that proved its marker discovery
+    complete (`oracle_rels`, e.g. the ranked search reading them out of the
+    whole index) gets ONE check-ignore co-process for the request, not one
+    per outermost marker."""
+    _fresh_cache(monkeypatch)
+    root = str(tmp_path)
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / ".gitignore").write_text("*.tmp\n", encoding="utf-8")
+    spawned = _counting_oracles(monkeypatch)
+    out = filter_corpus(_out(root, [
+        "a/.gitignore", "a/keep.py", "a/drop.log",
+        "b/.gitignore", "b/keep.py", "b/drop.tmp"]),
+        index_root=root, oracle_rels=["a", "b"])
+    assert spawned == [root]
+    rels = [e["rel"] for e in out["entries"]]
+    assert "a/drop.log" not in rels and "b/drop.tmp" not in rels
+    assert "a/keep.py" in rels and "b/keep.py" in rels
+
+
+def test_no_oracle_rels_still_spawns_one_oracle_per_marker(tmp_path, monkeypatch):
+    """The gate itself, pinned: WITHOUT a caller-supplied `oracle_rels`,
+    discovery keeps the ORIGINAL per-marker behaviour — one co-process per
+    outermost marker — even for a corpus shaped exactly like the one above
+    that consolidation collapses to one."""
+    _fresh_cache(monkeypatch)
+    root = str(tmp_path)
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / ".gitignore").write_text("*.tmp\n", encoding="utf-8")
+    spawned = _counting_oracles(monkeypatch)
+    filter_corpus(_out(root, [
+        "a/.gitignore", "a/keep.py", "a/drop.log",
+        "b/.gitignore", "b/keep.py", "b/drop.tmp"]))  # oracle_rels omitted
+    assert sorted(spawned) == sorted(
+        [str(tmp_path / "a"), str(tmp_path / "b")])
+
+
+def test_supplied_and_discovered_oracle_rels_agree_on_a_nested_corpus(
+        tmp_path, monkeypatch):
+    """Differential: the consolidated (`oracle_rels`-supplied) path and the
+    per-marker (discovery) path must call the exact same entries ignored for
+    a corpus with several nested and independent markers — a handful of
+    repos' worth of shape, not 300."""
+    root = str(tmp_path)
+    (tmp_path / "proj").mkdir()
+    (tmp_path / "proj" / ".gitignore").write_text("*.outer\n", encoding="utf-8")
+    (tmp_path / "proj" / "sub").mkdir()
+    (tmp_path / "proj" / "sub" / ".gitignore").write_text(
+        "*.inner\n", encoding="utf-8")
+    (tmp_path / "other").mkdir()
+    (tmp_path / "other" / ".gitignore").write_text("*.oth\n", encoding="utf-8")
+    (tmp_path / "clean").mkdir()  # no .gitignore anywhere near it
+    rels = [
+        "proj/.gitignore", "proj/a.outer", "proj/keep.py",
+        "proj/sub/.gitignore", "proj/sub/a.inner", "proj/sub/a.outer",
+        "proj/sub/keep.py",
+        "other/.gitignore", "other/a.oth", "other/keep.py",
+        "clean/keep.py",
+    ]
+    _fresh_cache(monkeypatch)
+    discovered = filter_corpus(_out(root, rels))
+    _fresh_cache(monkeypatch)
+    consolidated = filter_corpus(
+        _out(root, rels), index_root=root,
+        oracle_rels=["proj", "proj/sub", "other"])
+    assert ([e["rel"] for e in discovered["entries"]]
+           == [e["rel"] for e in consolidated["entries"]])
+
+
+def test_consolidation_does_not_reach_above_a_narrower_search_root(
+        tmp_path, monkeypatch):
+    """A caller may rank-search a SUBFOLDER of the configured index root (the
+    ranked endpoint answers in-folder queries too, not only the home root).
+    `oracle_rels` is only ever complete for what lies UNDER that subfolder —
+    an ancestor `.gitignore` between the subfolder and the wider index root
+    is invisible to it, exactly as it is invisible to the per-marker path and
+    to the live walk (which derives its own repo boundary from the browsed
+    folder, never from a wider ancestor). Consolidating must graft at the
+    REQUEST's OWN root, not at the wider index root — grafting any higher
+    would cascade that ancestor rule in, which is over-filtering: hiding a
+    file the per-marker path (and the live walk) would have shown.
+    """
+    _fresh_cache(monkeypatch)
+    base = str(tmp_path)
+    (tmp_path / "proj").mkdir()
+    # The ANCESTOR marker: sits ABOVE the subfolder actually being searched.
+    (tmp_path / "proj" / ".gitignore").write_text(
+        "*.secret\n", encoding="utf-8")
+    (tmp_path / "proj" / "sub").mkdir()
+    # The subfolder's OWN marker: the only one `oracle_rels` can ever see.
+    (tmp_path / "proj" / "sub" / ".gitignore").write_text(
+        "*.log\n", encoding="utf-8")
+    sub_root = str(tmp_path / "proj" / "sub")
+    # oracle_rels exactly as `index/query.py:_ignore_roots` computes them:
+    # scoped to `.gitignore` files UNDER the searched subfolder only, so the
+    # ancestor's marker never appears in this list.
+    out = filter_corpus(_out(sub_root, [
+        ".gitignore", "a.log", "a.secret", "keep.py"]),
+        index_root=base, oracle_rels=[""])
+    rels = [e["rel"] for e in out["entries"]]
+    assert "a.log" not in rels     # the subfolder's own rule still applies
+    assert "a.secret" in rels      # the ancestor's rule must NOT leak in
+    assert "keep.py" in rels


### PR DESCRIPTION
## Summary

Stacked on #741. That PR removed a per-request `git rev-parse` from the ranked-search path; benchmarking then showed `rev-parse` was only **0.8%** of a cold request, and that the real cost is elsewhere: `_ignored` spawns **one `git check-ignore` co-process per outermost `.gitignore` directory**. On a corpus of 300 repos that is 156 co-processes and 827ms of a 909ms request — 91%.

This collapses that to one oracle grafted at the search root, letting git cascade the nested `.gitignore` files itself, **but only when the caller has proven its marker discovery is complete** by supplying `oracle_rels`.

Measured on the 300-repo corpus:

| | before | after |
|---|---|---|
| Cold request | 925ms, 156 spawns | **115ms, 1 spawn** |
| 20 varied queries | 4,058 spawns | **18 spawns** |
| Each new query | ~1.3s | **~0.07s** |
| Warm median | 51ms | 50ms (no regression) |

The varied-query row is the one that matters: a stream of different search terms is normal typing, and each query's candidates span ~200 distinct marker directories that the verdict pool has never decided. That cost is paid *inside* one warm process, well within `VERDICT_MAX_AGE_S` — so it was never a staleness problem, and raising the TTL would not have touched it.

## Visuals

The gate is the whole safety argument: consolidation happens only on the branch where the caller supplied `oracle_rels`.

```mermaid
flowchart TD
    A["filter_corpus"] --> B["_pooled_verdicts"]
    B --> C{"oracle_rels supplied?"}
    C -->|"yes — discovery proven complete"| D["one oracle grafted at root"]
    C -->|"no — discovery from payload"| E["one oracle per marker"]
    D --> F["verdicts"]
    E --> F
```

## Usage

Not user-invocable. Search results are unchanged; only the number of `git` processes behind them differs.

## Test Plan

- [x] `test_supplied_oracle_rels_consolidate_to_one_oracle_at_root` — watched fail (2 spawns) before the fix, passes after.
- [x] `test_no_oracle_rels_still_spawns_one_oracle_per_marker` — pins the gate.
- [x] `test_supplied_and_discovered_oracle_rels_agree_on_a_nested_corpus` — differential equivalence over a nested multi-marker corpus.
- [x] `test_consolidation_does_not_reach_above_a_narrower_search_root` — pins the graft-point finding below; fails against a base-grafted implementation.
- [x] `test_a_narrower_marker_does_not_answer_for_the_outer_one` — **unmodified** and still passing. Editing it would have meant the gate was broken.
- [x] Scoped: `test_index_gitignore.py` 36 passed, `test_index_search.py` 62 passed, `test_index_api.py` 99 passed.
- [ ] Full suite + CI — running; stays draft until green.

## Two things reviewers should look at

**The graft point is `root`, not the index root.** The prototype grafted at the index root; that is unsafe. `/api/index/rank` serves in-folder search too (`useWalkSearch.ts:403` passes the browsed folder), and `index/query.py:_ignore_roots` scans only `WHERE path LIKE '<root>/%'` — so a `.gitignore` sitting *between* the search folder and the index root is invisible to `oracle_rels`, to the old per-marker code, and to the live walk. Grafting wider would let git cascade that rule and **hide a file the old code showed**. Grafting at `root` is provably equivalent to per-marker behaviour, since outermost-marker semantics guarantee no unaccounted `.gitignore` between `root` and any marker.

**One deliberate behavioural narrowing.** A nested real repo that is itself the outermost `.gitignore` holder currently gets a plain `git -C` oracle, which incidentally honors that repo's `.git/info/exclude`. A grafted oracle does not. This moves toward *showing* a file, never hiding one — the direction this module's stated bias already prefers — and it makes the header's existing admission ("a repo whose rules live only in `.git/info/exclude` goes unfiltered") uniformly true rather than accidentally-only-true-without-a-`.gitignore`. Documented in the module header.

**Caller audit.** All three `filter_corpus` call sites are in `routers/index.py`: `_ranked`/`drop_ignored` supplies `oracle_rels` (the only caller passing `gitignore_filter` into `search_ranked`); the startup warm and `api_index_search` do not, and stay per-marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
