### PR TITLE
pano: paint the sphere before op_open returns

### DIFF
--- a/fused_render/templates/pano/template.html
+++ b/fused_render/templates/pano/template.html
@@ -281,6 +281,7 @@
   let meta = null;
   let viewer = null;           // pannellum instance
   let viewerKey = "";          // panorama url the viewer was built for
+  let viewerKind = "";         // classification the viewer was built for (haov/etc)
   let renderSeq = 0;           // stale-response guard
   let lastView = null;         // {path,w,h,ms,cached} of current converted view
 
@@ -457,7 +458,44 @@
   }
 
   function destroyViewer() {
-    if (viewer) { try { viewer.destroy(); } catch (e) {} viewer = null; viewerKey = ""; }
+    if (viewer) { try { viewer.destroy(); } catch (e) {} viewer = null; viewerKey = ""; viewerKind = ""; }
+  }
+
+  // Comparison key for a file path, not the URL used to fetch it: the same
+  // absolute path can come through as forward slashes (a URL param, as typed
+  // in _file) or backslashes (pano.py's os.path.abspath, on Windows) — normalize
+  // before comparing so those two spellings of the same file don't look like a
+  // change and force a pointless viewer rebuild.
+  const pathKey = (p) => p.replace(/\\/g, "/");
+
+  function buildSphere(panoUrl, kind, key) {
+    if (viewerKey === key && viewerKind === kind) return;
+    destroyViewer();
+    viewerKey = key;
+    viewerKind = kind;
+    viewer = pannellum.viewer("pano360", {
+      type: "equirectangular",
+      panorama: panoUrl,
+      autoLoad: true, showControls: true, compass: false,
+      hfov: 100, friction: 0.12, backgroundColor: [0.94, 0.94, 0.95],
+      haov: kind === "equirect_180" ? 180 : 360,
+      minYaw: kind === "equirect_180" ? -90 : -180,
+      maxYaw: kind === "equirect_180" ? 90 : 180,
+    });
+    setViewStatus(`360° sphere · WebGL`, "");
+  }
+
+  // First paint, before pano.py's classification has come back: op_open only
+  // produces a different answer than "the file itself" for edge cases
+  // (non-browser format, >8192px, EXIF-rotated, cube layout) — for a plain
+  // upright equirect JPEG/PNG it just hands back the same path. So assume
+  // that common case and start the sphere straight from the raw file; draw360
+  // corrects it (rebuilds the viewer) once the real classification lands and
+  // disagrees (half-pano haov, or a cube layout that needs reprojecting).
+  function drawOptimistic(file) {
+    show("pano");
+    buildSphere(fused.rawUrl(file), "equirect", pathKey(file));
+    lastView = { path: file };
   }
 
   async function draw360(m) {
@@ -465,28 +503,18 @@
     // pano.py hands back absolute cache paths, so these go straight through
     // fused.rawUrl (no BASE_DIR join, unlike the vendored static assets above)
     let panoUrl = fused.rawUrl(m.display_path);
+    let key = pathKey(m.display_path);
     if (m.kind === "cube_dice" || m.kind === "cube_horizon") {
       // cube layouts must be reprojected to equirect for the sphere viewer
       busy(true, "reprojecting cube → equirect…");
       try {
         const r = await py({ action: "convert", mode: "equirect" });
         panoUrl = fused.rawUrl(r.path);
+        key = pathKey(r.path);
       } catch (err) { busy(false); toast(err.message, true); return; }
       busy(false);
     }
-    if (viewerKey === panoUrl) return;
-    destroyViewer();
-    viewerKey = panoUrl;
-    viewer = pannellum.viewer("pano360", {
-      type: "equirectangular",
-      panorama: panoUrl,
-      autoLoad: true, showControls: true, compass: false,
-      hfov: 100, friction: 0.12, backgroundColor: [0.94, 0.94, 0.95],
-      haov: m.kind === "equirect_180" ? 180 : 360,
-      minYaw: m.kind === "equirect_180" ? -90 : -180,
-      maxYaw: m.kind === "equirect_180" ? 90 : 180,
-    });
-    setViewStatus(`360° sphere · WebGL`, "");
+    buildSphere(panoUrl, m.kind, key);
     lastView = { path: m.display_path };
   }
 
@@ -590,11 +618,19 @@
   // ------------------------------------------------------------- boot
   $("fname").textContent = file.split(/[\\/]/).pop();
   fused.params.onChange(draw);
-  try {
+
+  // Kick off classification immediately, but don't block the first paint on
+  // it in the common view360 case — see drawOptimistic() above.
+  const metaPromise = py({ action: "open" });
+  if (mode() === "view360") {
+    drawOptimistic(file);
+  } else {
     skeleton(true);
     busy(true, "loading image…");
-    const r = await py({ action: "open" });
-    meta = r.asset;
+  }
+
+  try {
+    meta = (await metaPromise).asset;
     busy(false);
     skeleton(false);
     draw();

--- a/fused_render/templates/pano/template.html
+++ b/fused_render/templates/pano/template.html
@@ -284,6 +284,7 @@
   let viewerKind = "";         // classification the viewer was built for (haov/etc)
   let renderSeq = 0;           // stale-response guard
   let lastView = null;         // {path,w,h,ms,cached} of current converted view
+  let openFailed = false;      // pano.py's open() rejected — no meta is ever coming
 
   const $ = (id) => document.getElementById(id);
   const els = {
@@ -564,7 +565,16 @@
 
   function draw() {
     renderModes(); renderControls();
-    if (!meta) { destroyViewer(); show("empty"); emptyMsg.textContent = "No file selected";
+    if (!meta) {
+      // fused.params.onChange(draw) is registered before pano.py's open() call
+      // settles, so a param change (mode keys, etc.) during that window reaches
+      // here with meta still null. If open() is only pending, the optimistic
+      // view360 sphere (or the skeleton, for other modes) already covers the
+      // screen correctly — leave it alone rather than tearing it down and
+      // flashing "No file selected" for the rest of the wait. Only the true
+      // empty state (open() rejected outright) should actually blank the view.
+      if (!openFailed) return;
+      destroyViewer(); show("empty"); emptyMsg.textContent = "No file selected";
       els.warn.style.display = "none"; els.stAsset.textContent = ""; setViewStatus("", ""); return; }
     els.stAsset.textContent =
       `${meta.name} · ${meta.width}×${meta.height} · ${meta.format} · ${KIND_LABEL[meta.kind] || meta.kind}`;
@@ -637,6 +647,7 @@
   } catch (err) {
     busy(false);
     skeleton(false);
+    openFailed = true;
     toast(`failed to load image: ${err.message}`, true);
     draw();
   }


### PR DESCRIPTION
## Summary
- The pano viewer's default 360° view blocked its first paint on `pano.py`'s `open` classification call, a per-run subprocess round-trip observed taking anywhere from ~1.6s to ~9.6s.
- That call only produces a different result than "the file itself" for edge cases (non-browser format, oversized, EXIF-rotated, cube-cross layout) — for the common upright equirect JPEG/PNG it just echoes back the same path.
- Now the sphere starts immediately from the raw file assuming a plain equirect, while the real classification runs in the background. The viewer only rebuilds if the guess turns out wrong (half-pano `haov`, or a cube layout that needs reprojecting to equirect).
- Comparison uses a slash-normalized path key rather than the raw fetch URL — the JS-side path and pano.py's `os.path.abspath` differ only in separator style on Windows, which otherwise caused a pointless rebuild on every single load, even when the guess was right.

## Measurements (warm cache, same conditions, 5 runs each)
- Before: 3996, 3012, 2132, 3147, 3005 ms → avg ~3058ms
- After: 995, 996, 1979, 1031, 1347 ms → avg ~1270ms

One instrumented run showed `op_open` itself take 9.6s while the sphere was already visible at 781ms — the fix decouples first paint from backend latency entirely rather than just shaving a fixed amount off it.

## Test plan
- [x] Existing `fused_render/templates/pano/tests/test_pano.py` (13 tests) passes unchanged
- [x] Manually verified in-browser for: view360 (default, correct-guess no-rebuild case), equirect_180 half-pano (haov self-corrects 360→180, confirmed via `viewer.getConfig()`), cube_dice (self-corrects via reprojection), flat/invalid (warning band still shows), original, perspective, little_planet, fisheye180, cube_faces — no console errors in any case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only first-paint optimization in the pano template; classification still runs and corrects the viewer. No auth, data, or backend contract changes.
> 
> **Overview**
> The default 360° pano view no longer waits on `pano.py`'s `open` classification before first paint. It starts the sphere immediately from the raw file as a plain equirect, then rebuilds only if classification disagrees (half-pano `haov` or cube reprojection).
> 
> Viewer identity is now a slash-normalized path plus kind, so Windows `\` vs `/` of the same file no longer forces a rebuild. Param changes while `open` is still pending no longer flash “No file selected”; that empty state only appears if `open` actually failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76e18bb7772bf9b5d675caf14eacc8d7617e6fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->