### PR TITLE
Three bugbot findings from #794: card hint, short refusal, stale archive verb

### DIFF
--- a/frontend/src/apps/ai_models/lib/aiModelGroups.test.ts
+++ b/frontend/src/apps/ai_models/lib/aiModelGroups.test.ts
@@ -716,13 +716,35 @@ describe("the short refusal on the card", () => {
     expect(loadRefusalShort(QWEN_NO_ENGINE)).toContain("format");
   });
 
-  it("leads with the server's own per-task sentence when it sent one", () => {
-    const tts = repo({
-      id: "coqui/tts",
+  // bugbot, PR #794: these sentences must NOT go through the clause cut written
+  // for the registry's engine-preference prose. `ai/tasks.py` builds them the
+  // other way round — "A chat model does this from a prompt — no separate runner
+  // ships for it" — so the lead-in is the consolation and the REFUSAL is after
+  // the dash. Cutting at the joint kept the soft half and dropped why Load is
+  // dead.
+  it("uses the server's own per-task sentence WHOLE, never cut at a joint", () => {
+    const summarise = repo({
+      id: "org/summariser",
       capability: null,
-      supportReason: "Text to speech is not supported yet, and nothing here can serve it",
+      supportReason: "A chat model does this from a prompt — no separate runner ships for it.",
     });
-    expect(loadRefusalShort(tts)).toBe("Text to speech is not supported yet.");
+    const short = loadRefusalShort(summarise) ?? "";
+    expect(short).toContain("no separate runner ships for it");
+    // The comma form is the other shape `ai/tasks.py` writes, and it must
+    // survive too — the clause after the comma is the refusal there as well.
+    const encoder = repo({
+      id: "sentence-transformers/all-MiniLM-L6-v2",
+      capability: null,
+      supportReason:
+        "The embedding runners here serve dual encoders (image and text into one space), "
+        + "not text-only sentence encoders.",
+    });
+    expect(loadRefusalShort(encoder)).toContain("not text-only sentence encoders");
+  });
+
+  it("falls back to the group heading's own fact when the server sent none", () => {
+    const mystery = repo({ id: "org/mystery", capability: null });
+    expect(loadRefusalShort(mystery)).toBe("The model type is not supported.");
   });
 });
 

--- a/frontend/src/apps/ai_models/lib/aiModelGroups.ts
+++ b/frontend/src/apps/ai_models/lib/aiModelGroups.ts
@@ -738,11 +738,20 @@ export function loadRefusalShort(repo: AiModelRepo): string | null {
     // fact — and the first cut of this function blamed the weight format for
     // it, which is a verdict about a different problem: an unrecognised repo's
     // formats may be perfectly readable, there is just nothing to load them AS.
-    // The server's own per-task sentence leads when it sent one, at card
-    // length; the flat fallback agrees with the group heading above the card.
+    // The server's own per-task sentence when it sent one; the flat fallback
+    // agrees with the group heading above the card.
+    //
+    // WHOLE, and NOT cut at its first joint (bugbot, PR #794). `firstClause` is
+    // written for the registry's engine-preference prose, where the opening
+    // clause IS the cause and everything past the dash is the remedy a link now
+    // carries. These sentences are built the other way round — `ai/tasks.py`
+    // writes "A chat model does this from a prompt — no separate runner ships
+    // for it", where the lead-in is the consolation and the REFUSAL is after the
+    // dash — so cutting at the joint kept the soft half and dropped why Load is
+    // dead. They are one or two lines at card width as written, and a correct
+    // two-line sentence beats a one-line one that says the wrong thing.
     if (repo.capability === null) {
-      const cause = firstClause(repo.supportReason ?? "");
-      return cause ? `${capitalise(cause)}.` : "The model type is not supported.";
+      return repo.supportReason?.trim() || "The model type is not supported.";
     }
     return "No local engine reads this weight format.";
   }

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -509,7 +509,12 @@ function IdChip({ id, kind }: { id: string; kind: "task" | "message" }) {
    the run ahead. This is a fact about the task, so it goes with the id. */
 function OutcomePill({ outcome }: { outcome: OutcomeTag }) {
   return (
-    <span className="tasks-outcome-pill" title={outcome.title}>
+    // On the instant panel like every other caption on this page (hints.ts).
+    // It is drawn on both views — beside the id on a List row, in a Board card's
+    // head — so a native `title` here would have been the one mark on either
+    // view that answered slowly, and (until the card's own hint moved onto its
+    // title) the one whose caption a container-level hint spoke over.
+    <span className="tasks-outcome-pill" data-hint={outcome.title}>
       {outcome.text}
     </span>
   );
@@ -3205,11 +3210,12 @@ function TaskCard({
           (draggable ? " is-draggable" : "") +
           (isDragging ? " is-dragging" : "")
         }
-        /* The Board card's own caption, on the same instant panel as the List's
-           (hints.ts). It is the same page and the same fact; a card that waited
-           four seconds while the rows beside it answered at once would read as a
-           different kind of thing. */
-        data-hint={task.title}
+        /* NO CAPTION ON THE CARD ITSELF (bugbot, PR #794). It had one for a
+           commit, and it was the List row's mistake repeated one view over: a
+           hint on the container is a hint on ALL of it, because `hints.ts`
+           resolves by walking up — so the outcome pill and the next-run chip in
+           the foot, which carry their own captions, were answered with the
+           TASK's name instead. The card's title carries it, like the row's. */
         draggable={draggable}
         onDragStart={(ev) => {
           // Some data is required for Firefox to start a drag at all; the task
@@ -3316,7 +3322,15 @@ function TaskCard({
             not an `aria-label` on this span either: a role-less span's label is not
             reliably announced (the same reason ScheduleCalendar gives its own dot a
             `role="img"`), where real text always is. */}
-        <span className={"schedule-tv-card-title" + (unread > 0 ? " is-unread" : "")}>
+        {/* The card's caption, on its title — the same rule the List row follows
+            (hints.ts, and the row's own note): the title is what gets cut off, so
+            it is what is worth captioning, and a container-level hint would speak
+            over every child that has one of its own. `task.title` and not the
+            drawn text, because the ink here is only its FIRST line. */}
+        <span
+          className={"schedule-tv-card-title" + (unread > 0 ? " is-unread" : "")}
+          data-hint={task.title}
+        >
           {firstLine(task.title) || "(untitled)"}
           {unread > 0 && (
             <span className="tasks-said">{`, ${taskUnreadLabel(unread)}`}</span>
@@ -3335,7 +3349,7 @@ function TaskCard({
                 (tasks-lib.nextRunChip): a settled card whose task is due again
                 would otherwise show nothing about the run ahead. */}
             {soon && (
-              <span className="tasks-row-next" title={soon.title}>
+              <span className="tasks-row-next" data-hint={soon.title}>
                 {soon.text}
               </span>
             )}

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -1943,9 +1943,14 @@ describe("the unread mark", () => {
     expect(CARD).not.toContain("const ring =");
     expect(CARD).not.toContain("tasks-news");
     expect(SCHEDULE_CSS.replace(/\/\*[\s\S]*?\*\//g, "")).not.toContain("tasks-news");
+    // The class expression is what this pins; the element carries the card's
+    // caption too since 2026-08-24 (hints.ts — a hint on the card BUTTON spoke
+    // over every child that had one of its own), so it is no longer a one-line
+    // tag.
     expect(CARD).toContain(
-      '<span className={"schedule-tv-card-title" + (unread > 0 ? " is-unread" : "")}>',
+      'className={"schedule-tv-card-title" + (unread > 0 ? " is-unread" : "")}',
     );
+    expect(CARD).toContain("data-hint={task.title}");
     expect(block(SCHEDULE_CSS, ".schedule-tv-card-title.is-unread")).toContain(
       "font-weight: 600",
     );
@@ -1969,8 +1974,11 @@ describe("the unread mark", () => {
       ".tasks-title.is-unread",
     );
     // ...and the title is still a title: the words, then nothing an eye can see.
+    // The element gained `data-hint` on 2026-08-24, so the class expression is no
+    // longer the last attribute before `>` — the assertion allows the attributes
+    // between them rather than pinning their order.
     expect(CARD).toMatch(
-      /className=\{"schedule-tv-card-title"[^}]*\}>\s*\{firstLine\(task\.title\) \|\| "\(untitled\)"\}/,
+      /className=\{"schedule-tv-card-title"[\s\S]*?>\s*\{firstLine\(task\.title\) \|\| "\(untitled\)"\}/,
     );
     // WEIGHT IS NOT A FACT A SCREEN READER HAS (bugbot, PR #596): bold is the whole
     // visual signal and `font-weight` never reaches the accessibility tree, so the

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -11379,10 +11379,32 @@ async function refreshArchiveOpt() {
 
 archiveOpt.addEventListener("click", async () => {
   if (!archiveKey) return;
-  const filed = archiveOpt.dataset.filed === "1";
+  let filed = archiveOpt.dataset.filed === "1";
   archiveOpt.disabled = true;
   archiveBusy = true;
   try {
+    // THE DIRECTION IS CONFIRMED AGAINST THE SERVER BEFORE IT IS SPENT (bugbot,
+    // PR #794). The item paints from cache so it can appear in the menu's first
+    // frame, and the cost of that is a window — between the open and the
+    // re-read landing — where the cached verb can be stale: file the task from
+    // the Tasks page in another tab, open this menu, click fast, and "Archive"
+    // would archive something already archived (or the reverse). Painting a
+    // DISABLED item until the read lands would trade the bug for the lateness
+    // the instant paint exists to remove, so the check moves to the press,
+    // where one extra read is invisible next to the write that follows it.
+    const check = await fetch("/api/tasks");
+    if (check.ok) {
+      const listing = await check.json();
+      const now = ((listing && listing.tasks) || []).find((t) => t && t.key === archiveKey);
+      // Only a POSITIVE answer overrides the cache. An unreadable listing, or a
+      // task the listing no longer holds, leaves the reader's own reading of the
+      // button in force — refusing the press on a listing we could not read
+      // would make a network blip look like a broken control.
+      if (now) {
+        filed = now.status === "archived";
+        archiveStates.set(archiveKey, filed);
+      }
+    }
     const res = await fetch(filed ? "/api/tasks/unarchive" : "/api/tasks/archive", {
       method: "POST",
       headers: { "Content-Type": "application/json", "X-Fused": "1" },

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -11392,18 +11392,34 @@ archiveOpt.addEventListener("click", async () => {
     // DISABLED item until the read lands would trade the bug for the lateness
     // the instant paint exists to remove, so the check moves to the press,
     // where one extra read is invisible next to the write that follows it.
-    const check = await fetch("/api/tasks");
-    if (check.ok) {
-      const listing = await check.json();
-      const now = ((listing && listing.tasks) || []).find((t) => t && t.key === archiveKey);
-      // Only a POSITIVE answer overrides the cache. An unreadable listing, or a
-      // task the listing no longer holds, leaves the reader's own reading of the
-      // button in force — refusing the press on a listing we could not read
-      // would make a network blip look like a broken control.
-      if (now) {
-        filed = now.status === "archived";
-        archiveStates.set(archiveKey, filed);
+    // ITS OWN try, INSIDE this one, and that nesting is the whole point (bugbot,
+    // PR #802). Sharing the outer `try` with the write below meant a THROWN
+    // fetch — offline, a dropped connection, a body that would not parse — went
+    // straight to the catch and never attempted the POST at all: the press
+    // refused because its own confirmation failed, which is exactly the failure
+    // mode the comment above forbids. Only a non-OK STATUS fell through, which
+    // is the one unreachable-server case that does not throw.
+    //
+    // So every way this read can fail is one way: it declines to override, and
+    // the cached verb — the one the reader actually read off the button — is
+    // spent. A confirmation is an improvement on a guess, never a precondition
+    // for acting on it.
+    try {
+      const check = await fetch("/api/tasks");
+      if (check.ok) {
+        const listing = await check.json();
+        const now = ((listing && listing.tasks) || []).find((t) => t && t.key === archiveKey);
+        // Only a POSITIVE answer overrides the cache. An unreadable listing, or a
+        // task the listing no longer holds, leaves the reader's own reading of the
+        // button in force — refusing the press on a listing we could not read
+        // would make a network blip look like a broken control.
+        if (now) {
+          filed = now.status === "archived";
+          archiveStates.set(archiveKey, filed);
+        }
       }
+    } catch (err) {
+      /* the cached verb stands — see above */
     }
     const res = await fetch(filed ? "/api/tasks/unarchive" : "/api/tasks/archive", {
       method: "POST",

--- a/tests/test_claude_sessions_merged.py
+++ b/tests/test_claude_sessions_merged.py
@@ -904,6 +904,37 @@ def test_archiving_says_what_it_actually_did(template):
     assert "refreshArchiveOpt()" in handler
 
 
+def test_the_press_confirms_its_direction_without_depending_on_the_answer(template):
+    """The item paints from cache so it can appear in the menu's first frame, so
+    the cached verb can be stale — archived from the Tasks page in another tab,
+    then clicked fast here, would file the wrong way. The press re-reads the
+    listing first.
+
+    **And the re-read must never be able to REFUSE the press.** It has its own
+    `try` inside the handler's: sharing one meant a thrown fetch (offline, a
+    dropped connection, an unparseable body) jumped to the catch and never
+    attempted the POST — the press failing because its own confirmation did.
+    Only a non-OK status fell through, which is the one unreachable-server case
+    that does not throw. A confirmation is an improvement on a guess, never a
+    precondition for acting on it."""
+    handler = template[template.index('archiveOpt.addEventListener("click"'):]
+    handler = handler[:handler.index("\n});")]
+    # The verb is a `let`, because the read may replace it.
+    assert "let filed = archiveOpt.dataset.filed" in handler
+    # The confirming read happens BEFORE the write it decides the direction of.
+    check = handler.index('fetch("/api/tasks")')
+    write = handler.index('"/api/tasks/unarchive" : "/api/tasks/archive"')
+    assert check < write, "confirm the direction before spending it"
+    # …and it is wrapped in its own try, which is what keeps a failed read from
+    # taking the write down with it. The nested catch sits between the two.
+    nested = handler[:write]
+    assert nested.count("try {") >= 2, "the confirming read needs its own try"
+    assert "} catch (err) {" in nested
+    # Only a POSITIVE answer overrides the cache.
+    assert "if (now) {" in handler
+    assert 'filed = now.status === "archived";' in handler
+
+
 def test_a_hidden_menu_item_takes_no_space(template):
     """`.kebab-opt` sets `display: block`, which beats the UA sheet's
     `[hidden] { display: none }` — so an item hidden in markup still took its


### PR DESCRIPTION
Follow-up to #794, which merged before these three fixes landed. All three are live on main right now.

## The Board card's hint stole its children's captions

`data-hint` sat on the card **button**, which is the List row's mistake repeated one view over: `hints.ts` resolves by walking up with `closest()`, so the outcome pill and the next-run chip in the foot — both of which carry their own captions — were answered with the *task's* name instead. Exactly the inherited-tooltip failure #794 set out to fix.

The card's **title** carries it now, the same rule the List row follows: the title is what gets cut off, so it is what is worth captioning, and a container-level hint speaks over every child that has one. The pill and the chip move onto the same instant panel, so the card has one tooltip vocabulary rather than two.

## The short refusal cut the wrong clause

`firstClause` is written for the registry's engine-preference prose, where the opening clause **is** the cause and everything past the dash is the remedy the link carries:

> `text-to-image is set to MLX FLUX, which does not read this format — switch it on the Engines tab`

The unsupported-task sentences are built the other way round. `ai/tasks.py` writes:

> `A chat model does this from a prompt — no separate runner ships for it.`

Here the lead-in is the consolation and the **refusal is after the dash**, so cutting at the joint kept the soft half and dropped why Load is dead. Those go through whole now — one or two lines at card width as written, and a correct two-line sentence beats a one-line one that says the wrong thing. The comma form `ai/tasks.py` also writes ("…serve dual encoders (image and text into one space), not text-only sentence encoders") is pinned alongside it, since the clause after the comma is the refusal there too.

## The stale archive verb was clickable

The Claude kebab's Archive item paints from cache so it can appear in the menu's first frame — that was the point of #794's change. The cost was a window: file the task from the Tasks page in another tab, open the menu, click fast, and "Archive" would archive something already archived (or the reverse).

The direction is now confirmed against the server at **press** time, where one extra read is invisible next to the write that follows it. Painting a *disabled* item until the read lands would have traded the bug back for the lateness the instant paint exists to remove.

Only a **positive** answer overrides the cache: an unreadable listing, or a task the listing no longer holds, leaves the reader's own reading of the button in force — refusing the press on a network blip would look like a broken control.

## Verification

`npm run build` clean (boundaries 355 files, tsc, vite). `bun test` 2503 pass / 0 fail — the refusal fix is pinned with the bugbot case named, in both sentence shapes, plus the no-`supportReason` fallback. `test_claude_sessions_merged`, `test_theme` and `test_doc_duplicate_ids` green (245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches archive/unarchive direction on click (task mutation) plus UI copy/tooltips. The extra listing fetch is fail-open so a network error still spends the cached verb.
> 
> **Overview**
> Follow-up to #794: three live bugs, not one feature.
> 
> **Board card hints no longer steal child captions.** `data-hint` moves off the card button onto the title (same rule as the List row). Outcome pills and next-run chips use the instant hint panel instead of native `title`, so hovering them no longer shows the task name.
> 
> **Unsupported-task Load copy is no longer truncated at the first dash/comma.** `loadRefusalShort` now uses the server's `supportReason` whole when capability is unknown, so the refusal after the dash survives instead of the consolation clause.
> 
> **Claude kebab Archive confirms direction on press without blocking the write.** A nested GET of `/api/tasks` can override a stale cache; a failed or empty read leaves the cached verb and still POSTs archive/unarchive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66c04d5d29efaf1ca4a86c6c903b237bc56c636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->