### PR TITLE
Tasks: file-only scope mark, past-time button says Create

### DIFF
--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1773,30 +1773,33 @@ export function composeTaskMessage(title: string, description: string): string {
 //
 //   Schedule — the picked time is still ahead, or the task repeats. Something is
 //              being written into the future, and nothing runs on this press.
-//   Run      — the time is now or already past, which is what a card opened from
-//              the List or the Board and left alone means. The press starts work.
+//   Create   — the time is now or already past, which is what a card opened from
+//              the List or the Board and left alone means. It briefly said "Run"
+//              (2026-08-23), but the press creates the task — the run is a
+//              consequence — and "Run" over-promised on a card that may still be
+//              being written (Akshil, 2026-08-25).
 //
 // A repeat is always "Schedule" even when its anchor is behind: a past anchor
-// gets ONE catch-up run and then a pattern, and "Run" would describe the catch-up
-// while saying nothing about the standing rule, which is the bigger fact.
+// gets ONE catch-up run and then a pattern, and "Create" would describe the
+// catch-up while saying nothing about the standing rule, which is the bigger fact.
 //
 // An EDIT reads by the same rule rather than reverting to "Save": moving a task's
 // time forward and moving it into the past are the two things an edit does here,
 // and they deserve the same two words a create gets.
 //
 // Minute precision, matching the field and `pastNoteFor`: a card opened on the
-// current minute and saved unchanged says Run, not Schedule.
+// current minute and saved unchanged says Create, not Schedule.
 export function saveActionLabel(
   picked: Date | null,
   repeatOn: boolean,
   now: Date,
-): "Schedule" | "Run" {
+): "Schedule" | "Create" {
   if (repeatOn) return "Schedule";
   // An unreadable date cannot be claimed to run now. Save is refused on it
   // anyway (saveBlockedReason), so this is only about which word the disabled-
   // looking button wears.
   if (!picked || Number.isNaN(picked.getTime())) return "Schedule";
-  return startOfMinute(picked) > startOfMinute(now) ? "Schedule" : "Run";
+  return startOfMinute(picked) > startOfMinute(now) ? "Schedule" : "Create";
 }
 
 // The body POSTed to /api/schedule — api.ts's own parameter type, nothing
@@ -2881,7 +2884,7 @@ export default function NewJobModal({
               mid-save would schedule the message twice. */}
           <button type="button" className="btn btn-primary schedule-save"
                   disabled={busy} aria-disabled={!ready} onClick={trySubmit}>
-            {busy ? `${actionLabel === "Run" ? "Running" : "Scheduling"}…` : actionLabel}
+            {busy ? `${actionLabel === "Create" ? "Creating" : "Scheduling"}…` : actionLabel}
           </button>
         </>
       }

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -2202,24 +2202,12 @@ function TaskNode({
             The live ping used to sit here (see LivePulse's headstone above): a
             blue disc in the one position, and the one shape, that means unread
             everywhere else. This is a hollow outline and never blue. */}
-        {/* ONE MARK, EITHER WAY (Akshil, 2026-08-24): the file glyph on a task
-            about a document, the folder glyph on a task about its folder — "if
-            there is a file icon already there then we don't add folder icon, if
-            file icon not present then we add a folder icon". Never both, because
-            they are two answers to the SAME question and a row wearing both
-            would be claiming both.
-
-            This is the other half of taking the glyph off the folder chip
-            (IdentityChip's note). There it was decoration on a word that already
-            said "folder"; here it is the row's answer to what the task is about,
-            in the position the file mark already held — so the mark a reader
-            learns is "the thing after the title tells me the scope", with two
-            values instead of one-value-or-nothing.
-
-            The FOLDER arm is the common case, so its tooltip has to be worth
-            having on nearly every row: it names the project path, the same
-            string the chip at the far end of the row carries — deliberately,
-            because the two are one hover habit.
+        {/* FILE MARK ONLY (Akshil, 2026-08-25: "drop the folder icon, keep the
+            file icon as is"). The folder arm briefly lived here as the fallback
+            (2026-08-24's one-mark-either-way rule), but a folder-scoped task is
+            the common case and the mark restated what the folder chip at the
+            row's far end already says — so the glyph is back to marking the one
+            genuinely extra fact: this task is about a single document.
 
             A NATIVE `title`, like every caption on this row (2026-08-24, third
             pass): the custom panel drew displaced from what it captioned, and
@@ -2233,14 +2221,6 @@ function TaskNode({
             aria-label={`This task is about ${basename(taskFile_)}`}
           >
             {ICON_FILE}
-          </span>
-        ) : task.project ? (
-          <span
-            className="tasks-row-file"
-            data-hint={tildePath(task.project, home)}
-            aria-label={`This task is about the folder ${basename(task.project)}`}
-          >
-            {ICON_FOLDER}
           </span>
         ) : null}
 

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1755,17 +1755,17 @@ describe("what the primary button says it will do", () => {
     expect(saveActionLabel(new Date("2026-09-01T08:00:00"), false, now)).toBe("Schedule");
   });
 
-  test("now, or already past, is a Run", () => {
+  test("now, or already past, is a Create", () => {
     // MINUTE precision, matching the field: a card opened on this minute and
     // saved unchanged runs, and must not offer to schedule the moment it is in.
-    expect(saveActionLabel(new Date("2026-08-17T09:00:40"), false, now)).toBe("Run");
-    expect(saveActionLabel(new Date("2026-08-17T08:59:00"), false, now)).toBe("Run");
-    expect(saveActionLabel(new Date("2026-08-10T09:00:00"), false, now)).toBe("Run");
+    expect(saveActionLabel(new Date("2026-08-17T09:00:40"), false, now)).toBe("Create");
+    expect(saveActionLabel(new Date("2026-08-17T08:59:00"), false, now)).toBe("Create");
+    expect(saveActionLabel(new Date("2026-08-10T09:00:00"), false, now)).toBe("Create");
   });
 
   test("a repeat is always a Schedule, past anchor included", () => {
     // A past anchor gets ONE catch-up run and then a standing pattern, and the
-    // pattern is the bigger fact — "Run" would name the catch-up and hide it.
+    // pattern is the bigger fact — "Create" would name the catch-up and hide it.
     expect(saveActionLabel(new Date("2026-08-10T09:00:00"), true, now)).toBe("Schedule");
     expect(saveActionLabel(new Date("2026-09-10T09:00:00"), true, now)).toBe("Schedule");
   });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -4263,7 +4263,8 @@ describe("every caption on a row is an INSTANT hint", () => {
     // resolver stops at it instead of walking up. That survived two rewrites of
     // the mechanism underneath.
     expect(ROW).toContain("data-hint={tildePath(taskFile_, home)}");
-    expect(ROW).toContain("data-hint={tildePath(task.project, home)}");
+    // The folder glyph's own hint left with the glyph (2026-08-25) — the folder
+    // chip still captions the path through IdentityChip's `title` prop.
     expect(ROW).toContain('data-hint={`${shown} message${shown === 1 ? "" : "s"} in this task`}');
     expect(ROW).toContain("data-hint={when.title}");
     // The stretched link stays silent so the row's own title is the one copy of
@@ -7080,17 +7081,14 @@ describe("the file mark after a task's title", () => {
     expect(VIEWS).toContain("{ICON_FILE}");
   });
 
-  it("falls back to a FOLDER glyph in the same slot, never both", () => {
-    // Akshil, 2026-08-24: the folder icon came off the folder chip (where it
-    // restated the one thing that chip cannot be mistaken about) and landed
-    // here, on the tasks that have no file mark — "if there is a file icon
-    // already there then we don't add folder icon, if file icon not present then
-    // we add a folder icon". A ternary, not two guards, because the two are
-    // answers to the SAME question (what is this task about) and a row wearing
-    // both would be claiming both.
+  it("renders nothing on a folder task — the file mark has no fallback", () => {
+    // Akshil, 2026-08-25: "drop the folder icon, keep the file icon as is". The
+    // folder glyph briefly filled this slot on file-less tasks (2026-08-24's
+    // one-mark-either-way rule), but folder-scoped is the common case and the
+    // mark restated what the folder chip at the row's far end already says — so
+    // the slot is back to file-or-nothing.
     expect(VIEWS).toContain("{taskFile_ ? (");
-    expect(VIEWS).toContain("{ICON_FOLDER}");
-    expect(VIEWS).toContain("data-hint={tildePath(task.project, home)}");
+    expect(VIEWS).not.toContain('aria-label={`This task is about the folder ');
     // The glyph really is gone from inside the chip: its body is the name alone.
     expect(VIEWS).toContain('const body = <span className="schedule-tv-id-name">{name}</span>;');
   });


### PR DESCRIPTION
Two small task-view changes (Akshil, 2026-08-25):

**Task List row — drop the folder icon, keep the file icon.** The scope glyph after the title is file-or-nothing again. The folder fallback (added 2026-08-24) marked the common case and restated what the folder chip at the row's far end already says.

**New-task card — past/now time says "Create", not "Run".** `saveActionLabel` returns `"Schedule" | "Create"`; busy label is "Creating…". Future times and repeats still say "Schedule".

Tests updated (`tasks-lib.test.ts`, `new-task-form.test.ts`); shell suite 860 pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and conditional-render changes in the task shell with no API or scheduling logic touched; tests were updated accordingly.
> 
> **Overview**
> Two **copy and UI affordance** tweaks on tasks, with tests aligned to the new behavior.
> 
> **New-task card primary action** — For a one-off whose time is **now or in the past** (minute precision, unchanged), the footer button says **`Create`** instead of **`Run`**, and the in-flight label is **`Creating…`** instead of **`Running…`**. **`saveActionLabel`** now returns `"Schedule" | "Create"`; future times and any repeat still use **Schedule** / **Scheduling…**. Scheduling logic is unchanged; only the wording reflects that the press **creates the task** and execution is a follow-on.
> 
> **Task list scope mark** — The glyph after the title is **file-only** again: **`ICON_FILE`** when the task targets a document, **nothing** for folder-scoped tasks. The **folder fallback** added 2026-08-24 is removed so the common case does not duplicate the folder chip at the row’s end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f2739740a07045dcb1f718a55671dfb50bb3e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->