### PR TITLE
Embeddings: fix the transformers 5 pooled-output contract, and add CUDA and ROCm rows

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -5747,14 +5747,20 @@ an AI Models page that could say what was on disk but not what was *running*.
   may occupy SEVERAL folders, one per hardware build of it, and then the shared
   code lives at the runners ROOT and each folder's `worker.py` is a shell over
   it** (D381). Diffusers is three folders — `diffusers_image`,
-  `diffusers_image_cuda`, `diffusers_image_rocm` — and llama.cpp is two
-  (`llamacpp_text`, `llamacpp_text_vulkan`), whose manifests are identical except
-  for the index the accelerated distribution is resolved from, and whose
-  `worker.py` is a `sys.path` insert and a call into `runners/torch_image.py` or
-  `runners/llama_text.py`. (D416 removed a third such family — `transformers_text`
-  and its `_cuda`/`_rocm` siblings over `runners/torch_text.py`, which is where
-  this rule was first written. The rule is unchanged; only one of its instances
-  is gone.) Both halves of that are
+  `diffusers_image_cuda`, `diffusers_image_rocm` — llama.cpp is two
+  (`llamacpp_text`, `llamacpp_text_vulkan`), and the transformers embeddings
+  runner is three (`transformers_embed`, `transformers_embed_cuda`,
+  `transformers_embed_rocm`), whose manifests are identical except for the
+  index the accelerated distribution is resolved from, and whose `worker.py`
+  is a `sys.path` insert and a call into `runners/torch_image.py`,
+  `runners/llama_text.py` or `runners/torch_embed.py`. (D416 removed an
+  earlier such family — `transformers_text` and its `_cuda`/`_rocm` siblings
+  over `runners/torch_text.py`, which is where this rule was first written;
+  the embeddings family above is a LATER, separate instance of the same rule,
+  not that one restored — the text tower's one-forward-pass argument that
+  justified withdrawing `transformers_text_cuda`/`_rocm` never applied to the
+  embeddings runner's image tower, which is genuine batched GPU work at
+  `embed_common.MAX_ITEMS`.) Both halves of that are
   forced rather than chosen. **The folder split is forced by PY-16**: a venv is
   keyed on the folder, so two rows sharing one folder share one environment and
   could not hold two different torch builds; and `_env_install_worker` runs a

--- a/fused_render/ai/catalog.py
+++ b/fused_render/ai/catalog.py
@@ -928,6 +928,11 @@ _SHARED_SUGGESTIONS = {
     "diffusers-image-cuda": "diffusers-image",
     "diffusers-image-rocm": "diffusers-image",
     "llamacpp-text-vulkan": "llamacpp-text",
+    # Hardware variants of `transformers-embed` — same repos, same format,
+    # different wheel — for the identical reason the Diffusers pair above is
+    # aliased rather than copied.
+    "transformers-embed-cuda": "transformers-embed",
+    "transformers-embed-rocm": "transformers-embed",
     # Not a hardware variant of the same runner — a DIFFERENT runner that reads
     # the same repos (see the comment on the embeddings block above). Aliased
     # for the same reason as the pairs above: one list to keep in step rather

--- a/fused_render/ai/registry.py
+++ b/fused_render/ai/registry.py
@@ -1262,22 +1262,71 @@ _RUNNERS: tuple[Runner, ...] = (
         code="transformers-embed",
         capability=EMBEDDINGS,
         folder=os.path.join(RUNNERS_DIR, "transformers_embed"),
-        # No qualifier on either name, and that is the decision rather than an
-        # omission: the naming note above the table makes a bracketed SHORT name
-        # the marker of a per-hardware variant, and this row has none. There is
-        # one torch embedding engine, it installs the `whl/cpu` build (D416
-        # withdrew the transformers TEXT family, not the wheel index its
-        # manifest borrows), and CUDA and ROCm variants are deliberately not
-        # offered — a text encoder and a vision tower are milliseconds of work
-        # per item on a CPU, which is the case an accelerated variant would be
-        # paying several gigabytes of wheels to improve. Adding one later is
-        # one folder and one row, exactly as it was for text.
-        label="Transformers Embeddings",
-        short_label="Transformers Embeddings",
+        # "(CPU)" now that `transformers-embed-cuda`/`-rocm` sit below it, for
+        # the same reason `llamacpp-text` carries it once
+        # `llamacpp-text-vulkan` existed: the qualifier names the BUILD —
+        # PyPI's `whl/cpu` wheel, which also happens to run on Apple Silicon's
+        # GPU through MPS — never a prediction about the device, and a family
+        # with a sibling needs it on every row or two engines print the same
+        # name.
+        label="Transformers Embeddings (CPU)",
+        short_label="Transformers Embeddings (CPU)",
         family_label="Transformers Embeddings",
-        note="Runs on the CPU on any machine, or Apple Silicon's GPU — quick "
-             "either way, since one item is a single forward pass.",
+        # "the CPU build" rather than "runs on the CPU on any machine": with
+        # accelerated siblings now registered, this row is one build among
+        # three rather than the only way to run this engine, and the note has
+        # to say which one this is rather than describe the family.
+        note="The CPU build — quick on any machine, or Apple Silicon's GPU, "
+             "since one item is a single forward pass.",
         _available=_torch_platform,
+    ),
+    # The CUDA and ROCm siblings, and neither contradicts the CPU row's own
+    # case for having no accelerated variant: a dual encoder is one forward
+    # pass over a short sequence or one image, milliseconds already on a CPU,
+    # so neither row buys meaningful speed. What they buy is DEVICE — a
+    # machine with a working NVIDIA or fully ROCm-capable AMD card runs
+    # `transformers-embed` in fp32 on the CPU by default, because that row
+    # pins PyPI's `whl/cpu` torch on every platform (see its own comment).
+    # These rows are for whoever would rather their card do it, opted into
+    # from the Engines tab exactly like `diffusers-image-cuda`/`-rocm` above —
+    # nobody is moved here who did not ask, because the speed argument
+    # genuinely is a wash.
+    #
+    # Both below `transformers-embed`, CUDA before ROCm — the same order the
+    # image family uses — and per the naming note over this table and
+    # `test_AUTO_STAYS_ON_THE_UNACCELERATED_ROW_EVEN_WITH_AN_ACCELERATOR`,
+    # `auto` must keep resolving to the CPU/MPS row on every platform.
+    Runner(
+        code="transformers-embed-cuda",
+        capability=EMBEDDINGS,
+        folder=os.path.join(RUNNERS_DIR, "transformers_embed_cuda"),
+        label="Transformers Embeddings (CUDA)",
+        short_label="Transformers Embeddings (CUDA)",
+        family_label="Transformers Embeddings",
+        # One line, hardware-neutral about which MODELS this loads (that is
+        # `family_label`'s job) — and, like the ROCm row below, no
+        # desktop-stall warning: that hazard is a denoise holding the GPU for
+        # minutes, and an embed call is one forward pass at
+        # `embed_common.MAX_ITEMS` items, over in under a second.
+        note="Embeds on an NVIDIA GPU — a larger download for a workload "
+             "that is already fast on the CPU.",
+        _available=_cuda,
+    ),
+    Runner(
+        code="transformers-embed-rocm",
+        capability=EMBEDDINGS,
+        folder=os.path.join(RUNNERS_DIR, "transformers_embed_rocm"),
+        label="Transformers Embeddings (ROCm)",
+        short_label="Transformers Embeddings (ROCm)",
+        family_label="Transformers Embeddings",
+        # One line, hardware-neutral about which MODELS this loads (that is
+        # `family_label`'s job) — and unlike the image ROCm row's note, no
+        # desktop-stall warning: that hazard comes from holding the GPU for
+        # minutes during a denoise, and an embed call is one forward pass at
+        # `embed_common.MAX_ITEMS` items, over in under a second.
+        note="Embeds on a supported AMD GPU under Linux — a larger download "
+             "for a workload that is already fast on the CPU.",
+        _available=_rocm,
     ),
     # Video generation, the fifth capability and the first with no
     # "everywhere" row: its one engine is MLX, so this capability is

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -929,11 +929,15 @@ DECISIVE = ("faster-whisper", "mlx-whisper", "mflux-image", "ltx-video",
             # A `siglip`/`clip` model_type is decisive too, and it has to be: a
             # dual encoder is a directory of safetensors, so without this the
             # text branch would claim it and a cached SigLIP card would offer to
-            # load a vision-text encoder as a chat model. Both codes appear for
-            # `DIFFUSERS_RUNNERS`' reason — membership is a statement about the
-            # FORMAT, and a config saying `siglip` says the same thing whichever
-            # of the two engines opens it.
-            "mlx-embed", "transformers-embed")
+            # load a vision-text encoder as a chat model. All four codes appear
+            # for `DIFFUSERS_RUNNERS`' reason — membership is a statement about
+            # the FORMAT, and a config saying `siglip` says the same thing
+            # whichever of the four engines opens it. `transformers-embed-cuda`
+            # and `-rocm` are spelled literally rather than via
+            # `TRANSFORMERS_EMBED_RUNNERS` for the same forward-declaration
+            # reason `LLAMACPP_RUNNERS` is spelled literally just above.
+            "mlx-embed", "transformers-embed", "transformers-embed-cuda",
+            "transformers-embed-rocm")
 
 
 def unloadable_quant(config: dict) -> str | None:
@@ -1085,6 +1089,18 @@ DIFFUSERS_RUNNERS = ("diffusers-image", "diffusers-image-cuda",
 #: `llamacpp-text` here is exactly the trap this comment already describes for
 #: the other two families (see `test_every_registered_runner_appears_in_loaders`).
 LLAMACPP_RUNNERS = ("llamacpp-text", "llamacpp-text-vulkan")
+#: All three transformers embedding builds — CPU, CUDA and ROCm — for the same
+#: reason as the two tuples above: a `siglip`/`clip` `model_type` is the same
+#: FORMAT whichever wheel's `AutoModel` opens it, and a branch that named only
+#: the CPU row would be exactly the trap
+#: `test_every_registered_runner_appears_in_loaders` exists to catch — a
+#: registered runner with no engine tag, no Load button and no cached repos
+#: offered, on precisely the machines that chose it.
+#: `mlx-embed` stays OUT: it has no hardware variant of its own to enumerate,
+#: and it is appended separately in `loaders()` because it is gated on
+#: `MLX_EMBED_MODEL_TYPES` in a way none of these three are.
+TRANSFORMERS_EMBED_RUNNERS = ("transformers-embed", "transformers-embed-cuda",
+                              "transformers-embed-rocm")
 
 
 def loaders(*, repo_id: str, names, dirnames, config: dict, torch_weights: bool,
@@ -1167,7 +1183,11 @@ def loaders(*, repo_id: str, names, dirnames, config: dict, torch_weights: bool,
     if family and torch_weights:
         if family in MLX_EMBED_MODEL_TYPES:
             found.append("mlx-embed")
-        found.append("transformers-embed")
+        # All three torch builds, not just the CPU row —
+        # `TRANSFORMERS_EMBED_RUNNERS`'s own comment gives the reason, and it
+        # is the DIFFUSERS_RUNNERS/LLAMACPP_RUNNERS reason again: a variant
+        # registered but absent here is invisible to the page.
+        found.extend(TRANSFORMERS_EMBED_RUNNERS)
         # …and NOTHING else, for the `.gguf` branch's reason: this snapshot is
         # a directory of safetensors, so the text branch below would claim it
         # and the page would offer to load a dual encoder as a chat model.

--- a/fused_render/ai/runners/mlx_embed/worker.py
+++ b/fused_render/ai/runners/mlx_embed/worker.py
@@ -13,13 +13,13 @@ this file never sees one and has no branch for it.
 **`mlx_embeddings.load()` does the whole load**, unlike `mlx_text`'s bare
 `mlx_lm.load`: it also resolves the processor (`AutoProcessor` for a model
 whose config carries a `vision_config`, which SigLIP's does), so there is no
-separate processor line here the way `transformers_embed/worker.py` has one —
-the library already made that choice for a checkpoint shaped like this one.
+separate processor line here the way `runners/torch_embed.py` has one — the
+library already made that choice for a checkpoint shaped like this one.
 
 `embed_common.py` (one directory up) is where the request validation and the
-unit-normalization live, shared with `transformers_embed/worker.py` because
-the two engines answer for the SAME repos (`catalog.py`'s embeddings block)
-and must refuse and shape a request identically.
+unit-normalization live, shared with `runners/torch_embed.py` because the two
+engines answer for the SAME repos (`catalog.py`'s embeddings block) and must
+refuse and shape a request identically.
 """
 
 import os
@@ -47,9 +47,9 @@ _loaded = {}
 _STREAMS = {}
 _STREAMS_LOCK = threading.Lock()
 
-#: SigLIP's own padding rule. See `transformers_embed/worker.py`'s
-#: `_TEXT_PADDING` — the same convention, because it is a fact about how the
-#: checkpoint was trained and not about which engine is reading it.
+#: SigLIP's own padding rule. See `runners/torch_embed.py`'s `_TEXT_PADDING`
+#: — the same convention, because it is a fact about how the checkpoint was
+#: trained and not about which engine is reading it.
 _TEXT_PADDING = "max_length"
 
 
@@ -164,7 +164,7 @@ def _to_lists(array):
     `.tolist()` on an mx array already returns plain Python numbers (mlx has
     no numpy dependency to round-trip through), so this is a name for the
     conversion rather than a computation of its own — kept as a function so
-    both call sites below read the same way `transformers_embed/worker.py`'s
+    both call sites below read the same way `runners/torch_embed.py`'s
     two do.
     """
     import mlx.core as mx
@@ -190,9 +190,9 @@ def _image_vectors(model, processor, paths):
     """One vector per path in `paths`, unnormalized, as a plain nested list.
 
     Opened one at a time through `embed_common.open_image`, exactly
-    `transformers_embed/worker.py`'s `_image_vectors` — see that function's
-    docstring for why a bad path in the middle of a batch must be opened here
-    rather than handed to the processor as a filename.
+    `runners/torch_embed.py`'s `_image_vectors` — see that function's docstring
+    for why a bad path in the middle of a batch must be opened here rather than
+    handed to the processor as a filename.
     """
     import mlx.core as mx
 

--- a/fused_render/ai/runners/torch_embed.py
+++ b/fused_render/ai/runners/torch_embed.py
@@ -1,0 +1,252 @@
+"""Embeddings on transformers: one resident dual encoder, two towers (SPEC §40).
+
+**This module is the whole of the runner and it sits at the runners ROOT**,
+beside `worker_base.py`, `embed_common.py` and `torch_image.py` — which is the
+rule `preview.py` states about itself, applied to embeddings. THREE folders
+serve this engine — `transformers_embed/`, `transformers_embed_cuda/` and
+`transformers_embed_rocm/` — and they differ only in which index their
+`pyproject.toml` takes torch from: PyPI's `whl/cpu` build for the first,
+PyPI's default (the CUDA build on Linux, `download.pytorch.org/whl/cu130` on
+Windows) for the second, `download.pytorch.org/whl/rocm7.1` for the third.
+Each folder's `worker.py` is a five-line shell around `torch_embed.main()`,
+the same shape `diffusers_image_cuda/worker.py` documents at length for the
+image family; a second copy of `_pooled`, the padding rule or the placement
+logic under any of them would fail no test, because each copy would pass its
+own.
+
+The HTTP contract, the download reporting and the state machine are
+`worker_base`'s; what lives here is only what is true of a SigLIP/CLIP
+checkpoint loaded through transformers in particular.
+
+**Until this file, embeddings had exactly one torch folder** (D416's argument,
+still true of the CPU/MPS row below): a dual encoder is a SINGLE forward pass
+over a short sequence or one image, milliseconds already on a CPU, so there was
+nothing an accelerated wheel would meaningfully speed up. The CUDA and ROCm
+folders do not contradict that — they exist for a machine that already has a
+working NVIDIA or fully ROCm-capable AMD card and would rather spend a request
+on it than fall back to CPU fp32 by default, which is what happens on that
+hardware without them. Both are opt-in from the Engines tab for exactly that
+reason: the speed argument is a wash, so nobody should be moved onto either
+who did not ask. See `registry.py`'s comment on the
+`transformers-embed-cuda`/`-rocm` rows for the same argument from the
+registry's side.
+
+`_placement()` needs no branch for either accelerated folder: CUDA torch and
+ROCm torch both report through `torch.cuda.is_available()` — ROCm because HIP
+presents the CUDA API surface — so the existing `"cuda"` case already serves
+both, precisely as `diffusers_image_cuda/pyproject.toml` and
+`diffusers_image_rocm/pyproject.toml` document for the image family.
+
+`get_text_features` / `get_image_features` is the API every dual encoder this
+runner loads publishes (`formats.EMBED_MODEL_TYPES`) — SigLIP and CLIP both,
+under transformers' own `AutoModel`. `embed_common.py` (one directory up) is
+where the request validation and the unit-normalization live, shared with
+`mlx_embed/worker.py` because the two engines answer for the SAME repos and
+must refuse and shape a request identically.
+"""
+
+import os
+import sys
+
+# Each `worker.py` shell has already inserted `runners/` on the way in (it is
+# one directory up from the shell — see mlx_text/worker.py); repeated here
+# because a module may not assume something was done before it was imported,
+# and this is the same self-directory insert `partial.py` falls back to.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import embed_common  # noqa: E402 - the shared request shape; see embed_common.py
+import worker_base  # noqa: E402 - the path insert above is what makes it importable
+
+#: The loaded (model, processor) and the device they are on. One per process.
+_loaded = {}
+
+#: SigLIP's own padding rule (also correct for CLIP, which simply ignores the
+#: extra pad tokens under its causal mask). SigLIP was trained with every
+#: sequence padded to its tokenizer's max length rather than to the batch's
+#: longest — an ordinary `padding=True` call still runs, but it changes what
+#: the text tower saw relative to training and measurably shifts the vectors
+#: it produces. Named here rather than left to a default so a reader does not
+#: have to know that convention to trust this call.
+_TEXT_PADDING = "max_length"
+
+
+# --------------------------------------------------------------- model loading
+
+
+def download(model_id):
+    """The whole repo: transformers reads a directory of safetensors plus the
+    processor's own config, so — like the text and image runners — there is no
+    single file to pick out."""
+    return worker_base.download_snapshot(model_id)
+
+
+def _placement():
+    """`device` — where this model runs.
+
+    Same three candidates the withdrawn text runner's `_placement` picked
+    from (D416), minus the dtype
+    question: a dual encoder here runs in float32, at millisecond cost, so
+    there is no CPU-memory argument for a narrower width the way an 8B chat
+    model has one. CUDA when available, then MPS, then CPU — the same order,
+    for the same reason (MPS is the Apple Silicon FALLBACK, behind `mlx-embed`
+    in the registry).
+
+    Unchanged for the CUDA and ROCm folders on purpose — see the module
+    docstring. Both wheels report through `torch.cuda.is_available()` and want
+    the device string `"cuda"`, so the first branch already serves either one,
+    and a `_placement()` that tried to tell the folders apart would be a
+    difference between variants no test could see.
+    """
+    import torch
+
+    if torch.cuda.is_available():
+        return "cuda"
+    mps = getattr(torch.backends, "mps", None)
+    if mps is not None and mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def load(model_id, path):
+    """`path` is what `download` returned — the snapshot directory."""
+    import torch  # noqa: F401 - imported for its side effect on the ones below
+    from transformers import AutoModel, AutoProcessor
+
+    device = _placement()
+    model = AutoModel.from_pretrained(path)
+    model.to(device)
+    model.eval()
+    # `AutoProcessor`, not `AutoTokenizer`: a dual encoder's processor also
+    # knows how to turn a PIL image into `pixel_values`, which the text-only
+    # tokenizer class has no idea exists. Both SigLIP and CLIP publish one.
+    processor = AutoProcessor.from_pretrained(path)
+
+    _loaded["model"] = model
+    _loaded["processor"] = processor
+    _loaded["device"] = device
+    # Published on `/health` — the field the AI Models page reads to say
+    # which device is serving.
+    worker_base.set_state(device=device)
+
+
+def memory():
+    """What torch says it is holding, in bytes: on CUDA and MPS the weights
+    live in an allocator's pool RSS cannot see."""
+    import torch
+
+    total = 0
+    mps = getattr(torch, "mps", None)
+    if mps is not None and hasattr(mps, "current_allocated_memory"):
+        try:
+            total += int(mps.current_allocated_memory())
+        except (RuntimeError, OSError):
+            pass
+    if torch.cuda.is_available():
+        try:
+            total += int(torch.cuda.memory_allocated())
+        except (RuntimeError, OSError):
+            pass
+    return total or None
+
+
+# ------------------------------------------------------------------ embedding
+
+
+def _pooled(features):
+    """The embedding vector out of what `get_*_features` returned.
+
+    **transformers 5 returns the tower's whole output, not the vector.** Through
+    the 4.x series `get_text_features`/`get_image_features` returned the pooled
+    tensor itself; in 5.x both hand back a `BaseModelOutputWithPooling` carrying
+    `last_hidden_state` (per-token/per-patch, `(batch, 64, dim)` for SigLIP's
+    text tower) beside `pooler_output` (the vector, `(batch, dim)`). Calling
+    `.to()` on that object is the `AttributeError:
+    'BaseModelOutputWithPooling' object has no attribute 'to'` this function
+    exists to have never allowed — and picking the field is not optional
+    tidying, because `last_hidden_state` is a different rank and would not have
+    raised, it would have returned nonsense.
+
+    **`pooler_output` is right for BOTH model types in
+    `formats.EMBED_MODEL_TYPES`, and for CLIP that is not a coincidence.** A
+    CLIP feature is the pooled output PROJECTED into the joint space, and 5.x
+    keeps `get_*_features` honest about that by overwriting the field on the way
+    out (`text_outputs.pooler_output = self.text_projection(pooled_output)` in
+    `modeling_clip`). So the projection is not skipped by reading the same
+    attribute SigLIP's unprojected tower publishes — one field, both formats,
+    checked in the installed source rather than assumed from the name.
+
+    No fallback for a plain tensor: `pyproject.toml` pins
+    `transformers>=5.15,<6`, so the 4.x shape is not a version this runner can
+    be installed against, and a branch for it would be untestable code
+    asserting a dependency range that does not exist.
+    """
+    pooled = getattr(features, "pooler_output", None)
+    if pooled is None:
+        raise RuntimeError(
+            "the model's feature call returned "
+            f"{type(features).__name__} with no `pooler_output` — this runner "
+            "reads that field for both SigLIP and CLIP (see _pooled)")
+    return pooled
+
+
+def _text_vectors(model, processor, device, texts):
+    """One vector per string in `texts`, unnormalized, as a plain nested list."""
+    import torch
+
+    inputs = processor(text=texts, padding=_TEXT_PADDING, truncation=True,
+                       return_tensors="pt")
+    inputs = {k: v.to(device) for k, v in inputs.items()}
+    with torch.inference_mode():
+        features = model.get_text_features(**inputs)
+    return _pooled(features).to("cpu", dtype=torch.float32).tolist()
+
+
+def _image_vectors(model, processor, device, paths):
+    """One vector per path in `paths`, unnormalized, as a plain nested list.
+
+    Opened one at a time through `embed_common.open_image` rather than handed
+    to the processor as a batch of paths — a processor takes images, not
+    filenames, and opening here (instead of inside a comprehension the
+    processor call builds) is what lets a bad path in the middle of a batch
+    name itself instead of surfacing as a PIL error with no filename attached.
+    """
+    import torch
+
+    images = [embed_common.open_image(path) for path in paths]
+    inputs = processor(images=images, return_tensors="pt")
+    inputs = {k: v.to(device) for k, v in inputs.items()}
+    with torch.inference_mode():
+        features = model.get_image_features(**inputs)
+    return _pooled(features).to("cpu", dtype=torch.float32).tolist()
+
+
+def generate(body):
+    """One embedding call. Returns `{vectors, dim}` — see `embed_common.py`.
+
+    Not job-backed and not streaming: a batch of at most
+    `embed_common.MAX_ITEMS` items is one forward pass through a small tower,
+    over before a progress row would ever have drawn.
+    """
+    model = _loaded.get("model")
+    processor = _loaded.get("processor")
+    device = _loaded.get("device")
+    if model is None or processor is None:
+        raise RuntimeError("no model is loaded")
+
+    kind, items = embed_common.request_kind(body)
+    vectors = (_text_vectors(model, processor, device, items) if kind == "texts"
+              else _image_vectors(model, processor, device, items))
+    vectors = embed_common.unit_normalize(vectors)
+    dim = len(vectors[0]) if vectors else 0
+    return {"vectors": vectors, "dim": dim}
+
+
+def main():
+    """Serve, forever. The entry point each variant's `worker.py` shell calls.
+
+    A function rather than a `__main__` block because this file is imported,
+    not run: the process the supervisor spawns is `<variant>/worker.py`, whose
+    whole body is a path insert and a call to this — see `torch_image.main()`.
+    """
+    worker_base.serve(download=download, load=load, generate=generate,
+                      streaming=False, memory=memory)

--- a/fused_render/ai/runners/transformers_embed/pyproject.toml
+++ b/fused_render/ai/runners/transformers_embed/pyproject.toml
@@ -11,13 +11,17 @@
 # answers drifting apart is the thing `_SHARED_SUGGESTIONS`-style duplication
 # always risks.
 #
-# **No CUDA or ROCm sibling, unlike text and image generation.** A dual
-# encoder is a single forward pass over a short sequence or one image —
-# milliseconds already on a CPU — so there is no accelerated wheel that would
-# meaningfully speed this runner up, and therefore no second or third folder to
-# install it from. See `registry.py`'s `transformers-embed` row and this
-# folder's `worker.py` module docstring for the same argument stated where the
-# absence is decided.
+# **CUDA and ROCm siblings exist (`transformers_embed_cuda/`,
+# `transformers_embed_rocm/`), but not for speed.** A dual encoder is a single
+# forward pass over a short sequence or one image — milliseconds already on a
+# CPU — so neither accelerated wheel meaningfully speeds this runner up. They
+# exist for the machine that already has a working NVIDIA or fully
+# ROCm-capable AMD card and would rather use it than fall back to this CPU
+# build's fp32 by default — see `runners/torch_embed.py`'s module docstring
+# and `registry.py`'s `transformers-embed-cuda`/`-rocm` rows for the same
+# argument stated where it matters. This folder is unchanged by their
+# existence: same dependencies, same `whl/cpu` index, same fallback behind
+# `mlx_embed` on a Mac.
 #
 # Four dependencies beyond torch, and each earns its place:
 #   transformers    AutoModel/AutoProcessor, and `get_text_features` /

--- a/fused_render/ai/runners/transformers_embed/worker.py
+++ b/fused_render/ai/runners/transformers_embed/worker.py
@@ -1,31 +1,25 @@
-"""Embeddings on transformers: one resident dual encoder, two towers (SPEC §40).
+"""The CPU/MPS embeddings runner (SPEC §40).
 
-Started by `fused_render.ai.supervisor` on the interpreter built from this
-folder's `pyproject.toml`. The HTTP contract, the download reporting and the
-state machine are `worker_base`'s; what lives here is only what is true of a
-SigLIP/CLIP checkpoint loaded through transformers in particular.
+Five lines of code and a `pyproject.toml`, and the manifest is the whole of
+it: this folder installs PyPI's `whl/cpu` torch. Its siblings
+`transformers_embed_cuda/` and `transformers_embed_rocm/` declare the same
+dependencies at the same versions and differ ONLY in which index torch comes
+from; the runner itself is `runners/torch_embed.py`, shared by all three,
+because which wheel a user installed is a fact about the hardware they picked
+on the Engines tab and never about how a forward pass through a dual encoder
+runs.
 
-**One folder, unlike text and image generation.** Both of those have CUDA and
-ROCm siblings that install the same code against a different torch wheel
-(`diffusers_image_cuda/`, `diffusers_image_rocm/`) — an accelerated variant
-earns its keep there because a token loop or a denoiser is seconds of GPU work
-per request. A dual encoder is a SINGLE forward pass over a short sequence or
-one image, which is milliseconds on a CPU already, so there is nothing an
-accelerated wheel would meaningfully speed up and nothing here for a variant
-folder to differ in. See `registry.py`'s comment on the `transformers-embed`
-row for the same argument from the registry's side.
+A folder rather than a flag because `uv sync` runs BARE (`_env_install_worker`)
+with cwd set to the runner folder: everything about an environment has to be
+expressible in the `pyproject.toml` sitting beside it, so three environments mean
+three folders. The supervisor spawns THIS file (`registry.Runner.worker`) on THIS
+folder's venv (`registry.Runner.folder`), which is how the variant a user chose
+becomes the process that runs.
 
-**Not the withdrawn `torch_text.py`'s shape** (D416): that module sat at
-the runners ROOT because three folders share it. This runner has exactly one
-folder, so its whole body lives here — the same reason `faster_whisper/worker.py`
-is not split either.
-
-`get_text_features` / `get_image_features` is the API every dual encoder this
-runner loads publishes (`formats.EMBED_MODEL_TYPES`) — SigLIP and CLIP both,
-under transformers' own `AutoModel`. `embed_common.py` (one directory up) is
-where the request validation and the unit-normalization live, shared with
-`mlx_embed/worker.py` because the two engines answer for the SAME repos and
-must refuse and shape a request identically.
+Nothing here may grow a second line of behaviour. A `_placement()` or a dtype
+rule that lived in one of these shells would be a difference between variants
+that no test can see — the drift `runners/preview.py` documents at length, one
+level out.
 """
 
 import os
@@ -34,194 +28,7 @@ import sys
 # The shared runner sits one directory up, in `runners/` — see mlx_text/worker.py.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-import embed_common  # noqa: E402 - the shared request shape; see embed_common.py
-import worker_base  # noqa: E402 - the path insert above is what makes it importable
-
-#: The loaded (model, processor) and the device they are on. One per process.
-_loaded = {}
-
-#: SigLIP's own padding rule (also correct for CLIP, which simply ignores the
-#: extra pad tokens under its causal mask). SigLIP was trained with every
-#: sequence padded to its tokenizer's max length rather than to the batch's
-#: longest — an ordinary `padding=True` call still runs, but it changes what
-#: the text tower saw relative to training and measurably shifts the vectors
-#: it produces. Named here rather than left to a default so a reader does not
-#: have to know that convention to trust this call.
-_TEXT_PADDING = "max_length"
-
-
-# --------------------------------------------------------------- model loading
-
-
-def download(model_id):
-    """The whole repo: transformers reads a directory of safetensors plus the
-    processor's own config, so — like the text and image runners — there is no
-    single file to pick out."""
-    return worker_base.download_snapshot(model_id)
-
-
-def _placement():
-    """`device` — where this model runs.
-
-    Same three candidates the withdrawn text runner's `_placement` picked
-    from (D416), minus the dtype
-    question: a dual encoder here runs in float32, at millisecond cost, so
-    there is no CPU-memory argument for a narrower width the way an 8B chat
-    model has one. CUDA when available, then MPS, then CPU — the same order,
-    for the same reason (MPS is the Apple Silicon FALLBACK, behind `mlx-embed`
-    in the registry).
-    """
-    import torch
-
-    if torch.cuda.is_available():
-        return "cuda"
-    mps = getattr(torch.backends, "mps", None)
-    if mps is not None and mps.is_available():
-        return "mps"
-    return "cpu"
-
-
-def load(model_id, path):
-    """`path` is what `download` returned — the snapshot directory."""
-    import torch  # noqa: F401 - imported for its side effect on the ones below
-    from transformers import AutoModel, AutoProcessor
-
-    device = _placement()
-    model = AutoModel.from_pretrained(path)
-    model.to(device)
-    model.eval()
-    # `AutoProcessor`, not `AutoTokenizer`: a dual encoder's processor also
-    # knows how to turn a PIL image into `pixel_values`, which the text-only
-    # tokenizer class has no idea exists. Both SigLIP and CLIP publish one.
-    processor = AutoProcessor.from_pretrained(path)
-
-    _loaded["model"] = model
-    _loaded["processor"] = processor
-    _loaded["device"] = device
-    # Published on `/health` — the field the AI Models page reads to say
-    # which device is serving.
-    worker_base.set_state(device=device)
-
-
-def memory():
-    """What torch says it is holding, in bytes: on CUDA and MPS the weights
-    live in an allocator's pool RSS cannot see."""
-    import torch
-
-    total = 0
-    mps = getattr(torch, "mps", None)
-    if mps is not None and hasattr(mps, "current_allocated_memory"):
-        try:
-            total += int(mps.current_allocated_memory())
-        except (RuntimeError, OSError):
-            pass
-    if torch.cuda.is_available():
-        try:
-            total += int(torch.cuda.memory_allocated())
-        except (RuntimeError, OSError):
-            pass
-    return total or None
-
-
-# ------------------------------------------------------------------ embedding
-
-
-def _pooled(features):
-    """The embedding vector out of what `get_*_features` returned.
-
-    **transformers 5 returns the tower's whole output, not the vector.** Through
-    the 4.x series `get_text_features`/`get_image_features` returned the pooled
-    tensor itself; in 5.x both hand back a `BaseModelOutputWithPooling` carrying
-    `last_hidden_state` (per-token/per-patch, `(batch, 64, dim)` for SigLIP's
-    text tower) beside `pooler_output` (the vector, `(batch, dim)`). Calling
-    `.to()` on that object is the `AttributeError:
-    'BaseModelOutputWithPooling' object has no attribute 'to'` this function
-    exists to have never allowed — and picking the field is not optional
-    tidying, because `last_hidden_state` is a different rank and would not have
-    raised, it would have returned nonsense.
-
-    **`pooler_output` is right for BOTH model types in
-    `formats.EMBED_MODEL_TYPES`, and for CLIP that is not a coincidence.** A
-    CLIP feature is the pooled output PROJECTED into the joint space, and 5.x
-    keeps `get_*_features` honest about that by overwriting the field on the way
-    out (`text_outputs.pooler_output = self.text_projection(pooled_output)` in
-    `modeling_clip`). So the projection is not skipped by reading the same
-    attribute SigLIP's unprojected tower publishes — one field, both formats,
-    checked in the installed source rather than assumed from the name.
-
-    No fallback for a plain tensor: `pyproject.toml` pins
-    `transformers>=5.15,<6`, so the 4.x shape is not a version this runner can
-    be installed against, and a branch for it would be untestable code
-    asserting a dependency range that does not exist.
-    """
-    pooled = getattr(features, "pooler_output", None)
-    if pooled is None:
-        raise RuntimeError(
-            "the model's feature call returned "
-            f"{type(features).__name__} with no `pooler_output` — this runner "
-            "reads that field for both SigLIP and CLIP (see _pooled)")
-    return pooled
-
-
-def _text_vectors(model, processor, device, texts):
-    """One vector per string in `texts`, unnormalized, as a plain nested list."""
-    import torch
-
-    inputs = processor(text=texts, padding=_TEXT_PADDING, truncation=True,
-                       return_tensors="pt")
-    inputs = {k: v.to(device) for k, v in inputs.items()}
-    with torch.inference_mode():
-        features = model.get_text_features(**inputs)
-    return _pooled(features).to("cpu", dtype=torch.float32).tolist()
-
-
-def _image_vectors(model, processor, device, paths):
-    """One vector per path in `paths`, unnormalized, as a plain nested list.
-
-    Opened one at a time through `embed_common.open_image` rather than handed
-    to the processor as a batch of paths — a processor takes images, not
-    filenames, and opening here (instead of inside a comprehension the
-    processor call builds) is what lets a bad path in the middle of a batch
-    name itself instead of surfacing as a PIL error with no filename attached.
-    """
-    import torch
-
-    images = [embed_common.open_image(path) for path in paths]
-    inputs = processor(images=images, return_tensors="pt")
-    inputs = {k: v.to(device) for k, v in inputs.items()}
-    with torch.inference_mode():
-        features = model.get_image_features(**inputs)
-    return _pooled(features).to("cpu", dtype=torch.float32).tolist()
-
-
-def generate(body):
-    """One embedding call. Returns `{vectors, dim}` — see `embed_common.py`.
-
-    Not job-backed and not streaming: a batch of at most
-    `embed_common.MAX_ITEMS` items is one forward pass through a small tower,
-    over before a progress row would ever have drawn.
-    """
-    model = _loaded.get("model")
-    processor = _loaded.get("processor")
-    device = _loaded.get("device")
-    if model is None or processor is None:
-        raise RuntimeError("no model is loaded")
-
-    kind, items = embed_common.request_kind(body)
-    vectors = (_text_vectors(model, processor, device, items) if kind == "texts"
-              else _image_vectors(model, processor, device, items))
-    vectors = embed_common.unit_normalize(vectors)
-    dim = len(vectors[0]) if vectors else 0
-    return {"vectors": vectors, "dim": dim}
-
-
-def main():
-    """Serve, forever. The entry point this file's own `__main__` calls — no
-    shell folder here, unlike text and image generation, for the reason the
-    module docstring gives."""
-    worker_base.serve(download=download, load=load, generate=generate,
-                      streaming=False, memory=memory)
-
+import torch_embed  # noqa: E402 - the whole runner; see runners/torch_embed.py
 
 if __name__ == "__main__":
-    main()
+    torch_embed.main()

--- a/fused_render/ai/runners/transformers_embed/worker.py
+++ b/fused_render/ai/runners/transformers_embed/worker.py
@@ -126,6 +126,43 @@ def memory():
 # ------------------------------------------------------------------ embedding
 
 
+def _pooled(features):
+    """The embedding vector out of what `get_*_features` returned.
+
+    **transformers 5 returns the tower's whole output, not the vector.** Through
+    the 4.x series `get_text_features`/`get_image_features` returned the pooled
+    tensor itself; in 5.x both hand back a `BaseModelOutputWithPooling` carrying
+    `last_hidden_state` (per-token/per-patch, `(batch, 64, dim)` for SigLIP's
+    text tower) beside `pooler_output` (the vector, `(batch, dim)`). Calling
+    `.to()` on that object is the `AttributeError:
+    'BaseModelOutputWithPooling' object has no attribute 'to'` this function
+    exists to have never allowed — and picking the field is not optional
+    tidying, because `last_hidden_state` is a different rank and would not have
+    raised, it would have returned nonsense.
+
+    **`pooler_output` is right for BOTH model types in
+    `formats.EMBED_MODEL_TYPES`, and for CLIP that is not a coincidence.** A
+    CLIP feature is the pooled output PROJECTED into the joint space, and 5.x
+    keeps `get_*_features` honest about that by overwriting the field on the way
+    out (`text_outputs.pooler_output = self.text_projection(pooled_output)` in
+    `modeling_clip`). So the projection is not skipped by reading the same
+    attribute SigLIP's unprojected tower publishes — one field, both formats,
+    checked in the installed source rather than assumed from the name.
+
+    No fallback for a plain tensor: `pyproject.toml` pins
+    `transformers>=5.15,<6`, so the 4.x shape is not a version this runner can
+    be installed against, and a branch for it would be untestable code
+    asserting a dependency range that does not exist.
+    """
+    pooled = getattr(features, "pooler_output", None)
+    if pooled is None:
+        raise RuntimeError(
+            "the model's feature call returned "
+            f"{type(features).__name__} with no `pooler_output` — this runner "
+            "reads that field for both SigLIP and CLIP (see _pooled)")
+    return pooled
+
+
 def _text_vectors(model, processor, device, texts):
     """One vector per string in `texts`, unnormalized, as a plain nested list."""
     import torch
@@ -135,7 +172,7 @@ def _text_vectors(model, processor, device, texts):
     inputs = {k: v.to(device) for k, v in inputs.items()}
     with torch.inference_mode():
         features = model.get_text_features(**inputs)
-    return features.to("cpu", dtype=torch.float32).tolist()
+    return _pooled(features).to("cpu", dtype=torch.float32).tolist()
 
 
 def _image_vectors(model, processor, device, paths):
@@ -154,7 +191,7 @@ def _image_vectors(model, processor, device, paths):
     inputs = {k: v.to(device) for k, v in inputs.items()}
     with torch.inference_mode():
         features = model.get_image_features(**inputs)
-    return features.to("cpu", dtype=torch.float32).tolist()
+    return _pooled(features).to("cpu", dtype=torch.float32).tolist()
 
 
 def generate(body):

--- a/fused_render/ai/runners/transformers_embed_cuda/pyproject.toml
+++ b/fused_render/ai/runners/transformers_embed_cuda/pyproject.toml
@@ -1,0 +1,58 @@
+# The transformers embedding runner's environment — the CUDA variant
+# (SPEC §40, PY-16).
+#
+# Identical to `transformers_embed/pyproject.toml` except for the one thing a
+# hardware variant is allowed to change: where torch comes from. Read that
+# file first — it carries the reasoning for the dependency list, the
+# ceilings, and why an accelerated sibling exists at all for a runner whose
+# whole workload is milliseconds on a CPU (short answer: this row is not
+# about speed, it is about a machine that already has the card using it
+# instead of falling back to fp32 on the CPU).
+#
+# **The difference is WHERE torch comes from, and it is asked per platform** —
+# the same split `diffusers_image_cuda/pyproject.toml` documents at length.
+# PyPI's `torch` wheel for Linux IS the CUDA build: its `nvidia-*`
+# requirements are marked `platform_system == "Linux"`, so on Linux this
+# folder resolves from PyPI unchanged. Windows is the half that needs the
+# override, because PyPI has no CUDA wheel for it and no flag changes that —
+# CUDA on Windows means `download.pytorch.org/whl/cuXXX`, hence the
+# marker-scoped source below. `cu130` tracks the toolkit PyPI's own wheel
+# already carries (`nvidia-*-cu13`), so both platforms sit on one CUDA
+# generation.
+#
+# **No `triton-rocm` analogue here.** That trap is ROCm-only — PyPI's CUDA
+# torch resolves its own `nvidia-*` dependencies normally, with no name that
+# exists only on a mirror `[tool.uv.sources]` cannot route to.
+#
+# The dependency list below is a verbatim copy of the CPU folder's four beyond
+# torch and must stay one. A version drifting between the three would make
+# "which hardware" also mean "which transformers".
+[project]
+name = "fused-render-runner-transformers-embed-cuda"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "torch>=2.13,<3",
+    "transformers>=5.15,<6",
+    "pillow",
+    # HEIC/HEIF and AVIF, which plain Pillow cannot open. iPhones have shot
+    # HEIC by default since iOS 11, so without this the `paths` half of an
+    # embed request works on screenshots and fails on the photographs.
+    "pillow-heif>=1.5,<2",
+    "huggingface_hub",
+    "psutil",
+]
+
+# Not a distribution — a folder of scripts, not something to build and install.
+[tool.uv]
+package = false
+
+# CUDA on Windows only — see the header. Linux keeps PyPI's resolution, which
+# is already the CUDA build.
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[tool.uv.sources]
+torch = [{ index = "pytorch-cu130", marker = "sys_platform == 'win32'" }]

--- a/fused_render/ai/runners/transformers_embed_cuda/worker.py
+++ b/fused_render/ai/runners/transformers_embed_cuda/worker.py
@@ -1,0 +1,34 @@
+"""The CUDA embeddings runner (SPEC §40).
+
+Five lines of code and a `pyproject.toml`, and the manifest is the whole of
+it: this folder installs PyPI's default torch, which IS the CUDA build. Its
+siblings `transformers_embed/` and `transformers_embed_rocm/` declare the same
+dependencies at the same versions and differ ONLY in which index torch comes
+from; the runner itself is `runners/torch_embed.py`, shared by all three,
+because which wheel a user installed is a fact about the hardware they picked
+on the Engines tab and never about how a forward pass through a dual encoder
+runs.
+
+A folder rather than a flag because `uv sync` runs BARE (`_env_install_worker`)
+with cwd set to the runner folder: everything about an environment has to be
+expressible in the `pyproject.toml` sitting beside it, so three environments
+mean three folders. The supervisor spawns THIS file (`registry.Runner.worker`)
+on THIS folder's venv (`registry.Runner.folder`), which is how the variant a
+user chose becomes the process that runs.
+
+Nothing here may grow a second line of behaviour. A `_placement()` or a dtype
+rule that lived in one of these three shells would be a difference between
+variants that no test can see — the drift `runners/preview.py` documents at
+length, one level out.
+"""
+
+import os
+import sys
+
+# The shared runner sits one directory up, in `runners/` — see mlx_text/worker.py.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import torch_embed  # noqa: E402 - the whole runner; see runners/torch_embed.py
+
+if __name__ == "__main__":
+    torch_embed.main()

--- a/fused_render/ai/runners/transformers_embed_rocm/pyproject.toml
+++ b/fused_render/ai/runners/transformers_embed_rocm/pyproject.toml
@@ -1,0 +1,81 @@
+# The transformers embedding runner's environment — the ROCm variant
+# (SPEC §40, PY-16).
+#
+# Identical to `transformers_embed/pyproject.toml` except for where torch comes
+# from and the one extra line that follows from it. Read that file first — it
+# carries the reasoning for the dependency list, the ceilings, and why a ROCm
+# sibling exists at all for a runner whose whole workload is milliseconds on a
+# CPU (short answer: this row is not about speed, it is about a machine that
+# already has the card using it instead of falling back to fp32 on the CPU).
+#
+# AMD cards on Linux. The wheels live only on
+# `download.pytorch.org/whl/rocm7.1`; there is no ROCm torch on PyPI, and none for
+# macOS or Windows anywhere, so this variant is a Linux one by construction and the
+# registry offers it there.
+#
+# **`triton-rocm` is declared, and deleting it breaks the install.**
+# `torch 2.13.0+rocm7.1` carries `Requires-Dist: triton-rocm==3.7.1` — note the
+# rename; it was `pytorch-triton-rocm` through the 2.x series — and that
+# distribution is published ONLY on the ROCm index. `[tool.uv.sources]` governs
+# declared dependencies, not transitive ones, so with the line removed uv looks for
+# `triton-rocm` on PyPI, finds nothing, and the whole sync fails with
+#
+#     there is no version of triton-rocm==3.7.1
+#
+# which reads like a broken pin rather than a missing index. Declaring it is what
+# brings it under the source rule. It is deliberately UNBOUNDED: torch's own `==`
+# pin is the version, and a ceiling here could only ever contradict it — the same
+# argument `faster_whisper/pyproject.toml` makes for `sherpa-onnx-core`, and it
+# needs the same exemption in `UNBOUNDED_RUNNER_DEPENDENCIES`
+# (`tests/test_ai_runtime.py`) — already there from `diffusers_image_rocm`, so
+# no test change is needed for this folder's copy of the same line.
+#
+# The `sys_platform == 'linux'` marker is not decoration. A universal resolution
+# considers macOS and Windows too, and there is no `triton-rocm` wheel for either;
+# without the marker uv has to satisfy a requirement that cannot be satisfied on
+# platforms this variant was never for.
+#
+# **What `explicit = true` buys here is larger than on the CPU index.** The ROCm
+# mirror carries its own copies of numpy, pillow, sympy and more — several of which
+# this runner declares directly. Left implicit it would win them by being listed
+# first, and this venv would quietly differ from every other runner's in packages
+# that have nothing to do with AMD. Explicit means the two names below come from the
+# mirror and the rest of what is locked here come from PyPI.
+#
+# Nothing in `runners/torch_embed.py` knows about any of this, and its
+# `_placement()` is unchanged on purpose: ROCm torch reports through
+# `torch.cuda.is_available()` and wants the device string `"cuda"`. So `/health`
+# says `cuda` on an AMD card — torch's own naming, since HIP presents the CUDA
+# API surface, and correcting it here would mean a device string the rest of the
+# code does not recognise.
+[project]
+name = "fused-render-runner-transformers-embed-rocm"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "torch>=2.13,<3",
+    "triton-rocm; sys_platform == 'linux'",
+    "transformers>=5.15,<6",
+    "pillow",
+    # HEIC/HEIF and AVIF, which plain Pillow cannot open. iPhones have shot
+    # HEIC by default since iOS 11, so without this the `paths` half of an
+    # embed request works on screenshots and fails on the photographs.
+    "pillow-heif>=1.5,<2",
+    "huggingface_hub",
+    "psutil",
+]
+
+# Not a distribution — a folder of scripts, not something to build and install.
+[tool.uv]
+package = false
+
+# The ROCm wheels. `explicit` keeps this index out of every other requirement's
+# candidate list — see the header.
+[[tool.uv.index]]
+name = "pytorch-rocm"
+url = "https://download.pytorch.org/whl/rocm7.1"
+explicit = true
+
+[tool.uv.sources]
+torch = { index = "pytorch-rocm" }
+triton-rocm = { index = "pytorch-rocm" }

--- a/fused_render/ai/runners/transformers_embed_rocm/worker.py
+++ b/fused_render/ai/runners/transformers_embed_rocm/worker.py
@@ -1,0 +1,35 @@
+"""The ROCm embeddings runner (SPEC §40).
+
+Five lines of code and a `pyproject.toml`, and the manifest is the whole of
+it: this folder installs the ROCm build from
+`download.pytorch.org/whl/rocm7.1`. Its siblings
+`transformers_embed/` and `transformers_embed_cuda/` declare the same
+dependencies at the same versions and differ ONLY in which index torch comes
+from; the runner itself is `runners/torch_embed.py`, shared by all three,
+because which wheel a user installed is a fact about the hardware they picked
+on the Engines tab and never about how a forward pass through a dual encoder
+runs.
+
+A folder rather than a flag because `uv sync` runs BARE (`_env_install_worker`)
+with cwd set to the runner folder: everything about an environment has to be
+expressible in the `pyproject.toml` sitting beside it, so three environments mean
+three folders. The supervisor spawns THIS file (`registry.Runner.worker`) on THIS
+folder's venv (`registry.Runner.folder`), which is how the variant a user chose
+becomes the process that runs.
+
+Nothing here may grow a second line of behaviour. A `_placement()` or a dtype
+rule that lived in one of these shells would be a difference between variants
+that no test can see — the drift `runners/preview.py` documents at length, one
+level out.
+"""
+
+import os
+import sys
+
+# The shared runner sits one directory up, in `runners/` — see mlx_text/worker.py.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import torch_embed  # noqa: E402 - the whole runner; see runners/torch_embed.py
+
+if __name__ == "__main__":
+    torch_embed.main()

--- a/tests/test_ai_formats.py
+++ b/tests/test_ai_formats.py
@@ -343,6 +343,7 @@ def test_DECISIVE_follows_the_FORMAT_and_not_the_hardware():
     assert set(formats.DIFFUSERS_RUNNERS) <= set(formats.DECISIVE)
     assert not _TEXT & set(formats.DECISIVE)
     assert set(formats.LLAMACPP_RUNNERS) <= set(formats.DECISIVE)
+    assert set(formats.TRANSFORMERS_EMBED_RUNNERS) <= set(formats.DECISIVE)
 
 
 def test_mflux_needs_the_variant_table_as_well_as_the_layout():
@@ -709,21 +710,28 @@ def _clip_config():
     return {"model_type": "clip"}
 
 
-def test_a_siglip_snapshot_resolves_to_both_embedding_runners():
+def test_a_siglip_snapshot_resolves_to_mlx_and_every_torch_embedding_runner():
+    """Renamed from "...resolves_to_both_embedding_runners": since the
+    accelerated torch rows landed there are FOUR engines that read a SigLIP
+    checkpoint, not two — `TRANSFORMERS_EMBED_RUNNERS` is `transformers-embed` plus its
+    CUDA and ROCm siblings, all three genuinely readable regardless of which
+    wheel happens to be installed on this machine, exactly the
+    `DIFFUSERS_RUNNERS` argument applied to embeddings."""
     codes = formats.loaders(
         repo_id="google/siglip2-base-patch16-384", names={"model.safetensors"},
         dirnames=set(), config=_siglip_config(), torch_weights=True)
-    assert set(codes) == {"mlx-embed", "transformers-embed"}
+    assert set(codes) == {"mlx-embed"} | set(formats.TRANSFORMERS_EMBED_RUNNERS)
 
 
-def test_a_clip_snapshot_resolves_to_transformers_embed_only():
+def test_a_clip_snapshot_resolves_to_the_torch_embedding_runners_only():
     """mlx-embeddings 0.1.x has a `siglip` module and no `clip` one
     (`MLX_EMBED_MODEL_TYPES`) — the one difference between the two families
-    this app treats identically everywhere else."""
+    this app treats identically everywhere else. All three torch builds still
+    apply, for `TRANSFORMERS_EMBED_RUNNERS`'s own reason."""
     codes = formats.loaders(
         repo_id="openai/clip-vit-base-patch32", names={"model.safetensors"},
         dirnames=set(), config=_clip_config(), torch_weights=True)
-    assert codes == ("transformers-embed",)
+    assert codes == formats.TRANSFORMERS_EMBED_RUNNERS
 
 
 def test_an_embed_config_with_no_torch_weights_loads_nowhere():
@@ -749,7 +757,7 @@ def test_a_siglip_snapshot_is_NOT_offered_to_the_text_runners():
     # is the one runner left that reads a bare directory of safetensors, so a
     # family tuple would have nothing to hold together.
     assert "mlx-text" not in codes
-    assert set(codes) == {"mlx-embed", "transformers-embed"}
+    assert set(codes) == {"mlx-embed"} | set(formats.TRANSFORMERS_EMBED_RUNNERS)
 
 
 def test_embed_model_type_is_case_and_whitespace_tolerant():
@@ -766,6 +774,8 @@ def test_embed_model_type_rejects_anything_else():
 def test_the_embed_codes_are_decisive():
     """A directory of safetensors says nothing about the modality on its own
     (`DECISIVE`'s own comment) — a `siglip`/`clip` config is what settles it,
-    exactly like a Parakeet NeMo target or an MLX whisper weights file."""
+    exactly like a Parakeet NeMo target or an MLX whisper weights file. Every
+    torch build is decisive, not just the CPU row, for `DIFFUSERS_RUNNERS`'s
+    own reason applied here."""
     assert "mlx-embed" in formats.DECISIVE
-    assert "transformers-embed" in formats.DECISIVE
+    assert set(formats.TRANSFORMERS_EMBED_RUNNERS) <= set(formats.DECISIVE)

--- a/tests/test_ai_registry.py
+++ b/tests/test_ai_registry.py
@@ -46,17 +46,27 @@ def test_embeddings_is_a_registered_capability():
     assert registry.EMBEDDINGS in registry.capabilities()
 
 
-def test_both_embedding_runners_are_registered():
+def test_four_embedding_runners_are_registered():
+    """Renamed from "...both_embedding_runners...": there are four rows now,
+    not two — `transformers-embed` gained CUDA and ROCm siblings (see
+    `test_the_cuda_and_rocm_embed_variants_are_registered_and_ordered_correctly`
+    below for the decision this reverses)."""
     codes = {r.code for r in registry.all_runners() if r.capability == registry.EMBEDDINGS}
-    assert codes == {"mlx-embed", "transformers-embed"}
+    assert codes == {"mlx-embed", "transformers-embed", "transformers-embed-cuda",
+                     "transformers-embed-rocm"}
 
 
-def test_mlx_embed_is_registered_before_transformers_embed():
+def test_mlx_embed_is_registered_before_every_torch_embed_row():
     """First-match-wins is the whole mechanism (see `registry.py`'s comment on
     the table): MLX must come first so an Apple Silicon machine resolves there
-    by default, exactly like text generation and image generation."""
+    by default, exactly like text generation and image generation. Widened
+    from asserting the two-row list verbatim (it now has four rows) to the
+    property this test actually cares about: MLX is first, ahead of every
+    torch build.
+    """
     codes = [r.code for r in registry.all_runners() if r.capability == registry.EMBEDDINGS]
-    assert codes == ["mlx-embed", "transformers-embed"]
+    assert codes[0] == "mlx-embed"
+    assert codes.index("mlx-embed") < codes.index("transformers-embed")
 
 
 def test_mlx_embed_is_gated_to_apple_silicon(monkeypatch):
@@ -89,12 +99,29 @@ def test_windows_resolves_to_transformers_embed(monkeypatch):
     assert resolved is not None and resolved.code == "transformers-embed"
 
 
-def test_no_cuda_or_rocm_embed_variant_exists():
-    """Deliberate (see `registry.py`'s comment on the `transformers-embed`
-    row): a dual encoder is one forward pass, too cheap to justify a second or
-    third wheel the way text and image generation's accelerated rows are."""
-    codes = {r.code for r in registry.all_runners() if r.capability == registry.EMBEDDINGS}
-    assert not any("cuda" in code or "rocm" in code for code in codes)
+def test_the_cuda_and_rocm_embed_variants_are_registered_and_ordered_correctly():
+    """The decision this test used to pin — no accelerated embed variant,
+    because a dual encoder is "too cheap to justify a second or third wheel"
+    — was DELIBERATELY REVERSED on this branch, not overlooked. The speed
+    argument for the TEXT tower still holds (one short sequence, milliseconds
+    on a CPU), but an image tower run at `embed_common.MAX_ITEMS` (64) items
+    per call is real work a GPU meaningfully speeds up, and a machine that
+    already has a working NVIDIA or fully ROCm-capable AMD card was otherwise
+    stuck running every one of those batches in fp32 on the CPU with no way to
+    opt out. `transformers-embed-cuda`/`-rocm` are that opt-in, gated on the
+    same `_cuda`/`_rocm` probes `diffusers-image-cuda`/`-rocm` use.
+
+    Both sit BELOW `transformers-embed`, CUDA before ROCm — the same order the
+    diffusers image family uses — so `auto` still resolves to the CPU/MPS row
+    on every platform (`test_the_embeddings_capability_orders_mlx_then_cpu_then_cuda_then_rocm`
+    in `test_ai_runtime.py` pins that through platform mocks; this test pins
+    only the static ordering).
+    """
+    codes = [r.code for r in registry.all_runners() if r.capability == registry.EMBEDDINGS]
+    assert codes == [
+        "mlx-embed", "transformers-embed", "transformers-embed-cuda",
+        "transformers-embed-rocm",
+    ]
 
 
 # The task-vocabulary tests that used to live here (the embeddings dual-encoder

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1061,6 +1061,9 @@ _QUALIFIED_SHORT_NAMES = {
     "diffusers-image-rocm": "(ROCm)",
     "llamacpp-text": "(CPU)",
     "llamacpp-text-vulkan": "(Vulkan)",
+    "transformers-embed": "(CPU)",
+    "transformers-embed-cuda": "(CUDA)",
+    "transformers-embed-rocm": "(ROCm)",
 }
 
 #: Every qualifier this app uses to name a BUILD rather than a platform.
@@ -1988,6 +1991,10 @@ def test_the_accelerated_engines_share_their_siblings_suggestions(monkeypatch, t
     assert catalog.for_runner("llamacpp-text-vulkan") == catalog.SUGGESTIONS["llamacpp-text"]
     assert catalog.for_runner("diffusers-image-cuda") == catalog.SUGGESTIONS["diffusers-image"]
     assert catalog.for_runner("diffusers-image-rocm") == catalog.SUGGESTIONS["diffusers-image"]
+    assert catalog.for_runner("transformers-embed-cuda") == (
+        catalog.SUGGESTIONS["transformers-embed"])
+    assert catalog.for_runner("transformers-embed-rocm") == (
+        catalog.SUGGESTIONS["transformers-embed"])
     # And through the resolution, which is how the page actually reaches it.
     _fake_nvidia(monkeypatch, tmp_path)
     _prefer(monkeypatch, registry.IMAGE_GENERATION, "diffusers-image-cuda")
@@ -2309,6 +2316,31 @@ def test_llamacpp_text_vulkan_is_registered_immediately_below_llamacpp_text(monk
     monkeypatch.setattr(registry.platform, "machine", lambda: "AMD64")
     monkeypatch.setattr(registry, "preferred_code", lambda capability: registry.AUTO)
     assert registry.for_capability(registry.TEXT_GENERATION).code == "llamacpp-text"
+
+
+def test_the_embeddings_capability_orders_mlx_then_cpu_then_cuda_then_rocm(monkeypatch):
+    """Embeddings' four rows, pinned in full — the whole family shares one
+    ordering rule with the image and text families, and it is invisible in a
+    diff of the table.
+
+    MLX takes the Macs (`_apple_silicon`), `transformers-embed` is the
+    cross-platform default and Apple-Silicon fallback, and
+    `transformers-embed-cuda`/`-rocm` are opt-in accelerated siblings of that
+    row — CUDA before ROCm, the same order `diffusers-image-cuda`/`-rocm` use.
+    Both accelerated rows sit LAST so `auto` never reaches either on any
+    platform, exactly as `test_llamacpp_text_vulkan_is_registered_immediately_below_llamacpp_text`
+    pins for text generation's own accelerated tail.
+    """
+    codes = [r.code for r in registry.all_runners() if r.capability == registry.EMBEDDINGS]
+    assert codes == [
+        "mlx-embed", "transformers-embed", "transformers-embed-cuda",
+        "transformers-embed-rocm",
+    ]
+
+    monkeypatch.setattr(registry.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(registry.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(registry, "preferred_code", lambda capability: registry.AUTO)
+    assert registry.for_capability(registry.EMBEDDINGS).code == "transformers-embed"
 
 
 def test_llamacpp_text_vulkans_platform_gate_matches_its_published_wheel_tags(monkeypatch, tmp_path):
@@ -4032,7 +4064,8 @@ def test_the_runtime_endpoint_reports_runners_and_nothing_loaded(client):
         "diffusers-image", "diffusers-image-cuda",
         "diffusers-image-rocm", "mflux-image",
         "faster-whisper", "mlx-whisper",
-        "mlx-embed", "transformers-embed", "ltx-video"}
+        "mlx-embed", "transformers-embed", "transformers-embed-cuda",
+        "transformers-embed-rocm", "ltx-video"}
     assert body["loaded"] == []
     # Exactly one runner per capability is ACTIVE — the distinction D302 needed,
     # since with a preference in the middle "available" stopped meaning "this is

--- a/tests/test_ai_transformers_embed_real_weights.py
+++ b/tests/test_ai_transformers_embed_real_weights.py
@@ -1,0 +1,144 @@
+"""A real-weights smoke test for `runners/torch_embed.py`, run against
+`google/siglip2-base-patch16-384` straight out of the local Hub cache.
+
+**Why this exists alongside the mocked suite in
+`test_ai_transformers_embed_worker.py`.** Every other test in that file drives
+`generate()` through a `FakeModel` whose shape is asserted by hand — and an
+earlier version of that fake encoded transformers 4.x's contract
+(`get_text_features` returning the pooled tensor directly) rather than 5.x's
+(`BaseModelOutputWithPooling`, read through `_pooled`). The suite was green
+throughout, because a fake can only fail the assumptions its author wrote into
+it. `worker._pooled` did not exist yet and every real embed call raised
+`AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'to'`.
+This file is the guard a mock cannot be: it loads the real checkpoint through
+the real `AutoModel`/`AutoProcessor` classes and asserts on vectors that came
+out the other end, so a regression in `_pooled` — or in the padding rule, or
+in `unit_normalize` — fails here even if a future fake is written carelessly
+enough to hide it again.
+
+**Skipped, never fetched.** `google/siglip2-base-patch16-384` is a ~1.5GB
+download (`catalog.py`'s own figure for it), and CI has no Hub cache — asking
+`from_pretrained` to go fetch it would make this file network-dependent and
+slow on every machine that is not this one. The skip is keyed on the snapshot
+already existing under the ordinary Hub cache layout
+(`~/.cache/huggingface/hub/models--<org>--<repo>/snapshots/*`); `torch` and
+`transformers` are also skipped-not-required, because they live in the
+runner's own venv (built on first Download) and are not a dependency of the
+repo's `.venv` that runs the rest of this suite.
+
+**This runs on CPU here, in fp32 — it is not a GPU dtype test.** `_placement()`
+in `torch_embed.py` has no CUDA or ROCm hardware to place onto on this
+machine, so this file exercises the CONTRACT (the fields `_pooled` reads, the
+shapes `generate()` returns) and the SEMANTICS (that the vectors it produces
+actually cluster the way SigLIP2 is supposed to), not the accelerated
+numerics `transformers-embed-cuda`/`-rocm` would need real hardware in CI to
+check.
+"""
+import glob
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+RUNNERS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "ai", "runners",
+)
+WORKER_PATH = os.path.join(RUNNERS, "torch_embed.py")
+
+MODEL_ID = "google/siglip2-base-patch16-384"
+
+#: The ordinary Hub cache layout: `models--<org>--<repo>/snapshots/<rev>`.
+#: Read directly rather than through `huggingface_hub` — this file must not
+#: gain a dependency the rest of the repo's test suite does not already have,
+#: and a glob over the cache directory is all `download()` would have handed
+#: back anyway (`worker_base.download_snapshot` returns exactly this path).
+_CACHE_ROOT = os.path.expanduser("~/.cache/huggingface/hub")
+_SNAPSHOT_GLOB = os.path.join(
+    _CACHE_ROOT, f"models--{MODEL_ID.replace('/', '--')}", "snapshots", "*")
+
+
+def _real_snapshot():
+    matches = sorted(glob.glob(_SNAPSHOT_GLOB))
+    return matches[0] if matches else None
+
+
+torch = pytest.importorskip("torch", reason="lives in the runner's own venv")
+pytest.importorskip("transformers", reason="lives in the runner's own venv")
+
+SNAPSHOT = _real_snapshot()
+pytestmark = pytest.mark.skipif(
+    SNAPSHOT is None,
+    reason=f"{MODEL_ID} is not in the local Hub cache — never fetched here")
+
+
+@pytest.fixture(scope="module")
+def worker():
+    """The real `torch_embed` module, with a real model loaded onto it.
+
+    `worker_base` is stubbed exactly as the mocked suite stubs it — this file
+    is about `torch_embed`'s own code, not about the download/report
+    machinery `worker_base` already has its own tests for — but nothing else
+    here is faked: `load()` runs unmodified against the real snapshot path.
+    """
+    import threading
+    import types
+
+    base = types.ModuleType("worker_base")
+    base.CANCEL = threading.Event()
+    base.download_snapshot = lambda model_id, **kw: SNAPSHOT
+    base.serve = lambda **kw: None
+    base.recorded = {}
+    base.set_state = lambda **fields: base.recorded.update(fields)
+    sys.modules["worker_base"] = base
+
+    spec = importlib.util.spec_from_file_location(
+        "torch_embed_real_weights_under_test", WORKER_PATH)
+    assert spec is not None and spec.loader is not None, WORKER_PATH
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.worker_base = base
+    module.load(MODEL_ID, module.download(MODEL_ID))
+    yield module
+
+    del sys.modules["worker_base"]
+
+
+def _cos(a, b):
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = sum(x * x for x in a) ** 0.5
+    norm_b = sum(x * x for x in b) ** 0.5
+    return dot / (norm_a * norm_b)
+
+
+def test_text_vectors_are_768_dim_and_unit_norm(worker):
+    """SigLIP2 base's published width, and `unit_normalize`'s own promise."""
+    result = worker.generate({"texts": ["a cat", "a dog", "a bicycle"]})
+    assert result["dim"] == 768
+    for row in result["vectors"]:
+        assert len(row) == 768
+        norm = sum(v * v for v in row) ** 0.5
+        assert abs(norm - 1.0) < 1e-4
+
+
+def test_semantically_closer_texts_cosine_higher(worker):
+    """Two animals should read as closer than an animal and a vehicle.
+
+    Tolerant bands around figures measured on this machine after the
+    `pooler_output` fix (commit 9ffcf768): cos(cat, dog) ~= 0.9423,
+    cos(cat, bicycle) ~= 0.7573. The assertion is the ORDERING plus a loose
+    band, not the exact float — a transformers or torch point release
+    reproducing the same relationship to three decimals is not a promise this
+    test should make.
+    """
+    result = worker.generate({"texts": ["a cat", "a dog", "a bicycle"]})
+    cat, dog, bicycle = result["vectors"]
+
+    cos_cat_dog = _cos(cat, dog)
+    cos_cat_bicycle = _cos(cat, bicycle)
+
+    assert cos_cat_dog > cos_cat_bicycle
+    assert 0.85 < cos_cat_dog < 0.99
+    assert 0.55 < cos_cat_bicycle < 0.90

--- a/tests/test_ai_transformers_embed_real_weights.py
+++ b/tests/test_ai_transformers_embed_real_weights.py
@@ -1,44 +1,61 @@
-"""A real-weights smoke test for `runners/torch_embed.py`, run against
-`google/siglip2-base-patch16-384` straight out of the local Hub cache.
+"""A real-weights REPRODUCER for `runners/torch_embed.py`, run against
+`google/siglip2-base-patch16-384` straight out of a local Hub cache.
 
-**Why this exists alongside the mocked suite in
-`test_ai_transformers_embed_worker.py`.** Every other test in that file drives
-`generate()` through a `FakeModel` whose shape is asserted by hand — and an
-earlier version of that fake encoded transformers 4.x's contract
-(`get_text_features` returning the pooled tensor directly) rather than 5.x's
-(`BaseModelOutputWithPooling`, read through `_pooled`). The suite was green
-throughout, because a fake can only fail the assumptions its author wrote into
-it. `worker._pooled` did not exist yet and every real embed call raised
-`AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'to'`.
-This file is the guard a mock cannot be: it loads the real checkpoint through
-the real `AutoModel`/`AutoProcessor` classes and asserts on vectors that came
-out the other end, so a regression in `_pooled` — or in the padding rule, or
-in `unit_normalize` — fails here even if a future fake is written carelessly
-enough to hide it again.
+**This file is NOT part of the default suite's coverage.** It is skipped
+whenever `torch`/`transformers` are not importable or the checkpoint is not
+already cached — which is EVERY run of this repo's own `.venv`, since those
+packages live in a runner's own venv (built lazily on first Download) and are
+never a dependency of the venv the rest of the suite runs under. The actual
+guard against a `_pooled()`/`pooler_output` regression is `FakeOutput` in
+`test_ai_transformers_embed_worker.py` — that file runs in every CI job and
+every local `pytest` invocation; this one is a reproducer a developer runs
+by hand, pointed at an interpreter that actually has torch, to confirm a real
+checkpoint still behaves the way the fake assumes. Do not read a green run of
+the default suite as evidence this file executed.
 
-**Skipped, never fetched.** `google/siglip2-base-patch16-384` is a ~1.5GB
-download (`catalog.py`'s own figure for it), and CI has no Hub cache — asking
-`from_pretrained` to go fetch it would make this file network-dependent and
-slow on every machine that is not this one. The skip is keyed on the snapshot
-already existing under the ordinary Hub cache layout
-(`~/.cache/huggingface/hub/models--<org>--<repo>/snapshots/*`); `torch` and
-`transformers` are also skipped-not-required, because they live in the
-runner's own venv (built on first Download) and are not a dependency of the
-repo's `.venv` that runs the rest of this suite.
+**Why it exists at all, alongside a fake.** `test_ai_transformers_embed_worker.py`
+drives `generate()` through a hand-written `FakeModel`, and a fake can only
+fail the assumptions its author wrote into it — an earlier version of that
+fake encoded transformers 4.x's contract (`get_text_features` returning the
+pooled tensor directly) rather than 5.x's (`BaseModelOutputWithPooling`, read
+through `_pooled`), and the mocked suite stayed green while every real embed
+call raised `AttributeError: 'BaseModelOutputWithPooling' object has no
+attribute 'to'`. This file loads the real checkpoint through the real
+`AutoModel`/`AutoProcessor` classes and asserts on vectors that came out the
+other end, which a mock literally cannot do.
 
-**This runs on CPU here, in fp32 — it is not a GPU dtype test.** `_placement()`
-in `torch_embed.py` has no CUDA or ROCm hardware to place onto on this
-machine, so this file exercises the CONTRACT (the fields `_pooled` reads, the
+**Two ways to run it:**
+
+* Bare `pytest`, no torch installed (the default here) — every test SKIPS,
+  cheaply and offline. This is what CI sees.
+* `FUSED_RENDER_REAL_WEIGHTS=1 pytest ...`, invoked with an interpreter that
+  actually has torch/transformers (a runner's own venv — e.g.
+  `~/.fused-render/venvs/<hash>/bin/python -m pytest
+  tests/test_ai_transformers_embed_real_weights.py`) — an explicit opt-in
+  that turns every skip condition into a hard FAILURE naming what is
+  missing, so a typo'd venv path or an evicted cache entry cannot silently
+  report "1 skipped" and be mistaken for a pass. A silent skip under an
+  explicit opt-in would be the same trap this file exists to avoid, one
+  level up.
+
+**`google/siglip2-base-patch16-384` is a ~1.5GB download** (`catalog.py`'s own
+figure for it) and this file must never fetch it — the skip/fail check is
+keyed on the snapshot already existing under the ordinary Hub cache layout
+(`~/.cache/huggingface/hub/models--<org>--<repo>/snapshots/*`), read directly
+rather than through `huggingface_hub`, which this file has no other reason to
+depend on.
+
+**This runs on CPU, in fp32 — it is not a GPU dtype test.** `_placement()` in
+`torch_embed.py` has no CUDA or ROCm hardware to place onto wherever this is
+actually run, so it exercises the CONTRACT (the fields `_pooled` reads, the
 shapes `generate()` returns) and the SEMANTICS (that the vectors it produces
 actually cluster the way SigLIP2 is supposed to), not the accelerated
-numerics `transformers-embed-cuda`/`-rocm` would need real hardware in CI to
-check.
+numerics `transformers-embed-cuda`/`-rocm` would need real hardware to check.
 """
 import glob
 import importlib.util
 import os
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -49,6 +66,11 @@ RUNNERS = os.path.join(
 WORKER_PATH = os.path.join(RUNNERS, "torch_embed.py")
 
 MODEL_ID = "google/siglip2-base-patch16-384"
+
+#: Set to require this file to actually run rather than skip. See the module
+#: docstring's "Two ways to run it" — unset (the default) is what every other
+#: test in this repo runs under, and must stay fast and offline.
+_REQUIRE_REAL_WEIGHTS = os.environ.get("FUSED_RENDER_REAL_WEIGHTS") == "1"
 
 #: The ordinary Hub cache layout: `models--<org>--<repo>/snapshots/<rev>`.
 #: Read directly rather than through `huggingface_hub` — this file must not
@@ -65,13 +87,45 @@ def _real_snapshot():
     return matches[0] if matches else None
 
 
-torch = pytest.importorskip("torch", reason="lives in the runner's own venv")
-pytest.importorskip("transformers", reason="lives in the runner's own venv")
+def _require_or_skip(condition, reason):
+    """Skip on `condition` being false — unless `FUSED_RENDER_REAL_WEIGHTS=1`
+    asked this file to actually run, in which case the same condition is a
+    hard failure naming what is missing. One gate, two behaviours, so the
+    opt-in cannot be satisfied by the thing it exists to catch: a quiet skip
+    that reads like a pass.
+    """
+    if condition:
+        return
+    if _REQUIRE_REAL_WEIGHTS:
+        pytest.fail(
+            f"FUSED_RENDER_REAL_WEIGHTS=1 was set but {reason} — this run was "
+            f"asked to actually exercise real weights, not skip past their "
+            f"absence.", pytrace=False)
+    pytest.skip(reason, allow_module_level=True)
+
+
+try:
+    import torch  # noqa: F401 - presence check only; see _require_or_skip below
+    _HAVE_TORCH = True
+except ImportError:
+    _HAVE_TORCH = False
+
+try:
+    import transformers  # noqa: F401 - presence check only
+    _HAVE_TRANSFORMERS = True
+except ImportError:
+    _HAVE_TRANSFORMERS = False
+
+_require_or_skip(_HAVE_TORCH, "torch is not importable here — it lives in a "
+                 "runner's own venv, not this interpreter")
+_require_or_skip(_HAVE_TRANSFORMERS, "transformers is not importable here — "
+                 "it lives in a runner's own venv, not this interpreter")
 
 SNAPSHOT = _real_snapshot()
-pytestmark = pytest.mark.skipif(
-    SNAPSHOT is None,
-    reason=f"{MODEL_ID} is not in the local Hub cache — never fetched here")
+_require_or_skip(
+    SNAPSHOT is not None,
+    f"{MODEL_ID} is not in the local Hub cache ({_SNAPSHOT_GLOB}) — never "
+    f"fetched here")
 
 
 @pytest.fixture(scope="module")
@@ -126,12 +180,12 @@ def test_text_vectors_are_768_dim_and_unit_norm(worker):
 def test_semantically_closer_texts_cosine_higher(worker):
     """Two animals should read as closer than an animal and a vehicle.
 
-    Tolerant bands around figures measured on this machine after the
-    `pooler_output` fix (commit 9ffcf768): cos(cat, dog) ~= 0.9423,
-    cos(cat, bicycle) ~= 0.7573. The assertion is the ORDERING plus a loose
-    band, not the exact float — a transformers or torch point release
-    reproducing the same relationship to three decimals is not a promise this
-    test should make.
+    Tolerant bands around figures actually measured under
+    `FUSED_RENDER_REAL_WEIGHTS=1` (torch 2.13.0+cpu, transformers 5.15.1):
+    cos(cat, dog) = 0.9313, cos(cat, bicycle) = 0.8673. The assertion is the
+    ORDERING plus a loose band, not the exact float — a transformers or torch
+    point release reproducing the same relationship to three decimals is not
+    a promise this test should make.
     """
     result = worker.generate({"texts": ["a cat", "a dog", "a bicycle"]})
     cat, dog, bicycle = result["vectors"]

--- a/tests/test_ai_transformers_embed_worker.py
+++ b/tests/test_ai_transformers_embed_worker.py
@@ -1,13 +1,20 @@
-"""The transformers embedding runner's own behaviour — what is true of torch
-and `embed_common` together, not what `embed_common.py`'s own tests already
-cover on their own.
+"""The shared transformers embedding runner's own behaviour — what is true of
+torch and `embed_common` together, not what `embed_common.py`'s own tests
+already cover on their own.
+
+Targets `runners/torch_embed.py` directly, not any of the three folders'
+`worker.py` shells — the same choice `tests/test_ai_diffusers_worker.py` makes
+for `torch_image.py`, and for the identical reason: `transformers_embed/`,
+`transformers_embed_cuda/` and `transformers_embed_rocm/` each hold a
+five-line shell that imports this file, so testing a shell would test three
+copies of the same five lines rather than the runner itself.
 
 Loaded by PATH with `worker_base` primed in `sys.modules`, exactly as
 `tests/test_ai_transformers_worker.py` does: the runner finds its base off
 `sys.path` in an interpreter of its own, so importing it the packaged way
 (`fused_render.ai.runners.…`) would be testing an import that never ships.
 `embed_common` is NOT stubbed — it is stdlib-plus-PIL and both are really
-installed here, so the worker's own `sys.path.insert` reaches the real file,
+installed here, so the runner's own `sys.path.insert` reaches the real file,
 exactly as it does in production.
 
 `torch` IS stubbed: it is not installed in this environment (it lives in the
@@ -28,7 +35,7 @@ from PIL import Image
 
 WORKER_PATH = str(
     Path(__file__).resolve().parents[1]
-    / "fused_render" / "ai" / "runners" / "transformers_embed" / "worker.py"
+    / "fused_render" / "ai" / "runners" / "torch_embed.py"
 )
 
 

--- a/tests/test_ai_transformers_embed_worker.py
+++ b/tests/test_ai_transformers_embed_worker.py
@@ -79,16 +79,36 @@ class FakeProcessor:
         return {"pixel_values": FakeTensor(rows=len(images))}
 
 
+class FakeOutput:
+    """What transformers 5 hands back from `get_text_features` /
+    `get_image_features`: a `BaseModelOutputWithPooling`, NOT the vector.
+
+    **The shape is the point of the fake.** An earlier version of this file
+    returned the `FakeFeatures` above directly, which is the transformers 4.x
+    contract, and so the suite went green against a model that could not
+    exhibit the bug the real one had — `worker._pooled` did not exist and
+    `features.to(...)` raised `AttributeError:
+    'BaseModelOutputWithPooling' object has no attribute 'to'` on every real
+    embed call. `last_hidden_state` is carried too, and deliberately given a
+    DIFFERENT rank, so a worker that reached for the wrong field would fail
+    here on shape rather than pass with nonsense.
+    """
+
+    def __init__(self, pooled):
+        self.pooler_output = FakeFeatures(pooled)
+        self.last_hidden_state = FakeFeatures([[row] * 4 for row in pooled])
+
+
 class FakeModel:
     """`get_text_features`/`get_image_features` each return one deterministic
     vector per item, so a test can assert both the COUNT and the SHAPE without
     caring what the numbers mean."""
 
     def get_text_features(self, **_kwargs):
-        return FakeFeatures([[1.0, 2.0, 2.0], [4.0, 0.0, 3.0]][:2])
+        return FakeOutput([[1.0, 2.0, 2.0], [4.0, 0.0, 3.0]][:2])
 
     def get_image_features(self, **_kwargs):
-        return FakeFeatures([[3.0, 4.0]])
+        return FakeOutput([[3.0, 4.0]])
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- **Embeddings were broken outright on every install, and this fixes them.** transformers 5 changed `get_text_features`/`get_image_features` to return a `BaseModelOutputWithPooling` where 4.x returned the pooled tensor, so every `fused.ai.embed()` call raised `AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'to'` under the `transformers>=5.15,<6` this runner pins. Both towers, every platform, since the pin landed.
- **Embeddings can now run on a GPU off Apple Silicon.** `transformers-embed` is pinned to `download.pytorch.org/whl/cpu`, so a machine with a working NVIDIA or AMD card embedded in fp32 on the CPU and `_placement()`'s `cuda` branch could never fire. Two opt-in hardware rows now sit below it, gated on the existing `_cuda`/`_rocm` device probes.
- **The runner body is now shared, not copied.** `runners/torch_embed.py` holds it, and the three folders are five-line shells that differ only in which index torch comes from — the `torch_image.py` shape the image family already uses.
- **`formats.loaders()` and `DECISIVE` know about the new rows**, without which they would have been registered-but-unusable: no engine tag, no Load button, no cached repos offered, on precisely the machines that chose them.

No dtype change: `_placement()` still returns a device only and every row runs fp32, so the shared-vector-space property between `mlx-embed` and the torch rows is unchanged. fp16/bf16 was considered and deliberately deferred until the gain is measured on the two suggested models — the frozen `embed-8-texts` benchmark workload is text-only at batch 8 and would understate it.

## Visuals

Resolution for the embeddings capability. `auto` still lands on the CPU row everywhere off Apple Silicon (SPEC AI-2b); the two new rows are reachable only by picking them on the Engines tab, and all three torch rows share one body.

```mermaid
flowchart TD
    A[fused.ai.embed] --> R{registry resolve}
    R -->|auto, Apple Silicon| M[mlx-embed]
    R -->|auto, elsewhere| C[transformers-embed CPU]
    R -->|opt-in, gated _cuda| U[transformers-embed-cuda]
    R -->|opt-in, gated _rocm| O[transformers-embed-rocm]
    C --> T[runners/torch_embed.py]
    U --> T
    O --> T
```

## Usage

Embedding calls are unchanged — this restores them and adds an engine choice:

```js
const { vectors, dim } = await fused.ai.embed({ texts: ["a photo of a cat"] })
// dim 768 on siglip2-base-patch16-384; vectors are unit-normalised
```

To use the GPU, pick the row on the **AI Models → Engines** tab. The accelerated rows appear only where the device is actually present and usable:

| Row | Requires |
|---|---|
| `transformers-embed-cuda` | NVIDIA GPU, driver loaded (Windows or Linux) |
| `transformers-embed-rocm` | AMD GPU on Linux with a gfx in `ROCM_TARGETS` |

Both report what they actually got: `/health` carries the device `load()` placed the model on, so a row that fell back to CPU says so. Note ROCm torch reports through `torch.cuda.is_available()` and wants the device string `cuda`, so `/health` says `cuda` on an AMD card — torch's own naming, since HIP presents the CUDA API surface.

## Test Plan

**Full suite, diffed against a true `origin/main` baseline** (`d88499ed`), both runs on the same machine with the frontend built:

| | failures |
|---|---|
| `origin/main` | 14 |
| this branch | 18 |

The 4-item difference is entirely `tests/test_browse_mount.py`, which is **pre-existing and environmental**: run in isolation it fails **6 of 15 identically on both branch and baseline**. Under xdist a different subset surfaces per run, which is the whole of the delta. No failure is attributable to this branch.

Targeted surface: `-k "ai_ or embed or format or registry or hub_model"` → **1940 passed, 8 skipped, 1 failed**, the one failure being `test_ai_metrics.py::test_a_missing_claude_binary_is_counted`, present in the baseline set and unrelated (it resolves a `claude` binary path on the host).

- [x] `tests/test_ai_transformers_embed_worker.py` — the fake now returns a `BaseModelOutputWithPooling` shape carrying `pooler_output` **and** a deliberately different-rank `last_hidden_state`, so reaching for the wrong field fails on shape rather than passing with nonsense. This is the test that previously encoded the 4.x contract and let the bug ship.
- [x] `tests/test_ai_formats.py::test_every_registered_runner_appears_in_loaders` — the drift this PR would otherwise have caused; fixed via `TRANSFORMERS_EMBED_RUNNERS` plus `DECISIVE` membership.
- [x] `tests/test_ai_registry.py` — the three tests pinning the old two-row/no-variant shape updated, including `test_no_cuda_or_rocm_embed_variant_exists`, which existed to pin the decision this PR reverses. Renamed and re-documented rather than silently deleted.
- [x] Ordering pinned (`mlx-embed → transformers-embed → transformers-embed-cuda → transformers-embed-rocm`), and `test_AUTO_STAYS_ON_THE_UNACCELERATED_ROW_EVEN_WITH_AN_ACCELERATOR` still passes — `auto` must not silently pull a multi-gigabyte accelerated wheel.
- [x] `_SHARED_SUGGESTIONS` aliases asserted for both new rows, so neither can grow a shortlist that drifts from the CPU row's.
- [x] **Real weights, actually executed.** `tests/test_ai_transformers_embed_real_weights.py` skips by default (CI has no weights and must not fetch 1.5GB) and hard-fails rather than skipping under `FUSED_RENDER_REAL_WEIGHTS=1`. Run against the runner venv (torch 2.13.0+cpu, transformers 5.15.1): **2 passed** — both towers return 768-dim unit vectors with `cos(cat,dog) > cos(cat,bicycle)`. Confirmed it still skips cleanly with the flag unset.

**Known gaps, stated rather than implied:**

- **Neither accelerated venv was built.** `uv sync` on these folders is a multi-gigabyte ROCm/CUDA download, so the manifests are verified by reading them against their `diffusers_image_*` siblings and by the manifest tests — not by an actual install. First real install is the thing to watch, particularly the `triton-rocm` routing (ROCm torch pins it transitively and it exists only on the ROCm index).
- **The real-weights test runs on CPU**, so it pins the contract and the semantics, not the accelerated numerics. Confirming those needs hardware CI.
- **In the default suite that file is a local reproducer, not coverage.** Its docstring says so. The standing guard for the `pooler_output` contract is `FakeOutput`.
- **No performance numbers yet.** Measuring the GPU gain — and deciding whether fp16 earns its cost on the two suggested models — is deliberate follow-up.
