### PR TITLE
Share card: one brand, in the footer, and the caption folded into the title

### DIFF
--- a/frontend/src/apps/ai_models/benchmark/shareCard.test.ts
+++ b/frontend/src/apps/ai_models/benchmark/shareCard.test.ts
@@ -7,12 +7,14 @@
 import { describe, expect, it } from "bun:test";
 import type { AiBenchmarkMachine } from "@platform/lib/api";
 import { availableMetrics } from "@apps/ai_models/lib/benchmark";
+import { capabilityLabel } from "@apps/ai_models/lib/engines";
 import {
   hardwareLine,
   metricSubtitle,
   provenanceLine,
   shareCardFilename,
   shareCardHeight,
+  titleSuffix,
 } from "./shareCard";
 
 const MAC: AiBenchmarkMachine = {
@@ -83,8 +85,24 @@ describe("shareCardHeight", () => {
   });
 
   it("leaves room for the chrome even with a single bar", () => {
-    // Header, title, subtitle, axis and footer are all unconditional — a
-    // one-bar card that came out row-height tall would have cropped them.
-    expect(shareCardHeight(1)).toBeGreaterThan(200);
+    // Title, subtitle, axis and footer are all unconditional — a one-bar
+    // card that came out row-height tall would have cropped them. There is
+    // no separate brand row any more (the caption folded onto the title
+    // line, the mark moved to the footer), so the floor here is lower than
+    // it used to be — this pins the exact arithmetic rather than a loose
+    // bound, so a stale term left behind by a future edit would fail here.
+    expect(shareCardHeight(1)).toBe(198);
+  });
+});
+
+describe("titleSuffix", () => {
+  it("reads as one natural phrase after any capability label", () => {
+    // The user's own wording: "speech to text local ai benchmark" — sentence
+    // case, appended right after the label with no separator of its own
+    // (the drawing code supplies the single space between them).
+    const phrase = (capability: string) => `${capabilityLabel(capability)} ${titleSuffix()}`;
+    expect(phrase("automatic-speech-recognition")).toBe("Speech to text local AI benchmark");
+    expect(phrase("text-generation")).toBe("Text generation local AI benchmark");
+    expect(phrase("text-to-image")).toBe("Image generation local AI benchmark");
   });
 });

--- a/frontend/src/apps/ai_models/benchmark/shareCard.ts
+++ b/frontend/src/apps/ai_models/benchmark/shareCard.ts
@@ -128,6 +128,19 @@ export function shareCardFilename(capability: string, metric: MetricSpec): strin
   return `fused-render-benchmark-${slug(capability)}-${slug(metric.key)}.png`;
 }
 
+/** The muted phrase that turns a bare capability label into the whole title —
+ *  "Speech to text" becomes "Speech to text local AI benchmark". There is no
+ *  longer a separate caption row to say this (it used to live right-aligned
+ *  in the now-deleted brand row); folding it into the title keeps the card
+ *  saying what kind of benchmark this is without spending a whole line on it.
+ *  Sentence case, because it reads as a continuation of the label's phrase,
+ *  not as its own heading. Pulled out as its own function so the drawing
+ *  code can colour and size it separately from the label, and so a test can
+ *  pin the exact wording without a canvas. */
+export function titleSuffix(): string {
+  return "local AI benchmark";
+}
+
 function slug(text: string): string {
   return text
     .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
@@ -142,9 +155,10 @@ export function shareCardHeight(barCount: number): number {
   const plot = barCount * ROW_H + Math.max(0, barCount - 1) * ROW_GAP;
   return (
     PAD + // top padding
-    32 + // the brand row
-    26 + // gap under it
-    30 + // the title
+    // No separate brand row any more — the wordmark moved to the footer and
+    // the caption folded onto the title line below, so the card opens
+    // directly on the title rather than spending a row on branding first.
+    30 + // the title (capability label + its "local AI benchmark" suffix)
     20 + // the metric subtitle
     14 + // gap before the plot
     plot +
@@ -174,9 +188,11 @@ export interface ShareCardInput {
 /** Draw the card and hand back its PNG bytes.
  *
  *  Rejects only if the canvas itself is unavailable or refuses to encode; a
- *  missing LOGO is not a failure (the mark falls back to a drawn wordmark),
- *  because a card without its picture is still the result somebody asked to
- *  share. */
+ *  missing LOGO is not a failure. The footer's "fused render 0.4.53 · ..."
+ *  text is drawn unconditionally regardless of whether the mark loaded, so a
+ *  failed `loadLogo()` just means the footer ships without its mark, not that
+ *  the card loses its branding — the card without its picture is still the
+ *  result somebody asked to share. */
 export async function renderShareCard(input: ShareCardInput): Promise<Blob> {
   const { bars, metric } = input;
   const height = shareCardHeight(bars.length);
@@ -192,24 +208,32 @@ export async function renderShareCard(input: ShareCardInput): Promise<Blob> {
   ctx.fillRect(0, 0, WIDTH, height);
 
   let y = PAD;
-
-  // -- the brand row ---------------------------------------------------------
   const mark = await loadLogo();
-  if (mark) ctx.drawImage(mark, PAD, y, 32, 32);
-  ctx.fillStyle = INK.fg;
-  ctx.font = `600 17px ${SANS}`;
-  ctx.fillText("fused render", PAD + (mark ? 42 : 0), y + 8);
-  ctx.fillStyle = INK.muted;
-  ctx.font = `12px ${SANS}`;
-  ctx.textAlign = "right";
-  ctx.fillText("Local AI model benchmark", WIDTH - PAD, y + 12);
-  ctx.textAlign = "left";
-  y += 32 + 26;
 
   // -- title + metric --------------------------------------------------------
+  // The capability label carries the heading weight; the "local AI benchmark"
+  // suffix rides beside it in the muted colour at a smaller size, so the two
+  // read as one phrase ("Speech to text local AI benchmark") rather than a
+  // label plus an unrelated caption. The suffix's x is `label`'s MEASURED
+  // width, not a guessed offset — the label's text varies per capability
+  // ("Text generation" vs "Embeddings"), so a fixed offset would either
+  // collide with a wide label or leave a gap after a narrow one.
   ctx.fillStyle = INK.fg;
   ctx.font = `600 24px ${SANS}`;
-  ctx.fillText(capabilityLabel(input.capability), PAD, y);
+  const label = capabilityLabel(input.capability);
+  ctx.fillText(label, PAD, y);
+  const labelWidth = ctx.measureText(label).width;
+  ctx.fillStyle = INK.muted;
+  ctx.font = `14px ${SANS}`;
+  // `textBaseline` stays "top" throughout the card (set once, above), which
+  // means two different font sizes drawn at the same y sit on DIFFERENT
+  // baselines — a smaller font's glyphs hang noticeably higher than a bigger
+  // one's. The +8 nudges the suffix down onto the label's baseline; it is the
+  // same eyeballed offset the old brand row used to line up its 17px wordmark
+  // against a 12px caption (8 and 12 both landed the two baselines at ~21.6px
+  // below their own `y`), not a value derived from font metrics the Canvas
+  // API does not expose cheaply.
+  ctx.fillText(` ${titleSuffix()}`, PAD + labelWidth, y + 8);
   y += 30;
   ctx.fillStyle = INK.muted;
   ctx.font = `13px ${SANS}`;
@@ -287,7 +311,24 @@ export async function renderShareCard(input: ShareCardInput): Promise<Blob> {
   ctx.fillText(hardwareLine(input.machine, input.device), PAD, y);
   ctx.fillStyle = INK.muted;
   ctx.textAlign = "right";
-  ctx.fillText(provenanceLine(input.appVersion, input.now ?? new Date()), WIDTH - PAD, y);
+  const provenance = provenanceLine(input.appVersion, input.now ?? new Date());
+  ctx.fillText(provenance, WIDTH - PAD, y);
+  if (mark) {
+    // The mark moved down here from the old brand row: it now sits flush
+    // against the provenance text it used to sit above, so the two read as
+    // one group at the card's bottom right rather than two unrelated
+    // mentions of the brand. Sized for THIS line (14px, not the header's
+    // 32px) — measured off the provenance text's actual width via
+    // `measureText` rather than guessed, because the width changes with the
+    // app version and the date's month name.
+    const markSize = 14;
+    const markGap = 6;
+    const provenanceLeft = WIDTH - PAD - ctx.measureText(provenance).width;
+    // `y` is the top of the 12px line (textBaseline stays "top"); +6 is that
+    // line's vertical midpoint, so centring the mark there against half its
+    // own size keeps the mark and the text visually centred on each other.
+    ctx.drawImage(mark, provenanceLeft - markGap - markSize, y + 6 - markSize / 2, markSize, markSize);
+  }
   ctx.textAlign = "left";
 
   return await encode(canvas);

--- a/frontend/src/apps/ai_models/benchmark/shareCard.ts
+++ b/frontend/src/apps/ai_models/benchmark/shareCard.ts
@@ -212,28 +212,28 @@ export async function renderShareCard(input: ShareCardInput): Promise<Blob> {
 
   // -- title + metric --------------------------------------------------------
   // The capability label carries the heading weight; the "local AI benchmark"
-  // suffix rides beside it in the muted colour at a smaller size, so the two
-  // read as one phrase ("Speech to text local AI benchmark") rather than a
-  // label plus an unrelated caption. The suffix's x is `label`'s MEASURED
-  // width, not a guessed offset — the label's text varies per capability
-  // ("Text generation" vs "Embeddings"), so a fixed offset would either
-  // collide with a wide label or leave a gap after a narrow one.
+  // suffix rides beside it in the muted colour, so the two read as one phrase
+  // ("Speech to text local AI benchmark") rather than a label plus an
+  // unrelated caption. The suffix's x is `label`'s MEASURED width, not a
+  // guessed offset — the label's text varies per capability ("Text
+  // generation" vs "Embeddings"), so a fixed offset would either collide with
+  // a wide label or leave a gap after a narrow one.
+  //
+  // Both runs are drawn at the SAME 24px size — weight and colour do the
+  // distinguishing, not size. A smaller suffix (tried first) reads as a
+  // caption stapled onto a heading rather than as one phrase, and it also
+  // reintroduces the baseline mismatch below: `textBaseline` is "top", so two
+  // sizes sharing one `y` sit on different baselines and need a hand-eyeballed
+  // nudge to line back up. One size sidesteps both problems at once, which is
+  // why a future "shrink the suffix back down" edit should stop here.
   ctx.fillStyle = INK.fg;
   ctx.font = `600 24px ${SANS}`;
   const label = capabilityLabel(input.capability);
   ctx.fillText(label, PAD, y);
   const labelWidth = ctx.measureText(label).width;
   ctx.fillStyle = INK.muted;
-  ctx.font = `14px ${SANS}`;
-  // `textBaseline` stays "top" throughout the card (set once, above), which
-  // means two different font sizes drawn at the same y sit on DIFFERENT
-  // baselines — a smaller font's glyphs hang noticeably higher than a bigger
-  // one's. The +8 nudges the suffix down onto the label's baseline; it is the
-  // same eyeballed offset the old brand row used to line up its 17px wordmark
-  // against a 12px caption (8 and 12 both landed the two baselines at ~21.6px
-  // below their own `y`), not a value derived from font metrics the Canvas
-  // API does not expose cheaply.
-  ctx.fillText(` ${titleSuffix()}`, PAD + labelWidth, y + 8);
+  ctx.font = `24px ${SANS}`;
+  ctx.fillText(` ${titleSuffix()}`, PAD + labelWidth, y);
   y += 30;
   ctx.fillStyle = INK.muted;
   ctx.font = `13px ${SANS}`;


### PR DESCRIPTION
## Summary

- **The benchmark share card no longer says "fused render" twice.** It carried a brand row at the top — logo mark, bold wordmark, and a right-aligned "Local AI model benchmark" caption — and *then* said `fused render <version> · <date>` again in the footer. Two unrelated mentions of the same brand, on a card whose actual subject (the chart) had to wait 58px for its turn. The top row is gone; the branding now lives once, in the footer, where the provenance line already was.
- **The mark moved down to join it.** A 14px logo sits immediately left of the provenance text, right-flush as one group, so the two read as a single credit rather than a picture at the top and a string at the bottom.
- **The caption folded into the title instead of being dropped.** The card still has to say what kind of benchmark it is, so it now says it in the heading: `Speech to text local AI benchmark`, the capability label at 600 weight in the foreground ink and the suffix at the *same 24px* in the muted one. An earlier cut drew the suffix at 14px; rendered, that size jump read as a caption stapled onto a heading, so weight and colour carry the distinction and size no longer does. One size also means one baseline, which removed an eyeballed `+8` nudge the two-size version needed.

### Two details worth a reviewer's eye

The suffix's x is `ctx.measureText(label).width`, not a fixed offset — the label varies per capability ("Embeddings" vs "Video generation"), so a constant would either collide with a wide one or leave a hole after a narrow one. The footer mark is positioned the same way, off the provenance text's measured width, which changes with the version string and the month name.

`shareCardHeight` is a pure function of per-line arithmetic, so deleting a row means deleting its terms — a stale `32 + 26` left behind would have rendered as a silent band of dead space at the top. Its test moved from `toBeGreaterThan(200)` to an exact `toBe(198)` so that failure mode is caught precisely rather than passing a loose bound.

## Visuals

```mermaid
flowchart TD
    A["PAD"] --> B["brand row: mark + wordmark + caption"]
    B --> C["title: capability label"]
    C --> D["metric subtitle"]
    D --> E["plot + axis"]
    E --> F["footer: hardware · provenance"]
    B -.->|deleted, -58px| G["mark joins the footer"]
    B -.->|caption folds in| C
    G -.-> F
```

## Usage

Not separately invocable. The Benchmark tab's **Share chart** button on any capability section produces the PNG:

```
/ai-models/benchmark → pick a capability → Share chart
→ fused-render-benchmark-<capability>-<metric>.png
```

## Test Plan

- [x] `shareCard.test.ts` — `shareCardHeight(1)` pinned to the exact new total (198), and a new `titleSuffix` case asserting the phrase reads naturally after three different capability labels (`Speech to text local AI benchmark`, `Text generation local AI benchmark`, `Image generation local AI benchmark`). 10 pass.
- [x] `bun test` 2503 pass / 0 fail; `bun run typecheck` clean; `bun run check:boundaries` OK (355 files).
- [x] **Verified against a real rendered PNG**, not just the unit tests — a benchmarked whisper run shared from the running dev server, card inspected as an image. This is the only way to check it: `src/apps/ai_models` has no DOM shim, so canvas is unavailable under the test runner and nothing here can be asserted from a test.
- [x] No Python test asserts on this file's literal source lines (grepped `tests/` for `shareCard`, the deleted caption string, and the provenance prefix) — that class of breakage is a known hazard in this repo.
- [ ] **Overflow is estimated, not measured.** The widest capability label ("Video generation") plus the suffix is ~36 characters, ≈432px at 24px against 844px of usable width — comfortable, but arrived at by arithmetic rather than `measureText`, since measuring needs a canvas. No truncation logic was added on the strength of an estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
