### PR TITLE
AI video: pin the ltx-video runner's MLX streams so a second render does not abort

### DIFF
--- a/fused_render/ai/runners/ltx_video/worker.py
+++ b/fused_render/ai/runners/ltx_video/worker.py
@@ -51,6 +51,7 @@ import fnmatch
 import glob
 import os
 import sys
+import threading
 import time
 
 # The base sits one directory up, in `runners/` — see mlx_text/worker.py.
@@ -64,6 +65,61 @@ import worker_base  # noqa: E402 - the path insert above is what makes it import
 #: weights load happens inside `generate_and_save`, once per render, exactly
 #: as upstream's own CLI drives it).
 _loaded = {}
+
+#: The MLX streams every thread in this process works on, keyed by device name —
+#: ONE PER DEVICE. See `_pin_stream`.
+_STREAMS = {}
+_STREAMS_LOCK = threading.Lock()
+
+
+def _pin_stream():
+    """Put this thread's MLX work on the process's shared streams — EVERY device.
+
+    `mflux_image/worker.py::_pin_stream` is the same function with the long
+    story: from mlx 0.32 the default stream belongs to the THREAD that made
+    it, an unevaluated array is a graph pinned to the stream it was built on,
+    and forcing it from another thread aborts with `There is no Stream(cpu, 0)
+    in current thread`. Copied rather than imported, for the reason
+    `mlx_embed/worker.py`'s copy gives: these workers run in separate venvs
+    with no shared module between them.
+
+    **This runner reaches that abort on the SECOND render, not the first** —
+    which is why the pin was missed here when the four sibling MLX runners got
+    it. `DistilledPipeline` loads its weights inside `generate_and_save`, so
+    render #1 builds and evaluates everything on one `ThreadingTCPServer`
+    request thread and passes; the pipeline then KEEPS those components
+    (`self.dit`, the VAE blocks, `self.upsampler` — `low_memory` frees some
+    between stages, not all of them across calls), and render #2 arrives on a
+    fresh request thread whose graph now mixes in render #1's arrays.
+    Observed on mlx 0.32.1 against `dgrauet/ltx-2.3-mlx-q4`: renders #2 and #3
+    both died at `distilled.py::generate_two_stage`'s `_materialize(video_
+    upscaled)` — the first `mx.eval` after the upscaler runs — with exactly
+    that message.
+
+    `mx.cpu` as well as `default_device()`, `if key not in` rather than
+    `setdefault` (which would mint a fresh stream per call and keep the
+    first), and a no-op on an mlx too old to have the calls: all three are
+    `mflux_image`'s, and its docstring says why each one is load-bearing.
+    """
+    import mlx.core as mx
+
+    make = getattr(mx, "new_thread_unsafe_stream", None)
+    pin = getattr(mx, "set_default_stream", None)
+    if make is None or pin is None:
+        return None
+    devices = [mx.cpu, mx.default_device()]
+    with _STREAMS_LOCK:
+        streams = []
+        for device in devices:
+            key = str(device)
+            if key not in _STREAMS:
+                _STREAMS[key] = make(device)
+            if _STREAMS[key] not in streams:
+                streams.append(_STREAMS[key])
+    for stream in streams:
+        pin(stream)
+    return streams
+
 
 #: Upstream's own default (`DistilledPipeline.__init__`, `ltx_pipelines_mlx.
 #: distilled`) — named explicitly here rather than left to the pipeline's own
@@ -285,6 +341,11 @@ def load(model_id, fetched):
 
     _put_ffmpeg_on_path()
 
+    # Before the pipeline is built, not after: `__init__` composes MLX modules
+    # on THIS (bring-up) thread, and `generate` runs on another. See
+    # `_pin_stream`.
+    _pin_stream()
+
     from ltx_pipelines_mlx.distilled import DistilledPipeline
 
     # `low_memory=True` (the pipeline's own default) is left alone rather than
@@ -411,6 +472,11 @@ def generate(body):
     "why would I change this" — the same reasoning that keeps `guidance` off
     the API entirely for this engine.
     """
+    # FIRST, before a single MLX array is touched: this is a fresh
+    # `ThreadingTCPServer` request thread, and the components a previous render
+    # left on the pipeline were built on a different one. See `_pin_stream`.
+    _pin_stream()
+
     pipeline = _loaded.get("pipeline")
     if pipeline is None:
         raise RuntimeError("no model is loaded")

--- a/tests/test_ai_ltx_video_worker.py
+++ b/tests/test_ai_ltx_video_worker.py
@@ -16,6 +16,7 @@ import shutil
 import stat
 import sys
 import tempfile
+import threading
 import types
 
 import pytest
@@ -115,8 +116,38 @@ class FakePipeline:
 
 
 class FakeMlxCore(types.ModuleType):
-    def __init__(self):
+    """`mlx.core` as this runner uses it: two DEVICES and their STREAMS.
+
+    `tests/test_ai_mflux_worker.py`'s double, verbatim in shape — from mlx
+    0.32 the default stream is per (thread, DEVICE), so a worker that pinned
+    only `default_device()` would still abort on `Stream(cpu, 0)`. Both
+    devices are therefore distinct objects here, and every
+    `new_thread_unsafe_stream` records which one it was asked for.
+    """
+
+    def __init__(self, **extra):
         super().__init__("mlx.core")
+        self.cpu = "CPU"
+        self.gpu = "GPU"
+        #: the device of every `new_thread_unsafe_stream`, in order.
+        self.made = []
+        #: (thread name, stream) for every `set_default_stream`.
+        self.pinned = []
+        self._lock = threading.Lock()
+        for name, value in extra.items():
+            setattr(self, name, value)
+
+    def default_device(self):
+        return self.gpu
+
+    def new_thread_unsafe_stream(self, device):
+        with self._lock:
+            self.made.append(device)
+            return f"SHARED-{device}-STREAM"
+
+    def set_default_stream(self, stream):
+        with self._lock:
+            self.pinned.append((threading.current_thread().name, stream))
 
     def get_active_memory(self):
         return 0
@@ -163,7 +194,8 @@ def _fake_ffmpeg_binary():
 
 
 def load_worker(monkeypatch, base, pipeline=None, with_ffmpeg=True,
-                with_samplers_tqdm=True, hf_hub=None, ffmpeg_exe=None):
+                with_samplers_tqdm=True, hf_hub=None, ffmpeg_exe=None,
+                mlx_core=None):
     """A fresh import of the ltx_video worker against the fakes.
 
     `monkeypatch.setitem` rather than a save/restore, because this runner
@@ -204,8 +236,14 @@ def load_worker(monkeypatch, base, pipeline=None, with_ffmpeg=True,
         samplers_mod.tqdm = lambda iterable, **kwargs: iter(iterable)
     monkeypatch.setitem(sys.modules, "ltx_pipelines_mlx.utils.samplers", samplers_mod)
 
+    # `mlx.core` is no longer only `memory()`'s business: `load` and `generate`
+    # both pin this process's shared streams (`_pin_stream`), so a render test
+    # that left it out would be testing an import that cannot happen in
+    # production. A caller may still hand in its own — an mlx too old to have
+    # thread-local streams, say — and gets exactly that.
     mlx = types.ModuleType("mlx")
-    mlx_core = FakeMlxCore()
+    if mlx_core is None:
+        mlx_core = FakeMlxCore()
     mlx.core = mlx_core
     monkeypatch.setitem(sys.modules, "mlx", mlx)
     monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
@@ -622,3 +660,76 @@ def test_the_tqdm_patch_is_restored_even_after_a_cancel(monkeypatch, base, tmp_p
         worker.generate(_request(tmp_path))
 
     assert samplers.tqdm is original
+
+
+# -- the MLX stream every thread shares ------------------------------------------
+
+
+def _pinned_run(monkeypatch, base, tmp_path, mlx_core):
+    """A load and TWO renders, on the threads production uses.
+
+    `load` runs on `worker_base.serve`'s bring-up thread, which then EXITS, and
+    each `generate` arrives on its own `ThreadingTCPServer` request thread —
+    which is the whole of the bug, so the test has to reproduce the threading
+    and not just the calls.
+
+    Two renders rather than `test_ai_mflux_worker.py`'s one, because this
+    runner's abort lands on the SECOND: `DistilledPipeline` loads its weights
+    inside `generate_and_save`, so render #1 builds and evaluates everything on
+    one thread and passes, and it is render #2 — a fresh thread, reusing the
+    components render #1 left on the pipeline — that dies. A one-render version
+    of this test would have gone green against the unpinned worker.
+    """
+    pipeline = FakePipeline()
+    worker, _ = load_worker(monkeypatch, base, pipeline=pipeline, mlx_core=mlx_core)
+    loader = threading.Thread(
+        target=worker.load, args=(MODEL, snapshot(tmp_path)), name="bring-up")
+    loader.start()
+    loader.join()
+    for index in (1, 2):
+        render = threading.Thread(
+            target=worker.generate, args=(_request(tmp_path, steps=2),),
+            name="request-%d" % index)
+        render.start()
+        render.join()
+    return worker, pipeline
+
+
+def test_the_load_and_every_render_share_ONE_mlx_stream_PER_DEVICE(
+        monkeypatch, base, tmp_path):
+    """From mlx 0.32 the default stream belongs to the THREAD that made it, and
+    an unevaluated array forced anywhere else throws. Observed on mlx 0.32.1
+    against `dgrauet/ltx-2.3-mlx-q4`: the second and third renders in a worker's
+    life both died at `distilled.py::generate_two_stage`'s
+    `_materialize(video_upscaled)` with `RuntimeError: There is no Stream(cpu, 0)
+    in current thread`.
+
+    **BOTH devices**, for the reason `test_ai_mflux_worker.py`'s twin gives: the
+    default stream is per (thread, DEVICE), so pinning `default_device()` alone
+    leaves the CPU half of the graph owned by whichever thread first touched it
+    — precisely the stream that abort named.
+    """
+    mlx_core = FakeMlxCore()
+
+    _pinned_run(monkeypatch, base, tmp_path, mlx_core)
+
+    threads = {name for name, _stream in mlx_core.pinned}
+    streams = {stream for _name, stream in mlx_core.pinned}
+    assert len(threads) > 2, f"the render threads did not both pin: {mlx_core.pinned}"
+    assert streams == {"SHARED-CPU-STREAM", "SHARED-GPU-STREAM"}, mlx_core.pinned
+    # One stream per device for the whole process, not one per thread: a second
+    # would be a second owner, which is the thing being prevented.
+    assert sorted(mlx_core.made) == ["CPU", "GPU"], mlx_core.made
+
+
+def test_an_mlx_without_thread_local_streams_is_left_alone(
+        monkeypatch, base, tmp_path):
+    """Streams were process-wide before 0.32 and there was nothing to pin. A
+    runner that insisted on the newer call would turn a version skew into a
+    worker that cannot render at all."""
+    mlx_core = types.SimpleNamespace(cpu="CPU", gpu="GPU",
+                                     get_active_memory=lambda: 0)
+
+    _worker, pipeline = _pinned_run(monkeypatch, base, tmp_path, mlx_core)
+
+    assert len(pipeline.calls) == 2, "the renders never reached the pipeline"


### PR DESCRIPTION
## The failure

Rendering with `dgrauet/ltx-2.3-mlx-q4` dies with:

```
File ".../ltx_pipelines_mlx/distilled.py", line 323, in generate_two_stage
    _materialize(video_upscaled)
RuntimeError: There is no Stream(cpu, 0) in current thread.
```

From mlx 0.32 the default stream belongs to the **thread** that made it. An unevaluated array is a graph pinned to the stream it was built on, and forcing it from another thread aborts. Four MLX runners (`mflux_image`, `mlx_text`, `mlx_embed`, `mlx_whisper`) already share one stream per device across the process via `_pin_stream`. `ltx_video` never got it.

## Why it was missed

The sibling runners abort on their *first* render, so the bug was loud when they were written. Here `DistilledPipeline` loads its weights inside `generate_and_save`, so render #1 builds and evaluates everything on one `ThreadingTCPServer` request thread and passes. The pipeline keeps those components (`self.dit`, the VAE blocks, `self.upsampler` — `low_memory` frees some between stages, not all across calls), and render #2 arrives on a fresh request thread whose graph now mixes in render #1's arrays. In the worker log from this machine, render #1 completed and renders #2 and #3 both died at `_materialize(video_upscaled)` — the first `mx.eval` after the upscaler.

## The fix

`mflux_image`'s `_pin_stream`, copied (separate venvs, no shared module — same reason `mlx_embed` copies it): one shared `new_thread_unsafe_stream` per device for the whole process, `mx.cpu` as well as `default_device()`, no-op on an mlx too old to have the calls. Called from `load()` before the pipeline is constructed, and first thing in `generate()`.

## Tests

- `test_the_load_and_every_render_share_ONE_mlx_stream_PER_DEVICE` — drives a load plus **two** renders on their real threads. A one-render version would have gone green against the unpinned worker; verified this one fails without the fix (`the render threads did not both pin: []`).
- `test_an_mlx_without_thread_local_streams_is_left_alone` — the pre-0.32 no-op path still renders.

`tests/test_ai_ltx_video_worker.py` (23), `test_ai_mflux_worker.py`, `test_ai_runner_deps.py` — 89 passed.

**Not smoke-tested with a real render** (minutes per clip). The mechanism is the measured one from the mflux fix; a two-render smoke on a machine that already has the weights + venv is the obvious follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
