### PR TITLE
Apps hub: put the match count on the filter chips, not under them

### DIFF
--- a/frontend/src/apps/builder/Apps.tsx
+++ b/frontend/src/apps/builder/Apps.tsx
@@ -113,6 +113,22 @@ function useShowcaseSync(onSynced: () => void): Set<string> {
   return slugs;
 }
 
+// The grid's search predicate, shared with the chip counts so the two can
+// never drift: a chip promising (7) must be the same seven cards the click
+// leaves on screen.
+const matchesQuery = (a: AppInfo, q: string): boolean =>
+  q === "" ||
+  a.name.toLowerCase().includes(q) ||
+  (a.title ?? "").toLowerCase().includes(q) ||
+  (a.category ?? "").toLowerCase().includes(q) ||
+  a.tag.toLowerCase().includes(q);
+
+// The bracketed count on a chip. Deliberately colorless — it inherits the
+// chip's own color and only steps back with opacity, because the selected
+// chip's label is var(--bg) on a filled plate: a muted-grey token legible on
+// the unselected chips would be near-invisible on that one.
+const ChipCount = ({ n }: { n: number }) => <span className="apps-tag-count">({n})</span>;
+
 export default function Apps({ config }: { config: Config }) {
   const [apps, setApps] = useState<Loaded<AppInfo[]>>(
     catalogCache ? { status: "ok", data: catalogCache } : { status: "loading" },
@@ -260,17 +276,39 @@ export default function Apps({ config }: { config: Config }) {
           (a) =>
             (tag === null || a.tag === tag) &&
             (category === null || a.category === category) &&
-            (q === "" ||
-              a.name.toLowerCase().includes(q) ||
-              (a.title ?? "").toLowerCase().includes(q) ||
-              (a.category ?? "").toLowerCase().includes(q) ||
-              a.tag.toLowerCase().includes(q)),
+            matchesQuery(a, q),
         ),
       ),
     [cards, tag, category, q],
   );
   const chips = mode === "repo" ? tags : categories;
   const active = mode === "repo" ? tag : category;
+  // What a chip's bracketed number means: how many cards CLICKING IT would
+  // leave. So the search box narrows every count, but the current chip
+  // selection does not — the chips are one selector, and counts that collapsed
+  // to 0 on every chip but the chosen one would say nothing. Same predicate as
+  // the grid above, and the same exact-string match the grid filters on, so a
+  // count can never disagree with what its click produces.
+  //
+  // Counted over `all`, the exhaustive catalog, like the chips themselves —
+  // never over the partial row, which is why the numbers only print once the
+  // catalog has landed.
+  const counts = useMemo(() => {
+    const hits = all.filter((a) => matchesQuery(a, q));
+    const by = (pick: (a: AppInfo) => string | null | undefined) => {
+      const m = new Map<string, number>();
+      for (const a of hits) {
+        const k = pick(a);
+        if (k) m.set(k, (m.get(k) ?? 0) + 1);
+      }
+      return m;
+    };
+    return { all: hits.length, category: by((a) => a.category), repo: by((a) => a.tag) };
+  }, [all, q]);
+  const chipCounts = mode === "repo" ? counts.repo : counts.category;
+  // Only once the catalog is in: through the partial phase `all` is empty, so
+  // every label would read "(0)" under a grid visibly drawing cards.
+  const showCounts = apps.status === "ok";
 
   return (
     <div className="apps-page">
@@ -320,6 +358,7 @@ export default function Apps({ config }: { config: Config }) {
                 onClick={() => setFilter(mode, null)}
               >
                 All
+                {showCounts && <ChipCount n={counts.all} />}
               </button>
               {chips.map((c) => (
                 <button
@@ -329,6 +368,7 @@ export default function Apps({ config }: { config: Config }) {
                   onClick={() => setFilter(mode, active === c ? null : c)}
                 >
                   {c}
+                  {showCounts && <ChipCount n={chipCounts.get(c) ?? 0} />}
                 </button>
               ))}
             </div>
@@ -355,13 +395,14 @@ export default function Apps({ config }: { config: Config }) {
         {apps.status === "loading" && !error && <SkeletonLines rows={4} label="Loading apps" />}
         {apps.status !== "loading" && (
           <>
-            <div className="apps-count">
-              {apps.status === "partial"
-                ? "Recently opened — loading all apps…"
-                : shown.length === all.length
-                  ? `${all.length} app${all.length === 1 ? "" : "s"}`
-                  : `${shown.length} of ${all.length} apps`}
-            </div>
+            {/* The numeric count that used to live here — "12 apps", "3 of 12
+                apps" — now rides on the chips themselves, next to the filter
+                each number describes, instead of floating under the toolbar
+                restating it. What is left is the one thing the chips cannot
+                say: that the grid on screen is still only a prefix. */}
+            {apps.status === "partial" && (
+              <div className="apps-count">Recently opened — loading all apps…</div>
+            )}
             {shown.length === 0 ? (
               // Nothing to say yet during the partial phase: "no apps match" is
               // a claim about the whole catalog, which has not arrived.

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -27,7 +27,11 @@
   align-items: center;
   justify-content: flex-end;
   gap: 10px;
-  margin-bottom: 14px;
+  /* Carries the whole toolbar-to-grid gap now. It used to be 14px with the
+     count line and its own 12px margin below it making up the rest; with the
+     numbers moved onto the chips the grid would otherwise ride up against the
+     filter row. */
+  margin-bottom: 28px;
 }
 
 /* Search is the last item in the toolbar's right-aligned group (see
@@ -117,6 +121,23 @@
   border-color: color-mix(in srgb, var(--fg) 78%, var(--bg));
 }
 
+/* The chip's bracketed match count. A step smaller and a step back from the
+   chip's own label, so the row still reads as words with a number attached
+   rather than as two equal columns of text.
+
+   Backed off with `opacity`, not a color token: the count has to sit on the
+   selected chip too, whose label is var(--bg) on a filled plate (see
+   .apps-tag-chip.is-active). A --fg-muted that reads as "quieter" on the
+   unfilled chips would be all but invisible there, whereas opacity fades
+   whatever ink the chip is already using. */
+.apps-tag-count {
+  margin-left: 4px;
+  font-size: 11px;
+  opacity: 0.6;
+}
+
+/* Only the partial phase's "loading all apps…" line now — the numbers moved
+   onto the chips. */
 .apps-count {
   margin-bottom: 12px;
   font-size: 12px;


### PR DESCRIPTION
The /apps toolbar carried a line beneath it restating the grid — "95 apps", "7 of 95 apps" — a number floating away from the filter it described. Each chip now prints its own count, one step smaller and faded so the row still reads as words with numbers attached:

`All (95)` `starters (5)` `local-ai (7)` `productivity (7)` `geospatial (4)`

- **What a count means:** how many cards *clicking that chip* would leave. The search box narrows every count; the current chip selection does not (the chips are one selector — counts collapsing to 0 on every chip but the chosen one would say nothing).
- **No drift:** the grid's search predicate is extracted into `matchesQuery` and shared with the counts, and the counts use the same exact-string match the grid filters on.
- **Partial phase:** numbers print only once the exhaustive catalog lands. Through the fast-row phase `all` is empty, so every label would read `(0)` under a grid visibly drawing cards.
- **The line below** survives only for what the chips cannot say — "Recently opened — loading all apps…". The toolbar takes over its bottom margin so the grid doesn't ride up against the filter row.
- **Styling:** the count is backed off with `opacity`, not a colour token — it has to sit on the selected chip too, whose label is `var(--bg)` on a filled plate, where a muted grey would be near-invisible.

## Testing

`npm run typecheck` clean, `bun test` 2461 pass / 0 fail. Visual smoke in a headless Chrome against a local server: default Category row and the Folders facet with an active `showcase (19)` chip — the count is legible on the filled plate, and the spacing under the toolbar holds without the old count line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to the apps hub filter chips and spacing; no auth, data, or API behavior changes.
> 
> **Overview**
> Moves the /apps catalog count from a line under the toolbar onto each filter chip (`All (95)`, `starters (5)`), so the number sits next to the filter it describes.
> 
> Each count is how many cards **clicking that chip** would leave: search narrows every number, but the current chip selection does not. Grid search and counts share `matchesQuery` so they cannot drift. Counts wait until the full catalog lands (avoiding `(0)` during the fast-row phase). The old “N of M apps” line is gone; only “Recently opened — loading all apps…” remains. Toolbar bottom margin is increased to keep the grid from riding up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508d50ec98cdb9b318783575731a9e292dac4cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->