### PR TITLE
Model + effort pickers on the /apps hero composer

### DIFF
--- a/frontend/src/apps/builder/HomeHero.tsx
+++ b/frontend/src/apps/builder/HomeHero.tsx
@@ -3,13 +3,13 @@
 // new app's claude chat. Shared by Home ("/") and the /apps hub, which is why
 // it lives in the builder app rather than the shell.
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { aiComplete, createApp } from "@platform/lib/api";
+import { aiComplete, createApp, type DefaultModel, type SessionEffort } from "@platform/lib/api";
 import { navigate, navigateUrl, replaceSearch, urlForFsPath } from "@platform/lib/router";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { TroubleCard } from "@platform/ui/TroubleCard";
 import logoMarkDark from "@assets/logo-black-bg-transparent.png";
 import logoMarkLight from "@assets/logo-white-bg-transparent.png";
-import { TextArea } from "@platform/ui/field/fields";
+import { Select, TextArea } from "@platform/ui/field/fields";
 
 // URL of an app folder's claude chat, attached to a specific live run.
 // `_mode` is the shell's template selector; `run` is a plain view param the
@@ -27,8 +27,20 @@ import { TextArea } from "@platform/ui/field/fields";
 // returned — including its Windows-backslash normalization, which the old
 // segment split had to do by hand or silently take the drive-rooted path as one
 // segment.
-export function claudeChatUrl(appDir: string, runId: string): string {
+// `model`/`effort` ride along when the composer's pickers were used, so
+// the chat's own pills open showing what the scaffolding turn actually ran with
+// and the NEXT turn keeps it. Omitted when empty: the template reads these
+// through fused.params, and an empty param would beat its own detection of what
+// this project is really being worked in.
+export function claudeChatUrl(
+  appDir: string,
+  runId: string,
+  model: DefaultModel = "",
+  effort: SessionEffort = "",
+): string {
   const params = new URLSearchParams({ _mode: "claude", run: runId });
+  if (model) params.set("model", model);
+  if (effort) params.set("effort", effort);
   return urlForFsPath(appDir.replace(/\/+$/, ""), "?" + params.toString());
 }
 
@@ -79,11 +91,16 @@ async function suggestAppName(prompt: string): Promise<string> {
 
 // Create the app under a collision-proof name: on 409 retry with -2, -3, …
 // Any other failure propagates.
-async function createAppUnderFreeName(name: string, prompt: string) {
+async function createAppUnderFreeName(
+  name: string,
+  prompt: string,
+  model: DefaultModel,
+  effort: SessionEffort,
+) {
   for (let i = 1; ; i++) {
     const attempt = i === 1 ? name : `${name}-${i}`;
     try {
-      return await createApp(attempt, prompt);
+      return await createApp(attempt, prompt, model, effort);
     } catch (e) {
       if ((e as { status?: number }).status !== 409 || i >= 20) throw e;
     }
@@ -176,11 +193,112 @@ const SAMPLE_PROMPTS: { label: string; prompt: string; glyph: ReactNode }[] = [
   },
 ];
 
+// The composer's two session pickers — what the scaffolding turn runs
+// with, and what the chat it lands in opens showing. Both lists are the claude
+// template's own vocabulary (template.html MODELS / EFFORTS, and the server
+// validates against the same sets), because these values are handed straight to
+// the CLI as --model / --effort.
+//
+// "" is the FIRST option of each and the default: it means no flag at all, so
+// the session keeps whatever the template would have detected for this project
+// from its own transcripts and settings. A composer that shipped `sonnet` /
+// `medium` preselected would silently override that detection for every app
+// built from here, which is a stronger claim than the picker is making.
+//
+// The labels are BARE — "Auto", "opus", "high" — and not "Auto model" / "high
+// effort": each pill's glyph names its axis, so repeating it in the text is the
+// same word twice in one control. It is also what keeps two pills quiet enough
+// to sit unbordered in the footer of the box rather than reading as buttons.
+const MODEL_CHOICES: { value: DefaultModel; label: string }[] = [
+  { value: "", label: "Auto" },
+  { value: "fable", label: "fable" },
+  { value: "opus", label: "opus" },
+  { value: "sonnet", label: "sonnet" },
+  { value: "haiku", label: "haiku" },
+];
+
+const EFFORT_CHOICES: { value: SessionEffort; label: string }[] = [
+  { value: "", label: "Auto" },
+  { value: "low", label: "low" },
+  { value: "medium", label: "medium" },
+  { value: "high", label: "high" },
+  { value: "xhigh", label: "xhigh" },
+  { value: "max", label: "max" },
+];
+
+// A glyph each, because the two pickers sit side by side with no border to tell
+// them apart: the icon is what says which control you are looking at before the
+// value is read — and it is what lets the labels stay bare words ("Auto",
+// "high") instead of spelling their own axis out. Drawn in the composer's own weight (13px,
+// 2px stroke) rather than borrowed from MenuIcons, which is tuned 1.5px for menu
+// rows — a menu glyph beside these chips reads thin and unrelated.
+const PICK_GLYPHS = {
+  // Model — the sparkle MenuIcons uses for "new", the app's existing mark for
+  // the AI doing something on your behalf.
+  model: (
+    <path d="M11 3.5l1.6 4.4 4.4 1.6-4.4 1.6L11 15.5 9.4 11.1 5 9.5l4.4-1.6L11 3.5zM17.5 15l.8 2 2 .8-2 .8-.8 2-.8-2-2-.8 2-.8.8-2z" />
+  ),
+  // Effort — a gauge: a needle on a dial is the one figure that reads as "how
+  // hard is this being pushed" without a word beside it.
+  effort: (
+    <>
+      <path d="M4.5 17a8 8 0 1 1 15 0" />
+      <path d="M12 15l3.5-4" />
+    </>
+  ),
+};
+
+// One borderless picker: glyph, then a native select carrying its own chevron.
+// A <label> around both so the glyph is part of the control's hit area rather
+// than decoration beside it — the pill has no border to aim at, so the target
+// has to be the whole thing.
+function ComposerPick<T extends string>({
+  glyph,
+  label,
+  value,
+  choices,
+  disabled,
+  onPick,
+}: {
+  glyph: keyof typeof PICK_GLYPHS;
+  label: string;
+  value: T;
+  choices: { value: T; label: string }[];
+  disabled: boolean;
+  onPick: (next: T) => void;
+}) {
+  return (
+    <label className="home-composer-pick">
+      <span className="home-composer-pick-glyph" aria-hidden="true">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          {PICK_GLYPHS[glyph]}
+        </svg>
+      </span>
+      <Select
+        className="home-composer-pick-sel"
+        aria-label={label}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onPick(e.target.value as T)}
+      >
+        {choices.map((c) => (
+          <option key={c.value} value={c.value}>
+            {c.label}
+          </option>
+        ))}
+      </Select>
+    </label>
+  );
+}
+
 // The hero's prompt box — the claude.ai / v0 "what do you want to build?"
 // composer. Submitting names the app (haiku via /api/ai), scaffolds it, and
 // lands in the new folder's claude chat exactly like the New-app panel does.
 function HeroComposer({ onCreated }: { onCreated: () => void }) {
   const [prompt, setPrompt] = useState("");
+  // Empty = "let the chat decide", the default; see MODEL_CHOICES.
+  const [model, setModel] = useState<DefaultModel>("");
+  const [effort, setEffort] = useState<SessionEffort>("");
   const [phase, setPhase] = useState<"idle" | "naming" | "creating">("idle");
   const [error, setError] = useState<string | null>(null);
   // Claude would not start for an app that WAS created — see the submit path.
@@ -233,7 +351,7 @@ function HeroComposer({ onCreated }: { onCreated: () => void }) {
       const name = await suggestAppName(trimmed);
       if (!alive.current) return;
       setPhase("creating");
-      const res = await createAppUnderFreeName(name, trimmed);
+      const res = await createAppUnderFreeName(name, trimmed, model, effort);
       // The folder exists from here on, so the Recent grid is stale — refresh it
       // now, since the session-error branch below stays on this page.
       onCreated();
@@ -250,7 +368,7 @@ function HeroComposer({ onCreated }: { onCreated: () => void }) {
         }
         return;
       }
-      if (res.run_id) navigateUrl(claudeChatUrl(res.path, res.run_id), { isDir: true });
+      if (res.run_id) navigateUrl(claudeChatUrl(res.path, res.run_id, model, effort), { isDir: true });
       else navigate(res.entry_html, { isDir: false });
     } catch (e) {
       if (alive.current) {
@@ -282,15 +400,35 @@ function HeroComposer({ onCreated }: { onCreated: () => void }) {
           }}
         />
         <div className="home-composer-bar">
-          <span className="home-composer-hint">
-            {phase === "naming" && "Naming your app…"}
-            {phase === "creating" && "Creating the app…"}
-            {phase === "idle" && (
-              <>
-                <kbd>↵</kbd> to build · <kbd>⇧↵</kbd> for a new line
-              </>
-            )}
-          </span>
+          {/* The bar's left end used to spell out ↵ / ⇧↵. Those are the two
+              keystrokes every chat box on the machine already answers to, and
+              the space is worth more spent on the one thing this composer could
+              not say at all: WHICH Claude builds the app. The pickers
+              stay mounted while a create is in flight — disabled, like the
+              starter chips — and the phase text takes the space beside them
+              rather than replacing them, so nothing moves when it appears. */}
+          <div className="home-composer-picks">
+            <ComposerPick
+              glyph="model"
+              label="Model"
+              value={model}
+              choices={MODEL_CHOICES}
+              disabled={busy}
+              onPick={setModel}
+            />
+            <ComposerPick
+              glyph="effort"
+              label="Effort"
+              value={effort}
+              choices={EFFORT_CHOICES}
+              disabled={busy}
+              onPick={setEffort}
+            />
+            <span className="home-composer-hint">
+              {phase === "naming" && "Naming your app…"}
+              {phase === "creating" && "Creating the app…"}
+            </span>
+          </div>
           <button
             type="button"
             className="home-composer-send"

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1885,8 +1885,21 @@ export interface NewAppResult {
   session_error: string | null;
 }
 
-export function createApp(name: string, prompt: string): Promise<NewAppResult> {
-  return postJson<NewAppResult>("/api/apps/new", { name, prompt });
+// `model`/`effort` are the hero composer's pickers — short model names
+// from the same set as DefaultModel, effort from the claude template's own
+// EFFORTS list. "" means "don't pass the flag": the scaffolding session keeps
+// whatever a chat opened by hand would detect for this project. Anything else
+// is a 400 rather than a silent substitution, so a typo can't quietly buy a
+// different model than the one asked for.
+export type SessionEffort = "" | "low" | "medium" | "high" | "xhigh" | "max";
+
+export function createApp(
+  name: string,
+  prompt: string,
+  model: DefaultModel = "",
+  effort: SessionEffort = "",
+): Promise<NewAppResult> {
+  return postJson<NewAppResult>("/api/apps/new", { name, prompt, model, effort });
 }
 
 // -- Claude sessions (GET /api/claude-sessions) -------------------------------

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -211,13 +211,16 @@
   cursor: inherit;
 }
 
-/* .field-control's focus rule sets `outline: none` and colours the BORDER,
-   which is not a thing this control has any more — so the keyboard indicator
-   has to be drawn back, and only for keyboard: an outline on every click puts a
-   ring around a pill the mouse is already washing. */
-.home-composer .home-composer-pick-sel:focus-visible {
-  outline: 1px solid var(--fg-muted);
-  outline-offset: 1px;
+/* Focus is the HOVER WASH, on the whole pill, and no ring at all. An outline
+   drawn on the <select> traces the select alone — the glyph is the label's
+   child, not the select's, so the ring cut the pill in half and boxed the word
+   while the icon sat outside it. Washing the label instead marks the same thing
+   the pointer marks, at the size the control actually is. `:has(:focus-visible)`
+   and not `:focus-within`: a click already gets the hover wash, so keyboard is
+   the only case that still needs saying. */
+.home-composer-pick:has(:focus-visible) {
+  color: var(--fg);
+  background-color: var(--bg-alt);
 }
 
 /* The "Auto" option is muted by fields.css's placeholder rule (it is the

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -150,19 +150,86 @@
   padding: 6px 10px 10px 16px;
 }
 
+/* The bar's left end: the model/effort pickers, then the create phase text.
+   Wraps rather than squeezing the two selects, since the hero is as narrow as
+   the sidebar leaves it on a small window. (The ↵ / ⇧↵ hint that used to live
+   here is gone, and its `kbd` rule with it.) */
+.home-composer-picks {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+/* The pickers are UNBORDERED and unfilled at rest — glyph, word, chevron, and
+   nothing drawn around them. They are settings ON the send, not things to
+   press: the box already has a border, the send button is already filled, and
+   two more outlined pills inside that same box turned its footer into a row of
+   competing buttons. The wash arrives on hover, which is where a reader is
+   asking whether this is a control at all. */
+.home-composer-pick {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding-left: 6px;
+  border-radius: 999px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+.home-composer-pick:hover:not(:has(:disabled)) {
+  color: var(--fg);
+  background-color: var(--bg-alt);
+}
+
+.home-composer-pick:has(:disabled) {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.home-composer-pick-glyph {
+  display: inline-flex;
+  /* Optical only: the 24-box glyphs sit a hair low against 12px type. */
+  margin-top: -1px;
+}
+
+/* `background-COLOR`, never the `background` shorthand: the chevron is a
+   background-image on .field-control, and a shorthand here would erase it and
+   leave the select with no affordance at all now that the border is gone. The
+   right padding is the space that glyph is drawn in. */
+.home-composer .home-composer-pick-sel {
+  height: auto;
+  padding: 3px 18px 3px 2px;
+  font-size: 12px;
+  color: inherit;
+  background-color: transparent;
+  background-position: right 4px center;
+  border: none;
+  border-radius: 999px;
+  cursor: inherit;
+}
+
+/* .field-control's focus rule sets `outline: none` and colours the BORDER,
+   which is not a thing this control has any more — so the keyboard indicator
+   has to be drawn back, and only for keyboard: an outline on every click puts a
+   ring around a pill the mouse is already washing. */
+.home-composer .home-composer-pick-sel:focus-visible {
+  outline: 1px solid var(--fg-muted);
+  outline-offset: 1px;
+}
+
+/* The "Auto" option is muted by fields.css's placeholder rule (it is the
+   `value=""` one). Here that fights the pill's own hover, which lifts the whole
+   control to --fg — so the select keeps `inherit` and the pill decides. */
+.home-composer .home-composer-pick-sel:has(option[value=""]:checked) {
+  color: inherit;
+}
+
 .home-composer-hint {
   font-size: 11.5px;
   color: var(--fg-muted);
-}
-
-.home-composer-hint kbd {
-  font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 10.5px;
-  padding: 1px 5px;
-  border: 1px solid var(--border);
-  border-bottom-width: 2px;
-  border-radius: 4px;
-  background: var(--bg-alt);
 }
 
 .home-composer-send {

--- a/fused_render/claude_spawn.py
+++ b/fused_render/claude_spawn.py
@@ -104,22 +104,26 @@ def record_session_when_ready(agent, run_id: str, on_tick=None) -> None:
 #
 # `session_id` rides through as a real parameter because a scheduled message may
 # target an EXISTING conversation ("" is a fresh one, which is all the apps API
-# ever wants). model/effort stay empty: neither caller has a picker, so the
-# session takes the same defaults a chat opened by hand would.
+# ever wants). model/effort ride through the same way now that the /apps hero
+# composer has a picker for them: empty means "no --model/--effort flag
+# at all", which is what leaves the session on the same defaults a chat opened
+# by hand would detect for itself. `.get` and not `[...]`: the request dict is
+# built by whichever caller ran, and the ones with no picker send neither key.
 SESSION_HELPER = """\
 import importlib.util, json, sys
 req = json.load(sys.stdin)
 spec = importlib.util.spec_from_file_location("claude_agent", req["agent"])
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-print(json.dumps(mod._start(req["file"], req["message"], req["session_id"], "", "",
+print(json.dumps(mod._start(req["file"], req["message"], req["session_id"],
+                            req.get("model", ""), req.get("effort", ""),
                             permission_mode=req["permission_mode"],
                             message_via_stdin=True)))
 """
 
 
 def spawn_helper(target: str, prompt: str, permission_mode: str,
-                 session_id: str = "") -> dict:
+                 session_id: str = "", model: str = "", effort: str = "") -> dict:
     """Run `agent._start` in the fork-safe helper; return its result dict.
 
     close_fds=False + no cwd + no start_new_session keeps THIS Popen on the
@@ -143,7 +147,8 @@ def spawn_helper(target: str, prompt: str, permission_mode: str,
         [sys.executable, "-c", SESSION_HELPER],
         input=json.dumps(
             {"agent": agent_path(), "file": target, "message": prompt,
-             "session_id": session_id, "permission_mode": permission_mode}),
+             "session_id": session_id, "permission_mode": permission_mode,
+             "model": model, "effort": effort}),
         capture_output=True, text=True, encoding="utf-8", errors="replace",
         timeout=60, close_fds=False,
     )

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -52,6 +52,7 @@ from fastapi import APIRouter, Body, Header
 
 from fused_render import app_listing, claude_spawn
 from fused_render.server.common import _error, _require_fused
+from fused_render.shell.prefs import VALID_DEFAULT_MODELS
 from fused_render.shell.seed import fused_dir
 
 router = APIRouter()
@@ -458,19 +459,53 @@ _record_session_when_ready = claude_spawn.record_session_when_ready
 # the app's chat, which `run_id` in the response is there to let the UI do.
 _APP_SESSION_PERMISSION_MODE = "auto"
 
+# What the hero composer's two pickers may ask for. Models are the
+# default-model preference's own set — the claude template's MODELS vocabulary,
+# already written down once in shell/prefs.py — so a third copy of that list
+# cannot drift from the control it feeds. Efforts have no such home yet: the
+# template's EFFORTS list is JS, and this is the first Python caller that needs
+# it, so the tuple lives here until a second one does.
+#
+# `""` is a first-class member of both, exactly as it is in
+# VALID_DEFAULT_MODELS: it means NO --model/--effort flag on the spawn, i.e.
+# the session keeps whatever a chat opened by hand would have detected for
+# itself. That is what an absent key from an older client resolves to too.
+_VALID_SESSION_EFFORTS = ("", "low", "medium", "high", "xhigh", "max")
 
-def _spawn_session_helper(target: str, prompt: str) -> dict:
+
+def _session_choice_error(field: str, value, allowed) -> str | None:
+    """Reject a model/effort the pickers cannot produce, rather than
+    substituting one. Our own UI only ever sends a list value, so this fires
+    for a hand-rolled request — and a caller that asked for `opus` and
+    silently got the default has been answered with the wrong session, which
+    is worse than a 400. (The claude template falls BACK for an unknown
+    permission mode instead, but there the safe direction is the strict one;
+    here there is no strict direction, only a different model.)"""
+    if not isinstance(value, str):
+        return f"{field!r} must be a string"
+    if value not in allowed:
+        return (f"invalid {field} {value!r}: expected one of "
+                + ", ".join(repr(v) for v in allowed))
+    return None
+
+
+def _spawn_session_helper(target: str, prompt: str,
+                          model: str = "", effort: str = "") -> dict:
     """Run agent._start in the fork-safe helper; return its result dict.
 
     Thin wrapper over claude_spawn.spawn_helper, which holds the posix_spawn
     discipline this call depends on. What stays here is the one policy choice:
     the permission mode above, and a FRESH session always — an app is being
-    scaffolded, so there is no prior conversation to resume."""
+    scaffolded, so there is no prior conversation to resume.
+
+    `model`/`effort` are the composer's picks, already validated by the route;
+    empty means "leave the session on its own defaults"."""
     return claude_spawn.spawn_helper(
-        target, prompt, _APP_SESSION_PERMISSION_MODE)
+        target, prompt, _APP_SESSION_PERMISSION_MODE, model=model, effort=effort)
 
 
-def _start_app_session(app_dir: str, prompt: str) -> tuple[str | None, str | None]:
+def _start_app_session(app_dir: str, prompt: str, model: str = "",
+                       effort: str = "") -> tuple[str | None, str | None]:
     """Start a detached Claude Code session on the new app's FOLDER.
 
     The seam the tests stub. Reuses the claude agent's _start (via the
@@ -483,7 +518,7 @@ def _start_app_session(app_dir: str, prompt: str) -> tuple[str | None, str | Non
     rides back so the UI isn't silent about it, and the run_id lets the
     caller attach to the live run."""
     try:
-        res = _spawn_session_helper(app_dir, prompt)
+        res = _spawn_session_helper(app_dir, prompt, model, effort)
     except Exception as exc:
         return None, f"failed to start Claude session: {exc}"
     if res.get("error") or not res.get("run_id"):
@@ -510,6 +545,17 @@ def api_new_app(body: dict = Body(...), x_fused: str | None = Header(default=Non
     prompt = body.get("prompt", "")
     if not isinstance(prompt, str):
         return _error("'prompt' must be a string")
+
+    # The composer's model/effort pickers. Both optional and both
+    # defaulting to "" — an older client that sends neither gets exactly the
+    # session it got before this existed.
+    model = body.get("model", "")
+    effort = body.get("effort", "")
+    for field, value, allowed in (("model", model, VALID_DEFAULT_MODELS),
+                                  ("effort", effort, _VALID_SESSION_EFFORTS)):
+        err = _session_choice_error(field, value, allowed)
+        if err is not None:
+            return _error(err)
 
     root = fused_dir()
     dest = os.path.join(root, "local", name)
@@ -554,7 +600,7 @@ def api_new_app(body: dict = Body(...), x_fused: str | None = Header(default=Non
     entry_html = os.path.join(dest, "index.html")
     run_id, session_error = None, None
     if prompt.strip():
-        run_id, session_error = _start_app_session(dest, prompt)
+        run_id, session_error = _start_app_session(dest, prompt, model, effort)
 
     return {
         "path": os.path.abspath(dest),

--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -267,7 +267,8 @@ def test_new_app_requires_the_fused_header(client):
 def test_new_app_happy_path_no_prompt(client, workspace, monkeypatch):
     called = []
     monkeypatch.setattr(apps_mod, "_start_app_session",
-                        lambda entry, prompt: called.append((entry, prompt)) or ("r-1", None))
+                        lambda entry, prompt, *rest:
+                        called.append((entry, prompt)) or ("r-1", None))
     r = client.post("/api/apps/new", json={"name": "demo", "prompt": ""}, headers=HDRS)
     assert r.status_code == 200
     body = r.json()
@@ -293,7 +294,7 @@ def test_new_app_has_no_dot_claude_and_syncs_user_skills(
 
     claude_dir = tmp_path / "claude-config"
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_dir))
-    monkeypatch.setattr(apps_mod, "_start_app_session", lambda e, p: (None, "x"))
+    monkeypatch.setattr(apps_mod, "_start_app_session", lambda e, p, *rest: (None, "x"))
     client.post("/api/apps/new", json={"name": "demo", "prompt": ""}, headers=HDRS)
 
     assert not (workspace / "local" / "demo" / ".claude").exists()
@@ -306,9 +307,11 @@ def test_new_app_has_no_dot_claude_and_syncs_user_skills(
 def test_new_app_with_prompt_starts_a_session(client, workspace, monkeypatch):
     seen = {}
 
-    def fake_start(app_dir, prompt):
+    def fake_start(app_dir, prompt, model="", effort=""):
         seen["target"] = app_dir
         seen["prompt"] = prompt
+        seen["model"] = model
+        seen["effort"] = effort
         return "run-42", None
 
     monkeypatch.setattr(apps_mod, "_start_app_session", fake_start)
@@ -322,11 +325,68 @@ def test_new_app_with_prompt_starts_a_session(client, workspace, monkeypatch):
     # so its transcript lands where the split view lists sessions from.
     assert seen["target"] == str(workspace / "local" / "demo")
     assert seen["prompt"] == "build a todo app"
+    # no pickers touched: "" both, i.e. no --model/--effort on the spawn, so the
+    # session keeps whatever a chat opened by hand would have detected
+    assert (seen["model"], seen["effort"]) == ("", "")
+
+
+def test_the_composers_model_and_effort_reach_the_session(client, workspace,
+                                                          monkeypatch):
+    """The hero composer's two pickers are what the scaffolding turn runs
+    with, so they have to arrive at the spawn — a create that accepted them and
+    started a default session is the whole feature missing."""
+    seen = {}
+    monkeypatch.setattr(apps_mod, "_start_app_session",
+                        lambda e, p, model="", effort="":
+                        seen.update(model=model, effort=effort) or ("r-1", None))
+    r = client.post("/api/apps/new",
+                    json={"name": "demo", "prompt": "build it",
+                          "model": "opus", "effort": "xhigh"}, headers=HDRS)
+    assert r.status_code == 200
+    assert seen == {"model": "opus", "effort": "xhigh"}
+
+
+@pytest.mark.parametrize("body", [
+    {"model": "gpt-4"},          # not in the claude template's vocabulary
+    {"model": "claude-opus-5"},  # a full API id, not the short name
+    {"effort": "maximum"},
+    {"effort": "ultra"},
+    {"model": 7},
+    {"effort": None},
+])
+def test_an_unknown_model_or_effort_is_a_400_not_a_substitution(client, workspace,
+                                                               monkeypatch, body):
+    """A caller that asked for `opus` and silently got the default has been
+    handed the wrong session — worse than being told the value is unknown. Our
+    own UI can only send list values, so this only fires for a hand-rolled
+    request. And nothing is created: the folder must not survive a rejected
+    request any more than a bad name's does."""
+    monkeypatch.setattr(apps_mod, "_start_app_session",
+                        lambda *a, **k: pytest.fail("must not spawn"))
+    r = client.post("/api/apps/new",
+                    json={"name": "demo", "prompt": "hi", **body}, headers=HDRS)
+    assert r.status_code == 400
+    assert not (workspace / "local" / "demo").exists()
+
+
+def test_an_empty_pick_means_no_flag_and_older_clients_still_work(
+        client, workspace, monkeypatch):
+    """"" is a first-class value in both lists, not a rejected one — it is what
+    the pickers' "Auto" option sends and what a client predating them omits."""
+    seen = []
+    monkeypatch.setattr(apps_mod, "_start_app_session",
+                        lambda e, p, model="", effort="":
+                        seen.append((model, effort)) or ("r-1", None))
+    for body in ({"model": "", "effort": ""}, {}):
+        client.post("/api/apps/new",
+                    json={"name": f"demo{len(seen)}", "prompt": "hi", **body},
+                    headers=HDRS)
+    assert seen == [("", ""), ("", "")]
 
 
 def test_spawn_failure_does_not_fail_creation_and_says_why(client, workspace, monkeypatch):
     monkeypatch.setattr(apps_mod, "_start_app_session",
-                        lambda e, p: (None, "claude CLI not found"))
+                        lambda e, p, *rest: (None, "claude CLI not found"))
     r = client.post("/api/apps/new", json={"name": "demo", "prompt": "hi"}, headers=HDRS)
     assert r.status_code == 200
     assert r.json()["session_started"] is False
@@ -638,6 +698,9 @@ def test_spawn_runs_agent_start_in_a_helper_subprocess_not_in_process(
     assert req["permission_mode"] == "auto"
     # an app is being scaffolded: there is no prior conversation to resume
     assert req["session_id"] == ""
+    # no pickers used: both empty, which the helper turns into NO --model /
+    # --effort flag rather than into a hardcoded default
+    assert (req["model"], req["effort"]) == ("", "")
     # posix_spawn preconditions on the helper spawn (the crash was fork+exec)
     assert seen["kwargs"]["close_fds"] is False
     assert "cwd" not in seen["kwargs"]
@@ -649,6 +712,30 @@ def test_spawn_runs_agent_start_in_a_helper_subprocess_not_in_process(
     assert seen["kwargs"]["encoding"] == "utf-8"
     assert seen["kwargs"]["errors"] == "replace"
     assert started_threads  # the session-recording poll thread was kicked off
+
+
+def test_the_picked_model_and_effort_reach_the_helper_request(tmp_path, workspace,
+                                                             monkeypatch):
+    """The other half: the pickers' values have to survive the fork-safe hop
+    into the helper, which is where agent._start turns them into --model /
+    --effort."""
+    def fake_run(cmd, **kwargs):
+        seen.update(json.loads(kwargs["input"]))
+        return type("R", (), {"returncode": 0,
+                              "stdout": '{"run_id": "r-1"}', "stderr": ""})()
+
+    seen = {}
+    monkeypatch.setattr(apps_mod.claude_spawn.subprocess, "run", fake_run)
+    monkeypatch.setattr(apps_mod, "_claude_agent", lambda: None)
+    monkeypatch.setattr(apps_mod.threading, "Thread",
+                        lambda **kw: type("T", (), {"start": lambda s: None})())
+
+    run_id, err = apps_mod._start_app_session("/x/index.html", "hi", "haiku", "low")
+    assert (run_id, err) == ("r-1", None)
+    assert (seen["model"], seen["effort"]) == ("haiku", "low")
+    # still the apps API's own policy, unchanged by the new args
+    assert seen["permission_mode"] == "auto"
+    assert seen["session_id"] == ""
 
 
 def test_spawn_helper_failure_reports_why(tmp_path, workspace, monkeypatch):


### PR DESCRIPTION
## What

The new-app composer's footer said `↵ to build · ⇧↵ for a new line` — the two keystrokes every chat box on the machine already answers to — and had no way to say *which* Claude builds the app. Those labels are gone; a **model** picker and an **effort** picker take the space, and both values reach the scaffolding turn.

Note this composer is shared by Home (`/`) and the `/apps` hub, so the change lands on both — one composer, one control row.

## The wire

- `POST /api/apps/new` takes `model` / `effort`, validated against `shell/prefs.py`'s `VALID_DEFAULT_MODELS` (no third copy of the claude template's `MODELS`) and a new `_VALID_SESSION_EFFORTS`.
- `claude_spawn.spawn_helper` fills the two `""` slots `agent._start` already had → the run is spawned with `--model` / `--effort`. `agent.py` itself is untouched.
- The chat URL the create navigates to carries the same pair as `?model=&effort=`, so the template's own pills open on the picks and the *next* turn keeps them. Both destinations or neither: the spawn alone would build with `opus` and then show `sonnet` in the pill.

## Two calls worth flagging

- **`""` is a first-class value in both lists**, not an absence: it is what the "Auto" option sends and what a client predating this omits. It means no flag at all, so the template's own detection (what this project's transcripts and settings say it is actually worked in) still decides — a composer shipping `sonnet`/`medium` preselected would silently override that for every app built from here.
- **An unknown value is a 400, not a substitution.** A caller that asked for `opus` and silently got the default has been handed the wrong session. The pickers cannot produce an off-list value, so the only requests this rejects are hand-rolled ones. Validation runs before the folder is created, so a rejected request leaves nothing behind.

Permission mode is deliberately *not* offered: the scaffolding turn runs unattended from an HTTP POST with nobody polling `decide`, which is why it is pinned to `auto` in code.

## Design

Borderless and unfilled at rest — glyph, word, chevron, wash on hover. The box already has a border and the send button is already filled; two more outlined pills inside it read as competing buttons. Each pill carries a glyph (sparkle for model, gauge for effort), which is what lets the labels stay bare words (`Auto`, `opus`, `high`) instead of spelling their own axis out. Pickers stay mounted and disabled while a create is in flight, with the phase text beside them rather than replacing them.

## Tests

`tests/test_apps_api.py`: picks reach the spawn; picks survive the fork-safe hop into the helper (`req["model"]`/`req["effort"]`); unknown model/effort → 400 with no folder created and no spawn; `""` and an omitted key both resolve to no flag. Three existing `_start_app_session` stubs were two-arg lambdas and now take the extra args.

`68 passed` in `tests/test_apps_api.py`; `174 passed` across the other `spawn_helper` callers (schedule / canvases / queue-dock / subprocess-encoding). Frontend builds clean.

Wire verified live against the dev server: setting the pills to `opus` / `xhigh` and pressing build sends `{"name":"a-smoke-test-app","prompt":"a smoke-test app","model":"opus","effort":"xhigh"}`. The restyle (borderless + glyphs) landed after that check and has not been looked at on screen yet — @vasu is testing it.

No DECISIONS row, per owner's call on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app-creation spawn (model/effort flags on the Claude CLI) and validates new request fields. Defaults preserve prior behavior; invalid values are rejected rather than substituted.
> 
> **Overview**
> Lets users pick which Claude model and effort the scaffolding turn uses when creating an app from Home or `/apps`, instead of always taking the chat’s detected defaults.
> 
> The composer footer replaces the keyboard hint with two borderless **Auto**-default pickers. Those values go to `POST /api/apps/new`, through `spawn_helper` into `--model` / `--effort`, and onto the landing chat URL so the next turn keeps the same picks. Empty means no flag (older clients unchanged). Unknown values 400 before the folder is created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5403b61f4cb20d085d1c10b8b7e9dafbdcfd93f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->