### PR TITLE
map: release local raster/vector files instead of holding them open

### DIFF
--- a/fused_render/templates/map/raster_engine.py
+++ b/fused_render/templates/map/raster_engine.py
@@ -404,11 +404,18 @@ class _ReaderPool:
     blocks — a fresh Reader is opened when no idle handle is available — and idle
     handles are reused, bounded per locator and overall. The caller supplies the
     GDAL environment so a freshly opened handle picks up the same options.
+
+    A local original is never pooled (gated by ``poolable``): a kept-open handle
+    locks the user's file on Windows until they quit the app, and reopening a
+    local file is cheap. Only remote ``/vsi`` sources and cache derivatives —
+    costly to reopen, and never the user's file — stay warm.
     """
 
-    def __init__(self, max_idle_per_locator: int, max_idle: int):
+    def __init__(self, max_idle_per_locator: int, max_idle: int,
+                 poolable=None):
         self.max_idle_per_locator = max_idle_per_locator
         self.max_idle = max_idle
+        self.poolable = poolable
         self.lock = threading.Lock()
         self.idle: OrderedDict[str, list[Any]] = OrderedDict()
         self.idle_count = 0
@@ -441,7 +448,7 @@ class _ReaderPool:
 
     def _return(self, locator: str, reader: Any, healthy: bool) -> None:
         pooled = False
-        if healthy:
+        if healthy and (self.poolable is None or self.poolable(locator)):
             with self.lock:
                 stack = self.idle.setdefault(locator, [])
                 if len(stack) < self.max_idle_per_locator:
@@ -478,12 +485,25 @@ class RasterEngine:
         self.upstreams: dict[str, tuple[str, str]] = {}
         self.lock = threading.RLock()
         self.tile_cache: OrderedDict[tuple[Any, ...], bytes] = OrderedDict()
-        self.readers = _ReaderPool(MAX_IDLE_PER_LOCATOR, MAX_IDLE_READERS)
+        self.readers = _ReaderPool(
+            MAX_IDLE_PER_LOCATOR, MAX_IDLE_READERS, poolable=self._poolable
+        )
         # One persistent worker: an ephemeral /vsicurl thread deadlocks at exit
         # on Windows (loader lock vs the GIL - see daemon.RENDER_POOL).
         self.prepare_pool = ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="prepare"
         )
+
+    def _poolable(self, locator: str) -> bool:
+        """Whether a Reader for *locator* may stay open between tiles: remote
+        ``/vsi`` sources and cache derivatives may; a local original may not —
+        pooling it would lock the user's file (see the pool docstring)."""
+        if locator.startswith("/vsi"):
+            return True
+        try:
+            return Path(locator).resolve().is_relative_to(self.cache_dir.resolve())
+        except OSError:
+            return False
         self._evict_optimized()
 
     def _evict_optimized(self) -> None:

--- a/fused_render/templates/map/raster_engine.py
+++ b/fused_render/templates/map/raster_engine.py
@@ -493,6 +493,7 @@ class RasterEngine:
         self.prepare_pool = ThreadPoolExecutor(
             max_workers=1, thread_name_prefix="prepare"
         )
+        self._evict_optimized()
 
     def _poolable(self, locator: str) -> bool:
         """Whether a Reader for *locator* may stay open between tiles: remote
@@ -504,7 +505,6 @@ class RasterEngine:
             return Path(locator).resolve().is_relative_to(self.cache_dir.resolve())
         except OSError:
             return False
-        self._evict_optimized()
 
     def _evict_optimized(self) -> None:
         """Keep the on-disk derivative cache under OPTIMIZED_CACHE_MAX_BYTES,

--- a/fused_render/templates/map/vector_engine.py
+++ b/fused_render/templates/map/vector_engine.py
@@ -426,7 +426,6 @@ class VectorEngine:
             OrderedDict()
         )
         self.inflight: dict[tuple[str, int, int, int], threading.Event] = {}
-        self._sqlite: dict[str, sqlite3.Connection] = {}
         self._summaries: dict[str, tuple | None] = {}
         self._summary_jobs: dict[str, dict[str, Any]] = {}
         # One persistent worker builds feature-bbox overviews off the tile path,
@@ -697,19 +696,16 @@ class VectorEngine:
         except (OSError, sqlite3.Error):
             return
 
-    def _connection(self, source: VectorSource) -> sqlite3.Connection:
-        with self.lock:
-            connection = self._sqlite.get(source.source_id)
-            if connection is None:
-                # One reader per source, reused across tiles. VTILE_POOL
-                # serialises all tile work onto one persistent thread, but the
-                # connection is born wherever the first query runs.
-                connection = sqlite3.connect(
-                    source.sqlite_uri, uri=True, timeout=30,
-                    check_same_thread=False,
-                )
-                self._sqlite[source.source_id] = connection
-        return connection
+    @contextlib.contextmanager
+    def _open_connection(self, source: VectorSource):
+        """A fresh read-only connection, closed on exit. Opened per query, not
+        cached: a cached connection locks the user's GeoPackage for the daemon's
+        life. Reopening is cheap, and tile work is serialised by VTILE_POOL."""
+        connection = sqlite3.connect(source.sqlite_uri, uri=True, timeout=30)
+        try:
+            yield connection
+        finally:
+            connection.close()
 
     def _query(
         self,
@@ -718,14 +714,14 @@ class VectorEngine:
         sql: str,
         parameters: tuple,
     ) -> list:
-        connection = self._connection(source)
-        if cancel is not None:
-            connection.set_progress_handler(cancel.is_set, 100_000)
-        try:
-            return connection.execute(sql, parameters).fetchall()
-        finally:
+        with self._open_connection(source) as connection:
             if cancel is not None:
-                connection.set_progress_handler(None, 0)
+                connection.set_progress_handler(cancel.is_set, 100_000)
+            try:
+                return connection.execute(sql, parameters).fetchall()
+            finally:
+                if cancel is not None:
+                    connection.set_progress_handler(None, 0)
 
     def _transformer(self, source: VectorSource):
         transformer = self._transformers.get(source.source_id)
@@ -793,30 +789,30 @@ class VectorEngine:
     def _parse_node_summary(self, source: VectorSource) -> tuple | None:
         import numpy as np
 
-        connection = self._connection(source)
         node_table = _quote_identifier(f"{source.rtree_table}_node")
-        row = connection.execute(
-            f"SELECT data FROM {node_table} WHERE nodeno = 1"
-        ).fetchone()
-        if row is None:
-            raise ValueError("the rtree has no root node")
-        depth = int.from_bytes(row[0][:2], "big")
-        if depth < 1:
-            return None
-        blobs = [row[0]]
-        for level in range(depth):
-            ids, bounds = [], []
-            for blob in blobs:
-                count = int.from_bytes(blob[2:4], "big")
-                cells = np.frombuffer(
-                    blob, dtype=np.uint8, count=count * 24, offset=4
-                ).reshape(count, 24)
-                ids.append(cells[:, :8].copy().view(">i8").ravel())
-                bounds.append(cells[:, 8:].copy().view(">f4").reshape(count, 4))
-            child_ids = np.concatenate(ids)
-            child_bounds = np.concatenate(bounds).astype(np.float64)
-            if level < depth - 1:
-                blobs = self._fetch_nodes(connection, node_table, child_ids)
+        with self._open_connection(source) as connection:
+            row = connection.execute(
+                f"SELECT data FROM {node_table} WHERE nodeno = 1"
+            ).fetchone()
+            if row is None:
+                raise ValueError("the rtree has no root node")
+            depth = int.from_bytes(row[0][:2], "big")
+            if depth < 1:
+                return None
+            blobs = [row[0]]
+            for level in range(depth):
+                ids, bounds = [], []
+                for blob in blobs:
+                    count = int.from_bytes(blob[2:4], "big")
+                    cells = np.frombuffer(
+                        blob, dtype=np.uint8, count=count * 24, offset=4
+                    ).reshape(count, 24)
+                    ids.append(cells[:, :8].copy().view(">i8").ravel())
+                    bounds.append(cells[:, 8:].copy().view(">f4").reshape(count, 4))
+                child_ids = np.concatenate(ids)
+                child_bounds = np.concatenate(bounds).astype(np.float64)
+                if level < depth - 1:
+                    blobs = self._fetch_nodes(connection, node_table, child_ids)
         if not (source.feature_count / 500 <= len(child_bounds) <= source.feature_count):
             raise ValueError("the rtree node walk is inconsistent with the layer")
         weights = np.full(len(child_bounds), source.feature_count / len(child_bounds))


### PR DESCRIPTION
## Problem

The map viewer renders local rasters and vectors through a long-lived daemon that keeps the source file **open** to serve tiles efficiently:

- Raster `_ReaderPool` caches GDAL/rasterio datasets across tile requests.
- `VectorEngine` caches one read-only sqlite connection per GeoPackage.

On Windows an open handle blocks move/rename/edit/delete, so after opening a file in the viewer the user cannot touch it until they quit the whole app. This is a regression from the old cold-render model, where each render was a short-lived subprocess that released the handle within seconds.

## Fix

Release the handles for **local** files instead of pooling them:

- **Raster** (`raster_engine.py`): the reader pool never pools a local original — it opens and closes per tile (reopening a local dataset is ~50 ms). Remote `/vsi` sources (expensive to reopen) and app-owned cache derivatives are still pooled, gated by a new `poolable` predicate.
- **Vector** (`vector_engine.py`): the GeoPackage sqlite connection is opened per query and closed, instead of one cached connection held for the daemon's life.

Remote `/vsicurl` sources are unaffected. Tiles still render normally, and the file is free the moment the viewer is idle. The only residual window is the brief per-tile open during active panning.

## Testing

- Engine-level check: after describing + tiling a local COG and a GeoPackage, the source can now be renamed/moved while the daemon is alive (previously `WinError 32 — file in use`).
- Existing map tests pass (43): tile transport, daemon, raster locator, gdal env, true color, antimeridian, infer background, vector tiles.

## Notes

Independent of #763 (warm app workers) — disjoint files, no behavioral overlap (the map viewer runs as an engine-host *template* child; #763's changes are scoped to warm *app* workers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a7e16705337c6e549b6b2bd6719ce1f0cdb5cd76. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->