### PR TITLE
playground: lay the app strip out as a measured, folding grid

### DIFF
--- a/frontend/src/apps/ai_models/playground/PlaygroundApps.tsx
+++ b/frontend/src/apps/ai_models/playground/PlaygroundApps.tsx
@@ -19,12 +19,54 @@
 // for trying models must not be the thing that clones a git repo. No cache,
 // error, or nothing matching → the section renders nothing at all: an empty
 // heading would advertise a feature this machine cannot show.
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { matchPlaygroundApps, type ShowcaseAppMeta } from "./appMatch";
 import { AppPreviewCard } from "@platform/ui/AppPreviewCard";
 import { runCommunity, SHOWCASE_TAG, touchCommunityApp } from "@platform/lib/community";
 import { urlForFsPath } from "@platform/lib/router";
 import type { AppInfo } from "@platform/lib/api";
+
+// Card width + gap must match .pg-apps-row in ai-playground.css.
+const CARD_W = 300;
+const CARD_GAP = 18;
+// The fold: two full rows, whatever a full row happens to be at this width.
+const ROWS_BEFORE_FOLD = 2;
+
+// How many cards fit across the strip right now — the same measurement /home
+// makes for its one-row sections (shell/Home.tsx useStripCount), minus that
+// hook's `limit` half: Home sizes a FETCH by its count, while the showcase
+// catalog arrives whole here and "Show more" is a slice, not a request. The
+// numbers are this strip's own (300/18), not Home's (330/16).
+//
+// A CALLBACK ref, not useRef+useEffect, for the reason Home documents: the
+// measured element unmounts and remounts (a different model, a catalog that
+// lands late), and a mount-once effect goes on observing the detached node —
+// clientWidth 0, one card per row, forever. The callback tears the old
+// observer down and measures whatever is actually on screen.
+//
+// `null` until measured, and the section draws no cards until then: a guessed
+// default is a row that has to be redrawn. Nothing flashes for it — a callback
+// ref runs in the commit phase, so the count is in before the browser paints.
+function useRowCapacity() {
+  const [perRow, setPerRow] = useState<number | null>(null);
+  const roRef = useRef<ResizeObserver | null>(null);
+  const ref = useCallback((el: HTMLDivElement | null) => {
+    roRef.current?.disconnect();
+    roRef.current = null;
+    if (!el) return;
+    const measure = () => {
+      const fits = Math.max(1, Math.floor((el.clientWidth + CARD_GAP) / (CARD_W + CARD_GAP)));
+      // A ResizeObserver fires for every pixel of a window drag; only a
+      // changed card count is a reason to re-render.
+      setPerRow((prev) => (prev === fits ? prev : fits));
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    roRef.current = ro;
+  }, []);
+  return { ref, perRow };
+}
 
 type ShowcaseCatalog = {
   status?: string;
@@ -52,6 +94,12 @@ function showcaseAppInfo(cacheRoot: string, app: ShowcaseAppMeta): AppInfo {
 
 export function PlaygroundApps({ capability, modelId }: { capability: string; modelId: string }) {
   const [catalog, setCatalog] = useState<ShowcaseCatalog | null>(null);
+  const { ref: rowRef, perRow } = useRowCapacity();
+  // Folded again whenever the model changes: the next model's matches are a
+  // different, usually shorter list, and an expansion the reader asked for on
+  // one model is not consent to a wall of cards on the next.
+  const [expanded, setExpanded] = useState(false);
+  useEffect(() => setExpanded(false), [modelId]);
   useEffect(() => {
     let alive = true;
     runCommunity<ShowcaseCatalog>({ action: "catalog" }).then(
@@ -70,11 +118,26 @@ export function PlaygroundApps({ capability, modelId }: { capability: string; mo
   if (!offers.length) return null;
   const cacheRoot = catalog.cache_root;
 
+  // Pre-measure the row draws its own box (so the ResizeObserver has something
+  // to measure) and nothing inside it. Commit-phase only — see useRowCapacity.
+  const fold = perRow === null ? 0 : perRow * ROWS_BEFORE_FOLD;
+  const shown = expanded ? offers : offers.slice(0, fold);
+  // One grid rule covers both halves of the layout the section wants. Fewer
+  // cards than a row holds → fewer TRACKS, and `justify-content: center` puts
+  // that short row in the middle. More than a row holds → the full track count,
+  // so the grid fills left-to-right and a partial last row starts at the left
+  // edge under the first card above it, never floating mid-band.
+  const columns = Math.max(1, Math.min(shown.length, perRow ?? 1));
+
   return (
     <section className="pg-apps" aria-label="Apps that can use this model">
       <h4 className="pg-apps-head">Use it in an app</h4>
-      <div className="pg-apps-row">
-        {offers.map(({ app, recommended }) => (
+      <div
+        className="pg-apps-row"
+        ref={rowRef}
+        style={{ gridTemplateColumns: `repeat(${columns}, ${CARD_W}px)` }}
+      >
+        {shown.map(({ app, recommended }) => (
           <span
             key={app.slug}
             style={{ display: "contents" }}
@@ -96,6 +159,27 @@ export function PlaygroundApps({ capability, modelId }: { capability: string; mo
           </span>
         ))}
       </div>
+      {/* Only when the fold actually hides something — and only once measured,
+          so it never appears for a beat and then leaves. Reveals ALL of the
+          rest in one click: the list is a handful of matches, not a feed. */}
+      {perRow !== null && offers.length > fold && !expanded && (
+        <button type="button" className="pg-apps-more" onClick={() => setExpanded(true)}>
+          Show {offers.length - fold} more
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M6 9l6 6 6-6" />
+          </svg>
+        </button>
+      )}
     </section>
   );
 }

--- a/frontend/src/styles/ai-playground.css
+++ b/frontend/src/styles/ai-playground.css
@@ -452,22 +452,21 @@
      only what keeps an empty box from growing a scrollbar. `clip`, not
      `hidden`: there is nothing here to scroll to sideways, and `hidden` leaves
      a programmatically scrollable box that a stray focus or anchor jump can
-     shove sideways. The apps strip scrolls in its own box (`.pg-apps-row`), so
-     nothing legitimate is lost. */
+     shove sideways. Nothing in the stage scrolls sideways — the apps strip is
+     a wrapping grid measured to this box's width, not a scroller — so nothing
+     legitimate is lost. */
   overflow-x: hidden;
   overflow-x: clip;
 }
 
 /* The stage header as a banner — the model introducing itself before the work
    below it. Wider than the 680px column it heads, and on a 16px gutter rather
-   than 32px, because it is a header rather than part of the API surface. Its
-   max is exactly the pair below at its widest (column + gap + settings card),
-   so the banner spans everything the stage can ever put under it and its own
-   edges never move when the cog is clicked — the model's name stays a fixed
-   landmark while the column slides. Still a min(), not a bare max-width: the
-   gutter has to survive a narrow stage too. */
+   than 32px, because it is a header rather than part of the API surface. On
+   --pg-band, so the banner spans everything the stage can ever put under it
+   and its own edges never move when the cog is clicked — the model's name
+   stays a fixed landmark while the column slides. */
 .pg-hero {
-  width: min(calc(680px + var(--pg-gap) + var(--pg-card)), calc(100% - 32px));
+  width: var(--pg-band);
   /* Extra room below: the stage's own gap reads too tight under a card this
      heavy, and the work column needs to start as its own thing. */
   margin: 0 auto 16px;
@@ -873,6 +872,13 @@ a.pg-hero-repo:hover {
     100cqw - 680px - var(--pg-gap) - 32px,
     var(--pg-card-max)
   );
+  /* The stage's full-width band: exactly the pair below it at its widest
+     (column + gap + settings card), on the header's 16px gutter rather than
+     the column's 32px. The hero wears it and so does the apps strip — one
+     declaration rather than two identical min()s that read as independent and
+     can be edited apart. Still a min(), not a bare max-width: the gutter has to
+     survive a narrow stage too. */
+  --pg-band: min(calc(680px + var(--pg-gap) + var(--pg-card)), calc(100% - 32px));
 }
 
 /* Wide enough for the whole PAIR — column plus card at its NARROWEST — to sit
@@ -2500,10 +2506,12 @@ a.pg-hero-repo:hover {
  * concurrent redesign (#760) and this block must merge clean. ---- */
 .pg-apps {
   /* The banner's own gutters, so the stage's top and bottom bands share one
-   * pair of edges — the same min() expression, not a number copied. Auto side
-   * margins centre it; `margin-top: auto` is untouched by them and still does
-   * its main-axis job below. */
-  width: min(calc(680px + var(--pg-gap) + var(--pg-card)), calc(100% - 32px));
+   * pair of edges — literally the same declaration (--pg-band), not a number
+   * copied. This is also the box the card grid measures itself against: how
+   * many cards fit per row is a question about THIS width. Auto side margins
+   * centre it; `margin-top: auto` is untouched by them and still does its
+   * main-axis job below. */
+  width: var(--pg-band);
   margin-left: auto;
   margin-right: auto;
   /* Pinned to the bottom of the stage's viewport when the content above is
@@ -2514,27 +2522,43 @@ a.pg-hero-repo:hover {
   margin-top: auto;
   padding-top: 28px;
 }
-/* One horizontal row, never wrapping: overflow scrolls sideways inside the
- * strip. The card wrappers are display:contents, so the .app-pcard anchors
- * themselves are the flex items — fixed at the hub grid's minimum width. */
+/* A wrapping grid of fixed-width tracks, never a sideways scroller: matches
+ * are a handful of cards, and a card the reader has to discover by dragging
+ * horizontally is a card they do not open. PlaygroundApps writes the TRACK
+ * COUNT inline from its own measurement of this box (useRowCapacity, the same
+ * arithmetic /home's strips use) — CSS cannot express "as many 300px tracks as
+ * fit, but never more than there are cards", which is what makes a short row
+ * centre instead of stretching. `justify-content: center` is what centres it;
+ * with a full track count the tracks span the band and the same rule is a
+ * no-op, so a partial last row still starts hard left under the first card.
+ * The card wrappers are display:contents, so the .app-pcard anchors are the
+ * grid items and take their track's width. */
 .pg-apps-row {
-  display: flex;
+  display: grid;
+  justify-content: center;
   gap: 18px;
-  overflow-x: auto;
-  /* `overflow-x: auto` clips the BLOCK axis too, and .app-pcard's hover lifts
-   * the card 1px and casts an 18px-blur shadow — with the cards flush against
-   * this box the lifted top border reads as sliced off. So the strip carries
-   * padding on every side that the hover state can spill into, and negative
-   * margins hand the same amount back to the layout: the cards sit exactly
-   * where they did, only the clipping box grew. The side inset is 16px, which
-   * is precisely the slack .pg-apps' `100% - 32px` leaves, so the stage never
-   * gains a horizontal scrollbar. Bottom nets out at the 6px that keeps the
-   * scrollbar off the cards' edge. */
-  padding: 16px 16px 20px;
-  margin: -16px -16px -14px;
 }
-.pg-apps-row .app-pcard {
-  flex: 0 0 300px;
+/* The two-row fold's "Show more": the same quiet pill /files uses under its
+ * own folded grid (.fhb-more), restated here rather than imported — this
+ * section is deliberately self-contained, and fifteen lines of pill is a
+ * cheaper coupling than a shared component reaching across two apps. */
+.pg-apps-more {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 14px auto 0;
+  padding: 5px 14px;
+  font-size: 12px;
+  color: var(--fg-muted);
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+.pg-apps-more:hover {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--fg-muted) 35%, var(--border));
 }
 /* Sentence case, at reading size: "Use it in an app" is an invitation, and
  * caps-plus-tracking turns a sentence into a section label. */


### PR DESCRIPTION
The **Use it in an app** strip was a non-wrapping flex row that scrolled sideways. Cards past the first screenful were only reachable by dragging, which is how a card goes unopened.

### Width

The section already carried the hero's exact `min()` expression, so its band was correct. Both now read one shared `--pg-band` custom property instead of two identical expressions that read as independent and can be edited apart.

### Cards per row

The strip measures its own box and renders as many 300px tracks as fit — `useRowCapacity`, the same arithmetic `shell/Home.tsx`'s `useStripCount` uses for /home's one-row sections, minus that hook's `limit` half (Home sizes a *fetch* by its count; the showcase catalog arrives whole here). Callback ref, ResizeObserver, commit-phase measure, no guessed default.

### Layout

The track count produces both halves of the requested behaviour, with no conditional alignment:

- fewer cards than a row holds → fewer tracks, and `justify-content: center` puts that short row in the middle
- a full track count → the tracks span the band, so the grid fills left-to-right and a partial last row starts hard left under the first card above it

### Fold

Two full rows show; anything beyond that sits behind a **Show _n_ more** pill (the same quiet pill /files uses under its own folded grid), which reveals all of the rest in one click. Folded again whenever the model changes.

The row's `padding` / negative-margin hover-clip compensation is gone along with the `overflow-x: auto` that required it, and `.pg-stage`'s comment about the strip owning its own scroller is updated.

## Verified

Headless Chrome against a local server, measuring the live DOM at a 936px band (3 tracks):

| offers | tracks | rows | pill |
|---|---|---|---|
| 1 | 1 | centered | — |
| 2 | 2 | centered (card span centre == row centre) | — |
| 4 | 3 | 3 + 1 left-aligned | — |
| 7 | 3 | 3 + 3 | "Show 1 more" |
| 9 | 3 | 3 + 3 → 9 on click | "Show 3 more" → gone |

Narrowing the window to 1100px re-measures to a single track. `tsc --noEmit` and `npm run build` clean; `bun test src/apps/ai_models/playground` 54 pass.

No DECISIONS row — owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground-only layout and CSS; no auth, data, or API changes. ResizeObserver/fold logic is UI-scoped.
> 
> **Overview**
> Replaces the playground **Use it in an app** horizontal scroller with a wrapping grid so matching showcase cards stay visible without sideways drag.
> 
> The strip now measures its own width (`useRowCapacity`, same callback-ref + ResizeObserver pattern as Home’s `useStripCount`) and lays out as many 300px tracks as fit. Short rows center; a full row plus leftovers stay left-aligned. Two rows show by default; extra matches sit behind a **Show n more** pill that expands the rest in one click and resets when the model changes.
> 
> Hero and apps strip now share `--pg-band` instead of duplicated `min()` widths. Hover-clip padding and `overflow-x: auto` on the row are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ce11992d7a24019b9adb7ac9038c31c7915984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->