### PR TITLE
playground: stop the app strip clipping the cards' hover border

### DIFF
--- a/frontend/src/styles/ai-playground.css
+++ b/frontend/src/styles/ai-playground.css
@@ -2357,8 +2357,17 @@ a.pg-hero-repo:hover {
   display: flex;
   gap: 18px;
   overflow-x: auto;
-  /* Room for the scrollbar so it doesn't sit on the cards' bottom edge. */
-  padding-bottom: 6px;
+  /* `overflow-x: auto` clips the BLOCK axis too, and .app-pcard's hover lifts
+   * the card 1px and casts an 18px-blur shadow — with the cards flush against
+   * this box the lifted top border reads as sliced off. So the strip carries
+   * padding on every side that the hover state can spill into, and negative
+   * margins hand the same amount back to the layout: the cards sit exactly
+   * where they did, only the clipping box grew. The side inset is 16px, which
+   * is precisely the slack .pg-apps' `100% - 32px` leaves, so the stage never
+   * gains a horizontal scrollbar. Bottom nets out at the 6px that keeps the
+   * scrollbar off the cards' edge. */
+  padding: 16px 16px 20px;
+  margin: -16px -16px -14px;
 }
 .pg-apps-row .app-pcard {
   flex: 0 0 300px;


### PR DESCRIPTION
`.pg-apps-row` — the "Use it in an app" strip under the playground stage — scrolls sideways, and `overflow-x: auto` clips the block axis too. The cards in it are the hub's own `.app-pcard`, whose hover state lifts them 1px and casts an 18px-blur shadow. With the cards flush against the strip's content box, that lifted top border and its rounded corners read as sliced off.

The fix pads the strip on every side by the amount the hover state spills, and hands the same amount back to the layout with negative margins — the cards sit exactly where they did, only the clipping box grew:

```css
padding: 16px 16px 20px;
margin: -16px -16px -14px;
```

The side inset is 16px, precisely the slack `.pg-apps`' `100% - 32px` width leaves, so the stage never gains a horizontal scrollbar. The bottom nets out at the 6px that keeps the scrollbar off the cards' edge.

No `DECISIONS.md` row: this is padding on one selector, and the comment at the code says everything a D row would.

## Test

CSS-only. Checked first in a headless-Chrome harness that loads the real `apps.css` + `ai-playground.css` and replicates `.app-pcard:hover` as a forced class (headless can't hover): the top borders and corners render whole and the cards have not moved. Then smoke-tested by hand in the running app on the playground's Use-it-in-an-app strip — hovering a card no longer chops its top border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only padding/margin tweak on a non-critical playground layout strip; no logic, auth, or data handling changes.
> 
> **Overview**
> Stops the playground “Use it in an app” strip from clipping `.app-pcard` hover lift and shadow.
> 
> `.pg-apps-row` used `overflow-x: auto` with only 6px bottom padding, so the 1px lift and 18px-blur shadow were cut off. Padding is now `16px 16px 20px` with matching negative margins so cards stay in place, the clip box grows, and the stage does not pick up a horizontal scrollbar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a287897e9bebc4620efc5441adbd07c00192fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->