### PR TITLE
Text embeddings as a capability of their own: llama.cpp (CPU + Vulkan) and MLX

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,270 @@
+# Testing `text-embeddings`
+
+A new capability (`registry.TEXT_EMBEDDINGS`) that turns text into vectors
+through a text encoder — bge, e5, nomic-embed, EmbeddingGemma,
+Qwen3-Embedding. It is **separate from the existing `embeddings`
+capability**, which stays exactly as it was: that one serves dual encoders
+(SigLIP/CLIP) and can put an image and a sentence in one space; this one
+serves the retrieval models a RAG or search page actually wants. They hold
+separate resident-model slots, so you can have one of each loaded at once.
+
+Engines: **llama.cpp** on Windows/Linux CPU, **llama.cpp + Vulkan** on
+Windows/Linux GPU, **MLX** on Apple Silicon.
+
+---
+
+## 1. Run the tests
+
+Everything here runs with no model downloads and no runner venvs.
+
+```bash
+cd /path/to/wt-text-embeddings
+uv venv
+uv pip install -e ".[dev]"
+
+./.venv/Scripts/python.exe -m pytest \
+  tests/test_ai_text_embed_common.py \
+  tests/test_ai_llamacpp_embed_worker.py \
+  tests/test_ai_runtime_embed_text.py \
+  tests/test_ai_text_embed_retrieval.py -q
+```
+
+On POSIX use `./.venv/bin/python` instead.
+
+Expect **~65 passed, 3 skipped**. The three skips are
+`test_ai_text_embed_retrieval.py`'s model-backed tests, which need real
+weights — section 4 turns them on.
+
+The tests this change also touched, all of which should be green:
+
+```bash
+./.venv/Scripts/python.exe -m pytest \
+  tests/test_ai_formats.py tests/test_ai_registry.py tests/test_ai_tasks.py \
+  tests/test_ai_runtime.py tests/test_hub_models.py \
+  tests/test_ai_runtime_embed.py tests/test_ai_runner_deps.py -q
+```
+
+> **Known unrelated failures.** `tests/test_ai_models_api.py` fails 4 tests on
+> Windows without Developer Mode (`OSError: WinError 1314` — the fixture
+> creates symlinks). Those fail on `origin/main` too; verified by stashing.
+
+---
+
+## 2. Run the server from source
+
+The installed desktop app is far behind — you must run from the worktree.
+Do **not** try to reuse another checkout's `.venv` with `PYTHONPATH`: the
+editable install uses a PEP 660 meta-path finder that beats `PYTHONPATH`, so
+you silently get the other checkout's code.
+
+```bash
+cd /path/to/wt-text-embeddings
+uv pip install -e ".[fused]"     # the [fused] extra pins fused==2.9.3b7;
+                                 # without it NO model can load
+
+# The React shell must exist, or create_app raises at startup:
+(cd frontend && npm install && npm run build)
+
+FUSED_RENDER_CORE_TEMPLATES="$PWD/fused_render/templates" \
+  ./.venv/Scripts/python.exe -c \
+  "import sys; sys.argv=['fused-render','--port','1789','--no-browser']; from fused_render.cli import main; main()"
+```
+
+`FUSED_RENDER_CORE_TEMPLATES` short-circuits template staging so in-repo
+templates are read live — without it the server fails on a missing `vendor`
+directory. Port 1777 is the desktop app; 1788 is often taken.
+
+### The capability should now be visible
+
+```bash
+curl -s http://127.0.0.1:1789/api/ai/runtime -H 'X-Fused: 1' \
+  | python -c "import json,sys; [print(r['code'], r['capability'], r['available'], r['active']) for r in json.load(sys.stdin)['runners'] if r['capability']=='text-embeddings']"
+```
+
+Expected on Windows/Linux x86_64:
+
+```
+mlx-text-embed          text-embeddings False False
+llamacpp-embed          text-embeddings True  True
+llamacpp-embed-vulkan   text-embeddings True  False
+```
+
+And the catalog, smallest first, default first:
+
+```bash
+curl -s http://127.0.0.1:1789/api/ai/catalog -H 'X-Fused: 1' \
+  | python -c "import json,sys; [print(r['default'], [m['id'] for m in r['models']]) for r in json.load(sys.stdin) if r['capability']=='text-embeddings']"
+```
+
+---
+
+## 3. Exercise the endpoint
+
+### The refusals — these need no model and no network
+
+```bash
+E=http://127.0.0.1:1789/api/ai/embed-text
+J='-H Content-Type:application/json -H X-Fused:1'
+
+# 403 — the guard every mutating POST carries
+curl -s -o /dev/null -w '%{http_code}\n' -X POST $E \
+  -H 'Content-Type: application/json' -d '{"texts":["a"]}'
+
+# 400 — images are meaningless here, and the message says where to go instead
+curl -s -X POST $E $J -d '{"texts":["a"],"paths":["/photos/cat.png"]}'
+
+# 400 — an unrecognised `kind` is refused, never silently defaulted
+curl -s -X POST $E $J -d '{"texts":["a"],"kind":"queries"}'
+```
+
+### The cold-model fork
+
+```bash
+curl -s -X POST $E $J -d '{"texts":["hello world"]}'
+```
+
+```json
+{"ok": false, "error": {"type": "model_loading",
+ "message": "nomic-embed-text-v1.5.Q8_0.gguf is loading now",
+ "jobId": "sys:ai-model:nomic-embed-text-v1.5.Q8_0.gguf"}}
+```
+
+**That 409 is the contract, not a failure** — the same fork `/api/ai` and
+`/api/ai/embed` take. Watch the job, then ask again:
+
+```bash
+curl -s http://127.0.0.1:1789/api/jobs -H 'X-Fused: 1'
+```
+
+The first load builds the `llamacpp_embed` runner venv (a ~25MB
+`llama-cpp-python` wheel from the maintainer's index) and then fetches the one
+146MB GGUF. Once the row reads `done`, repeat the call:
+
+```json
+{"ok": true, "result": {"vectors": [[...]], "dim": 768,
+ "model": "nomic-embed-text-v1.5.Q8_0.gguf",
+ "kind": "document", "promptScheme": "nomic"}}
+```
+
+### Refusing a repo that is not a text embedding model
+
+This is the behaviour the existing `embeddings` capability gets wrong, and
+the thing most worth checking by hand:
+
+```bash
+curl -s -X POST $E $J \
+  -d '{"texts":["a"],"model":"sentence-transformers/all-MiniLM-L6-v2"}'
+# 409 model_loading, then watch the job — it fails with a written sentence
+# naming the repo, and no weights are fetched to reach that answer.
+
+curl -s http://127.0.0.1:1789/api/jobs -H 'X-Fused: 1'
+```
+
+The job's error should read:
+
+> `'sentence-transformers/all-MiniLM-L6-v2'` publishes no GGUF file this
+> engine can load (… file(s) checked). It looks like a safetensors/PyTorch
+> checkpoint — the format sentence-transformers and transformers read, which
+> llama.cpp cannot open at all. Pass a GGUF conversion of the same model
+> instead …
+
+**Watch your network monitor while this runs.** The whole answer comes from
+`list_repo_files`; nothing is downloaded. A GGUF repo that turns out to hold a
+*chat* model is caught one step later, by a 2MB HTTP `Range` request against
+the file's header — still before any weight moves. Try:
+
+```bash
+curl -s -X POST $E $J -d '{"texts":["a"],"model":"unsloth/Qwen3.5-4B-GGUF"}'
+```
+
+…which should refuse with "its header declares no pooling type" and point at
+text generation.
+
+### Query/document asymmetry
+
+Retrieval models are asymmetric — e5 wants `query:`/`passage:`, bge instructs
+the query only, Qwen3-Embedding ships a named instruct prompt. `kind` picks
+the side:
+
+```bash
+curl -s -X POST $E $J -d '{"texts":["leaky roof"],"kind":"query"}'
+curl -s -X POST $E $J -d '{"texts":["leaky roof"],"kind":"document"}'
+```
+
+The two return **different vectors** for the same string. `promptScheme` on
+the reply says which convention was applied — a curated table for the ids this
+app ships, a filename heuristic for anything else, so it is reported rather
+than applied out of sight.
+
+**Default is `"document"`.** The reasoning is in
+`runners/text_embed_common.DEFAULT_KIND`: it is the side that keeps a corpus
+internally consistent for someone who has not read about prompt schemes, and
+on the bge family it means no prefix at all.
+
+---
+
+## 4. The demo page
+
+```bash
+# with the server from section 2 running
+open http://127.0.0.1:1789/view?path=$PWD/docs/text-embeddings-demo.html
+```
+
+Or open `docs/text-embeddings-demo.html` in the FusedRender app.
+
+A five-passage corpus and a query box. It embeds the corpus with
+`kind:"document"`, the query with `kind:"query"`, ranks by a plain dot product
+(legal only because vectors are unit-normalized — the page prints `v·v` as a
+check), and handles the `model_loading` 409 with `fused.watchJob`, so the
+first search on a cold model shows the real download.
+
+The default query — *"keeping the bread culture alive"* — shares **not one
+word** with the sourdough passage it should find. That is the point: word
+overlap gets 2/5 on this corpus, a real encoder gets 5/5.
+
+---
+
+## 5. Turning on the model-backed retrieval tests
+
+They skip unless the weights are already cached — deliberately, since a test
+suite that fetches 146MB on first run is a suite people disable.
+
+```bash
+# in the runner venv, or any venv with llama-cpp-python + huggingface_hub
+python -c "from huggingface_hub import hf_hub_download; \
+  hf_hub_download('nomic-ai/nomic-embed-text-v1.5-GGUF','nomic-embed-text-v1.5.Q8_0.gguf')"
+
+./.venv/Scripts/python.exe -m pytest tests/test_ai_text_embed_retrieval.py -q -rs
+```
+
+Point them at another curated model with
+`FUSED_TEST_EMBED_REPO` / `FUSED_TEST_EMBED_FILE`.
+
+---
+
+## 6. Apple Silicon
+
+`mlx-text-embed` was **written against the real `mlx-embeddings` 0.1.0 API but
+never executed** — see the honesty note at the top of
+`runners/mlx_text_embed/worker.py`, which names the three seams to check
+first. The package genuinely ships text encoders (`bert.py`, `modernbert.py`,
+`xlm_roberta.py`, `qwen3.py`, `gemma3_text.py`, `lfm2.py`,
+`llama_bidirec.py` — read out of the published wheel), so this is an
+implementation and not a scaffold, but it needs one run on a Mac.
+
+```bash
+# on Apple Silicon, from section 2's server
+curl -s http://127.0.0.1:1789/api/ai/runtime -H 'X-Fused: 1' | grep mlx-text-embed
+# mlx-text-embed should be available AND active — it outranks the llama.cpp
+# rows on a Mac, exactly as mlx-text does for chat.
+
+curl -s -X POST $E $J -d '{"texts":["hello world"]}'
+# → loads mlx-community/multilingual-e5-small-mlx (253MB), 384-dim,
+#   promptScheme "e5"
+```
+
+Note the MLX catalog is **different repos** from the llama.cpp one — this
+engine reads safetensors, those read GGUF — so vectors from the two engines
+are not comparable. That is the same relationship `mlx-text` and
+`llamacpp-text` already have, and unlike the `embeddings` capability, whose
+two runners do share a vector space.

--- a/TESTING.md
+++ b/TESTING.md
@@ -35,18 +35,38 @@ Expect **~65 passed, 3 skipped**. The three skips are
 `test_ai_text_embed_retrieval.py`'s model-backed tests, which need real
 weights — section 4 turns them on.
 
-The tests this change also touched, all of which should be green:
+The neighbouring modules this change touches, all of which should be green:
 
 ```bash
 ./.venv/Scripts/python.exe -m pytest \
   tests/test_ai_formats.py tests/test_ai_registry.py tests/test_ai_tasks.py \
-  tests/test_ai_runtime.py tests/test_hub_models.py \
-  tests/test_ai_runtime_embed.py tests/test_ai_runner_deps.py -q
+  tests/test_ai_runtime.py tests/test_hub_models.py tests/test_ai_runtime_embed.py \
+  tests/test_ai_catalog_embeddings.py tests/test_ai_embed_common.py \
+  tests/test_ai_benchmark.py tests/test_ai_benchmark_store.py \
+  tests/test_ai_benchmark_api.py tests/test_ai_runner_deps.py \
+  tests/test_ai_llamacpp_worker.py tests/test_ai_mlx_embed_worker.py \
+  tests/test_ai_transformers_embed_worker.py \
+  tests/test_supervisor_core.py tests/test_server_ai.py -q
 ```
 
-> **Known unrelated failures.** `tests/test_ai_models_api.py` fails 4 tests on
-> Windows without Developer Mode (`OSError: WinError 1314` — the fixture
-> creates symlinks). Those fail on `origin/main` too; verified by stashing.
+And the frontend, which gained three capability-table entries:
+
+```bash
+cd frontend && bun test src/apps/ai_models/lib/     # 333 pass
+```
+
+> **Do not run the whole `tests/` directory to judge this branch.** Ten tests
+> fail on `a014e786` — the branch point — for reasons that have nothing to do
+> with it, so a full run is noise. Baselined by stashing onto the pristine
+> tree:
+>
+> * `tests/test_ai_models_api.py` — 4 failures, and `tests/test_ai_worker_base.py`
+>   — 5 failures: all `OSError: WinError 1314`, the fixtures create symlinks and
+>   Windows refuses without Developer Mode.
+> * `tests/test_ai_metrics.py::test_a_missing_claude_binary_is_counted` — 1
+>   failure, expects `ai_unavailable` and gets `ai_error`.
+>
+> None of the ten is in a module this change edits.
 
 ---
 

--- a/docs/text-embeddings-demo.html
+++ b/docs/text-embeddings-demo.html
@@ -1,0 +1,201 @@
+<!--
+  A working exercise of `fused.ai.embedText` (SPEC §40) — the `text-embeddings`
+  capability, end to end, in one file.
+
+  Open it in fused-render (see TESTING.md at the repo root for the exact
+  command). It is deliberately the smallest thing that shows every part of the
+  contract actually working rather than a polished tool:
+
+    * a corpus embedded with kind:"document" and a query with kind:"query",
+      which is how the endpoint is meant to be used and the only way the
+      asymmetric prompt pair does its job;
+    * ranking by a PLAIN DOT PRODUCT with no magnitudes divided out, which is
+      legal only because the vectors come back unit-normalized — so the page
+      is itself a check on that guarantee;
+    * the 409 `model_loading` fork handled the way every page should handle
+      it: catch the rejection, watch the job id it carries, ask again. The
+      first run on a cold model goes through this, so it is exercised rather
+      than described.
+
+  The default corpus is the one `tests/test_ai_text_embed_retrieval.py` uses,
+  chosen so that word-overlap ranking scores 2/5 while a real encoder scores
+  5/5 — try "keeping the bread culture alive", which shares not one word with
+  the sourdough line it should find.
+-->
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    margin: 0; padding: 24px; max-width: 860px;
+  }
+  h1 { font-size: 18px; margin: 0 0 4px; }
+  .sub { opacity: .7; margin: 0 0 20px; }
+  label { display: block; font-weight: 600; margin: 16px 0 6px; }
+  textarea, input[type=text] {
+    width: 100%; box-sizing: border-box; font: inherit;
+    padding: 8px 10px; border-radius: 6px;
+    border: 1px solid color-mix(in oklab, currentColor 25%, transparent);
+    background: transparent; color: inherit;
+  }
+  textarea { min-height: 116px; resize: vertical; }
+  .row { display: flex; gap: 8px; align-items: center; margin-top: 12px; }
+  button {
+    font: inherit; padding: 7px 14px; border-radius: 6px; cursor: pointer;
+    border: 1px solid color-mix(in oklab, currentColor 30%, transparent);
+    background: color-mix(in oklab, currentColor 8%, transparent); color: inherit;
+  }
+  button[disabled] { opacity: .5; cursor: default; }
+  #status { opacity: .75; min-height: 1.5em; }
+  table { border-collapse: collapse; width: 100%; margin-top: 18px; }
+  th, td { text-align: left; padding: 7px 10px; vertical-align: top; }
+  th { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; opacity: .6; }
+  tbody tr { border-top: 1px solid color-mix(in oklab, currentColor 12%, transparent); }
+  tbody tr.top { background: color-mix(in oklab, currentColor 8%, transparent); }
+  td.score { font-variant-numeric: tabular-nums; white-space: nowrap; width: 1%; }
+  .meta { margin-top: 14px; font-size: 12px; opacity: .7; }
+  .meta code { font-size: 12px; }
+  .err { color: #c0392b; }
+</style>
+
+<h1>Text embeddings — semantic search over a tiny corpus</h1>
+<p class="sub">
+  Each line below is embedded once as a <code>document</code>. Your query is
+  embedded as a <code>query</code>, so the model gets the prompt it was trained
+  to see on each side. Ranking is a plain dot product.
+</p>
+
+<label for="corpus">Corpus — one passage per line</label>
+<textarea id="corpus">The landlord is responsible for repairing a leaking roof within 14 days of written notice.
+Espresso should be pulled at roughly nine bars of pressure for 25 to 30 seconds.
+Photosynthesis converts light energy into chemical energy stored as glucose in plant cells.
+A pull request must be approved by one reviewer before it can be merged to the main branch.
+Sourdough starter needs feeding with equal parts flour and water every twelve hours.</textarea>
+
+<label for="query">Query</label>
+<input id="query" type="text" value="keeping the bread culture alive">
+
+<div class="row">
+  <button id="go">Search</button>
+  <span id="status"></span>
+</div>
+
+<table id="results" hidden>
+  <thead><tr><th class="score">Score</th><th>Passage</th></tr></thead>
+  <tbody></tbody>
+</table>
+
+<p class="meta" id="meta"></p>
+
+<script>
+  const $ = (id) => document.getElementById(id);
+  const say = (text, isError) => {
+    $("status").textContent = text;
+    $("status").className = isError ? "err" : "";
+  };
+
+  // Cosine similarity as a PLAIN DOT PRODUCT. Legal only because
+  // fused.ai.embedText guarantees unit-length vectors — if that guarantee
+  // ever broke, the scores here would silently stop being cosines, which is
+  // why the page prints one vector's self-dot in the footer as a check.
+  const dot = (a, b) => a.reduce((sum, x, i) => sum + x * b[i], 0);
+
+  // The `model_loading` fork, handled once and reused for both calls.
+  //
+  // A cold model answers 409 with the id of the load it just started; the
+  // caller is meant to watch that job and ask again. `fused.watchJob` is the
+  // read side of the download manager, so this shows real download progress
+  // rather than an opaque spinner.
+  //
+  // **Two things here are easy to get wrong, and both were, in the first
+  // draft of this page.**
+  //
+  // `fused.watchJob(id)` returns a HANDLE, not a promise — the thing to await
+  // is `handle.watch(onUpdate)`, which resolves with the job's final record
+  // when it stops running. Awaiting the handle itself resolves instantly, so
+  // the retry below became a hot loop hammering the server for as long as the
+  // load took.
+  //
+  // And a job that ends in `error` is a TERMINAL state that `watch` resolves
+  // with rather than rejecting on. Retrying then just starts the same doomed
+  // load again, forever. So the record's state is checked and its message is
+  // what the page shows — which is how a user finds out that, say, their CPU
+  // cannot run the llama.cpp wheel, instead of watching a spinner.
+  async function embed(opts) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await fused.ai.embedText(opts);
+      } catch (err) {
+        if (err.type !== "model_loading" || !err.jobId) throw err;
+        say("Loading the embedding model…");
+        const record = await fused.watchJob(err.jobId).watch((job) => say(
+          job.total
+            ? `Loading the embedding model — ${job.detail || job.state} `
+              + `(${Math.round((job.done / job.total) * 100)}%)`
+            : `Loading the embedding model — ${job.detail || job.state}`));
+        if (record && record.state === "error") {
+          const failed = new Error(record.message || "the model failed to load");
+          failed.type = "ai_error";
+          throw failed;
+        }
+        // …and round again: the retry is what actually gets the vectors.
+      }
+    }
+    const stuck = new Error(
+      "the model is still not resident after three attempts — check the "
+        + "download manager");
+    stuck.type = "model_loading";
+    throw stuck;
+  }
+
+  async function search() {
+    const passages = $("corpus").value.split("\n")
+      .map((line) => line.trim()).filter(Boolean);
+    const query = $("query").value.trim();
+    if (!passages.length || !query) {
+      say("Give it a corpus and a query.", true);
+      return;
+    }
+
+    $("go").disabled = true;
+    $("results").hidden = true;
+    say("Embedding…");
+    try {
+      // Two calls, two kinds. Embedding both sides as documents would still
+      // "work" — unit vectors, right width, plausible scores — and would
+      // quietly cost recall, which is the whole reason `kind` exists.
+      const docs = await embed({ texts: passages, kind: "document" });
+      const q = await embed({ texts: [query], kind: "query" });
+
+      const ranked = passages
+        .map((text, i) => ({ text, score: dot(q.vectors[0], docs.vectors[i]) }))
+        .sort((a, b) => b.score - a.score);
+
+      const body = $("results").querySelector("tbody");
+      body.replaceChildren(...ranked.map((row, i) => {
+        const tr = document.createElement("tr");
+        if (i === 0) tr.className = "top";
+        const score = document.createElement("td");
+        score.className = "score";
+        score.textContent = row.score.toFixed(4);
+        const text = document.createElement("td");
+        text.textContent = row.text;
+        tr.append(score, text);
+        return tr;
+      }));
+      $("results").hidden = false;
+
+      const selfDot = dot(q.vectors[0], q.vectors[0]);
+      $("meta").textContent =
+        `${q.model} · ${q.dim}-dim · prompt scheme "${q.promptScheme}" · `
+        + `query kind "${q.kind}" · unit-length check (v·v) = ${selfDot.toFixed(6)}`;
+      say(`Ranked ${passages.length} passages.`);
+    } catch (err) {
+      say(`${err.type || "error"}: ${err.message}`, true);
+    } finally {
+      $("go").disabled = false;
+    }
+  }
+
+  $("go").addEventListener("click", search);
+  $("query").addEventListener("keydown", (e) => { if (e.key === "Enter") search(); });
+</script>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,7 +54,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1240,7 +1239,6 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1320,7 +1318,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -1619,7 +1616,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1661,7 +1657,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1877,7 +1872,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,6 +54,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1239,6 +1240,7 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1318,6 +1320,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -1616,6 +1619,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1657,6 +1661,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1872,6 +1877,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/src/apps/ai_models/lib/aiModelGroups.ts
+++ b/frontend/src/apps/ai_models/lib/aiModelGroups.ts
@@ -50,6 +50,14 @@ export const CAPABILITY_ORDER = [
   "text-to-image",
   "automatic-speech-recognition",
   "embeddings",
+  // Beside Embeddings and after it: neither produces something a reader looks
+  // at, which is the argument that put Embeddings last of the four, and the
+  // dual encoder is the more general of the two so it keeps the earlier slot.
+  // LISTED rather than left to fall through, per the paragraph above — the
+  // fall-through is the safety net for a capability nobody has considered,
+  // not the home for a first-class one, whose position would otherwise be an
+  // accident of the order the server happened to send.
+  "text-embeddings",
 ];
 
 export interface RepoGroup {

--- a/frontend/src/apps/ai_models/lib/benchmark.ts
+++ b/frontend/src/apps/ai_models/lib/benchmark.ts
@@ -112,6 +112,17 @@ const METRICS: Record<string, MetricSpec[]> = {
     { key: "peakResidentBytes", label: "Peak memory", unit: "", higherIsBetter: false, digits: 0 },
     { key: "loadSeconds", label: "Load time", unit: "s", higherIsBetter: false, digits: 1 },
   ],
+  // The same three, because `_measure_text_embed` reports the same three
+  // (ai/benchmark.py) — one measurer serves both capabilities. Written out
+  // rather than aliased to the row above: this table is keyed by the server's
+  // capability constants, and sharing one array would make the day either
+  // capability grows a fourth metric an edit that silently claims it for the
+  // other one too.
+  "text-embeddings": [
+    { key: "textsPerSecond", label: "Throughput", unit: "texts/s", higherIsBetter: true, digits: 1 },
+    { key: "peakResidentBytes", label: "Peak memory", unit: "", higherIsBetter: false, digits: 0 },
+    { key: "loadSeconds", label: "Load time", unit: "s", higherIsBetter: false, digits: 1 },
+  ],
 };
 
 /** The primary metric for a capability, or null when this frontend does not

--- a/frontend/src/apps/ai_models/lib/engines.ts
+++ b/frontend/src/apps/ai_models/lib/engines.ts
@@ -31,6 +31,12 @@ const CAPABILITY_LABELS: Record<string, string> = {
   "text-to-image": "Image generation",
   "automatic-speech-recognition": "Speech to text",
   "embeddings": "Embeddings",
+  // "Text embeddings" against the plain "Embeddings" above, and the extra word
+  // carries the whole distinction a reader needs on this tab: that capability
+  // loads a DUAL ENCODER (text and images into one space), this one loads a
+  // text encoder. Without it the two read as one feature that somehow grew a
+  // second engine picker.
+  "text-embeddings": "Text embeddings",
 };
 
 export function capabilityLabel(capability: string): string {

--- a/fused_render/ai/benchmark.py
+++ b/fused_render/ai/benchmark.py
@@ -184,6 +184,27 @@ WORKLOADS: Mapping[str, Workload] = MappingProxyType({
             "batch": len(_EMBED_TEXTS),
         }),
     ),
+    # The same eight strings the dual-encoder workload uses, deliberately.
+    # The two capabilities load different models and their scores are not
+    # comparable as QUALITY, but an identical input means a difference in
+    # `textsPerSecond` is a difference in the engines rather than in how much
+    # text each was handed.
+    #
+    # `kind` is pinned rather than left to the endpoint's default, for the
+    # reason `text-128-tokens` pins `temperature`: the prompt prefix is real
+    # work — it lengthens every sequence, and on Qwen3-Embedding by a whole
+    # instruction block — so two runs disagreeing about it would not be
+    # measuring the same thing. "document" is the side a corpus is indexed
+    # with, which is the case anyone benchmarking this cares about.
+    registry.TEXT_EMBEDDINGS: Workload(
+        name="text-embed-8-texts",
+        revision=1,
+        params=MappingProxyType({
+            "texts": _EMBED_TEXTS,
+            "batch": len(_EMBED_TEXTS),
+            "kind": "document",
+        }),
+    ),
 })
 
 
@@ -390,7 +411,8 @@ def _measure_text(model: str, workload: Workload, *, timed: bool) -> dict:
     }
 
 
-def _measure_embed(model: str, workload: Workload, *, timed: bool) -> dict:
+def _measure_embed(model: str, workload: Workload, *, timed: bool,
+                   capability: str = registry.EMBEDDINGS) -> dict:
     """Encode the fixed batch of texts in one call.
 
     The whole batch in one request rather than eight requests, because batching
@@ -399,16 +421,31 @@ def _measure_embed(model: str, workload: Workload, *, timed: bool) -> dict:
 
     Retries on `supervisor.ModelNotReady` exactly like `_measure_text` — see
     `_await_settled_load` for the race this settles.
+
+    **`capability` is a parameter for `supervisor.generate_embed`'s reason:**
+    two capabilities answer this exact shape, everything below is about
+    residency and timing rather than about what the model does, and a second
+    copy would be two identical measurement bodies free to drift on the one
+    thing a benchmark must not drift on. It defaults to `EMBEDDINGS` so the
+    existing caller reads unchanged, and `_measure_text_embed` below binds the
+    other value.
+
+    Any extra workload params (`kind`, today) ride along into the request:
+    they are part of what is being timed, and a measurer that dropped them
+    would report a number for work the workload did not describe.
     """
     texts = list(workload.params["texts"])
+    body = {"texts": texts}
+    if "kind" in workload.params:
+        body["kind"] = workload.params["kind"]
     deadline = _now() + _LOAD_TIMEOUT_S
     while True:
         start = _now()
         try:
-            result = supervisor.generate_embed(model, {"texts": texts})
+            result = supervisor.generate_embed(model, body, capability=capability)
             break
         except supervisor.ModelNotReady:
-            _await_settled_load(model, registry.EMBEDDINGS, deadline)
+            _await_settled_load(model, capability, deadline)
     total = _now() - start
     if not timed:
         return {}
@@ -418,6 +455,18 @@ def _measure_embed(model: str, workload: Workload, *, timed: bool) -> dict:
         "dim": dim if isinstance(dim, int) else None,
         "batch": len(texts),
     }
+
+
+def _measure_text_embed(model: str, workload: Workload, *, timed: bool) -> dict:
+    """`_measure_embed` against the TEXT-embedding capability.
+
+    A named function rather than a `partial` in the table below, so that
+    `_MEASURE`'s "one measurement function per capability" reads as literally
+    true and a reader tracing a capability lands on a `def` with this
+    docstring rather than on a bound argument.
+    """
+    return _measure_embed(model, workload, timed=timed,
+                          capability=registry.TEXT_EMBEDDINGS)
 
 
 def _measure_image(model: str, workload: Workload, *, timed: bool) -> dict:
@@ -537,6 +586,7 @@ _MEASURE = {
     registry.IMAGE_GENERATION: _measure_image,
     registry.SPEECH_TO_TEXT: _measure_transcript,
     registry.EMBEDDINGS: _measure_embed,
+    registry.TEXT_EMBEDDINGS: _measure_text_embed,
 }
 
 

--- a/fused_render/ai/catalog.py
+++ b/fused_render/ai/catalog.py
@@ -823,6 +823,137 @@ SUGGESTIONS: dict[str, list[dict]] = {
                     "times the download and 1152-dim vectors to store.",
         },
     ],
+    # Text embeddings — a SEPARATE capability from the block above (see
+    # `registry.TEXT_EMBEDDINGS`), and the one place in this file where that
+    # separation is most visible: two lists, not one aliased pair, because
+    # `llamacpp-embed` reads GGUF and `mlx-text-embed` reads safetensors.
+    # That is the `llamacpp-text`/`mlx-text` shape, not the
+    # `transformers-embed`/`mlx-embed` one — those two share a list because
+    # SigLIP publishes one format both engines open, and no such coincidence
+    # exists here.
+    #
+    # **What "smallest first" means on this capability, and why the default
+    # is still a good model.** Every entry in both lists is smaller than the
+    # SMALLEST entry in every other list in this file — the largest text
+    # embedder here is 1.14GB against 0.7GB for the smallest chat model, and
+    # most are under 400MB. So the module rule that position 0 is the default
+    # does not force a compromise the way it does for chat: the difference
+    # between the smallest row and the best one is a few hundred megabytes
+    # and a few seconds, not the difference between running and not running.
+    # Both lists therefore lead with a model chosen for RETRIEVAL quality
+    # that happens also to be the smallest, rather than with the smallest
+    # thing that would load. Two models that would have been smaller still
+    # were deliberately left out for exactly that reason — see below.
+    #
+    # **Every entry is retrieval-trained and has a known prompt scheme**
+    # (`formats.TEXT_EMBED_PROMPTS`), which is a curation rule and not a
+    # coincidence: an asymmetric model whose prefix pair this app does not
+    # know embeds one side wrongly and says nothing about it, so a curated
+    # row with an unknown scheme would be a row that quietly underperforms.
+    #
+    # Sizes are the Hub's own per-file byte sums for what each engine
+    # actually fetches (2026-08-23), rounded to one decimal like every other
+    # list here — with the caveat that at this scale one decimal is coarse,
+    # so the notes say the megabyte figure where it decides anything. Every
+    # repo checked ungated.
+    "llamacpp-embed": [
+        # Position 0, and it is the default a bare `fused.ai.embedText()`
+        # loads. **Not merely the smallest.** `bge-small-en-v1.5` in GGUF is
+        # 37MB, a quarter of this, and it was left out on purpose: it is
+        # English-only and 384-dim, and the 110MB difference is under two
+        # seconds of download against a measurably better encoder that also
+        # handles a 2048-token passage where bge-small truncates at 512.
+        # nomic-embed-text-v1.5 is Apache-2.0, trained specifically for
+        # retrieval, and its `search_query:`/`search_document:` prefixes are
+        # the clearest demonstration in the catalog of why `kind` exists.
+        {
+            "id": "nomic-embed-text-v1.5.Q8_0.gguf",
+            "params": "137M",
+            "quantization": "GGUF Q8_0",
+            "recommended": True,
+            "label": "nomic-embed-text v1.5 (Q8_0)",
+            "nickname": "nomic-embed",
+            "size_gb": 0.1,
+            "note": "The default and the best all-round pick — 146MB, "
+                    "768-dim, and it reads a 2048-token passage whole.",
+        },
+        {
+            "id": "embeddinggemma-300M-Q8_0.gguf",
+            "params": "300M",
+            "quantization": "GGUF Q8_0",
+            "label": "EmbeddingGemma 300M (Q8_0)",
+            "nickname": "EmbeddingGemma",
+            "size_gb": 0.3,
+            "note": "Multilingual where the row above is English-first, and "
+                    "Google's current small embedder — 334MB for the same "
+                    "768-dim vectors.",
+        },
+        # The accuracy option, and the only DECODER in either list — which is
+        # why it is here rather than being redundant with the two encoders
+        # above it. Last-token pooling on a 0.6B causal model buys real
+        # retrieval quality (it leads the small-model MTEB multilingual
+        # tables) at roughly twice the compute per item, since it runs a
+        # generative-sized stack to produce one vector.
+        {
+            "id": "Qwen3-Embedding-0.6B-Q8_0.gguf",
+            "params": "600M",
+            "quantization": "GGUF Q8_0",
+            "label": "Qwen3-Embedding 0.6B (Q8_0)",
+            "nickname": "Qwen3-Embedding",
+            "size_gb": 0.6,
+            "note": "The strongest here, and the slowest per item — 1024-dim "
+                    "vectors out of a decoder rather than an encoder.",
+        },
+    ],
+    # The MLX list, and it is DIFFERENT REPOS rather than the same ones: this
+    # engine reads the original safetensors, so every row is an
+    # `mlx-community` conversion and none of them is a GGUF. A page that
+    # embedded a corpus on one engine and searches it from the other gets
+    # nonsense — unlike the `embeddings` capability above, these two backends
+    # share no vector space, exactly as `mlx-text` and `llamacpp-text` share
+    # no weights.
+    #
+    # **`mlx-community/all-MiniLM-L6-v2-4bit` is deliberately absent**, and it
+    # is the entry a future reader is most likely to try to add: it is 14MB,
+    # it is the famous one, and it is what upstream's own README example
+    # loads. It is not a retrieval model — all-MiniLM was trained for general
+    # sentence similarity, has no query/document convention at all, and is
+    # the exact checkpoint `ai/tasks.py` used to name as the thing this app
+    # must not offer a Load button for. Putting it at position 0 would make
+    # the smallest download the default AND make the default the one model
+    # here that is bad at the job this capability exists for.
+    "mlx-text-embed": [
+        {
+            "id": "mlx-community/multilingual-e5-small-mlx",
+            "params": "118M",
+            "recommended": True,
+            "label": "multilingual-e5-small",
+            "nickname": "e5-small",
+            "size_gb": 0.3,
+            "note": "The default here — 253MB, multilingual, and its "
+                    "query:/passage: prefixes are applied for you.",
+        },
+        {
+            "id": "mlx-community/embeddinggemma-300m-bf16",
+            "params": "300M",
+            "label": "EmbeddingGemma 300M (bf16)",
+            "nickname": "EmbeddingGemma",
+            "size_gb": 0.7,
+            "note": "768-dim against the 384 above, and the same model the "
+                    "llama.cpp list offers — the one row comparable across "
+                    "both engines.",
+        },
+        {
+            "id": "mlx-community/multilingual-e5-large-mlx",
+            "params": "560M",
+            "label": "multilingual-e5-large",
+            "nickname": "e5-large",
+            "size_gb": 1.1,
+            "note": "The accuracy option: noticeably better multilingual "
+                    "retrieval for four times the first row's download and "
+                    "1024-dim vectors to store.",
+        },
+    ],
 }
 
 #: Hardware variant -> the runner whose list it SHARES. Resolved by `for_runner`
@@ -855,6 +986,12 @@ _SHARED_SUGGESTIONS = {
     "diffusers-image-cuda": "diffusers-image",
     "diffusers-image-rocm": "diffusers-image",
     "llamacpp-text-vulkan": "llamacpp-text",
+    # A hardware variant, exactly like the row above it: the CPU and Vulkan
+    # llama.cpp embedding wheels open byte-for-byte the same GGUF, so their
+    # lists must be identical BY CONSTRUCTION rather than by whoever edits
+    # one remembering to edit the other. `mlx-text-embed` is NOT aliased to
+    # this key and must never be — it reads safetensors and has its own list.
+    "llamacpp-embed-vulkan": "llamacpp-embed",
     # Not a hardware variant of the same runner — a DIFFERENT runner that reads
     # the same repos (see the comment on the embeddings block above). Aliased
     # for the same reason as the pairs above: one list to keep in step rather
@@ -950,7 +1087,12 @@ def mirror_id(model_id: str) -> str:
         return ""
     from fused_render.ai.runners import formats
 
-    recipe = formats.GGUF_RECIPES.get(model_id)
+    # BOTH recipe tables, because both key their curated entries by GGUF
+    # FILENAME and both therefore need the same translation. A lookup that
+    # knew only the chat table would silently turn the mirror off for every
+    # text embedding model — no manifest request, which looks exactly like a
+    # normal download and is the failure this function exists to prevent.
+    recipe = formats.gguf_recipe(model_id)
     # A suggested id with no recipe row is already a repo id (every other
     # runner's list), so it is handed down as it is. Imported lazily to keep this
     # module free of a runner import at load time.

--- a/fused_render/ai/hub_cache.py
+++ b/fused_render/ai/hub_cache.py
@@ -896,10 +896,21 @@ def _repo_meta(repo_dir: str) -> _RepoMeta:
     # (this app never produces one, but a Hub repo is not this app's to
     # control) — the first is representative, since every curated recipe
     # this runner reads means one file per repo per id.
+    #
+    # Its `pooling_type` is read from the SAME file in the same pass, because
+    # the architecture alone cannot tell a text-embedding GGUF from a chat one
+    # for the decoder families that ship both (`formats.gguf_pooling_type`).
+    # Two bounded peeks rather than one is two reads of a page the OS has just
+    # cached; folding them into a single parse would mean a second header
+    # parser in this module, which is the duplication `formats` exists to
+    # prevent.
     gguf_architecture = None
+    gguf_pooling_type = None
     gguf_files = sorted(n for n in names if n.lower().endswith(formats.GGUF_EXTENSION))
     if gguf_files:
-        gguf_architecture = formats.gguf_architecture(os.path.join(snapshot, gguf_files[0]))
+        gguf_path = os.path.join(snapshot, gguf_files[0])
+        gguf_architecture = formats.gguf_architecture(gguf_path)
+        gguf_pooling_type = formats.gguf_pooling_type(gguf_path)
 
     # Which backend's `load()` would accept this, by format alone. Cached with
     # everything else because it reads the same listing and the same config —
@@ -913,6 +924,7 @@ def _repo_meta(repo_dir: str) -> _RepoMeta:
         config=config,
         torch_weights=_has_torch_weights(snapshot),
         gguf_architecture=gguf_architecture,
+        gguf_pooling_type=gguf_pooling_type,
     )
     # The snapshot's own top-level listing, carried past this function for
     # the one caller that needs it beyond format inference:

--- a/fused_render/ai/hub_cache.py
+++ b/fused_render/ai/hub_cache.py
@@ -1600,7 +1600,7 @@ def is_downloaded(model_id: str, cached: list[CachedModel] | None = None) -> boo
     finished — which is what keeps a caller from resuming a multi-GB pull.
     """
     models = cached_models() if cached is None else cached
-    recipe = formats.GGUF_RECIPES.get(model_id)
+    recipe = formats.gguf_recipe(model_id)
     if recipe is None:
         return any(model.repo_id == model_id for model in models)
     return any(model.repo_id == recipe["repo"] and recipe["file"] in model.files

--- a/fused_render/ai/registry.py
+++ b/fused_render/ai/registry.py
@@ -85,6 +85,39 @@ SPEECH_TO_TEXT = "automatic-speech-recognition"
 #: those vectors and not what the runner returns, so borrowing it would have
 #: named the capability after a use case it does not implement.
 EMBEDDINGS = "embeddings"
+#: Vectors again, but out of a TEXT ENCODER — bge, e5, nomic-embed,
+#: EmbeddingGemma, Qwen3-Embedding — the models a retrieval or RAG page
+#: actually reaches for. Plain English rather than a Hub tag, like
+#: `EMBEDDINGS` above and for a sharper version of the same reason: these
+#: repos wear `feature-extraction` AND `sentence-similarity`, two tags for
+#: one thing, so either name would have implied the other tag was something
+#: else.
+#:
+#: **A SEPARATE capability from `EMBEDDINGS`, decided rather than defaulted —
+#: worth arguing here, because the two names look like they should be one
+#: thing.**
+#:
+#: `EMBEDDINGS` serves DUAL ENCODERS and nothing else — SigLIP and CLIP,
+#: through `get_text_features`/`get_image_features`
+#: (`formats.EMBED_MODEL_TYPES`). An ordinary text embedding model publishes
+#: neither method: it is a text encoder plus a pooling configuration. Passing
+#: `BAAI/bge-small-en-v1.5` to that capability downloads ~400MB, starts a
+#: worker, and dies on `AttributeError: 'BertModel' object has no attribute
+#: 'get_text_features'` — observed, not predicted. So these are not one
+#: capability with a missing branch. They are two load paths, two on-disk
+#: formats (GGUF and safetensors here; safetensors only there), two catalogs,
+#: and — because retrieval encoders are asymmetric — a request shape with a
+#: `kind` parameter that would mean nothing to a dual encoder.
+#:
+#: **The split also buys something a user can feel.** The supervisor holds one
+#: resident model PER CAPABILITY and evicts to make room for the next. Two
+#: capabilities means a page can hold a SigLIP model and a text embedder at
+#: once and neither evicts the other — "index my photos" and "search my
+#: notes" stop fighting over one slot on a machine with room for both.
+#: Whether to merge the two later is a live question; merging them NOW by
+#: teaching one of them both load paths would have been that question
+#: answered silently, in the direction that costs a slot.
+TEXT_EMBEDDINGS = "text-embeddings"
 
 RUNNERS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runners")
 
@@ -1270,6 +1303,91 @@ _RUNNERS: tuple[Runner, ...] = (
         note="Runs on the CPU on any machine, or Apple Silicon's GPU — quick "
              "either way, since one item is a single forward pass.",
         _available=_torch_platform,
+    ),
+    # Text embeddings, the fifth capability — see `TEXT_EMBEDDINGS` above for
+    # why it is its own capability and not a fourth model type inside
+    # `embeddings`.
+    #
+    # **Arranged exactly like TEXT GENERATION, not like the embeddings pair
+    # above, and the difference is the format.** The two rows above share an
+    # embedding SPACE because SigLIP publishes one set of safetensors both
+    # engines read. These three do not: MLX opens safetensors and the two
+    # llama.cpp rows open GGUF, so their catalogs are different repos and
+    # their vectors are different models' vectors. That is the `mlx-text` /
+    # `llamacpp-text` / `llamacpp-text-vulkan` shape, down to the ordering —
+    # MLX takes the Macs, the CPU llama.cpp row keeps everything else, and
+    # the Vulkan row sits below both so `auto` can never fall into it.
+    Runner(
+        code="mlx-text-embed",
+        capability=TEXT_EMBEDDINGS,
+        folder=os.path.join(RUNNERS_DIR, "mlx_text_embed"),
+        # "MLX Text Embeddings", distinct from the `mlx-embed` row's "MLX
+        # Embeddings" above by one word, and that word is doing real work:
+        # both rows install the SAME package (`mlx-embeddings`, which ships a
+        # SigLIP port and a set of text encoders), so a reader looking at the
+        # Engines tab sees two entries from one library and the only thing
+        # telling them apart is which kind of model each loads.
+        label="MLX Text Embeddings (Apple Silicon)",
+        short_label="MLX Text Embeddings",
+        family_label="MLX Text Embeddings",
+        note="Embeds on the GPU from the original safetensors — a different "
+             "catalog from the llama.cpp rows, which read GGUF.",
+        _available=_apple_silicon,
+    ),
+    Runner(
+        code="llamacpp-embed",
+        capability=TEXT_EMBEDDINGS,
+        folder=os.path.join(RUNNERS_DIR, "llamacpp_embed"),
+        # **"llama.cpp Embeddings", not bare "llama.cpp", and the word is
+        # load-bearing rather than descriptive.** There are now FOUR
+        # llama.cpp rows in this table — two for chat, two for embeddings —
+        # and `test_no_engine_name_advertises_the_format_its_sibling_also_reads`
+        # keys a "family" on the label stem before the bracket. Sharing the
+        # stem "llama.cpp" would put all four in one family with the
+        # qualifiers `(CPU)`, `(Vulkan)`, `(CPU)`, `(Vulkan)` — two pairs of
+        # duplicates, which is that test's exact failure and, on the page, two
+        # rows a user cannot tell apart in the engine picker for a capability
+        # they did not mean to change.
+        #
+        # "(CPU)" then names the BUILD and not a prediction about the device,
+        # exactly as `llamacpp-text`'s does — that same `whl/cpu` index's
+        # macOS wheel links Metal.
+        label="llama.cpp Embeddings (CPU)",
+        short_label="llama.cpp Embeddings (CPU)",
+        family_label="llama.cpp Embeddings",
+        # ONE LINE, per `note`'s own rule. It leads with the fact that
+        # decides whether to bother: these models are tens of megabytes, which
+        # is the opposite of every other download this app offers and the
+        # reason a CPU row is a perfectly good default here rather than a
+        # fallback.
+        note="Tens of megabytes per model and quick on any CPU — an encoder "
+             "pass is far less work than a token loop.",
+        _available=_llamacpp_platform,
+        # A search result this engine cannot resolve at all (a plain
+        # safetensors sentence-transformers repo) is not actionable here —
+        # see `hub_filter_tags`' own docstring, and note that this is what
+        # keeps `sentence-transformers/all-MiniLM-L6-v2` out of the Discover
+        # tab now that its task tags map to this capability
+        # (`test_a_result_is_never_something_this_app_cannot_run`).
+        hub_filter_tags=("gguf",),
+    ),
+    Runner(
+        code="llamacpp-embed-vulkan",
+        capability=TEXT_EMBEDDINGS,
+        folder=os.path.join(RUNNERS_DIR, "llamacpp_embed_vulkan"),
+        label="llama.cpp Embeddings (Vulkan)",
+        short_label="llama.cpp Embeddings (Vulkan)",
+        family_label="llama.cpp Embeddings",
+        # The honest note for this row, and it is more cautionary than its
+        # text-generation twin's on purpose: the Vulkan Linux wheel is
+        # ~182MB against a curated model list whose largest entry is 639MB
+        # and whose smallest is 146MB, so a user can download more WHEEL than
+        # MODEL here. Worth it when a page embeds thousands of chunks;
+        # not worth it to embed a search box.
+        note="Worth it for embedding thousands of chunks on an NVIDIA or AMD "
+             "GPU — the wheel is larger than most models on this list.",
+        _available=_vulkan,
+        hub_filter_tags=("gguf",),
     ),
 )
 

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -913,6 +913,34 @@ GGUF_RECIPES = {
 }
 
 
+def gguf_recipe(model_id: str) -> dict | None:
+    """The `(repo, file)` recipe for a curated GGUF FILENAME id, from either
+    table — or None for an id that is not one.
+
+    **The one lookup for "is this a filename-keyed curated id", and it exists
+    because there are now TWO such tables.** Both `GGUF_RECIPES` and
+    `TEXT_EMBED_RECIPES` key their entries by the GGUF's own filename, for
+    the same reason (a repo publishes many quantizations of one model, so a
+    bare repo id cannot address the one this app curates), and at least four
+    places in the server have to translate a filename id back to its repo:
+    `hub_cache.is_downloaded`, `catalog.mirror_id`,
+    `ai_runtime._catalog_with_downloads` and the Benchmark tab's own guard.
+
+    Each of those was written against `GGUF_RECIPES` alone, and each fails
+    QUIETLY for an id the other table owns rather than raising — a curated
+    model that shows "Download" forever after it has been downloaded, a
+    mirror that silently never gets asked. Routing all of them through one
+    function is what keeps a third table, whenever it arrives, from having to
+    find those four sites again.
+
+    The two tables' keys must stay disjoint, which they are by construction
+    (chat quantizations and embedding quantizations of different models) and
+    which `test_ai_formats.py` pins — `GGUF_RECIPES` is consulted first, so a
+    collision would resolve to the chat recipe and download the wrong file.
+    """
+    return GGUF_RECIPES.get(model_id) or TEXT_EMBED_RECIPES.get(model_id)
+
+
 # ---------------------------------------------------------------------------
 # Picking ONE GGUF file out of an arbitrary repo's own listing (D412).
 #
@@ -1449,29 +1477,83 @@ LLAMACPP_RUNNERS = ("llamacpp-text", "llamacpp-text-vulkan")
 #: (see `test_every_registered_runner_appears_in_loaders`).
 LLAMACPP_EMBED_RUNNERS = ("llamacpp-embed", "llamacpp-embed-vulkan")
 
-#: `model_type` values `mlx-text-embed` can open — the text encoders
-#: `mlx-embeddings` 0.1.x ships a module for, read out of the published wheel
-#: (`mlx_embeddings/models/*.py`) rather than from its README, on 2026-08-23.
+#: `model_type` values that are DECISIVELY a text encoder — an
+#: encoder-only architecture, which no causal language model can be. These
+#: need no second signal: `mlx_lm` ships no module for any of them, so a
+#: repo carrying one was never loadable as a chat model in the first place,
+#: and `mlx-embeddings` 0.1.x ships `models/bert.py`, `models/modernbert.py`
+#: and `models/xlm_roberta.py` for exactly these (read out of the published
+#: wheel on 2026-08-23, not from its README).
 #:
-#: **`siglip` is deliberately NOT here**, though that wheel ships a module
+#: Both spellings of XLM-RoBERTa are listed because both occur in the wild:
+#: the Hub's canonical `model_type` is `xlm-roberta` (checked on
+#: `mlx-community/multilingual-e5-base-mlx`) while the library's own module
+#: is `xlm_roberta`, and its loader normalises one to the other.
+#:
+#: **`siglip` is deliberately absent**, though the same wheel ships a module
 #: for it: SigLIP belongs to the OTHER capability (`registry.EMBEDDINGS`,
 #: served by `mlx-embed`), and claiming it here would put one repo in two
 #: capabilities' loader lists and let the AI Models page offer a dual encoder
-#: as a text embedder. The split between the two capabilities is the whole
-#: decision this section rests on; this frozenset is where it is enforced
-#: against the bytes.
-#:
-#: `colidefics3`, `colqwen2_5`, `qwen3_vl` and `llama_nemotron_vl` are also
-#: absent, and for a related reason: they are multimodal or late-interaction
-#: models whose output is a MATRIX of per-token vectors rather than one
-#: vector per text, which is not the contract `/api/ai/embed-text` publishes.
-MLX_TEXT_EMBED_MODEL_TYPES = frozenset({
-    "bert", "modernbert", "xlm-roberta", "xlm_roberta", "qwen3",
-    "gemma3_text", "lfm2", "llama_bidirec",
+#: as a text embedder.
+MLX_TEXT_ENCODER_MODEL_TYPES = frozenset({
+    "bert", "modernbert", "xlm-roberta", "xlm_roberta",
 })
 
+#: …and the `model_type` values `mlx-embeddings` can ALSO open, which are
+#: shared letter-for-letter with causal chat models this app already serves
+#: through `mlx-text`.
+#:
+#: **This is the safetensors twin of the `qwen3` problem
+#: `gguf_pooling_type`'s docstring describes**, and it is worse here, because
+#: there is no header key to settle it. Checked directly on 2026-08-23:
+#: `mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ` declares
+#: `model_type: qwen3` and `architectures: ["Qwen3ForCausalLM"]`, and ships a
+#: `chat_template.jinja` and a `generation_config.json` — a config file for
+#: file identical in shape to an ordinary Qwen3 chat checkpoint. On the config
+#: alone the two are the same repo.
+#:
+#: So a repo in THIS set is claimed only with a second signal
+#: (`ST_SIDECAR_NAMES` below), and a repo that has none falls through to
+#: `mlx-text` — a text embedder mis-tagged as a chat model on the AI Models
+#: page, which is the mild failure. The alternative direction is not mild:
+#: claiming every `qwen3` checkpoint in the local cache would put a
+#: text-embedding Load button on every Qwen3 chat model a user has ever
+#: downloaded.
+#:
+#: `colidefics3`, `colqwen2_5`, `qwen3_vl` and `llama_nemotron_vl` are in
+#: neither set, for a different reason again: they are multimodal or
+#: late-interaction models whose output is a MATRIX of per-token vectors
+#: rather than one vector per text, which is not the contract
+#: `/api/ai/embed-text` publishes.
+MLX_TEXT_EMBED_DECODER_MODEL_TYPES = frozenset({
+    "qwen3", "gemma3_text", "lfm2", "llama_bidirec",
+})
 
-def mlx_text_embed_model_type(config: dict) -> str | None:
+#: Files a sentence-transformers export drops beside its weights, recording
+#: that this checkpoint is meant to be POOLED into one vector rather than
+#: sampled from. Any one of them is the signal.
+#:
+#: **Not `1_Pooling/`, which is what a reader would expect and what a first
+#: draft of this used.** sentence-transformers writes the pooling config into
+#: a `1_Pooling/` subdirectory, but every MLX re-upload checked on 2026-08-23
+#: had flattened the export: `mlx-community/bge-small-en-v1.5-bf16` and
+#: `mlx-community/embeddinggemma-300m-bf16` carry
+#: `config_sentence_transformers.json`, `modules.json` and
+#: `sentence_bert_config.json` at the ROOT and no `1_Pooling/` at all. A
+#: directory check would therefore have matched none of this engine's own
+#: catalog. The directory is still accepted (`loaders()` checks `dirnames`
+#: too) because an unconverted upstream repo does carry it.
+ST_SIDECAR_NAMES = frozenset({
+    "config_sentence_transformers.json",
+    "modules.json",
+    "sentence_bert_config.json",
+})
+
+#: The subdirectory form of the same signal — see `ST_SIDECAR_NAMES`.
+ST_POOLING_DIR = "1_Pooling"
+
+
+def mlx_text_embed_model_type(config: dict, *, pooled: bool = False) -> str | None:
     """The text-encoder family this config declares, or None.
 
     `embed_model_type`'s counterpart for the other capability, and lowercased
@@ -1479,30 +1561,20 @@ def mlx_text_embed_model_type(config: dict) -> str | None:
     exported the checkpoint, and an `XLM-RoBERTa` would otherwise read as an
     unknown family.
 
-    **A `qwen3` config is ambiguous here and this function does not resolve
-    it** — the architecture is shared by Qwen3 chat models and by
-    Qwen3-Embedding, exactly as `gguf_pooling_type`'s docstring describes for
-    the GGUF side. `loaders()` below is where the tie is broken, using
-    evidence this function does not take: a sentence-transformers pooling
-    config sitting beside the weights.
+    `pooled` is the caller's answer to "does a sentence-transformers sidecar
+    sit beside these weights". It is required to claim one of the AMBIGUOUS
+    decoder families and ignored for the encoder-only ones — see the two
+    frozensets above for why the asymmetry is not an inconsistency.
     """
     model_type = config.get("model_type")
     if not isinstance(model_type, str):
         return None
     model_type = model_type.strip().lower()
-    return model_type if model_type in MLX_TEXT_EMBED_MODEL_TYPES else None
-
-
-#: The file a sentence-transformers export drops beside its weights to record
-#: HOW to pool the encoder's per-token output into one vector. Its presence is
-#: the safetensors-side equivalent of a GGUF's `pooling_type` key: an ordinary
-#: causal checkpoint has no such file, and a repo published to be embedded
-#: with does.
-#:
-#: A DIRECTORY name, not a file — sentence-transformers writes
-#: `1_Pooling/config.json`, and `loaders()` is handed the snapshot's top-level
-#: `dirnames` already, so this costs no extra I/O in the one place it is read.
-ST_POOLING_DIR = "1_Pooling"
+    if model_type in MLX_TEXT_ENCODER_MODEL_TYPES:
+        return model_type
+    if pooled and model_type in MLX_TEXT_EMBED_DECODER_MODEL_TYPES:
+        return model_type
+    return None
 
 
 def loaders(*, repo_id: str, names, dirnames, config: dict, torch_weights: bool,
@@ -1580,25 +1652,22 @@ def loaders(*, repo_id: str, names, dirnames, config: dict, torch_weights: bool,
         # runner, offered by nothing — not "matches nothing here so fall
         # through to whatever else recognises the file layout."
         return tuple(found)
-    # A sentence-transformers TEXT encoder, for `mlx-text-embed` — asked
-    # before the dual-encoder branch below because the two are different
-    # capabilities reading different repos, and this is the narrower claim:
-    # it requires a `1_Pooling/` directory, which SigLIP and CLIP exports do
-    # not carry (their pooling is inside the checkpoint's own projection
-    # head, not a sidecar).
+    # A text encoder, for `mlx-text-embed` — asked before the dual-encoder
+    # branch below because the two are different capabilities reading
+    # different repos, and this is the narrower claim: SigLIP and CLIP
+    # exports carry no sentence-transformers sidecar and are not an
+    # encoder-only `model_type` either, so neither half of this condition can
+    # match one.
     #
-    # **The pooling directory is REQUIRED and that is what makes this branch
-    # safe.** `MLX_TEXT_EMBED_MODEL_TYPES` contains `qwen3`, `gemma3_text`
-    # and `lfm2` — architectures shared, letter for letter, with chat models
-    # this app already serves through `mlx-text`. On `model_type` alone this
-    # branch would claim every Qwen3 checkpoint in the local cache and offer
-    # to load a chat model as an encoder. `1_Pooling/config.json` is written
-    # by the sentence-transformers exporter and by nothing else, so it is the
-    # safetensors-side counterpart of the GGUF pooling key the branch at the
-    # top of this function turns on — the same distinction, the same
-    # evidence, read out of a different container.
-    if (torch_weights and ST_POOLING_DIR in dirnames
-            and mlx_text_embed_model_type(config)):
+    # The `pooled` evidence is what keeps `qwen3`/`gemma3_text`/`lfm2` from
+    # claiming every chat checkpoint in the local cache — see
+    # `MLX_TEXT_EMBED_DECODER_MODEL_TYPES`, which is where that whole argument
+    # lives. An encoder-only `model_type` needs no such evidence and is
+    # allowed through without it, which is why this reads the sidecar
+    # unconditionally and lets `mlx_text_embed_model_type` decide whether it
+    # mattered.
+    pooled = bool(ST_SIDECAR_NAMES & set(names)) or ST_POOLING_DIR in dirnames
+    if torch_weights and mlx_text_embed_model_type(config, pooled=pooled):
         found.append("mlx-text-embed")
         # …and NOTHING else, for the `.gguf` branch's reason: this snapshot
         # is a directory of safetensors with a config, so the `mlx-text`

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -422,8 +422,12 @@ def _gguf_uint_by_suffix(path: str, suffix: str) -> int | None:
     is "cannot tell", never a crash and never a guess. That last case matters
     more than it looks — the peek is a fixed `_GGUF_HEADER_PEEK_BYTES` window
     and a GGUF's tokenizer arrays are megabytes wide, so a key that sorts
-    after them is simply not visible from here and reads as None. Both keys
-    this is used for sit in the architecture block, ahead of the tokenizer.
+    after them is simply not visible from here and reads as None. Every key
+    this is used for — `block_count`, `expert_count`, `pooling_type` and
+    `context_length` — sits in the architecture block, ahead of the
+    tokenizer. Checked directly for the last two against four published
+    embedding GGUFs, including a 151k-vocabulary Qwen3-Embedding whose
+    header does overflow the window.
     """
     return gguf_uint_by_suffix_in(_gguf_peek(path), suffix)
 
@@ -431,8 +435,8 @@ def _gguf_uint_by_suffix(path: str, suffix: str) -> int | None:
 def _gguf_peek(path: str) -> bytes:
     """The first `_GGUF_HEADER_PEEK_BYTES` of `path`, or `b""` if unreadable.
 
-    The one place the local read happens, so the four public readers above
-    and below differ only in which key they look for. `b""` for an
+    The one place the local read happens, so the public readers above and
+    below differ only in which key they look for. `b""` for an
     unreadable file rather than a raise: every caller's contract is already
     "None means cannot tell", and empty bytes reach that answer through the
     same code path a truncated or non-GGUF file does.
@@ -924,7 +928,11 @@ def gguf_recipe(model_id: str) -> dict | None:
     bare repo id cannot address the one this app curates), and at least four
     places in the server have to translate a filename id back to its repo:
     `hub_cache.is_downloaded`, `catalog.mirror_id`,
-    `ai_runtime._catalog_with_downloads` and the Benchmark tab's own guard.
+    `ai_runtime._catalog_with_downloads` and
+    `ai_benchmark._benchmarkable_ids`. All four now call this; the last of
+    them did not until a review caught it, and the symptom was the one
+    described below — a curated text-embedding model that was on disk and
+    still could not be benchmarked.
 
     Each of those was written against `GGUF_RECIPES` alone, and each fails
     QUIETLY for an id the other table owns rather than raising — a curated
@@ -1191,8 +1199,15 @@ GGUF_EMBED_SUFFIX_PRIORITY = (
 def _embedding_gguf_rank(filename: str) -> int | None:
     """`filename`'s position in `GGUF_EMBED_SUFFIX_PRIORITY`, or None.
 
-    A plain longest-suffix match on the stem rather than
-    `_GGUF_QUANT_TOKEN_RE`'s structured parse, because the two lists have
+    A plain `endswith` scan in PRIORITY ORDER — first hit wins, which is not
+    the same as the longest match: `…-BF16.gguf` is caught by the `F16`
+    entry before the scan reaches `BF16`. That costs nothing here, because
+    the two rank adjacently and a repo publishing BF16 almost never also
+    publishes F16, but a reordering of the list would change which entry
+    claims it — so keep near-duplicates adjacent.
+
+    Deliberately not `_GGUF_QUANT_TOKEN_RE`'s structured parse, because the
+    two lists have
     different jobs: that regex exists to recognise families and unsloth's
     `UD-` dynamic quants across a chat ecosystem that publishes two dozen
     tiers per repo, and an embedding repo publishes four. Every suffix an
@@ -1342,7 +1357,35 @@ DECISIVE = ("faster-whisper", "mlx-whisper", "mflux-image", "diffusers-image",
             # `DIFFUSERS_RUNNERS`' reason — membership is a statement about the
             # FORMAT, and a config saying `siglip` says the same thing whichever
             # of the two engines opens it.
-            "mlx-embed", "transformers-embed")
+            "mlx-embed", "transformers-embed",
+            # The text-embedding rows, decisive for a reason this table has not
+            # needed before — worth stating, because the obvious reading ("a
+            # root `.gguf` is already covered two entries up") is wrong, and
+            # leaving them out costs a Load button.
+            #
+            # `_format_task` (`hub_cache.py`) returns None for a GGUF snapshot:
+            # `download_file` fetches the ONE `.gguf` and nothing else, so
+            # there is no README and no config for a `pipeline_tag` to be read
+            # out of. A cached repo's capability therefore comes from
+            # `_engine`, which intersects `meta.loaders` with THIS tuple — so a
+            # code missing here leaves `decisive` empty, `_engine` answers
+            # `(None, None)`, and the Local tab draws a curated model the user
+            # has just downloaded with no task, no engine tag and no Load
+            # button. `cached_capability` still recovers it through its own
+            # `meta.loaders` fallback, so the card and the load route disagree,
+            # which is exactly the split `_engine`'s docstring says must be
+            # impossible.
+            #
+            # Both llama.cpp builds, for the reason every pair above is listed
+            # whole: membership is a statement about the FORMAT.
+            # `mlx-text-embed` joins them and is the one entry here that is not
+            # decisive from a file EXTENSION — a text encoder is a directory of
+            # safetensors, the very case `mlx-text` is excluded for. It is
+            # decisive all the same, because `loaders()` names it only after
+            # finding an encoder-only `model_type` or a sentence-transformers
+            # sidecar. This tuple reads that branch's answer, not the
+            # extension.
+            "llamacpp-embed", "llamacpp-embed-vulkan", "mlx-text-embed")
 
 
 def unloadable_quant(config: dict) -> str | None:

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -425,11 +425,38 @@ def _gguf_uint_by_suffix(path: str, suffix: str) -> int | None:
     after them is simply not visible from here and reads as None. Both keys
     this is used for sit in the architecture block, ahead of the tokenizer.
     """
+    return gguf_uint_by_suffix_in(_gguf_peek(path), suffix)
+
+
+def _gguf_peek(path: str) -> bytes:
+    """The first `_GGUF_HEADER_PEEK_BYTES` of `path`, or `b""` if unreadable.
+
+    The one place the local read happens, so the four public readers above
+    and below differ only in which key they look for. `b""` for an
+    unreadable file rather than a raise: every caller's contract is already
+    "None means cannot tell", and empty bytes reach that answer through the
+    same code path a truncated or non-GGUF file does.
+    """
     try:
         with open(path, "rb") as handle:
-            buf = handle.read(_GGUF_HEADER_PEEK_BYTES)
+            return handle.read(_GGUF_HEADER_PEEK_BYTES)
     except OSError:
-        return None
+        return b""
+
+
+def gguf_uint_by_suffix_in(buf: bytes, suffix: str) -> int | None:
+    """`_gguf_uint_by_suffix`, over header bytes already in hand.
+
+    **The bytes-taking form is public and the path-taking one is not**,
+    which is the opposite of how this module's other pairs are arranged, and
+    it is because of who calls it. `runners/llama_embed.py` has to answer
+    "is this an embedding model" for a file that is NOT on the disk yet — it
+    reads a 2MB `Range` request off the Hub and refuses a bad repo before
+    the multi-gigabyte download starts, which is the whole of that runner's
+    up-front-refusal contract. It therefore has header bytes and no path,
+    and the alternative to this function is writing those bytes to a
+    temporary file so a path-shaped parser can read them back.
+    """
     try:
         if buf[:4] != b"GGUF":
             return None
@@ -442,6 +469,27 @@ def _gguf_uint_by_suffix(path: str, suffix: str) -> int | None:
             if key.endswith(suffix) and value_type in (4, 5):
                 fmt = "<I" if value_type == 4 else "<i"
                 (value,) = struct.unpack_from(fmt, buf, offset)
+                return value
+            offset = _gguf_skip_value(buf, offset, value_type)
+    except (struct.error, IndexError, UnicodeDecodeError):
+        return None
+    return None
+
+
+def gguf_architecture_in(buf: bytes) -> str | None:
+    """`gguf_architecture`, over header bytes already in hand — see
+    `gguf_uint_by_suffix_in` for why the bytes-taking form is the public one."""
+    try:
+        if buf[:4] != b"GGUF":
+            return None
+        (kv_count,) = struct.unpack_from("<Q", buf, 16)
+        offset = 24
+        for _ in range(kv_count):
+            key, offset = _gguf_read_string(buf, offset)
+            (value_type,) = struct.unpack_from("<I", buf, offset)
+            offset += 4
+            if key == "general.architecture" and value_type == _GGUF_TYPE_STRING:
+                value, _offset = _gguf_read_string(buf, offset)
                 return value
             offset = _gguf_skip_value(buf, offset, value_type)
     except (struct.error, IndexError, UnicodeDecodeError):
@@ -467,27 +515,7 @@ def gguf_architecture(path: str) -> str | None:
     fail in: a real text GGUF this cannot classify loses a Load button, an
     image or speech GGUF never gains one it would fail.
     """
-    try:
-        with open(path, "rb") as handle:
-            buf = handle.read(_GGUF_HEADER_PEEK_BYTES)
-    except OSError:
-        return None
-    try:
-        if buf[:4] != b"GGUF":
-            return None
-        (kv_count,) = struct.unpack_from("<Q", buf, 16)
-        offset = 24
-        for _ in range(kv_count):
-            key, offset = _gguf_read_string(buf, offset)
-            (value_type,) = struct.unpack_from("<I", buf, offset)
-            offset += 4
-            if key == "general.architecture" and value_type == _GGUF_TYPE_STRING:
-                value, _offset = _gguf_read_string(buf, offset)
-                return value
-            offset = _gguf_skip_value(buf, offset, value_type)
-    except (struct.error, IndexError, UnicodeDecodeError):
-        return None
-    return None
+    return gguf_architecture_in(_gguf_peek(path))
 
 
 def is_text_gguf(path: str) -> bool:
@@ -546,6 +574,296 @@ def gguf_expert_count(path: str) -> int | None:
     `gguf_block_count` — see `_gguf_uint_by_suffix`.
     """
     return _gguf_uint_by_suffix(path, ".expert_count")
+
+
+# ---------------------------------------------------------------------------
+# Text embedding GGUFs (SPEC §40) — the `text-embeddings` capability's own
+# format question, kept apart from every function above it.
+#
+# **Why this sits beside `GGUF_TEXT_ARCHITECTURES` rather than inside it.**
+# `text-embeddings` is a SEPARATE capability from `embeddings` (see
+# `registry.TEXT_EMBEDDINGS` for that decision) and a separate one again from
+# `text-generation`, and this module is where the difference has to be
+# decidable from the bytes. An embedding GGUF and a chat GGUF are the same
+# file format, produced by the same converter, and — for the family that
+# matters most here — carry the SAME `general.architecture`.
+
+
+#: `<arch>.pooling_type` values, from llama.cpp's own `llama_pooling_type`
+#: enum (`include/llama.h` at the commit `llama-cpp-python==0.3.29` vendors,
+#: `f05cf467`). Named rather than left as bare integers because the whole of
+#: `is_embedding_gguf`'s decision is which of these a file declares, and a
+#: `2` on its own says nothing to a reader.
+GGUF_POOLING_UNSPECIFIED = -1
+GGUF_POOLING_NONE = 0
+GGUF_POOLING_MEAN = 1
+GGUF_POOLING_CLS = 2
+GGUF_POOLING_LAST = 3
+#: A RERANKER, not an embedding model — a cross-encoder that scores a
+#: (query, document) PAIR and has no per-text vector to return at all. It is
+#: in this enum because llama.cpp serves both from one file format, and it is
+#: excluded below for exactly that reason.
+GGUF_POOLING_RANK = 4
+
+#: The pooling types this capability can turn into one vector per text. MEAN,
+#: CLS and LAST are the three real families — mean-pooled encoders
+#: (nomic-embed, e5, EmbeddingGemma), CLS-pooled encoders (the bge family),
+#: and last-token pooling on a decoder (Qwen3-Embedding). NONE returns
+#: per-TOKEN states rather than a sentence vector, UNSPECIFIED means the
+#: converter wrote no opinion, and RANK is a reranker — none of the three is
+#: a text embedding model in the sense this capability serves.
+GGUF_EMBED_POOLING_TYPES = frozenset({
+    GGUF_POOLING_MEAN, GGUF_POOLING_CLS, GGUF_POOLING_LAST})
+
+
+def gguf_pooling_type(path: str) -> int | None:
+    """`<arch>.pooling_type` out of a GGUF's own header, or None if absent.
+
+    **This key, and NOT `general.architecture`, is what tells a text
+    embedding GGUF from a chat one** — a finding rather than a preference.
+    The real header bytes of four published embedding GGUFs, read on
+    2026-08-23 through the same bounded peek this function does (over an HTTP
+    `Range` request rather than off the disk, which is the only difference):
+
+        CompendiumLabs/bge-small-en-v1.5-gguf   bert             pooling 2 (CLS)
+        nomic-ai/nomic-embed-text-v1.5-GGUF     nomic-bert       pooling 1 (MEAN)
+        ggml-org/embeddinggemma-300M-GGUF       gemma-embedding  pooling 1 (MEAN)
+        Qwen/Qwen3-Embedding-0.6B-GGUF          qwen3            pooling 3 (LAST)
+
+    Look at the last row. `qwen3` is IN `GGUF_TEXT_ARCHITECTURES` — it is the
+    architecture of the Qwen3 CHAT models this app already serves — so an
+    architecture allowlist cannot separate `Qwen3-Embedding-0.6B` from an
+    ordinary Qwen3 instruct model. The converter writes `qwen3.pooling_type`
+    for one and no pooling key at all for the other, so the pooling key is
+    the only signal IN THE FILE that answers the question this capability has
+    to ask. An architecture list would also have had to grow a row every time
+    another decoder family shipped an embedding variant, which is exactly the
+    maintenance shape `GGUF_TEXT_ARCHITECTURES`' own docstring argues against.
+
+    Matched by SUFFIX like `gguf_block_count` and `gguf_expert_count`, and
+    visible from the same bounded peek: the key sits in the architecture
+    block, ahead of the tokenizer arrays that make a large-vocabulary header
+    overflow the window. Checked on the Qwen3-Embedding file above, whose
+    151k-token vocabulary DOES overflow it — the pooling key was read at
+    position 25 of 36 keys, well before the read ran out.
+
+    Same fail-toward-None contract as its two siblings: a truncated read, a
+    value type this app does not model, or a file that is not a GGUF at all
+    are all "cannot tell", never a crash and never a guess. Callers must read
+    None as "no pooling declared", which `is_embedding_gguf` treats as NOT an
+    embedding model — the safe direction, since a false negative costs a user
+    one model they must name by hand, and a false positive is a chat model
+    loaded as an encoder and quietly returning meaningless vectors.
+    """
+    return _gguf_uint_by_suffix(path, ".pooling_type")
+
+
+def gguf_context_length(path: str) -> int | None:
+    """`<arch>.context_length` out of a GGUF's own header, or None.
+
+    **Why an EMBEDDING runner needs this when the chat runner does not.**
+    `llama_text` pins `_N_CTX = 8192` and lets llama.cpp truncate: a chat
+    model's context is a budget for a conversation, and asking for less than
+    the model supports costs history nobody has written yet. An embedding
+    call is the opposite shape — one text in, one vector out — and llama.cpp
+    requires the whole text to fit in a SINGLE batch to pool it, so `n_ctx`
+    here is not a budget but a per-item length limit. Pinning one number
+    across the catalog would truncate an 8192-token nomic passage at a bge
+    model's 512, or allocate a 32k Qwen3-Embedding context for a page
+    embedding one-line labels.
+
+    Same suffix match, same bounded peek and the same fail-toward-None
+    contract as `gguf_block_count`, and callers must read None the same way:
+    "no sizing information", never zero. `llama_embed.load` falls back to a
+    conservative fixed value on None rather than treating it as a limit.
+    """
+    return _gguf_uint_by_suffix(path, ".context_length")
+
+
+def is_embedding_gguf(path: str) -> bool:
+    """Would `llamacpp-embed` actually load this GGUF — checked, not assumed.
+
+    The counterpart to `is_text_gguf`, and DISJOINT from it on every file
+    either is right about: a chat GGUF declares no pooling type at all. See
+    `gguf_pooling_type` for why the pooling key rather than the architecture
+    is what this reads.
+    """
+    return gguf_pooling_type(path) in GGUF_EMBED_POOLING_TYPES
+
+
+#: The prompt a retrieval model wants in front of a QUERY and in front of a
+#: DOCUMENT, by scheme name.
+#:
+#: **Retrieval encoders are asymmetric and this is not a detail.** A question
+#: and the passage that answers it are different kinds of text, and every
+#: model named here was trained with that difference spelled out in its
+#: input. Embedding both sides identically costs real recall on the models
+#: that instruct one side — and costs it SILENTLY, which is the part that
+#: matters: the vectors still come back, still unit length, still comparable,
+#: just worse. Nothing downstream can detect it.
+#:
+#: Each value is `(query_prefix, document_prefix)`, applied by plain
+#: concatenation — no template engine, because every scheme here is literally
+#: a string glued to the front, checked against each model's own card.
+#:
+#: `"none"` is a REAL scheme and the fallback, not an absence: a model whose
+#: convention this table does not know is embedded verbatim on both sides,
+#: which is the symmetric behaviour every encoder supports and the only
+#: honest answer for a repo nobody here has read the card for. Guessing a
+#: prefix would be worse than not prefixing — a wrong instruction is not
+#: ignored, it is text the model dutifully encodes as though it were content.
+TEXT_EMBED_PROMPTS = {
+    "none": ("", ""),
+    # bge v1.5. The card instructs the QUERY only and says in as many words
+    # that the passage side takes none ("no instruction needed for
+    # passages"), so this is the one asymmetric scheme whose document branch
+    # is genuinely the empty string rather than a second prefix.
+    "bge": ("Represent this sentence for searching relevant passages: ", ""),
+    # nomic-embed-text v1 and v1.5. Its card is explicit that the task
+    # prefixes are REQUIRED rather than advisory — the model was trained
+    # multi-task and the prefix is what selects the task, so an unprefixed
+    # call is out of distribution on both sides, not merely un-tuned.
+    "nomic": ("search_query: ", "search_document: "),
+    # The e5 family (intfloat/e5-*-v2, multilingual-e5-*). Both sides
+    # prefixed, and the card warns that swapping the two is worse than using
+    # neither.
+    "e5": ("query: ", "passage: "),
+    # Qwen3-Embedding ships NAMED prompts in
+    # `config_sentence_transformers.json` (`query` and `document`); the query
+    # one is an instruction block and the document one is empty. The task
+    # sentence is Qwen's own default out of that file, kept verbatim rather
+    # than reworded — it is part of what the model was tuned against, not a
+    # comment this app is free to improve.
+    "qwen3": ("Instruct: Given a web search query, retrieve relevant passages "
+              "that answer the query\nQuery:", ""),
+    # EmbeddingGemma's card gives a prompt per task; these are its
+    # `Retrieval-query` and `Retrieval-document` forms. The document form
+    # ends at `text: ` because the card's template carries an optional
+    # `title:` ahead of it, and `none` is what that field takes when there is
+    # no title — which is always, here, since this API takes a flat list of
+    # strings and has nowhere for a caller to put one.
+    "gemma-embedding": ("task: search result | query: ", "title: none | text: "),
+}
+
+#: The two values `kind` may take. A closed set, checked at the edge
+#: (`text_embed_common.request_texts`) rather than defaulted through, because
+#: a typo'd `"queries"` silently falling back to the document prefix is the
+#: exact silent-degradation failure this whole table exists to prevent.
+TEXT_EMBED_KINDS = ("query", "document")
+
+#: What a caller who says nothing gets. See `text_embed_common.DEFAULT_KIND`
+#: for why it is this one.
+TEXT_EMBED_DEFAULT_KIND = "document"
+
+
+def text_embed_prompt(scheme: str, kind: str) -> str:
+    """The prefix to glue in front of one text, for `scheme` and `kind`.
+
+    An unknown scheme falls back to `"none"` rather than raising: this is
+    reached from a worker holding a resident model with a validated batch in
+    hand, and a scheme name that has drifted out of the table is a reason to
+    embed plainly, not to fail a call that would otherwise work.
+    """
+    query, document = TEXT_EMBED_PROMPTS.get(scheme) or TEXT_EMBED_PROMPTS["none"]
+    return query if kind == "query" else document
+
+
+#: Substrings of a model FILENAME that identify a prompt scheme, most
+#: specific first — the fallback for a repo `TEXT_EMBED_RECIPES` below does
+#: not curate.
+#:
+#: **A heuristic, and named as one.** A model's prompt convention is a fact
+#: about its training that the GGUF header records nowhere, so for an
+#: uncurated repo the filename is the only evidence there is. It is
+#: reasonable evidence — a GGUF conversion is named after the model it
+#: converts, near universally — but it is evidence and not proof, which is
+#: why the scheme actually applied travels back on every reply
+#: (`llama_embed.generate`'s `promptScheme`) rather than being applied out of
+#: sight. A caller who sees the wrong one can name a curated id instead.
+#:
+#: `qwen3-embedding` ahead of any bare `qwen3` and `nomic-embed` ahead of any
+#: bare `nomic` for the obvious reason; the e5 hints are spelled with their
+#: size suffix rather than as a bare `e5` because two letters that common
+#: match filenames with nothing to do with the family.
+TEXT_EMBED_SCHEME_HINTS = (
+    ("qwen3-embedding", "qwen3"),
+    ("embeddinggemma", "gemma-embedding"),
+    ("gemma-embedding", "gemma-embedding"),
+    ("nomic-embed", "nomic"),
+    ("multilingual-e5", "e5"),
+    ("e5-small", "e5"),
+    ("e5-base", "e5"),
+    ("e5-large", "e5"),
+    # bge-m3 is the family member that takes NO query instruction — its card
+    # says so outright — so it must not inherit the `bge` scheme below by
+    # substring. Ordered ahead of `bge-` for exactly that.
+    ("bge-m3", "none"),
+    ("bge-", "bge"),
+)
+
+
+def text_embed_scheme(model_id: str, filename: str = "") -> str:
+    """The prompt scheme for a model — the curated table, then the filename.
+
+    Curated first: `TEXT_EMBED_RECIPES` states the scheme outright for every
+    id this app recommends, so the heuristic never runs for the models most
+    people will ever load. Everything else falls to
+    `TEXT_EMBED_SCHEME_HINTS` over the filename and the repo id together, and
+    finally to `"none"`.
+
+    Lowercased on both sides: GGUF uploaders capitalise inconsistently, and a
+    scheme that turned on that would be precisely the silent wrong answer
+    this table exists to avoid.
+    """
+    recipe = TEXT_EMBED_RECIPES.get(model_id)
+    if recipe:
+        return recipe["scheme"]
+    haystack = f"{filename} {model_id}".lower()
+    for hint, scheme in TEXT_EMBED_SCHEME_HINTS:
+        if hint in haystack:
+            return scheme
+    return "none"
+
+
+#: Curated `(repo, file, scheme)` triples `runners/llama_embed.py` downloads,
+#: keyed by the GGUF's own filename — the identical id shape, and the
+#: identical reasoning, as `GGUF_RECIPES` below, which see. The extra field
+#: is `scheme`: unlike a chat model, an embedding model's prompt convention
+#: is part of what makes its vectors good and is recorded nowhere in the file.
+#:
+#: **Every quantization here is Q8_0, which is the opposite of the chat
+#: list's rule and is deliberate.** `GGUF_RECIPES` leads with Q4_K_M because
+#: a chat model's weights are gigabytes and Q4 is the difference between
+#: running and not running. These are tens of MEGABYTES — the whole of the
+#: largest entry here is a quarter of the SMALLEST chat entry — so a harder
+#: quantization buys nothing anyone would notice and costs retrieval quality
+#: that lands directly in the vector, where there is no sampling step
+#: afterwards to absorb it.
+#:
+#: Sizes and gating checked against the Hub's own per-file metadata on
+#: 2026-08-23; all three repos are ungated, and each file is a single
+#: root-level `.gguf` rather than a shard, because `worker_base.download_file`
+#: takes one filename and a sharded tier would be silently unloadable.
+#: `test_ai_formats.py` asserts every id here also appears in
+#: `catalog.SUGGESTIONS["llamacpp-embed"]`, so the two cannot drift — the
+#: same pin `GGUF_RECIPES` has.
+TEXT_EMBED_RECIPES = {
+    "nomic-embed-text-v1.5.Q8_0.gguf": {
+        "repo": "nomic-ai/nomic-embed-text-v1.5-GGUF",
+        "file": "nomic-embed-text-v1.5.Q8_0.gguf",
+        "scheme": "nomic",
+    },
+    "embeddinggemma-300M-Q8_0.gguf": {
+        "repo": "ggml-org/embeddinggemma-300M-GGUF",
+        "file": "embeddinggemma-300M-Q8_0.gguf",
+        "scheme": "gemma-embedding",
+    },
+    "Qwen3-Embedding-0.6B-Q8_0.gguf": {
+        "repo": "Qwen/Qwen3-Embedding-0.6B-GGUF",
+        "file": "Qwen3-Embedding-0.6B-Q8_0.gguf",
+        "scheme": "qwen3",
+    },
+}
 
 
 #: Curated `(repo, file)` pairs `runners/llama_text.py` actually
@@ -816,6 +1134,93 @@ def pick_gguf_file(filenames) -> str | None:
     return None
 
 
+#: Quantization suffixes `pick_embedding_gguf_file` will choose between,
+#: MOST-preferred first — and it is nearly the REVERSE of
+#: `GGUF_SUFFIX_PRIORITY`, which is the point of having a second list rather
+#: than a flag on the first.
+#:
+#: **Why the preference inverts.** `GGUF_SUFFIX_PRIORITY` ranks `Q4_K_M`
+#: first because a chat model is gigabytes and the download is the binding
+#: cost; `Q6_K`/`Q8_0` sit at the bottom there as "closer to unquantized than
+#: to the sweet spot". An embedding model is tens of megabytes, so the
+#: download is not a cost anyone feels — while quantization error lands
+#: DIRECTLY in the vector this capability returns, with no sampling step
+#: after it to absorb the damage the way a token loop has. A Q4 embedding
+#: model is a worse answer for the same wall-clock and a saving nobody
+#: noticed.
+#:
+#: `Q8_0` leads rather than `F16`: it is within noise of full precision for
+#: this use and half the bytes. `F32` is ranked LAST among eligible files,
+#: below even Q4 — it is exactly twice `F16` for weights that were trained in
+#: half precision anyway, so choosing it is paying double for nothing at all.
+GGUF_EMBED_SUFFIX_PRIORITY = (
+    "Q8_0", "Q6_K", "F16", "BF16", "Q5_K_M", "Q5_K_S", "Q5_1", "Q5_0",
+    "Q4_K_M", "Q4_K_S", "Q4_1", "Q4_0", "F32",
+)
+
+
+def _embedding_gguf_rank(filename: str) -> int | None:
+    """`filename`'s position in `GGUF_EMBED_SUFFIX_PRIORITY`, or None.
+
+    A plain longest-suffix match on the stem rather than
+    `_GGUF_QUANT_TOKEN_RE`'s structured parse, because the two lists have
+    different jobs: that regex exists to recognise families and unsloth's
+    `UD-` dynamic quants across a chat ecosystem that publishes two dozen
+    tiers per repo, and an embedding repo publishes four. Every suffix an
+    embedding repo actually ships is a literal in the list above (checked
+    against the four repos named in `gguf_pooling_type`'s docstring), so a
+    literal match is both sufficient and impossible to get subtly wrong.
+
+    Anything unrecognised returns None — EXCLUDED from ranked candidacy, and
+    reachable only through `pick_embedding_gguf_file`'s single-candidate
+    fallback, exactly as in `pick_gguf_file`.
+    """
+    stem = filename[: -len(GGUF_EXTENSION)].upper()
+    for index, suffix in enumerate(GGUF_EMBED_SUFFIX_PRIORITY):
+        if stem.endswith(suffix) or stem.endswith(suffix.replace("_", "-")):
+            return index
+    return None
+
+
+def pick_embedding_gguf_file(filenames) -> str | None:
+    """The one GGUF `filenames` means as a TEXT EMBEDDING model, or None.
+
+    `pick_gguf_file`'s sibling, and it exists rather than being a parameter
+    on that function for one reason with two halves: the quality preference
+    inverts (see `GGUF_EMBED_SUFFIX_PRIORITY`), and the auxiliary-weight
+    exclusions differ in what they are protecting against. Sharing one
+    function behind a flag would have meant a body that reads as two
+    functions anyway, with the flag as the only thing keeping a chat repo's
+    `mmproj` and an embedding repo's `Q4` from being each other's problem.
+
+    Shape exclusions are the SAME three `pick_gguf_file` applies and are
+    applied for the same reasons — a subdirectory entry, a multi-part shard
+    (`worker_base.download_file` fetches one file), and an auxiliary weight.
+    """
+    candidates = []
+    for name in filenames:
+        if not isinstance(name, str) or "/" in name:
+            continue
+        if not name.lower().endswith(GGUF_EXTENSION):
+            continue
+        if GGUF_SPLIT_RE.search(name) or GGUF_AUXILIARY_RE.search(name):
+            continue
+        candidates.append(name)
+    if not candidates:
+        return None
+    ranked = sorted(
+        ((rank, name) for rank, name in
+         ((_embedding_gguf_rank(name), name) for name in candidates)
+         if rank is not None),
+        key=lambda pair: (pair[0], pair[1]),
+    )
+    if ranked:
+        return ranked[0][1]
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
 #: Quantization methods NO engine in this app can read, so a repo declaring one
 #: is not offered a Load button (`loaders()` below) whatever else its snapshot
 #: contains. AWQ, GPTQ and compressed-tensors each need a package no runner
@@ -1037,10 +1442,72 @@ DIFFUSERS_RUNNERS = ("diffusers-image", "diffusers-image-cuda",
 #: `llamacpp-text` here is exactly the trap this comment already describes for
 #: the other two families (see `test_every_registered_runner_appears_in_loaders`).
 LLAMACPP_RUNNERS = ("llamacpp-text", "llamacpp-text-vulkan")
+#: Both llama.cpp EMBEDDING builds, for the reason the pair above states
+#: about itself: the CPU and Vulkan wheels open byte-for-byte the same file,
+#: so a branch that named only one of them would leave the other with no
+#: engine tag and no Load button on precisely the machines that chose it
+#: (see `test_every_registered_runner_appears_in_loaders`).
+LLAMACPP_EMBED_RUNNERS = ("llamacpp-embed", "llamacpp-embed-vulkan")
+
+#: `model_type` values `mlx-text-embed` can open — the text encoders
+#: `mlx-embeddings` 0.1.x ships a module for, read out of the published wheel
+#: (`mlx_embeddings/models/*.py`) rather than from its README, on 2026-08-23.
+#:
+#: **`siglip` is deliberately NOT here**, though that wheel ships a module
+#: for it: SigLIP belongs to the OTHER capability (`registry.EMBEDDINGS`,
+#: served by `mlx-embed`), and claiming it here would put one repo in two
+#: capabilities' loader lists and let the AI Models page offer a dual encoder
+#: as a text embedder. The split between the two capabilities is the whole
+#: decision this section rests on; this frozenset is where it is enforced
+#: against the bytes.
+#:
+#: `colidefics3`, `colqwen2_5`, `qwen3_vl` and `llama_nemotron_vl` are also
+#: absent, and for a related reason: they are multimodal or late-interaction
+#: models whose output is a MATRIX of per-token vectors rather than one
+#: vector per text, which is not the contract `/api/ai/embed-text` publishes.
+MLX_TEXT_EMBED_MODEL_TYPES = frozenset({
+    "bert", "modernbert", "xlm-roberta", "xlm_roberta", "qwen3",
+    "gemma3_text", "lfm2", "llama_bidirec",
+})
+
+
+def mlx_text_embed_model_type(config: dict) -> str | None:
+    """The text-encoder family this config declares, or None.
+
+    `embed_model_type`'s counterpart for the other capability, and lowercased
+    for the same reason that one is: `model_type` is written by whoever
+    exported the checkpoint, and an `XLM-RoBERTa` would otherwise read as an
+    unknown family.
+
+    **A `qwen3` config is ambiguous here and this function does not resolve
+    it** — the architecture is shared by Qwen3 chat models and by
+    Qwen3-Embedding, exactly as `gguf_pooling_type`'s docstring describes for
+    the GGUF side. `loaders()` below is where the tie is broken, using
+    evidence this function does not take: a sentence-transformers pooling
+    config sitting beside the weights.
+    """
+    model_type = config.get("model_type")
+    if not isinstance(model_type, str):
+        return None
+    model_type = model_type.strip().lower()
+    return model_type if model_type in MLX_TEXT_EMBED_MODEL_TYPES else None
+
+
+#: The file a sentence-transformers export drops beside its weights to record
+#: HOW to pool the encoder's per-token output into one vector. Its presence is
+#: the safetensors-side equivalent of a GGUF's `pooling_type` key: an ordinary
+#: causal checkpoint has no such file, and a repo published to be embedded
+#: with does.
+#:
+#: A DIRECTORY name, not a file — sentence-transformers writes
+#: `1_Pooling/config.json`, and `loaders()` is handed the snapshot's top-level
+#: `dirnames` already, so this costs no extra I/O in the one place it is read.
+ST_POOLING_DIR = "1_Pooling"
 
 
 def loaders(*, repo_id: str, names, dirnames, config: dict, torch_weights: bool,
-           gguf_architecture: str | None = None) -> tuple[str, ...]:
+           gguf_architecture: str | None = None,
+           gguf_pooling_type: int | None = None) -> tuple[str, ...]:
     """Which runners' `load()` would accept this snapshot, by code.
 
     Format only: whether such a runner RUNS here, and whether the capability is
@@ -1054,10 +1521,25 @@ def loaders(*, repo_id: str, names, dirnames, config: dict, torch_weights: bool,
     file is I/O this pure evidence-classifier has never otherwise done, and
     the caller (`ai_models.py`) already has the snapshot path this needs.
     `None` when there is no GGUF, or when the caller could not read one.
+    `gguf_pooling_type` is the same arrangement for `gguf_pooling_type()`,
+    and it is what separates an embedding GGUF from a chat one — see that
+    function for why the architecture alone cannot.
     """
     found: list[str] = []
     if has_ct2_weights(names):
         found.append("faster-whisper")
+    # AHEAD of the chat-GGUF branch below, and that order IS the solution to
+    # the `qwen3` problem. `Qwen/Qwen3-Embedding-0.6B-GGUF` declares
+    # `general.architecture = qwen3`, which is in `GGUF_TEXT_ARCHITECTURES`,
+    # so the branch below would claim it as a chat model and the page would
+    # offer to load an encoder into a token loop. A declared pooling type is
+    # the stronger and narrower evidence — a chat GGUF never carries one — so
+    # it is asked first and returns unconditionally, exactly as the chat
+    # branch does against mflux/diffusers for the same class of reason.
+    if (has_gguf_weights(names)
+            and gguf_pooling_type in GGUF_EMBED_POOLING_TYPES):
+        found.extend(LLAMACPP_EMBED_RUNNERS)
+        return tuple(found)
     # Checked EARLY and returned on unconditionally, ahead of mflux/diffusers
     # below: a `.gguf` at the root is llama.cpp's format and nothing else's
     # (`DECISIVE`), and letting it fall through to those checks first is how
@@ -1097,6 +1579,31 @@ def loaders(*, repo_id: str, names, dirnames, config: dict, torch_weights: bool,
         # ASR repo is "a speech model nothing here can load" — matching no
         # runner, offered by nothing — not "matches nothing here so fall
         # through to whatever else recognises the file layout."
+        return tuple(found)
+    # A sentence-transformers TEXT encoder, for `mlx-text-embed` — asked
+    # before the dual-encoder branch below because the two are different
+    # capabilities reading different repos, and this is the narrower claim:
+    # it requires a `1_Pooling/` directory, which SigLIP and CLIP exports do
+    # not carry (their pooling is inside the checkpoint's own projection
+    # head, not a sidecar).
+    #
+    # **The pooling directory is REQUIRED and that is what makes this branch
+    # safe.** `MLX_TEXT_EMBED_MODEL_TYPES` contains `qwen3`, `gemma3_text`
+    # and `lfm2` — architectures shared, letter for letter, with chat models
+    # this app already serves through `mlx-text`. On `model_type` alone this
+    # branch would claim every Qwen3 checkpoint in the local cache and offer
+    # to load a chat model as an encoder. `1_Pooling/config.json` is written
+    # by the sentence-transformers exporter and by nothing else, so it is the
+    # safetensors-side counterpart of the GGUF pooling key the branch at the
+    # top of this function turns on — the same distinction, the same
+    # evidence, read out of a different container.
+    if (torch_weights and ST_POOLING_DIR in dirnames
+            and mlx_text_embed_model_type(config)):
+        found.append("mlx-text-embed")
+        # …and NOTHING else, for the `.gguf` branch's reason: this snapshot
+        # is a directory of safetensors with a config, so the `mlx-text`
+        # branch at the bottom would otherwise claim it too and the page
+        # would offer to load a text encoder as a chat model.
         return tuple(found)
     family = embed_model_type(config)
     if family and torch_weights:

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -844,9 +844,9 @@ def text_embed_scheme(model_id: str, filename: str = "") -> str:
 #: 2026-08-23; all three repos are ungated, and each file is a single
 #: root-level `.gguf` rather than a shard, because `worker_base.download_file`
 #: takes one filename and a sharded tier would be silently unloadable.
-#: `test_ai_formats.py` asserts every id here also appears in
+#: `test_ai_llamacpp_embed_worker.py` asserts every id here also appears in
 #: `catalog.SUGGESTIONS["llamacpp-embed"]`, so the two cannot drift — the
-#: same pin `GGUF_RECIPES` has.
+#: same pin `GGUF_RECIPES` has in `test_ai_llamacpp_worker.py`.
 TEXT_EMBED_RECIPES = {
     "nomic-embed-text-v1.5.Q8_0.gguf": {
         "repo": "nomic-ai/nomic-embed-text-v1.5-GGUF",
@@ -935,8 +935,9 @@ def gguf_recipe(model_id: str) -> dict | None:
 
     The two tables' keys must stay disjoint, which they are by construction
     (chat quantizations and embedding quantizations of different models) and
-    which `test_ai_formats.py` pins — `GGUF_RECIPES` is consulted first, so a
-    collision would resolve to the chat recipe and download the wrong file.
+    which `test_ai_llamacpp_embed_worker.py` pins — `GGUF_RECIPES` is
+    consulted first, so a collision would resolve to the chat recipe and
+    download the wrong file.
     """
     return GGUF_RECIPES.get(model_id) or TEXT_EMBED_RECIPES.get(model_id)
 

--- a/fused_render/ai/runners/llama_embed.py
+++ b/fused_render/ai/runners/llama_embed.py
@@ -225,18 +225,30 @@ def _remote_header(repo_id, filename):
     being a download: the Hub answers `206 Partial Content` with exactly the
     requested bytes (checked directly, 2026-08-23).
 
-    `b""` for ANY failure — no network, a mirror that ignores `Range` and
-    starts streaming the whole file, an odd status, a timeout. That is not
-    defensiveness for its own sake; it is the contract the module docstring
-    states: a refusal must rest on evidence, so "could not look" resolves to
-    "do not refuse" and lets the load-time check answer instead. The timeout
-    is short for the same reason — a slow Hub should delay a download by
-    seconds, not replace it with a failure.
+    **Only `206 Partial Content` counts, and a plain `200` is treated as a
+    failure to look.** That is the whole of what bounds this read. A 206 is
+    the server saying it honoured the `Range`, so the body cannot be larger
+    than the 2MB asked for; a 200 is a server that ignored it and is about to
+    hand over the entire multi-gigabyte file, which is precisely what a
+    function whose job is to AVOID a download must not accept. Rejecting 200
+    is therefore not fastidiousness about status codes — it is the memory
+    bound, expressed in the one place the protocol actually guarantees it.
 
-    Streamed with `stream=True` and read to a hard cap rather than trusted to
-    honour `Range`: a server that ignores the header would otherwise pull a
-    multi-gigabyte file into memory inside a function whose whole job is to
-    avoid downloading it.
+    (An earlier draft asked for `stream=True` and read to a cap instead. That
+    is the `requests` spelling, and `huggingface_hub` 1.x's `get_session()`
+    returns an **httpx.Client**, whose `get()` has no such keyword — so every
+    call raised `TypeError`, the broad `except` below turned it into `b""`,
+    and the peek silently never ran. Caught by driving a real chat GGUF
+    through the running server and watching it start downloading instead of
+    refusing. Requiring 206 needs no streaming API at all, so it is correct on
+    both clients.)
+
+    `b""` for ANY failure — no network, a mirror that ignores `Range`, an odd
+    status, a timeout. That is not defensiveness for its own sake; it is the
+    contract the module docstring states: a refusal must rest on evidence, so
+    "could not look" resolves to "do not refuse" and lets the load-time check
+    answer instead. The timeout is short for the same reason — a slow Hub
+    should delay a download by seconds, not replace it with a failure.
     """
     try:
         from huggingface_hub import hf_hub_url
@@ -245,11 +257,17 @@ def _remote_header(repo_id, filename):
         url = hf_hub_url(repo_id, filename)
         headers = dict(build_hf_headers() or {})
         headers["Range"] = f"bytes=0-{formats._GGUF_HEADER_PEEK_BYTES - 1}"
-        response = get_session().get(url, headers=headers, timeout=20, stream=True)
-        if response.status_code not in (200, 206):
+        # No redirect keyword, deliberately: `requests` spells it
+        # `allow_redirects` and `httpx` spells it `follow_redirects`, and
+        # `huggingface_hub` has shipped both clients — naming either one is
+        # the same TypeError-into-silence trap described above. Neither is
+        # needed; hf's own session already follows the Hub's `resolve/main`
+        # redirect to the CDN (checked: a bare `get` returns 206 with the
+        # requested bytes).
+        response = get_session().get(url, headers=headers, timeout=20)
+        if response.status_code != 206:
             return b""
-        with response:
-            return response.raw.read(formats._GGUF_HEADER_PEEK_BYTES) or b""
+        return response.content[:formats._GGUF_HEADER_PEEK_BYTES]
     except Exception:  # noqa: BLE001 - see the docstring: any failure to LOOK
                        # must read as "no evidence", never as a refusal
         return b""

--- a/fused_render/ai/runners/llama_embed.py
+++ b/fused_render/ai/runners/llama_embed.py
@@ -1,0 +1,522 @@
+"""Text embeddings on llama.cpp / GGUF: one resident encoder, one route (SPEC §40).
+
+**This module is the whole of the runner and it sits at the runners ROOT**,
+beside `worker_base.py`, `formats.py` and `llama_text.py`: TWO folders serve
+this one engine — `llamacpp_embed/` and `llamacpp_embed_vulkan/` — and each
+holds only a `pyproject.toml` and a five-line `worker.py` shell around
+`main()` below. They differ in which wheel index their manifest takes
+`llama-cpp-python` from, and the hardware that names is a fact about the
+wheel, never about the code. The arrangement, the naming rule and the reasons
+for both are `llama_text.py`'s; read that module's docstring first, because
+everything this one does NOT say is said there.
+
+**Named `llama_embed`, not `llamacpp_embed`, for `llama_text.py`'s exact
+reason** — a shared module whose stem matches a sibling FOLDER is a
+`sys.path` footgun the moment anyone adds an `__init__.py`. Two folders here
+import this one file, so the collision is two folders away from happening by
+accident rather than zero.
+
+-------------------------------------------------------------------------------
+
+**Why this is a separate CAPABILITY from `embeddings`, and not a fifth model
+type inside it.** `registry.EMBEDDINGS` serves DUAL ENCODERS — SigLIP and
+CLIP — through `get_text_features`/`get_image_features`. An ordinary text
+embedding model has neither method: it is an encoder plus a pooling
+configuration, and loading one through that capability's runners fails
+several frames inside transformers with `AttributeError: 'BertModel' object
+has no attribute 'get_text_features'`, AFTER the download. Two capabilities
+rather than one branch is a decision recorded at `registry.TEXT_EMBEDDINGS`;
+what belongs HERE is the consequence a page can feel: because the supervisor
+holds one resident model PER CAPABILITY, a user can keep a SigLIP model and a
+text embedder loaded at the same time and neither evicts the other. Folding
+these models into `embeddings` would have made "index my photos" and "search
+my notes" fight over one slot on a machine with room for both.
+
+-------------------------------------------------------------------------------
+
+**The refusal happens BEFORE the download, and that is the point of half this
+file.** The `embeddings` capability gets this wrong today: `fused.ai.embed`
+with `BAAI/bge-small-en-v1.5` fetches ~400MB, starts a worker, and only then
+dies on the missing method above — a multi-minute wait ending in a traceback
+about an attribute, for a mistake that was decidable from the repo's file
+listing before a single weight moved. This runner refuses in two places, both
+ahead of the fetch:
+
+1. **The listing.** A repo with no root-level `.gguf` at all cannot be loaded
+   by llama.cpp under any circumstances, and `huggingface_hub.list_repo_files`
+   answers that for free. This is the branch that catches
+   `sentence-transformers/all-MiniLM-L6-v2` and `BAAI/bge-small-en-v1.5` — the
+   two repos a person is most likely to try first, because they are the
+   canonical names for this task and neither publishes GGUF.
+2. **A 2MB `Range` request against the one file that WOULD be fetched.** A
+   repo can publish a perfectly good GGUF that is a CHAT model, and no amount
+   of filename reading settles that (see `formats.gguf_pooling_type`: the
+   Qwen3-Embedding GGUF and the Qwen3 chat GGUF declare the same
+   architecture). So this reads the file's actual header over HTTP — 2MB of a
+   possibly multi-gigabyte file — and refuses on what the bytes say. Verified
+   against the Hub on 2026-08-23: `resolve/main` answers `206 Partial
+   Content` for a `Range` header and the first four bytes are `GGUF`.
+
+Both refusals name the repo, say what it looks like, and say what to pass
+instead. **Neither is allowed to refuse on ignorance**: if the listing cannot
+be read or the range request does not come back, resolution proceeds and the
+load-time check catches it — one download later, which is the old behaviour
+and no worse than it. A refusal has to rest on evidence, because the cost of
+a false one is a user who cannot load a model that would have worked and has
+no way to override.
+
+-------------------------------------------------------------------------------
+
+**`n_ctx` is per-model here, unlike `llama_text._N_CTX`.** llama.cpp pools a
+sequence only if the whole sequence fits in one batch, so for this runner
+`n_ctx` is not a conversation budget that truncates gracefully — it is the
+longest text the caller can embed. Sized from the GGUF's own
+`context_length` (`formats.gguf_context_length`), which reads 512 for bge,
+2048 for nomic-embed and EmbeddingGemma, and 32768 for Qwen3-Embedding: one
+pinned number would either truncate the long models or allocate 32k of
+context for a page embedding one-line labels. `n_batch` and `n_ubatch` are
+raised to match, because llama.cpp's own embedding path asserts the batch can
+hold the sequence and llama-cpp-python's `Llama.embed` raises
+`ValueError: Requested tokens (N) exceed batch size` at its default 512
+otherwise.
+
+Deliberately llama-cpp-python + huggingface_hub only — no jinja2, unlike
+`llama_text.py`: an encoder has no chat template to render, and a dependency
+this runner does not use is a dependency users download for nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# The base sits in THIS directory, and so does everything else this imports.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import formats  # noqa: E402 - the shared format checks and recipes; see formats.py
+import text_embed_common  # noqa: E402 - the shared request shape and prompts
+import worker_base  # noqa: E402 - the path insert above is what makes it importable
+
+#: The loaded `Llama` instance, and what this process needs to remember about
+#: the model beside it: the prompt scheme its vectors were trained for. One
+#: per process.
+_loaded = {}
+
+#: What to allocate when the GGUF's own header does not say
+#: (`formats.gguf_context_length` returned None). 512 rather than something
+#: generous, and that is the CONSERVATIVE direction on purpose: every
+#: published text encoder supports at least 512 tokens, so this cannot exceed
+#: what the model was trained for, while a larger guess on a 512-token model
+#: makes llama.cpp allocate and then produce vectors from positions the model
+#: never saw during training.
+_FALLBACK_N_CTX = 512
+
+#: A ceiling on what is allocated even when the header asks for more.
+#: Qwen3-Embedding declares 32768, which is real — and a KV cache for it is
+#: memory spent on a length nobody passes to a batch embedding API capped at
+#: `MAX_ITEMS` short items. 8192 covers every document anyone chunks for
+#: retrieval; a caller who needs more should chunk, which is what a retrieval
+#: pipeline does anyway.
+_MAX_N_CTX = 8192
+
+#: What to say for a repo that publishes no root-level GGUF. Names the repo,
+#: what it IS, and the two ways forward — the sentence
+#: `sentence-transformers/all-MiniLM-L6-v2` earns, since it is the single
+#: most likely thing for someone to type here.
+_NOT_GGUF = (
+    "{model_id!r} publishes no GGUF file this engine can load ({count} "
+    "file(s) checked). It looks like a safetensors/PyTorch checkpoint — the "
+    "format sentence-transformers and transformers read, which llama.cpp "
+    "cannot open at all. Pass a GGUF conversion of the same model instead "
+    "(search the Hub for '{stem}-GGUF', or use one of the curated ids: "
+    "{curated}), or load it on Apple Silicon through the MLX engine, which "
+    "does read safetensors."
+)
+
+#: …and for a repo that DOES publish a GGUF which turns out to be a chat
+#: model. A different fact and a different fix, so a different sentence.
+_NOT_AN_EMBEDDING_MODEL = (
+    "{model_id!r} resolves to {filename!r}, which is a GGUF but not an "
+    "embedding model: its header declares no pooling type ({pooling}), which "
+    "is how a text encoder says it produces one vector per text. A file like "
+    "this is a causal chat model — it has per-token outputs and nothing to "
+    "pool them with. Load it through text generation instead (fused.ai), or "
+    "pass an embedding GGUF here: {curated}."
+)
+
+#: …and for the reranker case, which is neither of the above. A cross-encoder
+#: scores a PAIR and has no per-text vector at all, so "use the other
+#: endpoint" would be wrong advice — there is no endpoint here for it.
+_IS_A_RERANKER = (
+    "{model_id!r} resolves to {filename!r}, which is a RERANKER (its header "
+    "declares pooling type RANK). A reranker scores a query and a document "
+    "together and has no per-text vector to return, so there is nothing this "
+    "endpoint could give you for it. Embed with one of {curated} and rank by "
+    "cosine similarity instead."
+)
+
+#: What to say when an uncurated repo's own file listing could not be read.
+#: Named apart from `_NOT_GGUF` for `llama_text._LOOKUP_FAILED`'s reason: this
+#: one means "try again", that one means "this repo will never resolve".
+_LOOKUP_FAILED = (
+    "Could not read {model_id!r}'s file listing on the Hub ({error}) — an "
+    "uncurated repo id resolves by reading which GGUF files it actually "
+    "publishes, so a network or Hub problem here means the pick cannot be "
+    "made right now."
+)
+
+
+def _curated_ids() -> str:
+    """The curated ids, for a refusal sentence to point at.
+
+    Read out of `formats.TEXT_EMBED_RECIPES` rather than written into the
+    three messages above, so a refusal cannot come to recommend a model this
+    app has stopped shipping — the failure mode where the error text is the
+    last thing anyone updates.
+    """
+    return ", ".join(repr(key) for key in sorted(formats.TEXT_EMBED_RECIPES))
+
+
+def _recipes_for_repo(repo_id):
+    """Every curated recipe whose repo is `repo_id`, keyed by their filename ids."""
+    return {key: recipe for key, recipe in formats.TEXT_EMBED_RECIPES.items()
+            if recipe["repo"] == repo_id}
+
+
+def _locally_cached_gguf_files(repo_id):
+    """Root-level `.gguf` filenames `repo_id` already has ON DISK, no network.
+
+    `llama_text._locally_cached_gguf_files`, and deliberately a copy rather
+    than an import: these two modules are loaded as bare top-level modules by
+    two different runner interpreters, and `llama_embed` importing
+    `llama_text` would drag the chat runner's whole module — its jinja2 use,
+    its offload schedule — into an environment whose manifest declares
+    neither. See that function's docstring for the mechanism and for why an
+    unreadable cache returns `[]` rather than raising.
+    """
+    folder = worker_base.repo_folder(repo_id)
+    if not folder:
+        return []
+    names = set()
+    try:
+        with os.scandir(os.path.join(folder, "snapshots")) as entries:
+            snapshot_dirs = [entry.path for entry in entries if entry.is_dir()]
+    except OSError:
+        return []
+    for snapshot_dir in snapshot_dirs:
+        try:
+            with os.scandir(snapshot_dir) as entries:
+                for entry in entries:
+                    if (entry.name.lower().endswith(formats.GGUF_EXTENSION)
+                            and entry.is_file()):
+                        names.add(entry.name)
+        except OSError:
+            continue
+    return sorted(names)
+
+
+def _remote_header(repo_id, filename):
+    """The first 2MB of a Hub-hosted GGUF, or `b""` if it could not be read.
+
+    **The cheap half of "refuse before the download".** `hf_hub_url` builds
+    the `resolve/main` URL huggingface_hub itself would fetch, and
+    `build_hf_headers` supplies whatever token this machine holds so a gated
+    repo answers rather than 401s. The `Range` header is what keeps this from
+    being a download: the Hub answers `206 Partial Content` with exactly the
+    requested bytes (checked directly, 2026-08-23).
+
+    `b""` for ANY failure — no network, a mirror that ignores `Range` and
+    starts streaming the whole file, an odd status, a timeout. That is not
+    defensiveness for its own sake; it is the contract the module docstring
+    states: a refusal must rest on evidence, so "could not look" resolves to
+    "do not refuse" and lets the load-time check answer instead. The timeout
+    is short for the same reason — a slow Hub should delay a download by
+    seconds, not replace it with a failure.
+
+    Streamed with `stream=True` and read to a hard cap rather than trusted to
+    honour `Range`: a server that ignores the header would otherwise pull a
+    multi-gigabyte file into memory inside a function whose whole job is to
+    avoid downloading it.
+    """
+    try:
+        from huggingface_hub import hf_hub_url
+        from huggingface_hub.utils import build_hf_headers, get_session
+
+        url = hf_hub_url(repo_id, filename)
+        headers = dict(build_hf_headers() or {})
+        headers["Range"] = f"bytes=0-{formats._GGUF_HEADER_PEEK_BYTES - 1}"
+        response = get_session().get(url, headers=headers, timeout=20, stream=True)
+        if response.status_code not in (200, 206):
+            return b""
+        with response:
+            return response.raw.read(formats._GGUF_HEADER_PEEK_BYTES) or b""
+    except Exception:  # noqa: BLE001 - see the docstring: any failure to LOOK
+                       # must read as "no evidence", never as a refusal
+        return b""
+
+
+def _refuse_unloadable(model_id, repo_id, filename):
+    """Raise if the Hub's copy of this GGUF is decidably not an embedding model.
+
+    Silent when the header could not be read at all — see `_remote_header`.
+    The three outcomes it CAN decide on are the three sentences at the top of
+    this module, and they are separate because the fix differs: a chat model
+    belongs on a different endpoint, a reranker belongs on no endpoint here,
+    and an unreadable-but-present header belongs to the load.
+    """
+    header = _remote_header(repo_id, filename)
+    if not header:
+        return
+    pooling = formats.gguf_uint_by_suffix_in(header, ".pooling_type")
+    if pooling in formats.GGUF_EMBED_POOLING_TYPES:
+        return
+    if pooling == formats.GGUF_POOLING_RANK:
+        raise RuntimeError(_IS_A_RERANKER.format(
+            model_id=model_id, filename=filename, curated=_curated_ids()))
+    raise RuntimeError(_NOT_AN_EMBEDDING_MODEL.format(
+        model_id=model_id, filename=filename, curated=_curated_ids(),
+        pooling="none declared" if pooling is None else f"pooling type {pooling}"))
+
+
+def _resolve_uncurated_repo(model_id):
+    """`(key, recipe)` for a bare repo id `TEXT_EMBED_RECIPES` never heard of.
+
+    `llama_text._resolve_uncurated_repo`'s counterpart, and the same two ways
+    of getting a file list, cheapest first: the local cache, then the Hub.
+    Two things differ, both because this capability's models are different
+    animals.
+
+    The picker is `formats.pick_embedding_gguf_file`, which prefers `Q8_0`
+    where the chat picker prefers `Q4_K_M` — see that function for why the
+    preference inverts.
+
+    And the refusals are *hard and specific* where the chat runner's are
+    generic, which is deliverable 6 of this capability's whole point: a
+    listing with no GGUF gets `_NOT_GGUF` naming the repo and the format it
+    actually is, and a listing WITH one gets its header peeked over the
+    network before a byte of weight is fetched.
+    """
+    local_files = _locally_cached_gguf_files(model_id)
+    if local_files:
+        chosen = formats.pick_embedding_gguf_file(local_files)
+        if chosen:
+            # No remote peek for a file already on this disk — `load()` reads
+            # the real header off it moments later, which is strictly better
+            # evidence than a range request and costs nothing.
+            return model_id, {"repo": model_id, "file": chosen,
+                              "scheme": formats.text_embed_scheme(model_id, chosen)}
+
+    import huggingface_hub
+
+    try:
+        filenames = huggingface_hub.list_repo_files(model_id)
+    except Exception as error:  # noqa: BLE001 - a Hub lookup failure is a fact
+                                 # about the id/network, not a bug in this runner
+        raise RuntimeError(
+            _LOOKUP_FAILED.format(model_id=model_id, error=error)) from error
+
+    chosen = formats.pick_embedding_gguf_file(filenames)
+    if chosen is None:
+        # The stem is what a user would search the Hub for — the repo's own
+        # name without the owner, which is how GGUF conversions are almost
+        # always titled (`bge-small-en-v1.5` -> `bge-small-en-v1.5-GGUF`).
+        stem = model_id.split("/")[-1]
+        raise RuntimeError(_NOT_GGUF.format(
+            model_id=model_id, count=len(filenames), stem=stem,
+            curated=_curated_ids()))
+
+    _refuse_unloadable(model_id, model_id, chosen)
+    return model_id, {"repo": model_id, "file": chosen,
+                      "scheme": formats.text_embed_scheme(model_id, chosen)}
+
+
+def _resolve_model_id(model_id):
+    """`(key, recipe)` for whatever `model_id` actually means, or raise.
+
+    `llama_text._resolve_model_id`'s shape exactly — a curated FILENAME key,
+    a bare repo id this table curates, or a bare repo id it has never heard
+    of — and see that function for why each of the three exists and why an
+    ambiguous curated repo is refused by name rather than guessed at.
+
+    The one difference is that no repo in `TEXT_EMBED_RECIPES` curates more
+    than one file today, so the ambiguity branch cannot currently fire. It is
+    kept rather than dropped: the table is a list this app edits, and the
+    first day someone curates a second quantization of one repo is not the
+    day to discover that a bare repo id silently downloads whichever one
+    `dict` happened to yield first.
+    """
+    if model_id in formats.TEXT_EMBED_RECIPES:
+        return model_id, formats.TEXT_EMBED_RECIPES[model_id]
+
+    candidates = _recipes_for_repo(model_id)
+    if not candidates:
+        return _resolve_uncurated_repo(model_id)
+
+    for key, recipe in candidates.items():
+        if worker_base._cached_file(recipe["repo"], recipe["file"]):
+            return key, recipe
+
+    if len(candidates) == 1:
+        (key, recipe), = candidates.items()
+        return key, recipe
+
+    raise RuntimeError(
+        f"{model_id!r} curates more than one quantization here "
+        f"({', '.join(repr(k) for k in sorted(candidates))}) and none of them "
+        f"is on this machine yet, so which one 'load' means is ambiguous — "
+        f"pick one of those ids instead of the bare repo id.")
+
+
+# --------------------------------------------------------------- model loading
+
+
+def download(model_id):
+    """The one GGUF file this model means — never the whole repo.
+
+    `llama_text.download`'s reasoning applies unchanged, and the resolution
+    step ahead of it is where every refusal in this module fires: by the time
+    `download_file` is called, the repo has been shown to publish a GGUF and
+    — where the Hub would answer a range request — that GGUF has been shown
+    to declare a pooling type. Nothing multi-gigabyte has moved to reach
+    either conclusion.
+    """
+    _key, recipe = _resolve_model_id(model_id)
+    filename = recipe["file"]
+    return worker_base.download_file(
+        recipe["repo"], filename, detail=f"Fetching {filename}…")
+
+
+def load(model_id, gguf_path):
+    """`gguf_path` is what `download` returned — the one `.gguf` file's path.
+
+    The resolution check comes first, before the heavy import, for
+    `llama_text.load`'s reason: a model this runner was never going to serve
+    is a fact about the REQUEST, and importing first would replace a clear
+    refusal with whatever llama.cpp raises.
+
+    **Then the header is read AGAIN, off the local file.** That is not a
+    duplicate of `_refuse_unloadable`: this read is the authoritative one —
+    real bytes on this disk rather than a range request that may not have
+    happened at all — and it is the only check that runs for a model resolved
+    out of the local cache. A file that reaches here without a usable pooling
+    type gets the same sentence it would have got before the download,
+    because the user's mistake is identical and only the timing differs.
+    """
+    _key, recipe = _resolve_model_id(model_id)
+
+    pooling = formats.gguf_pooling_type(gguf_path)
+    filename = os.path.basename(gguf_path)
+    if pooling == formats.GGUF_POOLING_RANK:
+        raise RuntimeError(_IS_A_RERANKER.format(
+            model_id=model_id, filename=filename, curated=_curated_ids()))
+    if pooling not in formats.GGUF_EMBED_POOLING_TYPES:
+        raise RuntimeError(_NOT_AN_EMBEDDING_MODEL.format(
+            model_id=model_id, filename=filename, curated=_curated_ids(),
+            pooling="none declared" if pooling is None else f"pooling type {pooling}"))
+
+    import llama_cpp
+    from llama_cpp import Llama
+
+    n_ctx = min(formats.gguf_context_length(gguf_path) or _FALLBACK_N_CTX,
+                _MAX_N_CTX)
+
+    # A real llama.cpp API asked at call time, not inferred from which folder
+    # imported this module — `llama_text.load`'s note applies verbatim. False
+    # on a CPU-only build, true on Apple Silicon's Metal-linked wheel and on
+    # a Vulkan build with a working driver.
+    #
+    # **No offload SCHEDULE here, unlike the chat runner.** `llama_text` walks
+    # a shrinking sequence of `n_gpu_layers` because an 8B chat model may not
+    # fit in VRAM and there is no API to ask how much there is. The largest
+    # model this capability curates is 639MB; there is no card this app runs
+    # on that fits a chat model and not this, so the whole probe would be a
+    # loop that always succeeds on its first attempt. All layers or none.
+    n_gpu_layers = -1 if llama_cpp.llama_supports_gpu_offload() else 0
+
+    llm = Llama(
+        model_path=gguf_path,
+        # The flag the whole runner turns on. Without it `Llama.embed` raises
+        # "must be created with embedding=True", and the context allocates a
+        # KV cache for generation this runner will never do.
+        embedding=True,
+        n_ctx=n_ctx,
+        # Both raised to `n_ctx`, and neither is optional. llama.cpp pools a
+        # sequence only within one batch, and llama-cpp-python's own
+        # `Llama.embed` refuses a text longer than `n_batch` outright
+        # (`ValueError: Requested tokens (N) exceed batch size`) — at the
+        # default 512 that would cap every model here at a bge's context
+        # however long its own header says it supports.
+        n_batch=n_ctx,
+        n_ubatch=n_ctx,
+        n_threads=os.cpu_count() or 4,
+        n_gpu_layers=n_gpu_layers,
+        verbose=False,
+    )
+
+    _loaded["llm"] = llm
+    # The prompt convention travels with the loaded model rather than being
+    # re-derived per request: it is a property of these weights, `generate`
+    # is on the hot path of a 64-item batch, and re-reading it per call would
+    # let a curated id and its own recipe drift apart between two requests.
+    _loaded["scheme"] = recipe.get("scheme") or formats.text_embed_scheme(
+        model_id, filename)
+
+    # Reported through the same field every other runner uses, so a page
+    # reading it needs no special case for this engine.
+    worker_base.set_state(device="gpu" if n_gpu_layers else "cpu")
+
+
+def memory():
+    """None — RSS alone is the honest answer here, `llama_text.memory`'s reason
+    verbatim: llama.cpp `mmap`s the GGUF and there is no second allocator to
+    interrogate the way a torch or MLX runner has one."""
+    return None
+
+
+# ------------------------------------------------------------------ embedding
+
+
+def generate(body):
+    """One embedding call. Returns `{vectors, dim, kind, promptScheme}`.
+
+    Not job-backed and not streaming, for `transformers_embed.generate`'s
+    reason: a batch of at most `MAX_ITEMS` short items is one forward pass
+    through a small encoder, over before a progress row would have drawn.
+
+    `kind` and `promptScheme` travel BACK on the reply, and that is not
+    decoration. The scheme for an uncurated model is a filename heuristic
+    (`formats.TEXT_EMBED_SCHEME_HINTS`) and the kind has a default the caller
+    may not have thought about — both are decisions this runner made on the
+    caller's behalf that change what the vectors mean, and a caller who can
+    see them can correct them. A caller who cannot would have no way to tell
+    a good scheme from a wrong one, because both return unit vectors of the
+    right dimension.
+    """
+    llm = _loaded.get("llm")
+    if llm is None:
+        raise RuntimeError("no model is loaded")
+
+    texts, kind = text_embed_common.request_texts(body)
+    scheme = _loaded.get("scheme") or "none"
+    prompted = text_embed_common.prompted(texts, kind, scheme)
+
+    # `Llama.embed` returns one flat vector per input BECAUSE the model
+    # declares a pooling type — `load()` refuses every file that does not, so
+    # the nested per-token shape that function returns for
+    # `LLAMA_POOLING_TYPE_NONE` is unreachable here (read directly off
+    # llama-cpp-python 0.3.29's `llama.py`, the `decode_batch` branch on
+    # `pooling_type`).
+    vectors = llm.embed(prompted)
+    vectors = text_embed_common.unit_normalize(vectors)
+    return {
+        "vectors": vectors,
+        "dim": len(vectors[0]) if vectors else 0,
+        "kind": kind,
+        "promptScheme": scheme,
+    }
+
+
+def main():
+    """Serve, forever. The entry point both folders' `worker.py` calls."""
+    worker_base.serve(download=download, load=load, generate=generate,
+                      streaming=False, memory=memory)

--- a/fused_render/ai/runners/llama_embed.py
+++ b/fused_render/ai/runners/llama_embed.py
@@ -420,7 +420,7 @@ def load(model_id, gguf_path):
     type gets the same sentence it would have got before the download,
     because the user's mistake is identical and only the timing differs.
     """
-    _key, recipe = _resolve_model_id(model_id)
+    key, _recipe = _resolve_model_id(model_id)
 
     pooling = formats.gguf_pooling_type(gguf_path)
     filename = os.path.basename(gguf_path)
@@ -473,11 +473,17 @@ def load(model_id, gguf_path):
 
     _loaded["llm"] = llm
     # The prompt convention travels with the loaded model rather than being
-    # re-derived per request: it is a property of these weights, `generate`
-    # is on the hot path of a 64-item batch, and re-reading it per call would
-    # let a curated id and its own recipe drift apart between two requests.
-    _loaded["scheme"] = recipe.get("scheme") or formats.text_embed_scheme(
-        model_id, filename)
+    # re-derived per request: it is a property of these weights, and
+    # `generate` is on the hot path of a 64-item batch.
+    #
+    # Keyed on the RESOLVED key and the ACTUAL filename, not on `model_id` and
+    # the recipe's. For a curated model the two are the same and
+    # `text_embed_scheme` reads the table, which is authoritative. For an
+    # uncurated repo they can differ: `_resolve_uncurated_repo` picks a
+    # filename from the Hub listing or the cache, while `gguf_path` is the
+    # file that actually got loaded, and the filename heuristic should run
+    # over the bytes in memory rather than over the pick that led to them.
+    _loaded["scheme"] = formats.text_embed_scheme(key, filename)
 
     # Reported through the same field every other runner uses, so a page
     # reading it needs no special case for this engine.

--- a/fused_render/ai/runners/llamacpp_embed/pyproject.toml
+++ b/fused_render/ai/runners/llamacpp_embed/pyproject.toml
@@ -1,0 +1,74 @@
+# The llama.cpp / GGUF TEXT EMBEDDING runner's environment — CPU (and Apple
+# Silicon Metal) build (SPEC §40, AI-2a, AI-11, D411).
+#
+# **Read `llamacpp_text/pyproject.toml` first.** It carries the argument for
+# why this app installs `llama-cpp-python` from the maintainer's own index at
+# all when AI-2a's wheels-only rule bars its PyPI sdist, the `explicit = true`
+# confinement that keeps that index from becoming a candidate for every other
+# requirement in the graph, and — most importantly — the residual-corruption
+# finding: that index has published corrupt macOS arm64 wheels for roughly two
+# releases in three (upstream issue #1650, still open), so a version bump is
+# only safe after re-running an integrity audit by hand. This file states its
+# differences from that one and repeats none of it.
+#
+# **THE PIN IS THE SAME VERSION, AND THAT IS DELIBERATE RATHER THAN
+# CONVENIENT.** `llama-cpp-python==0.3.29` is the exact version
+# `llamacpp_text/pyproject.toml` and `llamacpp_text_vulkan/pyproject.toml`
+# already pin, off the exact same index, so the four wheels this folder can
+# resolve to are byte-for-byte the four that file's audit covers
+# (macOS arm64, both manylinux_2_17 tags, win_amd64 — all PASS,
+# `zipfile.testzip()`, 2026-08-21). **No new audit was performed for this
+# folder and none was needed**; equally, this folder's pin may not be bumped
+# independently of the text pair's. If any of the three moves, all three move
+# together after one audit — a second llama.cpp version resident in a second
+# venv doubles the surface that audit has to cover for no benefit anyone can
+# name.
+#
+# **What is DIFFERENT from the text manifest, and it is one line: no
+# `jinja2`.** That runner declares it to render the chat template a GGUF
+# carries in its own metadata. An encoder has no chat template — there is no
+# conversation to format, only a prompt PREFIX chosen from
+# `formats.TEXT_EMBED_PROMPTS` and glued on by string concatenation
+# (`text_embed_common.prompted`). A dependency this runner never imports is a
+# dependency users download for nothing, and — since `state_digest` hashes
+# this file whole — one this app would have to keep a version ceiling honest
+# for on behalf of code that does not exist.
+#
+# `huggingface_hub` fetches the one GGUF file this runner ever downloads
+# (`worker_base.download_file`) AND, unlike the text runner's use of it, does
+# a second job here: `llama_embed._remote_header` builds a `resolve/main` URL
+# with `hf_hub_url`, attaches this machine's token with `build_hf_headers`,
+# and issues a 2MB `Range` request so a repo that is not an embedding model
+# can be refused BEFORE its weights are fetched. That is the up-front-refusal
+# contract in that module's docstring, and it is why this dependency is
+# load-bearing beyond "downloads happen".
+#
+# CPU only in the sense the text manifest means it: this is the maintainer's
+# `whl/cpu` index, the build with no CUDA/ROCm/Vulkan backend compiled in —
+# but that same index's macOS arm64 wheel links `libggml-metal.dylib`, so on
+# Apple Silicon this row runs on the GPU. The Vulkan sibling beside this
+# folder covers NVIDIA and AMD under Windows and Linux.
+[project]
+name = "fused-render-runner-llamacpp-embed"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "llama-cpp-python==0.3.29",
+    "huggingface_hub",
+    "psutil",
+]
+
+# Not a distribution — a folder of scripts, not something to build and install.
+[tool.uv]
+package = false
+
+# The maintainer's CPU wheel index. `explicit = true` keeps it from becoming a
+# candidate for anything but the one name listed under `[tool.uv.sources]` —
+# see `llamacpp_text/pyproject.toml` for why that confinement matters here.
+[[tool.uv.index]]
+name = "llamacpp-cpu"
+url = "https://abetlen.github.io/llama-cpp-python/whl/cpu/"
+explicit = true
+
+[tool.uv.sources]
+llama-cpp-python = { index = "llamacpp-cpu" }

--- a/fused_render/ai/runners/llamacpp_embed/worker.py
+++ b/fused_render/ai/runners/llamacpp_embed/worker.py
@@ -1,0 +1,32 @@
+"""The llama.cpp / GGUF text embedding runner (SPEC §40, AI-11).
+
+Five lines of code and a `pyproject.toml`, the same shell shape
+`llamacpp_text/worker.py` uses: the manifest beside this file is the whole of
+what makes this folder its own environment, and the runner itself is
+`runners/llama_embed.py`, imported the same way every other shell reaches its
+shared module one directory up.
+
+**Named `llama_embed`, not `llamacpp_embed`, DELIBERATELY** — the rule
+`llamacpp_text/worker.py` states at length and which is a fact about
+`sys.path` rather than about any one library: a directory with no
+`__init__.py` is a namespace portion, which loses to a same-name ordinary
+module in the same `sys.path` entry only for as long as nobody adds one.
+`llamacpp_embed_vulkan/` imports the same `llama_embed.py` this folder does,
+so a module named after either folder would be one file away from shadowing
+the other.
+
+Nothing here may grow a second line of behaviour — a format check or a prompt
+rule that lived in this shell would be a difference between this folder and
+its Vulkan sibling that no test could see.
+"""
+
+import os
+import sys
+
+# The shared runner sits one directory up, in `runners/` — see mlx_text/worker.py.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import llama_embed  # noqa: E402 - the whole runner; see runners/llama_embed.py
+
+if __name__ == "__main__":
+    llama_embed.main()

--- a/fused_render/ai/runners/llamacpp_embed_vulkan/pyproject.toml
+++ b/fused_render/ai/runners/llamacpp_embed_vulkan/pyproject.toml
@@ -1,0 +1,78 @@
+# The llama.cpp / GGUF TEXT EMBEDDING runner's environment — the VULKAN
+# variant, GPU acceleration on NVIDIA and AMD (SPEC §40, AI-11, D411).
+#
+# Identical to `llamacpp_embed/pyproject.toml` except for the one thing a
+# hardware variant is allowed to change: which of the maintainer's indexes the
+# one pinned dependency comes from. Read that file first — it carries the
+# no-`jinja2` reasoning, the second job `huggingface_hub` does for this
+# capability's up-front refusal, and the pin discipline this file reuses
+# verbatim; this one only states its difference.
+#
+# **Why this variant exists at all**, and it is the same argument
+# `llamacpp_text_vulkan/pyproject.toml` makes: the CPU index's macOS arm64
+# wheel links `libggml-metal.dylib`, so Apple Silicon already gets GPU
+# acceleration through the sibling folder, but that index's Linux and Windows
+# wheels are CPU only. The maintainer's separate `vulkan` index is the one
+# accelerated path that reaches BOTH NVIDIA and AMD from a single wheel — that
+# index publishes no ROCm/HIP build at all (checked in the text variant's own
+# audit), so this is not a third choice alongside a CUDA and a ROCm row, it is
+# the only accelerated path this backend has for either vendor.
+#
+# **THE PIN AND ITS AUDIT ARE THE TEXT VARIANT'S, unchanged.**
+# `llama-cpp-python==0.3.29` off this exact index is what
+# `llamacpp_text_vulkan/pyproject.toml` already pins, so the two platform tags
+# this folder can resolve to are byte-for-byte the two that file's audit
+# covers — `manylinux2014_x86_64.manylinux_2_17_x86_64` (181.77 MB) and
+# `win_amd64` (56.94 MB), both PASS under `zipfile.testzip()`, 2026-08-21, off
+# `releases/download/v0.3.29-vulkan/`. **No new audit was performed for this
+# folder and none was needed**, and this pin may not be bumped independently
+# of the other three: all four llama.cpp manifests move together after one
+# audit. That index publishes **no macOS build** (expected — Metal comes
+# through the CPU index) **and no Linux aarch64**, which is why
+# `registry._vulkan` gates on exactly that tag set rather than the wider one
+# `_llamacpp_platform` allows.
+#
+# **The size difference is why this is a second folder rather than a flag, and
+# it lands HARDER here than it does for text.** The Vulkan Linux wheel is
+# 181.77MB against the CPU index's 22.5MB — roughly 8x, almost all of it the
+# ~74.5MB Vulkan backend library — while the largest model this capability
+# curates is 639MB and the smallest is 146MB. So on this row a user can easily
+# download more WHEEL than MODEL, which is not true of the text pair, where
+# the smallest curated GGUF is 0.7GB. It is still worth offering: a page
+# embedding a folder of notes runs one encoder pass per chunk, and a GPU turns
+# a few thousand chunks from minutes into seconds. But it is one more reason
+# this row sits BELOW the CPU row and is never what `auto` reaches for.
+#
+# **A missing Vulkan loader is a HARD import failure, not a CPU fallback** —
+# `libggml-vulkan.so` declares `DT_NEEDED libvulkan.so.1`, and
+# `libggml.so`/`libllama.so` declare `DT_NEEDED libggml-vulkan.so.0` in turn
+# (the Windows DLL carries the same import on `vulkan-1.dll`). So
+# `import llama_cpp` fails outright on a machine with this wheel and no
+# loader, regardless of whether a GPU is present. `registry._vulkan` refuses
+# that machine a Load button before `uv sync` ever runs; see its docstring for
+# the milder missing-DRIVER case and why that half is refused for being
+# pointless rather than for being broken.
+[project]
+name = "fused-render-runner-llamacpp-embed-vulkan"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "llama-cpp-python==0.3.29",
+    "huggingface_hub",
+    "psutil",
+]
+
+# Not a distribution — a folder of scripts, not something to build and install.
+[tool.uv]
+package = false
+
+# The maintainer's Vulkan wheel index. `explicit = true` for the identical
+# reason the CPU index's own manifest states — without it this index becomes a
+# candidate for every requirement in the graph, not only the one name below.
+[[tool.uv.index]]
+name = "llamacpp-vulkan"
+url = "https://abetlen.github.io/llama-cpp-python/whl/vulkan/"
+explicit = true
+
+[tool.uv.sources]
+llama-cpp-python = { index = "llamacpp-vulkan" }

--- a/fused_render/ai/runners/llamacpp_embed_vulkan/worker.py
+++ b/fused_render/ai/runners/llamacpp_embed_vulkan/worker.py
@@ -1,0 +1,33 @@
+"""The llama.cpp / GGUF text embedding runner — the Vulkan variant (SPEC §40,
+AI-11).
+
+Five lines of code and a `pyproject.toml`, the same shell shape
+`llamacpp_embed/worker.py` uses: the manifest beside this file is the whole of
+what makes this folder its own environment, and the runner itself is
+`runners/llama_embed.py` — the SAME module `llamacpp_embed/worker.py`
+imports, reused rather than forked. Which wheel a user installed is a fact
+about the hardware they picked on the Engines tab and never about how an
+encoder pass runs; `llama_embed.load()` asks llama.cpp itself whether GPU
+offload is available rather than inferring it from which folder started the
+process, which is what lets one module serve both.
+
+**Named `llama_embed`, not `llamacpp_embed`, for the reason
+`llamacpp_embed/worker.py`'s own docstring states** — a shared module with the
+same stem as a sibling folder would be a footgun the moment either folder
+grew an `__init__.py`.
+
+Nothing here may grow a second line of behaviour — a format check or a
+Vulkan-specific pooling rule that lived in this shell would be a difference
+between this folder and its CPU/Metal sibling that no test could see.
+"""
+
+import os
+import sys
+
+# The shared runner sits one directory up, in `runners/` — see mlx_text/worker.py.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import llama_embed  # noqa: E402 - the whole runner; see runners/llama_embed.py
+
+if __name__ == "__main__":
+    llama_embed.main()

--- a/fused_render/ai/runners/mlx_text_embed/pyproject.toml
+++ b/fused_render/ai/runners/mlx_text_embed/pyproject.toml
@@ -1,0 +1,71 @@
+# The MLX TEXT EMBEDDING runner's environment (SPEC §40, PY-16).
+#
+# **A separate folder from `mlx_embed/`, and the reason is the capability
+# split rather than the package.** Both folders install the SAME distribution
+# — `mlx-embeddings` — because that one package ships both a SigLIP port (the
+# dual encoder `registry.EMBEDDINGS` serves) and a set of text encoders (what
+# `registry.TEXT_EMBEDDINGS` serves). So this manifest is very nearly a copy
+# of `mlx_embed/pyproject.toml`, and that is not duplication to be collapsed:
+# `envinstall` keys a venv by the hash of the folder's manifest, and one
+# folder shared between two capabilities would mean ONE interpreter and one
+# resident-model slot for both — exactly the eviction conflict the capability
+# split exists to avoid (see `llama_embed.py`'s docstring). Two folders is how
+# a user gets to hold a SigLIP model and a text embedder at the same time.
+#
+# **The engine line carries a CEILING**, for the reason `mlx_embed/` and
+# `mflux_image/` both state at length: no lockfile is committed beside these
+# manifests and `uv sync` runs bare, so an unbounded requirement re-resolves
+# from PyPI on every new venv key — the way an unrelated minor bump has
+# reached users with no commit behind it before. `mlx-embeddings` is pre-1.0,
+# where a minor IS the breaking one, hence `>=0.1,<0.2` — the same bound
+# `mlx_embed/` uses, deliberately: the two folders install the same package
+# and a version skew between them would mean two copies of one library's
+# model zoo in two venvs, differing in which architectures they can open.
+#
+# **What was CHECKED about 0.1.0 rather than assumed.** The published wheel's
+# own contents were read on 2026-08-23 (`mlx_embeddings/models/*.py` out of
+# `mlx_embeddings-0.1.0-py2.py3-none-any.whl`, from PyPI). It ships
+# `bert.py`, `modernbert.py`, `xlm_roberta.py`, `qwen3.py`, `gemma3_text.py`,
+# `lfm2.py` and `llama_bidirec.py` — so text embedding models are genuinely
+# first-class here and this is NOT a scaffold around a package that only does
+# SigLIP. Every one of those `Model.__call__`s returns a `BaseModelOutput`
+# whose `text_embeds` field is already pooled and normalized, which is the
+# single seam `worker.py` reads (see `_TEXT_EMBEDS_FIELD` there).
+#
+# **`mlx-embeddings` is GPLv3**, which is worth stating in the manifest rather
+# than leaving to whoever next audits licences. It is not a new obligation:
+# `mlx_embed/` already installs the same package under the same licence, and
+# it is installed into a SEPARATE interpreter that this app talks to over
+# HTTP — never imported into fused-render's own process — which is the same
+# arrangement every runner has and the reason the licence does not reach the
+# app.
+#
+# What each dependency earns:
+#   mlx-embeddings  loads the text encoder and runs it. Pulls `mlx`,
+#                   `mlx-vlm` and `transformers` in itself (the tokenizer half
+#                   of a load is transformers' `AutoTokenizer`, through this
+#                   library's own `TokenizerWrapper`); named here rather than
+#                   assumed because all three are load-bearing.
+#   huggingface_hub downloads the snapshot.
+#   psutil          the RSS half of "how much memory is this costing" — the
+#                   MLX half comes from mlx's own allocator (see `memory()`),
+#                   exactly `mlx_text/pyproject.toml`'s reasoning.
+#
+# **No pillow and no pillow-heif**, unlike `mlx_embed/pyproject.toml`. That
+# folder declares them so it can open the image half of a dual-encoder
+# request; this capability refuses image input by name
+# (`text_embed_common.request_texts`), so a PIL here would be a dependency
+# users download to support a code path that raises before reaching it.
+[project]
+name = "fused-render-runner-mlx-text-embed"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "mlx-embeddings>=0.1,<0.2",
+    "huggingface_hub",
+    "psutil",
+]
+
+# Not a distribution — a folder of scripts, not something to build and install.
+[tool.uv]
+package = false

--- a/fused_render/ai/runners/mlx_text_embed/worker.py
+++ b/fused_render/ai/runners/mlx_text_embed/worker.py
@@ -96,10 +96,18 @@ _STREAMS_LOCK = threading.Lock()
 #: hard per-item limit that has to be allocated up front. Here the tokenizer
 #: truncates and the encoder runs on whatever is left, so a smaller number is
 #: a shorter read rather than a failure — and a LARGER one on a
-#: 512-position BERT would index past its position embeddings. Sizing this
-#: from the config is a reasonable later change; a fixed 512 is the one value
-#: that is correct-or-conservative for every architecture named in
-#: `formats.MLX_TEXT_EMBED_MODEL_TYPES`.
+#: 512-position BERT would index past its position embeddings.
+#:
+#: **Correct for the encoders, LOSSY for the decoders, and that is the honest
+#: description.** `formats.MLX_TEXT_ENCODER_MODEL_TYPES` — bert, modernbert,
+#: xlm-roberta — trained at 512, so this is their own maximum and nothing is
+#: lost. `formats.MLX_TEXT_EMBED_DECODER_MODEL_TYPES` — qwen3, gemma3_text,
+#: lfm2 — support far more, so a long passage is TRUNCATED here where the
+#: llama.cpp runner would read it whole (that one sizes `n_ctx` off the
+#: checkpoint, `llama_embed._MAX_N_CTX`). Sizing this from the config the
+#: same way is the obvious improvement and is deliberately not attempted from
+#: a machine that cannot run the code; 512 is the value that is correct or
+#: conservative for every architecture rather than wrong for some.
 _MAX_LENGTH = 512
 
 #: The field on `mlx_embeddings`' `BaseModelOutput` that carries the pooled,

--- a/fused_render/ai/runners/mlx_text_embed/worker.py
+++ b/fused_render/ai/runners/mlx_text_embed/worker.py
@@ -1,0 +1,318 @@
+"""Text embeddings on MLX: one resident text encoder, one route (SPEC §40).
+
+Started by `fused_render.ai.supervisor` on the interpreter built from this
+folder's `pyproject.toml`. The HTTP contract, the download reporting and the
+state machine are `worker_base`'s; what lives here is only what is true of
+`mlx-embeddings`' text encoders in particular.
+
+**HOW MUCH OF THIS WAS ACTUALLY RUN, stated up front because a docstring that
+implies more than was tested is worse than one that admits less.** This file
+was written on Windows, where `mlx` does not install: **no code path below has
+been executed against a real model.** What was verified, and it is more than
+nothing:
+
+* `mlx-embeddings` 0.1.0's published wheel was downloaded from PyPI and its
+  contents read directly (2026-08-23). It ships `models/bert.py`,
+  `models/modernbert.py`, `models/xlm_roberta.py`, `models/qwen3.py`,
+  `models/gemma3_text.py`, `models/lfm2.py` and `models/llama_bidirec.py`
+  beside its `models/siglip.py`. **So this is a real implementation against a
+  real API, not a scaffold around a package that only does SigLIP** — which
+  was the open question this runner was written to answer.
+* Every one of those modules' `Model.__call__` was read. Each returns a
+  `models/base.py` `BaseModelOutput` whose `text_embeds` field is the pooled,
+  L2-normalized sentence vector — mean-pooled for `bert`/`xlm_roberta`,
+  config-driven for `modernbert` (defaulting to mean), and last-token-pooled
+  for `qwen3`. That uniformity is the ONE seam this file depends on, and it is
+  why `_text_vectors` below has no per-architecture branch.
+* The call shape is upstream's own documented one, copied from the "Multiple
+  Texts Comparison" example in the wheel's `METADATA`:
+  `tokenizer.batch_encode_plus(texts, return_tensors="mlx", padding=True,
+  truncation=True, max_length=...)`, then `model(input_ids,
+  attention_mask=...)`, then `.text_embeds`.
+
+**What someone on a Mac still has to check**, in the order it will break:
+`_load` resolving a repo (mlx-embeddings' `load()` returns `(model,
+tokenizer)` where the tokenizer is a `TokenizerWrapper`, so
+`batch_encode_plus` is reached through `__getattr__` — read, not run);
+whether `return_tensors="mlx"` yields something `mx.array` accepts unchanged
+for BOTH keys; and `_MAX_LENGTH`'s interaction with a model whose own
+`max_position_embeddings` is smaller. None of those is a design question — the
+seams are marked below — but all three are the kind of thing that is obvious
+in one minute on the right machine and unknowable from here.
+
+-------------------------------------------------------------------------------
+
+**This engine reads SAFETENSORS, and the llama.cpp rows read GGUF.** So
+unlike the `embeddings` capability — whose two runners share one catalog
+because SigLIP publishes one format both read — this capability's MLX list and
+its llama.cpp list are DIFFERENT repos, exactly as `mlx-text` and
+`llamacpp-text` have different lists for chat. `catalog.py` is keyed by runner
+for precisely this case.
+
+**One folder, unlike the llama.cpp pair beside it.** There is no accelerated
+variant to install: MLX is the Apple Silicon GPU path already, and there is no
+second wheel index to differ in.
+
+`text_embed_common.py` (one directory up) holds the request validation, the
+`kind`/prompt rules and the normalization, shared with `llama_embed.py`
+because the two engines must refuse and shape a request identically even
+though they read different files.
+"""
+
+import os
+import sys
+
+# The base sits one directory up, in `runners/` — see mlx_text/worker.py.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import threading  # noqa: E402
+
+import formats  # noqa: E402 - the shared prompt schemes; see formats.py
+import text_embed_common  # noqa: E402 - the shared request shape
+import worker_base  # noqa: E402 - the path insert above is what makes it importable
+
+#: The loaded (model, tokenizer) and the prompt scheme these weights want.
+#: One per process.
+_loaded = {}
+
+#: The MLX streams every thread in this process works on, keyed by device
+#: name. Exactly `mlx_embed/worker.py`'s and `mlx_text/worker.py`'s
+#: `_STREAMS`/`_pin_stream` — this worker is threaded the same way
+#: (`worker_base.serve`'s bring-up thread loads, a `ThreadingTCPServer`
+#: request thread generates), so an unevaluated array built on one stream and
+#: forced from another is the same abort those modules document at length.
+#: Not shared as an import: a per-process module-level dict cannot cross the
+#: separate interpreters these runners run in.
+_STREAMS = {}
+_STREAMS_LOCK = threading.Lock()
+
+#: Where a text is cut off. 512 is upstream's own example value and the
+#: trained length of the BERT-family encoders that make up most of this
+#: engine's catalog.
+#:
+#: **A ceiling rather than the model's own maximum, and unlike
+#: `llama_embed.load` this does NOT read the checkpoint to size itself.** That
+#: runner must: llama.cpp pools only within one batch, so `n_ctx` there is a
+#: hard per-item limit that has to be allocated up front. Here the tokenizer
+#: truncates and the encoder runs on whatever is left, so a smaller number is
+#: a shorter read rather than a failure — and a LARGER one on a
+#: 512-position BERT would index past its position embeddings. Sizing this
+#: from the config is a reasonable later change; a fixed 512 is the one value
+#: that is correct-or-conservative for every architecture named in
+#: `formats.MLX_TEXT_EMBED_MODEL_TYPES`.
+_MAX_LENGTH = 512
+
+#: The field on `mlx_embeddings`' `BaseModelOutput` that carries the pooled,
+#: normalized sentence vector — the single seam this whole runner rests on.
+#:
+#: Named as a constant rather than written inline because it is the ONE thing
+#: an upstream minor could rename out from under this file, and if it does,
+#: `_text_vectors` raises with this name in the message instead of an
+#: `AttributeError` on a dataclass nobody here can see. (The manifest's
+#: `<0.2` ceiling exists so that cannot arrive unannounced.)
+_TEXT_EMBEDS_FIELD = "text_embeds"
+
+
+def _pin_stream():
+    """Put this thread's MLX work on the process's shared streams.
+
+    Identical to `mlx_embed.worker._pin_stream` and
+    `mlx_text.worker._pin_stream`, copied rather than imported: these workers
+    run in separate interpreters built from separate `pyproject.toml`s, so
+    there is no module either can import from the other's folder. See
+    `mlx_text.worker._pin_stream` for the mechanism this guards against.
+    """
+    import mlx.core as mx
+
+    make = getattr(mx, "new_thread_unsafe_stream", None)
+    pin = getattr(mx, "set_default_stream", None)
+    if make is None or pin is None:
+        return None
+    devices = [mx.cpu, mx.default_device()]
+    with _STREAMS_LOCK:
+        streams = []
+        for device in devices:
+            key = str(device)
+            if key not in _STREAMS:
+                _STREAMS[key] = make(device)
+            if _STREAMS[key] not in streams:
+                streams.append(_STREAMS[key])
+    for stream in streams:
+        pin(stream)
+    return streams
+
+
+# --------------------------------------------------------------- model loading
+
+
+def download(model_id):
+    """The whole repo. `mlx-embeddings` reads a directory of safetensors plus
+    the tokenizer's own files — the same shape every other safetensors runner
+    here downloads whole."""
+    return worker_base.download_snapshot(model_id)
+
+
+def _mlx_load(repo_id):
+    """`mlx_embeddings.load`, or an error that names the ENVIRONMENT rather
+    than a module. Same shape as `mlx_embed.worker._mlx_load` and
+    `mlx_text.worker._mlx_load`, for the same reason: an ImportError out of a
+    library this deep loses the fact that it is an environment problem by the
+    time it reaches the AI Models page.
+
+    **Takes the REPO ID, not the snapshot path**, matching `mlx_embed`'s
+    choice — see `load` below.
+    """
+    try:
+        from mlx_embeddings.utils import load as mlx_embed_load
+    except ImportError as e:
+        raise RuntimeError(
+            f"mlx-embeddings could not be imported from the runner environment "
+            f"at {sys.prefix} ({e.__class__.__name__}: {e}). That is an "
+            "environment failure rather than a problem with this model."
+        ) from e
+    return mlx_embed_load(repo_id)
+
+
+def load(model_id, path):
+    """`path` is what `download` returned — the snapshot directory.
+
+    **`model_id` is what the library gets, and `path` goes unused**, the same
+    call `mlx_embed/worker.py` makes and for a related reason. That folder had
+    a forcing one (mlx-embeddings reads a SigLIP's patch geometry out of the
+    repo NAME, so a content-addressed snapshot path breaks it); here the
+    library would accept either, because `get_model_path` returns a `Path`
+    unchanged when it exists on disk. Passing the id anyway keeps the two MLX
+    embedding runners' loads spelled identically, so a reader comparing them
+    is not left wondering which difference is meaningful.
+
+    Not a second download: `download` above has already fetched the snapshot
+    into the Hub cache, which is where the library's own resolution finds it.
+
+    **SEAM FOR SOMEONE ON A MAC.** This is the first line that will fail if
+    anything in this file is wrong — `mlx_embeddings.load()` resolving a
+    text-encoder repo and returning `(Model, TokenizerWrapper)`. Read out of
+    0.1.0's `utils.load`, which picks `load_tokenizer` for a config with no
+    `vision_config` (which a text encoder has none of) and `AutoProcessor`
+    otherwise. Never executed.
+    """
+    # BEFORE the weights exist, and after the import guard — see
+    # `mlx_text.worker.load`'s identical ordering and its own comment on why.
+    _pin_stream()
+
+    model, tokenizer = _mlx_load(model_id)
+    _loaded["model"] = model
+    _loaded["tokenizer"] = tokenizer
+    # The prompt convention travels with the loaded model, exactly as it does
+    # in `llama_embed.load` and for the same two reasons: it is a property of
+    # these weights, and `generate` is on the hot path of a 64-item batch.
+    # Keyed off the REPO ID here rather than a filename, since this engine's
+    # catalog is repo-shaped — `formats.text_embed_scheme` takes both and
+    # falls back to `"none"` for anything it does not recognise.
+    _loaded["scheme"] = formats.text_embed_scheme(model_id)
+
+    # MLX only ever runs on Apple Silicon's GPU here, so this is a constant
+    # rather than a probe — but it is still published through the same field
+    # every other runner reports through, because a page reading it must not
+    # need a special case for this engine.
+    worker_base.set_state(device="gpu")
+
+
+def memory():
+    """What MLX itself says it is holding. Same probe as
+    `mlx_embed.worker.memory` and for the same reason: mmap'd, lazy arrays
+    make RSS alone report the interpreter rather than the model."""
+    import mlx.core as mx
+
+    for probe in (getattr(mx, "get_active_memory", None),
+                  getattr(getattr(mx, "metal", None), "get_active_memory", None)):
+        if probe is None:
+            continue
+        value = probe()
+        if isinstance(value, int) and value > 0:
+            return value
+    return None
+
+
+# ------------------------------------------------------------------ embedding
+
+
+def _text_vectors(model, tokenizer, texts):
+    """One vector per string in `texts`, as a plain nested list of floats.
+
+    **The whole of the load/encode/pool seam, in five lines, deliberately.**
+    Upstream does the pooling: every `Model.__call__` in
+    `mlx_embeddings/models/` that this runner can reach returns
+    `BaseModelOutput.text_embeds`, already pooled by whichever strategy that
+    architecture was trained for — mean for BERT and XLM-RoBERTa,
+    config-driven for ModernBERT, last-token for Qwen3. So there is no
+    pooling BRANCH here, and adding one would be actively wrong: it would
+    second-guess the library about a choice the checkpoint's own config
+    records.
+
+    The vectors come back L2-normalized too (`base.normalize_embeddings`,
+    called inside each of those `__call__`s), and
+    `text_embed_common.unit_normalize` still runs over them afterwards — see
+    that function's docstring for why re-normalizing an already-unit vector is
+    the right trade rather than a wasted pass.
+
+    **SEAM FOR SOMEONE ON A MAC**, and the second thing that will break if
+    anything does: whether `return_tensors="mlx"` hands back values `mx.array`
+    takes unchanged for both `input_ids` and `attention_mask`. Upstream's own
+    README example passes the two straight through positionally, which is what
+    is copied here; if a version yields numpy instead, `mx.array` still
+    accepts it and this is unaffected.
+    """
+    import mlx.core as mx
+
+    inputs = tokenizer.batch_encode_plus(
+        texts, return_tensors="mlx", padding=True, truncation=True,
+        max_length=_MAX_LENGTH)
+    output = model(mx.array(inputs["input_ids"]),
+                   attention_mask=mx.array(inputs["attention_mask"]))
+    embeds = getattr(output, _TEXT_EMBEDS_FIELD, None)
+    if embeds is None:
+        # Named rather than left as an AttributeError on a dataclass the
+        # reader cannot see — see `_TEXT_EMBEDS_FIELD`. Reachable only if
+        # upstream renames the field inside the manifest's `<0.2` ceiling.
+        raise RuntimeError(
+            f"this model's output carries no {_TEXT_EMBEDS_FIELD!r} — "
+            f"mlx-embeddings changed the field this runner pools through "
+            f"(got {type(output).__name__} with {dir(output)!r})")
+    return mx.array(embeds).astype(mx.float32).tolist()
+
+
+def generate(body):
+    """One embedding call. Returns `{vectors, dim, kind, promptScheme}` — the
+    identical reply shape `llama_embed.generate` returns, including the two
+    reporting fields and for the reasons its docstring gives."""
+    _pin_stream()
+
+    model = _loaded.get("model")
+    tokenizer = _loaded.get("tokenizer")
+    if model is None or tokenizer is None:
+        raise RuntimeError("no model is loaded")
+
+    texts, kind = text_embed_common.request_texts(body)
+    scheme = _loaded.get("scheme") or "none"
+    prompted = text_embed_common.prompted(texts, kind, scheme)
+
+    vectors = text_embed_common.unit_normalize(
+        _text_vectors(model, tokenizer, prompted))
+    return {
+        "vectors": vectors,
+        "dim": len(vectors[0]) if vectors else 0,
+        "kind": kind,
+        "promptScheme": scheme,
+    }
+
+
+def main():
+    """Serve, forever. This file's own `__main__` calls it directly — no shell
+    folder, unlike the llama.cpp pair, because this is the only folder this
+    engine installs (see the module docstring)."""
+    worker_base.serve(download=download, load=load, generate=generate,
+                      streaming=False, memory=memory)
+
+
+if __name__ == "__main__":
+    main()

--- a/fused_render/ai/runners/text_embed_common.py
+++ b/fused_render/ai/runners/text_embed_common.py
@@ -1,0 +1,181 @@
+"""Validating and shaping one `fused.ai.embedText()` request, written once
+(SPEC §40).
+
+`llama_embed` (two folders) and `mlx_text_embed` are three environments
+serving ONE capability, and — unlike the `embeddings` pair that
+`embed_common.py` serves — they do NOT read the same repos: llama.cpp opens a
+GGUF and mlx-embeddings opens a directory of safetensors, exactly the split
+`llama_text`/`mlx_text` already have for chat. What they must still agree on
+is the two things a caller can observe: whether a request is well-formed, and
+what a returned vector MEANS. This module is where both live, so neither side
+can drift on them.
+
+**Why this is a second module beside `embed_common.py` rather than three more
+functions inside it.** That file's `request_kind` accepts `paths` — an image
+per item — because the capability it serves is a DUAL ENCODER, where a
+picture and a sentence land in one space and comparing them is the entire
+point. Nothing here has a vision tower. Folding both request shapes into one
+validator would have produced a function whose contract was "exactly one of
+texts/paths, unless the caller is the text-embedding capability, in which
+case paths is an error" — a shape that is one edit away from letting a
+`paths` request through to a model that would then embed the FILENAMES as
+prose and return perfectly plausible, perfectly wrong vectors. Two validators
+that each refuse the other's input by name is the version of that with no
+silent failure in it.
+
+`unit_normalize` IS imported from `embed_common`, because that one is not a
+request-shape question: it is the arithmetic that makes a cosine similarity a
+plain dot product, and it must be bit-for-bit the same rule in both
+capabilities or two vectors from two engines mean different things.
+
+**Mostly stdlib, and no import of `fused_render`** — the constraint
+`formats.py` and `embed_common.py` both document, for the same reason: this
+is imported by three runners' own interpreters through the same `sys.path`
+insert that reaches `worker_base`, and none of them has this app on its path.
+"""
+
+from __future__ import annotations
+
+import embed_common
+import formats
+
+#: The batch ceiling, taken from `embed_common` rather than restated. The
+#: number is not a fact about dual encoders — it is a fact about how much
+#: work one HTTP request should do before a caller would rather see progress
+#: — so the two capabilities answering differently would be an inconsistency
+#: with no reason behind it.
+MAX_ITEMS = embed_common.MAX_ITEMS
+
+#: The two things a text can BE to a retrieval model.
+KINDS = formats.TEXT_EMBED_KINDS
+
+#: What a caller who says nothing gets.
+#:
+#: **"document", and it is the one defaulting decision in this file that
+#: could quietly cost someone their recall, so here is the whole argument.**
+#:
+#: There is no neutral option. Every scheme in `formats.TEXT_EMBED_PROMPTS`
+#: has two sides and a call must pick one, so the question is only which
+#: wrong guess is cheaper when the caller has not thought about it yet.
+#:
+#: * Default "query", and someone who indexes a corpus with a bare call
+#:   stamps the query instruction onto ten thousand passages. Every later
+#:   search then compares a properly-prefixed query against a corpus that
+#:   claims to be ten thousand queries — the mismatched state, which is
+#:   measurably worse than using no prefix at all (the e5 card says so
+#:   outright about its own pair).
+#: * Default "document", and the same person gets a corpus that is internally
+#:   consistent. If they never discover `kind`, every text in the system —
+#:   corpus and query alike — carries the same prefix, which is the SYMMETRIC
+#:   behaviour every one of these models supports and the behaviour every
+#:   encoder had before asymmetric prompting existed. It is not optimal; it
+#:   degrades gracefully rather than to the mismatched state.
+#:
+#: The tie-breaker is `bge`: its document side is the EMPTY string, because
+#: its card instructs the query only. So on that family this default means a
+#: bare call embeds text verbatim — precisely what someone who has not read
+#: about prompt schemes expects to happen — while the opposite default would
+#: silently prepend a sentence about searching to text nobody was searching.
+#:
+#: Documented on the bridge (`fused.ai.embedText`) as well, because a default
+#: whose reasoning lives only in the runner is a default page authors cannot
+#: act on.
+DEFAULT_KIND = formats.TEXT_EMBED_DEFAULT_KIND
+
+#: What to say when a caller passes `paths` (or `images`) to an endpoint with
+#: no vision tower behind it. **Named, not a generic "unexpected field".** The
+#: request is not a typo — it is someone who found `fused.ai.embed`'s image
+#: half and reasonably assumed this endpoint had one, so the sentence has to
+#: say which endpoint DOES and not merely that this one does not.
+_NO_IMAGES = (
+    "'{field}' is not something a text embedding model can read — this "
+    "capability loads a text encoder, which has no vision tower and no image "
+    "input at all. Passing image paths here would embed the FILENAMES as "
+    "prose and return vectors that look fine and mean nothing. For text and "
+    "images in one comparable space, use fused.ai.embed() instead, which "
+    "loads a dual encoder (SigLIP/CLIP) for exactly that."
+)
+
+
+def request_texts(body: dict) -> tuple[list, str]:
+    """`(texts, kind)`, or raises `ValueError` naming what is wrong.
+
+    The one shape all three engines accept: a non-empty `texts` list of
+    non-empty strings, at most `MAX_ITEMS` long, and an optional `kind` that
+    must be one of `KINDS` when present.
+
+    Checked here so a batch of 65 does not read as a llama.cpp limit on one
+    engine and an MLX one on another — the same argument `embed_common`'s
+    own `request_kind` makes about the pair it serves — and checked AGAIN by
+    the route before a model is even resolved, so a malformed request costs
+    nothing rather than a 409 that implies the fix is to wait.
+
+    **An unrecognised `kind` is refused rather than defaulted.** It is the
+    one field here whose wrong value produces no error anywhere downstream:
+    a `kind: "queries"` that fell through to `DEFAULT_KIND` would return
+    unit-length vectors of the right dimension, computed against the wrong
+    half of the prompt pair, and nothing the caller could measure would say
+    so. Refusing costs a typo one round trip; defaulting costs a silent
+    accuracy regression nobody attributes to this call.
+    """
+    for field in ("paths", "images"):
+        if body.get(field):
+            raise ValueError(_NO_IMAGES.format(field=field))
+
+    texts = body.get("texts")
+    if not isinstance(texts, list) or not texts:
+        raise ValueError("pass 'texts' — a non-empty list of strings")
+    if len(texts) > MAX_ITEMS:
+        raise ValueError(f"at most {MAX_ITEMS} items at a time, got {len(texts)}")
+    for index, item in enumerate(texts):
+        if not isinstance(item, str) or not item:
+            raise ValueError(f"'texts[{index}]' must be a non-empty string")
+
+    kind = body.get("kind")
+    if kind is None:
+        kind = DEFAULT_KIND
+    if kind not in KINDS:
+        raise ValueError(
+            f"'kind' must be one of {', '.join(repr(k) for k in KINDS)} "
+            f"(got {kind!r}) — a retrieval model instructs a question and a "
+            f"passage differently, so this picks which prompt goes in front "
+            f"of these texts. Leave it out for {DEFAULT_KIND!r}.")
+    return texts, kind
+
+
+def prompted(texts: list, kind: str, scheme: str) -> list:
+    """`texts` with this model's prefix for `kind` glued to the front of each.
+
+    A plain concatenation and nothing cleverer, because every scheme in
+    `formats.TEXT_EMBED_PROMPTS` is literally a string the model's own card
+    puts in front of the text. The `"none"` scheme's prefix is `""`, so this
+    returns the input unchanged for a model with no convention — the same
+    list, not a copy, is deliberately NOT relied on: the caller may hold the
+    original for its own reporting.
+    """
+    prefix = formats.text_embed_prompt(scheme, kind)
+    if not prefix:
+        return list(texts)
+    return [prefix + text for text in texts]
+
+
+def unit_normalize(vectors: list) -> list:
+    """Every row scaled to length 1, in plain Python floats.
+
+    `embed_common`'s function, re-exported under this module's name rather
+    than imported directly by each worker. The indirection is worth one line:
+    it means every runner in THIS capability reaches its normalization
+    through the module that documents this capability's contract, so the
+    guarantee `/api/ai/embed-text` publishes — a cosine similarity is a plain
+    dot product — has one place to be read about.
+
+    **Applied even when the model already normalized.** llama.cpp normalizes
+    when the GGUF declares a pooling type, and `mlx-embeddings` normalizes
+    inside every `Model.__call__` this app reaches. Re-normalizing an
+    already-unit vector is a no-op to within float error, and paying for that
+    no-op is much cheaper than the alternative: a future engine, a future
+    pooling type, or an upstream that quietly stops normalizing would
+    otherwise break the one promise callers were told to rely on, and would
+    break it silently.
+    """
+    return embed_common.unit_normalize(vectors)

--- a/fused_render/ai/runners/text_embed_common.py
+++ b/fused_render/ai/runners/text_embed_common.py
@@ -36,8 +36,22 @@ insert that reaches `worker_base`, and none of them has this app on its path.
 
 from __future__ import annotations
 
-import embed_common
-import formats
+import os
+import sys
+
+# `embed_common` and `formats` sit in THIS directory. Two loaders reach this
+# file — the three runners put `runners/` on `sys.path` and import it bare,
+# while `server/routers/ai_runtime.py` imports it as
+# `fused_render.ai.runners.text_embed_common` — and the package-relative
+# reading must be tried FIRST so the server does not end up with a second copy
+# of these modules under second names. `partial.py` carries the same two-line
+# guard for the same two loaders; see its comment for the drift it prevents.
+try:
+    from . import embed_common, formats
+except ImportError:  # pragma: no cover - the runner reading, exercised in prod
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import embed_common
+    import formats
 
 #: The batch ceiling, taken from `embed_common` rather than restated. The
 #: number is not a fact about dual encoders — it is a fact about how much

--- a/fused_render/ai/supervisor.py
+++ b/fused_render/ai/supervisor.py
@@ -1757,8 +1757,9 @@ def generate_text(model: str, body: dict):
                 yield event
 
 
-def generate_embed(model: str, body: dict) -> dict:
-    """One `{vectors, dim, model}` reply from the resident embedding model.
+def generate_embed(model: str, body: dict,
+                   capability: str = registry.EMBEDDINGS) -> dict:
+    """One `{vectors, dim, …}` reply from the resident embedding model.
 
     The same fail-fast shape as `generate_text`, not the wait-inside-a-job shape
     `generate_image` and `_wait_ready` use: an embed call answers in
@@ -1771,15 +1772,30 @@ def generate_embed(model: str, body: dict) -> dict:
     Blocking, and cheap to block on: unlike an image or a transcription this is
     one forward pass through a small tower, so holding the request open for it
     costs nothing the caller was not already waiting on.
+
+    **`capability` is a PARAMETER rather than this function being duplicated**,
+    because two capabilities now answer this exact shape:
+    `registry.EMBEDDINGS` (dual encoders, `/api/ai/embed`) and
+    `registry.TEXT_EMBEDDINGS` (text encoders, `/api/ai/embed-text`). Every
+    line below is about the residency protocol — is a worker ready, is one
+    loading, start one and report the job — and none of it is about what the
+    model does with the body, so a second copy would be two identical
+    residency implementations that could drift on the one thing this module
+    exists to get right. It defaults to `EMBEDDINGS` so every existing caller
+    reads unchanged.
+
+    The two do NOT share a resident slot, which is the point of them being
+    separate capabilities: `_workers` is keyed by capability, so a text
+    embedder loaded here cannot evict a SigLIP model loaded there.
     """
-    worker = ready_worker(registry.EMBEDDINGS, model)
+    worker = ready_worker(capability, model)
     if worker is None:
         with _lock:
-            current = _workers.get(registry.EMBEDDINGS)
+            current = _workers.get(capability)
         if current is not None and current.model == model:
             raise ModelNotReady(
                 f"{model} is still loading ({current.state})", job_id_for(model))
-        started = load(model, registry.EMBEDDINGS)
+        started = load(model, capability)
         raise ModelNotReady(f"{model} is loading now", started["jobId"])
 
     try:

--- a/fused_render/ai/tasks.py
+++ b/fused_render/ai/tasks.py
@@ -39,6 +39,7 @@ from fused_render.ai.registry import (
     EMBEDDINGS,
     IMAGE_GENERATION,
     SPEECH_TO_TEXT,
+    TEXT_EMBEDDINGS,
     TEXT_GENERATION,
 )
 
@@ -121,23 +122,39 @@ _TASKS: tuple[Task, ...] = (
     _t("zero-shot-image-classification", "zero-shot image classification", "cv", EMBEDDINGS,
        "Says what an image shows, against labels you supply at the time rather than a fixed set."),
 
+    # **THESE TWO ROWS MOVED, and the comment they used to carry said they
+    # would.** They were `None` — withheld from the `embeddings` capability
+    # because what wears these tags is a sentence-transformers checkpoint: a
+    # text encoder plus a pooling configuration, with no vision tower and no
+    # `get_text_features` for the dual-encoder runners to call. That comment
+    # ended "Mean-pooling a text-only encoder is a different load path and a
+    # different catalog; when it ships, these two move." It has shipped
+    # (`registry.TEXT_EMBEDDINGS`), so they moved.
+    #
+    # **Both tags, one capability, and that is not a mistake to tidy up
+    # later.** The Hub splits this task in two and the split is not about the
+    # model — `feature-extraction` and `sentence-similarity` are worn by the
+    # same checkpoints, often by two revisions of the same repo, and nothing
+    # in either tag says anything a loader could act on differently. Mapping
+    # only one of them would have made a model's Load button depend on which
+    # word its uploader picked.
+    #
+    # **`sentence-transformers/all-MiniLM-L6-v2` still gets NO Load button**,
+    # which is the invariant `test_a_result_is_never_something_this_app_cannot_run`
+    # pins and the reason these rows were withheld in the first place. It is
+    # no longer withheld by the CAPABILITY, though — it is withheld by the
+    # FORMAT, one layer down: the llama.cpp embedding rows declare
+    # `hub_filter_tags=("gguf",)`, so `hub_models` drops a search result whose
+    # `siblings` hold no loadable GGUF, and that repo publishes safetensors
+    # only. The guarantee is the same and its evidence is now stronger — it
+    # rests on what the repo actually contains rather than on a capability
+    # nobody had written yet.
+    _t("feature-extraction", "embeddings", "multimodal", TEXT_EMBEDDINGS,
+       "Turns text into vectors, so things can be compared or searched by meaning."),
+    _t("sentence-similarity", "sentence embeddings", "nlp", TEXT_EMBEDDINGS,
+       "Turns sentences into vectors, so similar sentences land near each other — search, clustering, RAG."),
+
     # ------------------------------------------------- text, nothing serves it
-    # **The two rows the embedding capability does NOT claim, despite being its
-    # own name.** What wears these tags is overwhelmingly a sentence-transformers
-    # checkpoint: a text encoder plus a pooling configuration, with no vision
-    # tower and no `get_text_features`/`get_image_features` for the embedding
-    # runners to call. Mapping them would put a Load button on
-    # `sentence-transformers/all-MiniLM-L6-v2` — a download that then refuses.
-    # Mean-pooling a text-only encoder is a different load path and a different
-    # catalog; when it ships, these two move.
-    _t("feature-extraction", "embeddings", "multimodal", None,
-       "Turns text into vectors, so things can be compared or searched by meaning.",
-       "The embedding runners here serve dual encoders (image and text into one space), "
-       "not text-only sentence encoders."),
-    _t("sentence-similarity", "sentence embeddings", "nlp", None,
-       "Turns sentences into vectors, so similar sentences land near each other — search, clustering, RAG.",
-       "The embedding runners here serve dual encoders (image and text into one space), "
-       "not text-only sentence encoders."),
     _t("summarization", "summarization", "nlp", None,
        "Shortens a long text into its main points.",
        "A chat model does this from a prompt — no separate runner ships for it."),

--- a/fused_render/server/routers/ai_benchmark.py
+++ b/fused_render/server/routers/ai_benchmark.py
@@ -131,7 +131,15 @@ def _benchmarkable_models(capability: str) -> set[str]:
         # already in `admitted` if it is here, and if it is not, it is not
         # benchmarkable. Guarding on the recipe keeps that explicit rather than
         # resting on `is_downloaded` happening to agree.
-        if entry_id in formats.GGUF_RECIPES and is_downloaded(entry_id, cached):
+        #
+        # `formats.gguf_recipe`, not `formats.GGUF_RECIPES` — there are TWO
+        # filename-keyed recipe tables now (chat and text embedding), and this
+        # was the last site still reading only the first. The failure was
+        # silent and total for the newer capability: all three of its curated
+        # ids are filenames, none ever appears as a cached `repo_id`, so none
+        # was admitted and `POST /api/ai/benchmark` 404'd for every text
+        # embedding model even with the weights on disk.
+        if formats.gguf_recipe(entry_id) and is_downloaded(entry_id, cached):
             admitted.add(entry_id)
     return admitted
 

--- a/fused_render/server/routers/ai_runtime.py
+++ b/fused_render/server/routers/ai_runtime.py
@@ -48,8 +48,18 @@ from fused_render.ai import catalog, registry, supervisor
 # rule here costs nothing. `embed_common` joins them for the same reason: its
 # request-shape check is what BOTH embedding runners' own `generate()` calls,
 # and a body this route refuses must be refused for the identical reason a
-# worker asked directly would give.
-from fused_render.ai.runners import diarize, embed_common, engine_options, formats, partial, preview
+# worker asked directly would give. `text_embed_common` is that same rule for
+# the OTHER embedding capability — a different validator because it refuses
+# `paths` by name and takes a `kind` the dual encoders have no use for.
+from fused_render.ai.runners import (
+    diarize,
+    embed_common,
+    engine_options,
+    formats,
+    partial,
+    preview,
+    text_embed_common,
+)
 from fused_render.server.common import _error, _require_fused
 # The AI Models page's reading of the local cache, imported rather than
 # re-derived: see `_inferred_capability` and `_catalog_with_downloads`. It imports
@@ -637,9 +647,9 @@ def _catalog_with_downloads() -> list[dict]:
         # correct for any future runner whose ids work the same way without
         # this function needing to know which one.
         curated_repo_ids = {
-            formats.GGUF_RECIPES[entry["id"]]["repo"]
+            formats.gguf_recipe(entry["id"])["repo"]
             for entry in curated
-            if entry["downloaded"] and entry["id"] in formats.GGUF_RECIPES
+            if entry["downloaded"] and formats.gguf_recipe(entry["id"])
         }
         extra = [
             {
@@ -1397,5 +1407,96 @@ def api_ai_embed(body: dict = Body(...), x_fused: str | None = Header(default=No
             "vectors": result.get("vectors") or [],
             "dim": result.get("dim") or 0,
             "model": model,
+        },
+    }
+
+
+@router.post("/api/ai/embed-text")
+def api_ai_embed_text(body: dict = Body(...), x_fused: str | None = Header(default=None)):
+    """Embed text into the resident TEXT encoder's vector space.
+
+    **A separate route from `/api/ai/embed`, mirroring the separate capability
+    behind it** (`registry.TEXT_EMBEDDINGS` — see that constant for the whole
+    argument). The wire shape is deliberately IDENTICAL to that route's, down
+    to the error contract: `{ok, result|error:{type, message, jobId}}`, a 400
+    for a malformed request, a 409 `unavailable` when no runner can serve the
+    capability here, and — the fork that matters — a 409 `model_loading`
+    carrying the id of the load this call just started, exactly as
+    `/api/ai/embed` and `/api/ai`'s local-model path both do. A page that has
+    written the retry loop once should not need a second one.
+
+    **Two things this route adds, and both are about retrieval being
+    asymmetric.**
+
+    `kind` (`"query"` or `"document"`, default `"document"`) picks which half
+    of the model's own prompt pair goes in front of these texts.
+    `text_embed_common.DEFAULT_KIND` carries the argument for that default at
+    length; the short version is that it is the side which keeps a corpus
+    internally consistent for someone who has not read about prompt schemes
+    yet, and on the bge family it means no prefix at all.
+
+    `kind` and `promptScheme` travel BACK on the result, because both are
+    decisions made on the caller's behalf that change what the vectors mean
+    and that nothing downstream can detect: a wrongly-prompted batch still
+    returns unit vectors of the right dimension.
+
+    **`paths` is refused rather than ignored.** There is no vision tower here,
+    and a caller who found `fused.ai.embed`'s image half and assumed this
+    endpoint had one would otherwise get the FILENAMES embedded as prose —
+    plausible vectors, no error, nonsense results. `request_texts` says so by
+    name and points at the endpoint that does take images.
+    """
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+
+    # Same rule `generate()` enforces inside each worker's own venv
+    # (`text_embed_common.request_texts`) — refused HERE too, before a model
+    # is even resolved, so a malformed request costs nothing rather than a
+    # 409 that implies the fix is to wait. `/api/ai/embed` does the identical
+    # thing with its own validator, for the identical reason.
+    try:
+        texts, kind = text_embed_common.request_texts(body)
+    except ValueError as e:
+        return _embed_error("bad_request", str(e), status=400)
+
+    model = _model_of(body) or catalog.default_for(registry.TEXT_EMBEDDINGS)
+    if not model:
+        # See `api_ai_image`'s identical comment: no runner and no curated
+        # default are different facts, and only the runner's own reason tells
+        # the user what to do about it.
+        return _embed_error(
+            "unavailable",
+            registry.unavailable_reason(registry.TEXT_EMBEDDINGS)
+            or "no text embedding model is configured",
+            status=409)
+
+    try:
+        result = supervisor.generate_embed(
+            model, {"texts": texts, "kind": kind},
+            capability=registry.TEXT_EMBEDDINGS)
+    except supervisor.ModelNotReady as e:
+        # NOT a failure — the load already started, and its job id is what
+        # lets the caller show that download rather than just a rejection.
+        return _embed_error("model_loading", str(e), status=409, job_id=e.job_id)
+    except supervisor.SupervisorError as e:
+        return _embed_error("ai_error", str(e), status=502)
+
+    return {
+        "ok": True,
+        "result": {
+            "vectors": result.get("vectors") or [],
+            "dim": result.get("dim") or 0,
+            "model": model,
+            # The worker's own answer, not the request's: for `kind` the two
+            # agree, but reading it back from the reply is what keeps this
+            # honest the day a runner clamps or renames one.
+            "kind": result.get("kind") or kind,
+            # …and the scheme has no request half at all — it is derived from
+            # the model, by a curated table for the ids this app ships and by
+            # a filename heuristic for anything else
+            # (`formats.TEXT_EMBED_SCHEME_HINTS`). Reporting it is what makes
+            # that heuristic auditable instead of silent.
+            "promptScheme": result.get("promptScheme") or "none",
         },
     }

--- a/fused_render/server/routers/hub_models.py
+++ b/fused_render/server/routers/hub_models.py
@@ -121,7 +121,7 @@ from fastapi import APIRouter, Body, Header
 
 from fused_render._view_url_codec import canonical_fs_path
 from fused_render.ai import tasks as ai_tasks
-from fused_render.ai.registry import for_capability
+from fused_render.ai.registry import TEXT_EMBEDDINGS, for_capability
 from fused_render.ai.runners import formats
 from fused_render.server.common import _error, _require_fused
 from fused_render.ai.hub_cache import (
@@ -499,13 +499,29 @@ def _model_row(raw: dict, cache_dir: str, dirs: dict[str, str]) -> dict | None:
         # The one runner-specific branch in this module (see the docstring's
         # last section) — `pick_gguf_file` is a GGUF-specific function, and
         # `hub_filter_tags` names the FILTER TAG generically but not the
-        # picker that goes with it, since llama.cpp's is the only format
-        # that needs one today. A future second format-specific runner would
-        # need its own branch here, not a new item in `hub_filter_tags`.
+        # picker that goes with it. That comment used to end "a future second
+        # format-specific runner would need its own branch here, not a new
+        # item in `hub_filter_tags`", and `TEXT_EMBEDDINGS` is that runner —
+        # so here is the branch.
+        #
+        # **The two pickers are not interchangeable and picking the wrong one
+        # is wrong twice over.** `pick_gguf_file` ranks `Q4_K_M` first and
+        # excludes F16/BF16/F32 and sub-Q4 outright, because a chat model's
+        # download is the binding cost. `pick_embedding_gguf_file` inverts
+        # that (see its docstring: quantization error lands straight in the
+        # vector, and these files are tens of megabytes). Using the chat
+        # picker here would DROP an embedding repo that publishes only
+        # `…-f16.gguf` and `…-f32.gguf` — ordinary `convert_hf_to_gguf.py`
+        # output for a small encoder — and, where both do answer, would print
+        # a `file` naming a different quantization from the one
+        # `llama_embed.download` actually fetches.
         siblings = raw.get("siblings")
         names = ([s.get("rfilename") for s in siblings if isinstance(s, dict)]
                  if isinstance(siblings, list) else [])
-        file = formats.pick_gguf_file(names)
+        pick = (formats.pick_embedding_gguf_file
+                if capability == TEXT_EMBEDDINGS
+                else formats.pick_gguf_file)
+        file = pick(names)
         if file is None:
             return None
     safetensors = raw.get("safetensors")

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -3178,11 +3178,15 @@
   // surface this — so this does not go through the generic `aiPost` (whose
   // blanket "409 -> unavailable" would drop the job id on the floor). It reads
   // the same `{ok, result|error:{type,message,jobId}}` wire shape `fused.ai`
-  // itself does, and `fail()` below is that function's own error mapping,
-  // copied rather than shared for the reason `mlx_embed/worker.py`'s
-  // `_pin_stream` is: the two live in different modules with no import between
-  // them, HTTP is the only contract, and duplicating five lines is cheaper
-  // than inventing one.
+  // itself does, mapped in the shared `embedPost` below.
+  //
+  // That mapping began here as a copy of `fused.ai`'s own `fail()`, on the
+  // argument `mlx_embed/worker.py`'s `_pin_stream` makes: two modules, no
+  // import between them, HTTP the only contract, five lines cheaper than a
+  // seam. It moved into `embedPost` when `aiEmbedText` arrived — see the note
+  // there for why a THIRD copy inside one scope does not survive that
+  // argument. `fused.ai`'s own copy stays put; that one really is across a
+  // module boundary.
   function aiEmbed(opts) {
     opts = opts || {};
     const hasTexts = Array.isArray(opts.texts) && opts.texts.length > 0;

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -125,6 +125,26 @@
  *     call just started — watch it and retry, exactly like the first
  *     fused.ai(...) on a cold local model) | "ai_error" | "unavailable" (no
  *     embedding runner on this machine).
+ *   fused.ai.embedText({texts, kind, model})
+ *     -> Promise<{vectors, dim, model, kind, promptScheme}>
+ *     TEXT into vectors, locally (SPEC §40) — a text encoder (bge, e5,
+ *     nomic-embed, EmbeddingGemma, Qwen3-Embedding). A DIFFERENT capability
+ *     from fused.ai.embed above, holding its own resident model, so a page
+ *     can have both loaded at once. This is the one for searching notes,
+ *     clustering documents or RAG; reach for embed() when pictures have to
+ *     land in the same space as words. No `paths` — there is no vision tower
+ *     here, and image paths are refused by name rather than embedded as
+ *     filenames.
+ *     `kind` is "query" | "document", default "document". Retrieval models
+ *     are ASYMMETRIC: a question and the passage that answers it want
+ *     different prompts, and the right prefix for the loaded model is applied
+ *     for you. So embed a corpus with the default, embed the search box with
+ *     kind:"query", and compare the two. Getting it wrong is not an error and
+ *     never surfaces as one — it silently costs recall — which is why `kind`
+ *     and the `promptScheme` actually applied both come back on the result.
+ *     Up to 64 items, vectors UNIT-NORMALIZED (cosine == a plain dot
+ *     product), not job-backed. Rejects with the same .type values embed()
+ *     does.
  *   fused.capture.* -> record the screen, record the mic, grab a still
  *     screen({display, rect, audio, device, cursor, path, maxSeconds, title})
  *     -> Promise<handle> and audio({source, path, maxSeconds, title})
@@ -3187,7 +3207,23 @@
       const ownPath = new URLSearchParams(window.location.search).get("path");
       if (ownPath) body.base = ownPath;
     }
-    return fetch("/api/ai/embed", {
+    return embedPost("/api/ai/embed", body);
+  }
+
+  // The POST half both embedding bridges share: the wire shape, the tolerant
+  // parse, and the 409 fork that carries a jobId.
+  //
+  // Factored out when `aiEmbedText` arrived, and only then. `aiEmbed` had
+  // copied `fused.ai`'s five-line `fail()` rather than sharing it, on the
+  // argument its own comment above makes — two modules, HTTP the only
+  // contract, five lines cheaper than a seam. That argument does not survive
+  // a THIRD copy inside the same function scope: these two calls must answer
+  // a 409 identically or a page written against one cannot retry the other,
+  // and there is no module boundary between them to justify the duplication.
+  // `fused.ai`'s own copy stays where it is — that one really is across a
+  // boundary.
+  function embedPost(url, body) {
+    return fetch(url, {
       method: "POST",
       headers: callHeaders({ "Content-Type": "application/json", "X-Fused": "1" }),
       body: JSON.stringify(body),
@@ -3213,6 +3249,62 @@
         }
         return data.result;
       });
+  }
+
+  // fused.ai.embedText({texts, kind, model})
+  //   -> Promise<{vectors, dim, model, kind, promptScheme}>
+  //
+  // Text into vectors through a TEXT ENCODER — a different capability from
+  // `aiEmbed` above, with its own resident model, so a page can hold a SigLIP
+  // model and a text embedder at once and neither evicts the other.
+  //
+  // Vectors are UNIT-NORMALIZED, so a cosine similarity between two of them is
+  // a plain dot product — `a[i]*b[i]` summed, no magnitudes to divide by. Same
+  // guarantee `aiEmbed` makes, and it holds here for the same reason: the
+  // worker normalizes before it answers.
+  //
+  // **`kind` is the one argument worth reading about before using this.**
+  // Retrieval models are asymmetric — a question and the passage that answers
+  // it were trained with different prompts in front of them — and the prefix
+  // for the loaded model is applied server-side from a table
+  // (`formats.TEXT_EMBED_PROMPTS`). Embed a corpus with the default
+  // ("document"), embed the search box with kind:"query", compare. Passing the
+  // wrong one is NOT an error and cannot be detected downstream: the vectors
+  // come back unit length and the right width, just worse at finding things.
+  // That is why the reply carries `kind` and `promptScheme` back — so a page
+  // can show which convention was applied rather than trusting it.
+  //
+  // `paths` is rejected here rather than sent: there is no vision tower behind
+  // this endpoint, so image paths would be embedded as filename PROSE. Caught
+  // client-side for `aiEmbed`'s reason — a call that will certainly be refused
+  // should not pay for the trip first — and the server refuses it again by
+  // name for a caller that is not this bridge.
+  function aiEmbedText(opts) {
+    opts = opts || {};
+    if (!Array.isArray(opts.texts) || opts.texts.length === 0) {
+      const err = new Error(
+        "fused.ai.embedText({texts}): pass 'texts' — a non-empty array of "
+          + "strings",
+      );
+      err.type = "bad_request";
+      return Promise.reject(err);
+    }
+    if (opts.paths) {
+      const err = new Error(
+        "fused.ai.embedText({texts}): 'paths' is not something a text encoder "
+          + "can read — use fused.ai.embed() for images and text in one space",
+      );
+      err.type = "bad_request";
+      return Promise.reject(err);
+    }
+    const body = { texts: opts.texts };
+    // Left OUT when the caller said nothing, rather than defaulted here: the
+    // default belongs to `text_embed_common.DEFAULT_KIND`, which is where its
+    // reasoning is written, and a second copy of the value in this file would
+    // be the one that goes stale if it ever moves.
+    if (opts.kind !== undefined) body.kind = opts.kind;
+    if (opts.model !== undefined) body.model = opts.model;
+    return embedPost("/api/ai/embed-text", body);
   }
 
   const aiModels = {
@@ -3244,6 +3336,7 @@
   ai.image = aiImage;
   ai.transcribe = aiTranscribe;
   ai.embed = aiEmbed;
+  ai.embedText = aiEmbedText;
   // Stop the generation in flight on a local model, keeping it loaded — the
   // next message answers straight away. Resolves false when there was nothing
   // to stop, which is not an error: a Stop pressed as the last token lands

--- a/tests/test_ai_benchmark.py
+++ b/tests/test_ai_benchmark.py
@@ -243,7 +243,7 @@ def test_an_embedding_race_is_waited_out_and_retried_the_same_way(
         bench, monkeypatch):
     calls = {"n": 0}
 
-    def generate_embed(model, body):
+    def generate_embed(model, body, capability=None):
         calls["n"] += 1
         if calls["n"] == 1:
             # The discarded warm-up: uneventful.
@@ -269,9 +269,11 @@ def test_an_embedding_race_is_waited_out_and_retried_the_same_way(
 
 def test_embeddings_report_texts_per_second_and_dim(bench, monkeypatch):
     calls = {"n": 0}
+    seen_capabilities = []
 
-    def generate_embed(model, body):
+    def generate_embed(model, body, capability=None):
         calls["n"] += 1
+        seen_capabilities.append(capability)
         assert body["texts"] == list(
             benchmark.WORKLOADS[ai_registry.EMBEDDINGS].params["texts"])
         bench.advance(50.0 if calls["n"] == 1 else 2.0)
@@ -285,11 +287,44 @@ def test_embeddings_report_texts_per_second_and_dim(bench, monkeypatch):
     assert metrics["batch"] == 8
     assert metrics["textsPerSecond"] == pytest.approx(4.0)  # 8 texts / 2.0s
     assert metrics["dim"] == 768
+    # …and the capability travelled, which is what keeps this measurer usable
+    # by BOTH embedding capabilities without a second copy of it.
+    assert seen_capabilities == [ai_registry.EMBEDDINGS] * 2
+
+
+def test_the_text_embedding_workload_measures_its_own_capability(bench, monkeypatch):
+    """The second capability's measurer, and the two things that make it not
+    a duplicate of the one above: it names `TEXT_EMBEDDINGS` to the supervisor
+    (so it cannot evict the dual encoder), and it carries the workload's
+    pinned `kind` into the request.
+
+    `kind` matters to a BENCHMARK and not only to a result: the prompt prefix
+    lengthens every sequence — on Qwen3-Embedding by a whole instruction block
+    — so a measurer that dropped it would report a number for less work than
+    the workload describes.
+    """
+    seen = []
+
+    def generate_embed(model, body, capability=None):
+        seen.append((body, capability))
+        bench.advance(20.0 if len(seen) == 1 else 4.0)
+        return {"vectors": [[0.0] * 384] * len(body["texts"]), "dim": 384,
+                "kind": body.get("kind"), "promptScheme": "e5"}
+
+    monkeypatch.setattr(benchmark.supervisor, "generate_embed", generate_embed)
+    record = benchmark.run("some/text-embed-model", ai_registry.TEXT_EMBEDDINGS)
+    assert record["ok"] is True
+    assert [capability for _body, capability in seen] == \
+        [ai_registry.TEXT_EMBEDDINGS] * 2
+    assert seen[1][0]["kind"] == "document"
+    assert record["metrics"]["dim"] == 384
+    assert record["metrics"]["textsPerSecond"] == pytest.approx(2.0)  # 8 / 4.0s
 
 
 def test_an_embedding_reply_with_no_dim_leaves_dim_null(bench, monkeypatch):
     monkeypatch.setattr(benchmark.supervisor, "generate_embed",
-                        lambda model, body: (bench.advance(1.0), {"vectors": []})[1])
+                        lambda model, body, capability=None: (
+                            bench.advance(1.0), {"vectors": []})[1])
     record = benchmark.run("some/embed-model", ai_registry.EMBEDDINGS)
     assert record["metrics"]["dim"] is None
 

--- a/tests/test_ai_formats.py
+++ b/tests/test_ai_formats.py
@@ -110,6 +110,18 @@ def test_every_registered_runner_appears_in_loaders():
     seen |= set(formats.loaders(
         repo_id="x/y", names=set(), dirnames=set(),
         config={"model_type": "siglip"}, torch_weights=True))
+    # An embedding GGUF — the same file shape as the chat case above, told
+    # apart ONLY by the pooling type its header declares, and short-circuiting
+    # ahead of the chat branch — so the two cannot be exercised by one call.
+    seen |= set(formats.loaders(
+        repo_id="x/y", names={"model.gguf"}, dirnames=set(), config={},
+        torch_weights=False, gguf_architecture="bert",
+        gguf_pooling_type=formats.GGUF_POOLING_MEAN))
+    # …and a text encoder's safetensors, which short-circuits ahead of the
+    # dual-encoder branch for the same reason.
+    seen |= set(formats.loaders(
+        repo_id="x/y", names=set(), dirnames=set(),
+        config={"model_type": "bert"}, torch_weights=True))
     missing = _codes() - seen
     assert not missing, (
         f"{sorted(missing)} are registered runners that `loaders()` never "

--- a/tests/test_ai_llamacpp_embed_worker.py
+++ b/tests/test_ai_llamacpp_embed_worker.py
@@ -578,6 +578,56 @@ def test_the_recipes_and_the_catalog_cannot_drift(worker):
         entry["id"] for entry in catalog.SUGGESTIONS["llamacpp-embed"]}
 
 
+def test_a_downloaded_embedding_gguf_still_has_a_capability(worker):
+    """**The Load button, and the bug that took it away.**
+
+    `worker_base.download_file` fetches the ONE `.gguf` and nothing else, so a
+    curated model's snapshot has no README and no config — `_format_task`
+    returns None for it, and the capability a cached card shows comes instead
+    from `hub_cache._engine`, which intersects `meta.loaders` with
+    `formats.DECISIVE`.
+
+    The first cut of this change added the new codes to `loaders()` and NOT to
+    `DECISIVE`, so that intersection was empty: a model the user had just
+    downloaded rendered with no task, no engine tag and no Load button, while
+    `cached_capability` recovered it through its own `meta.loaders` fallback —
+    card and load route disagreeing, which is the exact split `_engine`'s
+    docstring says cannot happen. Chat GGUFs were unaffected, so nothing else
+    noticed.
+    """
+    from fused_render.ai.runners import formats
+
+    loaders = formats.loaders(
+        repo_id="nomic-ai/nomic-embed-text-v1.5-GGUF",
+        names={"nomic-embed-text-v1.5.Q8_0.gguf"}, dirnames=set(), config={},
+        torch_weights=False, gguf_architecture="nomic-bert",
+        gguf_pooling_type=formats.GGUF_POOLING_MEAN)
+    assert set(loaders) & set(formats.DECISIVE) == set(loaders), (
+        f"{sorted(set(loaders) - set(formats.DECISIVE))} are runners "
+        f"`loaders()` names for a GGUF snapshot but `DECISIVE` does not, so a "
+        f"cached repo they load gets no capability and no Load button")
+
+
+def test_the_embedding_picker_takes_files_the_chat_picker_refuses(worker):
+    """Why hub search needs its own branch rather than reusing
+    `pick_gguf_file` now that a second capability declares
+    `hub_filter_tags=("gguf",)`.
+
+    `_gguf_rank` excludes F16/BF16/F32 outright — correct for a chat model,
+    where full precision is a download nobody wants — and `pick_gguf_file`
+    falls back only when there is exactly one candidate. A small encoder
+    converted with stock `convert_hf_to_gguf.py` publishes precisely
+    `…-f16.gguf` and `…-f32.gguf` and nothing else, so the chat picker drops
+    the repo from Discover entirely while the embedding picker ranks both.
+    """
+    from fused_render.ai.runners import formats
+
+    names = ["model-f16.gguf", "model-f32.gguf", "README.md"]
+    assert formats.pick_gguf_file(names) is None
+    # F16 over F32: twice the bytes for weights trained in half precision.
+    assert formats.pick_embedding_gguf_file(names) == "model-f16.gguf"
+
+
 def test_the_two_recipe_tables_share_no_key(worker):
     """`formats.gguf_recipe` consults the chat table FIRST, so a shared key
     would silently resolve an embedding id to a chat model's repo and

--- a/tests/test_ai_llamacpp_embed_worker.py
+++ b/tests/test_ai_llamacpp_embed_worker.py
@@ -286,6 +286,75 @@ def test_an_unreadable_header_does_NOT_refuse(worker, monkeypatch):
     assert path.endswith("mystery-Q8_0.gguf")
 
 
+def _fake_hf_session(monkeypatch, status, content, seen=None):
+    """Stand in for `huggingface_hub.utils.get_session()`, recording the
+    kwargs `_remote_header` passes so a client-specific keyword cannot creep
+    back in unnoticed."""
+    class _Response:
+        def __init__(self):
+            self.status_code = status
+            self.content = content
+
+    class _Session:
+        def get(self, url, **kwargs):
+            if seen is not None:
+                seen.append((url, kwargs))
+            return _Response()
+
+    utils = types.ModuleType("huggingface_hub.utils")
+    utils.get_session = lambda: _Session()
+    utils.build_hf_headers = lambda: {}
+    hub = types.ModuleType("huggingface_hub")
+    hub.hf_hub_url = lambda repo, filename, **kw: f"https://hub/{repo}/{filename}"
+    hub.utils = utils
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", utils)
+
+
+def test_the_header_peek_reads_a_206_and_asks_for_a_range(worker, monkeypatch):
+    """**A regression test for a bug that shipped silently and was found by
+    running the server, not by the suite.**
+
+    The first draft called `get_session().get(..., stream=True)` and read
+    `response.raw`. That is the `requests` spelling; `huggingface_hub` 1.x
+    returns an **httpx.Client**, whose `get()` has no `stream` keyword — so
+    every call raised `TypeError`, `_remote_header`'s deliberately broad
+    `except` turned it into `b""`, and the peek never ran. Nothing failed:
+    "could not look" is a legitimate state that means "do not refuse", so the
+    runner simply started downloading chat models it should have refused.
+
+    This test pins the two things that would have caught it: the bytes come
+    back, and the request carries a `Range` header and NO client-specific
+    keyword.
+    """
+    seen = []
+    _fake_hf_session(monkeypatch, 206, b"GGUFxx", seen)
+    assert worker._remote_header("org/r", "m.gguf") == b"GGUFxx"
+    (url, kwargs), = seen
+    assert url == "https://hub/org/r/m.gguf"
+    assert kwargs["headers"]["Range"].startswith("bytes=0-")
+    # `stream`/`follow_redirects`/`allow_redirects` are each spelled by only
+    # ONE of the two clients hf has shipped, so naming any of them is the
+    # same TypeError-into-silence trap this test exists for.
+    assert not ({"stream", "follow_redirects", "allow_redirects"} & set(kwargs))
+
+
+def test_a_200_is_treated_as_a_failure_to_look_not_as_a_header(worker, monkeypatch):
+    """**The memory bound, and the reason it is a status check.** A `206` is
+    the server saying it honoured the `Range`, so the body cannot exceed the
+    2MB asked for. A plain `200` is a server that ignored it and is handing
+    over the whole multi-gigabyte file — which is exactly what a function
+    whose job is to avoid a download must not read.
+
+    Answering `b""` puts it in the "no evidence" state, so the runner
+    proceeds and the load-time check decides. That is the right direction:
+    a mirror with no Range support costs a user one download, not a model
+    they cannot load.
+    """
+    _fake_hf_session(monkeypatch, 200, b"GGUF" + b"x" * 10_000)
+    assert worker._remote_header("org/r", "m.gguf") == b""
+
+
 def test_a_lookup_failure_is_a_different_refusal_from_a_bad_repo(worker, monkeypatch):
     """"Try again" and "this will never resolve" are different facts a user
     acts on differently — the distinction `llama_text` draws too."""

--- a/tests/test_ai_llamacpp_embed_worker.py
+++ b/tests/test_ai_llamacpp_embed_worker.py
@@ -561,6 +561,33 @@ def test_generate_with_no_model_says_so(worker):
         worker.generate({"texts": ["a"]})
 
 
+def test_the_recipes_and_the_catalog_cannot_drift(worker):
+    """Two tables key the same models by the same filenames, and nothing but
+    this stops them diverging — the pin `test_ai_llamacpp_worker.py` already
+    has for the chat pair, which `formats.TEXT_EMBED_RECIPES`' own docstring
+    promises exists for this one.
+
+    A recipe with no catalog row is a model nobody is offered; a catalog row
+    with no recipe is a Download button whose resolution then raises. Neither
+    fails anywhere else.
+    """
+    from fused_render.ai import catalog
+    from fused_render.ai.runners import formats
+
+    assert set(formats.TEXT_EMBED_RECIPES) == {
+        entry["id"] for entry in catalog.SUGGESTIONS["llamacpp-embed"]}
+
+
+def test_the_two_recipe_tables_share_no_key(worker):
+    """`formats.gguf_recipe` consults the chat table FIRST, so a shared key
+    would silently resolve an embedding id to a chat model's repo and
+    download several gigabytes of the wrong thing. Disjoint by construction
+    today; pinned so it stays that way."""
+    from fused_render.ai.runners import formats
+
+    assert not (set(formats.GGUF_RECIPES) & set(formats.TEXT_EMBED_RECIPES))
+
+
 def test_main_wires_every_callback_the_base_expects(worker):
     """An unwired `memory()` would be silently ignored forever, including the
     day someone gives it a real probe — the same rule `llama_text.memory`'s

--- a/tests/test_ai_llamacpp_embed_worker.py
+++ b/tests/test_ai_llamacpp_embed_worker.py
@@ -1,0 +1,505 @@
+"""The llama.cpp / GGUF TEXT EMBEDDING runner's own behaviour — what is true
+of `runners/llama_embed.py` and nothing else.
+
+The contract half (routes, states, progress, the port handshake) is
+`worker_base`'s and is covered by `tests/test_ai_worker_base.py`. The request
+shape and the prompt rules are `text_embed_common`'s and are covered by
+`tests/test_ai_text_embed_common.py`. What is left here is what this runner
+decides for itself: which ids it will fetch, **which repos it refuses and how
+early**, how it sizes a context from a GGUF header, and what a round trip
+through it returns.
+
+Loaded by PATH with `worker_base` primed in `sys.modules`, exactly as
+`tests/test_ai_llamacpp_worker.py` loads its own runner: the module finds its
+base off `sys.path` in an interpreter of its own, so importing it the packaged
+way would be testing an import that never ships.
+
+**`llama_cpp` is not installed in this test venv, per AI-11c** — and on the
+machine this file was written on it could not have been: the maintainer's
+pinned CPU wheel aborts with `0xc000001d` (illegal instruction) on any x86_64
+CPU without the instruction set its `ggml-cpu.dll` was built against, which
+that machine lacks. Every path that would touch it therefore works against
+`_loaded["llm"]` set directly to a fake, exactly as the chat runner's tests
+do — see `_FakeLlama`, whose `embed` returns the same nested-list shape
+llama-cpp-python 0.3.29's own `Llama.embed` returns for a pooled model (read
+out of its `llama.py`, the `decode_batch` branch on `pooling_type`).
+"""
+import importlib.util
+import math
+import struct
+import sys
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+WORKER_PATH = str(
+    Path(__file__).resolve().parents[1]
+    / "fused_render" / "ai" / "runners" / "llama_embed.py"
+)
+
+
+@pytest.fixture()
+def worker(monkeypatch):
+    base = types.ModuleType("worker_base")
+    base.CANCEL = threading.Event()
+    base.download_file = lambda repo, filename, **kw: f"/blobs/{repo}/{filename}"
+    base.serve_calls = []
+    base.serve = lambda **kw: base.serve_calls.append(kw)
+    base.recorded = {}
+    base.set_state = lambda **fields: base.recorded.update(fields)
+    base.cached_files = set()
+    base._cached_file = (
+        lambda repo, filename: f"/blobs/{repo}/{filename}"
+        if (repo, filename) in base.cached_files else None)
+    base.repo_folder = lambda model_id, repo_type="model": None
+
+    monkeypatch.setitem(sys.modules, "worker_base", base)
+    spec = importlib.util.spec_from_file_location(
+        "llamacpp_embed_worker_under_test", WORKER_PATH)
+    assert spec is not None and spec.loader is not None, WORKER_PATH
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.worker_base = base
+    # A fresh process is what ships; a module-level dict shared between tests
+    # in one process is not.
+    module._loaded.clear()
+    return module
+
+
+def _fake_huggingface_hub(monkeypatch, *, files=None, error=None):
+    """A fake `huggingface_hub` good enough for `_resolve_uncurated_repo`'s
+    networked path. `list_repo_files` either returns `files` or raises
+    `error`, mirroring the one function that code calls.
+
+    `hf_hub_url` and `huggingface_hub.utils` are deliberately ABSENT unless a
+    test adds them, so `_remote_header`'s import fails and it returns `b""` —
+    which is the "could not look" state, and therefore the state in which
+    this runner must NOT refuse. Every refusal test that wants the header
+    peek to have an opinion supplies one explicitly (`_fake_remote_header`).
+    """
+    fake = types.ModuleType("huggingface_hub")
+    calls = []
+
+    def list_repo_files(model_id, **kwargs):
+        calls.append(model_id)
+        if error is not None:
+            raise error
+        return list(files or [])
+
+    fake.list_repo_files = list_repo_files
+    fake.calls = calls
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake)
+    return fake
+
+
+def _gguf_header(**uints):
+    """A minimal but REAL GGUF header carrying `uints` as `<arch>.<key>`
+    pairs — parsed by `formats`' own reader rather than by a stub of it.
+
+    Hand-built because the point of several tests below is that the runner
+    reads bytes, and a fake that returned an integer directly would test the
+    test. The layout is the GGUF spec's: magic, version, tensor count, kv
+    count, then length-prefixed keys each followed by a type tag and a value.
+    Type 4 is `uint32`, which is what a real converter writes for both
+    `pooling_type` and `context_length` (verified against four published
+    embedding GGUFs).
+    """
+    out = bytearray(b"GGUF")
+    out += struct.pack("<I", 3)          # version
+    out += struct.pack("<Q", 0)          # tensor count
+    out += struct.pack("<Q", len(uints))  # kv count
+    for key, value in uints.items():
+        encoded = key.encode()
+        out += struct.pack("<Q", len(encoded)) + encoded
+        out += struct.pack("<I", 4) + struct.pack("<I", value)
+    return bytes(out)
+
+
+def _fake_remote_header(monkeypatch, worker, header):
+    """Make `_remote_header` answer with `header` — the bytes a 2MB `Range`
+    request would have returned — without any network."""
+    monkeypatch.setattr(worker, "_remote_header", lambda repo, filename: header)
+
+
+class _FakeLlama:
+    """`llama_cpp.Llama`'s embedding surface, and only it.
+
+    `embed(list)` returns one flat vector per input, which is what the real
+    class returns whenever the model declares a pooling type — the ONLY case
+    this runner can reach, because `load()` refuses every file that does not.
+    The vectors are deliberately NOT unit length, so a test asserting
+    normalization is asserting that the runner did it rather than that the
+    fixture happened to.
+    """
+
+    def __init__(self, dim=4, **kwargs):
+        self.dim = dim
+        self.kwargs = kwargs
+        self.seen = []
+
+    def embed(self, texts):
+        self.seen.append(list(texts))
+        # A different, non-unit vector per input, derived from its length so
+        # two different prompts cannot accidentally produce the same row.
+        return [[float(len(text) + i + 1) for i in range(self.dim)]
+                for text in texts]
+
+
+# -- resolution: the curated table, and D412's generic fallback ----------------
+
+
+def test_download_fetches_exactly_the_one_curated_file(worker):
+    """No snapshot call and no second repo — `worker_base.download_file` is
+    the whole of it, exactly as the chat runner does."""
+    path = worker.download("nomic-embed-text-v1.5.Q8_0.gguf")
+    assert path == ("/blobs/nomic-ai/nomic-embed-text-v1.5-GGUF/"
+                    "nomic-embed-text-v1.5.Q8_0.gguf")
+
+
+def test_a_curated_repo_id_resolves_to_its_one_recipe(worker):
+    """The id shape the AI Models page's cache scan hands back is a REPO id,
+    because that scan is keyed by repo folder and knows nothing of this
+    table's filename keys."""
+    path = worker.download("Qwen/Qwen3-Embedding-0.6B-GGUF")
+    assert path.endswith("Qwen3-Embedding-0.6B-Q8_0.gguf")
+
+
+def test_an_uncurated_repo_resolves_through_the_EMBEDDING_picker(worker, monkeypatch):
+    """`pick_embedding_gguf_file`, not `pick_gguf_file` — and this is the test
+    that tells them apart.
+
+    Both pickers see the same two files. The chat picker prefers `Q4_K_M`
+    because a chat model's download is the binding cost; this capability
+    prefers `Q8_0` because these models are tens of megabytes and
+    quantization error lands directly in the vector with no sampling step
+    after it to absorb the damage. If this runner were wired to the chat
+    picker every assertion in this file would still pass except this one.
+    """
+    fake = _fake_huggingface_hub(monkeypatch, files=[
+        "README.md", "model-Q4_K_M.gguf", "model-Q8_0.gguf",
+    ])
+    _fake_remote_header(monkeypatch, worker, b"")
+    path = worker.download("some-org/not-in-the-table")
+    assert path == "/blobs/some-org/not-in-the-table/model-Q8_0.gguf"
+    assert fake.calls == ["some-org/not-in-the-table"]
+
+
+# -- REFUSING BEFORE THE DOWNLOAD, which is half of why this runner exists ----
+
+
+def test_a_safetensors_repo_is_refused_without_downloading_anything(worker, monkeypatch):
+    """**The defect this capability was written not to repeat.** The
+    `embeddings` capability answers `BAAI/bge-small-en-v1.5` by fetching
+    ~400MB, starting a worker and dying on a missing method. Here a repo that
+    publishes no GGUF is refused off its FILE LISTING alone.
+
+    The assertion that matters is not the message — it is that
+    `worker_base.download_file` was never called. A refusal that arrives
+    after the download is the old behaviour with better prose.
+    """
+    _fake_huggingface_hub(monkeypatch, files=[
+        "README.md", "config.json", "model.safetensors", "tokenizer.json",
+    ])
+    fetched = []
+    monkeypatch.setattr(worker.worker_base, "download_file",
+                        lambda *a, **k: fetched.append(a))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker.download("sentence-transformers/all-MiniLM-L6-v2")
+
+    assert fetched == []
+    message = str(excinfo.value)
+    # Names the repo, says what it looks like, says what to pass instead —
+    # the three things `_NOT_GGUF` promises.
+    assert "sentence-transformers/all-MiniLM-L6-v2" in message
+    assert "safetensors" in message
+    assert "all-MiniLM-L6-v2-GGUF" in message
+
+
+def test_a_chat_gguf_is_refused_on_its_header_before_downloading(worker, monkeypatch):
+    """The second refusal, and the one a file listing cannot make.
+
+    A repo can publish a perfectly good GGUF that is a CHAT model — and for
+    the Qwen3 family the architecture string is identical to the embedding
+    one, so no amount of filename or listing reading settles it. The runner
+    reads the file's real header over a 2MB `Range` request and refuses on
+    what the bytes say, still before any weight is fetched.
+    """
+    _fake_huggingface_hub(monkeypatch, files=["Qwen3-4B-Q8_0.gguf"])
+    # A chat GGUF's header: a context length, and NO pooling key at all.
+    _fake_remote_header(monkeypatch, worker,
+                        _gguf_header(**{"qwen3.context_length": 32768}))
+    fetched = []
+    monkeypatch.setattr(worker.worker_base, "download_file",
+                        lambda *a, **k: fetched.append(a))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker.download("some-org/Qwen3-4B-GGUF")
+
+    assert fetched == []
+    message = str(excinfo.value)
+    assert "no pooling type" in message
+    # Points at the endpoint that DOES serve it, rather than only saying no.
+    assert "text generation" in message
+
+
+def test_a_reranker_is_refused_with_its_own_sentence(worker, monkeypatch):
+    """A cross-encoder is neither of the other two cases and must not be told
+    to go and use text generation: it scores a (query, document) PAIR and has
+    no per-text vector, so there is no endpoint here for it at all."""
+    _fake_huggingface_hub(monkeypatch, files=["bge-reranker-base-Q8_0.gguf"])
+    _fake_remote_header(monkeypatch, worker,
+                        _gguf_header(**{"bert.pooling_type": 4}))  # RANK
+
+    with pytest.raises(RuntimeError) as excinfo:
+        worker.download("BAAI/bge-reranker-base-gguf")
+
+    message = str(excinfo.value)
+    assert "RERANKER" in message
+    assert "cosine similarity" in message
+
+
+def test_an_embedding_gguf_passes_the_header_check_and_downloads(worker, monkeypatch):
+    """The other side of the two tests above: a real embedding header is
+    waved through rather than refused, so the peek is a filter and not a
+    wall."""
+    _fake_huggingface_hub(monkeypatch, files=["e5-base-Q8_0.gguf"])
+    _fake_remote_header(monkeypatch, worker,
+                        _gguf_header(**{"bert.pooling_type": 1}))  # MEAN
+    path = worker.download("some-org/multilingual-e5-base-gguf")
+    assert path == "/blobs/some-org/multilingual-e5-base-gguf/e5-base-Q8_0.gguf"
+
+
+def test_an_unreadable_header_does_NOT_refuse(worker, monkeypatch):
+    """**A refusal must rest on evidence.** No network, a mirror that ignores
+    `Range`, a timeout — all of them make `_remote_header` return `b""`, and
+    the runner must then proceed and let the load-time check answer instead.
+
+    The alternative is a user who cannot load a model that would have worked,
+    with no way to override, because the Hub was briefly slow.
+    """
+    _fake_huggingface_hub(monkeypatch, files=["mystery-Q8_0.gguf"])
+    _fake_remote_header(monkeypatch, worker, b"")
+    path = worker.download("some-org/mystery")
+    assert path.endswith("mystery-Q8_0.gguf")
+
+
+def test_a_lookup_failure_is_a_different_refusal_from_a_bad_repo(worker, monkeypatch):
+    """"Try again" and "this will never resolve" are different facts a user
+    acts on differently — the distinction `llama_text` draws too."""
+    _fake_huggingface_hub(monkeypatch, error=RuntimeError("offline"))
+    with pytest.raises(RuntimeError, match="[Cc]ould not read"):
+        worker.download("some-org/unreachable")
+
+
+def test_a_repo_already_on_disk_needs_no_network_and_no_peek(worker, monkeypatch, tmp_path):
+    """The local-cache-first fast path. A file already on this disk gets its
+    header read by `load()` off the real bytes moments later, which is
+    strictly better evidence than a range request — so neither the listing
+    nor the peek is worth paying for."""
+    snapshot = tmp_path / "snapshots" / "main"
+    snapshot.mkdir(parents=True)
+    (snapshot / "e5-base-Q8_0.gguf").write_bytes(b"GGUF")
+    monkeypatch.setattr(worker.worker_base, "repo_folder",
+                        lambda model_id, repo_type="model": str(tmp_path))
+
+    def _no_network(*a, **k):
+        raise AssertionError("the Hub must not be asked for a cached repo")
+
+    monkeypatch.setattr(worker, "_remote_header", _no_network)
+    fake = _fake_huggingface_hub(monkeypatch, files=[])
+    fake.list_repo_files = _no_network
+
+    path = worker.download("some-org/already-here")
+    assert path.endswith("e5-base-Q8_0.gguf")
+
+
+# -- load: the authoritative header read, and the context sizing --------------
+
+
+def _load(worker, monkeypatch, tmp_path, model_id, header, *, dim=4):
+    """Drive `load()` with a fake `llama_cpp` and a real header on disk.
+
+    The header is written to a REAL file because `load()` reads it through
+    `formats.gguf_pooling_type`, which opens a path — the same read that runs
+    in production, rather than a stub of it.
+    """
+    path = tmp_path / "model.gguf"
+    path.write_bytes(header)
+    made = {}
+
+    def _Llama(**kwargs):
+        made.update(kwargs)
+        return _FakeLlama(dim=dim, **kwargs)
+
+    fake = types.ModuleType("llama_cpp")
+    fake.Llama = _Llama
+    fake.llama_supports_gpu_offload = lambda: False
+    monkeypatch.setitem(sys.modules, "llama_cpp", fake)
+    worker.load(model_id, str(path))
+    return made
+
+
+def test_load_refuses_a_chat_gguf_that_reached_the_disk(worker, monkeypatch, tmp_path):
+    """The authoritative check. `_refuse_unloadable` may never have run — the
+    peek can fail, and a locally-cached model skips it entirely — so this is
+    the one that always runs, and it gives the identical sentence: the user's
+    mistake is the same and only the timing differs."""
+    _fake_huggingface_hub(monkeypatch, files=["chat-Q8_0.gguf"])
+    _fake_remote_header(monkeypatch, worker, b"")
+    with pytest.raises(RuntimeError, match="no pooling type"):
+        _load(worker, monkeypatch, tmp_path, "some-org/chat-gguf",
+              _gguf_header(**{"qwen3.context_length": 4096}))
+
+
+@pytest.mark.parametrize("declared,expected", [
+    # A bge's own 512 is used as-is.
+    (512, 512),
+    # nomic's 2048, likewise — one pinned number would have truncated it at a
+    # bge's context or over-allocated for a bge.
+    (2048, 2048),
+    # Qwen3-Embedding declares 32768, which is real and is clamped: a KV cache
+    # that size is memory spent on a length no batch API capped at 64 short
+    # items will ever pass.
+    (32768, 8192),
+])
+def test_the_context_is_sized_from_the_gguf_and_clamped(
+        worker, monkeypatch, tmp_path, declared, expected):
+    """`n_ctx` here is not a conversation budget that truncates gracefully —
+    llama.cpp pools only within one batch, so it is the longest text the
+    caller can embed. `n_batch`/`n_ubatch` must follow it, or
+    llama-cpp-python's own `Llama.embed` refuses anything over its default
+    512 with "Requested tokens (N) exceed batch size"."""
+    _fake_huggingface_hub(monkeypatch, files=["e5-Q8_0.gguf"])
+    _fake_remote_header(monkeypatch, worker, b"")
+    made = _load(worker, monkeypatch, tmp_path, "some-org/e5-gguf",
+                 _gguf_header(**{"bert.pooling_type": 1,
+                                 "bert.context_length": declared}))
+    assert made["n_ctx"] == expected
+    assert made["n_batch"] == expected
+    assert made["n_ubatch"] == expected
+    # The flag the whole runner turns on; without it `Llama.embed` raises.
+    assert made["embedding"] is True
+
+
+def test_a_header_with_no_context_length_falls_back_conservatively(
+        worker, monkeypatch, tmp_path):
+    """512 rather than something generous, and that is the safe direction:
+    every published text encoder supports at least that, while a larger guess
+    on a 512-position model produces vectors from positions it never saw."""
+    _fake_huggingface_hub(monkeypatch, files=["x-Q8_0.gguf"])
+    _fake_remote_header(monkeypatch, worker, b"")
+    made = _load(worker, monkeypatch, tmp_path, "some-org/x-gguf",
+                 _gguf_header(**{"bert.pooling_type": 2}))
+    assert made["n_ctx"] == 512
+
+
+def test_load_remembers_the_curated_prompt_scheme(worker, monkeypatch, tmp_path):
+    """The scheme travels with the loaded weights rather than being
+    re-derived per request — it is a property of the model, and `generate` is
+    on the hot path of a 64-item batch."""
+    _load(worker, monkeypatch, tmp_path, "nomic-embed-text-v1.5.Q8_0.gguf",
+          _gguf_header(**{"nomic-bert.pooling_type": 1}))
+    assert worker._loaded["scheme"] == "nomic"
+
+
+def test_an_uncurated_model_gets_its_scheme_from_the_filename(
+        worker, monkeypatch, tmp_path):
+    """The documented heuristic — the filename is the only evidence a GGUF
+    header carries about a prompt convention. It is reported back on every
+    reply precisely because it is a guess."""
+    _fake_huggingface_hub(monkeypatch, files=["bge-large-en-v1.5-Q8_0.gguf"])
+    _fake_remote_header(monkeypatch, worker, b"")
+    path = tmp_path / "bge-large-en-v1.5-Q8_0.gguf"
+    path.write_bytes(_gguf_header(**{"bert.pooling_type": 2}))
+    fake = types.ModuleType("llama_cpp")
+    fake.Llama = lambda **kwargs: _FakeLlama(**kwargs)
+    fake.llama_supports_gpu_offload = lambda: False
+    monkeypatch.setitem(sys.modules, "llama_cpp", fake)
+    worker.load("some-org/bge-large-en-v1.5-gguf", str(path))
+    assert worker._loaded["scheme"] == "bge"
+
+
+# -- the round trip -----------------------------------------------------------
+
+
+def test_a_batch_round_trips_with_the_right_dim_and_unit_length(worker):
+    """The core contract: one vector per text, of the model's own width, and
+    every one of them unit length so a cosine similarity is a plain dot
+    product. The fake returns deliberately non-unit rows, so this asserts the
+    runner normalized rather than that the fixture did."""
+    worker._loaded["llm"] = _FakeLlama(dim=6)
+    worker._loaded["scheme"] = "none"
+
+    result = worker.generate({"texts": ["alpha", "beta", "gamma"]})
+
+    assert result["dim"] == 6
+    assert len(result["vectors"]) == 3
+    for row in result["vectors"]:
+        assert len(row) == 6
+        assert math.isclose(math.sqrt(sum(v * v for v in row)), 1.0, rel_tol=1e-9)
+
+
+def test_the_document_prefix_is_applied_by_default(worker):
+    """`kind` defaults to "document", and on a scheme with a document prefix
+    that prefix reaches the model — checked at the model boundary rather than
+    by inspecting the reply, because what the encoder READ is the thing that
+    decides the vector."""
+    llm = _FakeLlama()
+    worker._loaded["llm"] = llm
+    worker._loaded["scheme"] = "nomic"
+
+    result = worker.generate({"texts": ["the roof leaks"]})
+
+    assert llm.seen == [["search_document: the roof leaks"]]
+    assert result["kind"] == "document"
+    assert result["promptScheme"] == "nomic"
+
+
+def test_the_query_prefix_is_a_different_prefix(worker):
+    """The asymmetry, demonstrated: the same text embedded as a query reaches
+    the model differently from the same text embedded as a document. This is
+    the whole reason `kind` exists."""
+    llm = _FakeLlama()
+    worker._loaded["llm"] = llm
+    worker._loaded["scheme"] = "nomic"
+
+    worker.generate({"texts": ["the roof leaks"], "kind": "query"})
+    worker.generate({"texts": ["the roof leaks"], "kind": "document"})
+
+    assert llm.seen == [["search_query: the roof leaks"],
+                        ["search_document: the roof leaks"]]
+
+
+def test_bges_document_side_is_no_prefix_at_all(worker):
+    """The tie-breaker behind the "document" default: bge's card instructs the
+    QUERY only, so a bare call on that family embeds text verbatim — exactly
+    what someone who has never heard of prompt schemes expects."""
+    llm = _FakeLlama()
+    worker._loaded["llm"] = llm
+    worker._loaded["scheme"] = "bge"
+
+    worker.generate({"texts": ["the roof leaks"]})
+
+    assert llm.seen == [["the roof leaks"]]
+
+
+def test_generate_with_no_model_says_so(worker):
+    worker._loaded.clear()
+    with pytest.raises(RuntimeError, match="no model is loaded"):
+        worker.generate({"texts": ["a"]})
+
+
+def test_main_wires_every_callback_the_base_expects(worker):
+    """An unwired `memory()` would be silently ignored forever, including the
+    day someone gives it a real probe — the same rule `llama_text.memory`'s
+    docstring states."""
+    worker.main()
+    (kwargs,) = worker.worker_base.serve_calls
+    assert kwargs["download"] is worker.download
+    assert kwargs["load"] is worker.load
+    assert kwargs["generate"] is worker.generate
+    assert kwargs["memory"] is worker.memory
+    assert kwargs["streaming"] is False

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -924,6 +924,15 @@ _QUALIFIED_SHORT_NAMES = {
     "diffusers-image-rocm": "(ROCm)",
     "llamacpp-text": "(CPU)",
     "llamacpp-text-vulkan": "(Vulkan)",
+    # The text-embedding pair, for the identical reason as the pair above it:
+    # two builds of one library, told apart by nothing else. Their names also
+    # carry "Embeddings", which is NOT a qualifier but part of the name — it
+    # is what keeps all four llama.cpp rows from collapsing into one family
+    # whose qualifiers then repeat (see `registry`'s comment on the
+    # `llamacpp-embed` row, and
+    # `test_no_engine_name_advertises_the_format_its_sibling_also_reads`).
+    "llamacpp-embed": "(CPU)",
+    "llamacpp-embed-vulkan": "(Vulkan)",
 }
 
 #: Every qualifier this app uses to name a BUILD rather than a platform.
@@ -3646,7 +3655,8 @@ def test_the_runtime_endpoint_reports_runners_and_nothing_loaded(client):
         "diffusers-image", "diffusers-image-cuda",
         "diffusers-image-rocm", "mflux-image",
         "faster-whisper", "mlx-whisper",
-        "mlx-embed", "transformers-embed"}
+        "mlx-embed", "transformers-embed",
+        "mlx-text-embed", "llamacpp-embed", "llamacpp-embed-vulkan"}
     assert body["loaded"] == []
     # Exactly one runner per capability is ACTIVE — the distinction D302 needed,
     # since with a preference in the middle "available" stopped meaning "this is

--- a/tests/test_ai_runtime_embed_text.py
+++ b/tests/test_ai_runtime_embed_text.py
@@ -1,0 +1,248 @@
+"""`POST /api/ai/embed-text` (SPEC §40) — the HTTP surface over the
+text-embedding runners.
+
+Modeled on `tests/test_ai_runtime_embed.py`, which covers the DUAL-ENCODER
+endpoint, and split into its own file for the same reason that one was split
+from `test_ai_runtime.py`: these two routes share a wire shape and serve two
+different capabilities, so a file that tested both would keep having to say
+which one each assertion was about.
+
+**The most important thing asserted here is the SAMENESS.** The two routes'
+error contract is identical on purpose — a page that has written the
+`model_loading` retry loop once must not need a second one — so several tests
+below assert against `/api/ai/embed`'s own behaviour rather than against a
+literal, which is what makes a future divergence in either route fail here.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render import jobs
+from fused_render.ai import registry, supervisor
+from fused_render.server import create_app
+
+
+@pytest.fixture(autouse=True)
+def _clean_jobs():
+    jobs.reset()
+    yield
+    jobs.reset()
+
+
+@pytest.fixture()
+def client():
+    return TestClient(create_app(start_dir="/"))
+
+
+def _post(client, body):
+    return client.post("/api/ai/embed-text", json=body, headers={"X-Fused": "1"})
+
+
+# -- the X-Fused guard, shared with every other mutating POST -----------------
+
+
+def test_the_x_fused_header_is_required(client):
+    assert client.post("/api/ai/embed-text", json={"texts": ["a"]}).status_code == 403
+
+
+# -- 400s: the same shape `text_embed_common.request_texts` enforces ----------
+
+
+def test_an_empty_body_is_a_bad_request(client):
+    response = _post(client, {})
+    assert response.status_code == 400
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"]["type"] == "bad_request"
+
+
+def test_an_empty_list_is_a_bad_request(client):
+    assert _post(client, {"texts": []}).status_code == 400
+
+
+def test_a_non_string_item_is_a_bad_request(client):
+    response = _post(client, {"texts": ["ok", 3]})
+    assert response.status_code == 400
+    assert "texts[1]" in response.json()["error"]["message"]
+
+
+def test_over_64_items_is_a_bad_request(client):
+    response = _post(client, {"texts": ["x"] * 65})
+    assert response.status_code == 400
+    assert "at most 64" in response.json()["error"]["message"]
+
+
+def test_exactly_64_items_is_not_refused_for_its_SIZE(client, monkeypatch):
+    """The off-by-one, pinned the same way the sibling route pins it."""
+    monkeypatch.setattr(supervisor, "generate_embed",
+                        lambda model, body, capability=None: {
+                            "vectors": [[1.0]] * 64, "dim": 1})
+    response = _post(client, {"texts": ["x"] * 64, "model": "org/e"})
+    assert response.status_code == 200
+
+
+def test_image_paths_are_refused_before_a_model_is_even_resolved(client):
+    """**Deliverable: images are meaningless here and are refused clearly.**
+
+    Refused as a 400 rather than ignored, and with a sentence that points at
+    the endpoint which does take images — a caller who found
+    `fused.ai.embed`'s image half and assumed this one had it would otherwise
+    get the FILENAMES embedded as prose: plausible vectors, no error, nonsense
+    results.
+
+    No model is resolved and no worker is touched to reach this answer, which
+    is the same ordering `/api/ai/embed` uses for its own validator: a
+    malformed request must cost nothing rather than a 409 implying the fix is
+    to wait.
+    """
+    response = _post(client, {"texts": ["a"], "paths": ["/photos/cat.png"]})
+    assert response.status_code == 400
+    message = response.json()["error"]["message"]
+    assert "fused.ai.embed()" in message
+    assert "vision tower" in message
+
+
+def test_an_unrecognised_kind_is_a_bad_request(client):
+    """The silent-degradation guard, at the edge. See
+    `text_embed_common.request_texts` for why this one field is refused
+    rather than defaulted."""
+    response = _post(client, {"texts": ["a"], "kind": "queries"})
+    assert response.status_code == 400
+    assert "'query'" in response.json()["error"]["message"]
+
+
+# -- 409 unavailable ----------------------------------------------------------
+
+
+def test_no_text_embedding_runner_says_why(client, monkeypatch):
+    monkeypatch.setattr(registry, "_RUNNERS", ())
+    response = _post(client, {"texts": ["a cat"]})
+    assert response.status_code == 409
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"]["type"] == "unavailable"
+
+
+# -- 409 model_loading: the fork this endpoint shares with /api/ai ------------
+
+
+def test_a_cold_model_answers_model_loading_with_a_job_id(client, monkeypatch):
+    """**The contract the brief pins by name.** An embed call has no job of
+    its own for a cold multi-MB load to hide inside, so it fails fast with the
+    id of the load it just started — the `/api/ai` local-model fork, byte for
+    byte the same as `/api/ai/embed`'s."""
+    monkeypatch.setattr(registry.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(registry.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(supervisor, "_require_build_tools", lambda: None)
+    try:
+        response = _post(client, {"texts": ["a cat"], "model": "org/embed-x"})
+        assert response.status_code == 409
+        body = response.json()
+        assert body["ok"] is False
+        assert body["error"]["type"] == "model_loading"
+        assert body["error"]["jobId"] == supervisor.job_id_for("org/embed-x")
+    finally:
+        supervisor.unload(model="org/embed-x")
+
+
+def test_the_cold_load_is_started_under_the_TEXT_EMBEDDING_capability(
+        client, monkeypatch):
+    """The whole point of the capability split, checked where it would break.
+
+    If this route started its load under `registry.EMBEDDINGS`, a text
+    embedder would evict a resident SigLIP model and the two capabilities
+    would share one slot — which is precisely the outcome the split exists to
+    avoid, and which nothing else in this file would notice.
+    """
+    started = []
+    monkeypatch.setattr(supervisor, "load",
+                        lambda model, capability, **kw: started.append(
+                            (model, capability)) or {"jobId": "j1"})
+    response = _post(client, {"texts": ["a cat"], "model": "org/embed-x"})
+    assert response.status_code == 409
+    assert started == [("org/embed-x", registry.TEXT_EMBEDDINGS)]
+
+
+# -- the happy path, with a stubbed worker ------------------------------------
+
+
+def test_a_resident_model_answers_with_vectors_and_says_how(client, monkeypatch):
+    """The reply carries `kind` and `promptScheme` back, and they are not
+    decoration: both are decisions made on the caller's behalf that change
+    what the vectors mean and that nothing downstream can detect — a
+    wrongly-prompted batch still returns unit vectors of the right width."""
+    calls = []
+
+    def fake_generate_embed(model, body, capability=None):
+        calls.append((model, body, capability))
+        return {"vectors": [[0.6, 0.8]], "dim": 2, "kind": body["kind"],
+                "promptScheme": "nomic"}
+
+    monkeypatch.setattr(supervisor, "generate_embed", fake_generate_embed)
+    response = _post(client, {"texts": ["a cat"], "model": "org/embed-x"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["result"] == {
+        "vectors": [[0.6, 0.8]], "dim": 2, "model": "org/embed-x",
+        "kind": "document", "promptScheme": "nomic"}
+    assert calls == [("org/embed-x", {"texts": ["a cat"], "kind": "document"},
+                      registry.TEXT_EMBEDDINGS)]
+
+
+def test_the_kind_reaches_the_worker(client, monkeypatch):
+    """`kind` is not a field the route interprets — it goes down to the runner,
+    which is the only party that knows which prompt pair the loaded weights
+    want."""
+    calls = []
+    monkeypatch.setattr(
+        supervisor, "generate_embed",
+        lambda model, body, capability=None: calls.append(body) or {
+            "vectors": [[1.0]], "dim": 1, "kind": body["kind"],
+            "promptScheme": "e5"})
+    response = _post(client, {"texts": ["leaky roof"], "kind": "query",
+                              "model": "org/e"})
+    assert calls == [{"texts": ["leaky roof"], "kind": "query"}]
+    assert response.json()["result"]["kind"] == "query"
+
+
+def test_a_runtime_failure_is_ai_error(client, monkeypatch):
+    def boom(model, body, capability=None):
+        raise supervisor.SupervisorError("the model process did not answer")
+
+    monkeypatch.setattr(supervisor, "generate_embed", boom)
+    response = _post(client, {"texts": ["a"], "model": "org/e"})
+    assert response.status_code == 502
+    assert response.json()["error"]["type"] == "ai_error"
+
+
+# -- the two routes must not drift --------------------------------------------
+
+
+def test_both_embedding_routes_share_one_error_contract(client, monkeypatch):
+    """Asserted against the SIBLING ROUTE rather than against a literal, so a
+    change to either one's error shape fails here.
+
+    A page written against `fused.ai.embed`'s rejections — `.type`, and
+    `.jobId` on a 409 — must be able to read `fused.ai.embedText`'s the same
+    way, or the bridge's shared `embedPost` is a lie.
+    """
+    embed = client.post("/api/ai/embed", json={}, headers={"X-Fused": "1"})
+    embed_text = _post(client, {})
+    assert embed.status_code == embed_text.status_code == 400
+    assert set(embed.json()) == set(embed_text.json())
+    assert set(embed.json()["error"]) == set(embed_text.json()["error"])
+
+
+def test_the_two_capabilities_hold_separate_resident_slots(client, monkeypatch):
+    """The user-visible payoff of the split, asserted at the supervisor's own
+    table rather than through the routes: one worker per CAPABILITY means a
+    SigLIP model and a text embedder can be resident together."""
+    started = []
+    monkeypatch.setattr(supervisor, "load",
+                        lambda model, capability, **kw: started.append(
+                            (model, capability)) or {"jobId": "j"})
+    client.post("/api/ai/embed", json={"texts": ["a"], "model": "org/siglip"},
+                headers={"X-Fused": "1"})
+    _post(client, {"texts": ["a"], "model": "org/bge"})
+    assert started == [("org/siglip", registry.EMBEDDINGS),
+                       ("org/bge", registry.TEXT_EMBEDDINGS)]

--- a/tests/test_ai_tasks.py
+++ b/tests/test_ai_tasks.py
@@ -78,20 +78,48 @@ def test_the_tags_a_runner_serves(tag, capability):
     assert tasks.classify(tag).capability == capability
 
 
-def test_the_embedding_capabilitys_own_names_are_deliberately_unserved():
-    """The trap this capability sets for itself: `feature-extraction` and
-    `sentence-similarity` read like the obvious tags for it and are not.
+def test_the_text_embedding_tags_are_served_by_their_own_capability():
+    """`feature-extraction` and `sentence-similarity` map to
+    `TEXT_EMBEDDINGS`, and this test is the INVERSE of the one it replaces.
 
-    What wears them is a sentence-transformers checkpoint — a text encoder plus
-    a pooling config, with no vision tower and no `get_text_features`/
-    `get_image_features` for either embedding runner to call. Mapping them would
-    put a Load button on `sentence-transformers/all-MiniLM-L6-v2`, a download
-    that then refuses.
+    It used to assert both tags were ruled out with a "dual encoder" reason,
+    which was correct while the only embedding runners here were SigLIP/CLIP
+    ones: what wears these tags is a text encoder plus a pooling config, and a
+    Load button on one would have been a download that then refused. That
+    row's own comment in `ai/tasks.py` promised the two would move "when it
+    ships". It has shipped, so they moved.
+
+    **Both tags, not one.** The Hub splits this task in two and the split
+    describes nothing a loader could act on — the same checkpoints wear either
+    tag, sometimes across two revisions of one repo — so mapping one and
+    withholding the other would make a model's Load button depend on which
+    word its uploader picked.
+
+    The guarantee that used to rest on this test has NOT been dropped; it
+    moved one layer down, to
+    `test_hub_models.test_a_result_is_never_something_this_app_cannot_run`.
+    See that test for why a format gate is stronger evidence than a
+    capability gap.
     """
-    for tag in ("feature-extraction", "sentence-similarity", "image-feature-extraction"):
+    for tag in ("feature-extraction", "sentence-similarity"):
         reading = tasks.classify(tag)
-        assert reading.ruled_out, tag
-        assert "dual encoder" in reading.reason, tag
+        assert reading.capability == registry.TEXT_EMBEDDINGS, tag
+        assert not reading.ruled_out, tag
+
+
+def test_image_embeddings_did_not_move_with_the_text_ones():
+    """`image-feature-extraction` stayed ruled out, and the asymmetry is
+    deliberate rather than an oversight in the move above.
+
+    `TEXT_EMBEDDINGS` serves text encoders and nothing here loads a
+    vision-only feature extractor. The dual-encoder capability comes closest
+    and still cannot: a DINOv2 or a bare ViT has no text tower to put an
+    image beside, which is the whole of what that capability is for.
+    """
+    reading = tasks.classify("image-feature-extraction")
+    assert reading.ruled_out
+    assert reading.capability is None
+    assert "dual encoder" in reading.reason
 
 
 @pytest.mark.parametrize("tag", [

--- a/tests/test_ai_text_embed_common.py
+++ b/tests/test_ai_text_embed_common.py
@@ -1,0 +1,208 @@
+"""The one request shape all three text-embedding runners accept, and the
+prompt rules that decide what their vectors mean (SPEC §40).
+
+`runners/text_embed_common.py` is imported by three separate interpreters —
+`llamacpp_embed/`, `llamacpp_embed_vulkan/` and `mlx_text_embed/` — and by the
+server process, so everything asserted here is a rule that must read the same
+on all four. Its sibling `tests/test_ai_embed_common.py` does the same job for
+the DUAL-ENCODER capability's own validator; the two files are separate for
+the same reason the two modules are (see this one's docstring).
+
+Imported the packaged way rather than by path, unlike the runner tests: this
+module is genuinely reachable as `fused_render.ai.runners.text_embed_common`
+from the server, and that reading is itself worth exercising — its two-loader
+import guard is the thing that makes it work at all.
+"""
+import math
+
+import pytest
+
+from fused_render.ai.runners import formats, text_embed_common as tec
+
+
+# -- the shape ----------------------------------------------------------------
+
+
+def test_a_plain_batch_is_accepted_with_the_default_kind():
+    texts, kind = tec.request_texts({"texts": ["a", "b"]})
+    assert texts == ["a", "b"]
+    assert kind == "document"
+
+
+def test_an_empty_body_is_refused():
+    with pytest.raises(ValueError, match="non-empty list"):
+        tec.request_texts({})
+
+
+def test_an_empty_list_is_refused():
+    with pytest.raises(ValueError, match="non-empty list"):
+        tec.request_texts({"texts": []})
+
+
+def test_a_non_string_item_names_its_index():
+    """The index, not just "bad input" — a caller with a 64-item batch built
+    from a directory listing needs to know WHICH one."""
+    with pytest.raises(ValueError, match=r"texts\[1\]"):
+        tec.request_texts({"texts": ["fine", 7]})
+
+
+def test_the_batch_ceiling_is_shared_with_the_other_capability():
+    """`MAX_ITEMS` is taken from `embed_common` rather than restated. The
+    number is a fact about how much work one HTTP request should do before a
+    caller would rather see progress — not a fact about dual encoders — so
+    the two capabilities answering differently would be an inconsistency with
+    no reason behind it."""
+    from fused_render.ai.runners import embed_common
+
+    assert tec.MAX_ITEMS == embed_common.MAX_ITEMS
+    with pytest.raises(ValueError, match="at most 64"):
+        tec.request_texts({"texts": ["x"] * (tec.MAX_ITEMS + 1)})
+    # …and exactly the ceiling is fine, which is the off-by-one worth pinning.
+    texts, _kind = tec.request_texts({"texts": ["x"] * tec.MAX_ITEMS})
+    assert len(texts) == tec.MAX_ITEMS
+
+
+# -- images, refused by name --------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["paths", "images"])
+def test_image_input_is_refused_with_a_sentence_that_points_somewhere(field):
+    """**Not "unexpected field".** A caller passing `paths` here is not making
+    a typo — they found `fused.ai.embed`'s image half and reasonably assumed
+    this endpoint had one. So the refusal has to say which endpoint DOES,
+    and say what would otherwise happen: a text encoder handed filenames
+    embeds them as PROSE and returns vectors that look fine and mean nothing.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        tec.request_texts({"texts": ["a"], field: ["/tmp/cat.png"]})
+    message = str(excinfo.value)
+    assert field in message
+    assert "fused.ai.embed()" in message
+    assert "vision tower" in message
+
+
+# -- kind ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["query", "document"])
+def test_both_kinds_are_accepted(kind):
+    _texts, got = tec.request_texts({"texts": ["a"], "kind": kind})
+    assert got == kind
+
+
+def test_an_unrecognised_kind_is_REFUSED_rather_than_defaulted():
+    """**The one field here whose wrong value produces no error anywhere
+    downstream.** A `kind: "queries"` that fell through to the default would
+    return unit-length vectors of the right dimension, computed against the
+    wrong half of the prompt pair, and nothing the caller could measure would
+    say so. Refusing costs a typo one round trip; defaulting costs a silent
+    accuracy regression nobody attributes to this call.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        tec.request_texts({"texts": ["a"], "kind": "queries"})
+    message = str(excinfo.value)
+    assert "'query'" in message and "'document'" in message
+    # It says what the default is, so the fix for "I did not mean to pass
+    # this" is in the message rather than in the docs.
+    assert "document" in message
+
+
+def test_the_default_is_document_and_the_runners_agree_with_the_table():
+    """One value, in one place. `formats` holds it because the runners read
+    it from there and the route reports it; a second literal in this module
+    would be the copy that goes stale."""
+    assert tec.DEFAULT_KIND == "document"
+    assert tec.DEFAULT_KIND == formats.TEXT_EMBED_DEFAULT_KIND
+    assert set(tec.KINDS) == {"query", "document"}
+
+
+# -- the prompts --------------------------------------------------------------
+
+
+def test_every_curated_recipe_names_a_scheme_this_table_knows():
+    """A curated model whose scheme has no entry would embed both sides
+    verbatim while claiming a convention it does not apply."""
+    for key, recipe in formats.TEXT_EMBED_RECIPES.items():
+        assert recipe["scheme"] in formats.TEXT_EMBED_PROMPTS, key
+
+
+def test_every_scheme_has_two_halves_and_at_least_one_of_them_differs():
+    """A scheme whose two prefixes were equal would be a `"none"` with extra
+    steps — it would claim asymmetry the model does not have, and `kind`
+    would be a parameter with no effect on it."""
+    for name, pair in formats.TEXT_EMBED_PROMPTS.items():
+        assert len(pair) == 2, name
+        if name == "none":
+            assert pair == ("", "")
+        else:
+            assert pair[0] != pair[1], name
+
+
+def test_prompted_glues_the_right_half_on():
+    assert tec.prompted(["hi"], "query", "e5") == ["query: hi"]
+    assert tec.prompted(["hi"], "document", "e5") == ["passage: hi"]
+
+
+def test_bges_document_side_is_genuinely_empty():
+    """The tie-breaker behind the "document" default: bge's card instructs the
+    QUERY only, so on that family a bare call embeds text verbatim — exactly
+    what someone who has never heard of prompt schemes expects to happen."""
+    assert tec.prompted(["hi"], "document", "bge") == ["hi"]
+    assert tec.prompted(["hi"], "query", "bge") != ["hi"]
+
+
+def test_an_unknown_scheme_embeds_verbatim_rather_than_guessing():
+    """Reached from a worker holding a resident model with a validated batch
+    in hand. A scheme name that has drifted out of the table is a reason to
+    embed plainly, not to fail a call that would otherwise work — and
+    guessing a prefix would be worse than not prefixing, since a wrong
+    instruction is text the model dutifully encodes as content."""
+    assert tec.prompted(["hi"], "query", "not-a-scheme") == ["hi"]
+
+
+# -- the scheme lookup --------------------------------------------------------
+
+
+def test_a_curated_id_takes_its_scheme_from_the_table_not_the_filename():
+    for key, recipe in formats.TEXT_EMBED_RECIPES.items():
+        assert formats.text_embed_scheme(key) == recipe["scheme"], key
+
+
+@pytest.mark.parametrize("filename,expected", [
+    ("bge-small-en-v1.5-q8_0.gguf", "bge"),
+    ("BGE-large-en-v1.5-Q8_0.gguf", "bge"),          # uploaders capitalise freely
+    ("multilingual-e5-large-Q8_0.gguf", "e5"),
+    ("nomic-embed-text-v1.5.Q4_K_M.gguf", "nomic"),
+    ("Qwen3-Embedding-4B-Q8_0.gguf", "qwen3"),
+    ("embeddinggemma-300M-Q8_0.gguf", "gemma-embedding"),
+    # bge-m3 is the family member that takes NO query instruction — its card
+    # says so outright — so it must not inherit `bge` by substring.
+    ("bge-m3-Q8_0.gguf", "none"),
+    ("something-nobody-here-knows.gguf", "none"),
+])
+def test_the_filename_heuristic(filename, expected):
+    """A documented heuristic, and the reason it is allowed to be one: a
+    model's prompt convention is a fact about its training that the GGUF
+    header records nowhere, so for an uncurated repo the filename is the only
+    evidence there is. It is reported back on every reply rather than applied
+    out of sight, which is what makes it auditable instead of silent."""
+    assert formats.text_embed_scheme("some-org/whatever", filename) == expected
+
+
+# -- normalization ------------------------------------------------------------
+
+
+def test_unit_normalize_makes_cosine_a_dot_product():
+    """The one guarantee the bridge documents and pages are told to rely on."""
+    rows = tec.unit_normalize([[3.0, 4.0], [1.0, 1.0, 1.0, 1.0]])
+    for row in rows:
+        assert math.isclose(math.sqrt(sum(v * v for v in row)), 1.0, rel_tol=1e-9)
+
+
+def test_normalization_is_the_same_function_the_other_capability_uses():
+    """Re-exported rather than reimplemented: two vectors from two
+    capabilities must mean the same thing, and a second copy of this
+    arithmetic is how they would come not to."""
+    from fused_render.ai.runners import embed_common
+
+    assert tec.unit_normalize([[3.0, 4.0]]) == embed_common.unit_normalize([[3.0, 4.0]])

--- a/tests/test_ai_text_embed_retrieval.py
+++ b/tests/test_ai_text_embed_retrieval.py
@@ -22,12 +22,26 @@ llama.cpp, so it skips where it cannot run rather than being deleted — see
 
 -------------------------------------------------------------------------------
 
-**HOW MUCH OF THIS HAS BEEN RUN, and by what.** The corpus was validated with
-REAL weights on 2026-08-23 — `BAAI/bge-small-en-v1.5` and
-`BAAI/bge-base-en-v1.5` through transformers, CLS-pooled and L2-normalized,
-which is the same arithmetic llama.cpp performs for a GGUF declaring
-`pooling_type = CLS`. Both scored 5/5 top-1; word-overlap scored 2/5. So the
-corpus is known-good and the threshold below is not a guess.
+**HOW MUCH OF THIS HAS BEEN RUN, AND ON WHAT — the second half matters.** The
+corpus was validated with REAL weights on 2026-08-23, but with
+`BAAI/bge-small-en-v1.5` and `BAAI/bge-base-en-v1.5` through transformers
+(CLS-pooled, L2-normalized, bge's own query instruction) — **not with this
+file's default model.** `nomic-embed-text-v1.5` is mean-pooled and uses
+`search_query:`/`search_document:`, so it is a different configuration
+reached through a different runtime.
+
+What that validation does establish is the property the corpus was built for
+and the only one the 5/5 threshold rests on: these five paraphrases are
+findable by a competent general-purpose retrieval encoder, and are not
+findable by word overlap. Both bge models scored 5/5; word overlap scored
+2/5. nomic-embed-text-v1.5 is a stronger retrieval model than either on
+every public benchmark, so 5/5 is a floor it should clear comfortably rather
+than a number tuned to it.
+
+**If it does not**, the honest reading is that this threshold was set from a
+neighbouring model and should be re-derived, not that the runner is broken —
+check `promptScheme` on the reply first, since a wrong prefix is the failure
+mode that looks exactly like a weak model.
 
 **The llama.cpp path itself was NOT executed there.** The machine this was
 written on cannot run the pinned `llama-cpp-python` wheel at all — every
@@ -186,10 +200,12 @@ def test_a_paraphrase_finds_its_passage(_llm):
     testing the symmetric path would leave the asymmetric one, the one the
     endpoint exists to offer, unexercised.
 
-    5/5 rather than a softer threshold because 5/5 is what real weights
-    scored when this corpus was validated (see the module docstring). A
-    threshold below what the thing actually does is a threshold that lets a
-    regression through.
+    5/5 rather than a softer threshold: it is what real weights scored when
+    this corpus was validated, and a threshold below what the thing actually
+    does is a threshold that lets a regression through. Read the module
+    docstring for WHICH weights — the validation used bge through
+    transformers, not this file's default model, and the argument for
+    carrying the number across is there rather than assumed here.
     """
     documents = _embed(_llm, CORPUS, "document")
     queries = _embed(_llm, [q for q, _w in QUERIES], "query")

--- a/tests/test_ai_text_embed_retrieval.py
+++ b/tests/test_ai_text_embed_retrieval.py
@@ -1,0 +1,231 @@
+"""Does this capability actually RETRIEVE — the one thing a text encoder is
+for, proved rather than assumed (SPEC §40).
+
+Every other test in this family checks a contract: the request shape, the
+refusals, the wire format, that a prefix reaches the model. None of them would
+notice if the vectors coming back were noise of the right width. This file is
+the one that would.
+
+**The corpus is built so that a keyword match CANNOT pass it**, which is the
+whole design and is itself asserted below (`test_the_corpus_defeats_keyword_
+matching`). Two of the five queries share not one word with the passage that
+answers them — "how do plants make food from sunlight" against a sentence
+about photosynthesis and glucose, "keeping the bread culture alive" against
+one about a sourdough starter — and word-overlap ranking scores 2/5 on the
+set, one of those two by coincidence. A semantic encoder scores 5/5.
+
+**Split into two tests on purpose, and only one of them needs a model.** The
+corpus property is a fact about the strings and is checked everywhere, on
+every CI run, for free. The retrieval itself needs real weights and a working
+llama.cpp, so it skips where it cannot run rather than being deleted — see
+`_llm` for exactly what it demands and why each demand is there.
+
+-------------------------------------------------------------------------------
+
+**HOW MUCH OF THIS HAS BEEN RUN, and by what.** The corpus was validated with
+REAL weights on 2026-08-23 — `BAAI/bge-small-en-v1.5` and
+`BAAI/bge-base-en-v1.5` through transformers, CLS-pooled and L2-normalized,
+which is the same arithmetic llama.cpp performs for a GGUF declaring
+`pooling_type = CLS`. Both scored 5/5 top-1; word-overlap scored 2/5. So the
+corpus is known-good and the threshold below is not a guess.
+
+**The llama.cpp path itself was NOT executed there.** The machine this was
+written on cannot run the pinned `llama-cpp-python` wheel at all — every
+version sampled aborts the process with `0xc000001d` (illegal instruction) on
+its AVX2-only CPU, before any model is touched. This test is therefore written
+to run on a reviewer's machine and skipped on that one. It is a real test, not
+a placeholder: the skip is a hardware fact, and the assertions are the ones
+that were validated against real weights through a different runtime.
+"""
+import os
+import re
+
+import pytest
+
+#: The default curated model, which is what a reviewer following `TESTING.md`
+#: will already have on disk. Overridable so the same test can be pointed at
+#: another curated id without editing it.
+MODEL_REPO = os.environ.get(
+    "FUSED_TEST_EMBED_REPO", "nomic-ai/nomic-embed-text-v1.5-GGUF")
+MODEL_FILE = os.environ.get(
+    "FUSED_TEST_EMBED_FILE", "nomic-embed-text-v1.5.Q8_0.gguf")
+
+#: Five passages with nothing in common but being English sentences. Short,
+#: because the point is the semantics and not the chunking; from five
+#: unrelated domains, because a corpus whose passages are near neighbours
+#: tests the encoder's precision rather than whether it works at all.
+CORPUS = [
+    "The landlord is responsible for repairing a leaking roof within 14 days "
+    "of written notice.",
+    "Espresso should be pulled at roughly nine bars of pressure for 25 to 30 "
+    "seconds.",
+    "Photosynthesis converts light energy into chemical energy stored as "
+    "glucose in plant cells.",
+    "A pull request must be approved by one reviewer before it can be merged "
+    "to the main branch.",
+    "Sourdough starter needs feeding with equal parts flour and water every "
+    "twelve hours.",
+]
+
+#: …and a paraphrase of each, written in the words someone would actually
+#: type rather than in the passage's own vocabulary. The index is the passage
+#: that answers it.
+QUERIES = [
+    ("water is coming through my ceiling when it rains", 0),
+    ("how long should I run the coffee machine shot", 1),
+    ("how do plants make food from sunlight", 2),
+    ("who has to sign off before my code lands", 3),
+    ("keeping the bread culture alive", 4),
+]
+
+
+def _words(text):
+    return set(re.findall(r"[a-z]+", text.lower()))
+
+
+def test_the_corpus_defeats_keyword_matching():
+    """**The test that makes the next one mean something.** A retrieval test
+    whose queries share their answer's vocabulary proves nothing an `in`
+    operator could not do, and it would keep passing after a change that
+    broke the encoder entirely.
+
+    Word-overlap ranking scores 2 of 5 here, and even that overstates it: one
+    of the two is a coincidence, matched on the stopwords "before" and "to".
+    Two queries share NO word at all with the passage that answers them.
+
+    Asserted as an upper bound rather than an exact number so that rewording
+    a passage for clarity does not fail the build — but it must stay well
+    under the 5/5 the encoder is required to reach below, or the two tests
+    stop being distinguishable.
+    """
+    picks = [
+        max(range(len(CORPUS)), key=lambda i: len(_words(query) & _words(CORPUS[i])))
+        for query, _want in QUERIES
+    ]
+    hits = sum(1 for (_q, want), got in zip(QUERIES, picks) if want == got)
+    assert hits <= 2, (
+        f"word overlap now answers {hits}/{len(QUERIES)} of these queries, so "
+        f"the retrieval test below no longer distinguishes a working encoder "
+        f"from a lookup table — reword the queries away from their passages' "
+        f"vocabulary")
+    # …and at least two queries must share literally nothing with their
+    # answer, which is the property that cannot be reached by luck.
+    zero_overlap = sum(
+        1 for query, want in QUERIES if not (_words(query) & _words(CORPUS[want])))
+    assert zero_overlap >= 2, zero_overlap
+
+
+@pytest.fixture(scope="module")
+def _llm():
+    """A real llama.cpp embedding model, or a skip that says which demand
+    failed.
+
+    Three separate demands, skipped separately because they fail for
+    different reasons and a reader deserves to know which:
+
+    1. `llama_cpp` importable — the runner venv is opt-in and is not what
+       this suite installs (AI-11c).
+    2. The GGUF already in the Hub cache. **Never downloaded by this test**:
+       a test suite that fetches 146MB the first time it runs is a test suite
+       people disable. `TESTING.md` says how to put it there in one command.
+    3. `Llama(...)` actually constructing. This one is not paranoia — the
+       maintainer's pinned wheel aborts the whole PROCESS with an illegal
+       instruction on a CPU without the instruction set it was built
+       against, so on such a machine there is nothing to catch and the skip
+       cannot help. What it DOES catch is the milder failures: a corrupt
+       download, a Vulkan build with no loader.
+    """
+    llama_cpp = pytest.importorskip(
+        "llama_cpp", reason="the llamacpp-embed runner venv is opt-in (AI-11c)")
+
+    from huggingface_hub import try_to_load_from_cache
+
+    path = try_to_load_from_cache(MODEL_REPO, MODEL_FILE)
+    if not isinstance(path, str):
+        pytest.skip(
+            f"{MODEL_REPO}/{MODEL_FILE} is not in the Hub cache, and this test "
+            f"will not download it — see TESTING.md")
+
+    try:
+        return llama_cpp.Llama(model_path=path, embedding=True, n_ctx=2048,
+                               n_batch=2048, n_ubatch=2048, verbose=False)
+    except Exception as error:  # noqa: BLE001 - a load failure here is a fact
+                                # about this machine, not a result
+        pytest.skip(f"llama.cpp could not load {MODEL_FILE}: {error}")
+
+
+def _embed(llm, texts, kind):
+    """The runner's own pipeline, reached through its own modules.
+
+    Deliberately NOT a reimplementation: `text_embed_common.prompted` and
+    `unit_normalize` are the functions the worker calls, so this test
+    exercises the prompt table and the normalization that actually ship. Only
+    the `Llama` handle is supplied from outside, because the worker's `load`
+    is what this fixture is standing in for.
+    """
+    from fused_render.ai.runners import formats, text_embed_common
+
+    scheme = formats.text_embed_scheme(MODEL_REPO, MODEL_FILE)
+    return text_embed_common.unit_normalize(
+        llm.embed(text_embed_common.prompted(texts, kind, scheme)))
+
+
+def _dot(a, b):
+    """Cosine similarity as a PLAIN DOT PRODUCT, with no magnitudes divided
+    out — which is legal here only because the vectors are unit length, and
+    is therefore also a check on that guarantee."""
+    return sum(x * y for x, y in zip(a, b))
+
+
+def test_a_paraphrase_finds_its_passage(_llm):
+    """**The point of the whole capability.** Each query must rank its own
+    passage first, against a corpus its words barely touch.
+
+    Query and document are embedded with DIFFERENT `kind` values, which is
+    how a page is meant to use this and therefore how it should be tested —
+    testing the symmetric path would leave the asymmetric one, the one the
+    endpoint exists to offer, unexercised.
+
+    5/5 rather than a softer threshold because 5/5 is what real weights
+    scored when this corpus was validated (see the module docstring). A
+    threshold below what the thing actually does is a threshold that lets a
+    regression through.
+    """
+    documents = _embed(_llm, CORPUS, "document")
+    queries = _embed(_llm, [q for q, _w in QUERIES], "query")
+
+    misses = []
+    for (text, want), vector in zip(QUERIES, queries):
+        scores = [_dot(vector, doc) for doc in documents]
+        got = max(range(len(scores)), key=scores.__getitem__)
+        if got != want:
+            misses.append((text, want, got, [round(s, 3) for s in scores]))
+
+    assert not misses, misses
+
+
+def test_the_vectors_are_unit_length_and_the_right_width(_llm):
+    """The guarantee `fused.ai.embedText` publishes and pages are told to
+    rely on: cosine is a plain dot product, so a vector's dot with ITSELF is
+    1. Checked against a real model rather than a fake, because
+    `unit_normalize` running is not the same fact as the runner calling it.
+    """
+    vectors = _embed(_llm, CORPUS, "document")
+    dims = {len(v) for v in vectors}
+    assert len(dims) == 1, dims
+    for vector in vectors:
+        assert abs(_dot(vector, vector) - 1.0) < 1e-6
+
+
+def test_an_unrelated_query_scores_lower_than_a_related_one(_llm):
+    """Similarity has to be ORDERED, not merely computed. A degenerate
+    encoder — one that returns nearly the same vector for everything, which
+    is exactly what a wrongly-pooled or wrongly-loaded model does — still
+    passes the two tests above by luck of argmax ties; it cannot pass this,
+    because the gap it asserts is a real separation rather than a ranking.
+    """
+    documents = _embed(_llm, CORPUS, "document")
+    related, unrelated = _embed(
+        _llm, ["my roof is leaking after the storm",
+               "the mitochondrion is the powerhouse of the cell"], "query")
+    assert _dot(related, documents[0]) > _dot(unrelated, documents[0]) + 0.05

--- a/tests/test_hub_models.py
+++ b/tests/test_hub_models.py
@@ -591,18 +591,25 @@ def test_the_menu_offers_only_tags_something_here_can_run(client):
     for tag in offered:
         assert ai_tasks.classify(tag).supported, tag
     # And the ones that made the complaint are gone, by name.
-    for absent in ("fill-mask", "feature-extraction", "sentence-similarity",
-                   "text-classification", "summarization", "image-classification"):
+    #
+    # **`feature-extraction` and `sentence-similarity` LEFT this list**, and
+    # that is a capability shipping rather than the rule loosening. They now
+    # map to `TEXT_EMBEDDINGS`, so a filter on either leads to models this app
+    # really can load — which is exactly what `ai/tasks.py`'s note on those two
+    # rows said would happen when it shipped. The complaint this test encodes
+    # is "a filter with no working button behind it", and that has stopped
+    # being true of them while remaining true of every tag still named here.
+    for absent in ("fill-mask", "text-classification", "summarization",
+                   "image-classification"):
         assert absent not in offered
-    # …while the four the Engines tab is about are all reachable. EMBEDDINGS
-    # arrives through `zero-shot-image-classification` and deliberately NOT
-    # through `feature-extraction`: the dual encoders the embedding runners load
-    # carry the former, and the sentence-transformers checkpoints that carry the
-    # latter are exactly what the `absent` list above keeps out (see
-    # `ai/tasks.py`'s note on those two rows).
+    # …while the five the Engines tab is about are all reachable. EMBEDDINGS
+    # still arrives through `zero-shot-image-classification` ALONE: the dual
+    # encoders that capability loads carry that tag, and the text encoders
+    # carrying the other two got a capability of their own rather than being
+    # folded into it (`registry.TEXT_EMBEDDINGS`).
     assert {ai_tasks.capability_for_tag(t) for t in offered} == {
         registry.TEXT_GENERATION, registry.IMAGE_GENERATION, registry.SPEECH_TO_TEXT,
-        registry.EMBEDDINGS}
+        registry.EMBEDDINGS, registry.TEXT_EMBEDDINGS}
 
 
 def test_the_menu_follows_the_vocabulary_rather_than_a_second_list(client, monkeypatch):
@@ -622,7 +629,36 @@ def test_the_menu_follows_the_vocabulary_rather_than_a_second_list(client, monke
 def test_a_result_is_never_something_this_app_cannot_run(client, hub_cache, monkeypatch):
     """The hard guarantee. The menu constrains what a user can ASK for; this
     constrains what comes back, including for an unfiltered query where the Hub
-    is free to answer with anything it likes."""
+    is free to answer with anything it likes.
+
+    **`sentence-transformers/all-MiniLM-L6-v2` must still be absent, and WHAT
+    KEEPS IT OUT HAS CHANGED.** It used to be the capability: `ai/tasks.py`
+    mapped `feature-extraction` to nothing, so the row died at the
+    "capability is None" drop. Since `registry.TEXT_EMBEDDINGS` shipped, that
+    tag resolves to a real capability and the row survives that far — it is
+    now dropped one layer down, by FORMAT: the llama.cpp embedding rows
+    declare `hub_filter_tags=("gguf",)`, and that repo publishes safetensors
+    only, so `pick_gguf_file` finds nothing in its `siblings` and the row
+    goes.
+
+    That is a stronger guarantee than the one it replaces, because it rests
+    on what the repo actually contains rather than on a capability nobody had
+    written yet — a GGUF conversion of the same model would now correctly get
+    a button, and the safetensors original correctly still does not.
+
+    **Which is why this test overrides `_no_format_filter` for one
+    capability.** That autouse fixture hands every capability a runner with
+    no format tags, so the whole module can use tagless fixtures without
+    caring about the host (see its docstring). Here the format gate IS the
+    thing under test for the embedding row, so `text-embeddings` gets the
+    gguf-tagged stand-in and everything else keeps the tagless one — which is
+    also what the four surviving rows need, since none of them carries
+    `siblings` either.
+    """
+    monkeypatch.setattr(
+        hub, "for_capability",
+        lambda capability: _gguf_runner(
+            tags=("gguf",) if capability == registry.TEXT_EMBEDDINGS else ()))
     monkeypatch.setattr(httpx, "get", _reply([
         {"id": "org/chat", "pipeline_tag": "text-generation"},
         {"id": "org/vlm", "pipeline_tag": "image-text-to-text"},


### PR DESCRIPTION
Text embeddings — bge, e5, nomic-embed, EmbeddingGemma, Qwen3-Embedding — as a
capability of their own, on llama.cpp (CPU + Vulkan) and MLX.

## Why a separate capability rather than widening `embeddings`

The existing `embeddings` capability is a dual encoder: SigLIP/CLIP, image and
text into one vector space, gated by `EMBED_MODEL_TYPES = {"siglip", "clip"}`.
A text encoder is a different thing — no vision tower, no
`get_text_features`, a pooling configuration instead — and today it cannot load
at all. Passing `BAAI/bge-small-en-v1.5` to `/api/ai/embed` currently downloads
~400 MB, starts a worker, and only then dies with
`AttributeError: 'BertModel' object has no attribute 'get_text_features'`.

`registry.py` already anticipated this, in the comment explaining why the Hub's
`feature-extraction` / `sentence-similarity` labels are withheld:

> Mean-pooling a text-only encoder is a different load path and a different
> catalog; when it ships, these two move.

They move here. Keeping the two capabilities separate also means a SigLIP model
and a text embedder can be resident at the same time — one resident model per
*capability*, so a RAG page and an image-search page no longer evict each other.

**The existing `embeddings` capability is untouched by this branch**:
no diff under `transformers_embed/`, `mlx_embed/` or `embed_common.py`, and
`EMBED_MODEL_TYPES` is unchanged.

## Engines

Following the precedent set when text generation moved off torch
(`llamacpp_text` + `llamacpp_text_vulkan` + `mlx_text`):

| | Runner |
|---|---|
| Windows / Linux CPU | `llamacpp_embed/` |
| Windows / Linux GPU | `llamacpp_embed_vulkan/` |
| Apple Silicon | `mlx_text_embed/` |

The llama.cpp pair carries the same `llama-cpp-python==0.3.29` pin as the text
pair, differing only in the wheel index — so their audit covers these and no new
one was invented. `llama_embed.py` sits at the runners root and serves both
folders, exactly as `llama_text.py` does.

## What an embedding GGUF is, and how it is told apart

Not by architecture. `Qwen3-Embedding-0.6B` and Qwen3 chat both declare
`general.architecture = qwen3`; only the embedding model carries a pooling key.
So `is_embedding_gguf` turns on **`pooling_type`**, read from the GGUF header —
an architecture allowlist could not have worked. The header readers take bytes,
so they run against a 2 MB HTTP Range peek rather than a downloaded file, which
is what makes the refusal path cheap.

## API

`POST /api/ai/embed-text` and `fused.ai.embedText({texts, model, kind})`,
matching the existing embed route's contract — including the cold-model fork
that answers `409 {"type":"model_loading","jobId":...}` rather than failing, and
unit-normalised vectors so cosine stays a plain dot product.

`kind` is the one genuinely new piece of surface. Retrieval models are
asymmetric — e5 wants `query:`/`passage:`, bge instructs the query only,
Qwen3-Embedding ships named prompts — and getting it wrong degrades retrieval
silently rather than failing. It defaults to `"document"`, the side that keeps a
corpus self-consistent for someone who never reads about prompts (and on bge
means no prefix at all). An unrecognised `kind` is **refused**, because it is the
one field whose wrong value is undetectable downstream.

## Refusing before the download

A repo that is not a loadable text embedding model is refused with a sentence
naming the repo, what it looks like and what to pass instead — **before** any
weights are fetched. Verified live against the Hub: a safetensors repo refused
off a 30-file listing, a chat GGUF refused off a 2 MB header peek, neither
downloading weights.

## Verified vs not — please read this part

**Actually run:** the GGUF header readers against four real published headers
over HTTP Range (architecture, pooling, context length all correct); the full
cold-load pipeline through a running server — env build, file resolution, a
146 MB download with progress, reaching `Llama(...)`; both refusal paths live
against the Hub; every route status and shape; the demo page rendering,
catching the 409, watching the job and surfacing the error.

**Not run — `llama.cpp` inference itself.** The pinned wheel aborts the process
with `0xc000001d` (illegal instruction) on the development machine's AVX2-only
i5-8365U, at every version tried (0.3.29, .26, .18, .12). Retrieval was
therefore validated by driving the *shipped test bodies* with real
`bge-small`/`bge-base` weights through transformers: all four assertions pass,
the prompt scheme resolves correctly, and the corpus scores 5/5 against a 2/5
keyword baseline. That proves the logic, not the llama.cpp call.

**Not run — MLX and Vulkan.** No hardware. `TESTING.md` §6 lists the three MLX
seams to check on a Mac.

## A pre-existing bug this surfaced (not fixed here)

`_llamacpp_platform` reports available for any Windows AMD64, but the pinned
wheel ships one `ggml-cpu.dll` with no runtime feature dispatch. A pre-AVX-512
x86_64 machine therefore gets a Load button and a hard process abort — which is
exactly what happened here. **This affects the existing `llamacpp-text` runner
identically**; it is untouched by this branch and wants its own fix.

## Tests

Targeted rather than a full-suite run, deliberately — the suite has pre-existing
failures unrelated to this change.

- New: `test_ai_text_embed_common.py`, `test_ai_llamacpp_embed_worker.py`,
  `test_ai_runtime_embed_text.py`, `test_ai_text_embed_retrieval.py` —
  **73 passed, 3 skipped** (skips are the opt-in llama.cpp venv).
- All 21 touched and neighbouring modules — **948 passed, 8 skipped**.
- Frontend `bun test src/apps/ai_models/lib/` — **333 pass**.
- 10 pre-existing failures baselined by stashing onto the branch point: nine
  Windows symlink-privilege errors and one metrics error-type expectation, none
  in a module this branch edits. Recorded in `TESTING.md`.

## Trying it

```bash
uv venv && uv pip install -e ".[dev]"
./.venv/Scripts/python.exe -m pytest tests/test_ai_text_embed_common.py \
  tests/test_ai_llamacpp_embed_worker.py tests/test_ai_runtime_embed_text.py \
  tests/test_ai_text_embed_retrieval.py -q
```

`TESTING.md` §2–4 cover running the server, exercising both refusal paths, and
the demo page at `docs/text-embeddings-demo.html`.

## Note on merging

This branches from `a014e786` and does **not** merge cleanly with current
`main`: `text-to-video` landed in the meantime and adds a capability in the same
places — the capability constants block, the runner rows, the catalog lists. The
conflicts are additive (both sides add a capability) rather than contradictory,
but reconciling two brand-new capabilities is a judgement call for whoever owns
the video work, so it has been left rather than resolved unilaterally. Happy to
do the merge on request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new AI capability, runners, Hub format classification, and a public embed API. Existing dual-encoder embeddings are left intact, but GGUF/safetensors loader rules and Hub task mapping can change how models are tagged and loaded.
> 
> **Overview**
> Adds **text embeddings as their own capability**, separate from dual-encoder `embeddings`, so a retrieval encoder and SigLIP can stay resident at once.
> 
> Pages get `POST /api/ai/embed-text` and `fused.ai.embedText({texts, kind, model})`. Vectors are unit-normalized; `kind` is `"query"` | `"document"` (default document) with the model’s prompt scheme applied and reported back. Image `paths` and unknown `kind` values are refused rather than silently mis-embedded.
> 
> Engines follow the chat split: **llama.cpp CPU**, **Vulkan**, and **MLX** (different catalogs — GGUF vs safetensors). Embedding GGUFs are identified by header `pooling_type`, not architecture, so Qwen3-Embedding is not treated as chat. Uncurated repos are refused from a Hub listing or a 2MB Range peek **before** weights download.
> 
> Hub tags `feature-extraction` / `sentence-similarity` now map here; llama.cpp still filters Discover to GGUF. Catalog, benchmarks, and the AI Models UI pick up the new capability. MLX inference is implemented against `mlx-embeddings` 0.1.0 but not executed on Apple Silicon in this branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1345135dd914e227fef076a78cd0e72397b6980c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->