### PR TITLE
Playground settings card opens beside the column at ~1000px windows

### DIFF
--- a/frontend/src/styles/ai-playground.css
+++ b/frontend/src/styles/ai-playground.css
@@ -806,22 +806,46 @@ a.pg-hero-repo:hover {
   gap: 14px;
 }
 
-/* The two numbers the placement below is built from, declared OUT here on the
+/* The numbers the placement below is built from, declared OUT here on the
    container itself: a `@container` rule can never target its own container —
    the query would resolve against .pg-stage's ANCESTOR — so a var declared on
    .pg-stage inside the block would simply never land, and every calc() that
    read it would fall over. */
 .pg-stage {
-  --pg-card: 240px;
   --pg-gap: 16px;
+  /* The card's band, not one number. A single 240px card put the side-by-side
+     threshold at 1000cqw, which a ~1000px window misses by a hair — the stage
+     gets ~950 of it — so a window with obvious room beside the column still
+     stacked the settings under it. Letting the card give up width instead of
+     the column moves the threshold down to where that window lands, and hands
+     the full 240 back as soon as there is room for it. */
+  --pg-card-min: 192px;
+  --pg-card-max: 240px;
 }
 
-/* Wide enough for the whole PAIR — column plus card — to sit centered with the
-   stage's own 32px edges: 680 + 16 gap + 240 card + 2×32 = 1000cqw. Below this
-   the card stays in flow under the input, the placement the cog pass shipped. That band used to
-   keep the card beside the column by letting the column give up width; it no
-   longer does, which is the price of never resizing the input. */
-@container (min-width: 1000px) {
+/* The card's actual width, resolved on the stage's CHILDREN rather than the
+   stage: `cqw` on the container itself measures the container's own ANCESTOR,
+   the same trap as the vars above, and every box that reads --pg-card (hero,
+   work column, apps strip, and the card itself by inheritance) is a descendant
+   of .pg-stage, so each one resolves it against the stage. It is one shared
+   expression, so all four still agree to the pixel — the hero and the apps
+   strip keep spanning exactly the pair below them. */
+.pg-stage > * {
+  --pg-card: clamp(
+    var(--pg-card-min),
+    100cqw - 680px - var(--pg-gap) - 32px,
+    var(--pg-card-max)
+  );
+}
+
+/* Wide enough for the whole PAIR — column plus card at its NARROWEST — to sit
+   centered with the stage's own 32px edges: 680 + 16 gap + 192 card + 2×32 =
+   920cqw. Above it the clamp above widens the card until it reaches 240 (at
+   968cqw) and holds. Below it the card stays in flow under the input, the
+   placement the cog pass shipped. That band used to keep the card beside the
+   column by letting the column give up width; it no longer does, which is the
+   price of never resizing the input. */
+@container (min-width: 920px) {
   /* The work column slides left by HALF the card's footprint: what the pair
      gives up on the right it takes back on the left, so the PAIR is centered on
      the stage while the column stays the same 680px it was before the cog was
@@ -832,8 +856,11 @@ a.pg-hero-repo:hover {
   .pg-work.has-config {
     margin-left: calc((100cqw - 680px) / 2 - (var(--pg-gap) + var(--pg-card)) / 2);
     margin-right: 0;
-    /* Fixed, not a min(): the threshold above already guarantees it fits, and
-       the point of this layout is that this number never moves. */
+    /* A plain calc, not a min(): the threshold above already guarantees the
+       pair fits, so nothing here has to clamp. The number tracks the stage's
+       width through --pg-card, but it is blind to the cog — which is the
+       invariant this layout exists for: opening the panel never resizes the
+       input. */
     width: calc(680px + var(--pg-gap) + var(--pg-card));
     grid-template-columns: minmax(0, 1fr) var(--pg-card);
     column-gap: var(--pg-gap);
@@ -853,7 +880,7 @@ a.pg-hero-repo:hover {
      exists to avoid. An abspos grid child takes its grid area as its
      containing block, with the row edges falling back to the container's
      padding box when the row placement is auto, so `inset: 0` is a full-height
-     rail in a 240px track. (`grid-row: 1 / -1` would NOT do this: negative
+     rail in the --pg-card track. (`grid-row: 1 / -1` would NOT do this: negative
      line numbers resolve against the EXPLICIT grid, and there are no explicit
      rows here.) The track holds its width whether anything is in it or not, so
      the column-width math above is untouched. */


### PR DESCRIPTION
## What

On a ~1000px window the Playground's settings panel stacked **under** the prompt instead of sitting beside it, even though there was clearly room in the gutter.

Cause: the side-by-side placement is gated on `@container (min-width: 1000px)`, which is exactly what a fixed 240px card costs — `680` column + `16` gap + `240` card + `2×32` stage edges. The shell sidebar and `cc-main`'s padding leave `.pg-stage` about 950 of a 1000px window, so it missed the threshold by a hair.

## Change

`--pg-card` becomes a band rather than one number:

```css
.pg-stage { --pg-card-min: 192px; --pg-card-max: 240px; }
.pg-stage > * {
  --pg-card: clamp(var(--pg-card-min), 100cqw - 680px - var(--pg-gap) - 32px, var(--pg-card-max));
}
@container (min-width: 920px) { /* was 1000px */ }
```

Below the old threshold the **card** gives up width, not the column. `192px` is the narrowest the card's content still reads at (widest control label + the 64px number field is 150px inside a 192px box). The clamp hands the full 240 back once the stage passes 968cqw, so nothing at or above the old threshold changes.

Two things this deliberately keeps:

- **The cog still never resizes the input.** The clamp is a function of the *stage's* width and is blind to the panel's state, so `.pg-work.has-config` is still a 680px column that slides left rather than narrowing. Letting the column narrow through the band is what an earlier pass did and was reversed for.
- **The banner and apps strip still span exactly the pair between them.** The clamp is declared on `.pg-stage > *`, not on `.pg-stage`, because `cqw` on a container measures that container's own *ancestor* — the same trap the existing vars already sit outside the `@container` block to avoid. Every box that reads `--pg-card` (`.pg-hero`, `.pg-work`, `.pg-apps`, and `.pg-config-card` by inheritance) is a descendant, so all four resolve one shared expression against the stage and agree to the pixel.

Rejected: a smaller *fixed* card (216/208). It buys one window a few pixels of margin, pays for it on every wider screen, and the next window a hair under the new number is the same bug with a new threshold.

## Verified

- `npm run build` (boundary check + `tsc --noEmit` + vite) clean; minified output keeps the `clamp()` and emits `@container (min-width: 920px)`.
- Confirmed side-by-side in the real app at the reporting window size.

No DECISIONS row — owner's call; this tunes the threshold the cog pass already documented rather than setting a new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only playground layout tweak; no logic, auth, or data handling changes.
> 
> **Overview**
> The Playground settings panel now sits beside the prompt at ~1000px windows instead of stacking under it.
> 
> `--pg-card` is no longer a fixed 240px. It clamps between **192px and 240px** from leftover stage width, and the side-by-side `@container` threshold drops from **1000px to 920px**. The card shrinks in that band; the 680px input column still only slides, never resizes when the cog opens. The clamp is declared on `.pg-stage > *` so hero, work, apps strip, and the card all share one `cqw` value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9d4c7676b90982676411fa14e01b4a92e37071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->