### PR TITLE
Local tab: match a curated GGUF to its own disk card by repo id

### DIFF
--- a/frontend/src/apps/ai_models/lib/aiModelGroups.test.ts
+++ b/frontend/src/apps/ai_models/lib/aiModelGroups.test.ts
@@ -567,6 +567,71 @@ describe("which rows exist at all", () => {
   });
 });
 
+// The llama.cpp half of the curation is keyed by the GGUF's own FILENAME, and
+// the disk map is keyed by repo id — so the filter that drops a downloaded
+// recommendation had nothing to match on and dropped nothing. Every cached GGUF
+// suggestion kept its Download button next to the finished disk card its own
+// bytes had made, and pressing it re-ran a fetch that completed instantly
+// having nothing to fetch, changing nothing on screen.
+describe("a curated entry keyed by filename rather than by repo id", () => {
+  const GGUF_ON_DISK = repo({
+    id: "LiquidAI/LFM2.5-1.2B-Instruct-GGUF",
+    size: 730_895_208,
+    capability: "text-generation",
+    engine: engine({
+      code: "llamacpp-text-vulkan",
+      shortLabel: "llama.cpp (Vulkan)",
+      label: "llama.cpp (Vulkan)",
+    }),
+  });
+  // Its own filename as the id, its repo in `repo` — the shape the server sends
+  // for every `GGUF_RECIPES` entry.
+  const GGUF_CATALOG: AiCatalogCapability[] = [
+    capability("text-generation", [
+      curated("LFM2.5-1.2B-Instruct-Q4_K_M.gguf", {
+        repo: "LiquidAI/LFM2.5-1.2B-Instruct-GGUF",
+        // The verdict is seeded WRONG on purpose, like every other fixture
+        // here: the fix must ride on the identity, not on this flag.
+        downloaded: false,
+      }),
+      curated("LFM2.5-8B-A1B-Q4_K_M.gguf", { repo: "LiquidAI/LFM2.5-8B-A1B-GGUF" }),
+    ]),
+  ];
+
+  const textRow = (repos: AiModelRepo[], cat = GGUF_CATALOG) =>
+    mergeSections(groupRepos(repos).models.groups, cat, resident(), disked(repos)).find(
+      (s) => s.key === "text-generation",
+    );
+
+  it("stops recommending it once its REPO has a disk card", () => {
+    const text = textRow([GGUF_ON_DISK]);
+    expect(text?.disk.map((r) => r.id)).toEqual(["LiquidAI/LFM2.5-1.2B-Instruct-GGUF"]);
+    // The one still absent is still offered; the downloaded one is gone from the
+    // recommendations rather than drawn twice under two different ids.
+    expect(text?.recommended.map((m) => m.id)).toEqual(["LFM2.5-8B-A1B-Q4_K_M.gguf"]);
+  });
+
+  it("still recommends it when nothing of its repo is on the disk", () => {
+    expect(textRow([])?.recommended.map((m) => m.id)).toEqual([
+      "LFM2.5-1.2B-Instruct-Q4_K_M.gguf",
+      "LFM2.5-8B-A1B-Q4_K_M.gguf",
+    ]);
+  });
+
+  // An older server sends no `repo`, and the fallback has to be the id — which
+  // is the correct repo id for every entry that is not filename-keyed, so a
+  // stale server loses this one fix and nothing else.
+  it("falls back to the id when the server sends no repo", () => {
+    const noRepo: AiCatalogCapability[] = [
+      capability("text-generation", [curated("mlx-community/Qwen3.5-9B-OptiQ-4bit")]),
+    ];
+    expect(textRow([QWEN_LOADABLE], noRepo)?.recommended).toEqual([]);
+    expect(textRow([], noRepo)?.recommended.map((m) => m.id)).toEqual([
+      "mlx-community/Qwen3.5-9B-OptiQ-4bit",
+    ]);
+  });
+});
+
 describe("what a merged row says it costs, and which engine loads it", () => {
   // D249/D251: the figure beside a heading is a claim about THIS DISK. A
   // recommended model is not on it, so it cannot be in the number — otherwise

--- a/frontend/src/apps/ai_models/lib/aiModelGroups.ts
+++ b/frontend/src/apps/ai_models/lib/aiModelGroups.ts
@@ -520,6 +520,20 @@ export function runnersByCapability(
  *  posture the download cards take, since a recommendation is a claim that this
  *  machine does not have the model.
  *
+ *  **The lookup is by `repo`, not by `id`, and that is what makes the filter
+ *  able to fire at all for llama.cpp.** Those curated ids are bare GGUF
+ *  FILENAMES (`AiCatalogModel.repo` says why), and `diskCards` is keyed by REPO
+ *  id — so `LFM2.5-1.2B-Instruct-Q4_K_M.gguf` never matched
+ *  `LiquidAI/LFM2.5-1.2B-Instruct-GGUF`, and every downloaded GGUF suggestion
+ *  stayed recommended forever, wearing a Download button next to the finished
+ *  disk card its own bytes had made. Pressing it re-ran a download that
+ *  completed instantly with nothing left to fetch and changed nothing on
+ *  screen, which is indistinguishable from a download that does not work. This
+ *  is the same duplicate the server already drops from its "cached" tail
+ *  (`curated_repo_ids`, ai_runtime.py) — resolved here through the identity it
+ *  puts on the wire for exactly this, rather than through a second copy of
+ *  `GGUF_RECIPES` in TypeScript.
+ *
  *  Client side for the reason `groupRepos` above is: which rows sit in which
  *  order is a question about this page's layout, and every field it reads is
  *  already in two payloads the page has.
@@ -549,7 +563,12 @@ export function mergeSections(
     if (!onDisk) return [];
     const entry = byCapability.get(key);
     if (!entry) return [];
-    return entry.models.filter((m) => m.source === "curated" && !onDisk.has(m.id));
+    return entry.models.filter(
+      // `m.repo ?? m.id`, so an older server that does not send the field still
+      // filters correctly for every entry whose id IS its repo id — which is
+      // every entry but a llama.cpp one.
+      (m) => m.source === "curated" && !onDisk.has(m.repo ?? m.id),
+    );
   };
 
   const sections: MergedSection[] = groups.map((group) => ({

--- a/frontend/src/apps/ai_models/local/LocalTab.tsx
+++ b/frontend/src/apps/ai_models/local/LocalTab.tsx
@@ -216,15 +216,33 @@ export function LocalTab({ scan }: { scan: CacheScan }) {
   // nor "you don't" while the tab still has no idea.
   const onCard = data ? diskCards(repos) : null;
 
+  // A curated id → the repo id that ADDRESSES its bytes (`AiCatalogModel.repo`),
+  // which is the id itself for everything but a llama.cpp GGUF. Needed wherever
+  // a model id meets `onCard`, whose keys are repo ids — see `mergeSections`.
+  const repoById = new Map<string, string>(
+    (catalog ?? []).flatMap((entry) =>
+      entry.models.map((m) => [m.id, m.repo ?? m.id] as const),
+    ),
+  );
+
   // The click is held until something ELSE can speak for the pull — the runtime
   // reporting it, `settling` carrying it through the walk, or the walk finding
   // it on disk (a "download" that was a cache hit and finished before any poll
   // saw it). Clearing on the POST's reply would put the card back to "Download"
   // for the beat before the next runtime poll, which reads as the button having
   // done nothing.
+  //
+  // **That third arm is the ONLY one a cache hit ever reaches, so it is the one
+  // that has to speak the disk's language.** `downloading`/`settling` are keyed
+  // by model id, but `onCard` is keyed by repo id, and asking it about a bare
+  // GGUF filename could never be true — a Download pressed on a model already
+  // fully cached had no arm that could settle it, and the click stayed held
+  // until the next thing re-rendered the tab.
   const spokenFor =
     starting !== null &&
-    (downloading.has(starting) || settling.has(starting) || !!onCard?.has(starting));
+    (downloading.has(starting) ||
+      settling.has(starting) ||
+      !!onCard?.has(repoById.get(starting) ?? starting));
   useEffect(() => {
     if (spokenFor) setStarting(null);
   }, [spokenFor]);

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2686,6 +2686,24 @@ export function getAiRuntime(): Promise<AiRuntime> {
  *  listing's answer — joined by the page so both tabs mean one thing by it. */
 export interface AiCatalogModel {
   id: string;
+  /** The repo id whose cache folder holds this model — equal to `id` for every
+   *  entry but a llama.cpp one, whose curated id is the GGUF's bare FILENAME so
+   *  that one repo's several quantizations can be curated separately
+   *  (`formats.GGUF_RECIPES`, server side).
+   *
+   *  **Read this, not `id`, against anything keyed by repo id** — above all the
+   *  Local tab's `diskCards` map, built from `/api/ai-models`. Matching on `id`
+   *  there could never hit for a filename-keyed entry, so a finished
+   *  `LFM2.5-1.2B-Instruct-Q4_K_M.gguf` stayed "recommended" and kept its
+   *  Download button beside the very disk card its own bytes had produced.
+   *  `downloaded` is NOT the substitute: it is the server's verdict at scan
+   *  time, and `mergeSections` deliberately answers on-disk from the page's own
+   *  walk instead so one page cannot hold two definitions of it. This field is
+   *  the missing IDENTITY, which is a different question from the verdict.
+   *
+   *  Optional only because an older server does not send it; fall back to `id`,
+   *  which is correct for every entry that is not filename-keyed. */
+  repo?: string;
   label: string;
   /** The short human name the Playground sidebar shows — the model without its
    *  quantization/engine qualifier. A curated field beside `label`, never a

--- a/fused_render/server/routers/ai_runtime.py
+++ b/fused_render/server/routers/ai_runtime.py
@@ -720,6 +720,22 @@ def _catalog_with_downloads() -> list[dict]:
     `curated_repo_ids` then removes the SAME repo from the "cached"
     tail below whenever any of ITS curated entries resolved as downloaded, so
     the two halves cannot show the one download twice under two different ids.
+
+    **`repo` puts that same translation ON THE WIRE, because a client cannot
+    redo it.** Every entry carries the repo id whose cache folder holds it —
+    equal to `id` everywhere but a filename-keyed one, where it is the recipe's
+    `repo`. The Local tab has the identical duplicate to avoid and no way to
+    avoid it: its "do I already have a card for this" map is keyed by repo id
+    (`/api/ai-models`, the page's own walk), so `LFM2.5-1.2B-Instruct-Q4_K_M.gguf`
+    never matched `LiquidAI/LFM2.5-1.2B-Instruct-GGUF` and the row kept its
+    Download button beside its own finished disk card — the same "Download
+    forever" this docstring describes, one layer up and still open. It cannot
+    read `downloaded` instead (`mergeSections` states why: two definitions of
+    on-disk on one page are two moments they were true), so what it needs is the
+    IDENTITY, not the verdict. A field rather than a client-side table for the
+    reason `GGUF_RECIPES` is server-side at all: which repo publishes a curated
+    quantization is the curation's fact, and a second copy in TypeScript is one
+    that goes stale the next time a recipe's repo changes.
     """
     rows = catalog.describe()
     cached = cached_models()
@@ -740,9 +756,17 @@ def _catalog_with_downloads() -> list[dict]:
         # `cached` is passed so a row of twenty entries pays for the scan once.
         return is_downloaded(entry_id, cached)
 
+    def _repo_of(entry_id: str) -> str:
+        # The repo id that ADDRESSES this entry's bytes, which is the entry id
+        # itself for every runner but the filename-keyed one. One lookup in the
+        # curation's own table, so no consumer has to keep a second copy of it.
+        recipe = formats.GGUF_RECIPES.get(entry_id)
+        return recipe["repo"] if recipe else entry_id
+
     for row in rows:
         curated = [
             dict(entry, source="curated", downloaded=_downloaded(entry["id"]),
+                 repo=_repo_of(entry["id"]),
                  loaded=entry["id"] in resident,
                  # Normalised to a bool HERE rather than left absent, because
                  # the curation writes it opt-in (`catalog.py`) and a consumer
@@ -753,14 +777,15 @@ def _catalog_with_downloads() -> list[dict]:
         ]
         curated_ids = {entry["id"] for entry in curated}
         # Repo ids already spoken for by a DOWNLOADED filename-keyed curated
-        # entry — see the docstring. Built from `curated` (post-`_downloaded`)
-        # rather than re-checking `formats.GGUF_RECIPES` here, so this stays
-        # correct for any future runner whose ids work the same way without
-        # this function needing to know which one.
+        # entry — see the docstring. Read off `repo` (post-`_downloaded`) rather
+        # than re-checking `formats.GGUF_RECIPES` here, so this stays correct for
+        # any future runner whose ids work the same way without this function
+        # needing to know which one. `repo != id` IS "filename-keyed", by
+        # `_repo_of`'s own definition, and is why that translation is a field
+        # rather than a second lookup here.
         curated_repo_ids = {
-            formats.GGUF_RECIPES[entry["id"]]["repo"]
-            for entry in curated
-            if entry["downloaded"] and entry["id"] in formats.GGUF_RECIPES
+            entry["repo"] for entry in curated
+            if entry["downloaded"] and entry["repo"] != entry["id"]
         }
         extra = [
             {
@@ -774,6 +799,12 @@ def _catalog_with_downloads() -> list[dict]:
                 "note": None,
                 "source": "cached",
                 "downloaded": True,
+                # Its own repo id, so `repo` is on EVERY entry rather than on
+                # the half that needed it: a consumer reading it only where it
+                # differs from `id` is a consumer that has to know which half it
+                # is holding, which is the distinction this field exists to
+                # remove.
+                "repo": model.repo_id,
                 # Never recommended: `recommended` is a curator's mark and
                 # nobody has made one about a repo the user found themselves.
                 # It costs the Playground nothing — a cached entry is on the

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -8462,6 +8462,40 @@ def test_a_llamacpp_curated_id_is_marked_downloaded_and_not_duplicated(
     assert curated_match["source"] == "curated"
     # The repo id itself must NOT also appear as a second, "cached" row.
     assert not any(m["id"] == recipe["repo"] for m in row["models"])
+    # And the translation that made both answers possible is ON THE WIRE, since
+    # the Local tab has the same duplicate to avoid and cannot redo it: its
+    # "already have a card for this" map is keyed by repo id, so without this
+    # field the entry kept a Download button beside its own finished disk card.
+    assert curated_match["repo"] == recipe["repo"]
+
+
+def test_every_catalog_entry_carries_the_repo_that_addresses_it(client, hub, monkeypatch):
+    """`repo` is on EVERY entry, not just the filename-keyed half.
+
+    A consumer that had to know which half it was holding before reading the
+    field would be back to making the distinction this field exists to remove —
+    so a repo-keyed curated entry and a cached one both answer with their own
+    id, and only a `GGUF_RECIPES` entry answers with something different.
+    """
+    monkeypatch.setattr(registry.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(registry.platform, "machine", lambda: "x86_64")
+    _prefer(monkeypatch, registry.TEXT_GENERATION, "llamacpp-text")
+
+    # One cached repo the curation has never heard of, so the "cached" tail is
+    # populated too.
+    _cached_repo(hub, "somebody/found-on-disk", files=("config.json",))
+
+    rows = _catalog(client)
+    seen_filename_keyed = False
+    for row in rows.values():
+        for entry in row["models"]:
+            recipe = formats.GGUF_RECIPES.get(entry["id"])
+            expected = recipe["repo"] if recipe else entry["id"]
+            assert entry["repo"] == expected, entry["id"]
+            seen_filename_keyed = seen_filename_keyed or recipe is not None
+    # Guards the assertion above against going vacuous if the llama.cpp
+    # shortlist ever stops being filename-keyed.
+    assert seen_filename_keyed
 
 
 def test_a_llamacpp_curated_id_with_a_sibling_quant_not_downloaded_is_told_apart(


### PR DESCRIPTION
## Summary

- **A downloaded llama.cpp model went on offering its own Download button forever.** Every curated GGUF on this disk was drawn twice in its capability row — once as the disk card its bytes had made, once as a recommendation. Pressing that Download re-ran a fetch that completed in ~2s having nothing left to fetch, changing nothing on screen, which is indistinguishable from a download that does not work. Reported as "why does LFM2.5 1.2B Instruct (Q4_K_M) model download not work for me?"; Qwen3.5 4B and LFM2.5 8B-A1B had it identically.
- **The cause is two id spaces meeting.** `formats.GGUF_RECIPES` keys `llamacpp-text`'s catalog entries by the GGUF's bare FILENAME, so one repo's several quantizations can be curated separately — but `diskCards` is keyed by repo id, off `/api/ai-models`. `LFM2.5-1.2B-Instruct-Q4_K_M.gguf` could never match `LiquidAI/LFM2.5-1.2B-Instruct-GGUF`, so the filter that drops a downloaded recommendation had nothing to match on and dropped nothing.
- **The server already made this exact translation** for the same duplicate on its own side (`curated_repo_ids`), so this puts the identity on the wire — a `repo` field on every catalog entry — rather than copying `GGUF_RECIPES` into TypeScript, where it would go stale the next time a recipe's repo changes. `downloaded` is deliberately *not* the fix: `mergeSections` answers on-disk from the page's own walk so one page cannot hold two definitions of it, and what it was missing is the identity, not the verdict.
- **A second live bug fell out of the same mismatch.** `spokenFor`'s disk arm is the only one a cache hit ever reaches (`downloading`/`settling` are keyed by model id, and a fetch with nothing to fetch never appears in either), so a Download pressed on an already-cached model had no arm that could settle the held click.

## Visuals

The Local tab's recommendation filter, which decides whether a curated model is drawn a second time with a Download button:

```mermaid
flowchart TD
    E["Curated entry<br/>LFM2.5-…-Q4_K_M.gguf"] --> Q{"in diskCards?<br/>keyed by repo id"}
    Q -->|"was: id → never matches"| R["Recommended<br/>+ Download"]
    Q -->|"now: repo → matches"| D["Dropped;<br/>disk card stands alone"]
    R --> B["Duplicate card;<br/>Download does nothing visible"]
```

What the Text generation row actually drew, before and after, for one model whose bytes were fully cached the whole time:

| | Card drawn | Size shown | Actions |
|---|---|---|---|
| Before | `LFM2.5 1.2B Instruct (Q4_K_M)` | 668 MB | **Download** (completed instantly, changed nothing) |
| Before | `LiquidAI/LFM2.5-1.2B-Instruct-GGUF` | 697 MB | Load · Try |
| After | `LiquidAI/LFM2.5-1.2B-Instruct-GGUF` | 697 MB | Load · Try |

The two sizes are the same download seen twice: 668 MB is the curation's own figure for the one GGUF, 697 MB is the walk's measurement of the snapshot holding it.

## Usage

Not user-invocable — it is a correction to what the Local tab draws. To see it, open **AI Models → Models** with a curated llama.cpp GGUF already in the Hugging Face cache. Each such model is now one card with Load/Try, where it used to be a disk card plus a recommendation with a dead Download.

The new wire field is readable directly:

```bash
curl -s -H 'X-Fused: 1' localhost:1777/api/ai/catalog \
  | jq '.capabilities[].models[] | select(.repo != .id) | {id, repo, downloaded}'
```

```json
{ "id": "LFM2.5-1.2B-Instruct-Q4_K_M.gguf", "repo": "LiquidAI/LFM2.5-1.2B-Instruct-GGUF", "downloaded": true }
```

`repo` is on **every** entry (equal to `id` for all but the filename-keyed ones), so a consumer never has to know which half it is holding. It is optional on the client type: an older server sends nothing and `m.repo ?? m.id` stays correct for every entry whose id already is its repo id.

## Test Plan

- [x] **Added** `aiModelGroups.test.ts` → "a curated entry keyed by filename rather than by repo id": stops recommending once its repo has a disk card; still recommends when the repo is absent; falls back to `id` when the server sends no `repo`. Verified red on revert — the first case fails with the duplicate still present.
- [x] **Added** `test_every_catalog_entry_carries_the_repo_that_addresses_it`: every entry's `repo` resolves through `GGUF_RECIPES` or is its own id, with a guard so the assertion cannot go vacuous if the shortlist stops being filename-keyed.
- [x] **Extended** `test_a_llamacpp_curated_id_is_marked_downloaded_and_not_duplicated` to assert the translation reaches the wire, not just the server's own dedup.
- [x] `pytest tests/test_ai_runtime.py tests/test_server_ai.py` → 522 passed. `bun test src/apps/ai_models` → 458 passed. `tsc --noEmit` clean.
- [x] **Manual, against a live server** with all three GGUFs cached: `/api/ai/catalog` reports `repo` + `downloaded: true` for each; the Local tab's Text generation row draws one card per model and no `Q4_K_M` Download card.
- [ ] **Worth a reviewer's eye:** the `spokenFor` arm is only exercised manually. Press Download on a curated GGUF whose bytes are already cached — the click should settle to the disk card rather than stay held.

### Out of scope, found on the way

- **Our mirror does not hold these repos.** `render.fused.io/mirror/models/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/…` is 404 (`NoSuchKey`) for both the repo and the single-file manifest shape, so these downloads fall through to huggingface.co. They work, just not from our own distribution.
- **A stale docstring** at `ai_runtime.py:713` says a bare repo id's Load "then failed". `llama_text._resolve_model_id` has accepted bare repo ids since D412, so the repo-id disk card's Load does work. Left alone rather than folded into this fix.
