### PR TITLE
Home search: live path detection, depth-penalized ranking, and cancellable rank requests

### DIFF
--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -5,49 +5,88 @@
 // exactly what sections 2 and 7 of the overhaul touch.
 //
 // react-test-renderer, the same tool hook-harness.ts uses: no DOM, real React,
-// real effects. The Clock/Deferred/flush trio is reused from there rather than
+// real effects. The Clock/flush pair is reused from there rather than
 // re-invented — the same virtual-timer shape a per-query round trip needs.
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+//
+// Deliberately NOT `mock.module("@platform/lib/api", ...)`. That looks like
+// the obvious way to control indexRank/statPath, and it is exactly what broke
+// CI: `mock.module` replaces the module for the WHOLE bun process — every
+// FILE, not just this one — and a real ES module namespace export is frozen
+// (confirmed directly: assigning to one throws "Attempted to assign to
+// readonly property"), so there is no way to patch just the two functions
+// this file needs and leave the rest of the module alone. Registering the
+// mock AGAIN with the real module as the factory does not reliably undo it
+// either — a module that already imported the mocked version (fs-actions.ts,
+// loaded fresh by fs-actions.test.ts AFTER this file's restore had already
+// run) still came back with a stale/broken binding, which is what turned
+// into a passing-locally, hanging-in-CI 5s timeout in a file this diff never
+// touches. The REAL functions here are both thin `getJson`/fetch wrappers, so
+// this stubs `globalThis.fetch` instead — a plain, unfrozen global — exactly
+// the technique fs-actions.test.ts/fs-clipboard.test.ts already use for the
+// same reason.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { createElement } from "react";
 import type { IndexRankResult, StatResult } from "@platform/lib/api";
-import { Clock, Deferred } from "@apps/explorer/listing/hook-harness";
+import { Clock } from "@apps/explorer/listing/hook-harness";
 import { STALE_CLEAR_MS } from "@platform/lib/instant-search";
 
-// --- the module boundary -----------------------------------------------------
-const rankCalls: { root: string; q: string; reply: Deferred<IndexRankResult> }[] = [];
-const statCalls: { path: string; reply: Deferred<StatResult> }[] = [];
+// --- the module boundary: a fetch stub, not a module mock -------------------
+interface RankCall {
+  root: string;
+  q: string;
+  resolve: (data: IndexRankResult) => void;
+}
+interface StatCall {
+  path: string;
+  resolve: (data: StatResult) => void;
+  /** A 404, exactly what the real /api/fs/stat sends for a path that does not
+   * exist — not a network-level rejection, so this matches what statPath()
+   * actually throws (an HttpError) in that case. */
+  reject: () => void;
+}
+const rankCalls: RankCall[] = [];
+const statCalls: StatCall[] = [];
+
+const realFetch = globalThis.fetch;
+
+/** Every indexRank/statPath call becomes an entry in rankCalls/statCalls,
+ * settled only when the test calls `.resolve()`/`.reject()` — the same
+ * leading-edge control the old Deferred-based mock gave, without touching
+ * the module registry at all. */
+function fakeFetch(url: string | URL): Promise<Response> {
+  const u = String(url);
+  if (u.startsWith("/api/index/rank")) {
+    const params = new URL(u, "http://localhost").searchParams;
+    return new Promise<Response>((settle) => {
+      rankCalls.push({
+        root: params.get("root") ?? "",
+        q: params.get("q") ?? "",
+        resolve: (data) => settle(new Response(JSON.stringify(data), { status: 200 })),
+      });
+    });
+  }
+  if (u.startsWith("/api/fs/stat")) {
+    const params = new URL(u, "http://localhost").searchParams;
+    return new Promise<Response>((settle) => {
+      statCalls.push({
+        path: params.get("path") ?? "",
+        resolve: (data) => settle(new Response(JSON.stringify(data), { status: 200 })),
+        reject: () =>
+          settle(new Response(JSON.stringify({ error: "no such file" }), { status: 404 })),
+      });
+    });
+  }
+  throw new Error("FilesHome.render.test.tsx: unexpected fetch " + u);
+}
 
 // router.ts reads `location` at MODULE INIT (a legacy /embed/ rewrite), before
 // any beforeEach runs — this has to exist before FilesHome (which imports it
-// transitively) is ever imported below.
+// transitively) is ever imported below. It is torn down again in `afterEach`
+// (below) exactly like the other globals this file stubs — module-scope
+// setup with no matching teardown is what leaked `document` across files the
+// first time this file was written (see the afterEach comment).
 (globalThis as Record<string, unknown>).location = { pathname: "/explorer", search: "" };
-(globalThis as Record<string, unknown>).history = {
-  state: null,
-  replaceState: () => {},
-  pushState: () => {},
-};
-// FilesSearch listens on `document` (the "typing anywhere is typing here"
-// redirect) and calls `.focus()` on the input ref.
-(globalThis as Record<string, unknown>).document = {
-  addEventListener: () => {},
-  removeEventListener: () => {},
-};
-
-const realApi = await import("@platform/lib/api");
-mock.module("@platform/lib/api", () => ({
-  ...realApi,
-  indexRank: (root: string, q: string) => {
-    const reply = new Deferred<IndexRankResult>();
-    rankCalls.push({ root, q, reply });
-    return reply.promise;
-  },
-  statPath: (path: string) => {
-    const reply = new Deferred<StatResult>();
-    statCalls.push({ path, reply });
-    return reply.promise;
-  },
-}));
 
 const { FilesSearch } = await import("@apps/explorer/FilesHome");
 
@@ -55,22 +94,46 @@ const HOME = "/Users/me";
 
 const clock = new Clock();
 
+// Every renderer `mount()` creates, so `afterEach` can unmount it
+// UNCONDITIONALLY — including when a test's own assertions throw partway
+// through and never reach its own `box.unmount()` call. An unmounted-less
+// FilesSearch keeps its `subscribeFsMutations`/`subscribeIndexLifecycle`
+// listeners registered on those SHARED, module-level Sets
+// (platform/lib/index-freshness) for the rest of the process: the next
+// unrelated test file to call `noteFsMutation` invokes every listener still
+// registered, including this stale one, which is exactly the kind of
+// leaked-subscriber failure a "clean" run cannot reproduce locally but CI
+// (running every file in one process) can.
+const mounted: ReactTestRenderer[] = [];
+
 beforeEach(() => {
   rankCalls.length = 0;
   statCalls.length = 0;
+  globalThis.fetch = fakeFetch as typeof fetch;
   clock.install();
   // Clock.install() sets up `window`/`location`; the real router module also
-  // touches `history` (replaceSearch/navigateUrl), which nothing here calls
-  // directly but which module-level code may still reach for.
+  // touches `history` (replaceSearch/navigateUrl) and `document` (the
+  // "typing anywhere is typing here" redirect), which nothing here calls
+  // directly but which module-level or effect code may still reach for.
   (globalThis as Record<string, unknown>).history = {
     state: null,
     replaceState: () => {},
     pushState: () => {},
   };
+  (globalThis as Record<string, unknown>).document = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
 });
 afterEach(() => {
+  while (mounted.length) {
+    const renderer = mounted.pop()!;
+    act(() => renderer.unmount());
+  }
+  globalThis.fetch = realFetch;
   clock.restore();
   delete (globalThis as Record<string, unknown>).history;
+  delete (globalThis as Record<string, unknown>).document;
 });
 
 /** Run `fn` inside `act` and let any microtasks it releases settle. */
@@ -94,6 +157,10 @@ function mount(): { renderer: ReactTestRenderer; input: () => any; unmount: () =
       }),
     );
   });
+  // Tracked for the unconditional afterEach sweep (above) — removed here on a
+  // NORMAL unmount so that sweep does not try to unmount an already-unmounted
+  // renderer for every test that reaches its own cleanup.
+  mounted.push(renderer);
   return {
     renderer,
     input: () => renderer.root.findByProps({ className: "files-search-input" }),
@@ -101,7 +168,11 @@ function mount(): { renderer: ReactTestRenderer; input: () => any; unmount: () =
     // document listener) must run in the same batched world the rest of the
     // test drives, or React can warn about — or in practice mis-schedule —
     // work outside act().
-    unmount: () => act(() => renderer.unmount()),
+    unmount: () => {
+      const i = mounted.indexOf(renderer);
+      if (i !== -1) mounted.splice(i, 1);
+      act(() => renderer.unmount());
+    },
   };
 }
 
@@ -189,7 +260,7 @@ describe("stale rows: narrow first, clear only if narrowing empties out", () => 
   test("an extending query narrows the held rows with no round trip, and survives the deadline", async () => {
     const box = mount();
     await type(box, "form");
-    await flush(() => rankCalls[0].reply.resolve(
+    await flush(() => rankCalls[0].resolve(
       answer({ hits: [hit("formula.txt"), hit("format.md")], total: 2 })));
 
     // Extend the query; the second request is left hanging.
@@ -210,7 +281,7 @@ describe("stale rows: narrow first, clear only if narrowing empties out", () => 
   test("an unrelated query narrows to nothing, and the deadline drops to a bare 'Searching…'", async () => {
     const box = mount();
     await type(box, "form");
-    await flush(() => rankCalls[0].reply.resolve(
+    await flush(() => rankCalls[0].resolve(
       answer({ hits: [hit("formula.txt"), hit("format.md")], total: 2 })));
     expect(noteText(box)).not.toContain("Searching");
 
@@ -236,7 +307,7 @@ describe("a query that is really an address (section 7)", () => {
     expect(rankCalls).toHaveLength(0);
     expect(statCalls.map((c) => c.path)).toEqual(["/tmp/report.csv"]);
 
-    await flush(() => statCalls[0].reply.resolve({
+    await flush(() => statCalls[0].resolve({
       path: "/tmp/report.csv", name: "report.csv", is_dir: false, size: 1, mtime: 1, templates: [],
     }));
     // The Open row renders in place of any AI row.
@@ -255,7 +326,7 @@ describe("a query that is really an address (section 7)", () => {
   test("suppresses the AI row even when the address does not resolve", async () => {
     const box = mount();
     await type(box, "/tmp/does-not-exist");
-    await flush(() => statCalls[0].reply.reject(new Error("not found")));
+    await flush(() => statCalls[0].reject());
     // Falls through to a normal search (7d) — but still no AI row (7e).
     expect(rankCalls.map((c) => c.q)).toEqual(["/tmp/does-not-exist"]);
     expect(findByClass(box, "fh-ai-glyph")).toHaveLength(0);

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -109,6 +109,16 @@ function type(box: { input: () => any }, value: string): Promise<void> {
   return flush(() => box.input().props.onChange({ target: { value } }));
 }
 
+/** Elements carrying `cls` among possibly several space-separated classes —
+ * `findAllByProps` does exact string equality, which a compound className
+ * (e.g. "fh-result-icon fh-ai-glyph") never satisfies. */
+function findByClass(box: { renderer: ReactTestRenderer }, cls: string): unknown[] {
+  return box.renderer.root.findAll(
+    (n) =>
+      typeof n.props?.className === "string" && n.props.className.split(" ").includes(cls),
+  );
+}
+
 function answer(over: Partial<IndexRankResult> = {}): IndexRankResult {
   return {
     covered: true,
@@ -214,6 +224,48 @@ describe("stale rows: narrow first, clear only if narrowing empties out", () => 
 
     await flush(() => clock.advance(STALE_CLEAR_MS + 50));
     expect(noteText(box)).toBe("Searching…");
+    box.unmount();
+  });
+});
+
+describe("a query that is really an address (section 7)", () => {
+  test("a resolving absolute path issues no indexRank and offers no AI row", async () => {
+    const box = mount();
+    await type(box, "/tmp/report.csv");
+    // No rank request for a literal address — 7c skips it entirely.
+    expect(rankCalls).toHaveLength(0);
+    expect(statCalls.map((c) => c.path)).toEqual(["/tmp/report.csv"]);
+
+    await flush(() => statCalls[0].reply.resolve({
+      path: "/tmp/report.csv", name: "report.csv", is_dir: false, size: 1, mtime: 1, templates: [],
+    }));
+    // The Open row renders in place of any AI row.
+    expect(findByClass(box, "fh-ai-glyph")).toHaveLength(0);
+    expect(box.renderer.root.findAllByProps({ id: "fh-row-0" }).length).toBeGreaterThan(0);
+    box.unmount();
+  });
+
+  test("suppresses the AI row even while the stat is still in flight", async () => {
+    const box = mount();
+    await type(box, "/tmp/still-checking");
+    expect(findByClass(box, "fh-ai-glyph")).toHaveLength(0);
+    box.unmount();
+  });
+
+  test("suppresses the AI row even when the address does not resolve", async () => {
+    const box = mount();
+    await type(box, "/tmp/does-not-exist");
+    await flush(() => statCalls[0].reply.reject(new Error("not found")));
+    // Falls through to a normal search (7d) — but still no AI row (7e).
+    expect(rankCalls.map((c) => c.q)).toEqual(["/tmp/does-not-exist"]);
+    expect(findByClass(box, "fh-ai-glyph")).toHaveLength(0);
+    box.unmount();
+  });
+
+  test("a plain query still gets its AI row back", async () => {
+    const box = mount();
+    await type(box, "readme");
+    expect(findByClass(box, "fh-ai-glyph").length).toBeGreaterThan(0);
     box.unmount();
   });
 });

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -536,3 +536,29 @@ describe("the AI row's ↵ hint only claims Enter when Enter runs it", () => {
     box.unmount();
   });
 });
+
+describe("the AI row's sticky positioning is on the LIST ITEM, not the button inside it", () => {
+  // `position: sticky` is constrained to its element's containing block —
+  // here the <li>, whose content box is exactly the <button>'s height once
+  // the class carrying `position: sticky; bottom: 0` sits on the button
+  // instead: the offset range is zero and the row never actually detaches,
+  // scrolling out of view underneath the fold like any other row (silently
+  // undoing the whole point of HOME_RESULT_CAP=20 plus a scrolling
+  // `.fh-results` — see home-search.ts's own comment on why the cap is safe
+  // only because this row is reachable without scrolling). preferences.css
+  // must carry `.fh-ai-row`'s sticky/background/border-top rules on the
+  // <li>, not the <button>.
+  test("the fh-ai-row class is on the <li>, not the <button>", async () => {
+    const box = mount();
+    await type(box, "zzzqqqnomatch");
+    await flush(() => rankCalls[0].resolve(answer({ hits: [], total: 0 })));
+    const carriers = box.renderer.root.findAll(
+      (n) =>
+        typeof n.props?.className === "string" &&
+        n.props.className.split(" ").includes("fh-ai-row"),
+    );
+    expect(carriers.length).toBeGreaterThan(0);
+    for (const n of carriers) expect(n.type).toBe("li");
+    box.unmount();
+  });
+});

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -351,3 +351,60 @@ describe("a query that is really an address (section 7)", () => {
     box.unmount();
   });
 });
+
+/** Whether the AI row's `<kbd>↵</kbd>` Enter-affordance is on screen. Scoped
+ * to `.fh-ai-hint` specifically — the page has other `<kbd>`s (the open-row
+ * hint, the "↑↓ to pick" caption) that a bare `n.type === "kbd"` search would
+ * also match. */
+function hasAiEnterHint(box: { renderer: ReactTestRenderer }): boolean {
+  const hint = box.renderer.root.findByProps({ className: "fh-ai-hint" });
+  return hint.findAll((n) => n.type === "kbd").length > 0;
+}
+
+function pressArrow(box: { input: () => any }, dir: "down" | "up"): Promise<void> {
+  return flush(() =>
+    box.input().props.onKeyDown({
+      key: dir === "down" ? "ArrowDown" : "ArrowUp",
+      preventDefault: () => {},
+    }),
+  );
+}
+
+describe("the AI row's ↵ hint only claims Enter when Enter runs it", () => {
+  // The badge is the strongest affordance in the row; it used to render
+  // unconditionally whenever the row wasn't `running`, including while the
+  // top FILE hit — not the AI row — was what Enter would actually commit.
+  test("absent with file hits showing and the AI row not highlighted", async () => {
+    const box = mount();
+    await type(box, "readme");
+    await flush(() =>
+      rankCalls[0].resolve(answer({ hits: [hit("readme.md")], total: 1 })),
+    );
+    // The top file row pre-selects (the highlight fix); the AI row is on
+    // screen but not the active one, so its Enter hint must not be.
+    expect(hasAiEnterHint(box)).toBe(false);
+    box.unmount();
+  });
+
+  test("appears once the highlight reaches the AI row", async () => {
+    const box = mount();
+    await type(box, "readme");
+    await flush(() =>
+      rankCalls[0].resolve(answer({ hits: [hit("readme.md")], total: 1 })),
+    );
+    expect(hasAiEnterHint(box)).toBe(false);
+    await pressArrow(box, "down"); // file row 0 -> the AI row (a one-hit list)
+    expect(hasAiEnterHint(box)).toBe(true);
+    box.unmount();
+  });
+
+  test("present in the settled-zero-hit case, where the AI row pre-selects", async () => {
+    const box = mount();
+    await type(box, "zzzqqqnomatch");
+    await flush(() => rankCalls[0].resolve(answer({ hits: [], total: 0 })));
+    // No file hits and settled: activeRow pre-selects the AI row unprompted,
+    // so its hint should already show without pressing a key.
+    expect(hasAiEnterHint(box)).toBe(true);
+    box.unmount();
+  });
+});

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -30,6 +30,7 @@ import { createElement } from "react";
 import type { IndexRankResult, StatResult } from "@platform/lib/api";
 import { Clock } from "@apps/explorer/listing/hook-harness";
 import { STALE_CLEAR_MS } from "@platform/lib/instant-search";
+import { resetFsMutations } from "@platform/lib/index-freshness";
 
 // --- the module boundary: a fetch stub, not a module mock -------------------
 interface RankCall {
@@ -110,6 +111,15 @@ beforeEach(() => {
   rankCalls.length = 0;
   statCalls.length = 0;
   globalThis.fetch = fakeFetch as typeof fetch;
+  // `indexRescanPending` (platform/lib/index-freshness) reads a module-level
+  // `mutatedAt` set by real, non-virtual `Date.now()` — a leaked subscriber
+  // isn't the only way that module bites a later file; a PREDECESSOR test
+  // (anywhere in the process) that called `noteFsMutation` and never reset
+  // leaves this app "still indexing" for up to a real minute, and nothing
+  // about mounting/unmounting a component clears it. Reset unconditionally
+  // so every test here mounts against a known-idle index, whatever ran
+  // before it in CI's single bun process.
+  resetFsMutations();
   clock.install();
   // Clock.install() sets up `window`/`location`; the real router module also
   // touches `history` (replaceSearch/navigateUrl) and `document` (the
@@ -134,6 +144,7 @@ afterEach(() => {
   clock.restore();
   delete (globalThis as Record<string, unknown>).history;
   delete (globalThis as Record<string, unknown>).document;
+  resetFsMutations();
 });
 
 /** Run `fn` inside `act` and let any microtasks it releases settle. */

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -52,21 +52,6 @@ const { FilesSearch } = await import("@apps/explorer/FilesHome");
 
 const HOME = "/Users/me";
 
-function answer(over: Partial<IndexRankResult> = {}): IndexRankResult {
-  return {
-    covered: true,
-    fresh: true,
-    reason: "",
-    root: HOME,
-    hits: [],
-    truncated: false,
-    total: 0,
-    updated: 1,
-    age_s: 1,
-    ...over,
-  };
-}
-
 const clock = new Clock();
 
 beforeEach(() => {

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -409,6 +409,28 @@ describe("a query that is really an address (section 7)", () => {
     box.unmount();
   });
 
+  test("the stale-clear deadline still fires while suppressRank holds the rank request back", async () => {
+    // `pending` is false on the suppressed-rank path (the rank effect
+    // early-returns before ever setting it) — the deadline effect used to
+    // gate on `pending`, which never fires here, so the held answer (and its
+    // `is-stale` dimming) stayed behind indefinitely instead of clearing once
+    // narrowing empties it out, same as the pending-request path does.
+    const box = mount();
+    await type(box, "readme");
+    await flush(() => rankCalls[0].resolve(
+      answer({ hits: [hit("readme.md")], total: 137, truncated: true })));
+
+    await flush(() => box.input().props.onChange({ target: { value: "/tmp/report.csv" } }));
+    expect(statCalls).toHaveLength(1); // the stat is issued but left hanging
+    expect(box.renderer.root.findByProps({ id: "fh-result-list" }).props.className)
+      .toContain("is-stale");
+
+    await flush(() => clock.advance(STALE_CLEAR_MS + 50));
+    expect(box.renderer.root.findByProps({ id: "fh-result-list" }).props.className)
+      .not.toContain("is-stale");
+    box.unmount();
+  });
+
   test("suppresses the AI row even when the address does not resolve", async () => {
     const box = mount();
     await type(box, "/tmp/does-not-exist");

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -1,0 +1,156 @@
+// FilesSearch, DRIVEN: a query is typed, a rank/stat reply lands, the clock
+// moves past the debounce. Everything here is a SEQUENCE, which a plain
+// function test over `home-search.ts` cannot exercise — the component wires
+// the pure helpers there to real state and real timers, and that wiring is
+// exactly what sections 2 and 7 of the overhaul touch.
+//
+// react-test-renderer, the same tool hook-harness.ts uses: no DOM, real React,
+// real effects. The Clock/Deferred/flush trio is reused from there rather than
+// re-invented — the same virtual-timer shape a per-query round trip needs.
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { createElement } from "react";
+import type { IndexRankResult, StatResult } from "@platform/lib/api";
+import { Clock, Deferred } from "@apps/explorer/listing/hook-harness";
+
+// --- the module boundary -----------------------------------------------------
+const rankCalls: { root: string; q: string; reply: Deferred<IndexRankResult> }[] = [];
+const statCalls: { path: string; reply: Deferred<StatResult> }[] = [];
+
+// router.ts reads `location` at MODULE INIT (a legacy /embed/ rewrite), before
+// any beforeEach runs — this has to exist before FilesHome (which imports it
+// transitively) is ever imported below.
+(globalThis as Record<string, unknown>).location = { pathname: "/explorer", search: "" };
+(globalThis as Record<string, unknown>).history = {
+  state: null,
+  replaceState: () => {},
+  pushState: () => {},
+};
+// FilesSearch listens on `document` (the "typing anywhere is typing here"
+// redirect) and calls `.focus()` on the input ref.
+(globalThis as Record<string, unknown>).document = {
+  addEventListener: () => {},
+  removeEventListener: () => {},
+};
+
+const realApi = await import("@platform/lib/api");
+mock.module("@platform/lib/api", () => ({
+  ...realApi,
+  indexRank: (root: string, q: string) => {
+    const reply = new Deferred<IndexRankResult>();
+    rankCalls.push({ root, q, reply });
+    return reply.promise;
+  },
+  statPath: (path: string) => {
+    const reply = new Deferred<StatResult>();
+    statCalls.push({ path, reply });
+    return reply.promise;
+  },
+}));
+
+const { FilesSearch } = await import("@apps/explorer/FilesHome");
+
+const HOME = "/Users/me";
+
+function answer(over: Partial<IndexRankResult> = {}): IndexRankResult {
+  return {
+    covered: true,
+    fresh: true,
+    reason: "",
+    root: HOME,
+    hits: [],
+    truncated: false,
+    total: 0,
+    updated: 1,
+    age_s: 1,
+    ...over,
+  };
+}
+
+const clock = new Clock();
+
+beforeEach(() => {
+  rankCalls.length = 0;
+  statCalls.length = 0;
+  clock.install();
+  // Clock.install() sets up `window`/`location`; the real router module also
+  // touches `history` (replaceSearch/navigateUrl), which nothing here calls
+  // directly but which module-level code may still reach for.
+  (globalThis as Record<string, unknown>).history = {
+    state: null,
+    replaceState: () => {},
+    pushState: () => {},
+  };
+});
+afterEach(() => {
+  clock.restore();
+  delete (globalThis as Record<string, unknown>).history;
+});
+
+/** Run `fn` inside `act` and let any microtasks it releases settle. */
+async function flush(fn: () => void = () => {}): Promise<void> {
+  await act(async () => {
+    fn();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function mount(): { renderer: ReactTestRenderer; input: () => any } {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      createElement(FilesSearch, {
+        home: HOME,
+        initialQuery: "",
+        indexScan: null,
+        onActiveChange: () => {},
+      }),
+    );
+  });
+  return {
+    renderer,
+    input: () => renderer.root.findByProps({ className: "files-search-input" }),
+  };
+}
+
+function type(box: { input: () => any }, value: string): Promise<void> {
+  return flush(() => box.input().props.onChange({ target: { value } }));
+}
+
+describe("MIN_QUERY_CHARS: nothing is asked below it", () => {
+  test("one character issues no indexRank", async () => {
+    const box = mount();
+    await type(box, "a");
+    // The idle warm on mount fires its own indexRank(WARM_QUERY); give it a
+    // beat to land so it cannot be mistaken for a query-driven call.
+    expect(rankCalls.filter((c) => c.q === "a")).toHaveLength(0);
+    box.renderer.unmount();
+  });
+
+  test("two characters ask, at the leading edge", async () => {
+    const box = mount();
+    await type(box, "ab");
+    expect(rankCalls.filter((c) => c.q === "ab")).toHaveLength(1);
+    box.renderer.unmount();
+  });
+
+  test('the note reads "Keep typing…" under the threshold', async () => {
+    const box = mount();
+    await type(box, "a");
+    const note = box.renderer.root.findByProps({ className: "fh-result-note" });
+    expect(note.children.join("")).toContain("Keep typing");
+    box.renderer.unmount();
+  });
+
+  test("no result list (and so no AI row) renders under the threshold", async () => {
+    const box = mount();
+    await type(box, "a");
+    expect(box.renderer.root.findAllByProps({ id: "fh-result-list" })).toHaveLength(0);
+    box.renderer.unmount();
+  });
+});
+
+// Section 7 (below) adds this describe block back once the path-shortcut row
+// exists to assert against; landed separately so this file's tests stay green
+// commit-by-commit rather than carrying a red one across the gap.

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -12,6 +12,7 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { createElement } from "react";
 import type { IndexRankResult, StatResult } from "@platform/lib/api";
 import { Clock, Deferred } from "@apps/explorer/listing/hook-harness";
+import { STALE_CLEAR_MS } from "@platform/lib/instant-search";
 
 // --- the module boundary -----------------------------------------------------
 const rankCalls: { root: string; q: string; reply: Deferred<IndexRankResult> }[] = [];
@@ -81,7 +82,7 @@ async function flush(fn: () => void = () => {}): Promise<void> {
   });
 }
 
-function mount(): { renderer: ReactTestRenderer; input: () => any } {
+function mount(): { renderer: ReactTestRenderer; input: () => any; unmount: () => void } {
   let renderer!: ReactTestRenderer;
   act(() => {
     renderer = create(
@@ -96,11 +97,49 @@ function mount(): { renderer: ReactTestRenderer; input: () => any } {
   return {
     renderer,
     input: () => renderer.root.findByProps({ className: "files-search-input" }),
+    // Unmount INSIDE act(): effect cleanups (the pending timers, the
+    // document listener) must run in the same batched world the rest of the
+    // test drives, or React can warn about — or in practice mis-schedule —
+    // work outside act().
+    unmount: () => act(() => renderer.unmount()),
   };
 }
 
 function type(box: { input: () => any }, value: string): Promise<void> {
   return flush(() => box.input().props.onChange({ target: { value } }));
+}
+
+function answer(over: Partial<IndexRankResult> = {}): IndexRankResult {
+  return {
+    covered: true,
+    fresh: true,
+    reason: "",
+    root: HOME,
+    hits: [],
+    truncated: false,
+    total: 0,
+    updated: 1,
+    age_s: 1,
+    ...over,
+  };
+}
+
+const hit = (rel: string) => ({
+  rel, is_dir: false, size: 1, mtime: 1, score: 10, longest_run: 3, tier: 1, depth: 1,
+});
+
+/** The result note's flattened text, kbd/span children included. */
+function noteText(box: { renderer: ReactTestRenderer }): string {
+  const node = box.renderer.root.findByProps({ className: "fh-result-note" });
+  const walk = (n: unknown): string => {
+    if (typeof n === "string") return n;
+    if (Array.isArray(n)) return n.map(walk).join("");
+    if (n && typeof n === "object" && "children" in (n as Record<string, unknown>)) {
+      return walk((n as { children: unknown }).children);
+    }
+    return "";
+  };
+  return walk(node);
 }
 
 describe("MIN_QUERY_CHARS: nothing is asked below it", () => {
@@ -110,14 +149,14 @@ describe("MIN_QUERY_CHARS: nothing is asked below it", () => {
     // The idle warm on mount fires its own indexRank(WARM_QUERY); give it a
     // beat to land so it cannot be mistaken for a query-driven call.
     expect(rankCalls.filter((c) => c.q === "a")).toHaveLength(0);
-    box.renderer.unmount();
+    box.unmount();
   });
 
   test("two characters ask, at the leading edge", async () => {
     const box = mount();
     await type(box, "ab");
     expect(rankCalls.filter((c) => c.q === "ab")).toHaveLength(1);
-    box.renderer.unmount();
+    box.unmount();
   });
 
   test('the note reads "Keep typing…" under the threshold', async () => {
@@ -125,17 +164,56 @@ describe("MIN_QUERY_CHARS: nothing is asked below it", () => {
     await type(box, "a");
     const note = box.renderer.root.findByProps({ className: "fh-result-note" });
     expect(note.children.join("")).toContain("Keep typing");
-    box.renderer.unmount();
+    box.unmount();
   });
 
   test("no result list (and so no AI row) renders under the threshold", async () => {
     const box = mount();
     await type(box, "a");
     expect(box.renderer.root.findAllByProps({ id: "fh-result-list" })).toHaveLength(0);
-    box.renderer.unmount();
+    box.unmount();
   });
 });
 
-// Section 7 (below) adds this describe block back once the path-shortcut row
-// exists to assert against; landed separately so this file's tests stay green
-// commit-by-commit rather than carrying a red one across the gap.
+describe("stale rows: narrow first, clear only if narrowing empties out", () => {
+  test("an extending query narrows the held rows with no round trip, and survives the deadline", async () => {
+    const box = mount();
+    await type(box, "form");
+    await flush(() => rankCalls[0].reply.resolve(
+      answer({ hits: [hit("formula.txt"), hit("format.md")], total: 2 })));
+
+    // Extend the query; the second request is left hanging.
+    await flush(() => box.input().props.onChange({ target: { value: "forma" } }));
+    await flush(() => clock.advance(200)); // past the trailing debounce
+    expect(rankCalls).toHaveLength(2);
+    expect(box.renderer.root.findAllByProps({ className: "fh-result-name" }).length)
+      .toBeGreaterThan(0); // narrowed rows are on screen already, no round trip needed
+
+    // Run the clock well past the staleness deadline: narrowing left rows, so
+    // they must NOT be thrown away.
+    await flush(() => clock.advance(1_000));
+    expect(box.renderer.root.findAllByProps({ className: "fh-result-name" }).length)
+      .toBeGreaterThan(0);
+    box.unmount();
+  });
+
+  test("an unrelated query narrows to nothing, and the deadline drops to a bare 'Searching…'", async () => {
+    const box = mount();
+    await type(box, "form");
+    await flush(() => rankCalls[0].reply.resolve(
+      answer({ hits: [hit("formula.txt"), hit("format.md")], total: 2 })));
+    expect(noteText(box)).not.toContain("Searching");
+
+    // A paste-over: nothing held matches this at all.
+    await flush(() => box.input().props.onChange({ target: { value: "zzzqqq" } }));
+    await flush(() => clock.advance(200));
+    expect(rankCalls).toHaveLength(2);
+
+    // Before the deadline: still the previous (stale) note, not "Searching…".
+    expect(noteText(box)).not.toBe("Searching…");
+
+    await flush(() => clock.advance(STALE_CLEAR_MS + 50));
+    expect(noteText(box)).toBe("Searching…");
+    box.unmount();
+  });
+});

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -48,6 +48,12 @@ interface StatCall {
 }
 const rankCalls: RankCall[] = [];
 const statCalls: StatCall[] = [];
+/** Every `history.pushState(..., url)` the router's `navigate()` makes — the
+ * observable trace of a navigation, since `navigate` itself is a frozen ES
+ * module export this file cannot spy on (see the file-header comment on why
+ * `mock.module` is out) and `window.dispatchEvent`/`history.pushState` are
+ * plain stubbed globals same as `fetch` above. */
+const navPushes: string[] = [];
 
 const realFetch = globalThis.fetch;
 
@@ -110,6 +116,7 @@ const mounted: ReactTestRenderer[] = [];
 beforeEach(() => {
   rankCalls.length = 0;
   statCalls.length = 0;
+  navPushes.length = 0;
   globalThis.fetch = fakeFetch as typeof fetch;
   // `indexRescanPending` (platform/lib/index-freshness) reads a module-level
   // `mutatedAt` set by real, non-virtual `Date.now()` — a leaked subscriber
@@ -125,10 +132,17 @@ beforeEach(() => {
   // touches `history` (replaceSearch/navigateUrl) and `document` (the
   // "typing anywhere is typing here" redirect), which nothing here calls
   // directly but which module-level or effect code may still reach for.
+  // `navigate()` (router.ts) also fires `window.dispatchEvent(new
+  // Event(NAV_EVENT))` — Clock's stubbed `window` has no such method, so
+  // anything that reaches `navigate()` (an Enter that commits a resolved
+  // address) throws without this.
+  (globalThis as unknown as { window: Record<string, unknown> }).window.dispatchEvent = () => true;
   (globalThis as Record<string, unknown>).history = {
     state: null,
     replaceState: () => {},
-    pushState: () => {},
+    pushState: (_state: unknown, _title: string, url?: string | URL | null) => {
+      if (url) navPushes.push(String(url));
+    },
   };
   (globalThis as Record<string, unknown>).document = {
     addEventListener: () => {},
@@ -289,7 +303,7 @@ describe("stale rows: narrow first, clear only if narrowing empties out", () => 
     box.unmount();
   });
 
-  test("an unrelated query narrows to nothing, and the deadline drops to a bare 'Searching…'", async () => {
+  test("an unrelated query narrows to nothing: the note says so immediately, and the deadline only clears the stale-rows dimming", async () => {
     const box = mount();
     await type(box, "form");
     await flush(() => rankCalls[0].resolve(
@@ -301,11 +315,52 @@ describe("stale rows: narrow first, clear only if narrowing empties out", () => 
     await flush(() => clock.advance(200));
     expect(rankCalls).toHaveLength(2);
 
-    // Before the deadline: still the previous (stale) note, not "Searching…".
-    expect(noteText(box)).not.toBe("Searching…");
+    // Before the deadline: the note already reads the RENDERED (narrowed,
+    // now-empty) rows, not the previous request's non-zero count — it used
+    // to keep reporting that stale count until the deadline dropped `answer`
+    // to null, over a list that had already narrowed to nothing.
+    expect(noteText(box)).toBe("Searching…");
+    // The rows themselves are still `behind` (dimmed): the held answer is
+    // for "form", not yet given up on.
+    expect(box.renderer.root.findByProps({ id: "fh-result-list" }).props.className)
+      .toContain("is-stale");
 
     await flush(() => clock.advance(STALE_CLEAR_MS + 50));
+    // Past the deadline `answer` itself drops to null: the note still reads
+    // "Searching…" (nothing changed about what's on screen), but the rows
+    // are no longer flagged stale — there is nothing stale left to dim.
     expect(noteText(box)).toBe("Searching…");
+    expect(box.renderer.root.findByProps({ id: "fh-result-list" }).props.className)
+      .not.toContain("is-stale");
+    box.unmount();
+  });
+
+  test("the count note narrows together with the rows, not left describing the held answer", async () => {
+    const box = mount();
+    await type(box, "form");
+    // A broad first answer: the note claims 137 matches.
+    await flush(() => rankCalls[0].resolve(
+      answer({
+        hits: [hit("formula.txt"), hit("format.md"), hit("formal.doc")],
+        total: 137,
+        truncated: true,
+      }),
+    ));
+    expect(noteText(box)).toContain("137");
+
+    // Extend to a query only ONE of the three held hits still matches
+    // ("formula.txt" — the others lack a "u"). The second request is left
+    // hanging, so this is all narrowing, no round trip.
+    await flush(() => box.input().props.onChange({ target: { value: "formu" } }));
+    await flush(() => clock.advance(200));
+    // Only the file row with an href is a FILE hit — the AI row also carries
+    // `.fh-result-name` (its "Search with AI" label), so counting that class
+    // alone would double-count it.
+    expect(box.renderer.root.findAll((n) => typeof n.props?.href === "string")).toHaveLength(1);
+    // The note used to keep reporting the OLD request's total (137) over the
+    // now-narrowed 1-row list — describing a search that was never sent for
+    // "formu" at all. It must track what's actually on screen.
+    expect(noteText(box)).not.toContain("137");
     box.unmount();
   });
 });
@@ -334,6 +389,26 @@ describe("a query that is really an address (section 7)", () => {
     box.unmount();
   });
 
+  test("the note does not describe a search that was never sent while the stat is in flight", async () => {
+    const box = mount();
+    // A normal query first, so a stale answer with a real count exists to
+    // wrongly fall back to.
+    await type(box, "readme");
+    await flush(() => rankCalls[0].resolve(
+      answer({ hits: [hit("readme.md")], total: 137, truncated: true })));
+    expect(noteText(box)).toContain("137");
+
+    // Paste a path over it: suppressRank holds the rank request back
+    // entirely (no request goes out for "/tmp/report.csv"), and the stat
+    // hasn't answered yet (showOpenRow is false) — so the note must not fall
+    // through to describing the OLD answer.
+    await flush(() => box.input().props.onChange({ target: { value: "/tmp/report.csv" } }));
+    expect(statCalls).toHaveLength(1);
+    expect(rankCalls).toHaveLength(1); // no second rank request
+    expect(noteText(box)).not.toContain("137");
+    box.unmount();
+  });
+
   test("suppresses the AI row even when the address does not resolve", async () => {
     const box = mount();
     await type(box, "/tmp/does-not-exist");
@@ -348,6 +423,59 @@ describe("a query that is really an address (section 7)", () => {
     const box = mount();
     await type(box, "readme");
     expect(findByClass(box, "fh-ai-glyph").length).toBeGreaterThan(0);
+    box.unmount();
+  });
+});
+
+function pressEnter(box: { input: () => any }): Promise<void> {
+  return flush(() =>
+    box.input().props.onKeyDown({ key: "Enter", preventDefault: () => {} }),
+  );
+}
+
+describe("Enter while a pasted path's stat is still resolving (section 7 paste-and-go)", () => {
+  // `submitRow` has nothing to commit here: `suppressRank` holds ranking
+  // back (no rank request, no file rows), `showOpenRow` is false (the stat
+  // hasn't answered yet) and the AI row is suppressed too (`address !==
+  // null`). Enter used to be a silent no-op in this exact window — which is
+  // precisely the paste-and-go gesture the address feature exists for.
+  test("commits the address once the in-flight stat resolves", async () => {
+    const box = mount();
+    await type(box, "/tmp/report.csv");
+    expect(statCalls).toHaveLength(1);
+    await pressEnter(box);
+    expect(navPushes).toHaveLength(0); // nothing yet — the stat is still out
+    await flush(() =>
+      statCalls[0].resolve({
+        path: "/tmp/report.csv", name: "report.csv", is_dir: false, size: 1, mtime: 1, templates: [],
+      }),
+    );
+    expect(navPushes.some((u) => u.includes("report.csv"))).toBe(true);
+    box.unmount();
+  });
+
+  test("does NOT navigate when the stat resolves to missing", async () => {
+    const box = mount();
+    await type(box, "/tmp/does-not-exist");
+    await pressEnter(box);
+    await flush(() => statCalls[0].reject());
+    expect(navPushes).toHaveLength(0);
+    box.unmount();
+  });
+
+  test("a superseded stat (aborted by a newer keystroke) still does not navigate", async () => {
+    const box = mount();
+    await type(box, "/tmp/report.csv");
+    await pressEnter(box);
+    // Edit the query before the stat comes back — the pending commit must
+    // not fire for an address the user has since typed past.
+    await flush(() => box.input().props.onChange({ target: { value: "/tmp/other.csv" } }));
+    await flush(() =>
+      statCalls[0].resolve({
+        path: "/tmp/report.csv", name: "report.csv", is_dir: false, size: 1, mtime: 1, templates: [],
+      }),
+    );
+    expect(navPushes).toHaveLength(0);
     box.unmount();
   });
 });

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -775,7 +775,12 @@ export function FilesSearch({
             if (e.key === "ArrowDown" || e.key === "ArrowUp") {
               if (!active || showingAi || (!searchable && !showOpenRow)) return;
               e.preventDefault();
-              setHighlight((h) => stepHighlight(h, rowModel, e.key === "ArrowDown" ? 1 : -1));
+              // Step from `current` (the RESOLVED row, `activeRow` above), not
+              // the raw `highlight` state: the top file row can be active with
+              // `highlight` still null (activeRow's implicit pre-select), and
+              // stepping from null would land the first ArrowDown back on row
+              // 0 — the already-visible selection — instead of row 1.
+              setHighlight(stepHighlight(current, rowModel, e.key === "ArrowDown" ? 1 : -1));
             } else if (e.key === "Enter") {
               e.preventDefault();
               submit();

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -612,8 +612,24 @@ export function FilesSearch({
   // deadline drop to `answer = null`, which renders as the plain "Searching…"
   // note — no rows and an honest label beats rows for a query the user has
   // visibly moved past.
+  //
+  // `pending` was the only qualifying condition before `suppressRank`
+  // existed — there was always a real request "outliving" the query to time
+  // out on. An address-shaped query holds ranking back entirely (`suppressRank`
+  // is a THIRD reason `behind` can be true, alongside `pending` and, briefly,
+  // neither): `pending` is never true on that path (the rank effect
+  // early-returns before setting it), so a guard reading only `pending` never
+  // fires here at all — the held answer, and its `is-stale` dimming, stayed
+  // behind indefinitely regardless of how long the stat took. `suppressRank`
+  // is included in the gate for exactly the same reason `pending` is: it is
+  // the other case where nothing is going to replace `answer` for THIS query
+  // on its own — this one because the stat, not the ranking round trip, is
+  // what has to resolve first (and if it resolves to "missing", 7d's fallback
+  // fires a real rank request, which unsticks this the normal way, but until
+  // then the deadline is what stops a slow stat from pinning a stale answer
+  // in place).
   useEffect(() => {
-    if (!pending || !behind) return;
+    if (!behind || (!pending && !suppressRank)) return;
     const timer = window.setTimeout(() => {
       setAnswer((prev) => {
         if (prev === null || prev.query === q) return prev;
@@ -621,7 +637,7 @@ export function FilesSearch({
       });
     }, STALE_CLEAR_MS);
     return () => window.clearTimeout(timer);
-  }, [pending, behind, q]);
+  }, [pending, suppressRank, behind, q]);
 
   // -- the box is where typing goes ------------------------------------------
   //

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -248,10 +248,17 @@ function AiActionRow({
   onRun: () => void;
 }) {
   return (
-    <li role="option" id={id} aria-selected={active}>
+    // `fh-ai-row` (sticky/background/border-top — preferences.css) lives on
+    // THIS <li>, not the button inside it: `position: sticky` is bound to its
+    // element's own containing block, and a <li> that wraps exactly one
+    // full-width button has no room of its own to offset within — sticky on
+    // the button was a no-op that never actually stuck. `fh-ai-action`
+    // carries what genuinely IS about the button (the accent name, the
+    // disabled cursor).
+    <li className="fh-ai-row" role="option" id={id} aria-selected={active}>
       <button
         type="button"
-        className={"fh-result fh-ai-row" + (active ? " is-active" : "")}
+        className={"fh-result fh-ai-action" + (active ? " is-active" : "")}
         disabled={running}
         onClick={onRun}
       >

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -32,6 +32,7 @@ import { useIndexStatus } from "@platform/lib/index-status";
 import {
   PENDING_INDICATOR_MS,
   QueryMemo,
+  STALE_CLEAR_MS,
   searchDelay,
 } from "@platform/lib/instant-search";
 import {
@@ -42,6 +43,7 @@ import {
   homeCountNote,
   isAiRow,
   nameStart,
+  narrowAnswer,
   pathShortcut,
   positionsWithin,
   rankingSettled,
@@ -431,8 +433,37 @@ export function FilesSearch({
   // next answer is in flight: results → nothing → results is the single most
   // visible way this can feel worse than ranking locally, which never had an
   // empty frame. `behind` is what dims them and what the caveat chip explains.
-  const hits = answer?.hits ?? [];
+  //
+  // While behind, render `narrowAnswer`'s re-filtered subset rather than the
+  // held answer's raw hits: the overwhelmingly common case is the query
+  // EXTENDING the held one ("read" -> "readme"), and re-running fuzzyMatch
+  // over hits already in hand narrows the list with no round trip and no
+  // blank frame — strictly better than dimming rows that cannot possibly
+  // match. It can only ever remove rows, never add or reorder them, so this
+  // is always a subset of the true (still in-flight) answer.
   const behind = answer !== null && answer.query !== q;
+  const hits = behind && answer ? narrowAnswer(answer, q) : (answer?.hits ?? []);
+
+  // The staleness deadline: past STALE_CLEAR_MS of a request outliving the
+  // query it was asked for, "a little behind" stops being true — this used to
+  // hold for a ~40ms local rank, not a multi-second round trip. Narrowing
+  // (above) is tried FIRST and takes priority: if it leaves real rows, those
+  // are a provable subset of the answer to THIS query, and the deadline must
+  // not throw them away out from under the user. Only when narrowing leaves
+  // nothing (an unrelated query, a paste, a select-all retype) does the
+  // deadline drop to `answer = null`, which renders as the plain "Searching…"
+  // note — no rows and an honest label beats rows for a query the user has
+  // visibly moved past.
+  useEffect(() => {
+    if (!pending || !behind) return;
+    const timer = window.setTimeout(() => {
+      setAnswer((prev) => {
+        if (prev === null || prev.query === q) return prev;
+        return narrowAnswer(prev, q).length > 0 ? prev : null;
+      });
+    }, STALE_CLEAR_MS);
+    return () => window.clearTimeout(timer);
+  }, [pending, behind, q]);
 
   // -- the box is where typing goes ------------------------------------------
   //

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -35,6 +35,7 @@ import {
   searchDelay,
 } from "@platform/lib/instant-search";
 import {
+  MIN_QUERY_CHARS,
   RANK_FETCH_LIMIT,
   activeRow,
   answerFrom,
@@ -275,6 +276,12 @@ export function FilesSearch({
   const [highlight, setHighlight] = useState<number | null>(null);
   const q = query.trim();
   const active = q !== "";
+  // Below MIN_QUERY_CHARS the REQUEST is gated, not `active`: `active` is what
+  // hides bookmarks/recents and hands the page body to this panel, and doing
+  // that on the first character would bounce the whole page as the user types
+  // their second one. `searchable` instead governs whether a rank request goes
+  // out and whether the AI row can ever be armed for the current query.
+  const searchable = q.length >= MIN_QUERY_CHARS;
   useEffect(() => onActiveChange(active), [active, onActiveChange]);
 
   // -- the ranked answer -----------------------------------------------------
@@ -342,7 +349,11 @@ export function FilesSearch({
   useEffect(() => () => inflight.current?.abort(), []);
 
   useEffect(() => {
-    if (!active) {
+    // `!searchable` is the same early-out as `!active`: nothing is asked, and
+    // anything already in flight (from a longer query since backspaced away)
+    // is abandoned rather than left to land over a query too short to have
+    // earned an answer.
+    if (!active || !searchable) {
       inflight.current?.abort();
       setPending(false);
       return;
@@ -397,7 +408,7 @@ export function FilesSearch({
     }
     const timer = window.setTimeout(run, delay);
     return () => window.clearTimeout(timer);
-  }, [home, q, active, lifecycle, mutations, retryNonce]);
+  }, [home, q, active, searchable, lifecycle, mutations, retryNonce]);
 
   useEffect(() => {
     if (!pending) {
@@ -536,8 +547,11 @@ export function FilesSearch({
   const showingAi = ai.status === "done" && ai.query === q;
   // Whether the instant list is a finished answer FOR THIS QUERY. Gates the AI
   // row's pre-selection, so Enter while the request is in flight cannot spend a
-  // model call on a query that was about to answer itself.
-  const settled = rankingSettled(answer, q, pending, failure !== "");
+  // model call on a query that was about to answer itself. `!searchable` short-
+  // circuits it to false outright: a query under MIN_QUERY_CHARS never asked
+  // anything, so there is nothing for it to be settled ON, and a model call on
+  // "a" is never the intent.
+  const settled = searchable && rankingSettled(answer, q, pending, failure !== "");
   // The indexing caveat, same helper and same two messages as the listing's
   // search chip (listing/index-caveat) so the two boxes make the same claim in
   // the same words. It is the piece that makes a lagging answer read as
@@ -554,7 +568,7 @@ export function FilesSearch({
   // changed a file, the server is re-indexing that folder, and until a status
   // poll catches the run nothing else would say so.
   const caveat =
-    active && !showingAi
+    active && !showingAi && searchable
       ? searchCaveat(indexScan, { behind, pending, rescanPending: indexRescanPending() })
       : null;
   const current = activeRow(highlight, hits.length, settled);
@@ -607,10 +621,10 @@ export function FilesSearch({
           placeholder="Search your files — or paste a path like ~/Downloads"
           aria-label="Search your files"
           role="combobox"
-          aria-expanded={active && !showingAi}
+          aria-expanded={active && !showingAi && searchable}
           aria-controls="fh-result-list"
           aria-activedescendant={
-            active && !showingAi && current !== null ? "fh-row-" + current : undefined
+            active && !showingAi && searchable && current !== null ? "fh-row-" + current : undefined
           }
           autoComplete="off"
           spellCheck={false}
@@ -618,7 +632,7 @@ export function FilesSearch({
           onChange={(e) => edit(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-              if (!active || showingAi) return;
+              if (!active || showingAi || !searchable) return;
               e.preventDefault();
               setHighlight((h) => stepHighlight(h, hits.length, e.key === "ArrowDown" ? 1 : -1));
             } else if (e.key === "Enter") {
@@ -660,8 +674,15 @@ export function FilesSearch({
                 new query is in flight the previous answer is what is on screen,
                 and a note that denies having rows over rows that are visibly
                 there is the mid-rescan "still building" bug in another costume.
-                Only having never had an answer may say so. */}
-            {answer === null && failure !== "" ? (
+                Only having never had an answer may say so.
+
+                `!searchable` comes FIRST, ahead of every other branch: under
+                MIN_QUERY_CHARS no request went out, so `answer` (if any) is
+                whatever an earlier, longer query left behind, and reporting
+                on it here would describe a search that didn't happen. */}
+            {!searchable ? (
+              "Keep typing…"
+            ) : answer === null && failure !== "" ? (
               `The file index could not be searched: ${failure}`
             ) : answer === null ? (
               "Searching…"
@@ -701,7 +722,9 @@ export function FilesSearch({
                 PENDING_INDICATOR_MS the answer beats the words onto the screen,
                 and a note that appears and vanishes reads as slower than one
                 that never appeared. */}
-            {slow && hits.length > 0 && <span className="fh-searching-note"> · Searching…</span>}
+            {searchable && slow && hits.length > 0 && (
+              <span className="fh-searching-note"> · Searching…</span>
+            )}
             {caveat && (
               <span className="fh-index-chip" title={caveat.title}>
                 {/* Only while a scan is actually running. The chip also carries
@@ -715,30 +738,36 @@ export function FilesSearch({
               </span>
             )}
           </p>
-          <ul
-            className={"fh-results" + (behind ? " is-stale" : "")}
-            id="fh-result-list"
-            role="listbox"
-            aria-label="Search results"
-          >
-            {hits.map((hit, i) => (
-              <FileRow
-                key={hit.path}
-                hit={hit}
-                home={home}
-                active={current === i}
-                id={"fh-row-" + i}
-                onHover={() => setHighlight(i)}
+          {/* Nothing to show below MIN_QUERY_CHARS: no request went out, so
+              `hits` is stale leftover from a longer query, and offering the AI
+              row here would arm a model call on "a". The note above already
+              says why the list is empty. */}
+          {searchable && (
+            <ul
+              className={"fh-results" + (behind ? " is-stale" : "")}
+              id="fh-result-list"
+              role="listbox"
+              aria-label="Search results"
+            >
+              {hits.map((hit, i) => (
+                <FileRow
+                  key={hit.path}
+                  hit={hit}
+                  home={home}
+                  active={current === i}
+                  id={"fh-row-" + i}
+                  onHover={() => setHighlight(i)}
+                />
+              ))}
+              <AiActionRow
+                query={q}
+                active={current === hits.length}
+                running={ai.status === "running"}
+                id={"fh-row-" + hits.length}
+                onRun={() => runAi(q)}
               />
-            ))}
-            <AiActionRow
-              query={q}
-              active={current === hits.length}
-              running={ai.status === "running"}
-              id={"fh-row-" + hits.length}
-              onRun={() => runAi(q)}
-            />
-          </ul>
+            </ul>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -260,8 +260,16 @@ function AiActionRow({
         </span>
         <span className="fh-result-name">Search with AI</span>
         <span className="fh-ai-query">“{query}”</span>
+        {/* The badge only claims Enter when Enter actually runs THIS row.
+            `activeRow` pre-selects the AI row exactly when it is the only
+            content on screen (settled, zero file hits) — every other time
+            Enter opens the top file hit instead, and showing `↵` here would
+            be the strongest affordance in the row pointing the wrong way.
+            The span stays in the layout (not conditionally rendered) even
+            empty, so the row's columns do not reflow as the highlight moves
+            onto or off it. */}
         <span className="fh-ai-hint">
-          {running ? "Asking…" : <kbd>↵</kbd>}
+          {running ? "Asking…" : active ? <kbd>↵</kbd> : null}
         </span>
       </button>
     </li>

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -179,6 +179,14 @@ function FileRow({
 // it (accent glyph, no path, no size) because activating it costs a model call
 // and a wait, and because on a zero-hit query it is the only thing on screen.
 //
+// It does NOT reuse `.fh-result-path` / `.fh-result-meta` for the query echo
+// and the `↵` hint, even though it reuses `.fh-result`/`.fh-result-name` for
+// layout: those two classes are the file rows' PATH and DATE/SIZE columns, and
+// borrowing them here made the query — "parquet" — land in the same visual
+// column as a file's `~/Work/...` path, and the `↵` align with a date. Nothing
+// about this row is a file, so it gets its own two classes instead
+// (`.fh-ai-query`, `.fh-ai-hint`; preferences.css).
+//
 // Deliberately NOT hoverable, unlike the file rows: setting the highlight on
 // mousemove meant nudging the pointer across the list armed Enter to spend a
 // model call. A pointer merely crossing a row must not arm a paid action —
@@ -208,8 +216,8 @@ function AiActionRow({
           <SparkIcon />
         </span>
         <span className="fh-result-name">Search with AI</span>
-        <span className="fh-result-path">“{query}”</span>
-        <span className="fh-result-meta">
+        <span className="fh-ai-query">“{query}”</span>
+        <span className="fh-ai-hint">
           {running ? "Asking…" : <kbd>↵</kbd>}
         </span>
       </button>

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -400,6 +400,35 @@ export function FilesSearch({
     return () => window.clearTimeout(timer);
   }, [address]);
   useEffect(() => () => addrCtl.current?.abort(), []);
+
+  // Enter pressed WHILE the stat above is still in flight (addr.status ===
+  // "unknown") used to be a silent no-op: `suppressRank` holds the rank
+  // request back, `showOpenRow` is false (nothing has resolved yet), and the
+  // AI row is suppressed too (`address !== null`) — so `submitRow` has
+  // nothing to commit. That drops exactly the paste-and-go gesture the
+  // address feature exists for: paste a path, hit Enter immediately, expect
+  // it to open the moment the stat lands.
+  //
+  // `awaitingCommit` remembers the SPECIFIC address Enter was pressed for.
+  // The effect below fires once `addr` settles (either resolution) and
+  // commits — navigating only on "exists", never on "missing" — but ONLY if
+  // `address` still equals the address the commit was requested for: a newer
+  // keystroke changes `address` before the stat answers (and aborts the old
+  // stat's controller, so a still-in-flight reply for the OLD address is
+  // also ignored on its own terms), and the mismatch here is what stops a
+  // late-arriving answer for an address the user has since typed past from
+  // committing anyway.
+  const awaitingCommit = useRef<string | null>(null);
+  useEffect(() => {
+    if (awaitingCommit.current === null || addr.status === "unknown") return;
+    const target = awaitingCommit.current;
+    awaitingCommit.current = null;
+    if (target !== address) return; // superseded by a newer keystroke
+    if (addr.status === "exists") navigate(addr.path, { isDir: addr.is_dir });
+    // "missing" resolves to nothing: Enter must not navigate to a path that
+    // does not exist.
+  }, [addr, address]);
+
   // There is no "Open" row until the stat is back and says the address is
   // real.
   const showOpenRow = address !== null && addr.status === "exists";
@@ -751,6 +780,13 @@ export function FilesSearch({
   // effect above as the query is typed, so by the time Enter is pressed the
   // row model already reflects it — `activeRow`/`submitRow` do the rest.
   const submit = () => {
+    if (address !== null && addr.status === "unknown") {
+      // The paste-and-go gesture: Enter fired before the stat came back.
+      // Await it instead of dropping the keystroke — the effect above
+      // commits once `addr` settles.
+      awaitingCommit.current = address;
+      return;
+    }
     const row = submitRow(highlight, rowModel, settled);
     if (row !== null) activateRow(row);
   };
@@ -838,13 +874,23 @@ export function FilesSearch({
                 address resolves, the row IS the content, and reporting on
                 `answer` (whatever a previous, non-address query left behind,
                 or nothing at all) would describe a search that was never
-                sent (7c skips it entirely). */}
+                sent (7c skips it entirely). `suppressRank`, right below it,
+                is the SAME protection one beat earlier in the address's
+                lifecycle: the stat hasn't resolved yet (addr.status is
+                "unknown", neither "exists" nor "missing"), so no rank
+                request went out for this query either — `answer` is still
+                whatever the PREVIOUS, non-address query left behind. This
+                used to fall all the way through to the count-note branch
+                below, reporting that stale answer's total over rows that
+                (see `hits`, above) have likely narrowed to nothing. */}
             {showOpenRow ? (
               <>
                 <kbd>↵</kbd> to open · <kbd>esc</kbd> to clear
               </>
             ) : !searchable ? (
               "Keep typing…"
+            ) : suppressRank ? (
+              "Checking…"
             ) : answer === null && failure !== "" ? (
               `The file index could not be searched: ${failure}`
             ) : answer === null ? (
@@ -869,19 +915,39 @@ export function FilesSearch({
               // Never "no matches" for an index that has not been built: that
               // would blame the user's files for the app's state.
               "The file index is still building — AI search can answer in the meantime."
-            ) : answer.hits.length === 0 && settled && rowModel.aiRow ? (
+            ) : hits.length === 0 && settled && rowModel.aiRow ? (
+              // `hits`, not `answer.hits`: `settled` already rules out
+              // `behind` (see `hits`'s own comment — `rankingSettled` is
+              // false whenever `answer.query !== q`), so the two agree here,
+              // but reading the rendered array rather than the held answer's
+              // is what keeps every branch below honest about what's on
+              // screen instead of what a previous request found.
               `No file name matched “${q}” — AI search can look at dates, types and sizes.`
-            ) : answer.hits.length === 0 && settled ? (
+            ) : hits.length === 0 && settled ? (
               // Settled, zero hits, but the AI row is suppressed (address !==
               // null: this query is shaped like a path that did not resolve —
               // 7e). Offering AI search here would point at a row that is not
               // being rendered.
               `No file name matched “${q}”.`
-            ) : answer.hits.length === 0 ? (
+            ) : hits.length === 0 ? (
+              // Reads `hits`, the narrowed set, not `answer.hits`: while
+              // `behind`, the previous answer can hold plenty of hits that
+              // narrowed to none for THIS query — "Searching…" (a new answer
+              // may yet fill the list) is the honest note there, not silence
+              // followed by whatever the old answer's non-zero count would
+              // have said below.
               "Searching…"
             ) : (
               <>
-                {homeCountNote(answer.total, answer.truncated)}
+                {/* `behind` (narrowed, no round trip landed for `q` yet) means
+                    `answer.total`/`answer.truncated` describe the PREVIOUS
+                    query, not this one — the only honest total for the
+                    current query is a LOWER bound, `hits.length` (narrowing
+                    can only ever remove rows, never add — see `narrowAnswer`),
+                    and `truncated` must read as true unconditionally: more
+                    could still be out there for `q` that the held answer
+                    never had a chance to include. */}
+                {homeCountNote(behind ? hits.length : answer.total, behind || answer.truncated)}
                 {" · "}
                 <kbd>↑</kbd>
                 <kbd>↓</kbd> to pick · <kbd>esc</kbd> to clear

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -42,6 +42,7 @@ import {
   answerFrom,
   homeCountNote,
   isAiRow,
+  isOpenRow,
   nameStart,
   narrowAnswer,
   pathShortcut,
@@ -52,6 +53,7 @@ import {
   submitRow,
   type HomeAnswer,
   type HomeHit,
+  type RowModel,
 } from "@apps/explorer/lib/home-search";
 import { renderHighlight } from "@apps/explorer/listing/bits";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
@@ -177,6 +179,45 @@ function FileRow({
   );
 }
 
+// Row 0, when the query is really an ADDRESS that resolved: an ACTION, like
+// the AI row below, but at the OPPOSITE end of the list and for the opposite
+// reason — this one is offered because ranking would have been noise on a
+// literal path, not because ranking came up empty. No query echo (the
+// resolved path already answers "what did this address mean"), and the icon
+// follows `isDir` the same way a file row's does.
+function OpenRow({
+  path,
+  isDir,
+  active,
+  id,
+  onOpen,
+}: {
+  path: string;
+  isDir: boolean;
+  active: boolean;
+  id: string;
+  onOpen: () => void;
+}) {
+  return (
+    <li role="option" id={id} aria-selected={active}>
+      <button
+        type="button"
+        className={"fh-result fh-open-row" + (active ? " is-active" : "")}
+        onClick={onOpen}
+      >
+        <span className="fh-result-icon" aria-hidden="true">
+          {iconForEntry(basename(path), isDir)}
+        </span>
+        <span className="fh-result-name">Open</span>
+        <span className="fh-result-path">{path}</span>
+        <span className="fh-result-meta">
+          <kbd>↵</kbd>
+        </span>
+      </button>
+    </li>
+  );
+}
+
 // The last row: an ACTION, not a hit. Deliberately unlike the file rows above
 // it (accent glyph, no path, no size) because activating it costs a model call
 // and a wait, and because on a zero-hit query it is the only thing on screen.
@@ -294,6 +335,75 @@ export function FilesSearch({
   const searchable = q.length >= MIN_QUERY_CHARS;
   useEffect(() => onActiveChange(active), [active, onActiveChange]);
 
+  // -- a query that is really an address --------------------------------------
+  //
+  // `pathShortcut` (lib/home-search) detects the SHAPE — `/…`, `~/…`, `C:\…` —
+  // on every render, not just at submit: consulting it only on Enter left the
+  // whole screen while typing lying about what Enter would do. A pasted
+  // `/tmp/report.csv` used to rank nothing, render "No file name matched…",
+  // and pre-arm the AI row — a paid model call offered on a filesystem path —
+  // while Enter would in fact have navigated straight there.
+  //
+  // `address` is pure and cheap (a regex), computed fresh every render. What
+  // it resolves TO takes a stat, so that part is debounced/abortable exactly
+  // like the rank request below (leading-edge `searchDelay`, one
+  // AbortController) — a query that merely LOOKS like a path is typed one
+  // character at a time same as any other.
+  const address = pathShortcut(q, home);
+  const [addr, setAddr] = useState<
+    | { status: "unknown" }
+    | { status: "exists"; path: string; is_dir: boolean }
+    | { status: "missing" }
+  >({ status: "unknown" });
+  const addrCtl = useRef<AbortController | null>(null);
+  const addrIssuedAt = useRef(0);
+  useEffect(() => {
+    addrCtl.current?.abort();
+    if (address === null) {
+      setAddr({ status: "unknown" });
+      return;
+    }
+    setAddr({ status: "unknown" });
+    const run = () => {
+      addrCtl.current?.abort();
+      const ctl = new AbortController();
+      addrCtl.current = ctl;
+      addrIssuedAt.current = Date.now();
+      statPath(address, ctl.signal).then(
+        (st) => {
+          if (ctl.signal.aborted) return;
+          setAddr({ status: "exists", path: st.path, is_dir: st.is_dir });
+        },
+        (err: Error) => {
+          if (ctl.signal.aborted || err.name === "AbortError") return;
+          // Not found, or not statable (permissions, a dead mount): either
+          // way it is not a navigable address, so it falls back to a search
+          // (7d) — a half-typed path is a legitimate query prefix.
+          setAddr({ status: "missing" });
+        },
+      );
+    };
+    const delay = searchDelay(Date.now(), addrIssuedAt.current);
+    if (delay === 0) {
+      run();
+      return;
+    }
+    const timer = window.setTimeout(run, delay);
+    return () => window.clearTimeout(timer);
+  }, [address]);
+  useEffect(() => () => addrCtl.current?.abort(), []);
+  // There is no "Open" row until the stat is back and says the address is
+  // real.
+  const showOpenRow = address !== null && addr.status === "exists";
+  // The rank request itself is suppressed more broadly than the open row: a
+  // query shaped like a path is held back from ranking THE MOMENT it looks
+  // like one, not only once it is confirmed to exist — firing a rank request
+  // for something that is very likely about to resolve is a wasted round
+  // trip, and a half-typed path is not yet a case anyone can rank sensibly.
+  // Only once the stat comes back "missing" does 7d's fallback apply: this IS
+  // a legitimate search query after all.
+  const suppressRank = address !== null && addr.status !== "missing";
+
   // -- the ranked answer -----------------------------------------------------
   //
   // ONE REQUEST PER QUERY. This page used to fetch the whole home corpus (19.8
@@ -362,8 +472,12 @@ export function FilesSearch({
     // `!searchable` is the same early-out as `!active`: nothing is asked, and
     // anything already in flight (from a longer query since backspaced away)
     // is abandoned rather than left to land over a query too short to have
-    // earned an answer.
-    if (!active || !searchable) {
+    // earned an answer. `suppressRank` is a THIRD early-out (7c/7d): a query
+    // shaped like a path is held back from ranking the moment it looks like
+    // one — the noise that used to produce "No file name matched" over a
+    // path that Enter would have navigated to — until the stat says it is
+    // NOT one, at which point it is a legitimate search query again.
+    if (!active || !searchable || suppressRank) {
       inflight.current?.abort();
       setPending(false);
       return;
@@ -418,7 +532,7 @@ export function FilesSearch({
     }
     const timer = window.setTimeout(run, delay);
     return () => window.clearTimeout(timer);
-  }, [home, q, active, searchable, lifecycle, mutations, retryNonce]);
+  }, [home, q, active, searchable, suppressRank, lifecycle, mutations, retryNonce]);
 
   useEffect(() => {
     if (!pending) {
@@ -499,16 +613,7 @@ export function FilesSearch({
 
   // -- AI search -------------------------------------------------------------
   const aiCtl = useRef<AbortController | null>(null);
-  // The path shortcut's stat, cancellable for the same reason: both outlive the
-  // gesture that started them, and both act on the app when they land.
-  const statCtl = useRef<AbortController | null>(null);
-  useEffect(
-    () => () => {
-      aiCtl.current?.abort();
-      statCtl.current?.abort();
-    },
-    [],
-  );
+  useEffect(() => () => aiCtl.current?.abort(), []);
   const syncQueryParam = (value: string | null) => {
     const params = new URLSearchParams(location.search);
     if (value) params.set("q", value);
@@ -547,7 +652,6 @@ export function FilesSearch({
 
   const clear = () => {
     aiCtl.current?.abort();
-    statCtl.current?.abort();
     setQuery("");
     setAi(AI_OFF);
     setHighlight(null);
@@ -557,9 +661,6 @@ export function FilesSearch({
   const edit = (value: string) => {
     setQuery(value);
     setHighlight(null);
-    // Editing the query retracts the address that was submitted from it, so a
-    // stat still in flight for the old one must not navigate when it lands.
-    statCtl.current?.abort();
     // Typing is a user gesture, so it is also the retry for a failed request —
     // the same way useWalkSearch re-arms its stream from setQuery. (Editing to
     // a query that was never asked re-runs anyway; this covers editing BACK to
@@ -607,44 +708,43 @@ export function FilesSearch({
   // changed a file, the server is re-indexing that folder, and until a status
   // poll catches the run nothing else would say so.
   const caveat =
-    active && !showingAi && searchable
+    active && !showingAi && searchable && !showOpenRow
       ? searchCaveat(indexScan, { behind, pending, rescanPending: indexRescanPending() })
       : null;
-  const current = activeRow(highlight, hits.length, settled);
 
-  const openRow = (row: number) => {
-    if (isAiRow(row, hits.length)) runAi(q);
-    else navigate(hits[row].path, { isDir: hits[row].is_dir });
+  // The row-model descriptor (lib/home-search): at most one leading "Open"
+  // row, then files, then at most one AI row. `showOpenRow` forces the other
+  // two off — the request that would have produced file hits was never sent
+  // (7c), and a paid model call is never the intent for something shaped like
+  // a path (7e, independent of whether it actually resolved).
+  const rowModel: RowModel = {
+    openRow: showOpenRow,
+    fileCount: showOpenRow ? 0 : hits.length,
+    aiRow: searchable && !showOpenRow && address === null,
+  };
+  const current = activeRow(highlight, rowModel, settled);
+
+  const activateRow = (row: number) => {
+    if (isOpenRow(row, rowModel)) {
+      if (addr.status === "exists") navigate(addr.path, { isDir: addr.is_dir });
+      return;
+    }
+    if (isAiRow(row, rowModel)) {
+      runAi(q);
+      return;
+    }
+    const fi = row - (rowModel.openRow ? 1 : 0);
+    navigate(hits[fi].path, { isDir: hits[fi].is_dir });
   };
 
-  // Enter with no row chosen: a query that is really an ADDRESS goes straight
-  // there (a pasted ~/Downloads is not a search); otherwise it commits the top
-  // hit, or — only once ranking has settled on nothing — the AI row.
-  const submit = async () => {
-    if (highlight === null) {
-      const target = pathShortcut(q, home);
-      if (target !== null) {
-        // A stat on a slow or network mount can outlive the intent behind it, and
-        // navigating on a stale answer is the worst kind of wrong: it yanks the
-        // user out of wherever they went next. Superseded by the next submit,
-        // cancelled by clear()/unmount, and re-checked after the await — a
-        // resolved-but-abandoned stat must not move anyone.
-        statCtl.current?.abort();
-        const ctl = new AbortController();
-        statCtl.current = ctl;
-        try {
-          const st = await statPath(target, ctl.signal);
-          if (ctl.signal.aborted) return;
-          navigate(st.path, { isDir: st.is_dir });
-          return;
-        } catch {
-          if (ctl.signal.aborted) return;
-          // not a real path — treat it as a search query
-        }
-      }
-    }
-    const row = submitRow(highlight, hits.length, settled);
-    if (row !== null) openRow(row);
+  // Enter with no row chosen: a resolved address (the open row) or the top
+  // hit commits, or — only once ranking has settled on nothing — the AI row.
+  // The address itself is no longer resolved HERE: `addr` is kept live by the
+  // effect above as the query is typed, so by the time Enter is pressed the
+  // row model already reflects it — `activeRow`/`submitRow` do the rest.
+  const submit = () => {
+    const row = submitRow(highlight, rowModel, settled);
+    if (row !== null) activateRow(row);
   };
 
   return (
@@ -660,10 +760,12 @@ export function FilesSearch({
           placeholder="Search your files — or paste a path like ~/Downloads"
           aria-label="Search your files"
           role="combobox"
-          aria-expanded={active && !showingAi && searchable}
+          aria-expanded={active && !showingAi && (searchable || showOpenRow)}
           aria-controls="fh-result-list"
           aria-activedescendant={
-            active && !showingAi && searchable && current !== null ? "fh-row-" + current : undefined
+            active && !showingAi && (searchable || showOpenRow) && current !== null
+              ? "fh-row-" + current
+              : undefined
           }
           autoComplete="off"
           spellCheck={false}
@@ -671,12 +773,12 @@ export function FilesSearch({
           onChange={(e) => edit(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-              if (!active || showingAi || !searchable) return;
+              if (!active || showingAi || (!searchable && !showOpenRow)) return;
               e.preventDefault();
-              setHighlight((h) => stepHighlight(h, hits.length, e.key === "ArrowDown" ? 1 : -1));
+              setHighlight((h) => stepHighlight(h, rowModel, e.key === "ArrowDown" ? 1 : -1));
             } else if (e.key === "Enter") {
               e.preventDefault();
-              void submit();
+              submit();
             } else if (e.key === "Escape" && active) {
               e.preventDefault();
               clear();
@@ -719,7 +821,16 @@ export function FilesSearch({
                 MIN_QUERY_CHARS no request went out, so `answer` (if any) is
                 whatever an earlier, longer query left behind, and reporting
                 on it here would describe a search that didn't happen. */}
-            {!searchable ? (
+            {/* `showOpenRow` comes ahead of everything below it too: once an
+                address resolves, the row IS the content, and reporting on
+                `answer` (whatever a previous, non-address query left behind,
+                or nothing at all) would describe a search that was never
+                sent (7c skips it entirely). */}
+            {showOpenRow ? (
+              <>
+                <kbd>↵</kbd> to open · <kbd>esc</kbd> to clear
+              </>
+            ) : !searchable ? (
               "Keep typing…"
             ) : answer === null && failure !== "" ? (
               `The file index could not be searched: ${failure}`
@@ -745,8 +856,14 @@ export function FilesSearch({
               // Never "no matches" for an index that has not been built: that
               // would blame the user's files for the app's state.
               "The file index is still building — AI search can answer in the meantime."
-            ) : answer.hits.length === 0 && settled ? (
+            ) : answer.hits.length === 0 && settled && rowModel.aiRow ? (
               `No file name matched “${q}” — AI search can look at dates, types and sizes.`
+            ) : answer.hits.length === 0 && settled ? (
+              // Settled, zero hits, but the AI row is suppressed (address !==
+              // null: this query is shaped like a path that did not resolve —
+              // 7e). Offering AI search here would point at a row that is not
+              // being rendered.
+              `No file name matched “${q}”.`
             ) : answer.hits.length === 0 ? (
               "Searching…"
             ) : (
@@ -761,7 +878,7 @@ export function FilesSearch({
                 PENDING_INDICATOR_MS the answer beats the words onto the screen,
                 and a note that appears and vanishes reads as slower than one
                 that never appeared. */}
-            {searchable && slow && hits.length > 0 && (
+            {searchable && !showOpenRow && slow && hits.length > 0 && (
               <span className="fh-searching-note"> · Searching…</span>
             )}
             {caveat && (
@@ -777,34 +894,48 @@ export function FilesSearch({
               </span>
             )}
           </p>
-          {/* Nothing to show below MIN_QUERY_CHARS: no request went out, so
-              `hits` is stale leftover from a longer query, and offering the AI
-              row here would arm a model call on "a". The note above already
-              says why the list is empty. */}
-          {searchable && (
+          {/* Nothing to show below MIN_QUERY_CHARS UNLESS an address resolved
+              (an "Open" row needs no search — it isn't ranked, it's stat'd —
+              so it is not gated on the same threshold): otherwise no request
+              went out, `hits` is stale leftover from a longer query, and
+              offering the AI row here would arm a model call on "a". The note
+              above already says why the list is empty. */}
+          {(searchable || showOpenRow) && (
             <ul
               className={"fh-results" + (behind ? " is-stale" : "")}
               id="fh-result-list"
               role="listbox"
               aria-label="Search results"
             >
-              {hits.map((hit, i) => (
-                <FileRow
-                  key={hit.path}
-                  hit={hit}
-                  home={home}
-                  active={current === i}
-                  id={"fh-row-" + i}
-                  onHover={() => setHighlight(i)}
+              {showOpenRow && addr.status === "exists" && (
+                <OpenRow
+                  path={addr.path}
+                  isDir={addr.is_dir}
+                  active={current === 0}
+                  id="fh-row-0"
+                  onOpen={() => navigate(addr.path, { isDir: addr.is_dir })}
                 />
-              ))}
-              <AiActionRow
-                query={q}
-                active={current === hits.length}
-                running={ai.status === "running"}
-                id={"fh-row-" + hits.length}
-                onRun={() => runAi(q)}
-              />
+              )}
+              {!showOpenRow &&
+                hits.map((hit, i) => (
+                  <FileRow
+                    key={hit.path}
+                    hit={hit}
+                    home={home}
+                    active={current === i}
+                    id={"fh-row-" + i}
+                    onHover={() => setHighlight(i)}
+                  />
+                ))}
+              {rowModel.aiRow && (
+                <AiActionRow
+                  query={q}
+                  active={current === hits.length}
+                  running={ai.status === "running"}
+                  id={"fh-row-" + hits.length}
+                  onRun={() => runAi(q)}
+                />
+              )}
             </ul>
           )}
         </div>

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -105,6 +105,16 @@ describe("pathShortcut", () => {
     expect(pathShortcut("file:///etc/hosts", HOME)).toBe("/etc/hosts");
   });
 
+  it("strips a Windows file:// URI's authority slash ahead of the drive letter", () => {
+    // file:///C:/Users/x is "C:/Users/x", not "/C:/Users/x" — the third slash
+    // is the URI's (empty) authority separator, not part of the path. Getting
+    // this wrong used to pass the leading-slash guard branch as if it were an
+    // absolute POSIX path, producing a confidently wrong address.
+    expect(pathShortcut("file:///C:/Users/x", HOME)).toBe("C:/Users/x");
+    // A bare POSIX file:// URL has no such extra slash to drop.
+    expect(pathShortcut("file:///home/x", HOME)).toBe("/home/x");
+  });
+
   it("tolerates a trailing newline from a multi-line paste", () => {
     expect(pathShortcut("/etc/hosts\n", HOME)).toBe("/etc/hosts");
   });
@@ -320,6 +330,23 @@ describe("keyboard rows — without an open row (the pre-section-7 shape)", () =
     expect(isOpenRow(0, m)).toBe(false);
     expect(isAiRow(3, m)).toBe(true);
     expect(isAiRow(0, m)).toBe(false);
+  });
+
+  it("a genuinely empty model (no open row, no files, no AI row) has no row to move to or land on", () => {
+    // Reachable when a path-shaped query does not resolve (addr.status ===
+    // "missing"): ranking runs and comes back with zero hits, but the AI row
+    // stays suppressed because the query is still shaped like a path
+    // (rowModel.aiRow requires `address === null`). `stepHighlight` used to
+    // return 0 here — a row index into a list that has no row 0 — and
+    // `activeRow` used to clamp that into -1 (`Math.min(0, -1)`), which
+    // `activateRow` then dereferenced as `hits[-1]`.
+    const m = rowModel({ openRow: false, fileCount: 0, aiRow: false });
+    expect(stepHighlight(null, m, 1)).toBeNull();
+    expect(stepHighlight(null, m, -1)).toBeNull();
+    expect(stepHighlight(0, m, 1)).toBeNull();
+    expect(activeRow(null, m, true)).toBeNull();
+    expect(activeRow(null, m, false)).toBeNull();
+    expect(activeRow(0, m, true)).toBeNull();
   });
 });
 

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -5,6 +5,7 @@ import {
   answerFrom,
   homeCountNote,
   nameStart,
+  narrowAnswer,
   pathShortcut,
   positionsWithin,
   rankingSettled,
@@ -12,6 +13,7 @@ import {
   stepHighlight,
   submitRow,
   type HomeAnswer,
+  type HomeHit,
 } from "./home-search";
 import type { IndexRankHit, IndexRankResult } from "@platform/lib/api";
 
@@ -303,6 +305,43 @@ describe("rankingSettled", () => {
     // A failed request is settled: nothing further is coming, and the AI row is
     // the only content left — so Enter must reach it.
     expect(rankingSettled(null, "read", false, true)).toBe(true);
+  });
+});
+
+describe("narrowAnswer", () => {
+  function homeHit(rel: string, over: Partial<HomeHit> = {}): HomeHit {
+    return { path: `${HOME}/${rel}`, rel, is_dir: false, size: 1, mtime: 1, ...over };
+  }
+
+  it("keeps only the held hits that still match an EXTENDED query, no round trip", () => {
+    const held = answer({
+      query: "read",
+      hits: [homeHit("README.md"), homeHit("docs/readme.txt"), homeHit("other.txt")],
+    });
+    const narrowed = narrowAnswer(held, "readme");
+    expect(narrowed.map((h) => h.rel)).toEqual(["README.md", "docs/readme.txt"]);
+  });
+
+  it("recomputes positions for the NEW query, not the one the hits were fetched for", () => {
+    const held = answer({ query: "read", hits: [homeHit("README.md")] });
+    const [hit] = narrowAnswer(held, "readme");
+    expect(hit.positions!.map((i) => "README.md"[i]).join("").toLowerCase()).toBe("readme");
+  });
+
+  it("empties out for a query that is not an extension — a paste, not a keystroke", () => {
+    const held = answer({ query: "read", hits: [homeHit("README.md"), homeHit("other.txt")] });
+    expect(narrowAnswer(held, "zzz-nope")).toEqual([]);
+  });
+
+  it("never re-ranks or adds rows — it is a subset of what was held, in the same order", () => {
+    const held = answer({
+      query: "e",
+      hits: [homeHit("code-file.txt"), homeHit("readme.md"), homeHit("one-file.txt")],
+    });
+    const narrowed = narrowAnswer(held, "e-file");
+    // "readme.md" has no "e-file" subsequence and is dropped, but the
+    // surviving order is the HELD order, not a re-sort.
+    expect(narrowed.map((h) => h.rel)).toEqual(["code-file.txt", "one-file.txt"]);
   });
 });
 

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -4,6 +4,8 @@ import {
   activeRow,
   answerFrom,
   homeCountNote,
+  isAiRow,
+  isOpenRow,
   nameStart,
   narrowAnswer,
   pathShortcut,
@@ -14,6 +16,7 @@ import {
   submitRow,
   type HomeAnswer,
   type HomeHit,
+  type RowModel,
 } from "./home-search";
 import type { IndexRankHit, IndexRankResult } from "@platform/lib/api";
 
@@ -85,6 +88,29 @@ describe("pathShortcut", () => {
     // A backslash is a legal POSIX filename char, so this is not a path.
     expect(pathShortcut("a\\b", HOME)).toBeNull();
     expect(pathShortcut("  ", HOME)).toBeNull();
+    // A RELATIVE query is a search, not an address, even one that looks
+    // file-shaped.
+    expect(pathShortcut("docs/readme.md", HOME)).toBeNull();
+  });
+
+  it("accepts a paste wrapped in matching quotes", () => {
+    expect(pathShortcut('"~/Downloads"', HOME)).toBe(`${HOME}/Downloads`);
+    expect(pathShortcut("'/etc/hosts'", HOME)).toBe("/etc/hosts");
+    // Mismatched quotes are not a wrapping pair — left as-is (and then not a
+    // path shape at all here).
+    expect(pathShortcut("'/etc/hosts\"", HOME)).toBeNull();
+  });
+
+  it("strips a file:// scheme, same as a terminal or Finder paste would carry", () => {
+    expect(pathShortcut("file:///etc/hosts", HOME)).toBe("/etc/hosts");
+  });
+
+  it("tolerates a trailing newline from a multi-line paste", () => {
+    expect(pathShortcut("/etc/hosts\n", HOME)).toBe("/etc/hosts");
+  });
+
+  it("unescapes a shell-escaped space, regardless of platform", () => {
+    expect(pathShortcut("/Users/me/My\\ Files", HOME)).toBe("/Users/me/My Files");
   });
 });
 
@@ -183,17 +209,21 @@ describe("rankingSettled over a failure", () => {
   });
 });
 
+function rowModel(over: Partial<RowModel> = {}): RowModel {
+  return { openRow: false, fileCount: 5, aiRow: true, ...over };
+}
+
 describe("submitRow over a failure with stale rows", () => {
   it("commits nothing when Enter has no explicit choice", () => {
     // The whole point of the rule above: with rows for a previous query on
     // screen, the top-hit fallthrough opens a file the user did not ask for.
     const settled = rankingSettled(answer({ query: "read" }), "readme", false, true);
-    expect(submitRow(null, 10, settled)).toBeNull();
+    expect(submitRow(null, rowModel({ fileCount: 10 }), settled)).toBeNull();
   });
 
   it("still commits a row the user pointed at", () => {
     const settled = rankingSettled(answer({ query: "read" }), "readme", false, true);
-    expect(submitRow(3, 10, settled)).toBe(3);
+    expect(submitRow(3, rowModel({ fileCount: 10 }), settled)).toBe(3);
   });
 });
 
@@ -212,38 +242,77 @@ describe("homeCountNote", () => {
 });
 
 
-describe("keyboard rows", () => {
-  // Rows are the file hits followed by ONE action row (Search with AI), so the
-  // AI row's index is always the file count.
+describe("keyboard rows — without an open row (the pre-section-7 shape)", () => {
+  // Rows are the file hits followed by ONE action row (Search with AI), so
+  // the AI row's index is always the file count.
   it("steps down from nothing to the first row and wraps at both ends", () => {
-    expect(stepHighlight(null, 3, 1)).toBe(0);
-    expect(stepHighlight(2, 3, 1)).toBe(3); // the AI row
-    expect(stepHighlight(3, 3, 1)).toBe(0); // wrapped past the AI row
-    expect(stepHighlight(null, 3, -1)).toBe(3); // up from nothing = the AI row
-    expect(stepHighlight(0, 3, -1)).toBe(3);
+    const m = rowModel({ fileCount: 3 });
+    expect(stepHighlight(null, m, 1)).toBe(0);
+    expect(stepHighlight(2, m, 1)).toBe(3); // the AI row
+    expect(stepHighlight(3, m, 1)).toBe(0); // wrapped past the AI row
+    expect(stepHighlight(null, m, -1)).toBe(3); // up from nothing = the AI row
+    expect(stepHighlight(0, m, -1)).toBe(3);
   });
 
   it("walks only the AI row when there are no file hits", () => {
-    expect(stepHighlight(null, 0, 1)).toBe(0);
-    expect(stepHighlight(0, 0, 1)).toBe(0);
+    const m = rowModel({ fileCount: 0 });
+    expect(stepHighlight(null, m, 1)).toBe(0);
+    expect(stepHighlight(0, m, 1)).toBe(0);
   });
 
   it("pre-selects the AI row on zero matches, and nothing otherwise", () => {
-    expect(activeRow(null, 0, true)).toBe(0); // the AI row is the only content
-    expect(activeRow(null, 5, true)).toBeNull(); // no highlight to render
-    expect(activeRow(2, 5, true)).toBe(2);
+    expect(activeRow(null, rowModel({ fileCount: 0 }), true)).toBe(0); // the AI row is the only content
+    expect(activeRow(null, rowModel({ fileCount: 5 }), true)).toBeNull(); // no highlight to render
+    expect(activeRow(2, rowModel({ fileCount: 5 }), true)).toBe(2);
     // A highlight past the end of a shrinking list clamps to the AI row rather
     // than addressing a row that is no longer on screen.
-    expect(activeRow(9, 3, true)).toBe(3);
+    expect(activeRow(9, rowModel({ fileCount: 3 }), true)).toBe(3);
   });
 
   it("does not pre-select the AI row until ranking has settled on zero", () => {
     // "Nothing scored yet" and "zero matches" look identical as a count, and
     // pre-selecting on the first made Enter during the corpus load or the
     // 120ms debounce spend a model call on a query with instant matches.
-    expect(activeRow(null, 0, false)).toBeNull();
+    expect(activeRow(null, rowModel({ fileCount: 0 }), false)).toBeNull();
     // An explicit arrow-key choice is the user's, settled or not.
-    expect(activeRow(1, 0, false)).toBe(0);
+    expect(activeRow(1, rowModel({ fileCount: 0 }), false)).toBe(0);
+  });
+
+  it("isAiRow/isOpenRow agree with the wrap-around walk", () => {
+    const m = rowModel({ fileCount: 3 });
+    expect(isOpenRow(0, m)).toBe(false);
+    expect(isAiRow(3, m)).toBe(true);
+    expect(isAiRow(0, m)).toBe(false);
+  });
+});
+
+describe("keyboard rows — WITH an open row (a resolving path address)", () => {
+  // An open row implies zero file rows and no AI row (FilesHome skips the
+  // rank request and suppresses the AI row entirely once an address
+  // resolves), so a RowModel with openRow:true is a single-row list in
+  // practice — but the functions here take whatever shape they are given.
+  it("is the only content, pre-selected unconditionally — no `settled` needed", () => {
+    const m = rowModel({ openRow: true, fileCount: 0, aiRow: false });
+    expect(activeRow(null, m, false)).toBe(0);
+    expect(activeRow(null, m, true)).toBe(0);
+  });
+
+  it("wraps as a one-row list", () => {
+    const m = rowModel({ openRow: true, fileCount: 0, aiRow: false });
+    expect(stepHighlight(null, m, 1)).toBe(0);
+    expect(stepHighlight(0, m, 1)).toBe(0);
+    expect(stepHighlight(null, m, -1)).toBe(0);
+  });
+
+  it("isOpenRow identifies row 0, and it is never also the AI row", () => {
+    const m = rowModel({ openRow: true, fileCount: 0, aiRow: false });
+    expect(isOpenRow(0, m)).toBe(true);
+    expect(isAiRow(0, m)).toBe(false);
+  });
+
+  it("submitRow commits the open row on a bare Enter", () => {
+    const m = rowModel({ openRow: true, fileCount: 0, aiRow: false });
+    expect(submitRow(null, m, false)).toBe(0);
   });
 });
 
@@ -251,7 +320,7 @@ describe("submitRow", () => {
   it("opens the top hit when Enter is pressed with no highlight", () => {
     // Previously a silent no-op: every other search box in the app commits on
     // Enter, and the top hit is what the list is offering.
-    expect(submitRow(null, 5, true)).toBe(0);
+    expect(submitRow(null, rowModel({ fileCount: 5 }), true)).toBe(0);
   });
 
   it("commits NOTHING while the rows on screen answer the previous query", () => {
@@ -260,21 +329,21 @@ describe("submitRow", () => {
     // then "readme", press Enter before the answer lands, and the app
     // navigated to "read"'s best match. Opening a file is now gated on
     // `settled` exactly as the AI row already was.
-    expect(submitRow(null, 5, false)).toBeNull();
+    expect(submitRow(null, rowModel({ fileCount: 5 }), false)).toBeNull();
     // An explicit arrow-key choice still commits: the user pointed at a row
     // they can see.
-    expect(submitRow(2, 5, false)).toBe(2);
+    expect(submitRow(2, rowModel({ fileCount: 5 }), false)).toBe(2);
   });
 
   it("runs the AI row only once ranking has settled on zero hits", () => {
-    expect(submitRow(null, 0, true)).toBe(0); // fileCount 0 → the AI row
+    expect(submitRow(null, rowModel({ fileCount: 0 }), true)).toBe(0); // fileCount 0 → the AI row
     // Mid-scan: nothing to commit yet, and the AI row must not be armed.
-    expect(submitRow(null, 0, false)).toBeNull();
+    expect(submitRow(null, rowModel({ fileCount: 0 }), false)).toBeNull();
   });
 
   it("honours an explicit highlight, including the AI row", () => {
-    expect(submitRow(2, 5, true)).toBe(2);
-    expect(submitRow(5, 5, true)).toBe(5);
+    expect(submitRow(2, rowModel({ fileCount: 5 }), true)).toBe(2);
+    expect(submitRow(5, rowModel({ fileCount: 5 }), true)).toBe(5);
   });
 });
 

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -260,22 +260,59 @@ describe("keyboard rows — without an open row (the pre-section-7 shape)", () =
     expect(stepHighlight(0, m, 1)).toBe(0);
   });
 
-  it("pre-selects the AI row on zero matches, and nothing otherwise", () => {
+  it("pre-selects the top hit with file hits, the AI row with none", () => {
     expect(activeRow(null, rowModel({ fileCount: 0 }), true)).toBe(0); // the AI row is the only content
-    expect(activeRow(null, rowModel({ fileCount: 5 }), true)).toBeNull(); // no highlight to render
+    // Previously null: an unhighlighted list that Enter still committed
+    // against (submitRow's old, separate fallthrough). One rule now — the row
+    // that visually pre-selects is the row Enter commits — so the top hit
+    // pre-selects rather than leaving the list looking unselected.
+    expect(activeRow(null, rowModel({ fileCount: 5 }), true)).toBe(0);
     expect(activeRow(2, rowModel({ fileCount: 5 }), true)).toBe(2);
     // A highlight past the end of a shrinking list clamps to the AI row rather
     // than addressing a row that is no longer on screen.
     expect(activeRow(9, rowModel({ fileCount: 3 }), true)).toBe(3);
   });
 
-  it("does not pre-select the AI row until ranking has settled on zero", () => {
+  it("does not pre-select anything until ranking has settled", () => {
     // "Nothing scored yet" and "zero matches" look identical as a count, and
     // pre-selecting on the first made Enter during the corpus load or the
-    // 120ms debounce spend a model call on a query with instant matches.
+    // 120ms debounce spend a model call on a query with instant matches. The
+    // same gate applies to the top-hit pre-select: the list is never blanked,
+    // so unsettled rows on screen belong to a DIFFERENT (previous) query, and
+    // pre-selecting one of them would be exactly the stale-commit bug
+    // `rankingSettled`'s doc comment describes.
     expect(activeRow(null, rowModel({ fileCount: 0 }), false)).toBeNull();
+    expect(activeRow(null, rowModel({ fileCount: 5 }), false)).toBeNull();
     // An explicit arrow-key choice is the user's, settled or not.
     expect(activeRow(1, rowModel({ fileCount: 0 }), false)).toBe(0);
+  });
+
+  it("activeRow and submitRow agree — Enter commits exactly what is highlighted", () => {
+    const settledHits = rowModel({ fileCount: 5 });
+    expect(activeRow(null, settledHits, true)).toBe(0);
+    expect(submitRow(null, settledHits, true)).toBe(activeRow(null, settledHits, true));
+    // Unsettled: still nothing to highlight and nothing for Enter to commit.
+    expect(activeRow(null, settledHits, false)).toBeNull();
+    expect(submitRow(null, settledHits, false)).toBeNull();
+  });
+
+  it("the first ArrowDown from an implicit pre-select lands on row 1, not row 0 again", () => {
+    // FilesHome steps from the RESOLVED row (`current`, i.e. activeRow's
+    // answer), not the raw highlight state — which is still null here even
+    // though row 0 is already visually selected. Stepping from null would
+    // land back on 0 (stepHighlight's own "enter from either end" rule) and
+    // the first press would look like it did nothing.
+    const m = rowModel({ fileCount: 5 });
+    const current = activeRow(null, m, true);
+    expect(current).toBe(0);
+    expect(stepHighlight(current, m, 1)).toBe(1);
+  });
+
+  it("the first ArrowUp from an implicit pre-select wraps to the last row", () => {
+    const m = rowModel({ fileCount: 5 }); // 5 file rows (0..4) + the AI row (5)
+    const current = activeRow(null, m, true);
+    expect(current).toBe(0);
+    expect(stepHighlight(current, m, -1)).toBe(5); // the AI row
   });
 
   it("isAiRow/isOpenRow agree with the wrap-around walk", () => {

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -41,14 +41,18 @@ import { fuzzyMatch } from "@platform/lib/fuzzy";
 
 // Rows rendered at most. Far smaller than the listing's SEARCH_RESULT_CAP, and
 // the number is set by what has to stay VISIBLE rather than by how many hits are
-// interesting: "Search with AI" is the LAST row of this list, so any cap that
-// overflows the viewport hides the one action a user who isn't finding their file
-// needs — at 40 it sat two screens down, reachable only by scrolling past the
-// results that had already failed them. Ten rows plus the AI row fit a laptop
-// screen. Ranking still runs over the whole corpus (the note below owns up to
-// what is not shown); past ten rows the useful move is a better query or the AI
-// row, not more scrolling.
-export const HOME_RESULT_CAP = 10;
+// interesting: at 40 "Search with AI" — the LAST row of this list, and the one
+// action a user who isn't finding their file needs — sat two screens down,
+// reachable only by scrolling past results that had already failed them.
+// Twenty rows go below the fold on their own, which is why the AI row is now a
+// STICKY footer (`.fh-ai-row`, preferences.css — `position: sticky; bottom: 0`
+// over a scrolling `.fh-results`) instead of a row that scrolls away with the
+// rest of the list: the row is always reachable without scrolling, which is
+// the guarantee this constant originally existed to protect, at four times the
+// cap it was first sized for. Ranking still runs over the whole corpus (the
+// note below owns up to what is not shown); past twenty rows the useful move
+// is a better query or the AI row, not more scrolling.
+export const HOME_RESULT_CAP = 20;
 
 // Below this many characters, a query is not sent at all. One or two letters
 // match almost every file in a home tree — a substring-pass candidate cap gets

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -141,6 +141,38 @@ export function answerFrom(res: IndexRankResult, query: string, home: string): H
 }
 
 /**
+ * The held answer's hits, re-filtered against a NEWER query with no round
+ * trip.
+ *
+ * The common case while a request is in flight is the new query EXTENDING the
+ * old one ("read" -> "readm"): re-running `fuzzyMatch` (the same matcher
+ * rank.py mirrors) over the hits already in hand and keeping only the ones
+ * that still match — with `positions` recomputed for the new query — narrows
+ * the list on screen with no round trip and no blank frame, which is strictly
+ * better than dimming rows that cannot possibly be answers to what is now
+ * typed.
+ *
+ * Deliberately does NOT re-rank or add rows: it can only ever REMOVE hits from
+ * the held answer, which is what makes the result a provable SUBSET of the
+ * true answer for `q` — it can never show something the fresh answer
+ * wouldn't. A query that is not an extension of the old one (a paste, a
+ * select-all retype) narrows to whichever held hits happen to still
+ * fuzzy-match `q` directly, which is usually few or none; that emptiness is
+ * exactly the signal the staleness deadline (`STALE_CLEAR_MS`,
+ * platform/lib/instant-search) uses to decide there is nothing worth holding
+ * onto.
+ */
+export function narrowAnswer(answer: HomeAnswer, q: string): HomeHit[] {
+  const out: HomeHit[] = [];
+  for (const hit of answer.hits) {
+    const m = fuzzyMatch(q, hit.rel);
+    if (!m) continue;
+    out.push({ ...hit, positions: m.positions });
+  }
+  return out;
+}
+
+/**
  * The filesystem path a query is really an address for, or null.
  *
  * A pasted or typed `/…`, `~/…` or `C:\…` is an exact address, and searching

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -178,9 +178,23 @@ export function narrowAnswer(answer: HomeAnswer, q: string): HomeHit[] {
  * A pasted or typed `/…`, `~/…` or `C:\…` is an exact address, and searching
  * for it would be answering a question nobody asked. The caller still has to
  * `statPath` it: a path that does not exist falls back to being a search.
+ *
+ * Real pastes are not as clean as a typed shortcut, so the shape test runs
+ * only after stripping, in order: surrounding whitespace/newlines (a paste
+ * from a terminal or a chat window often carries one), matching wrapping
+ * quotes (`"~/Downloads"`), a `file://` scheme, and a shell backslash-escape
+ * before a space (`My\ File` -> `My File`) — that last one applies regardless
+ * of platform, unlike the drive-letter de-backslashing below: a `\` followed
+ * by a space is overwhelmingly a shell escape, never a real two-character
+ * POSIX filename fragment, so unescaping it does not touch the POSIX
+ * backslash-is-a-legal-char rule the drive-letter branch exists for.
  */
 export function pathShortcut(query: string, home: string): string | null {
-  const q = query.trim();
+  let q = query.trim().replace(/[\r\n]+/g, " ").trim();
+  const quoted = q.match(/^(['"])([\s\S]*)\1$/);
+  if (quoted) q = quoted[2].trim();
+  if (/^file:\/\//i.test(q)) q = q.slice("file://".length);
+  q = q.replace(/\\ /g, " ");
   if (!/^(\/|~\/|~$|[A-Za-z]:[\\/])/.test(q)) return null;
   let fsPath = q === "~" || q.startsWith("~/") ? home + q.slice(1) : q;
   // Backslashes are only separators in drive-letter paths (same rule as the
@@ -278,23 +292,45 @@ export function redirectsToSearch(e: KeyIntent): boolean {
 
 // -- the row model the keyboard walks ----------------------------------------
 //
-// The rendered list is `fileCount` file rows followed by exactly ONE action row
-// (Search with AI), so the AI row's index is always `fileCount`. Keeping that
-// as arithmetic rather than a flag is what makes ↑/↓ a single wrap-around step
-// over a heterogeneous list.
+// The list used to be a fixed shape — `fileCount` file rows followed by
+// exactly ONE action row — which let the AI row's index be plain arithmetic
+// (`fileCount`). Section 7 adds a second, EARLIER action row (an "Open" row
+// for a resolving path address), which arithmetic cannot express: `fileCount`
+// alone no longer says where anything is once a row can also come BEFORE the
+// files. `RowModel` replaces the arithmetic with a small descriptor every
+// other row-model function derives from, so ↑/↓ is still a single wrap-around
+// step over a heterogeneous list, however many of its three parts are present.
+
+/** The shape of the rendered list: at most one open row, then files, then at
+ * most one AI row — any of the three may be absent. */
+export interface RowModel {
+  /** A resolving path address is offered as row 0, ahead of any file rows. */
+  openRow: boolean;
+  /** File hits, in rendered order — between the open row (if any) and the AI
+   * row (if any). */
+  fileCount: number;
+  /** "Search with AI" as the LAST row. */
+  aiRow: boolean;
+}
+
+function totalRows(m: RowModel): number {
+  return (m.openRow ? 1 : 0) + m.fileCount + (m.aiRow ? 1 : 0);
+}
+
+/** Whether row `index` is the leading "Open" row. */
+export function isOpenRow(index: number, m: RowModel): boolean {
+  return m.openRow && index === 0;
+}
 
 /** Whether row `index` is the AI action row rather than a file. */
-export function isAiRow(index: number, fileCount: number): boolean {
-  return index >= fileCount;
+export function isAiRow(index: number, m: RowModel): boolean {
+  return m.aiRow && index === totalRows(m) - 1;
 }
 
 /** Move the highlight by one row, wrapping, entering the list from either end. */
-export function stepHighlight(
-  current: number | null,
-  fileCount: number,
-  delta: 1 | -1,
-): number {
-  const n = fileCount + 1;
+export function stepHighlight(current: number | null, m: RowModel, delta: 1 | -1): number {
+  const n = totalRows(m);
+  if (n === 0) return 0;
   if (current === null) return delta === 1 ? 0 : n - 1;
   return (current + delta + n) % n;
 }
@@ -339,20 +375,33 @@ export function rankingSettled(
 /**
  * The row the highlight is ON: the explicit choice, clamped into the list.
  *
- * With no highlight there is one default, and it is the settled zero-hit case:
- * the AI row is then the only content on screen, so it is pre-selected. That
- * pre-selection is gated on `settled` because it ARMS Enter — offering it while
- * the scan is still running spends a model call on a query that was about to
- * answer itself. With file hits showing there is no highlight until the user
- * picks one; `submitRow` is what Enter consults.
+ * With no highlight there are two defaults, checked in this order:
+ *
+ *  * an open row pre-selects UNCONDITIONALLY — unlike the AI row, resolving an
+ *    address costs nothing to arm (it navigates, it does not call a model),
+ *    and by the time `RowModel.openRow` is true the stat has already settled
+ *    on "this address exists", so there is no in-flight ambiguity to gate on.
+ *    It is also, by construction, the only content on screen: an open row
+ *    implies zero file rows (the request is skipped entirely once an address
+ *    resolves — see FilesHome).
+ *  * failing that, the settled zero-hit case: the AI row is then the only
+ *    content, so IT pre-selects. Gated on `settled` because it ARMS Enter —
+ *    offering it while the scan is still running spends a model call on a
+ *    query that was about to answer itself.
+ *
+ * With file hits showing (and no open row), there is no highlight until the
+ * user picks one; `submitRow` is what Enter consults instead.
  */
 export function activeRow(
   highlight: number | null,
-  fileCount: number,
+  m: RowModel,
   settled: boolean,
 ): number | null {
-  if (highlight === null) return fileCount === 0 && settled ? 0 : null;
-  return Math.min(highlight, fileCount);
+  if (highlight === null) {
+    if (m.openRow) return 0;
+    return m.fileCount === 0 && m.aiRow && settled ? totalRows(m) - 1 : null;
+  }
+  return Math.min(highlight, totalRows(m) - 1);
 }
 
 /**
@@ -362,7 +411,8 @@ export function activeRow(
  * to resolve to null and do nothing at all — a silent no-op, in the one box in
  * this app where Enter is the obvious gesture. It still never falls through to
  * the AI row that way: reaching a paid action takes either zero settled hits or
- * an explicit highlight.
+ * an explicit highlight. (An open row, if present, is handled by `activeRow`
+ * above before this fallthrough is ever reached.)
  *
  * That fallthrough is gated on `settled` for the same reason the AI row is, and
  * the reason arrived with server-side ranking: the list is deliberately never
@@ -374,10 +424,10 @@ export function activeRow(
  */
 export function submitRow(
   highlight: number | null,
-  fileCount: number,
+  m: RowModel,
   settled: boolean,
 ): number | null {
-  const row = activeRow(highlight, fileCount, settled);
+  const row = activeRow(highlight, m, settled);
   if (row !== null) return row;
-  return settled && fileCount > 0 ? 0 : null;
+  return settled && m.fileCount > 0 ? (m.openRow ? 1 : 0) : null;
 }

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -373,9 +373,16 @@ export function rankingSettled(
 }
 
 /**
- * The row the highlight is ON: the explicit choice, clamped into the list.
+ * The row the highlight is ON — the explicit choice, clamped into the list —
+ * and, with no explicit choice, the row Enter would commit. Those used to be
+ * two different answers: this function pre-selected nothing over file hits,
+ * while `submitRow` (below) still opened the top one on a bare Enter. The
+ * user saw an unhighlighted list and pressed Enter anyway, because Enter is
+ * the obvious gesture in a search box — and got a row they were never shown
+ * as selected. One rule now: the row that visually pre-selects IS the row
+ * Enter commits, always.
  *
- * With no highlight there are two defaults, checked in this order:
+ * With no highlight there are three defaults, checked in this order:
  *
  *  * an open row pre-selects UNCONDITIONALLY — unlike the AI row, resolving an
  *    address costs nothing to arm (it navigates, it does not call a model),
@@ -384,13 +391,20 @@ export function rankingSettled(
  *    It is also, by construction, the only content on screen: an open row
  *    implies zero file rows (the request is skipped entirely once an address
  *    resolves — see FilesHome).
- *  * failing that, the settled zero-hit case: the AI row is then the only
- *    content, so IT pre-selects. Gated on `settled` because it ARMS Enter —
+ *  * failing that, with file hits on screen, the TOP hit pre-selects — gated
+ *    on `settled` for the reason that gate exists everywhere else in this
+ *    file: the list is deliberately never blanked, so rows for the PREVIOUS
+ *    query are on screen while this one is in flight (or its answer failed),
+ *    and "the top hit" then means the top hit for something the user has
+ *    already finished typing over. Type "read", get ten rows, type "readme",
+ *    have that request fail before Enter — `settled` is false, so there is no
+ *    highlight AND Enter does nothing, rather than opening "read"'s best
+ *    match. An explicit highlight still commits regardless — the user
+ *    pointed at a row they can actually see.
+ *  * failing THAT, the settled zero-hit case: the AI row is then the only
+ *    content, so IT pre-selects. Gated on `settled` for the same reason —
  *    offering it while the scan is still running spends a model call on a
  *    query that was about to answer itself.
- *
- * With file hits showing (and no open row), there is no highlight until the
- * user picks one; `submitRow` is what Enter consults instead.
  */
 export function activeRow(
   highlight: number | null,
@@ -399,35 +413,20 @@ export function activeRow(
 ): number | null {
   if (highlight === null) {
     if (m.openRow) return 0;
-    return m.fileCount === 0 && m.aiRow && settled ? totalRows(m) - 1 : null;
+    if (!settled) return null;
+    if (m.fileCount > 0) return 0;
+    return m.aiRow ? totalRows(m) - 1 : null;
   }
   return Math.min(highlight, totalRows(m) - 1);
 }
 
-/**
- * The row Enter commits, which is not always the highlighted one.
- *
- * With hits on screen and no arrow-key choice, Enter opens the TOP hit. It used
- * to resolve to null and do nothing at all — a silent no-op, in the one box in
- * this app where Enter is the obvious gesture. It still never falls through to
- * the AI row that way: reaching a paid action takes either zero settled hits or
- * an explicit highlight. (An open row, if present, is handled by `activeRow`
- * above before this fallthrough is ever reached.)
- *
- * That fallthrough is gated on `settled` for the same reason the AI row is, and
- * the reason arrived with server-side ranking: the list is deliberately never
- * blanked, so rows for the PREVIOUS query are on screen while this one is in
- * flight, and "the top hit" then means the top hit for something the user has
- * already finished typing over. Typing "read", then "readme", then Enter
- * navigated to "read"'s best match. An explicit highlight still commits —
- * the user pointed at a row they can actually see.
- */
+/** The row Enter commits. Now just `activeRow` — see its doc comment — kept
+ * as its own name because "what Enter commits" and "what is highlighted" are
+ * different QUESTIONS even though they now always share one answer. */
 export function submitRow(
   highlight: number | null,
   m: RowModel,
   settled: boolean,
 ): number | null {
-  const row = activeRow(highlight, m, settled);
-  if (row !== null) return row;
-  return settled && m.fileCount > 0 ? (m.openRow ? 1 : 0) : null;
+  return activeRow(highlight, m, settled);
 }

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -193,7 +193,18 @@ export function pathShortcut(query: string, home: string): string | null {
   let q = query.trim().replace(/[\r\n]+/g, " ").trim();
   const quoted = q.match(/^(['"])([\s\S]*)\1$/);
   if (quoted) q = quoted[2].trim();
-  if (/^file:\/\//i.test(q)) q = q.slice("file://".length);
+  if (/^file:\/\//i.test(q)) {
+    q = q.slice("file://".length);
+    // A Windows file:// URI's third slash is the URI's (empty) authority
+    // separator, not part of the path — file:///C:/Users/x is "C:/Users/x".
+    // Left in, it makes the string start with "/C:/…", which then PASSES the
+    // shape guard below via its leading-slash (POSIX) alternative instead of
+    // failing the drive-letter one, so a bogus absolute path is returned with
+    // full confidence instead of falling back to search. A bare POSIX
+    // file:// URL has no such extra slash: file:///home/x really is
+    // "/home/x", and is left untouched.
+    if (/^\/[A-Za-z]:[\\/]/.test(q)) q = q.slice(1);
+  }
   q = q.replace(/\\ /g, " ");
   if (!/^(\/|~\/|~$|[A-Za-z]:[\\/])/.test(q)) return null;
   let fsPath = q === "~" || q.startsWith("~/") ? home + q.slice(1) : q;
@@ -327,10 +338,18 @@ export function isAiRow(index: number, m: RowModel): boolean {
   return m.aiRow && index === totalRows(m) - 1;
 }
 
-/** Move the highlight by one row, wrapping, entering the list from either end. */
-export function stepHighlight(current: number | null, m: RowModel, delta: 1 | -1): number {
+/**
+ * Move the highlight by one row, wrapping, entering the list from either end.
+ *
+ * Null on a genuinely empty model (no open row, no files, no AI row — reachable
+ * when a path-shaped query does not resolve: ranking runs and comes back with
+ * zero hits, but the AI row stays suppressed because the query is still
+ * shaped like a path). There is no row 0 to land the arrow key on; returning
+ * 0 here used to hand `activeRow` a position to clamp into -1 instead.
+ */
+export function stepHighlight(current: number | null, m: RowModel, delta: 1 | -1): number | null {
   const n = totalRows(m);
-  if (n === 0) return 0;
+  if (n === 0) return null;
   if (current === null) return delta === 1 ? 0 : n - 1;
   return (current + delta + n) % n;
 }
@@ -411,6 +430,13 @@ export function activeRow(
   m: RowModel,
   settled: boolean,
 ): number | null {
+  // A genuinely empty model — no open row, no files, no AI row — has no row
+  // to pre-select AND no row an explicit `highlight` could have meant, so
+  // this returns null unconditionally before consulting `highlight` at all.
+  // Falling through to `Math.min(highlight, totalRows(m) - 1)` below used to
+  // clamp any non-null highlight to -1 here (`totalRows(m) - 1` === -1),
+  // which `activateRow` (FilesHome.tsx) then dereferenced as `hits[-1]`.
+  if (totalRows(m) === 0) return null;
   if (highlight === null) {
     if (m.openRow) return 0;
     if (!settled) return null;

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -50,6 +50,17 @@ import { fuzzyMatch } from "@platform/lib/fuzzy";
 // row, not more scrolling.
 export const HOME_RESULT_CAP = 10;
 
+// Below this many characters, a query is not sent at all. One or two letters
+// match almost every file in a home tree — a substring-pass candidate cap gets
+// hit on "a" or "e" alone — so the round trip is pure cost: it burns the
+// escalation ladder's expensive half on a query that could never narrow
+// anything, and it pre-arms "Search with AI" (a paid model call) on a query
+// nobody meant to submit yet. Gated on the REQUEST, not on `active`
+// (`FilesHome.tsx`'s `q !== ""`): `active` is what gives the search panel the
+// page body, and flipping it on the first character would bounce the whole
+// page as the user types their second one.
+export const MIN_QUERY_CHARS = 2;
+
 // Hits asked of the server per query. The list renders HOME_RESULT_CAP of
 // them; the rest are what makes the count note ("Showing top 10 of 137") true
 // without a second request. 200 rows is a few KB.

--- a/frontend/src/apps/explorer/listing/search.test.ts
+++ b/frontend/src/apps/explorer/listing/search.test.ts
@@ -23,13 +23,36 @@ test("an exact name match outranks a longer name containing it", () => {
 
 test("an entry whose own name matches beats one that only inherits an ancestor", () => {
   // scoreEntries matches the whole rel path, so a matching ANCESTOR DIRECTORY
-  // donated its score to every descendant: "render" scored
-  // render/a/b/c/d/e/f/deep-thing.bin at 26 and myrender.ts at 21, and depth is
-  // only reachable on an exact score tie, so the deep file won. The name-match
-  // tier sits above score and settles it.
+  // donates its score to every descendant, and depth is only reachable on an
+  // exact score tie — so raw score alone cannot be trusted to prefer the name
+  // match. The name-match tier sits above score and settles it regardless.
   expect(ranked("render", ["render/a/b/c/d/junk.bin", "myrender.ts"])[0]).toBe(
     "myrender.ts",
   );
+});
+
+test("a deep, scattered ancestor-only match no longer wins on score alone", () => {
+  // The reported bug: a vague query where NOBODY's own name matches (tier 3
+  // for every candidate), so the sort falls through to raw score — where a
+  // long ancestor chain simply offers more +5 segment-start bonuses than a
+  // short one, independent of relevance. Same tier, same longestRun (a
+  // scattered subsequence for both), so this is decided by score/depth alone —
+  // exactly the case DEPTH_PENALTY exists for.
+  const deep =
+    "src/chat/ChatInterface/components/MessageList/components/MessageScrollbackRail/index.ts";
+  const shallow = "cache-config/comp/widget.ts";
+  const hits = ranked("cccm", [deep, shallow]);
+  expect(hits[0]).toBe(shallow);
+});
+
+test("a deep EXACT name match still wins over a shallow fuzzy one", () => {
+  // The penalty must not swamp the +100 exact-name bonus. Tier already
+  // guarantees this (tier 1 sits above tier/score), but it is worth pinning
+  // directly: a name match many segments deep must still beat a shallow
+  // fuzzy-only hit.
+  const deep = "a/b/c/d/e/f/g/h/exact-match.txt";
+  const shallow = "s/fuzzy-only.txt";
+  expect(ranked("exact-match.txt", [shallow, deep])[0]).toBe(deep);
 });
 
 test("a fuzzy name match still beats an ancestor-only match", () => {

--- a/frontend/src/apps/explorer/listing/search.ts
+++ b/frontend/src/apps/explorer/listing/search.ts
@@ -40,6 +40,35 @@ function depthOf(rel: string): number {
   return depth;
 }
 
+// A deep, vague match (a subsequence scattered across a long ancestor chain)
+// used to beat a shallow one on raw `score` alone, because score accumulates
+// over the WHOLE rel: +5 per segment start rewards every path separator a
+// query happens to land near, and a long path simply offers more of them. A
+// 130-char path with 14 separators out-scored a short exact-ish match even
+// though `longestRun`/`tier` were tied, because `depth` (the tie-break for
+// exactly that case) is only reached on an exact score tie — which a scattered
+// match essentially never produces.
+//
+// The fix has to be PER-SEGMENT, because the thing being cancelled (the +5
+// segment-start bonus) is per-segment: a flat penalty or a divide-by-length
+// both mis-shape it (either too weak on very deep paths or too strong on
+// merely-nested ones). DEPTH_PENALTY kept just under the +5 it offsets means a
+// segment that genuinely matched still pays for itself — a real hit is not
+// swamped — while a segment that merely EXISTS on the path stops being free
+// score. SHALLOW_FREE exempts normal project nesting (`src/foo/bar.ts`) from
+// any penalty at all; only past it does depth start to cost anything.
+//
+// Applied in `scoreEntries`/`rank_entries` (the ranking layer), not in
+// `fuzzyMatch`/`fuzzy_match` (the matcher): this must not move a single
+// highlight position or change what counts as a match, only how deep matches
+// are ORDERED against shallow ones. Any change here has to be mirrored into
+// rank.py and the fixture regenerated (index/rank.py's module docstring) — do
+// NOT promote `depth` above `score` in rankCompare instead; that ranks a
+// shallow `~/a.txt` over a perfect deep match on every query and breaks the
+// tier/longestRun invariants above.
+const DEPTH_PENALTY = 4;
+const SHALLOW_FREE = 3;
+
 // How much of the match landed on the entry's OWN name: 1 = the query is a
 // substring of the name, 2 = the name matched only fuzzily, 3 = only ancestor
 // directories matched. Derived from what the matcher already returned plus the
@@ -58,9 +87,13 @@ function nameTier(name: string, nameStart: number, q: string,
 export function rankCompare(a: SearchHit, b: SearchHit): number {
   if (b.longestRun !== a.longestRun) return b.longestRun - a.longestRun;
   // Above `score`, because scoring runs over the whole rel path and a matching
-  // ancestor directory therefore donates its score to every descendant: query
-  // "render" scored render/a/b/c/d/e/f/deep-thing.bin at 26 and myrender.ts at
-  // 21, and `depth` below is only reachable on an exact score tie.
+  // ancestor directory therefore donates its score to every descendant — a
+  // tier-3 (ancestor-only) hit under a long path can still out-score a tier-1
+  // (name) hit under a short one even after DEPTH_PENALTY (above), which only
+  // damps that effect rather than eliminating it. `depth` below is reachable
+  // only on an exact score tie, which is why it alone was never enough to fix
+  // the deep-path-wins-by-construction case; the penalty is what actually
+  // fixes it, ahead of any tie-break.
   //
   // BELOW `longestRun`, which is what already guarantees substring-over-fuzzy:
   // fuzzyMatch's substring branch sets longestRun = q.length (the maximum the
@@ -105,9 +138,11 @@ export function scoreEntries(
     const name = entry.rel.slice(nameStart).toLowerCase();
     if (name === q) score += 100;
     else if (name.startsWith(q)) score += 25;
+    const depth = depthOf(entry.rel);
+    score -= DEPTH_PENALTY * Math.max(0, depth - SHALLOW_FREE);
     hits.push({ entry, positions: m.positions, score, longestRun: m.longestRun,
                 tier: nameTier(name, nameStart, q, m.positions),
-                depth: depthOf(entry.rel) });
+                depth });
   }
   return hits;
 }

--- a/frontend/src/platform/lib/instant-search.test.ts
+++ b/frontend/src/platform/lib/instant-search.test.ts
@@ -4,8 +4,10 @@
 import { describe, expect, it } from "bun:test";
 import {
   INSTANT_DEBOUNCE_MS,
+  PENDING_INDICATOR_MS,
   QUERY_MEMO_LIMIT,
   QueryMemo,
+  STALE_CLEAR_MS,
   searchDelay,
 } from "@platform/lib/instant-search";
 
@@ -77,5 +79,16 @@ describe("QueryMemo", () => {
 
   it("defaults to a small trail, not a cache", () => {
     expect(QUERY_MEMO_LIMIT).toBe(20);
+  });
+});
+
+describe("STALE_CLEAR_MS", () => {
+  it("gives a request longer to answer than the pending indicator does", () => {
+    // Admitting a wait is happening (PENDING_INDICATOR_MS) is a much cheaper
+    // decision than throwing away the rows on screen (STALE_CLEAR_MS) — the
+    // second has to wait longer than the first, or a request that is merely
+    // slow (already past PENDING_INDICATOR_MS) would immediately also count
+    // as stale.
+    expect(STALE_CLEAR_MS).toBeGreaterThan(PENDING_INDICATOR_MS);
   });
 });

--- a/frontend/src/platform/lib/instant-search.ts
+++ b/frontend/src/platform/lib/instant-search.ts
@@ -34,6 +34,20 @@ export const PENDING_INDICATOR_MS = 200;
 // clears it wholesale).
 export const QUERY_MEMO_LIMIT = 20;
 
+// How long a request may run before the rows still on screen (an OLDER
+// query's answer, since the list is never blanked) are dropped rather than
+// held. Never-blank was written for a ~40 ms local round trip, where showing
+// the previous answer for one more frame is free; a server round trip can run
+// into seconds, and past this long the rows on screen stop being "a little
+// behind" and start being flatly wrong — narrowing them locally (home-search's
+// `narrowAnswer`) is the first line of defense, and this is what fires when
+// narrowing leaves nothing: no rows and an honest "Searching…" beats rows for
+// a query the user has visibly moved past. Longer than PENDING_INDICATOR_MS
+// for the same reason a doctor's second opinion takes longer than the first
+// glance: this is a decision to throw away information, not just to admit a
+// wait is happening.
+export const STALE_CLEAR_MS = 600;
+
 /**
  * Milliseconds to wait before issuing the request for a freshly typed query.
  *

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -618,17 +618,30 @@
    it — the fix for both this row reading as a stray selection and for it
    sliding below the fold at HOME_RESULT_CAP=20. `background: var(--bg)` here
    is not a selection tint — it is an opaque backdrop so scrolling rows
-   disappear cleanly UNDER a sticky element instead of showing through it. */
+   disappear cleanly UNDER a sticky element instead of showing through it.
+
+   `.fh-ai-row` is on the <li>, NOT the <button> inside it (FilesHome.tsx's
+   `AiActionRow`). `position: sticky` offsets an element within its own
+   containing block, and a <li> that wraps exactly one full-width button has
+   no room of its own for the button to offset within — sticky landed on the
+   button once did nothing at all: the row scrolled out of view under the
+   fold exactly like an ordinary file row, silently reopening the very
+   problem HOME_RESULT_CAP=20 plus this scrolling list exists to fix.
+   `.fh-ai-action`, below, is the button's own class for what genuinely is
+   about the button. */
 .fh-ai-row {
   position: sticky;
   bottom: 0;
   background: var(--bg);
   border-top: 1px solid var(--border);
+}
+
+.fh-ai-action {
   padding-top: 12px;
   padding-bottom: 12px;
 }
 
-.fh-ai-row .fh-result-name {
+.fh-ai-action .fh-result-name {
   color: var(--accent);
 }
 
@@ -636,7 +649,7 @@
   color: var(--accent);
 }
 
-.fh-ai-row:disabled {
+.fh-ai-action:disabled {
   cursor: default;
 }
 

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -487,18 +487,35 @@
 /* Search results: a flat scannable list (relevance order), not the launcher
    card grid — icon, name, path, then size/date pushed to the right edge.
 
-   HOME_RESULT_CAP (home-search.ts) is 20, which does not fit a laptop
+   HOME_RESULT_CAP (home-search.ts) is 20, which does not fit a SHORT
    viewport on its own — so the list SCROLLS internally rather than pushing
-   the AI row below the fold: `max-height` bounds it to comfortably fewer than
-   20 rows, and `.fh-ai-row`'s `position: sticky; bottom: 0` keeps the action
-   in view regardless of how far the file rows scroll underneath it. Without
-   the max-height the sticky row would simply sit at the end of a tall list,
-   never actually needing to stick. */
+   the AI row below the fold: `max-height` bounds it, and `.fh-ai-row`'s
+   `position: sticky; bottom: 0` keeps the action in view regardless of how
+   far the file rows scroll underneath it. Without a bound the sticky row
+   would simply sit at the end of a tall list, never actually needing to
+   stick.
+
+   That bound must NOT be a flat pixel value, though — 440px unconditionally
+   was measured against a laptop window and then applied to every window: on
+   a tall one it capped the list at ~13 rows and left the whole lower portion
+   of the page blank rather than using the space that was actually there.
+   `max()` makes 440px a FLOOR (short viewports still get a usable list, and
+   still scroll) while `calc(100dvh - 11rem)` gives a tall viewport the rest
+   of its height instead. `dvh` rather than `vh`: `vh` on a mobile browser
+   includes the area the address bar can retract into, which would size this
+   against space that is not actually available.
+
+   11rem is the measured chrome above the list on the explorer page — page
+   padding + the search bar + the result-note line + a little breathing
+   room before the window edge — checked against the running app at a short
+   (700px) and a tall (1346px) viewport: short still shows the internal
+   scrollbar with the AI row pinned under it, tall shows all 20 rows with no
+   scrollbar at all. Re-measure this if that chrome changes size. */
 .fh-results {
   list-style: none;
   margin: 0;
   padding: 0;
-  max-height: 440px;
+  max-height: max(440px, calc(100dvh - 11rem));
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 10px;

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -485,14 +485,23 @@
 }
 
 /* Search results: a flat scannable list (relevance order), not the launcher
-   card grid — icon, name, path, then size/date pushed to the right edge. */
+   card grid — icon, name, path, then size/date pushed to the right edge.
+
+   HOME_RESULT_CAP (home-search.ts) is 20, which does not fit a laptop
+   viewport on its own — so the list SCROLLS internally rather than pushing
+   the AI row below the fold: `max-height` bounds it to comfortably fewer than
+   20 rows, and `.fh-ai-row`'s `position: sticky; bottom: 0` keeps the action
+   in view regardless of how far the file rows scroll underneath it. Without
+   the max-height the sticky row would simply sit at the end of a tall list,
+   never actually needing to stick. */
 .fh-results {
   list-style: none;
   margin: 0;
   padding: 0;
+  max-height: 440px;
+  overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 10px;
-  overflow: hidden;
 }
 
 .fh-results li + li {
@@ -571,16 +580,35 @@
 
 /* -- the AI action row -------------------------------------------------------
    The last row in the list is not a file: it costs a model call and a wait, so
-   it reads as an action — accent glyph, accent label, a faint accent wash — and
-   never like the hits above it. On a zero-hit query it is the only row, and
-   FilesHome pre-selects it. */
-.fh-ai-row {
-  background: color-mix(in srgb, var(--accent) 6%, transparent);
-}
+   it reads as an action — accent glyph, accent label — and never like the hits
+   above it. On a zero-hit query it is the only row, and FilesHome pre-selects
+   it.
 
-.fh-ai-row:hover,
-.fh-ai-row.is-active {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
+   It used to ALSO carry a faint accent background wash at rest, which is what
+   made it look like a second selected row: a background wash is this app's
+   existing signal for "the keyboard is here" (`.fh-result:hover,
+   .fh-result.is-active` below), and painting a resting row with one made a
+   hovered file row and the untouched AI row read as the same gesture at
+   different tints. The wash is gone; selection now means exactly one thing
+   across the whole list, and this row leans on the glyph/label/rule instead —
+   which does the "this is an action, not a hit" job without competing with
+   selection for the same visual channel.
+
+   Structural separation instead: a rule ABOVE it (border-top) says "the
+   results end here, this is something else", and STICKY positioning
+   (`.fh-results`'s max-height/overflow-y above) keeps it reachable at the
+   bottom of the viewport regardless of how many file rows scroll past above
+   it — the fix for both this row reading as a stray selection and for it
+   sliding below the fold at HOME_RESULT_CAP=20. `background: var(--bg)` here
+   is not a selection tint — it is an opaque backdrop so scrolling rows
+   disappear cleanly UNDER a sticky element instead of showing through it. */
+.fh-ai-row {
+  position: sticky;
+  bottom: 0;
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 .fh-ai-row .fh-result-name {
@@ -595,12 +623,36 @@
   cursor: default;
 }
 
-.fh-ai-row .fh-result-meta kbd {
+/* The query echo — its own column, not `.fh-result-path` (the file rows' PATH
+   column): "parquet" is not a filesystem path, and sharing the class made it
+   read as one. Muted and quoted rather than the path's plain-text treatment,
+   so it reads as an ECHO of what was typed. */
+.fh-ai-query {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--fg-muted);
+}
+
+/* The `↵` hint — its own column, not `.fh-result-meta` (the file rows'
+   size/date column): aligning it with the dates above claimed it was more
+   metadata about a hit, when it is the key that runs the action. */
+.fh-ai-hint {
+  flex: none;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+}
+
+.fh-ai-hint kbd {
   font: inherit;
   padding: 0 4px;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: var(--bg);
+  background: var(--bg-alt);
 }
 
 /* The AI badge on the spec echo above AI results — the results on screen came

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -623,6 +623,17 @@
   cursor: default;
 }
 
+/* -- the "Open" row (section 7) ----------------------------------------------
+   The other action row — a resolving path address, offered at row 0 instead
+   of the last row, and for the opposite reason (ranking would be noise, not
+   ranking coming up empty). Shares `.fh-result`'s column layout (icon, name,
+   PATH — this one really is a path, unlike the AI row's query echo, so it
+   keeps `.fh-result-path`) and gets the same accent name treatment item 6
+   gives the AI row, so both read as "an action" the same way. */
+.fh-open-row .fh-result-name {
+  color: var(--accent);
+}
+
 /* The query echo — its own column, not `.fh-result-path` (the file rows' PATH
    column): "parquet" is not a filesystem path, and sharing the class made it
    read as one. Muted and quoted rather than the path's plain-text treatment,

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -668,9 +668,19 @@
 
 /* The `↵` hint — its own column, not `.fh-result-meta` (the file rows'
    size/date column): aligning it with the dates above claimed it was more
-   metadata about a hit, when it is the key that runs the action. */
+   metadata about a hit, when it is the key that runs the action WHEN THE ROW
+   IS SELECTED — with file hits on screen Enter opens the top hit instead, so
+   the badge only renders while `active` (FilesHome.tsx's AiActionRow).
+
+   A fixed width (sized to "Asking…", the widest of the three states this
+   span cycles through — the badge, that text, or nothing while unselected)
+   keeps the row's columns from reflowing as the highlight moves onto or off
+   it; `text-align: right` keeps the badge and the text sharing the same
+   right edge the way the empty state's blank column implicitly does. */
 .fh-ai-hint {
   flex: none;
+  width: 52px;
+  text-align: right;
   font-size: 11.5px;
   color: var(--fg-muted);
 }

--- a/fused_render/index/cancel.py
+++ b/fused_render/index/cancel.py
@@ -1,0 +1,75 @@
+"""Cooperative cancellation for a rank request that has outlived its client.
+
+`api_index_rank` (server/routers/index.py) dispatches the actual query onto a
+worker thread via `asyncio.to_thread`, and `asyncio.to_thread` CANNOT KILL
+THAT THREAD — Python gives no way to preempt one. So cancelling has to be
+cooperative from inside the thread, and it needs BOTH pieces below, because
+neither alone is enough:
+
+  * `check()` — a flag the query thread polls at cheap, frequent points
+    between phases (query.py's `pass_over`: before the `execute`, after the
+    `fetchall`, before `rank_entries`, before the gitignore filter). This is
+    what makes the thread actually RETURN.
+  * `cancel()` also calls `con.interrupt()` on the bound duckdb connection —
+    the same mechanism `guarded_query.py` already arms from a
+    `threading.Timer` for the SQL panel's timeout. This is what unblocks a
+    `con.execute()` that is already running when cancellation arrives; a
+    `check()` between phases cannot reach INTO a call already in flight.
+
+`bind`/`cancel` ordering matters: a token cancelled BEFORE `bind` (the
+abandoned-before-the-connect-even-finished case) must still stop the query,
+so `bind` interrupts immediately if the flag is already set, under the same
+lock `cancel()` uses — otherwise a fast abort races the connect and is lost.
+"""
+import threading
+
+
+class Cancelled(Exception):
+    """Raised by `CancelToken.check()`, and by `search_ranked` when an
+    interrupted duckdb call is attributable to this token.
+
+    NOT an error: a cancelled rank is a client that stopped waiting, which is
+    normal operation for a per-keystroke request. Callers must not log this
+    the way a real failure is logged (see routers/index.py's `api_index_rank`,
+    which uses `logger.debug` here for the same reason it already does for the
+    candidate-cap line)."""
+
+
+class CancelToken:
+    """One per rank request. `cancel()` is called from the disconnect-watcher
+    task (a different thread than the query); `bind()`/`check()` run on the
+    query thread itself."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._cancelled = False
+        self._con = None
+
+    def bind(self, con) -> None:
+        """Register the live connection, immediately after `duckdb.connect()`."""
+        with self._lock:
+            self._con = con
+            already_cancelled = self._cancelled
+        # Outside the lock: `interrupt()` itself does its own cross-thread
+        # synchronization inside duckdb, and holding this lock across it would
+        # only widen the window `cancel()` blocks in for no reason.
+        if already_cancelled:
+            con.interrupt()
+
+    def cancel(self) -> None:
+        """Safe to call from any thread — cross-thread is exactly what
+        `duckdb.Connection.interrupt()` exists for."""
+        with self._lock:
+            self._cancelled = True
+            con = self._con
+        if con is not None:
+            con.interrupt()
+
+    def check(self) -> None:
+        """Raise `Cancelled` if `cancel()` has been called."""
+        if self._cancelled:
+            raise Cancelled()
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled

--- a/fused_render/index/cancel.py
+++ b/fused_render/index/cancel.py
@@ -20,6 +20,12 @@ neither alone is enough:
 abandoned-before-the-connect-even-finished case) must still stop the query,
 so `bind` interrupts immediately if the flag is already set, under the same
 lock `cancel()` uses — otherwise a fast abort races the connect and is lost.
+
+`unbind`/`cancel` ordering matters just as much at the OTHER end: the
+caller's `finally` must call `unbind()` before `con.close()`, so a `cancel()`
+racing the very end of the query (the disconnect watcher firing just as the
+query thread is already returning) finds no connection to `interrupt()`
+rather than one that is closed, or about to be.
 """
 import threading
 
@@ -55,6 +61,27 @@ class CancelToken:
         # only widen the window `cancel()` blocks in for no reason.
         if already_cancelled:
             con.interrupt()
+
+    def unbind(self) -> None:
+        """Detach the connection, so a `cancel()` that arrives after this
+        point does not call `interrupt()` on it.
+
+        The caller (`search_ranked`) must call this in its `finally`, BEFORE
+        `con.close()` — the same ordering `guarded_query.py` already uses for
+        its own connection-owning `threading.Timer` (`timer.cancel()` before
+        `close()`, not after). Without it, `_watch_disconnect`
+        (server/routers/index.py) calling `cancel()` after the query thread
+        has already returned and closed its connection makes `interrupt()`
+        land on an already-closed `duckdb.DuckDBPyConnection`, which raises
+        `duckdb.ConnectionException` — on a task nothing ever awaits again
+        once the route only `.cancel()`s it, so a perfectly normal client
+        disconnect surfaces as an unhandled "Task exception was never
+        retrieved" warning instead of nothing at all.
+
+        `cancelled` itself is untouched: `check()` must keep raising for a
+        token cancelled before this call, connection or no connection."""
+        with self._lock:
+            self._con = None
 
     def cancel(self) -> None:
         """Safe to call from any thread — cross-thread is exactly what

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -757,4 +757,16 @@ def search_ranked(cfg: IndexConfig, root: str, q: str = "",
             raise Cancelled() from None
         raise
     finally:
+        # `unbind` BEFORE `close`, not after: the disconnect watcher
+        # (server/routers/index.py's `_watch_disconnect`) can call
+        # `token.cancel()` from another thread at any time, including in the
+        # window right here between the query finishing and the connection
+        # closing. Closing first would let that `cancel()` call `interrupt()`
+        # on an already-closed connection (`duckdb.ConnectionException`, on a
+        # task nothing then retrieves the result of — an unhandled-exception
+        # warning on a perfectly normal disconnect). Same ordering
+        # `guarded_query.py` already uses for its own connection-owning
+        # `threading.Timer` (`timer.cancel()` before `close()`).
+        if token is not None:
+            token.unbind()
         con.close()

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -18,6 +18,7 @@ import os
 import re
 import time
 
+from fused_render.index.cancel import Cancelled
 from fused_render.index.config import IndexConfig
 from fused_render.index.ignore import is_inside_leaf_dir, is_leaf_dir, norm
 from fused_render.index.rank import query_wants_hidden as _wants_hidden
@@ -493,7 +494,7 @@ def _ignore_roots(con, cfg: IndexConfig, parts, root: str, prefix: str,
 def search_ranked(cfg: IndexConfig, root: str, q: str = "",
                   limit: int = RANK_LIMIT, include_dirs: bool = True,
                   cap: int = RANK_CANDIDATE_CAP,
-                  gitignore_filter=None) -> dict:
+                  gitignore_filter=None, token=None) -> dict:
     """Search `root` for `q` — filtered AND ranked here, top `limit` returned.
 
     The home page used to fetch the whole corpus and rank it in the browser:
@@ -564,6 +565,18 @@ def search_ranked(cfg: IndexConfig, root: str, q: str = "",
     missing index or a package directory answers `covered: false` with no hits
     — never an error, because "no index yet", "not covered" and "a scan is
     running" are one condition to a search box.
+
+    `token` (index/cancel.CancelToken), when given, is bound to the duckdb
+    connection the moment it exists and checked at every phase boundary in
+    `pass_over` — before each `execute`, after the `fetchall`, before
+    `rank_entries`, before the gitignore filter. A `duckdb.InterruptException`
+    from an `execute()` this token caused is re-raised as `Cancelled`; one this
+    token did NOT cause (a real duckdb error, or another caller's timeout on
+    a connection this function does not own — it never shares one) keeps
+    surfacing as itself. `search_ranked` cannot make the abandoned THREAD
+    return on its own (`asyncio.to_thread` has no such power); this is what
+    makes the QUERY inside it return quickly instead, which is what the caller
+    is actually waiting on.
     """
     root = _root_or_bare(
         norm(os.path.abspath(os.path.expanduser((root or "").strip()))).rstrip("/"))
@@ -589,115 +602,148 @@ def search_ranked(cfg: IndexConfig, root: str, q: str = "",
     age = (time.time() - updated) if isinstance(updated, (int, float)) else None
     fresh = age is not None and age <= FRESH_MAX_AGE_S
     con = duckdb.connect()
-    miss = _coverage_reason(con, cfg, root)
-    if miss:
-        return {**empty, "reason": miss, "updated": updated, "age_s": age}
-    # See stats()'s identical fix above: root already ends in "/" for
-    # any bare root (POSIX or a Windows drive), not only "/" itself.
-    prefix = root if root.endswith("/") else root + "/"
-    prefix_like = like_literal(prefix)
-    limit = max(0, min(int(limit), MAX_RANK_LIMIT))
-    cap = max(1, int(cap))
-    hit = prune(m["partitions"], prefix)
-    base = {"covered": True, "fresh": fresh, "updated": updated, "age_s": age,
-            "root": root, "reason": "", "scanned_partitions": len(hit),
-            "of_partitions": len(m["partitions"])}
-    qs = (q or "").strip()
-    if not qs:
-        # Nothing typed is not "everything": the empty query has no ranking to
-        # apply, and answering with an arbitrary 200 files would be noise.
-        return {**base, "hits": [], "truncated": False, "total": 0,
-                "escalated": False}
+    # Bound the instant the connection exists: a token cancelled before this
+    # point still has to stop it (CancelToken.bind's own docstring), and every
+    # `return`/`raise` from here on must close it — hence the try/finally
+    # wrapping the entire rest of the function, replacing what used to be a
+    # connection leaked on any early return or raised exception.
+    if token is not None:
+        token.bind(con)
+    try:
+        miss = _coverage_reason(con, cfg, root)
+        if miss:
+            return {**empty, "reason": miss, "updated": updated, "age_s": age}
+        # See stats()'s identical fix above: root already ends in "/" for
+        # any bare root (POSIX or a Windows drive), not only "/" itself.
+        prefix = root if root.endswith("/") else root + "/"
+        prefix_like = like_literal(prefix)
+        limit = max(0, min(int(limit), MAX_RANK_LIMIT))
+        cap = max(1, int(cap))
+        hit = prune(m["partitions"], prefix)
+        base = {"covered": True, "fresh": fresh, "updated": updated, "age_s": age,
+                "root": root, "reason": "", "scanned_partitions": len(hit),
+                "of_partitions": len(m["partitions"])}
+        qs = (q or "").strip()
+        if not qs:
+            # Nothing typed is not "everything": the empty query has no ranking to
+            # apply, and answering with an arbitrary 200 files would be noise.
+            return {**base, "hits": [], "truncated": False, "total": 0,
+                    "escalated": False}
 
-    # `substr` from the prefix's length, so every comparison below is against
-    # the REL — exactly the string stage B scores. Filtering on the full path
-    # would let the root's own spelling admit rows no fuzzy match will keep.
-    rel_from = len(prefix) + 1
-    branches = []
-    if hit:
-        fsrc = files_src(cfg, hit)
-        branches.append(
-            f"SELECT substr(path, {rel_from}) AS rel, size, mtime, "
-            f"false AS is_dir, {_depth_col(con, fsrc, 'path')} AS depth "
-            f"FROM {fsrc} WHERE path LIKE '{prefix_like}%' ESCAPE '\\'")
-    if include_dirs:
-        dsrc = dirs_src(cfg)
-        branches.append(
-            f"SELECT substr(dir, {rel_from}) AS rel, CAST(NULL AS BIGINT) AS size, "
-            f"nullif(mtime_ns, 0) / 1e9 AS mtime, true AS is_dir, "
-            f"{_depth_col(con, dsrc, 'dir')} AS depth "
-            f"FROM {dsrc} WHERE dir LIKE '{prefix_like}%' ESCAPE '\\'")
-    if not branches:
-        return {**base, "hits": [], "truncated": False, "total": 0,
-                "escalated": False}
+        # `substr` from the prefix's length, so every comparison below is against
+        # the REL — exactly the string stage B scores. Filtering on the full path
+        # would let the root's own spelling admit rows no fuzzy match will keep.
+        rel_from = len(prefix) + 1
+        branches = []
+        if hit:
+            fsrc = files_src(cfg, hit)
+            branches.append(
+                f"SELECT substr(path, {rel_from}) AS rel, size, mtime, "
+                f"false AS is_dir, {_depth_col(con, fsrc, 'path')} AS depth "
+                f"FROM {fsrc} WHERE path LIKE '{prefix_like}%' ESCAPE '\\'")
+        if include_dirs:
+            dsrc = dirs_src(cfg)
+            branches.append(
+                f"SELECT substr(dir, {rel_from}) AS rel, CAST(NULL AS BIGINT) AS size, "
+                f"nullif(mtime_ns, 0) / 1e9 AS mtime, true AS is_dir, "
+                f"{_depth_col(con, dsrc, 'dir')} AS depth "
+                f"FROM {dsrc} WHERE dir LIKE '{prefix_like}%' ESCAPE '\\'")
+        if not branches:
+            return {**base, "hits": [], "truncated": False, "total": 0,
+                    "escalated": False}
 
-    ql = like_literal(qs.lower())
-    qq = _q(qs.lower())
-    # The coarse tier. Deliberately cruder than `rank_entries`' — it exists to
-    # decide which `cap` rows are worth scoring properly, not to order the
-    # answer, and every extra SQL expression here is paid on all 571k rows.
-    tier = (f"CASE WHEN nm = '{qq}' THEN 1 "
-            f"WHEN nm LIKE '{ql}%' ESCAPE '\\' THEN 2 "
-            f"WHEN nm LIKE '%{ql}%' ESCAPE '\\' THEN 3 "
-            f"WHEN lrel LIKE '%{ql}%' ESCAPE '\\' THEN 4 "
-            f"ELSE 5 END")
-    # Hidden entries are dropped HERE as well as in the ranker, so a query that
-    # does not want them cannot spend the candidate cap on them (rank.py's
-    # query_wants_hidden / is_hidden_rel are the definitions; this mirrors them).
-    hidden = ("" if _wants_hidden(qs)
-              else " AND NOT (lrel LIKE '.%' OR lrel LIKE '%/.%')")
-    inner = (f"SELECT *, lower(rel) AS lrel, "
-             f"regexp_extract(lower(rel), '[^/]*$') AS nm FROM ("
-             + " UNION ALL ".join(branches) + ")")
+        ql = like_literal(qs.lower())
+        qq = _q(qs.lower())
+        # The coarse tier. Deliberately cruder than `rank_entries`' — it exists to
+        # decide which `cap` rows are worth scoring properly, not to order the
+        # answer, and every extra SQL expression here is paid on all 571k rows.
+        tier = (f"CASE WHEN nm = '{qq}' THEN 1 "
+                f"WHEN nm LIKE '{ql}%' ESCAPE '\\' THEN 2 "
+                f"WHEN nm LIKE '%{ql}%' ESCAPE '\\' THEN 3 "
+                f"WHEN lrel LIKE '%{ql}%' ESCAPE '\\' THEN 4 "
+                f"ELSE 5 END")
+        # Hidden entries are dropped HERE as well as in the ranker, so a query that
+        # does not want them cannot spend the candidate cap on them (rank.py's
+        # query_wants_hidden / is_hidden_rel are the definitions; this mirrors them).
+        hidden = ("" if _wants_hidden(qs)
+                  else " AND NOT (lrel LIKE '.%' OR lrel LIKE '%/.%')")
+        inner = (f"SELECT *, lower(rel) AS lrel, "
+                 f"regexp_extract(lower(rel), '[^/]*$') AS nm FROM ("
+                 + " UNION ALL ".join(branches) + ")")
 
-    def pass_over(predicate: str, name: str):
-        """One candidate pass: `predicate` over every row under the root, coarse
-        tier order, one row past the cap so "the cap bit" needs no count."""
-        t0 = time.monotonic()
-        rows = con.execute(
-            f"SELECT rel, size, mtime, is_dir FROM ({inner}) "
-            f"WHERE {predicate}{hidden} "
-            f"ORDER BY {tier}, depth, rel LIMIT {cap + 1}").fetchall()
-        # DEBUG: stage A's own cost, per pass, separate from stage B's ranking
-        # and the gitignore filter below — this fires on every keystroke, so
-        # it stays DEBUG rather than something louder (same reasoning as the
-        # cap-bit line right after it).
-        logger.debug("index rank: stage A (%s) for %r under %s: %d row(s) "
-                    "in %.1fms", name, qs, root,
-                    len(rows), (time.monotonic() - t0) * 1000)
-        if len(rows) > cap:
-            # DEBUG, not WARNING: this fires on every keystroke of any broad
-            # query — "a" and "e" alone exceed the cap on the substring pass —
-            # and a line that appears whenever the app is working normally
-            # trains everyone to ignore the log. The response says the same
-            # thing where it can be acted on (`truncated: true`), so nothing is
-            # silent; it is just not shouted.
-            logger.debug(
-                "index rank: the candidate cap (%d) bit for %r under %s — the "
-                "ranked answer is drawn from stage A's coarse top rows only",
-                cap, qs, root)
-        entries = [{"rel": rel, "is_dir": bool(is_dir),
-                    "size": int(size) if size is not None else None,
-                    "mtime": float(mtime) if mtime is not None else None}
-                   for rel, size, mtime, is_dir in rows[:cap]]
-        ranked = rank_entries(qs, entries)
-        if gitignore_filter is not None:
-            ranked = gitignore_filter(
-                root, ranked,
-                _ignore_roots(con, cfg, hit, root, prefix, updated))
-        return ranked, len(rows) > cap
+        def pass_over(predicate: str, name: str):
+            """One candidate pass: `predicate` over every row under the root, coarse
+            tier order, one row past the cap so "the cap bit" needs no count.
 
-    # The LADDER (see the docstring): the cheap substring pass first, and the
-    # regex only when the cheap one cannot fill the cut. `capped` also stops the
-    # escalation — a pass that filled the candidate cap already handed stage B
-    # more coarsely-better rows than it can return, so widening the filter can
-    # only push MORE of them out of the cap.
-    ranked, capped = pass_over(f"lrel LIKE '%{ql}%' ESCAPE '\\'", "substring")
-    escalated = False
-    if not capped and len(ranked) < limit:
-        escalated = True
-        ranked, capped = pass_over(
-            f"regexp_matches(lrel, '{_subseq_regex(qs.lower())}')", "subsequence")
-    return {**base, "hits": ranked[:limit],
-            "truncated": capped or len(ranked) > limit,
-            "total": len(ranked[:limit]), "escalated": escalated}
+            The between-passes check (the one before `rank_entries`, and the
+            one before this function is even called a second time for the
+            escalated pass) is the highest-value cancellation point: escalation
+            is the expensive half, and it runs precisely for the broad queries
+            a fast typist is most likely to have already abandoned."""
+            if token is not None:
+                token.check()
+            t0 = time.monotonic()
+            try:
+                rows = con.execute(
+                    f"SELECT rel, size, mtime, is_dir FROM ({inner}) "
+                    f"WHERE {predicate}{hidden} "
+                    f"ORDER BY {tier}, depth, rel LIMIT {cap + 1}").fetchall()
+            except duckdb.InterruptException:
+                # An interrupt with NO token, or one this token did not cause,
+                # is a real error (someone else's timeout, a genuine duckdb
+                # abort) and must keep surfacing as one — only attribute it to
+                # cancellation when this token says it actually happened.
+                if token is not None and token.cancelled:
+                    raise Cancelled() from None
+                raise
+            if token is not None:
+                token.check()
+            # DEBUG: stage A's own cost, per pass, separate from stage B's ranking
+            # and the gitignore filter below — this fires on every keystroke, so
+            # it stays DEBUG rather than something louder (same reasoning as the
+            # cap-bit line right after it).
+            logger.debug("index rank: stage A (%s) for %r under %s: %d row(s) "
+                        "in %.1fms", name, qs, root,
+                        len(rows), (time.monotonic() - t0) * 1000)
+            if len(rows) > cap:
+                # DEBUG, not WARNING: this fires on every keystroke of any broad
+                # query — "a" and "e" alone exceed the cap on the substring pass —
+                # and a line that appears whenever the app is working normally
+                # trains everyone to ignore the log. The response says the same
+                # thing where it can be acted on (`truncated: true`), so nothing is
+                # silent; it is just not shouted.
+                logger.debug(
+                    "index rank: the candidate cap (%d) bit for %r under %s — the "
+                    "ranked answer is drawn from stage A's coarse top rows only",
+                    cap, qs, root)
+            entries = [{"rel": rel, "is_dir": bool(is_dir),
+                        "size": int(size) if size is not None else None,
+                        "mtime": float(mtime) if mtime is not None else None}
+                       for rel, size, mtime, is_dir in rows[:cap]]
+            if token is not None:
+                token.check()
+            ranked = rank_entries(qs, entries)
+            if gitignore_filter is not None:
+                if token is not None:
+                    token.check()
+                ranked = gitignore_filter(
+                    root, ranked,
+                    _ignore_roots(con, cfg, hit, root, prefix, updated))
+            return ranked, len(rows) > cap
+
+        # The LADDER (see the docstring): the cheap substring pass first, and the
+        # regex only when the cheap one cannot fill the cut. `capped` also stops the
+        # escalation — a pass that filled the candidate cap already handed stage B
+        # more coarsely-better rows than it can return, so widening the filter can
+        # only push MORE of them out of the cap.
+        ranked, capped = pass_over(f"lrel LIKE '%{ql}%' ESCAPE '\\'", "substring")
+        escalated = False
+        if not capped and len(ranked) < limit:
+            escalated = True
+            ranked, capped = pass_over(
+                f"regexp_matches(lrel, '{_subseq_regex(qs.lower())}')", "subsequence")
+        return {**base, "hits": ranked[:limit],
+                "truncated": capped or len(ranked) > limit,
+                "total": len(ranked[:limit]), "escalated": escalated}
+    finally:
+        con.close()

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -569,14 +569,19 @@ def search_ranked(cfg: IndexConfig, root: str, q: str = "",
     `token` (index/cancel.CancelToken), when given, is bound to the duckdb
     connection the moment it exists and checked at every phase boundary in
     `pass_over` — before each `execute`, after the `fetchall`, before
-    `rank_entries`, before the gitignore filter. A `duckdb.InterruptException`
-    from an `execute()` this token caused is re-raised as `Cancelled`; one this
-    token did NOT cause (a real duckdb error, or another caller's timeout on
-    a connection this function does not own — it never shares one) keeps
-    surfacing as itself. `search_ranked` cannot make the abandoned THREAD
-    return on its own (`asyncio.to_thread` has no such power); this is what
-    makes the QUERY inside it return quickly instead, which is what the caller
-    is actually waiting on.
+    `rank_entries`, before the gitignore filter. Binding is to the whole
+    CONNECTION, though, not just `pass_over`'s statement, so a
+    `duckdb.InterruptException` can land in any query run on it —
+    `_coverage_reason`'s and `_ignore_roots`' included, both of which execute
+    on this same connection before `pass_over` ever does. One try/except
+    around the whole bound region (not one per query site) re-raises as
+    `Cancelled` an interrupt this token caused; one it did NOT cause (a real
+    duckdb error, or another caller's timeout on a connection this function
+    does not own — it never shares one) keeps surfacing as itself.
+    `search_ranked` cannot make the abandoned THREAD return on its own
+    (`asyncio.to_thread` has no such power); this is what makes the QUERY
+    inside it return quickly instead, which is what the caller is actually
+    waiting on.
     """
     root = _root_or_bare(
         norm(os.path.abspath(os.path.expanduser((root or "").strip()))).rstrip("/"))
@@ -683,19 +688,10 @@ def search_ranked(cfg: IndexConfig, root: str, q: str = "",
             if token is not None:
                 token.check()
             t0 = time.monotonic()
-            try:
-                rows = con.execute(
-                    f"SELECT rel, size, mtime, is_dir FROM ({inner}) "
-                    f"WHERE {predicate}{hidden} "
-                    f"ORDER BY {tier}, depth, rel LIMIT {cap + 1}").fetchall()
-            except duckdb.InterruptException:
-                # An interrupt with NO token, or one this token did not cause,
-                # is a real error (someone else's timeout, a genuine duckdb
-                # abort) and must keep surfacing as one — only attribute it to
-                # cancellation when this token says it actually happened.
-                if token is not None and token.cancelled:
-                    raise Cancelled() from None
-                raise
+            rows = con.execute(
+                f"SELECT rel, size, mtime, is_dir FROM ({inner}) "
+                f"WHERE {predicate}{hidden} "
+                f"ORDER BY {tier}, depth, rel LIMIT {cap + 1}").fetchall()
             if token is not None:
                 token.check()
             # DEBUG: stage A's own cost, per pass, separate from stage B's ranking
@@ -745,5 +741,20 @@ def search_ranked(cfg: IndexConfig, root: str, q: str = "",
         return {**base, "hits": ranked[:limit],
                 "truncated": capped or len(ranked) > limit,
                 "total": len(ranked[:limit]), "escalated": escalated}
+    except duckdb.InterruptException:
+        # `token.bind(con)` above binds the WHOLE connection, not just
+        # pass_over's own SELECT — con.interrupt() can land in any statement
+        # run on it, including `_coverage_reason`'s and `_ignore_roots`'
+        # queries above, both of which run on this same bound connection
+        # before pass_over ever does. Handled once here for the entire bound
+        # region rather than wrapping each query site separately.
+        #
+        # An interrupt with NO token, or one this token did not cause, is a
+        # real error (someone else's timeout, a genuine duckdb abort) and
+        # must keep surfacing as one — only attribute it to cancellation when
+        # this token says it actually happened.
+        if token is not None and token.cancelled:
+            raise Cancelled() from None
+        raise
     finally:
         con.close()

--- a/fused_render/index/rank.py
+++ b/fused_render/index/rank.py
@@ -22,8 +22,10 @@ where the reason is not visible in the code:
 - +1 per char, +3 for a consecutive run, +5 for a segment start (tested on the
   ORIGINAL-case text so the camelCase hump survives lowercasing),
 - the `max_span(n) = n * 3 + 8` refusal,
-- name bonuses (+100 exact, +25 prefix), the 1/2/3 name tier, and the
-  `longest_run desc, tier asc, score desc, depth asc, path` ordering.
+- name bonuses (+100 exact, +25 prefix), the depth penalty
+  (`DEPTH_PENALTY * max(0, depth - SHALLOW_FREE)`, applied after the name
+  bonuses), the 1/2/3 name tier, and the `longest_run desc, tier asc, score
+  desc, depth asc, path` ordering.
 
 ONE known divergence, deliberate: the JS final tie-break is
 `Intl.Collator(sensitivity: "base")`, and this uses `str.lower()`. They agree
@@ -37,6 +39,20 @@ this note is what gets updated.
 # Chars that open a new "segment" in a path/name; a match right after one of
 # these reads as the start of a word and scores higher.
 SEPARATORS = frozenset("/.-_ ")
+
+# A deep, vague match used to out-score a shallow one on raw `score` alone —
+# score accumulates over the WHOLE rel, so a long ancestor chain simply offers
+# more +5 segment-start bonuses than a short one, independent of relevance.
+# The correction is PER-SEGMENT because the bonus it offsets is per-segment
+# (a flat penalty or a divide-by-length both mis-shape it); DEPTH_PENALTY
+# stays just under +5 so a segment that genuinely matched still pays for
+# itself, and SHALLOW_FREE exempts ordinary project nesting from any penalty
+# at all. Mirrors search.ts exactly — change one, change both, then regenerate
+# the fixture (see this module's docstring). Do NOT promote `depth` above
+# `score` in `_sort_key` instead; see search.ts's rankCompare for why that is
+# a trap, not a fix.
+DEPTH_PENALTY = 4
+SHALLOW_FREE = 3
 
 
 def max_span(query_length: int) -> int:
@@ -167,8 +183,12 @@ def _sort_key(hit: dict):
     asc, then a case-insensitive path compare.
 
     `tier` sits above `score` because scoring runs over the whole rel path, so
-    a matching ancestor directory donates its score to every descendant. It
-    sits BELOW `longest_run`, which is what already guarantees
+    a matching ancestor directory donates its score to every descendant — a
+    tier-3 (ancestor-only) hit under a long path can still out-score a tier-1
+    (name) hit under a short one even after DEPTH_PENALTY, which only damps
+    that effect rather than eliminating it; `depth` alone (reachable only on
+    an exact score tie) was never enough to fix it, which is why the penalty
+    exists. It sits BELOW `longest_run`, which is what already guarantees
     substring-over-fuzzy — that invariant must survive any change here."""
     return (-hit["longest_run"], hit["tier"], -hit["score"], hit["depth"],
             hit["rel"].lower())
@@ -201,9 +221,11 @@ def rank_entries(query: str, entries) -> list:
             score += 100
         elif name.startswith(q):
             score += 25
+        depth = _depth_of(rel)
+        score -= DEPTH_PENALTY * max(0, depth - SHALLOW_FREE)
         hits.append({**entry, "positions": m["positions"], "score": score,
                      "longest_run": m["longest_run"],
                      "tier": _name_tier(name, name_start, q, m["positions"]),
-                     "depth": _depth_of(rel)})
+                     "depth": depth})
     hits.sort(key=_sort_key)
     return hits

--- a/fused_render/server/index_gitignore.py
+++ b/fused_render/server/index_gitignore.py
@@ -135,6 +135,14 @@ _inflight: dict = {}
 # against the ~1.5 s a home-sized sweep takes rather than tightly.
 SWEEP_WAIT_MAX_S = 30.0
 
+# How often a waiting caller re-checks its CancelToken (when it has one)
+# instead of blocking the whole SWEEP_WAIT_MAX_S in one call. This is per
+# ABANDONED-REQUEST cost, not per sweep: a rank request that outlives its
+# client used to sit out someone else's sweep for up to 30s of pure dead
+# time; polling this often is what turns that into ~0.25s. Small enough that
+# the added wakeups are noise against a sweep that is itself seconds long.
+_SWEEP_POLL_S = 0.25
+
 # How long a pool may live before it is discarded and git is re-asked about
 # everything.
 #
@@ -196,7 +204,7 @@ class _Verdicts:
 
 
 def filter_corpus(out: dict, index_root: str | None = None,
-                  oracle_rels: list | None = None) -> dict:
+                  oracle_rels: list | None = None, token=None) -> dict:
     """`search_under`'s response with gitignored entries removed.
 
     Only a covered response with entries is touched; `total` is recomputed and
@@ -217,6 +225,11 @@ def filter_corpus(out: dict, index_root: str | None = None,
     which its SQL has already dropped every dot-leading rel, so no `.gitignore`
     could ever be among them, every entry came back undecided and nothing was
     filtered at all. `index/query.py` reads them out of the index instead.
+
+    `token` (index/cancel.CancelToken), when given, is forwarded to
+    `_pooled_verdicts` — it is what lets an abandoned rank request stop
+    waiting for someone ELSE's in-flight sweep (`SWEEP_WAIT_MAX_S`) in ~0.25s
+    instead of riding it out to the full 30.
     """
     root = out.get("root") or ""
     entries = out.get("entries")
@@ -240,7 +253,7 @@ def filter_corpus(out: dict, index_root: str | None = None,
     # today, but nothing here should depend on that) and the decider is
     # per-entry.
     drop = _pooled_verdicts(base, prefix, root, entries, persist=persist,
-                            oracle_rels=oracle_rels)
+                            oracle_rels=oracle_rels, token=token)
     if not drop:
         return {**out, "total": len(entries)}
     kept = [e for i, e in enumerate(entries) if i not in drop]
@@ -260,9 +273,31 @@ def _rel_prefix(base: str, root: str):
     return None
 
 
+def _wait_for_sweep(waiter, token=None) -> None:
+    """Wait for `waiter` to fire, up to `SWEEP_WAIT_MAX_S` total — but in
+    `_SWEEP_POLL_S` slices with a `token.check()` between them when a token is
+    given, rather than blocking the whole ceiling in one call.
+
+    This is the difference between an abandoned rank request riding out up to
+    30s of SOMEONE ELSE'S sweep and returning in ~0.25s once its own client
+    has gone. Scoped separately from the rest of section 1's cancellation
+    work because this module is shared with `api_index_search` (the in-folder
+    corpus route, which passes no token) and the corpus-building path — a
+    wrong change here under-filters gitignored files for those callers too."""
+    deadline = time.monotonic() + SWEEP_WAIT_MAX_S
+    while True:
+        if token is not None:
+            token.check()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        if waiter.wait(timeout=remaining if token is None else min(_SWEEP_POLL_S, remaining)):
+            return
+
+
 def _pooled_verdicts(base: str, prefix: str, root: str, entries: list,
                      persist: bool = True,
-                     oracle_rels: list | None = None) -> set:
+                     oracle_rels: list | None = None, token=None) -> set:
     """The INDEXES into `entries` that git calls ignored.
 
     Reads what the pool already decided UNDER THE SAME ORACLE, queries git for
@@ -282,6 +317,11 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list,
     not hypothetical: the startup warm sweeps on a detached thread for exactly
     the ~2.2 s in which the user's first keystroke arrives, and both used to
     build the same 200k-entry query set and shell out to git for it twice.
+
+    `token`, when given, lets the WAIT for someone else's sweep be abandoned
+    early (`_wait_for_sweep`) — it does not shorten the sweep this call itself
+    performs, which is a bounded git subprocess call, not a loop with anywhere
+    natural to check.
     """
     # Pure string work, no git: which oracle this request would consult for
     # each entry. Computed for the WHOLE corpus every time — a few tens of
@@ -338,9 +378,12 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list,
         # Someone else is asking git for this very base. Their answers land in
         # the pool we just read, so wait and read it again. The timeout is the
         # floor under a sweeper that somehow never finishes: worst case we do
-        # what the old code always did and sweep concurrently.
+        # what the old code always did and sweep concurrently. Polled in
+        # slices when a token is given (`_wait_for_sweep`) so an abandoned
+        # caller can stop waiting in ~_SWEEP_POLL_S rather than riding this
+        # out to the full ceiling.
         _wait_t0 = time.monotonic()
-        waiter.wait(timeout=SWEEP_WAIT_MAX_S)
+        _wait_for_sweep(waiter, token)
         # DEBUG: this is dead time on the request thread spent waiting for
         # SOMEONE ELSE'S sweep rather than doing any of its own work — worth
         # separating from the sweep's own timing below when a rank request

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -25,11 +25,12 @@ import os
 import re
 import threading
 
-from fastapi import APIRouter, Body, Header, Query
+from fastapi import APIRouter, Body, Header, Query, Request
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse, Response
 
 from fused_render.index import freshness, runner
+from fused_render.index.cancel import CancelToken, Cancelled
 from fused_render.index.freshness import enclosing_root
 from fused_render.index.config import IndexConfig, load_config, save_config
 from fused_render.index.guarded_query import MAX_LIMIT, run_guarded
@@ -245,7 +246,8 @@ def _wait_for_scan(cfg: IndexConfig, run_id: str) -> bool:
 WARM_RANK_QUERY = "zqxjv"
 
 
-def _ranked(cfg: IndexConfig, root: str, q: str, limit: int = RANK_LIMIT) -> dict:
+def _rank_body(cfg: IndexConfig, root: str, q: str, limit: int = RANK_LIMIT,
+               token: CancelToken | None = None) -> dict:
     """`search_ranked` with the server's gitignore filter wired in.
 
     The index package cannot import the server, so `search_ranked` takes the
@@ -258,14 +260,20 @@ def _ranked(cfg: IndexConfig, root: str, q: str, limit: int = RANK_LIMIT) -> dic
     `oracle_rels` comes from the caller, not from the payload: a ranked answer
     is ~200 rows with no dot-leading rels among them, so the filter's own
     discovery would find no `.gitignore`, decide nothing, and drop nothing
-    (index_gitignore.filter_corpus says this at length)."""
+    (index_gitignore.filter_corpus says this at length).
+
+    `token`, when given, is forwarded to `search_ranked` unchanged — it
+    already checks it right before calling `drop_ignored` (query.py's
+    `pass_over`), which is "before entering the sweep" from this function's
+    side without anything extra needed here."""
     def drop_ignored(canonical_root: str, hits: list, oracle_rels: list) -> list:
         index_root = enclosing_root(scan_roots(cfg), canonical_root)
         return filter_corpus({"covered": True, "root": canonical_root,
                               "entries": hits}, index_root=index_root,
                              oracle_rels=oracle_rels)["entries"]
 
-    return index_rank(cfg, root, q=q, limit=limit, gitignore_filter=drop_ignored)
+    return index_rank(cfg, root, q=q, limit=limit, gitignore_filter=drop_ignored,
+                      token=token)
 
 
 def _covers(a: str, b: str) -> bool:
@@ -447,7 +455,7 @@ def run_startup_warm() -> None:
         # connection cost, same gitignore pool, but its own two-stage SQL —
         # warming only the corpus would leave the home page's first keystroke
         # paying for the ranked plan.
-        _ranked(cfg, out.get("root") or root, WARM_RANK_QUERY)
+        _rank_body(cfg, out.get("root") or root, WARM_RANK_QUERY)
     except Exception:  # noqa: BLE001 - a warm must never take the server down
         logger.exception("could not warm the index search path")
 
@@ -935,9 +943,30 @@ def api_index_search(root: str = Query(default=""), q: str = Query(default=""),
     return _corpus_response(_columnar({"ok": True, **out}), accept_encoding)
 
 
+# How often the disconnect watcher polls `request.is_disconnected()` while a
+# rank request is in flight on the worker thread. `is_disconnected()` is the
+# only signal an async route that is ALSO doing real work off the event loop
+# has for "the client gave up" — the same tradeoff `api_fs_walk` already makes
+# (fs_read.py's WALK_DISCONNECT_CHECK_EVERY) — and a `receive`-driven variant
+# is not worth the added complexity here.
+_RANK_DISCONNECT_POLL_S = 0.1
+
+
+async def _watch_disconnect(request: Request, token: CancelToken) -> None:
+    """Cancel `token` the moment `request` disconnects; otherwise run forever
+    until the caller cancels THIS task (the route's `finally`, once the rank
+    finished on its own — see `api_index_rank`)."""
+    while True:
+        if await request.is_disconnected():
+            token.cancel()
+            return
+        await asyncio.sleep(_RANK_DISCONNECT_POLL_S)
+
+
 @router.get("/api/index/rank")
-def api_index_rank(root: str = Query(default=""), q: str = Query(default=""),
-                   limit: int = Query(default=RANK_LIMIT)):
+async def api_index_rank(request: Request, root: str = Query(default=""),
+                         q: str = Query(default=""),
+                         limit: int = Query(default=RANK_LIMIT)):
     """The home search: filtered AND ranked here, top `limit` hits returned.
 
     The corpus route next door hands the client every entry under `root`
@@ -964,13 +993,51 @@ def api_index_rank(root: str = Query(default=""), q: str = Query(default=""),
     platform/lib/fuzzy.ts stays the single source of truth for what highlights
     — and the ranker here stays free to carry positions internally without
     them becoming a wire contract.
+
+    ASYNC, and doing real cancellation, not merely handling a request that
+    happens to be a coroutine — a fast typist fires and abandons this route
+    on every keystroke, and the abandoned ones used to run to completion:
+    both duckdb ladder passes, the Python ranking, and (worst case) up to
+    `SWEEP_WAIT_MAX_S` blocked on another request's git sweep
+    (index_gitignore.py). The actual query runs on a worker thread
+    (`asyncio.to_thread`), watched by `_watch_disconnect` polling
+    `request.is_disconnected()`; on disconnect it calls `token.cancel()`,
+    which is index/cancel.py's job from there. Two honest limitations:
+
+      * `asyncio.to_thread` cannot kill the thread it started — nothing in
+        Python can. `token.cancel()` is what makes the QUERY inside that
+        thread return (the `check()` calls between phases); `con.interrupt()`
+        (also part of `cancel()`) is what unblocks a `con.execute()` already
+        running, which a between-phase check cannot reach. The route still
+        `await`s the worker thread either way — cancellation makes that wait
+        take milliseconds instead of seconds, it does not make the `await`
+        itself skippable.
+      * `is_disconnected()` polling is the only disconnect signal available
+        to a route that is also doing work; a `receive`-driven variant is not
+        worth the complexity here (see `_watch_disconnect`).
+
+    `Cancelled` escaping the worker thread is NOT logged as an error — a
+    cancelled rank is a client that stopped waiting, which is normal
+    operation for a per-keystroke request (same reasoning the candidate-cap
+    line above already applies to `logger.debug`) — and the response is a
+    body nobody reads, because nobody is listening by the time it is sent.
     """
     if not root.strip():
         return _error("'root' is required")
     import time
     t0 = time.monotonic()
     cfg = load_config()
-    out = _ranked(cfg, root, q, limit)
+    token = CancelToken()
+    work = asyncio.create_task(asyncio.to_thread(_rank_body, cfg, root, q, limit, token))
+    watch = asyncio.create_task(_watch_disconnect(request, token))
+    try:
+        out = await work
+    except Cancelled:
+        logger.debug("index rank: %r under %s abandoned by the client after %.1fms",
+                    q, root, (time.monotonic() - t0) * 1000)
+        return Response(status_code=499)
+    finally:
+        watch.cancel()
     out["hits"] = [{k: v for k, v in h.items() if k != "positions"}
                    for h in out["hits"]]
     out["reason"] = _rank_reason(cfg, root, out)

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -270,7 +270,7 @@ def _rank_body(cfg: IndexConfig, root: str, q: str, limit: int = RANK_LIMIT,
         index_root = enclosing_root(scan_roots(cfg), canonical_root)
         return filter_corpus({"covered": True, "root": canonical_root,
                               "entries": hits}, index_root=index_root,
-                             oracle_rels=oracle_rels)["entries"]
+                             oracle_rels=oracle_rels, token=token)["entries"]
 
     return index_rank(cfg, root, q=q, limit=limit, gitignore_filter=drop_ignored,
                       token=token)

--- a/scripts/gen-rank-fixture.ts
+++ b/scripts/gen-rank-fixture.ts
@@ -65,6 +65,13 @@ const paths = [
   // path compare (and by case alone, which is what makes it case-INsensitive).
   "notes/Alpha.txt",
   "notes/alpha.txt",
+  // The reported depth-penalty regression: a vague query ("cccm") where
+  // NEITHER candidate's own name matches at all (tier 3 for both), so before
+  // DEPTH_PENALTY the sort fell through to raw score — where the long
+  // ancestor chain's extra +5 segment-start bonuses made it win purely for
+  // being deep. Same tier, same longestRun; pins that the shallower one wins.
+  "src/chat/ChatInterface/components/MessageList/components/MessageScrollbackRail/index.ts",
+  "cache-config/comp/widget.ts",
 ];
 
 const dirs = new Set([
@@ -85,6 +92,9 @@ const queries = [
   // Ancestor-only (tier 3), a hidden query with a mid-path dot segment,
   // an alpha tie-break, a case-only difference, and a camel-hump name.
   "specs/", "frontend/.", "alpha", "FILE.TXT", "downloadstage",
+  // The depth-penalty regression (see the path pair added above): tier 3 for
+  // every candidate, so this is decided by score/depth alone.
+  "cccm",
 ];
 
 const expected: Record<string, string[]> = {};

--- a/tests/fixtures/rank-parity.json
+++ b/tests/fixtures/rank-parity.json
@@ -254,6 +254,18 @@
       "mtime": 1
     },
     {
+      "rel": "src/chat/ChatInterface/components/MessageList/components/MessageScrollbackRail/index.ts",
+      "is_dir": false,
+      "size": 10,
+      "mtime": 1
+    },
+    {
+      "rel": "cache-config/comp/widget.ts",
+      "is_dir": false,
+      "size": 10,
+      "mtime": 1
+    },
+    {
       "rel": "docs",
       "is_dir": true,
       "size": null,
@@ -398,7 +410,8 @@
     "frontend/.",
     "alpha",
     "FILE.TXT",
-    "downloadstage"
+    "downloadstage",
+    "cccm"
   ],
   "expected": {
     "readme": [
@@ -426,6 +439,7 @@
       "docs/architecture/index.md",
       "index/specs/index-store.md",
       "fused_render/server/routers/index.py",
+      "src/chat/ChatInterface/components/MessageList/components/MessageScrollbackRail/index.ts",
       "tests/test_index_api.py",
       "index/specs",
       "index/store.py",
@@ -492,7 +506,8 @@
       "c/f/g",
       "config.yaml",
       "a/b/config.yaml",
-      "c/f/g/notes.txt"
+      "c/f/g/notes.txt",
+      "cache-config/comp/widget.ts"
     ],
     "fr/fe": [],
     "search": [
@@ -530,6 +545,10 @@
     "downloadstage": [
       "DownloadStage",
       "DownloadStage/notes.txt"
+    ],
+    "cccm": [
+      "cache-config/comp/widget.ts",
+      "src/chat/ChatInterface/components/MessageList/components/MessageScrollbackRail/index.ts"
     ]
   }
 }

--- a/tests/test_index_cancel.py
+++ b/tests/test_index_cancel.py
@@ -78,3 +78,31 @@ def test_binding_a_second_connection_only_interrupts_the_current_one():
     token.cancel()
     assert first.interrupts == 0
     assert second.interrupts == 1
+
+
+def test_unbind_stops_a_later_cancel_from_touching_the_connection():
+    """The disconnect-lands-after-close race (server/routers/index.py):
+    `_watch_disconnect` can call `token.cancel()` after `search_ranked` has
+    already returned and closed its connection. `unbind()` — called in
+    `search_ranked`'s `finally`, right before `con.close()` — is what a later
+    `cancel()` needs to see so it does not call `interrupt()` on a connection
+    that is closed, or about to be: a real duckdb connection raises
+    `ConnectionException` for that, same shape of bug
+    guarded_query.py's own `timer.cancel()`-before-`close()` ordering already
+    exists to avoid for its Timer."""
+    token = CancelToken()
+    con = _FakeConnection()
+    token.bind(con)
+    token.unbind()
+    token.cancel()
+    assert con.interrupts == 0
+    # `cancelled` still flips — `check()` (the between-phase guard) must keep
+    # working even once the connection is gone.
+    assert token.cancelled is True
+
+
+def test_unbind_with_nothing_bound_is_a_safe_no_op():
+    token = CancelToken()
+    token.unbind()  # must not raise
+    token.cancel()
+    assert token.cancelled is True

--- a/tests/test_index_cancel.py
+++ b/tests/test_index_cancel.py
@@ -1,0 +1,80 @@
+"""CancelToken: the plumbing that lets a rank request outlived by its client
+actually stop, rather than running to completion on an abandoned connection.
+
+`asyncio.to_thread` (server/routers/index.py) cannot kill the worker thread it
+dispatches onto, so cancellation has to be cooperative — these tests are
+about the token itself; `search_ranked`'s use of it (the phase-boundary
+`check()` calls, the `duckdb.InterruptException` -> `Cancelled` translation)
+is covered in tests/test_index_search.py alongside the rest of that
+function's tests.
+"""
+import pytest
+
+from fused_render.index.cancel import CancelToken, Cancelled
+
+
+class _FakeConnection:
+    """Stands in for a duckdb connection: `interrupt()` calls are what these
+    tests assert on, and nothing here needs a real database."""
+
+    def __init__(self):
+        self.interrupts = 0
+
+    def interrupt(self):
+        self.interrupts += 1
+
+
+def test_check_is_a_no_op_until_cancelled():
+    token = CancelToken()
+    token.check()  # must not raise
+    assert token.cancelled is False
+
+
+def test_cancel_makes_check_raise():
+    token = CancelToken()
+    token.cancel()
+    assert token.cancelled is True
+    with pytest.raises(Cancelled):
+        token.check()
+
+
+def test_cancel_interrupts_a_bound_connection():
+    token = CancelToken()
+    con = _FakeConnection()
+    token.bind(con)
+    assert con.interrupts == 0
+    token.cancel()
+    assert con.interrupts == 1
+
+
+def test_a_token_cancelled_BEFORE_bind_still_stops_the_connection():
+    """Ordering the plan calls out explicitly: a fast abort that lands before
+    `bind()` (the connect is still in flight) must not be lost — `bind` has to
+    notice the flag is already set and interrupt immediately, or the query
+    would run uninterrupted to completion."""
+    token = CancelToken()
+    token.cancel()
+    con = _FakeConnection()
+    assert con.interrupts == 0
+    token.bind(con)
+    assert con.interrupts == 1
+
+
+def test_cancel_with_nothing_bound_yet_does_not_raise():
+    # No connection to interrupt — must be a safe no-op, not an AttributeError.
+    token = CancelToken()
+    token.cancel()
+    assert token.cancelled is True
+
+
+def test_binding_a_second_connection_only_interrupts_the_current_one():
+    # `bind` is called once per connect; the token only ever knows about the
+    # LATEST connection, which is the only one search_ranked ever has live.
+    token = CancelToken()
+    first = _FakeConnection()
+    token.bind(first)
+    second = _FakeConnection()
+    token.bind(second)
+    token.cancel()
+    assert first.interrupts == 0
+    assert second.interrupts == 1

--- a/tests/test_index_gitignore.py
+++ b/tests/test_index_gitignore.py
@@ -10,6 +10,7 @@ import subprocess
 import time
 from threading import Event, Thread
 
+from fused_render.index.cancel import CancelToken, Cancelled
 from fused_render.index.ignore import norm
 from fused_render.server import index_gitignore
 from fused_render.server.index_gitignore import filter_corpus
@@ -511,6 +512,59 @@ def test_a_waiting_caller_still_sweeps_what_the_other_did_not_cover(tmp_path,
     first.join(timeout=30)
     assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore",
                                                   "proj/a.py", "proj/b.py"]
+
+
+def test_a_cancelled_waiter_stops_in_a_poll_slice_not_the_full_ceiling(
+    tmp_path, monkeypatch,
+):
+    """Section 1, phase 2: an abandoned rank request must not sit out
+    SOMEONE ELSE'S in-flight sweep for up to SWEEP_WAIT_MAX_S (30s) of pure
+    dead time — it should stop in about one `_SWEEP_POLL_S` slice once its own
+    token is cancelled, the same way `test_a_waiting_caller_still_sweeps_...`
+    above proves the ORIGINAL wait-then-sweep behaviour still works when
+    nothing is cancelled."""
+    _fresh_cache(monkeypatch)
+    monkeypatch.setattr(index_gitignore, "SWEEP_WAIT_MAX_S", 30.0)
+    monkeypatch.setattr(index_gitignore, "_SWEEP_POLL_S", 0.05)
+    root, rels = _proj_with_a_log(tmp_path)
+    real = index_gitignore._ignored
+    started = Event()
+
+    def slow(*a, **k):
+        started.set()
+        # Long enough that the second caller's cancellation (below) has to
+        # actually fire for this test to finish quickly, but short enough to
+        # keep the test itself fast — the assertion is on ELAPSED TIME, not
+        # on outliving this sleep.
+        time.sleep(1.0)
+        return real(*a, **k)
+
+    monkeypatch.setattr(index_gitignore, "_ignored", slow)
+    first = Thread(target=lambda: filter_corpus(_out(root, rels), index_root=root))
+    first.start()
+    started.wait(timeout=10)
+
+    token = CancelToken()
+
+    def cancel_soon():
+        time.sleep(0.15)  # a couple of poll slices into the wait
+        token.cancel()
+
+    Thread(target=cancel_soon, daemon=True).start()
+
+    t0 = time.monotonic()
+    try:
+        with_token_raised = False
+        filter_corpus(_out(root, rels + ["proj/b.log", "proj/b.py"]),
+                     index_root=root, token=token)
+    except Cancelled:
+        with_token_raised = True
+    elapsed = time.monotonic() - t0
+    assert with_token_raised
+    # Comfortably under the 30s ceiling — a regression here would time out
+    # this test at 5s+ instead of finishing in well under a second.
+    assert elapsed < 2.0
+    first.join(timeout=30)
 
 
 def test_the_disk_load_does_not_hold_the_cache_lock(tmp_path, monkeypatch):

--- a/tests/test_index_rank.py
+++ b/tests/test_index_rank.py
@@ -82,3 +82,38 @@ def test_the_span_bound_refuses_a_whole_path_smear():
 def test_hidden_entries_need_a_dot_leading_query_segment():
     assert ".env" not in [h["rel"] for h in rank_entries("env", FIXTURE["entries"])]
     assert ".env" in [h["rel"] for h in rank_entries(".env", FIXTURE["entries"])]
+
+
+def _rels(query, entries):
+    return [h["rel"] for h in rank_entries(query, [{"rel": r} for r in entries])]
+
+
+def test_a_shallow_name_match_beats_a_deep_ancestor_only_match():
+    """A vague query where the deep candidate's own name doesn't match at all
+    (tier 3) must not beat a shallow candidate whose name matches, even
+    fuzzily (tier 2) — this is `tier` doing its job, not the depth penalty,
+    but it's the floor the penalty is layered on top of."""
+    deep = "a/b/c/d/e/f/g/h/notes.txt"
+    shallow = "cfg-manager.txt"
+    assert _rels("cfg", [deep, shallow])[0] == shallow
+
+
+def test_a_deep_scattered_ancestor_only_match_no_longer_wins_on_score_alone():
+    """The reported bug: a vague query where NOBODY's own name matches (tier 3
+    for everyone), so the sort falls through to raw score — where a long
+    ancestor chain simply offers more +5 segment-start bonuses than a short
+    one, independent of relevance. Same tier, same longest_run (a scattered
+    subsequence for both), so this is decided by score/depth alone — exactly
+    the case DEPTH_PENALTY exists for. Mirrors search.test.ts's identical
+    case, which is where this pair was found."""
+    deep = ("src/chat/ChatInterface/components/MessageList/components/"
+            "MessageScrollbackRail/index.ts")
+    shallow = "cache-config/comp/widget.ts"
+    assert _rels("cccm", [deep, shallow])[0] == shallow
+
+
+def test_a_deep_exact_name_match_still_wins_over_a_shallow_fuzzy_one():
+    """The penalty must not swamp the +100 exact-name bonus."""
+    deep = "a/b/c/d/e/f/g/h/exact-match.txt"
+    shallow = "s/fuzzy-only.txt"
+    assert _rels("exact-match.txt", [shallow, deep])[0] == deep

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -628,9 +628,12 @@ def test_an_interrupt_attributed_to_the_token_becomes_cancelled(tmp_path, monkey
             self._real = real
 
         def execute(self, sql, *a, **kw):
-            # Only pass_over's own SELECT — search_ranked runs several OTHER
-            # execute() calls first (_coverage_reason, _ignore_roots) that are
-            # not wrapped in the try/except this test is targeting.
+            # Only pass_over's own SELECT. search_ranked runs several OTHER
+            # execute() calls first (_coverage_reason, _ignore_roots) — those
+            # are covered by their own tests below
+            # (test_a_coverage_check_interrupt_*, test_an_ignore_roots_*); this
+            # one is scoped to pass_over's SELECT specifically so a change to
+            # either of the earlier queries cannot accidentally satisfy it.
             if "SELECT rel, size, mtime, is_dir FROM" in sql:
                 # The real cross-thread sequence: `cancel()` flips the flag
                 # AND calls interrupt(), which is what makes THIS raise.
@@ -683,6 +686,78 @@ def test_an_interrupt_with_no_token_is_not_swallowed_as_cancellation(tmp_path, m
                         lambda *a, **kw: _SpyConnection(real_connect(*a, **kw)))
     with pytest.raises(duckdb_module.InterruptException):
         search_ranked(cfg, "/r", "readme.md")
+
+
+def test_a_coverage_check_interrupt_attributed_to_the_token_becomes_cancelled(
+    tmp_path, monkeypatch
+):
+    """`_coverage_reason` runs its own `execute()` on the SAME bound
+    connection, before `pass_over` ever runs — `token.bind(con)` binds the
+    whole connection, not just pass_over's statement, so `con.interrupt()` can
+    land here too. A normal superseded keystroke landing exactly here must not
+    surface as a raw `duckdb.InterruptException` (a 500, and log noise) any
+    more than one landing in pass_over does."""
+    import duckdb as duckdb_module
+
+    cfg = _index(tmp_path, "/r", ["/r/readme.md"])
+    token = CancelToken()
+
+    class _SpyConnection:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, sql, *a, **kw):
+            if "FROM " in sql and "WHERE dir = " in sql:
+                token.cancel()
+                raise duckdb_module.InterruptException(
+                    "simulated cross-thread interrupt during coverage check"
+                )
+            return self._real.execute(sql, *a, **kw)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    real_connect = duckdb_module.connect
+    monkeypatch.setattr(duckdb_module, "connect",
+                        lambda *a, **kw: _SpyConnection(real_connect(*a, **kw)))
+    with pytest.raises(Cancelled):
+        search_ranked(cfg, "/r", "readme.md", token=token)
+
+
+def test_an_ignore_roots_interrupt_attributed_to_the_token_becomes_cancelled(
+    tmp_path, monkeypatch
+):
+    """`_ignore_roots` runs on the same bound connection too, and only when a
+    `gitignore_filter` is supplied (search_ranked's caller, server/routers/
+    index.py, always supplies one) — so a client abort landing in the
+    gitignore-root discovery query must also come out as `Cancelled`, not an
+    unhandled `duckdb.InterruptException`."""
+    import duckdb as duckdb_module
+
+    cfg = _index(tmp_path, "/r", ["/r/readme.md"])
+    token = CancelToken()
+
+    class _SpyConnection:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, sql, *a, **kw):
+            if "/.gitignore" in sql:
+                token.cancel()
+                raise duckdb_module.InterruptException(
+                    "simulated cross-thread interrupt during ignore-roots discovery"
+                )
+            return self._real.execute(sql, *a, **kw)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    real_connect = duckdb_module.connect
+    monkeypatch.setattr(duckdb_module, "connect",
+                        lambda *a, **kw: _SpyConnection(real_connect(*a, **kw)))
+    with pytest.raises(Cancelled):
+        search_ranked(cfg, "/r", "readme.md", token=token,
+                      gitignore_filter=lambda root, es, oracles: es)
 
 
 def test_search_ranked_filters_gitignored_entries_BEFORE_cutting_to_limit(tmp_path):

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -4,6 +4,8 @@
 mtime), so the client's fuzzy scoring is untouched by where the corpus came
 from — the only difference is that this one is instant and cross-session.
 """
+import asyncio
+import logging
 import os
 
 import pyarrow as pa
@@ -11,6 +13,7 @@ import pyarrow.parquet as pq
 import pytest
 from fastapi.testclient import TestClient
 
+from fused_render.index.cancel import CancelToken, Cancelled
 from fused_render.index.config import IndexConfig, load_config
 from fused_render.index.query import search_ranked, search_under
 from fused_render.index.runner import canonical_root
@@ -294,6 +297,65 @@ def test_rank_route_requires_a_root(home, tmp_path):
     assert resp.status_code == 400
 
 
+def test_rank_route_answers_a_disconnected_client_with_a_quiet_499(
+    home, tmp_path, monkeypatch, caplog,
+):
+    """The end-to-end shape of section 1: an abandoned request is cancelled,
+    answered with a body nobody reads, and does NOT log as an error — a
+    cancelled rank is normal operation for a per-keystroke request, the same
+    reasoning the candidate-cap DEBUG line already applies.
+
+    `_rank_body` is monkeypatched to a controllable stand-in rather than a
+    real (tiny, near-instant) index: the real query would very likely finish
+    before `_watch_disconnect` — polling an ALWAYS-disconnected fake request —
+    gets scheduled at all, making the outcome a coin flip on scheduling order
+    instead of a pinned behaviour. The stand-in sleeps briefly (blocking only
+    its OWN worker thread — asyncio.to_thread — never the event loop the
+    watcher runs on) and then consults the very token `api_index_rank` handed
+    it, exactly as the real `search_ranked` does."""
+    from fused_render.index.cancel import Cancelled
+    from fused_render.server.routers import index as index_router
+
+    def slow_cancellable_rank(cfg, root, q, limit, token=None):
+        import time as _time
+
+        _time.sleep(0.05)
+        if token is not None and token.cancelled:
+            raise Cancelled()
+        return {"covered": True, "hits": [], "truncated": False, "total": 0,
+                "escalated": False, "reason": ""}
+
+    monkeypatch.setattr(index_router, "_rank_body", slow_cancellable_rank)
+
+    class _DisconnectedRequest:
+        async def is_disconnected(self):
+            return True
+
+    with caplog.at_level(logging.DEBUG):
+        resp = asyncio.run(
+            index_router.api_index_rank(
+                request=_DisconnectedRequest(), root=str(tmp_path), q="x", limit=10))
+    assert resp.status_code == 499
+    # Debug is fine (and expected — the "abandoned by the client" line); an
+    # ERROR-or-louder record would mean this is being treated as a failure.
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+    assert any("abandoned by the client" in r.message for r in caplog.records)
+
+
+def test_rank_route_is_unaffected_by_cancellation_machinery_when_nothing_disconnects(
+    home, tmp_path,
+):
+    """Regression: a normal (non-abandoned) request must answer exactly as it
+    did before section 1 — the async rewrite and the CancelToken plumbing
+    must be invisible to the common case."""
+    root = str(tmp_path / "proj")
+    client = _ranked_client(tmp_path, root, [root + "/readme.md", root + "/other.bin"])
+    body = client.get("/api/index/rank",
+                      params={"root": root, "q": "readme.md"}).json()
+    assert body["ok"] is True and body["covered"] is True
+    assert body["hits"][0]["rel"] == "readme.md"
+
+
 def test_rank_route_filters_a_gitignored_dir_under_a_NON_repo_root(home, tmp_path):
     """The hole a narrowed payload opens, closed.
 
@@ -471,6 +533,156 @@ def test_search_ranked_is_a_quiet_miss_on_an_uncovered_root(tmp_path):
     cfg = _index(tmp_path, "/r", ["/r/alpha.txt"])
     out = search_ranked(cfg, "/elsewhere", "alpha")
     assert out["covered"] is False and out["hits"] == []
+
+
+# -- cancellation: a `token` handed to search_ranked -------------------------
+#
+# `asyncio.to_thread` (server/routers/index.py) cannot kill the thread it
+# dispatches search_ranked onto, so cancelling has to make the QUERY itself
+# return — CancelToken.check() at the phase boundaries in `pass_over`.
+# CancelToken's own bind/cancel/check mechanics (the interrupt() plumbing) are
+# unit-tested in isolation in tests/test_index_cancel.py; these are about
+# search_ranked actually consulting the token it is handed.
+
+def test_an_uncancelled_token_changes_nothing(tmp_path):
+    """Regression: passing a token that is never cancelled must be byte-
+    identical to not passing one at all."""
+    cfg = _index(tmp_path, "/r", ["/r/readme.md", "/r/unrelated.bin"])
+    token = CancelToken()
+    with_token = search_ranked(cfg, "/r", "readme.md", token=token)
+    without_token = search_ranked(cfg, "/r", "readme.md")
+    # `age_s` is a wall-clock measurement taken independently by each call, so
+    # it is the one field expected to differ between two otherwise-identical
+    # calls made microseconds apart.
+    with_token.pop("age_s")
+    without_token.pop("age_s")
+    assert with_token == without_token
+
+
+def test_a_token_cancelled_before_the_call_raises_promptly(tmp_path):
+    """The between-passes check is the highest-value one (the plan's own
+    words) — cancelled BEFORE the call is the simplest case that exercises it:
+    `pass_over`'s very first `check()`, ahead of any SQL at all."""
+    cfg = _index(tmp_path, "/r", ["/r/readme.md"])
+    token = CancelToken()
+    token.cancel()
+    with pytest.raises(Cancelled):
+        search_ranked(cfg, "/r", "readme.md", token=token)
+
+
+def test_a_cancelled_token_still_closes_the_connection(tmp_path, monkeypatch):
+    """The `finally: con.close()` this section adds must run on the
+    `Cancelled` path too, not only on a normal return.
+
+    A real `duckdb.DuckDBPyConnection`'s methods are read-only C-extension
+    attributes (assigning `con.close = ...` raises AttributeError), so this
+    wraps the connection in a thin delegating proxy rather than patching the
+    method in place — `search_ranked` only ever calls a handful of methods on
+    `con`, and `__getattr__` forwards everything else untouched."""
+    import duckdb as duckdb_module
+
+    cfg = _index(tmp_path, "/r", ["/r/readme.md"])
+    closed = []
+
+    class _SpyConnection:
+        def __init__(self, real):
+            self._real = real
+
+        def close(self):
+            closed.append(True)
+            self._real.close()
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    real_connect = duckdb_module.connect
+    monkeypatch.setattr(duckdb_module, "connect",
+                        lambda *a, **kw: _SpyConnection(real_connect(*a, **kw)))
+    token = CancelToken()
+    token.cancel()
+    with pytest.raises(Cancelled):
+        search_ranked(cfg, "/r", "readme.md", token=token)
+    assert closed == [True]
+
+
+def test_an_interrupt_attributed_to_the_token_becomes_cancelled(tmp_path, monkeypatch):
+    """The other path into `Cancelled`, alongside the between-phase `check()`
+    calls: an `execute()` that raises `duckdb.InterruptException` while THIS
+    token is the one that called `interrupt()` (the case a real cross-thread
+    cancel lands mid-statement, which `check()` between phases cannot reach)
+    must still come out as `Cancelled`, not a raw duckdb exception.
+
+    Forcing a REAL mid-statement interrupt deterministically needs a query
+    slow enough to race a background thread against — exactly
+    test_index_guarded_query.py's `test_a_runaway_statement_is_interrupted`,
+    which already pins that duckdb's own interrupt() does what this relies
+    on. This test is about search_ranked's OWN logic: given that exception,
+    with a token that says it caused it, the result is `Cancelled`."""
+    import duckdb as duckdb_module
+
+    cfg = _index(tmp_path, "/r", ["/r/readme.md"])
+    token = CancelToken()
+
+    class _SpyConnection:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, sql, *a, **kw):
+            # Only pass_over's own SELECT — search_ranked runs several OTHER
+            # execute() calls first (_coverage_reason, _ignore_roots) that are
+            # not wrapped in the try/except this test is targeting.
+            if "SELECT rel, size, mtime, is_dir FROM" in sql:
+                # The real cross-thread sequence: `cancel()` flips the flag
+                # AND calls interrupt(), which is what makes THIS raise.
+                token.cancel()
+                raise duckdb_module.InterruptException("simulated cross-thread interrupt")
+            return self._real.execute(sql, *a, **kw)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    real_connect = duckdb_module.connect
+    monkeypatch.setattr(duckdb_module, "connect",
+                        lambda *a, **kw: _SpyConnection(real_connect(*a, **kw)))
+    with pytest.raises(Cancelled):
+        search_ranked(cfg, "/r", "readme.md", token=token)
+
+
+def test_an_interrupt_with_no_token_is_not_swallowed_as_cancellation(tmp_path, monkeypatch):
+    """An interrupted connection that ISN'T this function's doing (no token at
+    all — someone else's timeout, or a genuine duckdb abort) must keep
+    surfacing as a real error rather than being read as `Cancelled`.
+
+    duckdb only actually raises `InterruptException` while a query is
+    genuinely running (a plain `interrupt()` before any query starts is a
+    no-op — verified directly against real duckdb, not asserted from memory),
+    which is awkward to force deterministically in a unit test. The exception
+    handling this section adds is tested directly instead: `con.execute`
+    raising `InterruptException` with no token bound must propagate, not
+    become `Cancelled`. The Timer-forced REAL interrupt is already covered
+    for this exact exception class by
+    test_index_guarded_query.py::test_a_runaway_statement_is_interrupted."""
+    import duckdb as duckdb_module
+
+    cfg = _index(tmp_path, "/r", ["/r/readme.md"])
+
+    class _SpyConnection:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, sql, *a, **kw):
+            if "SELECT rel, size, mtime, is_dir FROM" in sql:
+                raise duckdb_module.InterruptException("simulated, not this token's doing")
+            return self._real.execute(sql, *a, **kw)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    real_connect = duckdb_module.connect
+    monkeypatch.setattr(duckdb_module, "connect",
+                        lambda *a, **kw: _SpyConnection(real_connect(*a, **kw)))
+    with pytest.raises(duckdb_module.InterruptException):
+        search_ranked(cfg, "/r", "readme.md")
 
 
 def test_search_ranked_filters_gitignored_entries_BEFORE_cutting_to_limit(tmp_path):

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -760,6 +760,27 @@ def test_an_ignore_roots_interrupt_attributed_to_the_token_becomes_cancelled(
                       gitignore_filter=lambda root, es, oracles: es)
 
 
+def test_a_cancel_after_search_ranked_returns_does_not_touch_the_closed_connection(
+    tmp_path,
+):
+    """The real disconnect-lands-after-close race (server/routers/index.py):
+    `_watch_disconnect` can call `token.cancel()` after `search_ranked` has
+    already returned NORMALLY and closed its connection — a fast typist's
+    keystroke landing a beat too late to matter, not a mid-query interrupt at
+    all. `search_ranked`'s `finally` must `token.unbind()` before
+    `con.close()`, or this `cancel()` calls `interrupt()` on an already-closed
+    real `duckdb.DuckDBPyConnection`, which raises `duckdb.ConnectionException`
+    — on a task nothing ever retrieves the result of once the route only
+    `.cancel()`s it, so a perfectly normal disconnect would surface as nothing
+    but an unhandled "Task exception was never retrieved" warning."""
+    cfg = _index(tmp_path, "/r", ["/r/readme.md"])
+    token = CancelToken()
+    search_ranked(cfg, "/r", "readme.md", token=token)
+    # Must not raise.
+    token.cancel()
+    assert token.cancelled is True
+
+
 def test_search_ranked_filters_gitignored_entries_BEFORE_cutting_to_limit(tmp_path):
     """Filtering after the cut is what makes today's corpus report `truncated`
     while holding fewer rows than it says: the cap was spent on entries that


### PR DESCRIPTION
## Summary

Fixes to the explorer home search, all driven by things the box got visibly wrong while typing. Several are the same defect in different clothes: **the UI and the Enter key disagreed about what was selected.**

- **The selection is now honest.** Enter always opened the top hit, but nothing was highlighted until you pressed ↓ — `activeRow` returned `null` for the very case `submitRow` resolved to row 0. Two functions, two answers to "what row is Enter on". They're collapsed into one rule, so the row Enter commits is the row you can see. The AI row's `↵` badge was unconditional for the same reason and now shows only when Enter would actually run it.
- **A keystroke can no longer strand work on the server.** Aborting the fetch used to stop at the browser: `/api/index/rank` was a sync route on the anyio threadpool, so every superseded keystroke ran both duckdb ladder passes, the Python ranking, and a gitignore sweep that could block 30s — into the void. The route is now `async`, races the worker thread against a disconnect watcher, and a new `CancelToken` calls `con.interrupt()` to unblock duckdb mid-statement.
- **Deep paths stop winning vague queries.** Scoring runs over the whole rel at +5 per segment start, so on a scattered match everyone tied on `longestRun`/`tier` and the *longest* path won by construction — `depth` was the 4th sort key and effectively never fired. A per-segment depth penalty cancels the accumulation.
- **A pasted absolute path is recognized while you type.** `pathShortcut` already existed but was only consulted on Enter, so pasting a path rendered "No file name matched" and pre-armed a paid AI call — while Enter would in fact have navigated. Every pixel said the opposite of what the gesture did.
- **Smaller box fixes:** no request below 2 characters, top 20 instead of 10, held rows narrowed locally instead of dimmed, the list's height bound made viewport-relative (`max(440px, calc(100dvh - 11rem))` — 440px was a hard-coded laptop bound that scrolled a tall window at row 13 with 800px sitting empty), and the "Search with AI" row no longer borrows the selection highlight.

## Visuals

What one keystroke now does, before any request is issued:

```mermaid
flowchart TD
    K[Keystroke] --> A{Path-shaped?}
    A -->|yes| O[Stat live, Open row, no rank call]
    A -->|no| M{2+ chars?}
    M -->|no| T[Keep typing…]
    M -->|yes| R[Debounced rank call, previous aborted]
    R --> N[Narrow held rows, then paint]
```

The AI row also changed from an accent-washed list row into a sticky footer band, because a background wash was already the app's selection signal — one CSS property was carrying two unrelated meanings in the same list. UI screenshots are worth attaching on review.

## Usage

Nothing new is invocable; this is all in the home search box (`/` or `/home`). To see each change:

| Change | How to see it |
|---|---|
| Min length | Type one character — "Keep typing…", no network request |
| Cap 20 | Any broad query; note the count reads "Showing top 20 of N" |
| Selection honesty | Type a query — the top hit is highlighted before you touch a key; the AI row shows no `↵` until you arrow onto it |
| List height | Any broad query on a tall window — all 20 rows, no scrollbar |
| Path detection | Paste any absolute path — an **Open** row appears, no AI row |
| Local narrowing | Type fast on a big home; rows narrow instead of dimming |
| Cancellation | Type fast and watch the server log — superseded ranks now stop |

Tunables, all commented at their definitions: `MIN_QUERY_CHARS`, `HOME_RESULT_CAP`, `STALE_CLEAR_MS` (`instant-search.ts`), `DEPTH_PENALTY` / `SHALLOW_FREE` (`search.ts` + `rank.py`).

## Test Plan

- [x] **Cross-language rank parity regenerated.** `search.ts` is the authority, `rank.py` mirrors it, `tests/fixtures/rank-parity.json` regenerated via `bun scripts/gen-rank-fixture.ts`; asserted in both `tests/test_index_rank.py` and `listing/rank-parity.test.ts`. The fixture gained the reported deep-vs-shallow shape.
- [x] **New Python tests:** `test_index_cancel.py` (token binds/interrupts, cancel-before-bind ordering), `test_index_gitignore.py` (sliced sweep wait), additions to `test_index_rank.py` and `test_index_search.py`.
- [x] **New frontend tests:** `FilesHome.render.test.tsx`, plus additions to `home-search.test.ts`, `instant-search.test.ts`, `search.test.ts`. The keyboard-walk tests were rewritten against the new `RowModel` descriptor, which replaces the old "AI row index is always `fileCount`" arithmetic that the Open row invalidates, and again for the pre-selected top hit (first ↓ must land on row 1, not row 0).
- [x] **Two test-isolation bugs fixed, not worked around.** `mock.module("@platform/lib/api", …)` leaked across the whole bun process and could not be reliably undone — replaced with `globalThis.fetch` stubbing, the technique the neighbouring tests already use. A module-level index-lifecycle store also leaked state between tests (`"Searching…"` arriving as `"Searching…indexing…"`); it's now reset per test. Three apparently unrelated `fs-actions`/`fs-move` timeouts were casualties of the same leak.
- [x] **Local frontend:** `bun test` green in a single process (CI's shape), run twice.
- [x] **Local Python:** no regressions. Remaining local failures are pre-existing/environmental, each confirmed with an empty `git diff a28e6e49 HEAD -- <file>`: missing `rasterio`/`joblib` in this venv, a real `claude` binary on the dev machine defeating "nothing installed" fixtures, and two template dirs sharing a `tests/test_reader.py` with no `__init__.py`.
- [ ] **CI green** — `frontend` and `bundle-contents` pass; `test-python` (3.10–3.13) and the desktop jobs are running. This PR stays a draft until they finish. Note `test-python` was *skipped* on earlier runs by design: it declares `needs: frontend`, and `bun test` runs inside that job.
- [ ] **Manual:** paste a path that does *not* exist (must fall back to searching), a path with surrounding quotes and a `file://` prefix (must normalize), and confirm ↑/↓ wrap-around still reaches both the Open row and the AI row.

Branch is based on `a28e6e49`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
