### PR TITLE
apps: @-chip for Playground model handoff instead of inline prose

### DIFF
--- a/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
+++ b/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
@@ -35,7 +35,7 @@ import { modelSizeHint, modelSizeLabel } from "@apps/ai_models/shared/modelSize"
 import { formatSize } from "@platform/lib/format";
 import { capabilityLabel } from "@apps/ai_models/lib/engines";
 import { PLAYGROUND_GROUPS } from "./groups";
-import { buildAppSeed, modelName } from "./appSeed";
+import { buildAppAnnotation, modelName } from "./appSeed";
 import { capabilityIcon, unsupportedIcon } from "./capabilityIcons";
 import { pickPlaygroundModel, playgroundModels } from "./pick";
 import { PlaygroundApps } from "./PlaygroundApps";
@@ -698,17 +698,19 @@ export default function PlaygroundTab() {
                 <div className="pg-stage-actions">
                   {/* The playground's exit ramp: everything tried here is one
                       `fused.ai` call in a page, and this hands the /apps
-                      composer a seed naming the model, the tuned settings and
-                      the call — the user finishes the sentence with the app
-                      they want. */}
+                      composer an annotation naming the model and the tuned
+                      settings — shown as a chip, not dumped into the prompt
+                      box — so the user just types the app they want. */}
                   <button
                     type="button"
                     className="btn btn-secondary"
                     title="Open the app builder with this model and your settings pre-filled"
                     onClick={() =>
                       navigateUrl(
-                        "/apps?seed=" +
-                          encodeURIComponent(buildAppSeed(selected.model, selected.row.capability)),
+                        "/apps?annot=" +
+                          encodeURIComponent(
+                            JSON.stringify(buildAppAnnotation(selected.model, selected.row.capability)),
+                          ),
                       )
                     }
                   >

--- a/frontend/src/apps/ai_models/playground/appSeed.ts
+++ b/frontend/src/apps/ai_models/playground/appSeed.ts
@@ -7,6 +7,7 @@
 // the page file the place every playground concern happened to land.
 import { readParam } from "@apps/ai_models/lib/params";
 import { type AiCatalogModel } from "@platform/lib/api";
+import { type AppAnnotation } from "@platform/lib/appAnnotation";
 
 /** The display name everywhere on this tab: the curated nickname, or the label
  *  for a cached entry nobody curated. A fallback read, never a derivation. */
@@ -14,13 +15,21 @@ export function modelName(model: AiCatalogModel): string {
   return model.nickname || model.label;
 }
 
-/** The seed for the /apps composer: everything the Playground knows about the
- *  moment — which model, what it is good for, the settings the user dialled in
- *  (read off the URL, where every non-default already lives), and the page API
- *  that reaches it (`runtime.js`'s names — the seed is read by an app AUTHOR's
- *  session, and camelCase is that API's vocabulary). Ends mid-sentence on
- *  purpose: the user finishes it with what they actually want built. */
-export function buildAppSeed(model: AiCatalogModel, capability: string): string {
+/** An annotation the /apps composer shows as a chip (`@LFM2.5`, Cursor-file-tag
+ *  style) instead of dumping prose into the prompt box. `detail` carries the
+ *  same instructions the old inline seed used to open with — model id, what
+ *  it's good for, the settings tuned in the Playground, the page API that
+ *  reaches it — spliced into the prompt at submit time, invisible to the user. */
+export function buildAppAnnotation(model: AiCatalogModel, capability: string): AppAnnotation {
+  return { id: model.id, name: modelName(model), detail: buildAppSeedDetail(model, capability) };
+}
+
+/** Everything the Playground knows about the moment — which model, what it is
+ *  good for, the settings the user dialled in (read off the URL, where every
+ *  non-default already lives), and the page API that reaches it (`runtime.js`'s
+ *  names — read by an app AUTHOR's session, so camelCase is that API's
+ *  vocabulary). Used as an `AppAnnotation`'s `detail`. */
+function buildAppSeedDetail(model: AiCatalogModel, capability: string): string {
   const name = model.nickname || model.label;
   const lines: string[] = [
     `Build a fused app around the local AI model "${name}" (${model.id}) — it runs fully offline on this machine.`,
@@ -105,8 +114,6 @@ export function buildAppSeed(model: AiCatalogModel, capability: string): string 
     "Before writing any AI code, load the `fused-render-ai` skill — it documents the " +
       "fused.ai contract: streaming, model loading and download progress, every error " +
       "type and how a page should respond, and what an exported app may call.",
-    "",
-    "The app I want: ",
   );
   return lines.join("\n");
 }

--- a/frontend/src/apps/builder/HomeHero.tsx
+++ b/frontend/src/apps/builder/HomeHero.tsx
@@ -10,6 +10,7 @@ import { TroubleCard } from "@platform/ui/TroubleCard";
 import logoMarkDark from "@assets/logo-black-bg-transparent.png";
 import logoMarkLight from "@assets/logo-white-bg-transparent.png";
 import { Select, TextArea } from "@platform/ui/field/fields";
+import { type AppAnnotation } from "@platform/lib/appAnnotation";
 
 // URL of an app folder's claude chat, attached to a specific live run.
 // `_mode` is the shell's template selector; `run` is a plain view param the
@@ -296,6 +297,10 @@ function ComposerPick<T extends string>({
 // lands in the new folder's claude chat exactly like the New-app panel does.
 function HeroComposer({ onCreated }: { onCreated: () => void }) {
   const [prompt, setPrompt] = useState("");
+  // The chip above the box — set by the Playground's "Build an app with this
+  // AI" button (?annot=). null means no model is annotated; the composer
+  // reads as a plain prompt box exactly like today.
+  const [annotation, setAnnotation] = useState<AppAnnotation | null>(null);
   // Empty = "let the chat decide", the default; see MODEL_CHOICES.
   const [model, setModel] = useState<DefaultModel>("");
   const [effort, setEffort] = useState<SessionEffort>("");
@@ -313,29 +318,26 @@ function HeroComposer({ onCreated }: { onCreated: () => void }) {
     [],
   );
 
-  // A `?seed=` in the URL pre-fills the composer — the Playground's "Build an
-  // app with this AI" hands its model + tuned settings through here. Consumed
-  // once and removed (replaceSearch, no history entry): a seed that survived
-  // in the URL would re-stomp whatever the user typed on the next mount.
+  // A `?annot=` in the URL pre-fills the chip — the Playground's "Build an
+  // app with this AI" hands its model + tuned settings through here as a
+  // JSON `AppAnnotation`, encoded rather than dumped into the prompt text.
+  // Consumed once and removed (replaceSearch, no history entry): an annot
+  // that survived in the URL would reappear on the next mount.
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   useEffect(() => {
     const params = new URLSearchParams(location.search);
-    const seed = params.get("seed");
-    if (!seed) return;
-    setPrompt(seed);
-    params.delete("seed");
+    const raw = params.get("annot");
+    if (!raw) return;
+    try {
+      setAnnotation(JSON.parse(raw) as AppAnnotation);
+    } catch {
+      // Malformed/tampered param — drop it silently rather than crash the
+      // composer over a URL someone hand-edited.
+    }
+    params.delete("annot");
     const search = params.toString();
     replaceSearch(location.pathname + (search ? "?" + search : ""));
-    // The seed ends mid-sentence ("The app I want: ") — put the person at the
-    // end of it, ready to finish it. After the render that paints the value:
-    // focusing first and selecting in the same tick reads a still-empty box.
-    requestAnimationFrame(() => {
-      const box = inputRef.current;
-      if (!box) return;
-      box.focus();
-      box.setSelectionRange(box.value.length, box.value.length);
-      box.scrollTop = box.scrollHeight;
-    });
+    requestAnimationFrame(() => inputRef.current?.focus());
   }, []);
 
   const busy = phase !== "idle";
@@ -344,6 +346,11 @@ function HeroComposer({ onCreated }: { onCreated: () => void }) {
   const submit = async () => {
     if (!canSubmit) return;
     const trimmed = prompt.trim();
+    // The chip's detail is instructions for the CLAUDE SESSION, not something
+    // the user typed — spliced in ahead of what they wrote so it reads as
+    // "here's the model, here's the app I want" without the user ever
+    // seeing or editing the model prose.
+    const full = annotation ? `${annotation.detail}\n\nThe app I want: ${trimmed}` : trimmed;
     setError(null);
     setSessionError(null);
     setPhase("naming");
@@ -351,7 +358,7 @@ function HeroComposer({ onCreated }: { onCreated: () => void }) {
       const name = await suggestAppName(trimmed);
       if (!alive.current) return;
       setPhase("creating");
-      const res = await createAppUnderFreeName(name, trimmed, model, effort);
+      const res = await createAppUnderFreeName(name, full, model, effort);
       // The folder exists from here on, so the Recent grid is stale — refresh it
       // now, since the session-error branch below stays on this page.
       onCreated();
@@ -381,6 +388,23 @@ function HeroComposer({ onCreated }: { onCreated: () => void }) {
   return (
     <div className="home-composer-wrap">
       <div className={"home-composer" + (busy ? " is-busy" : "")}>
+        {annotation && (
+          <div className="home-composer-annots">
+            <span className="home-composer-annot" title={annotation.detail}>
+              <span className="home-composer-annot-at" aria-hidden="true">@</span>
+              {annotation.name}
+              <button
+                type="button"
+                className="home-composer-annot-x"
+                aria-label={`Remove ${annotation.name} annotation`}
+                disabled={busy}
+                onClick={() => setAnnotation(null)}
+              >
+                ✕
+              </button>
+            </span>
+          </div>
+        )}
         <TextArea
           ref={inputRef}
           className="home-composer-input"

--- a/frontend/src/platform/lib/appAnnotation.ts
+++ b/frontend/src/platform/lib/appAnnotation.ts
@@ -1,0 +1,9 @@
+// The shape of a /apps composer annotation chip (`@LFM2.5`, Cursor-file-tag
+// style): a model reference the Playground hands the composer via `?annot=`.
+// Lives in platform because it crosses the apps/ai_models -> apps/builder
+// boundary — an app may only import platform + itself.
+export interface AppAnnotation {
+  id: string;
+  name: string;
+  detail: string;
+}

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -141,8 +141,8 @@
   gap: 4px;
   padding: 3px 6px 3px 8px;
   border-radius: 8px;
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+  color: var(--fg);
   font-size: 12.5px;
   font-weight: 500;
   line-height: 1.4;

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -128,6 +128,50 @@
   opacity: 0.75;
 }
 
+.home-composer-annots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 12px 16px 0;
+}
+
+.home-composer-annot {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px 3px 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.home-composer-annot-at {
+  opacity: 0.6;
+}
+
+.home-composer-annot-x {
+  border: none;
+  background: none;
+  padding: 0 2px;
+  margin-left: 2px;
+  font-size: 11px;
+  line-height: 1;
+  color: inherit;
+  opacity: 0.55;
+  cursor: pointer;
+}
+
+.home-composer-annot-x:hover:not(:disabled) {
+  opacity: 1;
+}
+
+.home-composer-annot-x:disabled {
+  cursor: default;
+}
+
 .home-composer .home-composer-input,
 .home-composer .home-composer-input:focus {
   display: block;


### PR DESCRIPTION
## Summary
- "Build an app with this AI" now hands the /apps composer a compact `AppAnnotation` (`{id, name, detail}`) via `?annot=` instead of a full prose seed dumped into the textarea.
- Composer renders it as a removable `@LFM2.5`-style chip above the box (Cursor file-tag pattern); the box stays empty for the user's own words.
- Chip's `detail` (model/settings prose, same content as before) splices back in ahead of the user's text only at submit time — invisible to the user.
- `AppAnnotation` type lives in `platform/lib/appAnnotation.ts` since it crosses the apps/ai_models -> apps/builder boundary.

## Test plan
- [ ] Playground -> pick a local model -> "Build an app with this AI" -> confirm chip shows with model name, box is empty
- [ ] Remove chip via ✕, confirm it clears
- [ ] Type a prompt with chip present, submit, confirm created app's chat sees full model context
- [ ] Submit with no chip (direct /apps visit), confirm unchanged behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only composer UX change. Submit still sends the same model context to createApp; JSON from the URL is parsed with a try/catch and is not a security-critical path.
> 
> **Overview**
> **Playground → /apps** no longer dumps model prose into the composer textarea. "Build an app with this AI" now navigates with `?annot=` carrying a JSON `AppAnnotation` (`id`, `name`, `detail`).
> 
> The composer shows a removable `@ModelName` chip and leaves the box empty for the user's own words. Model/settings instructions stay in `detail` and are spliced in only at submit (`The app I want: …`). App naming still uses the user's text, not the hidden prose. Malformed `annot` is dropped silently; the param is consumed once via `replaceSearch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01990297d9d0430bbc68faf718b11721a0d26935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->