### PR TITLE
AI benchmark: a live measurement row, a shareable chart card, and icon row actions

### DIFF
--- a/frontend/src/apps/ai_models/benchmark/BenchmarkTab.tsx
+++ b/frontend/src/apps/ai_models/benchmark/BenchmarkTab.tsx
@@ -50,17 +50,28 @@
 // as if it were a save. Only the pressed capability's buttons go dead; the rest
 // of the page stays live.
 //
-// **A benchmark opens no download-manager row, and this tab must not reach for
-// one.** Server job rows are keyed by TITLE (`useCacheScan` maps
-// `job.title -> job`) and `supervisor.load` already owns the row titled with the
-// model id, so a benchmark row either cannot be found or shadows the load's —
-// which put the manager's only ✕ on the load and let a cold run spin to its
-// hour-long timeout. So the in-progress state is a plain spinner in the row, and
-// through a COLD run the load's own row shows up in the manager with real byte
-// counts, which is the progress that was always worth watching. See
-// `ai/benchmark.py`.
+// **A benchmark now opens its OWN download-manager row for the measurement
+// phase, titled distinctly from the load's** (`ai/benchmark.py`'s
+// `_MeasurementRow`/`_bench_job_title`) — the fourth design, after three that
+// collided on TITLE. Server job rows are keyed by TITLE (`useCacheScan` maps
+// `job.title -> job`) and `supervisor.load` already owns the row titled with
+// the bare model id; a benchmark row sharing that title either could not be
+// found or SHADOWED the load's, which put the manager's only ✕ on the load and
+// let a cold run spin to its hour-long timeout. `_bench_job_title` fixes the
+// title rather than removing the row, so through a COLD run the load's own row
+// still shows up first, with real byte counts, and once loading ends this
+// module's own row takes over — the phase that used to be total silence.
+//
+// **This tab's OWN busy row is a second, complementary view of the same run —
+// phase plus a REAL elapsed clock, never an invented percentage** (see
+// `busyRowText` in lib/benchmark.ts, and the ai-models.css comment near line
+// 1282 for the house rule against invented bars). It reuses `lib/aiRuntime.ts`'s
+// already-polled table rather than adding a second poll: while that table
+// still reports the model loading, the row says so; once it does not, the row
+// switches to "Measuring — mm:ss" ticking from the moment Run was pressed.
 import { useEffect, useRef, useState } from "react";
 import { ComparisonChart } from "./ComparisonChart";
+import { ShareChartButton } from "./ShareChartButton";
 import { ModelTrendChart } from "./ModelTrendChart";
 import { CAPABILITY_ORDER } from "@apps/ai_models/lib/aiModelGroups";
 import { capabilityLabel } from "@apps/ai_models/lib/engines";
@@ -76,6 +87,7 @@ import {
   formatLoad,
   formatMemory,
   benchmarkableCapabilities,
+  busyRowText,
   formatMetricSpecValue,
   formatPrimary,
   latestByModel,
@@ -121,9 +133,12 @@ import {
   deleteAiBenchmarks,
   getAiBenchmarks,
   runAiBenchmark,
+  type AiBenchmarkMachine,
   type AiBenchmarkRun,
+  type AiRuntime,
 } from "@platform/lib/api";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
+import { MenuIcons } from "@platform/ui/MenuIcons";
 import { SkeletonLines } from "@platform/ui/Skeleton";
 
 export function BenchmarkTab({ scan }: { scan: CacheScan }) {
@@ -137,6 +152,15 @@ export function BenchmarkTab({ scan }: { scan: CacheScan }) {
   // render that reads `all` until `runs` and this land together out of the
   // same response.
   const [workloadCapabilities, setWorkloadCapabilities] = useState<string[]>([]);
+  // THIS machine, as the server sees it now — the caption the share card is
+  // unshareable without ("62 tok/s" means nothing without the laptop that
+  // produced it). Read from the history rather than from each run, because it
+  // travels there for exactly this reason (`AiBenchmarkHistory.machine`): the
+  // page has to caption a comparison spanning several runs, and picking one
+  // run's block would caption every bar with whichever model happened to be
+  // last. `null` until the first fetch answers — `hardwareLine` draws what it
+  // has, so a card made in that window is short a line rather than broken.
+  const [machine, setMachine] = useState<AiBenchmarkMachine | null>(null);
   const [error, setError] = useState<string | null>(null);
   // Which capability has a run in flight, and on which model. **Keyed by
   // capability, not a single slot**, because that is the unit the server
@@ -145,6 +169,27 @@ export function BenchmarkTab({ scan }: { scan: CacheScan }) {
   // explicitly permitted. A single slot greyed out every other section under a
   // tooltip claiming a per-capability rule, making a legal action unreachable.
   const [inFlight, setInFlight] = useState<RunsInFlight>({});
+  // WHEN the currently in-flight run was pressed, epoch ms, keyed by
+  // capability like `inFlight` itself — the busy row's elapsed clock
+  // (`busyRowText`, lib/benchmark.ts) counts from here, not from whenever the
+  // load happens to finish, so "Measuring — 1:24" means what it says: time
+  // actually spent, including the load, matching the wall clock a person
+  // watching the tab experienced.
+  const [runStartedAt, setRunStartedAt] = useState<Record<string, number>>({});
+  // Ticks once a second while ANYTHING is in flight, for no reason but to
+  // force the busy row's elapsed clock to re-render — `busyRowText` is pure
+  // and reads `Date.now()` itself, so this state's VALUE is never read,
+  // only its change. Stopped the moment `inFlight` empties: an idle tab
+  // re-rendering every second for a clock nothing is showing would be the
+  // exact kind of waste `useAiRuntime`'s own idle/active split (aiRuntime.ts)
+  // exists to avoid elsewhere on this page.
+  const [, setClockTick] = useState(0);
+  const anyInFlight = Object.keys(inFlight).length > 0;
+  useEffect(() => {
+    if (!anyInFlight) return;
+    const timer = window.setInterval(() => setClockTick((n) => n + 1), 1000);
+    return () => window.clearInterval(timer);
+  }, [anyInFlight]);
   // A run that came back STOPPED rather than measured. Its own state, not
   // `error`: this is not a request failure and must not draw the ErrorBanner —
   // see `stoppedNote`. Cleared when the next run starts, rather than on a timer:
@@ -193,6 +238,7 @@ export function BenchmarkTab({ scan }: { scan: CacheScan }) {
         if (!alive) return;
         setRuns(history.runs);
         setWorkloadCapabilities(history.workloadCapabilities);
+        setMachine(history.machine);
         setError(null);
       },
       (e) => {
@@ -222,6 +268,7 @@ export function BenchmarkTab({ scan }: { scan: CacheScan }) {
     // and a `{...inFlight}` closed over at click time would drop whichever one
     // started in between.
     setInFlight((prev) => ({ ...prev, [capability]: model }));
+    setRunStartedAt((prev) => ({ ...prev, [capability]: Date.now() }));
     try {
       const { run, cancelled } = await runAiBenchmark(model, capability);
       // Stopped from outside — say so. Silence here was finding 6: nothing
@@ -353,6 +400,7 @@ export function BenchmarkTab({ scan }: { scan: CacheScan }) {
       const history = await deleteAiBenchmarks([id]);
       setRuns(history.runs);
       setWorkloadCapabilities(history.workloadCapabilities);
+      setMachine(history.machine);
     } catch (e) {
       setError((e as Error).message);
     }
@@ -506,12 +554,15 @@ export function BenchmarkTab({ scan }: { scan: CacheScan }) {
           metricSpecs={metricSpecs}
           onSelectMetric={setMetricParam}
           runs={capabilityRuns}
+          machine={machine}
           ranked={ranked}
           gone={gone}
           selectedModel={selectedModel}
           trendRuns={trendRuns}
           onSelectModel={setModelParam}
           inFlight={inFlight}
+          runStartedAt={runStartedAt}
+          runtime={scan.runtime}
           onRun={start}
           onForget={forget}
           queue={queues[selected]}
@@ -529,12 +580,15 @@ function CapabilitySection({
   metricSpecs,
   onSelectMetric,
   runs,
+  machine,
   ranked,
   gone,
   selectedModel,
   trendRuns,
   onSelectModel,
   inFlight,
+  runStartedAt,
+  runtime,
   onRun,
   onForget,
   queue,
@@ -555,6 +609,10 @@ function CapabilitySection({
   onSelectMetric: (key: string) => void;
   /** null while the history has not answered. */
   runs: AiBenchmarkRun[] | null;
+  /** This machine, for the share card's caption — null until the history has
+   *  answered. Nothing on screen reads it: a reader looking at their own
+   *  laptop does not need it spelled out, but a card leaving the laptop does. */
+  machine: AiBenchmarkMachine | null;
   /** Every model this capability knows about, ranked best-first — computed by
    *  `BenchmarkTab` (`leaderboard`), since its length already answers "is
    *  there anything to show" (repos + history, deleted models included). */
@@ -574,6 +632,17 @@ function CapabilitySection({
    *  reads its own key out, which keeps the "which capability blocks which"
    *  rule in one tested place rather than in each section's props. */
   inFlight: RunsInFlight;
+  /** When the in-flight run on THIS capability was pressed, epoch ms — absent
+   *  for a capability with nothing running. Feeds the busy row's elapsed
+   *  clock (`busyRowText`); `BenchmarkTab` is the one place that knows when a
+   *  click happened, so it owns this rather than each row inventing its own
+   *  start time. */
+  runStartedAt: Record<string, number>;
+  /** The AI runtime table (`lib/aiRuntime.ts`), already polled by the page —
+   *  read here ONLY to answer "is the in-flight model still loading, or is it
+   *  measuring now" (`busyRowText`'s `stillLoading`). Reusing this poll is
+   *  why the busy row does not need one of its own. */
+  runtime: AiRuntime;
   onRun: (model: string, capability: string) => void;
   onForget: (id: string) => void;
   /** This capability's own "Run all" queue, or undefined before one has ever
@@ -607,6 +676,21 @@ function CapabilitySection({
   // queue's own `start()` calls do, and the server allows only one resident
   // model per capability either way.
   const busy = inFlight[capability] !== undefined;
+  // The busy row's own text, computed here rather than in `BenchmarkRow`:
+  // this is where `capability` and `inFlight` are both already in scope, and
+  // a single site keeps "which phase" (the runtime's own answer) and "how
+  // long" (this tab's own click timestamp) from drifting into two different
+  // readings for two different rows of the same run.
+  const busyModel = inFlight[capability];
+  const stillLoading = busyModel
+    ? runtime.loaded.some(
+        (m) => m.model === busyModel && m.capability === capability &&
+          m.state !== "ready" && m.state !== "error",
+      )
+    : false;
+  const busyText = busyModel
+    ? busyRowText(stillLoading, runStartedAt[capability] ?? Date.now(), Date.now())
+    : null;
   // The device most of THIS section's models last ran on — the hardware
   // doesn't change per model, so a row's own detail line (`BenchmarkRow`
   // below, via `rowDetail`) drops it whenever it MATCHES this, and keeps it
@@ -614,6 +698,12 @@ function CapabilitySection({
   const expectedDevice = commonDevice(
     ranked.map((r) => r.row).filter((row): row is ModelLatest => row !== null),
   );
+  // The app version the plotted numbers were MEASURED under — the newest run's
+  // (`runs` is oldest-first), not the running build. The app is part of what a
+  // benchmark measures, so a card drawn after an upgrade must keep naming the
+  // version that produced the bars. Only the share card reads this; nothing on
+  // screen does (a per-run "Details" expander already shows each run's own).
+  const measuredVersion = runs && runs.length > 0 ? runs[runs.length - 1]!.appVersion : null;
 
   return (
     <section className="am-section">
@@ -647,24 +737,46 @@ function CapabilitySection({
           this select does not need it restated a few lines down. */}
       <div className="am-section-head am-bench-section-head">
         <h3 className="am-section-title">{capabilityLabel(capability)}</h3>
-        {metricSpecs.length > 0 && (
-          <div className="am-bench-metricsel">
-            <label htmlFor={`am-bench-metric-${capability}`}>Metric</label>
-            <select
-              id={`am-bench-metric-${capability}`}
-              className="field-control am-bench-capsel-input"
-              value={metric?.key ?? ""}
-              onChange={(e) => onSelectMetric(e.target.value)}
-            >
-              {metricSpecs.map((spec) => (
-                <option key={spec.key} value={spec.key}>
-                  {spec.label}
-                </option>
-              ))}
-            </select>
-            {metric && <span className="am-bench-metric">{metricUnitAndCue(metric)}</span>}
-          </div>
-        )}
+        {/* The head's controls, as one group: the Metric select and — only
+            when there is actually a chart to send — Share. Share sits HERE
+            rather than over the chart because what it shares is this
+            section's current selection (capability + metric), which is
+            precisely what these two controls between them decide. */}
+        <div className="am-bench-headtools">
+          {metricSpecs.length > 0 && (
+            <div className="am-bench-metricsel">
+              <label htmlFor={`am-bench-metric-${capability}`}>Metric</label>
+              <select
+                id={`am-bench-metric-${capability}`}
+                className="field-control am-bench-capsel-input"
+                value={metric?.key ?? ""}
+                onChange={(e) => onSelectMetric(e.target.value)}
+              >
+                {metricSpecs.map((spec) => (
+                  <option key={spec.key} value={spec.key}>
+                    {spec.label}
+                  </option>
+                ))}
+              </select>
+              {metric && <span className="am-bench-metric">{metricUnitAndCue(metric)}</span>}
+            </div>
+          )}
+          {/* Rendered on exactly the condition the chart itself is (below): a
+              Share button above "no runs recorded yet" offers to send an empty
+              axis. */}
+          {metric && bars.length > 0 && (
+            <ShareChartButton
+              card={{
+                capability,
+                metric,
+                bars,
+                machine,
+                device: expectedDevice,
+                appVersion: measuredVersion,
+              }}
+            />
+          )}
+        </div>
       </div>
 
       {runs === null ? (
@@ -734,8 +846,14 @@ function CapabilitySection({
                     Running {queue.started} of {queue.models.length} —{" "}
                     {shortModelName(queue.current!)}
                   </span>
-                  <button type="button" className="cc-btn" onClick={() => onStopAll(capability)}>
-                    Stop
+                  <button
+                    type="button"
+                    className="cc-iconbtn"
+                    onClick={() => onStopAll(capability)}
+                    title="Stop"
+                    aria-label="Stop"
+                  >
+                    {MenuIcons.stop}
                   </button>
                 </>
               ) : (
@@ -804,6 +922,7 @@ function CapabilitySection({
                   metric={metric}
                   expectedDevice={expectedDevice}
                   button={button}
+                  busyText={model === busyModel ? busyText : null}
                   gone={gone.has(model)}
                   selected={model === selectedModel}
                   onSelect={() => onSelectModel(model)}
@@ -869,6 +988,7 @@ function BenchmarkRow({
   metric,
   expectedDevice,
   button,
+  busyText,
   gone,
   selected,
   onSelect,
@@ -888,6 +1008,11 @@ function BenchmarkRow({
    *  is exactly the thing a screenshot cannot check. Absent for a `gone` row,
    *  which has no button at all. */
   button?: RunButtonState;
+  /** `busyRowText`'s own answer for THIS model, or null when it is not the one
+   *  running — computed once in `CapabilitySection` (`busyRowText`,
+   *  lib/benchmark.ts) from the AI runtime's own phase plus the tab's own
+   *  click timestamp, never invented here. */
+  busyText?: string | null;
   /** The model is no longer on disk; its history is shown, its button is not. */
   gone?: boolean;
   /** This row is the one the trend chart above is currently showing. */
@@ -938,14 +1063,19 @@ function BenchmarkRow({
       </div>
       <div className="am-bench-latest">
         {button?.busy ? (
-          // A plain spinner, not `ModelProgress`: that component draws a JOB
-          // row's detail and byte counts, and a benchmark has no row. There is
-          // genuinely nothing to report until the request returns — the server
-          // is holding it open — so pretending otherwise with an invented
-          // percentage is what makes live work read as frozen.
+          // A plain spinner, not `ModelProgress`: that component draws a
+          // download-manager row's OWN detail and byte counts, and reading it
+          // here would be a second, possibly-stale copy of exactly what the
+          // corner already shows for `ai/benchmark.py`'s own measurement row
+          // (see that module's docstring). This is a DIFFERENT view of the
+          // same run: phase plus a real elapsed clock (`busyText`,
+          // `busyRowText` in lib/benchmark.ts) rather than an invented
+          // percentage — "Loading weights into memory…" while the AI runtime
+          // still reports this model coming up, then "Measuring — 1:24"
+          // ticking from the moment Run was pressed.
           <span className="am-bench-busy" role="status">
             <span className="am-runtime-dot" />
-            Benchmarking… this takes minutes
+            {busyText}
           </span>
         ) : row ? (
           <>
@@ -971,7 +1101,20 @@ function BenchmarkRow({
                 // on a row you did NOT mean to select would select it anyway.
                 onClick={(e) => e.stopPropagation()}
               >
-                <summary>{row.latest.ok ? "Details" : "Failed — details"}</summary>
+                {/* Icon-only, per the icon-buttons pass — but still a real
+                    `<summary>`, so the disclosure semantics (native toggle,
+                    keyboard, screen-reader "expanded/collapsed" state) are
+                    untouched. `aria-label`/`title` carry the exact words the
+                    icon replaced; `am-bench-rowdetail-chevron` is what rotates
+                    the glyph 90° on `[open]` (ai-models.css) rather than
+                    swapping to a second path. */}
+                <summary
+                  className="am-bench-rowdetail-chevron"
+                  aria-label={row.latest.ok ? "Details" : "Failed — details"}
+                  title={row.latest.ok ? "Details" : "Failed — details"}
+                >
+                  {MenuIcons.chevron}
+                </summary>
                 <p>{detail}</p>
               </details>
             )}
@@ -989,12 +1132,21 @@ function BenchmarkRow({
         // there is nothing here for the two handlers to disagree about.
         <button
           type="button"
-          className="cc-btn"
+          className="cc-iconbtn"
           disabled={button.blocked}
           onClick={onRun}
           title={button.title}
+          aria-label={button.label}
         >
-          {button.label}
+          {/* `button.busy`'s spinner is still disabled (`button.blocked` is
+              true whenever `busy` is — `runButtonState`, lib/benchmark.ts) —
+              this is a status glyph on a dead button, not a second way to
+              start or stop the run. `.am-icon-spin` (ai-models.css) is the
+              only thing that turns the static ring into motion; the glyph
+              itself does not encode spinning. */}
+          <span className={button.busy ? "am-icon-spin" : undefined}>
+            {button.busy ? MenuIcons.spinner : MenuIcons.play}
+          </span>
         </button>
       )}
     </div>

--- a/frontend/src/apps/ai_models/benchmark/ShareChartButton.tsx
+++ b/frontend/src/apps/ai_models/benchmark/ShareChartButton.tsx
@@ -33,9 +33,22 @@ export function ShareChartButton({ card }: { card: ShareCardInput }) {
   const [error, setError] = useState<string | null>(null);
   // A card takes a beat to encode; a component unmounted in between (a
   // capability switch remounts the section) must not set state afterwards.
+  //
+  // Set on the way IN as well as cleared on the way out — `useRef(true)`'s
+  // initializer only ever runs on the FIRST render, so leaving it out here
+  // was a flag only ever cleared: a dev double-mount (which reuses this same
+  // instance and its refs — this app does not run under StrictMode today, but
+  // `TranscribeStage.tsx`'s `aliveRef` documents the identical hazard for
+  // when it does) runs mount -> cleanup -> mount again with no render in
+  // between, so `alive.current` latches `false` on that synthetic cleanup and
+  // the button never clears `busy` or shows a receipt again for the rest of
+  // the session, even though the component is genuinely still mounted.
   const alive = useRef(true);
-  useEffect(() => () => {
-    alive.current = false;
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
   }, []);
 
   useEffect(() => {

--- a/frontend/src/apps/ai_models/benchmark/ShareChartButton.tsx
+++ b/frontend/src/apps/ai_models/benchmark/ShareChartButton.tsx
@@ -1,0 +1,94 @@
+// The comparison chart's Share button: draws the chart, this machine's
+// hardware and the fused render mark into one PNG (`shareCard.ts`) and hands it
+// to the OS share sheet, the clipboard, or a download — whichever the browser
+// actually supports.
+//
+// It lives beside the chart's own heading rather than over the chart, because
+// what it shares is the SECTION's current selection (capability + metric), not
+// a hovered row — and it renders only when there is a chart to share, the same
+// rule the chart itself follows: a Share button above "no runs recorded yet"
+// offers to send an empty axis.
+//
+// The outcome is SAID, not assumed. The three channels put the card in three
+// completely different places (a share sheet, the clipboard, the Downloads
+// folder), and a silent success leaves the reader hunting for a file that is
+// actually on their clipboard. Cleared on a timer, since the note is a
+// receipt for an action already finished — nothing later depends on it having
+// been read.
+import { useEffect, useRef, useState } from "react";
+import { MenuIcons } from "@platform/ui/MenuIcons";
+import {
+  deliverShareCard,
+  renderShareCard,
+  shareCardFilename,
+  shareOutcomeNote,
+  type ShareCardInput,
+} from "./shareCard";
+
+const NOTE_MS = 4000;
+
+export function ShareChartButton({ card }: { card: ShareCardInput }) {
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // A card takes a beat to encode; a component unmounted in between (a
+  // capability switch remounts the section) must not set state afterwards.
+  const alive = useRef(true);
+  useEffect(() => () => {
+    alive.current = false;
+  }, []);
+
+  useEffect(() => {
+    if (note === null) return;
+    const timer = window.setTimeout(() => setNote(null), NOTE_MS);
+    return () => window.clearTimeout(timer);
+  }, [note]);
+
+  const share = async () => {
+    setBusy(true);
+    setError(null);
+    setNote(null);
+    try {
+      const blob = await renderShareCard(card);
+      const outcome = await deliverShareCard(blob, shareCardFilename(card.capability, card.metric));
+      if (!alive.current) return;
+      // A dismissed share sheet has no receipt to show — the reader is the one
+      // who cancelled it.
+      const receipt = shareOutcomeNote(outcome);
+      if (receipt) setNote(receipt);
+    } catch (e) {
+      if (alive.current) setError((e as Error).message);
+    } finally {
+      if (alive.current) setBusy(false);
+    }
+  };
+
+  return (
+    <span className="am-bench-share">
+      {/* Icon-only, per the icon-buttons pass — "Share chart" (and, while
+          busy, "Preparing…") survives as `aria-label`/`title` rather than on
+          screen, and the RECEIPT below still says in words what happened
+          ("Copied as an image" / "Saved as a PNG"), so the one thing this
+          button does that a glyph cannot say for itself is still said. */}
+      <button
+        type="button"
+        className="cc-iconbtn"
+        disabled={busy}
+        title={busy ? "Preparing…" : "Save this chart, with your hardware, as a PNG you can share"}
+        aria-label={busy ? "Preparing…" : "Share chart"}
+        onClick={() => void share()}
+      >
+        <span className={busy ? "am-icon-spin" : undefined}>
+          {busy ? MenuIcons.spinner : MenuIcons.share}
+        </span>
+      </button>
+      {/* One slot for both, because they are the same slot's two answers —
+          `role="status"` so the receipt is announced rather than only seen. */}
+      {(note || error) && (
+        <span className={error ? "am-bench-share-error" : "am-bench-share-note"} role="status">
+          {error ?? note}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/apps/ai_models/benchmark/shareCard.test.ts
+++ b/frontend/src/apps/ai_models/benchmark/shareCard.test.ts
@@ -1,0 +1,90 @@
+// The share card's PURE parts — the caption, the provenance line, the
+// filename, the layout arithmetic. The drawing itself is not tested here: it
+// needs a real `CanvasRenderingContext2D` (bun has none), and a fake one would
+// only assert that this file calls the methods this file calls. What IS worth
+// pinning is the text a card carries away from the machine that made it, since
+// that is the part somebody else has to read.
+import { describe, expect, it } from "bun:test";
+import type { AiBenchmarkMachine } from "@platform/lib/api";
+import { availableMetrics } from "@apps/ai_models/lib/benchmark";
+import {
+  hardwareLine,
+  metricSubtitle,
+  provenanceLine,
+  shareCardFilename,
+  shareCardHeight,
+} from "./shareCard";
+
+const MAC: AiBenchmarkMachine = {
+  platform: "Darwin",
+  arch: "arm64",
+  cpuCount: 12,
+  totalMemoryBytes: 32 * 1024 ** 3,
+};
+
+const metric = (capability: string, key: string) => {
+  const spec = availableMetrics(capability, []).find((m) => m.key === key);
+  if (!spec) throw new Error(`no ${key} metric for ${capability}`);
+  return spec;
+};
+
+describe("hardwareLine", () => {
+  it("names the machine the way a person would, not the way the kernel does", () => {
+    expect(hardwareLine(MAC, "mps")).toBe("macOS · arm64 · 12 cores · 32 GB RAM · mps");
+  });
+
+  it("omits what the server did not report rather than printing a gap", () => {
+    // Windows reports no RAM at all (`benchmark._total_memory_bytes`), and a
+    // card saying "— RAM" reads as a bug in the card.
+    expect(hardwareLine({ platform: "Windows", arch: "AMD64", cpuCount: null, totalMemoryBytes: null }, null))
+      .toBe("Windows · AMD64");
+  });
+
+  it("keeps the device even when the machine block has not arrived", () => {
+    // The device is the one part that changes the numbers by an order of
+    // magnitude (`cpu` vs `mps`), so it must survive on its own.
+    expect(hardwareLine(null, "cuda")).toBe("cuda");
+    expect(hardwareLine(null, null)).toBe("");
+  });
+});
+
+describe("provenanceLine", () => {
+  it("names the version the runs were measured under", () => {
+    expect(provenanceLine("0.7.3", new Date("2026-08-24T10:00:00Z"))).toContain("fused render 0.7.3");
+  });
+
+  it("still brands the card when no run reported a version", () => {
+    const line = provenanceLine(null, new Date("2026-08-24T10:00:00Z"));
+    expect(line.startsWith("fused render · ")).toBe(true);
+  });
+});
+
+describe("metricSubtitle", () => {
+  it("states the direction BOTH ways — the card has no page around it", () => {
+    expect(metricSubtitle(metric("text-generation", "tokensPerSecond"))).toContain("higher is better");
+    expect(metricSubtitle(metric("text-generation", "ttftMs"))).toContain("lower is better");
+  });
+});
+
+describe("shareCardFilename", () => {
+  it("slugs both identifying halves, so a folder of cards is readable", () => {
+    expect(shareCardFilename("text-generation", metric("text-generation", "tokensPerSecond"))).toBe(
+      "fused-render-benchmark-text-generation-tokens-per-second.png",
+    );
+  });
+});
+
+describe("shareCardHeight", () => {
+  it("grows by one row's pitch per bar", () => {
+    const one = shareCardHeight(1);
+    const two = shareCardHeight(2);
+    expect(two - one).toBe(28); // ROW_H + ROW_GAP
+    expect(shareCardHeight(6) - shareCardHeight(1)).toBe(5 * 28);
+  });
+
+  it("leaves room for the chrome even with a single bar", () => {
+    // Header, title, subtitle, axis and footer are all unconditional — a
+    // one-bar card that came out row-height tall would have cropped them.
+    expect(shareCardHeight(1)).toBeGreaterThan(200);
+  });
+});

--- a/frontend/src/apps/ai_models/benchmark/shareCard.ts
+++ b/frontend/src/apps/ai_models/benchmark/shareCard.ts
@@ -1,0 +1,390 @@
+// The SHARE CARD: the comparison chart, this machine's hardware, and the
+// fused render mark, redrawn as one self-contained PNG (SPEC AI-14).
+//
+// A benchmark number is only meaningful WITH the machine that produced it, so
+// the hardware block is not decoration here — it is the caption without which
+// the chart is unshareable. "62 tok/s" pasted into a chat says nothing; "62
+// tok/s, macOS arm64, 12 cores, 32 GB, mps" is a result somebody else can
+// compare against.
+//
+// **Drawn on a canvas from the same data the chart has, NOT rasterized from the
+// DOM.** The two DOM routes both fail here: `html2canvas`-style serialization
+// would need the app's whole cascade re-resolved into inline styles (the chart
+// is CSS flex + percentage widths — see ComparisonChart.tsx), and
+// SVG-foreignObject rasterization silently drops anything it cannot fetch,
+// which is the same reliably-blank failure `platform/lib/appShot.ts` documents
+// for the export path. Tab capture (appShot's answer) is wrong for a different
+// reason: it needs the browser's share prompt, photographs the surrounding
+// page chrome, and cannot include a hardware caption that is not on screen.
+// The chart's inputs are `bars` + `metric` + `machine` — a few dozen numbers —
+// so redrawing them is both exact and cheap.
+//
+// **The card is always DARK, whatever theme the app is in.** It is a poster,
+// not a screenshot: every shared card should look like the same artefact, and
+// the lime mark reads as branding on dark and as a highlighter stain on white.
+// That is why the palette below is literal hex rather than a `getComputedStyle`
+// read of the app's tokens — the values are the dark palette's own
+// (styles/tokens.css), copied deliberately, because a canvas cannot reference a
+// CSS variable and a theme-following card would ship two different brands.
+import { formatSize } from "@platform/lib/format";
+import {
+  formatMetricSpecValue,
+  middleEllipsis,
+  niceAxisTicks,
+  shortModelName,
+  type ComparisonBar,
+  type MetricSpec,
+} from "@apps/ai_models/lib/benchmark";
+import { capabilityLabel } from "@apps/ai_models/lib/engines";
+import { type AiBenchmarkMachine } from "@platform/lib/api";
+import logoMark from "@assets/logo-black-bg-transparent.png";
+
+// The dark palette, value for value from styles/tokens.css' `:root` block.
+const INK = {
+  bg: "#131417",
+  fg: "#e8eaed",
+  muted: "#9aa0a6",
+  border: "#2a2d33",
+  accent: "#E5FF44",
+};
+
+const SANS = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+const MONO = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+// Geometry, in CSS pixels — the whole card is then drawn at `SCALE` device
+// pixels per unit, so the PNG is crisp on a retina screen and in a chat client
+// that shows it at half size.
+const SCALE = 2;
+const WIDTH = 900;
+const PAD = 28;
+// The name column, matching the on-screen chart's own 26-character clamp
+// (ComparisonChart.tsx) at the mono size used below.
+const NAME_W = 208;
+const NAME_GAP = 12;
+// Reserved to the right of the plot so a full-length bar's value label still
+// fits inside the card rather than running off its edge — the same
+// bar-then-label order the on-screen chart uses.
+const VALUE_W = 96;
+const ROW_H = 22;
+const ROW_GAP = 6;
+const BAR_H = 12;
+
+/** This machine, in one line — the caption that makes the chart shareable.
+ *
+ *  Every part is omitted when the server did not report it (`cpuCount` and
+ *  `totalMemoryBytes` are both nullable, and Windows reports no RAM at all —
+ *  see `benchmark._total_memory_bytes`), because a card that says
+ *  "— cores" reads as a bug in the card rather than as a gap in the data. */
+export function hardwareLine(machine: AiBenchmarkMachine | null, device: string | null): string {
+  if (!machine) return device ?? "";
+  const parts: string[] = [platformLabel(machine.platform)];
+  if (machine.arch) parts.push(machine.arch);
+  if (machine.cpuCount) parts.push(`${machine.cpuCount} cores`);
+  if (machine.totalMemoryBytes) parts.push(`${formatSize(machine.totalMemoryBytes)} RAM`);
+  // The device the weights actually landed on — `mps`, `cuda`, `cpu`. Part of
+  // the hardware story, not of the chart's: the same laptop benchmarks very
+  // differently on `cpu` than on `mps`, so a card without it invites exactly
+  // the wrong comparison.
+  if (device) parts.push(device);
+  return parts.filter(Boolean).join(" · ");
+}
+
+/** `platform.system()`'s answer, as a person names it. Only the one rename
+ *  worth making — "Darwin" is the kernel, and nobody shares a benchmark taken
+ *  on "Darwin". Linux and Windows already say what they are. */
+function platformLabel(platform: string): string {
+  return platform === "Darwin" ? "macOS" : platform;
+}
+
+/** The card's own provenance: the app version the runs were measured under and
+ *  the day the card was made.
+ *
+ *  The VERSION is the measured one (a run's `appVersion`), never the running
+ *  build — the app is part of what a benchmark measures, so a card redrawn
+ *  after an upgrade must keep saying which version produced the numbers. */
+export function provenanceLine(appVersion: string | null, now: Date): string {
+  const day = now.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  return appVersion ? `fused render ${appVersion} · ${day}` : `fused render · ${day}`;
+}
+
+/** The line under the title: which metric these bars are, and which way it
+ *  points.
+ *
+ *  **Direction is stated BOTH ways here, unlike the on-screen badge**
+ *  (`metricUnitAndCue`, which deliberately says "lower is better" only for the
+ *  metrics where the ordinary habit misreads, so that one cue is not buried).
+ *  That reasoning holds beside a `<select>` a reader just used; it does not
+ *  hold on a card that lands in somebody else's chat with no page around it,
+ *  where "is a longer bar good here?" has no other way to be answered. The
+ *  unit is left to the value labels, which all carry it. */
+export function metricSubtitle(metric: MetricSpec): string {
+  return `${metric.label} · ${metric.higherIsBetter ? "higher" : "lower"} is better`;
+}
+
+/** What the download is called. Slugged from the two things that identify the
+ *  chart — its capability and its metric — so a folder of several cards is
+ *  readable rather than "share (3).png". */
+export function shareCardFilename(capability: string, metric: MetricSpec): string {
+  return `fused-render-benchmark-${slug(capability)}-${slug(metric.key)}.png`;
+}
+
+function slug(text: string): string {
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** The card's height for `bars.length` rows — pure, so the layout can be
+ *  reasoned about (and tested) without a canvas. */
+export function shareCardHeight(barCount: number): number {
+  const plot = barCount * ROW_H + Math.max(0, barCount - 1) * ROW_GAP;
+  return (
+    PAD + // top padding
+    32 + // the brand row
+    26 + // gap under it
+    30 + // the title
+    20 + // the metric subtitle
+    14 + // gap before the plot
+    plot +
+    22 + // the axis labels
+    18 + // gap down to the footer rule
+    16 + // the footer line
+    PAD
+  );
+}
+
+export interface ShareCardInput {
+  capability: string;
+  metric: MetricSpec;
+  /** Already ranked best-first by `comparisonBars` — drawn in the order given,
+   *  exactly as the on-screen chart draws it. */
+  bars: ComparisonBar[];
+  machine: AiBenchmarkMachine | null;
+  /** The capability's common device (`commonDevice`), or null where the models
+   *  disagree — in which case the card names no device rather than picking one
+   *  model's and captioning every bar with it. */
+  device: string | null;
+  appVersion: string | null;
+  /** Injected so the drawing is deterministic under a test. */
+  now?: Date;
+}
+
+/** Draw the card and hand back its PNG bytes.
+ *
+ *  Rejects only if the canvas itself is unavailable or refuses to encode; a
+ *  missing LOGO is not a failure (the mark falls back to a drawn wordmark),
+ *  because a card without its picture is still the result somebody asked to
+ *  share. */
+export async function renderShareCard(input: ShareCardInput): Promise<Blob> {
+  const { bars, metric } = input;
+  const height = shareCardHeight(bars.length);
+  const canvas = document.createElement("canvas");
+  canvas.width = WIDTH * SCALE;
+  canvas.height = height * SCALE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("This browser would not give us a canvas to draw the card on.");
+  ctx.scale(SCALE, SCALE);
+  ctx.textBaseline = "top";
+
+  ctx.fillStyle = INK.bg;
+  ctx.fillRect(0, 0, WIDTH, height);
+
+  let y = PAD;
+
+  // -- the brand row ---------------------------------------------------------
+  const mark = await loadLogo();
+  if (mark) ctx.drawImage(mark, PAD, y, 32, 32);
+  ctx.fillStyle = INK.fg;
+  ctx.font = `600 17px ${SANS}`;
+  ctx.fillText("fused render", PAD + (mark ? 42 : 0), y + 8);
+  ctx.fillStyle = INK.muted;
+  ctx.font = `12px ${SANS}`;
+  ctx.textAlign = "right";
+  ctx.fillText("Local AI model benchmark", WIDTH - PAD, y + 12);
+  ctx.textAlign = "left";
+  y += 32 + 26;
+
+  // -- title + metric --------------------------------------------------------
+  ctx.fillStyle = INK.fg;
+  ctx.font = `600 24px ${SANS}`;
+  ctx.fillText(capabilityLabel(input.capability), PAD, y);
+  y += 30;
+  ctx.fillStyle = INK.muted;
+  ctx.font = `13px ${SANS}`;
+  ctx.fillText(metricSubtitle(metric), PAD, y);
+  y += 20 + 14;
+
+  // -- the plot --------------------------------------------------------------
+  // Same axis machinery the on-screen chart uses (`niceAxisTicks`), so the
+  // shared card's gridlines are the ones the reader was looking at rather
+  // than a second, differently-rounded scale.
+  let peak = 0;
+  for (const bar of bars) if (bar.value > peak) peak = bar.value;
+  const ticks = niceAxisTicks(peak, metric, 4);
+  const axisMax = ticks.length > 0 ? ticks[ticks.length - 1]!.value : peak || 1;
+  const plotX = PAD + NAME_W + NAME_GAP;
+  const plotW = WIDTH - PAD - VALUE_W - plotX;
+  const plotTop = y;
+  const plotH = bars.length * ROW_H + Math.max(0, bars.length - 1) * ROW_GAP;
+  const at = (value: number) => plotX + (value / axisMax) * plotW;
+
+  for (const tick of ticks) {
+    const x = Math.round(at(tick.value)) + 0.5;
+    ctx.beginPath();
+    ctx.setLineDash(tick.value === 0 ? [] : [3, 3]);
+    ctx.strokeStyle = INK.border;
+    ctx.lineWidth = 1;
+    ctx.moveTo(x, plotTop);
+    ctx.lineTo(x, plotTop + plotH);
+    ctx.stroke();
+  }
+  ctx.setLineDash([]);
+
+  bars.forEach((bar, i) => {
+    const top = plotTop + i * (ROW_H + ROW_GAP);
+    const mid = top + ROW_H / 2;
+    ctx.fillStyle = INK.fg;
+    ctx.font = `12px ${MONO}`;
+    ctx.textBaseline = "middle";
+    ctx.fillText(middleEllipsis(shortModelName(bar.model), 26), PAD, mid);
+    // `min-width: 2px` on screen, and the same floor here: a real measurement
+    // that rounds to nothing must still leave a mark, or the card shows a row
+    // with no bar at all where the number says otherwise.
+    const width = Math.max(2, (bar.value / axisMax) * plotW);
+    ctx.fillStyle = INK.accent;
+    roundedRect(ctx, plotX, mid - BAR_H / 2, width, BAR_H, 3);
+    ctx.fill();
+    ctx.fillStyle = INK.muted;
+    ctx.font = `12px ${SANS}`;
+    ctx.fillText(formatMetricSpecValue(bar.value, metric), plotX + width + 8, mid);
+    ctx.textBaseline = "top";
+  });
+  y = plotTop + plotH + 8;
+
+  // The tick labels, pulled back onto the plot at both ends exactly as the
+  // on-screen axis does (`.am-bench-compare-axis span:first-child/:last-child`)
+  // — a centred label under the first or last gridline would hang off the card.
+  ctx.fillStyle = INK.muted;
+  ctx.font = `11px ${SANS}`;
+  ticks.forEach((tick, i) => {
+    ctx.textAlign = i === 0 ? "left" : i === ticks.length - 1 ? "right" : "center";
+    ctx.fillText(tick.label, at(tick.value), y);
+  });
+  ctx.textAlign = "left";
+  y += 14 + 18;
+
+  // -- the footer: the machine, and where the card came from ------------------
+  ctx.beginPath();
+  ctx.strokeStyle = INK.border;
+  ctx.moveTo(PAD, Math.round(y) + 0.5);
+  ctx.lineTo(WIDTH - PAD, Math.round(y) + 0.5);
+  ctx.stroke();
+  y += 14;
+  ctx.font = `12px ${SANS}`;
+  ctx.fillStyle = INK.fg;
+  ctx.fillText(hardwareLine(input.machine, input.device), PAD, y);
+  ctx.fillStyle = INK.muted;
+  ctx.textAlign = "right";
+  ctx.fillText(provenanceLine(input.appVersion, input.now ?? new Date()), WIDTH - PAD, y);
+  ctx.textAlign = "left";
+
+  return await encode(canvas);
+}
+
+function roundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+) {
+  const radius = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+  ctx.closePath();
+}
+
+function encode(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("The card could not be encoded as a PNG."))),
+      "image/png",
+    );
+  });
+}
+
+// The mark, decoded once per session and reused — a share is a repeatable
+// click, and re-decoding a 699² PNG on each press is work with no answer to
+// give. `null` (never a throw) when the asset will not load, which the caller
+// draws around.
+let logo: Promise<HTMLImageElement | null> | null = null;
+
+function loadLogo(): Promise<HTMLImageElement | null> {
+  logo ??= new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => resolve(null);
+    img.src = logoMark;
+  });
+  return logo;
+}
+
+/** How a card actually left the app. `cancelled` is the share sheet being
+ *  dismissed — a deliberate "never mind", which must NOT then fall through to
+ *  saving a file the reader just declined to send. */
+export type ShareOutcome = "shared" | "copied" | "downloaded" | "cancelled";
+
+/** Hand the PNG over, best channel first: the OS share sheet where the browser
+ *  has one, the clipboard where it does not (the bytes are `image/png`, the one
+ *  format `ClipboardItem` accepts — so unlike the Playground's rendered images
+ *  a clipboard write is legitimate here), and a plain download as the floor
+ *  that always works. */
+export async function deliverShareCard(blob: Blob, filename: string): Promise<ShareOutcome> {
+  const file = new File([blob], filename, { type: "image/png" });
+  if (navigator.canShare?.({ files: [file] })) {
+    try {
+      await navigator.share({ files: [file] });
+      return "shared";
+    } catch (e) {
+      // Dismissing the sheet rejects with AbortError. Anything else is a real
+      // failure of the share channel, and falls through to the next one.
+      if ((e as Error).name === "AbortError") return "cancelled";
+    }
+  }
+  try {
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+    return "copied";
+  } catch {
+    // No clipboard permission, no ClipboardItem, or a non-secure context.
+  }
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+  return "downloaded";
+}
+
+/** What the button says after a delivery — the outcomes differ in WHERE the
+ *  card went, and a single "Done" would leave a reader hunting for a file that
+ *  is actually on their clipboard. */
+export function shareOutcomeNote(outcome: ShareOutcome): string {
+  switch (outcome) {
+    case "shared":
+      return "Shared";
+    case "copied":
+      return "Copied as an image";
+    case "downloaded":
+      return "Saved as a PNG";
+    case "cancelled":
+      return "";
+  }
+}

--- a/frontend/src/apps/ai_models/benchmark/shareCard.ts
+++ b/frontend/src/apps/ai_models/benchmark/shareCard.ts
@@ -368,8 +368,17 @@ export async function deliverShareCard(blob: Blob, filename: string): Promise<Sh
   const link = document.createElement("a");
   link.href = url;
   link.download = filename;
+  // Appended before the click, and removed right after: some browsers (most
+  // reliably Firefox) only honour a synthetic `.click()` on an anchor that is
+  // actually IN the document — a detached one is free to be silently ignored.
+  // The revoke is deferred a tick past that, not run synchronously right
+  // after `.click()`: revoking here raced the browser's own async read of the
+  // blob URL to start the save, which could win and leave `deliverShareCard`
+  // reporting "downloaded" for a save that never actually landed a file.
+  document.body.appendChild(link);
   link.click();
-  URL.revokeObjectURL(url);
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
   return "downloaded";
 }
 

--- a/frontend/src/apps/ai_models/lib/benchmark.test.ts
+++ b/frontend/src/apps/ai_models/lib/benchmark.test.ts
@@ -38,6 +38,7 @@ import {
   runCountsByCapability,
   runCountsByModel,
   runsFor,
+  busyRowText,
   shortModelName,
   stoppedNote,
   summaryLine,
@@ -439,6 +440,34 @@ describe("runButtonState", () => {
     expect(runButtonState("text-generation", "org/text", {
       "text-generation": "org/text",
     }, true).label).toBe("Running…");
+  });
+});
+
+// -- the busy row: phase + a real elapsed clock, never an invented bar --------
+
+describe("busyRowText", () => {
+  it("says the model is still loading, while it is", () => {
+    // Matches the AI runtime's OWN state for this model — never a guess from
+    // elapsed time, which cannot distinguish a slow cold load from a slow
+    // measurement.
+    expect(busyRowText(true, 1_000, 5_000)).toBe("Loading weights into memory…");
+  });
+
+  it("switches to a ticking elapsed clock once loading ends", () => {
+    // 84 seconds since the click -> 1:24, `TranscribeStage.tsx`'s own mm:ss
+    // shape.
+    expect(busyRowText(false, 0, 84_000)).toBe("Measuring — 1:24");
+  });
+
+  it("pads seconds under ten", () => {
+    expect(busyRowText(false, 0, 65_000)).toBe("Measuring — 1:05");
+  });
+
+  it("never goes negative on a clock skew", () => {
+    // `now` before `startedAt` should not happen, but a floor at 0 is cheaper
+    // than a nonsense negative count and matches the null-over-estimate
+    // spirit the rest of this feature holds elsewhere.
+    expect(busyRowText(false, 5_000, 1_000)).toBe("Measuring — 0:00");
   });
 });
 

--- a/frontend/src/apps/ai_models/lib/benchmark.ts
+++ b/frontend/src/apps/ai_models/lib/benchmark.ts
@@ -864,19 +864,58 @@ export function runButtonState(
   };
 }
 
+/** `mm:ss`, floored, never negative — the same shape `TranscribeStage.tsx`'s
+ *  own `clock()` uses, so the app states elapsed time one way. Negative would
+ *  only happen from a clock skew between "when the click fired" and "now",
+ *  and floored to 0 rather than shown as a nonsense negative count. */
+function benchClock(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+/** The busy row's own text: phase, then elapsed time — never an invented
+ *  percentage (`styles/ai-models.css`'s own rule, and the busy row's previous
+ *  static "this takes minutes" is exactly the silence that rule exists to
+ *  replace).
+ *
+ *  **`stillLoading` is the AI runtime's OWN answer, not a guess.** `run()`
+ *  opens its measurement row only once `_load_to_ready` returns
+ *  (`ai/benchmark.py`), so the runtime's `loaded[]` entry for this model is
+ *  the one honest signal for "which phase is this, right now" — a client-side
+ *  timer cannot know when the load actually finished, and guessing from
+ *  elapsed time alone would show "Measuring" for a cold model still pulling
+ *  gigabytes. `useAiRuntime` is already polled by the page (`lib/aiRuntime.ts`)
+ *  for exactly this table, so this reuses that poll rather than adding a
+ *  second one.
+ *
+ *  Once loading ends, the label switches to a ticking elapsed clock from the
+ *  moment the button was pressed (`startedAt`, `now` in epoch milliseconds) —
+ *  real, measured time, matching the row `_MeasurementRow` now keeps open on
+ *  the server for exactly this phase. */
+export function busyRowText(
+  stillLoading: boolean,
+  startedAt: number,
+  now: number,
+): string {
+  if (stillLoading) return "Loading weights into memory…";
+  return `Measuring — ${benchClock((now - startedAt) / 1000)}`;
+}
+
 /** What to tell the user when a run came back stopped rather than measured.
  *
- *  **The cause is elsewhere in the app, and the note does not guess which.** A
- *  benchmark owns no download-manager row and offers no ✕ of its own (see
- *  `ai/benchmark.py`), so a run that ends `cancelled` was stopped by something
- *  reaching the model it was using — which one resident model per capability,
- *  shared by the whole app, makes possible. `fused.ai.cancel()` from any open
- *  page does it; so does the ✕ on a download row the load opened, and so does
+ *  **The cause could be the run's own row now, or something else entirely, and
+ *  the note does not guess which.** A benchmark's own measurement row
+ *  (`ai/benchmark.py`'s `_MeasurementRow`) offers a ✕ during the timed
+ *  phase — but a run that ends `cancelled` could just as well have been
+ *  stopped by something ELSE reaching the model it was using, since one
+ *  resident model per capability, shared by the whole app, makes that
+ *  possible too. `fused.ai.cancel()` from any open page does it; so does the
+ *  ✕ on the model's own LOAD row while it was still coming up, and so does
  *  the ✕ on a queued-transcription row a speech benchmark can inherit. The
  *  client cannot tell those apart, so the wording names the SHAPE of the cause
  *  and offers the commonest one as an example rather than asserting it — an
  *  earlier draft said "most likely fused.ai.cancel()" and was simply wrong for
- *  the two ✕ cases.
+ *  the ✕ cases.
  *
  *  Without this the failure was silent in the worst way: nothing appended, no
  *  error set, the button quietly re-enabled — so somebody who pressed Run and

--- a/frontend/src/platform/ui/MenuIcons.tsx
+++ b/frontend/src/platform/ui/MenuIcons.tsx
@@ -213,4 +213,54 @@ export const MenuIcons: Record<string, ReactNode> = {
       <path d="M6.5 15h.01M10 15h.01" />
     </svg>
   ),
+
+  // ---- Benchmark tab buttons (SPEC AI-14) ----------------------------------
+  // These four replace text labels with icons on the Benchmark tab; each
+  // caller keeps the word it replaced as both `aria-label` and `title`, so the
+  // glyph is a shorthand for the label rather than its only carrier.
+
+  // Run — a plain outline play triangle. Doubles for both "Run benchmark" and
+  // "Run again": the action is identical, only the tooltip's wording differs.
+  play: (
+    <svg {...svgProps}>
+      <path d="M8 5l11 7-11 7z" />
+    </svg>
+  ),
+  // Running — a partial ring, spun by `.am-icon-spin` (ai-models.css) rather
+  // than baked into the path, so the SAME glyph works in a static context
+  // (none today, but a second consumer should not need a second path). Not
+  // `refresh` (a full two-arrow loop, already meaning "fetch this again") —
+  // this is a plainer arc, the shape most spinners actually use.
+  spinner: (
+    <svg {...svgProps}>
+      <path d="M20 12a8 8 0 1 1-2.34-5.66" />
+    </svg>
+  ),
+  // Details disclosure — a chevron. Rotated 90° by `[open] > summary` in
+  // ai-models.css rather than swapped for a second path: a `<details>` is
+  // already the open/closed state, and a CSS rotation of one glyph is a
+  // smaller vocabulary than a "closed" and an "open" glyph that must always
+  // agree with each other.
+  chevron: (
+    <svg {...svgProps}>
+      <path d="M9 6l6 6-6 6" />
+    </svg>
+  ),
+  // Share — an upward arrow lifting out of a tray. The mirror image of
+  // `download`'s arrow dropping INTO one: sharing a chart is sending
+  // something out, not pulling something in.
+  share: (
+    <svg {...svgProps}>
+      <path d="M12 15V4" />
+      <path d="M7.5 8.5L12 4l4.5 4.5" />
+      <path d="M5 13v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6" />
+    </svg>
+  ),
+  // Stop — a plain filled-outline square, the universal "halt" glyph and
+  // distinct from `trash` (this does not delete anything that ran).
+  stop: (
+    <svg {...svgProps}>
+      <rect x="6" y="6" width="12" height="12" rx="1.5" />
+    </svg>
+  ),
 };

--- a/frontend/src/styles/ai-models.css
+++ b/frontend/src/styles/ai-models.css
@@ -1842,6 +1842,38 @@
    keeps a visible "Metric" caption — it sits beside a card's `<h3>`, not
    alone in the page-level toolbar, so the two are not read as a matched pair
    and the caption stays legible chrome here rather than redundant chrome. */
+/* The section head's control group — the Metric select and the Share button.
+   One flex group rather than two children of the head itself, so
+   `.am-section-head`'s own `justify-content: space-between` keeps holding the
+   heading at one end and ALL the controls at the other, instead of pushing the
+   select into the middle of the row once a second control appeared. */
+.am-bench-headtools {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+/* Share: the chart, this machine's hardware and the fused render mark as one
+   PNG (benchmark/shareCard.ts). The receipt beside it says WHERE the card went
+   — the three delivery channels (share sheet, clipboard, download) leave it in
+   three different places, and a silent success sends the reader hunting for a
+   file that is actually on their clipboard. */
+.am-bench-share {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 11px;
+}
+
+.am-bench-share-note {
+  color: var(--fg-muted);
+}
+
+.am-bench-share-error {
+  color: var(--error);
+}
+
 .am-bench-metricsel {
   display: flex;
   align-items: baseline;
@@ -2172,11 +2204,51 @@
   color: var(--fg);
 }
 
+/* The icon-only disclosure summary (icon-buttons pass): no default marker —
+   the chevron glyph itself IS the marker — and a plain inline-flex box so the
+   16×16 SVG doesn't inherit `<summary>`'s own list-item box model, which pads
+   asymmetrically in a way a tiny icon makes obvious. */
+.am-bench-rowdetail-chevron {
+  display: inline-flex;
+  align-items: center;
+  list-style: none;
+}
+
+.am-bench-rowdetail-chevron::-webkit-details-marker {
+  display: none;
+}
+
+/* Rotated open rather than swapped for a second "collapse" glyph — the
+   `<details>` element already IS the open/closed state (MenuIcons.tsx's own
+   comment on `chevron`), so a second path would just be a second place that
+   state could get out of sync with what is actually shown. */
+.am-bench-rowdetail[open] > .am-bench-rowdetail-chevron {
+  transform: rotate(90deg);
+}
+
 .am-bench-rowdetail > p {
   margin: 4px 0 0;
   max-width: 60ch;
   color: var(--fg-muted);
   white-space: pre-wrap;
+}
+
+/* -- icon-only buttons: the spinner glyph's motion (SPEC AI-14) --------------
+   The glyph itself (`MenuIcons.spinner`) is a static partial ring; this is
+   the only thing that turns it into "working". Shared by the Benchmark tab's
+   Run button and the Share button, so one rule covers both rather than two
+   copies drifting apart. */
+.am-icon-spin {
+  display: inline-flex;
+  animation: am-icon-spin 0.9s linear infinite;
+}
+
+@keyframes am-icon-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .am-icon-spin { animation: none; }
 }
 
 /* A run stopped from outside — `fused.ai.cancel()` from another page reaching

--- a/fused_render/ai/benchmark.py
+++ b/fused_render/ai/benchmark.py
@@ -363,6 +363,24 @@ def _bench_job_title(model: str) -> str:
     return f"Benchmark · {model}"
 
 
+#: Capabilities whose WORKER actually watches `worker_base.CANCEL` mid-call, so
+#: a ✕ on this row can really stop them. Verified per runner, not assumed:
+#: `llama_text.py` (llamacpp-text/-vulkan) and `mlx_text/worker.py` check it
+#: between tokens, `torch_image.py` checks it in its per-step callback, and
+#: `faster_whisper`/`mlx_whisper` check it in their segment loop. The embedding
+#: runners (`mlx_embed`, `transformers_embed`) make ONE blocking
+#: `model.encode()` call with no callback to check anything from — a cancel
+#: request against one would sit unread until the call returns on its own,
+#: complete normally, and get recorded as `ok:true` for a run somebody tried to
+#: stop, which is the opposite of `Cancelled`'s whole guarantee. So an
+#: embeddings row advertises no ✕ at all rather than one that silently does
+#: nothing — the honest answer, not a race against how long `model.encode()`
+#: happens to take.
+_CANCELLABLE_CAPABILITIES = frozenset({
+    registry.TEXT_GENERATION, registry.IMAGE_GENERATION, registry.SPEECH_TO_TEXT,
+})
+
+
 class _MeasurementRow:
     """The job row `run()` opens once loading is done, for the MEASUREMENT
     phase only — the warm-up pass and the timed pass that follows it.
@@ -378,27 +396,46 @@ class _MeasurementRow:
 
     **The detail is never invented.** A measurement function calls
     `set_detail` with a CHEAP, already-formatted string as often as it likes —
-    text-generation does it every decoded token — and this class is what turns
-    that into an occasional job-row write instead of one HTTP-shaped update
-    per token: the watcher thread below only calls `_report` when the string
-    has actually changed, on its own `_BENCH_ROW_POLL_S` cadence, so a
-    measurement function's own hot loop pays for a lock and a string format
-    and nothing else. That is the whole answer to "must not perturb the
-    measurement" — `tokensPerSecond` is timed independently of how often this
-    class happens to publish, so a slower or faster row update cannot move it.
+    text-generation does it every decoded token — and `_poll_once` is what
+    turns that into an occasional job-row write instead of one HTTP-shaped
+    update per token: it runs on the watcher thread's own `_BENCH_ROW_POLL_S`
+    cadence, so a measurement function's own hot loop pays for a lock and a
+    string format and nothing else. That is the whole answer to "must not
+    perturb the measurement" — `tokensPerSecond` is timed independently of how
+    often this class happens to publish, so a slower or faster row update
+    cannot move it.
 
-    **The image and speech paths need no `set_detail` call at all**, because
-    `supervisor.generate_image`/`generate_transcript` already accept a `job`
-    id and the WORKER reports its own progress straight onto it
-    (`torch_image.py`'s `on_step_end` posts "Denoising — step N/steps" to
-    exactly this mechanism for every other queued render) — `_measure_image`
-    hands this row's own `job` to the call instead of a disposable one, and
-    the real step count arrives on the row for free, from the same channel a
-    Playground render already uses.
+    **`_poll_once` restates the row IN FULL on every tick, not only when the
+    detail changed.** The first cut only wrote when the string differed, which
+    left `updated_at` frozen for as long as the phase text did not change — a
+    single-call embed measurement (one `set_detail`, ever) or a slow warm-up
+    (no `set_detail` at all — see `run`) could sit long enough to trip
+    `jobs._sweep`'s `STALE_DROP_S` (600s), which drops a RUNNING row with no
+    exemption for `OWNER_SERVER` and, once dropped, adds the id to
+    `_dismissed` — after which `jobs.upsert` refuses every later tick as a
+    "late" one UNLESS it carries `state: "running"` again, so even this row's
+    own terminal report from `close()` would be silently swallowed and the ✕
+    would read as gone (`_cancel_state` returns None for a missing row).
+    Restating `title`/`state`/`cancellable` every tick is exactly what
+    `_wait_ready`/`_await_turn` already do for their own rows, and for the same
+    reason: it is what lets a tick both keep `updated_at` moving AND
+    re-create the row if it is ever evicted, rather than only preventing the
+    first.
+
+    **The image and speech paths need no `set_detail` call for their WORKER'S
+    progress**, because `supervisor.generate_image` already accepts a `job` id
+    and the WORKER reports its own straight onto it (`torch_image.py`'s
+    `on_step_end` posts "Denoising — step N/steps" to exactly this mechanism
+    for every other queued render) — `_measure_image` hands this row's own
+    `job` to that call instead of a disposable one, and the real step count
+    arrives on the row for free. Speech does NOT do this — see
+    `_measure_transcript`'s own comment for why handing this row's job to
+    `generate_transcript` would be actively wrong, not merely unnecessary.
 
     **The ✕ cancels COOPERATIVELY, through `supervisor.cancel_generation`,
-    never `unload`.** See `BenchmarkTab.tsx`'s header comment for what
-    `unload` broke the one time this app tried it for a benchmark's Stop
+    never `unload`, and ONLY where a worker can actually honour it**
+    (`_CANCELLABLE_CAPABILITIES`). See `BenchmarkTab.tsx`'s header comment for
+    what `unload` broke the one time this app tried it for a benchmark's Stop
     button: it tears down the worker PROCESS rather than asking it to set its
     own `cancelled` flag, so the held-open request sees the process vanish out
     from under it rather than a clean `cancelled: true` frame, and that lands
@@ -407,13 +444,18 @@ class _MeasurementRow:
     history must never contain. `cancel_generation` is the same channel the
     tab's own queue Stop button already uses, and it acts on whichever worker
     is resident for the capability — it does not need this row's job id at
-    all, only the fact that the ✕ was pressed.
+    all, only the fact that the ✕ was pressed. Its own `False` (no ready
+    worker, or the `/cancel` POST raising) is NOT treated as "done cancelling"
+    — `_poll_once` retries on the next tick rather than giving up, since a
+    watcher that stopped on the first transient failure would freeze the row
+    for the rest of a multi-minute run with the ✕ never actually honoured.
     """
 
     def __init__(self, model: str, capability: str) -> None:
         self._job = jobs.SERVER_ID_PREFIX + "ai-benchmark-" + uuid.uuid4().hex
         self._capability = capability
         self._title = _bench_job_title(model)
+        self._cancellable = capability in _CANCELLABLE_CAPABILITIES
         self._lock = threading.Lock()
         self._detail = "Measuring…"
         self._sent: str | None = None
@@ -422,8 +464,9 @@ class _MeasurementRow:
 
     @property
     def job(self) -> str:
-        """The `sys:`-prefixed id `generate_image`/`generate_transcript` can be
-        handed so the worker's own progress lands here instead of nowhere."""
+        """The `sys:`-prefixed id `generate_image` can be handed so the
+        worker's own progress lands here instead of nowhere. `_measure_transcript`
+        deliberately does NOT use this — see its own comment."""
         return self._job
 
     def set_detail(self, detail: str) -> None:
@@ -434,7 +477,8 @@ class _MeasurementRow:
 
     def start(self) -> None:
         supervisor._report(self._job, title=self._title, state="running",
-                           kind="task", cancellable=True, detail=self._detail)
+                           kind="task", cancellable=self._cancellable,
+                           detail=self._detail)
         self._sent = self._detail
         self._thread = threading.Thread(
             target=self._watch, daemon=True, name="ai-benchmark-row")
@@ -446,20 +490,47 @@ class _MeasurementRow:
                 return
 
     def _poll_once(self) -> bool:
-        """One tick: push a changed detail, then forward a pressed ✕. Returns
-        True once the ✕ has been forwarded (nothing left for the watcher
-        thread to do). Split out from `_watch` so a test can drive exactly one
-        tick directly, without waiting through `_BENCH_ROW_POLL_S` of real
-        wall clock to observe it."""
+        """One watcher tick: restate the row in FULL (see the class docstring
+        for why a changed-only write is not enough), then forward a pressed ✕
+        if this capability can actually honour one. Returns True only once a
+        forward has genuinely SUCCEEDED (`cancel_generation` returned True) —
+        a False (no ready worker yet, or the request failing) is retried on
+        the next tick rather than treated as done, which is what stopped a
+        transient failure from silently freezing the row. Split out from
+        `_watch` so a test can drive exactly one tick directly, without
+        waiting through `_BENCH_ROW_POLL_S` of real wall clock to observe it.
+        """
+        with self._lock:
+            detail = self._detail
+        supervisor._report(self._job, title=self._title, state="running",
+                           kind="task", cancellable=self._cancellable,
+                           detail=detail)
+        self._sent = detail
+        if not self._cancellable:
+            return False
+        if supervisor._cancel_requested(self._job):
+            return supervisor.cancel_generation(self._capability)
+        return False
+
+    def _flush_detail(self) -> None:
+        """Push the LAST detail synchronously — detail only, never a cancel
+        forward. Called from `close()`, after the run is already over: by then
+        `cancel_requested` may still read True (nothing but a terminal state
+        clears it — see `jobs.upsert`), and forwarding it here would ask
+        `cancel_generation` to stop whatever is CURRENTLY resident for this
+        capability, which by now could be an unrelated generation — a
+        Playground chat the user started the instant this run finished. Detail
+        only avoids that: a fast run (an embedding call answering in
+        milliseconds) can finish before the watcher thread's own
+        `_BENCH_ROW_POLL_S` cadence ever ticks, and without this the row would
+        sit on "Measuring…" its entire life even though `set_detail` recorded
+        a real phase.
+        """
         with self._lock:
             detail = self._detail
         if detail != self._sent:
             supervisor._report(self._job, detail=detail)
             self._sent = detail
-        if supervisor._cancel_requested(self._job):
-            supervisor.cancel_generation(self._capability)
-            return True
-        return False
 
     def close(self, failure: BaseException | None = None) -> None:
         """Stop watching and put a terminal state on the row. Reuses
@@ -469,12 +540,7 @@ class _MeasurementRow:
         self._stop.set()
         if self._thread is not None:
             self._thread.join(timeout=1.0)
-        # Flush the LAST detail synchronously: a fast run (an embedding call
-        # answering in milliseconds) can finish before the watcher thread's
-        # own `_BENCH_ROW_POLL_S` cadence ever ticks, and without this the row
-        # would sit on "Measuring…" its entire life even though `set_detail`
-        # recorded a real phase.
-        self._poll_once()
+        self._flush_detail()
         _close_any_row(self._job, failure)
 
 

--- a/fused_render/ai/benchmark.py
+++ b/fused_render/ai/benchmark.py
@@ -770,6 +770,24 @@ def _measure_transcript(model: str, workload: Workload, *, timed: bool,
     A phase word, not a percentage: the worker's own decode has no per-chunk
     tick this module reads (unlike the image path's step callback), so a bar
     here would be invented rather than measured.
+
+    **`row.job` is NEVER handed to `generate_transcript`, on either pass, and
+    that is deliberate rather than an oversight.** `_TRANSCRIBE_LOCK`
+    (`supervisor.py`) serialises EVERY transcription in the process — real
+    ones from the Playground included — regardless of whether this model is
+    already resident, so `generate_transcript` always goes through
+    `_transcribe_turn`/`_await_turn` first. If that lock is held by a real,
+    concurrent transcription, `_await_turn` reports the QUEUED wait onto
+    whatever `job` it was given, using `_transcribe_row(title, ...)` — and
+    `title` there is the audio FILE's basename, not this row's identity.
+    Handing it this row's real `job` would let that queued-wait report
+    OVERWRITE "Benchmark · <model>" with "fused-benchmark-tone.wav" for as
+    long as the wait lasts (which can be minutes), with nothing to restore it
+    afterwards — destroying the one property `_bench_job_title` exists to
+    guarantee. A private, disposable id absorbs that rename harmlessly instead,
+    exactly as it always has; `row.set_detail` above already put the real
+    phase text on THIS row through its own channel, independent of whatever
+    `generate_transcript` does with the id it is given.
     """
     params = workload.params
     seconds = float(params["audioSeconds"])
@@ -795,25 +813,21 @@ def _measure_transcript(model: str, workload: Workload, *, timed: bool,
             "outText": os.path.join(tmp, "fused-benchmark-tone.txt"),
             # No `row` REQUEST KEY: that is how a caller gives the worker a
             # QUEUE-WAIT row to restate its identity onto (`_await_turn`'s own
-            # `row=` parameter), a different thing from the `_MeasurementRow`
-            # below — this benchmark already confirmed the model ready before
-            # calling here (`run`'s own ordering), so it is never queued
-            # behind anything and has no wait row to restate.
+            # `row=` parameter) — a benchmark has none to give, on either
+            # pass, for the same reason `job` below is always disposable.
         }
-        job = row.job if row is not None else _unwatched_job()
+        # ALWAYS disposable — see the docstring's own note on why this is the
+        # one measurement function that never hands the real `_MeasurementRow`
+        # its job, on either the warm-up or the timed pass.
+        job = _unwatched_job()
         start = _now()
         try:
             supervisor.generate_transcript(model, request, job)
         except BaseException as e:
-            # `row is None` on the warm-up pass — see `_measure_image`'s
-            # identical guard for why the timed pass's own row is closed once,
-            # by `run()`, after memory/device sampling, rather than here.
-            if row is None:
-                _close_any_row(job, e)
+            _close_any_row(job, e)
             raise
         else:
-            if row is None:
-                _close_any_row(job)
+            _close_any_row(job)
         total = _now() - start
     if not timed:
         return {}

--- a/fused_render/ai/benchmark.py
+++ b/fused_render/ai/benchmark.py
@@ -59,6 +59,7 @@ import platform
 import secrets
 import struct
 import tempfile
+import threading
 import time
 import uuid
 import wave
@@ -335,7 +336,150 @@ def _write_tone_wav(path: str, seconds: float, sample_rate: int, hz: float) -> N
         out.writeframes(samples)
 
 
-def _measure_text(model: str, workload: Workload, *, timed: bool) -> dict:
+#: How often the measurement row's watcher writes a changed detail and checks
+#: for a pressed ✕. Independent of `_LOAD_POLL_S`, which polls a worker's local
+#: HTTP health endpoint every generation: this loop polls an in-process dict
+#: (`jobs.list_jobs()`) and a `threading.Event` a measurement function wrote
+#: to, so tying the two cadences together would make one look like it costs
+#: what the other does, which it does not.
+_BENCH_ROW_POLL_S = 0.2
+
+
+def _bench_job_title(model: str) -> str:
+    """The measurement row's title: distinct from `supervisor.load`'s own row,
+    which is titled bare `model`.
+
+    This is the whole mechanism. `useCacheScan.ts` maps `job.title -> model`,
+    so two rows sharing a title are indistinguishable to every consumer — the
+    ORIGINAL design opened no row at all specifically because a decorated
+    title ("Benchmark: <model>") is a row no consumer can find and the bare
+    model id SHADOWS the load row, putting the download manager's only ✕ on
+    the load instead of the benchmark and letting a cold run spin to its
+    hour-long timeout (see `run`'s own docstring, still accurate about why a
+    naive row is worse than none). A title that is neither of those two shapes
+    is a row of its own, findable by the corner and never confused with the
+    load underneath it.
+    """
+    return f"Benchmark · {model}"
+
+
+class _MeasurementRow:
+    """The job row `run()` opens once loading is done, for the MEASUREMENT
+    phase only — the warm-up pass and the timed pass that follows it.
+
+    **Why a row now, when three earlier attempts explicitly rejected one.**
+    Those attempts collided on TITLE (see `_bench_job_title`); this is the
+    fourth design, and the one that actually works, because it fixes the part
+    that was broken (the title) rather than giving up on having a row at all.
+    Without one, a cold run's "Loading weights into memory…" (the LOAD row,
+    reported by the supervisor) is followed by total silence for the whole
+    measurement — no row, no percentage, nothing — which reads as the app
+    having frozen even though it has not.
+
+    **The detail is never invented.** A measurement function calls
+    `set_detail` with a CHEAP, already-formatted string as often as it likes —
+    text-generation does it every decoded token — and this class is what turns
+    that into an occasional job-row write instead of one HTTP-shaped update
+    per token: the watcher thread below only calls `_report` when the string
+    has actually changed, on its own `_BENCH_ROW_POLL_S` cadence, so a
+    measurement function's own hot loop pays for a lock and a string format
+    and nothing else. That is the whole answer to "must not perturb the
+    measurement" — `tokensPerSecond` is timed independently of how often this
+    class happens to publish, so a slower or faster row update cannot move it.
+
+    **The image and speech paths need no `set_detail` call at all**, because
+    `supervisor.generate_image`/`generate_transcript` already accept a `job`
+    id and the WORKER reports its own progress straight onto it
+    (`torch_image.py`'s `on_step_end` posts "Denoising — step N/steps" to
+    exactly this mechanism for every other queued render) — `_measure_image`
+    hands this row's own `job` to the call instead of a disposable one, and
+    the real step count arrives on the row for free, from the same channel a
+    Playground render already uses.
+
+    **The ✕ cancels COOPERATIVELY, through `supervisor.cancel_generation`,
+    never `unload`.** See `BenchmarkTab.tsx`'s header comment for what
+    `unload` broke the one time this app tried it for a benchmark's Stop
+    button: it tears down the worker PROCESS rather than asking it to set its
+    own `cancelled` flag, so the held-open request sees the process vanish out
+    from under it rather than a clean `cancelled: true` frame, and that lands
+    as a real `ok:false` failure — a permanent "this model failed" row for a
+    run somebody stopped on purpose, which is the one thing this feature's
+    history must never contain. `cancel_generation` is the same channel the
+    tab's own queue Stop button already uses, and it acts on whichever worker
+    is resident for the capability — it does not need this row's job id at
+    all, only the fact that the ✕ was pressed.
+    """
+
+    def __init__(self, model: str, capability: str) -> None:
+        self._job = jobs.SERVER_ID_PREFIX + "ai-benchmark-" + uuid.uuid4().hex
+        self._capability = capability
+        self._title = _bench_job_title(model)
+        self._lock = threading.Lock()
+        self._detail = "Measuring…"
+        self._sent: str | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @property
+    def job(self) -> str:
+        """The `sys:`-prefixed id `generate_image`/`generate_transcript` can be
+        handed so the worker's own progress lands here instead of nowhere."""
+        return self._job
+
+    def set_detail(self, detail: str) -> None:
+        """Publish a new phase/progress string. Called from the measurement
+        function's own thread — cheap on purpose, see the class docstring."""
+        with self._lock:
+            self._detail = detail
+
+    def start(self) -> None:
+        supervisor._report(self._job, title=self._title, state="running",
+                           kind="task", cancellable=True, detail=self._detail)
+        self._sent = self._detail
+        self._thread = threading.Thread(
+            target=self._watch, daemon=True, name="ai-benchmark-row")
+        self._thread.start()
+
+    def _watch(self) -> None:
+        while not self._stop.wait(_BENCH_ROW_POLL_S):
+            if self._poll_once():
+                return
+
+    def _poll_once(self) -> bool:
+        """One tick: push a changed detail, then forward a pressed ✕. Returns
+        True once the ✕ has been forwarded (nothing left for the watcher
+        thread to do). Split out from `_watch` so a test can drive exactly one
+        tick directly, without waiting through `_BENCH_ROW_POLL_S` of real
+        wall clock to observe it."""
+        with self._lock:
+            detail = self._detail
+        if detail != self._sent:
+            supervisor._report(self._job, detail=detail)
+            self._sent = detail
+        if supervisor._cancel_requested(self._job):
+            supervisor.cancel_generation(self._capability)
+            return True
+        return False
+
+    def close(self, failure: BaseException | None = None) -> None:
+        """Stop watching and put a terminal state on the row. Reuses
+        `_close_any_row`'s outcome-follows-the-exception rule, so a cancel, a
+        real failure and a success are told apart exactly the way the
+        image/speech paths already are."""
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+        # Flush the LAST detail synchronously: a fast run (an embedding call
+        # answering in milliseconds) can finish before the watcher thread's
+        # own `_BENCH_ROW_POLL_S` cadence ever ticks, and without this the row
+        # would sit on "Measuring…" its entire life even though `set_detail`
+        # recorded a real phase.
+        self._poll_once()
+        _close_any_row(self._job, failure)
+
+
+def _measure_text(model: str, workload: Workload, *, timed: bool,
+                  row: "_MeasurementRow | None" = None) -> dict:
     """Decode the fixed prompt, splitting prefill from decode.
 
     Two numbers, because one would hide the other: `ttftMs` is everything up to
@@ -362,10 +506,12 @@ def _measure_text(model: str, workload: Workload, *, timed: bool) -> dict:
         "max_tokens": params["maxTokens"],
         "temperature": params["temperature"],
     }
+    max_tokens = params["maxTokens"]
     deadline = _now() + _LOAD_TIMEOUT_S
     while True:
         start = _now()
         first_token_at = None
+        count = 0
         # `None`, not `{}` — a stream that closes WITHOUT ever yielding a
         # `done` frame (a worker killed or OOM-reaped mid-generation, the
         # socket simply reaching EOF with no exception) must not be
@@ -377,8 +523,19 @@ def _measure_text(model: str, workload: Workload, *, timed: bool) -> dict:
         try:
             for event in supervisor.generate_text(model, body):
                 kind = event.get("type")
-                if kind == "chunk" and first_token_at is None:
-                    first_token_at = _now()
+                if kind == "chunk":
+                    if first_token_at is None:
+                        first_token_at = _now()
+                    count += 1
+                    if row is not None:
+                        # A cheap counter plus a string format, called once
+                        # PER TOKEN — never a network call, see
+                        # `_MeasurementRow`'s own docstring for why that is
+                        # safe: the watcher thread, not this loop, decides how
+                        # often that turns into an actual job-row write, so
+                        # this cannot perturb `tokensPerSecond` no matter how
+                        # fast or slow decode is.
+                        row.set_detail(f"Decoding — {count}/{max_tokens} tokens")
                 elif kind == "done":
                     done = event
             break
@@ -434,7 +591,8 @@ def _measure_text(model: str, workload: Workload, *, timed: bool) -> dict:
     }
 
 
-def _measure_embed(model: str, workload: Workload, *, timed: bool) -> dict:
+def _measure_embed(model: str, workload: Workload, *, timed: bool,
+                   row: "_MeasurementRow | None" = None) -> dict:
     """Encode the fixed batch of texts in one call.
 
     The whole batch in one request rather than eight requests, because batching
@@ -443,8 +601,14 @@ def _measure_embed(model: str, workload: Workload, *, timed: bool) -> dict:
 
     Retries on `supervisor.ModelNotReady` exactly like `_measure_text` — see
     `_await_settled_load` for the race this settles.
+
+    One call, so there is no PER-CALL progress to count — the row gets a
+    single phase word rather than an invented percentage over a request that
+    either has not answered yet or has.
     """
     texts = list(workload.params["texts"])
+    if row is not None:
+        row.set_detail(f"Encoding {len(texts)} texts…")
     deadline = _now() + _LOAD_TIMEOUT_S
     while True:
         start = _now()
@@ -464,12 +628,21 @@ def _measure_embed(model: str, workload: Workload, *, timed: bool) -> dict:
     }
 
 
-def _measure_image(model: str, workload: Workload, *, timed: bool) -> dict:
+def _measure_image(model: str, workload: Workload, *, timed: bool,
+                   row: "_MeasurementRow | None" = None) -> dict:
     """Render one image at the fixed canvas and this model's own step count.
 
     The PNG goes to a temp file that is deleted on the way out: a benchmark is a
     measurement, not a picture somebody asked for, and putting it in the user's
     images folder would leave the Playground's gallery full of lighthouses.
+
+    **No `set_detail` call here, and that is deliberate.** `generate_image`
+    already takes a `job` id and the WORKER reports its own step progress
+    straight onto it (`torch_image.py`'s `on_step_end`, "Denoising — step
+    N/steps") — the exact channel a Playground render already uses. Handing it
+    THIS row's own job, when there is one, means that real per-step detail
+    lands on the row with no invented number in between; the warm-up pass gets
+    a disposable job instead (see `run`), same as before this row existed.
     """
     params = workload.params
     steps = _image_steps(model)
@@ -483,18 +656,24 @@ def _measure_image(model: str, workload: Workload, *, timed: bool) -> dict:
             "seed": params["seed"],
             "out": os.path.join(tmp, "benchmark.png"),
         }
-        job = _unwatched_job()
+        job = row.job if row is not None else _unwatched_job()
         start = _now()
         try:
             supervisor.generate_image(model, request, job)
         except BaseException as e:
-            # The image path has no queue and so inherits no row today; closing
-            # anyway costs one swallowed `JobError` and means the two long calls
-            # do not differ in a way somebody has to remember.
-            _close_any_row(job, e)
+            # `row is None` on the WARM-UP pass (see `run`), which is exactly
+            # when `job` is the disposable, titleless one — closing it anyway
+            # costs one swallowed `JobError` and means the two long calls do
+            # not differ in a way somebody has to remember. When `row` is not
+            # None this is the row `run()` itself opened and will close once,
+            # AFTER sampling memory/device — closing it here too would report
+            # "done" a beat before that sampling actually happens.
+            if row is None:
+                _close_any_row(job, e)
             raise
         else:
-            _close_any_row(job)
+            if row is None:
+                _close_any_row(job)
         total = _now() - start
     if not timed:
         return {}
@@ -507,8 +686,8 @@ def _measure_image(model: str, workload: Workload, *, timed: bool) -> dict:
     }
 
 
-def _measure_transcript(model: str, workload: Workload, *,
-                        timed: bool) -> dict:
+def _measure_transcript(model: str, workload: Workload, *, timed: bool,
+                        row: "_MeasurementRow | None" = None) -> dict:
     """Decode the synthesized tone and report how many times faster than
     realtime it was.
 
@@ -521,9 +700,15 @@ def _measure_transcript(model: str, workload: Workload, *,
     optional passes that change what the decode IS, and a model benchmarked with
     speech detection on a tone would be measured on how much of it it decided to
     skip.
+
+    A phase word, not a percentage: the worker's own decode has no per-chunk
+    tick this module reads (unlike the image path's step callback), so a bar
+    here would be invented rather than measured.
     """
     params = workload.params
     seconds = float(params["audioSeconds"])
+    if row is not None:
+        row.set_detail(f"Transcribing {seconds:.0f}s of audio…")
     with tempfile.TemporaryDirectory(prefix="fused-bench-") as tmp:
         # Named so that a row INHERITED from the transcribe queue reads as ours:
         # `supervisor._transcribe_title` titles that row with this basename, and
@@ -542,26 +727,27 @@ def _measure_transcript(model: str, workload: Workload, *,
             "words": False,
             "out": os.path.join(tmp, "fused-benchmark-tone.json"),
             "outText": os.path.join(tmp, "fused-benchmark-tone.txt"),
-            # No `row`: that key is how a caller gives the worker a progress row
-            # to restate its identity onto, and a benchmark has none by design
-            # (see `run`). Without it the worker's ticks carry no title,
-            # `jobs.upsert` refuses them and `worker_base.report` swallows the
-            # refusal — so the decode runs and no row is created, which is
-            # exactly what is wanted here.
+            # No `row` REQUEST KEY: that is how a caller gives the worker a
+            # QUEUE-WAIT row to restate its identity onto (`_await_turn`'s own
+            # `row=` parameter), a different thing from the `_MeasurementRow`
+            # below — this benchmark already confirmed the model ready before
+            # calling here (`run`'s own ordering), so it is never queued
+            # behind anything and has no wait row to restate.
         }
-        job = _unwatched_job()
+        job = row.job if row is not None else _unwatched_job()
         start = _now()
         try:
             supervisor.generate_transcript(model, request, job)
         except BaseException as e:
-            # Both arms close the row, because the row this closes is inherited on
-            # the QUEUED path and a run that raises out of the queue (a ✕, a dead
-            # worker) is exactly when a row left running is most misleading. What
-            # the arms do NOT share is the state — see `_close_any_row`.
-            _close_any_row(job, e)
+            # `row is None` on the warm-up pass — see `_measure_image`'s
+            # identical guard for why the timed pass's own row is closed once,
+            # by `run()`, after memory/device sampling, rather than here.
+            if row is None:
+                _close_any_row(job, e)
             raise
         else:
-            _close_any_row(job)
+            if row is None:
+                _close_any_row(job)
         total = _now() - start
     if not timed:
         return {}
@@ -834,20 +1020,20 @@ def run(model: str, capability: str) -> dict:
     inventing a second protocol for a third long call would be new machinery
     with no new capability.
 
-    **No download-manager row is created, deliberately, and this is the third
-    design after two failures.** Server job rows are a TITLE-KEYED global
-    namespace — a page's only route to one is `useCacheScan.ts`'s map of
-    `job.title -> job` — and `supervisor.load` already owns the row titled
-    exactly `model`. Both spellings of a benchmark row are therefore broken: a
-    decorated title ("Benchmark: <model>") is a row no consumer can find, and the
-    bare model id SHADOWS the load row, which put the download manager's only
-    visible ✕ on the load rather than on the benchmark and let a cold run spin to
-    its hour-long timeout and record a phantom "did not finish loading in time".
-    A benchmark cannot own a row for a model that already has one, so it owns
-    none: the tab shows its own in-tab spinner for the duration. What the user
-    still sees through the expensive phase is the LOAD's own row, reported by the
-    supervisor with real byte counts, which is the row that was always right for
-    that wait.
+    **A download-manager row is opened for the MEASUREMENT phase only, and
+    this is the fourth design after three failures — see `_bench_job_title`
+    and `_MeasurementRow`.** Server job rows are a TITLE-KEYED global namespace
+    — a page's only route to one is `useCacheScan.ts`'s map of `job.title ->
+    job` — and `supervisor.load` already owns the row titled exactly `model`.
+    The first three attempts collided on that title (a decorated one no
+    consumer can find, or the bare model id shadowing the load row and letting
+    a cold run spin to its hour-long timeout) and gave up on having a row at
+    all, which meant total silence through the whole measurement — no row, no
+    percentage, nothing, which reads as the app having frozen. The fix was the
+    title, not the absence: `_bench_job_title` names a row that collides with
+    neither, so through the LOAD phase the user still watches the supervisor's
+    own row (real byte counts, exactly as before), and once loading ends this
+    module's own row opens for the phase that used to be silent.
 
     **A failure is a RESULT, and it is stored.** "This model OOMs on this
     laptop" is precisely the sort of thing somebody benchmarks to find out, so a
@@ -865,20 +1051,28 @@ def run(model: str, capability: str) -> dict:
     1. Resolve the runner FIRST. A capability this machine cannot serve fails
        with the registry's own sentence before anything is loaded or timed.
     2. Load to ready, timed (`None` when already resident).
-    3. One discarded warm-up pass. A first generation pays for graph
+    3. Open the measurement row (`_MeasurementRow`) — after loading, never
+       before, because the LOAD already has its own row and this one's whole
+       reason to exist is the phase that row does not cover.
+    4. One discarded warm-up pass. A first generation pays for graph
        compilation, a lazily-built tokenizer and a cold cache; timing it would
        make every benchmark a measurement of the first token in the process's
        life. Uniform across capabilities rather than tuned per capability, which
        does cost a second image render — accepted, because a warm-up rule that
        varies by capability is a rule nobody can hold in their head while
-       reading two numbers side by side.
-    4. The timed pass.
-    5. Memory and device off `describe()`.
-    6. **Unload, if step 2 loaded it** (D446) — success, failure or exception
+       reading two numbers side by side. Runs with NO row (`row=None`): the
+       warm-up is thrown away, and a progress row for work whose own timing is
+       discarded is more noise than signal.
+    5. The timed pass, with the row.
+    6. Memory and device off `describe()`.
+    7. **Unload, if step 2 loaded it** (D446) — success, failure or exception
        alike. A benchmark is a measurement, not a claim on the model's
        residency, so a cold run must not leave gigabytes parked after the
        button stops spinning; a WARM run (step 2 returned `None`) unloads
        nothing, because the model belongs to whoever already had it running.
+    8. Close the row with the outcome — cancelled, error with the reason, or
+       done — the same three-way split `_close_any_row` already uses for the
+       image/speech paths.
     """
     workload = WORKLOADS.get(capability)
     measure = _MEASURE.get(capability)
@@ -921,41 +1115,61 @@ def run(model: str, capability: str) -> dict:
         loaded_seconds = _load_to_ready(model, capability)
         record["loadSeconds"] = loaded_seconds
 
+        # Opened AFTER the load, never before — see the docstring's ordering
+        # and `_MeasurementRow`'s own for the whole design. `row_failure`
+        # travels the exception to the row's own `close()` at the very
+        # bottom of this block, rather than closing inline at each raise
+        # site: there are three of them below (Cancelled, SupervisorError,
+        # BaseException) and a row closed at only one would leave the other
+        # two "running" forever on a run that already ended.
+        row = _MeasurementRow(model, capability)
+        row.start()
+        row_failure: BaseException | None = None
         try:
-            # The discarded warm-up, then the timed pass. Same function twice — see
-            # step 3 of the docstring for why the first one's timings are thrown away
-            # and why the rule is uniform across capabilities.
-            measure(model, workload, timed=False)
-            record["metrics"] = measure(model, workload, timed=True)
+            try:
+                # The discarded warm-up (no row — see the docstring), then the
+                # timed pass, which gets the row so its own progress and its ✕
+                # both reach somewhere real.
+                measure(model, workload, timed=False)
+                record["metrics"] = measure(model, workload, timed=True, row=row)
 
-            record["peakResidentBytes"], record["device"] = _memory_and_device(
-                model, capability)
-            record["ok"] = True
+                record["peakResidentBytes"], record["device"] = _memory_and_device(
+                    model, capability)
+                record["ok"] = True
+            finally:
+                # D446: a benchmark that had to COLD-LOAD the model tears it back
+                # down when it is done — success, a failed workload, a timeout, or
+                # an exception mid-measurement alike, which is exactly the `finally`
+                # shape. `loaded_seconds` is `None` precisely when `_load_to_ready`
+                # found the model already resident (its own docstring's
+                # null-over-estimate rule, reused here as the unload signal rather
+                # than adding a second piece of state to track the same fact): a
+                # model somebody else was already using — a Playground chat, another
+                # tab — is never ours to unload, and the capability may not even be
+                # ours any more by the time we get here. Placed AFTER the memory and
+                # device read above, which needs the worker still resident to answer
+                # at all — unloading first would record both as null. `unload`'s own
+                # exception is swallowed rather than left to propagate: a teardown
+                # that fails must not steal the traceback from a measurement that
+                # failed for a real reason (and on the success path there is no
+                # exception in flight for it to compete with).
+                if loaded_seconds is not None:
+                    try:
+                        supervisor.unload(
+                            model=model, capability=capability,
+                            reason="Unloaded — a benchmark run loaded it and is done")
+                    except Exception:
+                        logger.exception(
+                            "benchmark: failed to unload %s after measuring it", model)
+        except BaseException as e:
+            row_failure = e
+            raise
         finally:
-            # D446: a benchmark that had to COLD-LOAD the model tears it back
-            # down when it is done — success, a failed workload, a timeout, or
-            # an exception mid-measurement alike, which is exactly the `finally`
-            # shape. `loaded_seconds` is `None` precisely when `_load_to_ready`
-            # found the model already resident (its own docstring's
-            # null-over-estimate rule, reused here as the unload signal rather
-            # than adding a second piece of state to track the same fact): a
-            # model somebody else was already using — a Playground chat, another
-            # tab — is never ours to unload, and the capability may not even be
-            # ours any more by the time we get here. Placed AFTER the memory and
-            # device read above, which needs the worker still resident to answer
-            # at all — unloading first would record both as null. `unload`'s own
-            # exception is swallowed rather than left to propagate: a teardown
-            # that fails must not steal the traceback from a measurement that
-            # failed for a real reason (and on the success path there is no
-            # exception in flight for it to compete with).
-            if loaded_seconds is not None:
-                try:
-                    supervisor.unload(
-                        model=model, capability=capability,
-                        reason="Unloaded — a benchmark run loaded it and is done")
-                except Exception:
-                    logger.exception(
-                        "benchmark: failed to unload %s after measuring it", model)
+            # Closed once, here, regardless of which of the three outer
+            # `except` clauses below ends up handling `row_failure` (or
+            # whether none of them do, on success) — see this row's own
+            # comment above for why a single close site is load-bearing.
+            row.close(row_failure)
     except (KeyboardInterrupt, SystemExit):
         # NOT a result, and not ours to swallow. A Ctrl-C on the dev server or
         # an interpreter shutdown arriving on this threadpool thread is not a

--- a/fused_render/ai/benchmark.py
+++ b/fused_render/ai/benchmark.py
@@ -595,13 +595,28 @@ def _measure_text(model: str, workload: Workload, *, timed: bool,
                     count += 1
                     if row is not None:
                         # A cheap counter plus a string format, called once
-                        # PER TOKEN — never a network call, see
+                        # PER CHUNK — never a network call, see
                         # `_MeasurementRow`'s own docstring for why that is
                         # safe: the watcher thread, not this loop, decides how
                         # often that turns into an actual job-row write, so
                         # this cannot perturb `tokensPerSecond` no matter how
                         # fast or slow decode is.
-                        row.set_detail(f"Decoding — {count}/{max_tokens} tokens")
+                        #
+                        # `count` is a CHUNK count standing in for a token
+                        # count, and the two are not the same thing by
+                        # definition (AI-3: the authoritative token counts —
+                        # `outputTokens`/`tokensPerSecond` below — are always
+                        # the WORKER's own `done["tokens"]`, never derived
+                        # here). Verified 1:1 for every runner this capability
+                        # currently has (`llama_text.py`'s `create_completion`
+                        # stream and `mlx_lm.stream_generate` both yield
+                        # exactly one chunk per sampled token), so the label
+                        # is accurate today — but `min(...)` keeps a live
+                        # display honest even against a hypothetical future
+                        # runner whose chunks are not 1:1, rather than trusting
+                        # that invariant to hold forever un-enforced.
+                        row.set_detail(
+                            f"Decoding — {min(count, max_tokens)}/{max_tokens} tokens")
                 elif kind == "done":
                     done = event
             break

--- a/fused_render/server/routers/ai_benchmark.py
+++ b/fused_render/server/routers/ai_benchmark.py
@@ -6,10 +6,12 @@ Three routes and nothing else:
   request is **held open for the whole run**, which is minutes, exactly as
   `POST /api/ai/image` and `POST /api/ai/transcribe` already are for work of the
   same length. Inventing a poll-a-benchmark-job protocol for a third long call
-  would be new machinery with no new capability. **No job id comes back and no
-  download-manager row is created** — see `benchmark.run` for why a benchmark
-  cannot own a row for a model that already has a load row; the tab shows its own
-  spinner for the duration.
+  would be new machinery with no new capability. **No `jobId` comes back on the
+  wire** — a titled download-manager row IS created for the measurement phase
+  (`benchmark._MeasurementRow`), but a page finds it the same way it finds any
+  other server row, through `useCacheScan.ts`'s `job.title -> job` map, never
+  through a value this endpoint hands back. See `benchmark.run` for why the row
+  is titled the way it is and why it opens only once loading ends.
 * `GET /api/ai/benchmark` — every stored run, plus THIS machine. The machine
   block travels with the history rather than only on each run because the page
   has to caption a comparison ("these numbers are from this laptop") before it

--- a/tests/test_ai_benchmark.py
+++ b/tests/test_ai_benchmark.py
@@ -1034,6 +1034,32 @@ def test_close_flushes_detail_without_re_forwarding_a_stale_cancel(bench, monkey
     assert jobs.list_jobs()[0]["detail"] == "Decoding — 100/128 tokens"
 
 
+def test_a_queued_transcription_does_not_rename_the_measurement_row(bench,
+                                                                    monkeypatch):
+    """Regression for the finding that handing this row's OWN job to
+    `generate_transcript` would let a real transcription's queue wait
+    (`_await_turn`'s `_transcribe_row(title, ...)`, `title` being the audio
+    file's basename) overwrite "Benchmark · <model>" for as long as the wait
+    lasted, with nothing to restore it. `_measure_transcript` now never hands
+    out its row's real job at all — this simulates exactly what a contended
+    `_TRANSCRIBE_LOCK` would do to whatever id it IS given, and the
+    measurement row must come through untouched."""
+    def generate_transcript(model, request, job):
+        jobs.upsert({"id": job, "title": os.path.basename(request["path"]),
+                     "state": "running", "kind": "task", "cancellable": True,
+                     "unit": "s", "detail": "Queued behind another transcription…"},
+                    server=True)
+        bench.advance(1.0)
+        return {"text": "beep"}
+
+    monkeypatch.setattr(benchmark.supervisor, "generate_transcript",
+                        generate_transcript)
+    benchmark.run("org/whisper", ai_registry.SPEECH_TO_TEXT)
+    ours = [r for r in jobs.list_jobs() if r["title"] == "Benchmark · org/whisper"]
+    assert len(ours) == 1, "the measurement row's title was renamed or lost"
+    assert ours[0]["state"] == "done"
+
+
 
 # -- cancellation is not a measurement ------------------------------------------
 #

--- a/tests/test_ai_benchmark.py
+++ b/tests/test_ai_benchmark.py
@@ -17,6 +17,7 @@ would assert one thing here and another there.
 """
 import json
 import os
+import time
 import wave
 
 import types
@@ -884,6 +885,154 @@ def test_the_measurement_rows_title_never_collides_with_the_load_row(bench):
     model = "org/some-model"
     assert benchmark._bench_job_title(model) != model
     assert model in benchmark._bench_job_title(model)
+
+
+# -- code review findings: the heartbeat, cancellable capabilities, retrying a
+# -- failed cancel forward, the close()-time flush, and the queue rename ------
+#
+# A review of the job-row feature above raised eight findings; the ones
+# confirmed as real bugs are regression-tested here (see the code comments at
+# each fix site for the full reasoning this section only summarises). Every
+# test here that starts a real `_MeasurementRow` pins `_BENCH_ROW_POLL_S` to a
+# large number first, so the row's OWN background watcher thread cannot tick
+# during the test and race the manual `_poll_once()`/`close()` calls the test
+# is trying to observe deterministically.
+
+
+def test_an_unchanged_detail_still_advances_updated_at(bench, monkeypatch):
+    """The FIRST cut only wrote to the job when the detail string changed —
+    which meant `jobs.upsert` (and its unconditional `job.updated_at = now`)
+    was never even CALLED for a tick with nothing new to say. A single-call
+    embedding measurement (one `set_detail`, ever) or a long warm-up (none at
+    all) could then sit long enough to trip `jobs._sweep`'s `STALE_DROP_S`
+    (600s, no exemption for a RUNNING server row) with `updated_at` frozen at
+    whatever it was on the LAST change. `_poll_once` now restates the row in
+    full on every tick regardless, so `updated_at` moves even when nothing
+    the reader would call "new" happened."""
+    monkeypatch.setattr(benchmark, "_BENCH_ROW_POLL_S", 60.0)
+    wall = {"t": 1_700_000_000.0}
+    monkeypatch.setattr(time, "time", lambda: wall["t"])
+    row = benchmark._MeasurementRow("some/text-model", ai_registry.TEXT_GENERATION)
+    row.start()
+    try:
+        before = jobs.list_jobs()[0]["updated_at"]
+        wall["t"] += 1.0
+        # No `set_detail` call in between — the detail is UNCHANGED.
+        row._poll_once()
+        after = next(r for r in jobs.list_jobs() if r["id"] == row.job)["updated_at"]
+        assert after == pytest.approx(before + 1.0), (
+            "a tick with nothing new to say must still advance updated_at, or "
+            "jobs._sweep's STALE_DROP_S silently drops a long-running row"
+        )
+    finally:
+        row.close()
+
+
+def test_a_stale_but_untouched_row_is_not_dropped_by_the_sweep(bench, monkeypatch):
+    """The concrete failure this heartbeat prevents: without it, a row whose
+    detail never changed for `STALE_DROP_S` was `_forget`'n by `jobs._sweep`,
+    which also adds its id to `_dismissed` — after which every later report,
+    including `close()`'s own terminal one, is refused as a "late tick"
+    (`jobs.upsert` only reopens a dismissed id on a report that carries
+    `state: "running"`, which a bare `detail=` tick does not)."""
+    monkeypatch.setattr(benchmark, "_BENCH_ROW_POLL_S", 60.0)
+    wall = {"t": 1_700_000_000.0}
+    monkeypatch.setattr(time, "time", lambda: wall["t"])
+    row = benchmark._MeasurementRow("some/text-model", ai_registry.TEXT_GENERATION)
+    row.start()
+    try:
+        # From `start()`'s own report to the sweep below is comfortably more
+        # than STALE_DROP_S — the exact shape a long warm-up or a
+        # single-shot embedding measurement produces — but a heartbeat lands
+        # WELL INSIDE STALE_DROP_S of the sweep itself.
+        wall["t"] += jobs.STALE_DROP_S - 1.0
+        row._poll_once()  # the heartbeat — the only thing keeping this alive
+        wall["t"] += jobs.STALE_DROP_S - 1.0  # another window, still no change
+        with jobs._lock:
+            jobs._sweep(wall["t"])
+        assert row.job in jobs._jobs, (
+            "the row was forgotten despite a heartbeat well inside "
+            "STALE_DROP_S of the sweep — the restate-every-tick fix did not "
+            "reach jobs._sweep"
+        )
+    finally:
+        row.close()
+
+
+def test_embeddings_row_is_not_cancellable(bench, monkeypatch):
+    """Neither embedding runner (`mlx_embed`, `transformers_embed`) checks
+    `worker_base.CANCEL` — a single blocking `model.encode()` call has no
+    callback to check it from — so a ✕ on an embeddings row would be silently
+    ignored, the call would finish normally, and the run would be recorded
+    `ok:true` despite the user trying to stop it. The row must not offer a ✕
+    that does nothing."""
+    monkeypatch.setattr(benchmark.supervisor, "generate_embed",
+                        lambda model, body: (bench.advance(0.1),
+                                             {"vectors": [], "dim": 8})[1])
+    benchmark.run("some/embed-model", ai_registry.EMBEDDINGS)
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert rows[0]["cancellable"] is False
+
+
+def test_text_image_and_speech_rows_stay_cancellable(bench, monkeypatch):
+    """The other three capabilities' workers DO check `worker_base.CANCEL`
+    (verified per runner — see `_CANCELLABLE_CAPABILITIES`'s own comment), so
+    their rows must keep advertising a ✕ that actually works."""
+    _text_run(bench, monkeypatch)
+    assert jobs.list_jobs()[0]["cancellable"] is True
+
+
+def test_a_failed_cancel_forward_is_retried_not_abandoned(bench, monkeypatch):
+    """`cancel_generation` returning False (no ready worker yet, or the
+    `/cancel` POST raising `OSError`) used to be read as "done" — `_poll_once`
+    returned True unconditionally after CALLING it, regardless of what it
+    returned — which stopped the watcher thread for good and froze the row's
+    detail for the rest of a multi-minute run, ✕ never actually honoured."""
+    monkeypatch.setattr(benchmark, "_BENCH_ROW_POLL_S", 60.0)
+    attempts = []
+
+    def cancel_generation(capability):
+        attempts.append(capability)
+        return len(attempts) >= 3  # fails twice, then finally reaches a worker
+
+    monkeypatch.setattr(benchmark.supervisor, "cancel_generation", cancel_generation)
+    row = benchmark._MeasurementRow("some/text-model", ai_registry.TEXT_GENERATION)
+    row.start()
+    try:
+        jobs.request_cancel(row.job)
+        assert row._poll_once() is False, "a failed forward must not read as done"
+        assert row._poll_once() is False
+        assert row._poll_once() is True, "the third attempt succeeds and should stop the watcher"
+        assert len(attempts) == 3
+    finally:
+        row.close()
+
+
+def test_close_flushes_detail_without_re_forwarding_a_stale_cancel(bench, monkeypatch):
+    """`cancel_requested` is server state that only a TERMINAL report clears
+    (`jobs.upsert`'s own rule) — so if the run finishes a beat after somebody
+    pressed the ✕ but before the watcher thread's next tick, `cancel_requested`
+    is still True when `close()` runs. The old `close()` flushed detail by
+    calling `_poll_once()` — the SAME method that forwards a cancel — which
+    would ask `cancel_generation` to stop whatever is CURRENTLY resident for
+    the capability, possibly an unrelated generation the user started the
+    instant this run ended. `close()` must flush detail only."""
+    monkeypatch.setattr(benchmark, "_BENCH_ROW_POLL_S", 60.0)
+    cancelled = []
+    monkeypatch.setattr(benchmark.supervisor, "cancel_generation",
+                        lambda capability: cancelled.append(capability) or True)
+    row = benchmark._MeasurementRow("some/text-model", ai_registry.TEXT_GENERATION)
+    row.start()
+    row.set_detail("Decoding — 100/128 tokens")
+    jobs.request_cancel(row.job)  # the ✕, pressed but never yet observed by a tick
+    row.close()  # the run ended on its own before the watcher saw it
+    assert cancelled == [], (
+        "close() forwarded a cancel to whatever is resident NOW, after the "
+        "run it belonged to was already over"
+    )
+    assert jobs.list_jobs()[0]["detail"] == "Decoding — 100/128 tokens"
+
 
 
 # -- cancellation is not a measurement ------------------------------------------

--- a/tests/test_ai_benchmark.py
+++ b/tests/test_ai_benchmark.py
@@ -1060,6 +1060,38 @@ def test_a_queued_transcription_does_not_rename_the_measurement_row(bench,
     assert ours[0]["state"] == "done"
 
 
+def test_the_displayed_token_count_never_exceeds_max_tokens(bench, monkeypatch):
+    """`count` counts CHUNK events as a live stand-in for a token count — true
+    1:1 for every runner this capability currently has, but a live display
+    should not trust that invariant to hold forever un-enforced. A runner
+    that ever emitted more chunks than the workload's own `maxTokens` (128)
+    must not display an impossible "140/128 tokens"."""
+    workload = benchmark.WORKLOADS[ai_registry.TEXT_GENERATION]
+    max_tokens = workload.params["maxTokens"]
+
+    def generate_text_warmup(model, body):
+        bench.advance(0.1)
+        yield {"type": "chunk", "text": "x"}
+        yield {"type": "done", "ok": True, "tokens": 1}
+
+    def generate_text_overshoot(model, body):
+        bench.advance(0.1)
+        for _ in range(max_tokens + 12):
+            yield {"type": "chunk", "text": "x"}
+        yield {"type": "done", "ok": True, "tokens": max_tokens + 12}
+
+    calls = {"n": 0}
+
+    def dispatch(model, body):
+        calls["n"] += 1
+        gen = generate_text_warmup if calls["n"] == 1 else generate_text_overshoot
+        return gen(model, body)
+
+    monkeypatch.setattr(benchmark.supervisor, "generate_text", dispatch)
+    benchmark.run("some/text-model", ai_registry.TEXT_GENERATION)
+    detail = jobs.list_jobs()[0]["detail"]
+    assert detail == f"Decoding — {max_tokens}/{max_tokens} tokens"
+
 
 # -- cancellation is not a measurement ------------------------------------------
 #

--- a/tests/test_ai_benchmark.py
+++ b/tests/test_ai_benchmark.py
@@ -54,6 +54,13 @@ def bench(tmp_path, monkeypatch):
     """A clock, a forced runner resolution, a tmp store, and a resident model.
 
     Returns the `Clock` — every test scripts its own timeline onto it.
+
+    `jobs.reset()` on both ends: every `run()` now opens a real
+    `_MeasurementRow` (see that class), so a test that does not otherwise care
+    about job rows would still leave one behind in the module-global `_jobs`
+    dict for whichever test runs next in the same session — this fixture used
+    to need no such reset because the OLD design opened no row a real test
+    could ever see.
     """
     monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
     clock = Clock()
@@ -68,7 +75,9 @@ def bench(tmp_path, monkeypatch):
     # tests here are warm and must never reach it at all; the ones that force a
     # cold load override this with a recording fake (see D446's section below).
     monkeypatch.setattr(benchmark.supervisor, "unload", lambda **kwargs: False)
-    return clock
+    jobs.reset()
+    yield clock
+    jobs.reset()
 
 
 # -- text generation ------------------------------------------------------------
@@ -656,67 +665,61 @@ def test_a_capability_with_no_runner_here_fails_without_loading(bench, monkeypat
     assert record["runner"] is None
 
 
-# -- no job row of our own -----------------------------------------------------
+# -- the measurement row ---------------------------------------------------
 #
-# **A benchmark deliberately OPENS no download-manager row.** Three rounds of
-# trying produced three new defects, all of them the same root cause: server job
-# rows are a TITLE-KEYED global namespace (`useCacheScan.ts` maps
-# `job.title -> job`) with several consumers, and `supervisor.load` already owns
-# the row titled exactly `model`. A prefixed title cannot be found by any
-# consumer; the bare title SHADOWS the load row, which put the only visible ✕ on
-# the load instead of the benchmark and left a cold run spinning to its hour-long
-# timeout to record a phantom "did not finish loading in time".
-#
-# So the tab shows a plain in-tab spinner. These tests are the guard on that, and
-# it is why they assert an ABSENCE. The one row a benchmark can INHERIT rather
-# than open — the transcribe queue's — has its own section further down.
+# **A benchmark now OPENS a download-manager row for the measurement phase —
+# the fourth design, after three that gave up on a row entirely.** Every
+# earlier attempt collided on TITLE (`useCacheScan.ts` maps `job.title ->
+# job`, and `supervisor.load` already owns the row titled exactly `model`): a
+# decorated title is a row no consumer can find, the bare model id SHADOWS the
+# load row and puts the manager's only ✕ on the load instead. `_bench_job_title`
+# fixes the actual defect (the title) rather than removing the row, so these
+# tests assert PRESENCE — a row, titled distinctly, that reaches a terminal
+# state — where the previous round asserted an absence. The one row a
+# benchmark can INHERIT rather than open — the transcribe queue's — keeps its
+# own section further down, unchanged by this.
 
 
-@pytest.fixture
-def norows(tmp_path, monkeypatch):
-    """`bench`, but with progress reporting left REAL and the job store empty, so
-    a row created anywhere on the path is visible to the assertion."""
-    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
-    clock = Clock()
-    monkeypatch.setattr(benchmark, "_now", clock)
-    monkeypatch.setattr(benchmark.registry, "for_capability", lambda cap: FakeRunner)
-    monkeypatch.setattr(benchmark.supervisor, "ready_worker",
-                        lambda cap, model=None: object())
-    monkeypatch.setattr(benchmark.supervisor, "describe", lambda: {"loaded": []})
-    jobs.reset()
-    yield clock
-    jobs.reset()
-
-
-def test_a_run_creates_no_job_row(norows, monkeypatch):
-    record, _ = _text_run(norows, monkeypatch)
+def test_a_run_opens_a_row_titled_distinctly_from_the_load_row(bench, monkeypatch):
+    record, _ = _text_run(bench, monkeypatch)
     assert record["ok"] is True
-    assert jobs.list_jobs() == [], (
-        "a benchmark opened a download-manager row; it must not — the title "
-        "namespace is shared with supervisor.load and collides on the model id"
-    )
+    rows = jobs.list_jobs()
+    assert len(rows) == 1, "exactly one row for a benchmark, never zero or two"
+    assert rows[0]["title"] == "Benchmark · some/text-model"
+    # Distinct from the LOAD row's own title (the bare model id) — colliding
+    # here is the exact defect the first three designs shipped.
+    assert rows[0]["title"] != "some/text-model"
+    assert rows[0]["state"] == "done"
+    assert rows[0]["cancellable"] is True
 
 
-def test_a_cold_run_creates_no_job_row_either(norows, monkeypatch):
-    """The cold path is where the collision bit: `supervisor.load` opens the row
-    titled `model`, and anything of ours sharing that namespace shadowed it."""
+def test_a_cold_run_opens_no_row_until_loading_ends(bench, monkeypatch):
+    """Through the load, the row worth watching is the supervisor's own — real
+    byte counts, exactly as before this feature. This benchmark's own row
+    opens only once `_load_to_ready` returns, so `useCacheScan` still resolves
+    the bare-titled LOAD row for a model that has not finished loading yet."""
     states = {"ready": False}
     monkeypatch.setattr(benchmark.supervisor, "ready_worker",
                         lambda cap, model=None: object() if states["ready"] else None)
 
     def start_resident(model, capability):
-        norows.advance(8.5)
+        bench.advance(8.5)
         states["ready"] = True
         return {"jobId": "sys:ai-model:x", "model": model, "state": "loading"}, FakePending()
 
     monkeypatch.setattr(benchmark.supervisor, "_start_resident", start_resident)
     monkeypatch.setattr(benchmark, "_LOAD_POLL_S", 0.0)
-    record, _ = _text_run(norows, monkeypatch)
+    record, _ = _text_run(bench, monkeypatch)
     assert record["loadSeconds"] == pytest.approx(8.5)
-    assert jobs.list_jobs() == []
+    # The fake `_start_resident` above never calls `jobs.upsert` itself (the
+    # real one is `supervisor`'s business, not this module's), so the only row
+    # that can appear is this benchmark's own measurement row.
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Benchmark · some/text-model"
 
 
-def test_a_failed_run_creates_no_job_row(norows, monkeypatch):
+def test_a_failed_run_still_closes_its_row_as_an_error(bench, monkeypatch):
     def generate_text(model, body):
         raise benchmark.supervisor.SupervisorError("out of memory")
         yield  # pragma: no cover
@@ -724,35 +727,35 @@ def test_a_failed_run_creates_no_job_row(norows, monkeypatch):
     monkeypatch.setattr(benchmark.supervisor, "generate_text", generate_text)
     record = benchmark.run("some/text-model", ai_registry.TEXT_GENERATION)
     assert record["ok"] is False
-    assert jobs.list_jobs() == []
-
-
-def test_the_module_offers_no_job_row_machinery():
-    """Named absences, so re-adding any of them is a deliberate act with a test
-    to argue with rather than an innocent-looking convenience."""
-    for gone in ("row_fields", "job_id", "BENCH_JOB_PREFIX", "_report",
-                 "_WORKER_HONOURS_CANCEL"):
-        assert not hasattr(benchmark, gone), gone
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert rows[0]["state"] == "error"
+    assert "out of memory" in rows[0]["message"]
 
 
 def test_run_takes_no_job_argument():
     """The signature is the enforcement: a caller cannot hand this a row to
-    report on, so no caller can quietly reintroduce one."""
+    report on — `run()` opens its OWN internally, via `_MeasurementRow`, so no
+    caller can be handed the wrong one or forget to pass one at all."""
     import inspect
     assert list(inspect.signature(benchmark.run).parameters) == ["model", "capability"]
 
 
-def test_a_generation_the_worker_needs_a_job_id_for_gets_a_private_one(norows,
-                                                                      monkeypatch):
+def test_a_generation_the_worker_needs_a_job_id_for_gets_the_measurement_row(
+        bench, monkeypatch):
     """`generate_image`/`generate_transcript` take a job id structurally, and
-    `worker_base.report`'s `job or JOB_ID` falls back to the model's own LOAD row
-    when handed a falsy one — which would paint benchmark progress onto the
-    load's bar. So the id is real, private, and names no row."""
+    `worker_base.report`'s `job or JOB_ID` falls back to the model's own LOAD
+    row when handed a falsy one — which would paint benchmark progress onto
+    the load's bar. The discarded warm-up pass still gets a private,
+    disposable id (a progress row for work whose own timing is thrown away is
+    more noise than signal — see `run`'s docstring); only the TIMED pass gets
+    the real measurement row, so the worker's own step progress lands
+    somewhere a person can see it."""
     seen = []
 
     def generate_image(model, request, job):
         seen.append(job)
-        norows.advance(1.0)
+        bench.advance(1.0)
         return {"path": request["out"], "steps": request["steps"]}
 
     monkeypatch.setattr(benchmark.supervisor, "generate_image", generate_image)
@@ -762,7 +765,125 @@ def test_a_generation_the_worker_needs_a_job_id_for_gets_a_private_one(norows,
     # Never the model id, and never anything a page could write.
     assert all(job != "some/image-model" for job in seen)
     assert all(job.startswith("sys:") for job in seen)
-    assert jobs.list_jobs() == []
+    # The warm-up's own private id, then the measurement row's — never the same.
+    assert seen[0] != seen[1]
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert rows[0]["id"] == seen[1]
+
+
+def test_text_progress_updates_the_row_with_real_token_counts(bench, monkeypatch):
+    """`_measure_text` calls `set_detail` once per decoded token; `close()`
+    flushes the LAST one synchronously (see its own docstring), so a person
+    watching the corner sees the real count out of the workload's own
+    `maxTokens` — never an invented percentage."""
+    def generate_text(model, body):
+        bench.advance(0.1)
+        yield {"type": "chunk", "text": "x"}
+        yield {"type": "done", "ok": True, "tokens": 1}
+
+    monkeypatch.setattr(benchmark.supervisor, "generate_text", generate_text)
+    benchmark.run("some/text-model", ai_registry.TEXT_GENERATION)
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    # The workload's fixed `maxTokens` (128) is the denominator — see
+    # `WORKLOADS[TEXT_GENERATION]`.
+    assert "1/128 tokens" in rows[0]["detail"]
+
+
+def test_an_embedding_row_states_the_phase_not_a_percentage(bench, monkeypatch):
+    monkeypatch.setattr(benchmark.supervisor, "generate_embed",
+                        lambda model, body: (bench.advance(0.1),
+                                             {"vectors": [], "dim": 8})[1])
+    benchmark.run("some/embed-model", ai_registry.EMBEDDINGS)
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert "Encoding" in rows[0]["detail"]
+    assert "8 texts" in rows[0]["detail"]
+
+
+def test_a_speech_row_states_the_phase_not_a_percentage(bench, monkeypatch):
+    def generate_transcript(model, request, job):
+        bench.advance(0.1)
+        return {"text": "beep"}
+
+    monkeypatch.setattr(benchmark.supervisor, "generate_transcript",
+                        generate_transcript)
+    benchmark.run("some/whisper", ai_registry.SPEECH_TO_TEXT)
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert "Transcribing" in rows[0]["detail"]
+    assert "30s" in rows[0]["detail"]
+
+
+# -- the row's ✕ cancels cooperatively, never through unload --------------------
+#
+# `_MeasurementRow._poll_once` is what forwards a pressed ✕ to
+# `supervisor.cancel_generation` — the SAME channel the tab's own Stop button
+# already uses. Tested directly, on the unit responsible, rather than through
+# `run()`'s own background watcher thread: that thread's cadence is real wall
+# clock (`_BENCH_ROW_POLL_S`), and racing a background poll against a
+# synchronous fake generator is exactly the kind of test that is fast nine
+# times out of ten and flaky the tenth.
+
+
+def test_a_pressed_x_is_forwarded_to_cancel_generation(bench, monkeypatch):
+    cancelled = []
+    monkeypatch.setattr(benchmark.supervisor, "cancel_generation",
+                        lambda capability: cancelled.append(capability) or True)
+    row = benchmark._MeasurementRow("some/text-model", ai_registry.TEXT_GENERATION)
+    row.start()
+    try:
+        jobs.request_cancel(row.job)
+        assert row._poll_once() is True
+        assert cancelled == [ai_registry.TEXT_GENERATION]
+    finally:
+        row.close()
+
+
+def test_an_unpressed_row_never_calls_cancel_generation(bench, monkeypatch):
+    cancelled = []
+    monkeypatch.setattr(benchmark.supervisor, "cancel_generation",
+                        lambda capability: cancelled.append(capability) or True)
+    row = benchmark._MeasurementRow("some/text-model", ai_registry.TEXT_GENERATION)
+    row.start()
+    try:
+        assert row._poll_once() is False
+        assert cancelled == []
+    finally:
+        row.close()
+
+
+def test_a_cancelled_run_never_calls_unload(bench, monkeypatch):
+    """`unload` tears down the worker PROCESS — the exact thing `BenchmarkTab`'s
+    header comment documents as the wrong tool for a ✕, because it turns a
+    deliberate stop into a permanent 'this model failed' row. `run()`'s own
+    D446 teardown only ever fires for a COLD load, and this run is warm."""
+    unloaded = []
+    monkeypatch.setattr(benchmark.supervisor, "unload",
+                        lambda **kwargs: unloaded.append(kwargs) or False)
+
+    def generate_text(model, body):
+        raise benchmark.supervisor.SupervisorError("cancelled")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(benchmark.supervisor, "generate_text", generate_text)
+    with pytest.raises(benchmark.Cancelled):
+        benchmark.run("some/text-model", ai_registry.TEXT_GENERATION)
+    assert unloaded == []
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert rows[0]["state"] == "cancelled"
+
+
+def test_the_measurement_rows_title_never_collides_with_the_load_row(bench):
+    """The whole mechanism: `useCacheScan.ts` maps `job.title -> job`, so a
+    title equal to the bare model id would be indistinguishable from
+    `supervisor.load`'s own row — the exact defect three earlier designs
+    shipped (see the module's own docstring)."""
+    model = "org/some-model"
+    assert benchmark._bench_job_title(model) != model
+    assert model in benchmark._bench_job_title(model)
 
 
 # -- cancellation is not a measurement ------------------------------------------
@@ -1046,7 +1167,11 @@ def test_a_warm_model_never_asks_the_supervisor_to_load(bench, monkeypatch):
 # none of them could see any of this.
 
 
-def test_a_row_inherited_from_the_transcribe_queue_is_closed(norows, monkeypatch):
+def test_a_row_inherited_from_the_transcribe_queue_is_closed(bench, monkeypatch):
+    """The WARM-UP pass still gets a disposable, titleless job id (`row` is
+    `None` for that call — see `run`), so it is still the one path a real
+    transcribe queue can INHERIT a row onto; the TIMED pass gets this
+    benchmark's own already-titled measurement row instead."""
     seen = {}
 
     def generate_transcript(model, request, job):
@@ -1057,7 +1182,7 @@ def test_a_row_inherited_from_the_transcribe_queue_is_closed(norows, monkeypatch
                     server=True)
         seen["job"] = job
         seen["title"] = os.path.basename(request["path"])
-        norows.advance(3.0)
+        bench.advance(3.0)
         return {"text": "beep"}
 
     monkeypatch.setattr(benchmark.supervisor, "generate_transcript",
@@ -1089,15 +1214,18 @@ def test_the_temp_audio_is_named_so_an_inherited_row_reads_as_a_benchmark(
     assert seen[-1].endswith(".wav")
 
 
-def test_a_text_run_creates_no_row_and_reaches_no_closer(norows, monkeypatch):
-    """The ordinary path stays row-free. It does not reach `_close_any_row` at
-    all — only the image and transcript paths do — which is why the property that
-    the terminal report cannot CREATE a row is pinned on a transcript run
-    instead, further down. This test used to claim that property and never call
-    the function."""
-    record, _ = _text_run(norows, monkeypatch)
+def test_a_text_run_never_reaches_close_any_row_directly(bench, monkeypatch):
+    """`_measure_text` never calls `_close_any_row` itself — only the image and
+    transcript paths do, because only they hand the worker a job id it can
+    report progress to. The one row a text run shows is `run()`'s own
+    `_MeasurementRow`, closed through `row.close()`, not through that
+    function directly — which is why the property that a terminal report
+    cannot CREATE a row is pinned on a transcript run instead, further down."""
+    record, _ = _text_run(bench, monkeypatch)
     assert record["ok"] is True
-    assert jobs.list_jobs() == []
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert rows[0]["state"] == "done"
 
 
 # -- the inherited row's terminal state tells the truth -------------------------
@@ -1119,7 +1247,7 @@ def _queue_row(job: str, path: str) -> None:
 
 
 def test_a_cancelled_queued_transcription_closes_its_row_as_cancelled(
-        norows, monkeypatch):
+        bench, monkeypatch):
     seen = {}
 
     def generate_transcript(model, request, job):
@@ -1137,7 +1265,7 @@ def test_a_cancelled_queued_transcription_closes_its_row_as_cancelled(
     )
 
 
-def test_a_failed_queued_transcription_closes_its_row_as_an_error(norows,
+def test_a_failed_queued_transcription_closes_its_row_as_an_error(bench,
                                                                  monkeypatch):
     seen = {}
 
@@ -1158,13 +1286,13 @@ def test_a_failed_queued_transcription_closes_its_row_as_an_error(norows,
 
 
 def test_a_successful_queued_transcription_still_closes_its_row_as_done(
-        norows, monkeypatch):
+        bench, monkeypatch):
     seen = {}
 
     def generate_transcript(model, request, job):
         _queue_row(job, request["path"])
         seen["job"] = job
-        norows.advance(3.0)
+        bench.advance(3.0)
         return {"text": "beep"}
 
     monkeypatch.setattr(benchmark.supervisor, "generate_transcript",
@@ -1174,7 +1302,7 @@ def test_a_successful_queued_transcription_still_closes_its_row_as_done(
     assert row["state"] == "done"
 
 
-def test_a_cancelled_image_render_closes_its_row_as_cancelled(norows, monkeypatch):
+def test_a_cancelled_image_render_closes_its_row_as_cancelled(bench, monkeypatch):
     """The image path inherits no row today, but it takes the same code — so the
     two long calls must not differ in a way somebody has to remember."""
     seen = {}
@@ -1193,21 +1321,26 @@ def test_a_cancelled_image_render_closes_its_row_as_cancelled(norows, monkeypatc
 
 
 def test_closing_a_row_that_does_not_exist_creates_nothing_on_the_real_path(
-        norows, monkeypatch):
-    """Drives a TRANSCRIPT run, which is the only path that calls
-    `_close_any_row` — the earlier version of this test drove a text run and so
-    asserted an absence on a path that never called the function it documents.
-    Titlelessness is the property: `jobs.upsert` refuses a first report with no
-    title, so the report closes a row that exists and cannot bring one about."""
+        bench, monkeypatch):
+    """Drives a TRANSCRIPT run whose fake never opens a queue row on either
+    call. The warm-up pass's `_close_any_row` closes a titleless, disposable
+    job that was never made visible — closing a row that does not exist
+    creates nothing, `jobs.upsert`'s own titleless-refusal rule. The one row
+    that DOES appear is the measurement row `run()` itself always opens now
+    (see the section above) — this test is about the OTHER one staying
+    invisible, not about a benchmark leaving no trace at all."""
     def generate_transcript(model, request, job):
-        norows.advance(3.0)
+        bench.advance(3.0)
         return {"text": "beep"}
 
     monkeypatch.setattr(benchmark.supervisor, "generate_transcript",
                         generate_transcript)
     record = benchmark.run("org/whisper", ai_registry.SPEECH_TO_TEXT)
     assert record["ok"] is True
-    assert jobs.list_jobs() == []
+    rows = jobs.list_jobs()
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Benchmark · org/whisper"
+    assert rows[0]["state"] == "done"
 
 
 # -- an error state that has not been written yet -------------------------------

--- a/tests/test_ai_benchmark_api.py
+++ b/tests/test_ai_benchmark_api.py
@@ -382,17 +382,20 @@ def test_posting_a_curated_but_undownloaded_model_is_a_404_not_a_download(
     assert loads == []
 
 
-def test_the_response_carries_no_job_id_and_no_row_is_created(client, on_disk,
-                                                              monkeypatch):
-    """The removal, guarded end to end.
+def test_the_response_carries_no_job_id_but_a_titled_row_is_created(
+        client, on_disk, monkeypatch):
+    """The wire contract, guarded end to end.
 
-    A benchmark used to hand back a `jobId`, and three attempts to make that row
-    work produced three defects: a decorated title no consumer could find, then a
-    bare title that SHADOWED the row `supervisor.load` opens for the same model —
-    putting the download manager's only ✕ on the load and letting a cold run spin
-    to its hour-long timeout. Server job rows are a title-keyed namespace shared
-    with the load path, so a benchmark cannot have one. Reporting is left REAL
-    here, so a row created anywhere on the path shows up in this assertion.
+    The HTTP response never carries a `jobId` — a page finds the measurement
+    row the same way it finds any other server row, through
+    `useCacheScan.ts`'s `job.title -> job` map, never through a value handed
+    back by this endpoint. Three earlier attempts at the row itself collided
+    on TITLE (a decorated one no consumer could find, then a bare one that
+    SHADOWED the row `supervisor.load` opens for the same model — putting the
+    download manager's only ✕ on the load and letting a cold run spin to its
+    hour-long timeout); `_bench_job_title` is the fix, so THIS test asserts a
+    row exists, titled distinctly, rather than asserting none does. Reporting
+    is left REAL here, so the row the run actually opened shows up.
     """
     monkeypatch.setattr(benchmark.registry, "for_capability", lambda cap: FakeRunner)
     monkeypatch.setattr(benchmark.supervisor, "ready_worker",
@@ -410,9 +413,11 @@ def test_the_response_carries_no_job_id_and_no_row_is_created(client, on_disk,
                      capability=ai_registry.TEXT_GENERATION).json()
         assert "jobId" not in body
         assert body["run"]["ok"] is True
-        assert jobs.list_jobs() == [], (
-            "a benchmark request created a download-manager row"
-        )
+        rows = jobs.list_jobs()
+        assert len(rows) == 1, "exactly one row for a benchmark, never zero or two"
+        assert rows[0]["title"] == "Benchmark · bench/model"
+        assert rows[0]["title"] != "bench/model"
+        assert rows[0]["state"] == "done"
     finally:
         jobs.reset()
 


### PR DESCRIPTION
## Summary

- **A benchmark run is no longer silent.** After "Loading weights into memory…" the whole measurement phase — minutes of it — reported nothing at all: no job row in the corner, and only a static "Benchmarking… this takes minutes" in the tab. `benchmark.run` now opens a real download-manager row for the measurement phase, titled `Benchmark · <model>` so it collides with neither `supervisor.load`'s bare-model-id row nor the undiscoverable decorated titles that made three earlier attempts give up on a row entirely. The row's ✕ cancels **cooperatively** via `supervisor.cancel_generation` — never `unload`, which tears down the worker process and records a deliberate stop as a permanent "this model failed".
- **The detail is measured, never invented.** Text generation counts decoded tokens (`Decoding — 41/128 tokens`); image generation hands the worker this row's own job id so its existing per-step callback lands here for free (`Denoising — step 12/20`); speech and embeddings get a phase sentence. No capability gets a fabricated percentage. The per-token `set_detail` is a string format under a lock — a watcher thread decides how often that becomes an actual row write, so row updates cannot perturb `tokensPerSecond`.
- **The tab's own busy row ticks.** `Loading weights into memory…` → `Measuring — 1:24`, with the phase read from the AI runtime's already-polled `loaded[]` table rather than guessed from elapsed time, so a cold model still pulling gigabytes is not labelled "Measuring".
- **Share the comparison chart as a PNG.** A new Share button beside the metric picker draws the chart, this machine's hardware line (`macOS · arm64 · 12 cores · 32 GB RAM · mps`) and the fused render mark onto one canvas card, then delivers it through the OS share sheet, the clipboard, or a download — whichever the browser supports — and says which of the three actually happened.
- **Row actions are icons now.** Run / Run again → play, running → spun spinner, Details → chevron (still a real `<details>` disclosure), Share → share, queue Stop → stop. Every one keeps its former words as `aria-label` **and** `title`. `Run all N models` stays text on purpose: that label is the only warning that each run is a cold load costing minutes and gigabytes.

## Visuals

What a cold run reports, phase by phase — the middle box is the part that used to be silence.

```mermaid
flowchart TD
    A[Run pressed] --> B[Load phase]
    B --> B1["supervisor.load row<br/>real byte counts"]
    B --> B2["tab: Loading weights…"]
    B --> C[Measurement phase]
    C --> C1["Benchmark · model row<br/>real detail + cancel"]
    C --> C2["tab: Measuring — 1:24"]
    C1 --> D{Outcome}
    D -->|cancelled| E["cancel_generation<br/>nothing recorded"]
    D -->|done / error| F[Row closed, run stored]
```

## Usage

**Progress.** AI Models → Benchmark → Run on any capability. The corner job row appears once loading finishes, titled `Benchmark · <model>`, with live detail and a ✕. The row in the tab reads `Loading weights into memory…` then `Measuring — m:ss`.

**Share.** Pick a metric on a capability that has at least one successful run, then press the share glyph beside the Metric picker. The button reports where the card went ("Saved as a PNG", "Copied to the clipboard", or nothing when a share sheet was dismissed). Filenames look like `fused-render-benchmark-text-generation-tokens-per-second.png`.

## Test Plan

- [x] `tests/test_ai_benchmark.py`, `test_ai_benchmark_api.py`, `test_ai_benchmark_store.py` — the ~15 "no job row" assertions rewritten to assert the row's presence, title and terminal state, plus new tests for token-progress detail, phase-only detail, cancel-forwards-to-`cancel_generation`, and title non-collision with the load row (104 passed).
- [x] `frontend`: new `shareCard.test.ts` (hardware line, provenance, metric subtitle, filename, layout arithmetic) and `benchmark.test.ts` cases for `busyRowText`; `bun test src/apps/ai_models` 435 pass; `bun run typecheck` and `check-boundaries.mjs` clean.
- [ ] **Needs a human on a real run:** the corner row appearing exactly once (not two rows) alongside the model's load row during a genuine multi-minute benchmark; icon legibility and hover/click feel at 16px in both themes; the chevron's rotation; whether the `Failed — details` state now needs a colour cue since the word is only in `aria-label`/`title`.
