### PR TITLE
download page: make it work under a path prefix

### DIFF
--- a/scripts/download_page/about.html
+++ b/scripts/download_page/about.html
@@ -9,6 +9,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Fused Render — why we built it</title>
+<link rel="canonical" href="https://render.fused.io/about.html">
 <meta name="description" content="The ethos and architecture of Fused Render: local-first file rendering, renderable HTML, and Python as the compute engine.">
 <script type="application/fused-bundle">
 { "include": ["index.html", "assets/*.jpg"] }

--- a/scripts/download_page/ai.html
+++ b/scripts/download_page/ai.html
@@ -14,7 +14,7 @@
 
      Every visual is drawn in CSS with real text content — no screenshots, no
      web fonts, no third-party scripts. The only network call at load is
-     same-origin /latest.json for the download links, exactly as ai.html and
+     same-origin latest.json for the download links, exactly as ai.html and
      index.html do it. That is also the claim the page makes about itself. -->
 <html lang="en">
 <head>
@@ -28,6 +28,7 @@
 <meta property="og:title" content="AI that lives on your computer">
 <meta property="og:description" content="Make small tools that do your work for you, and run them offline against your own files. Your files stay on your machine.">
 <meta property="og:url" content="https://render.fused.io/ai.html">
+<link rel="canonical" href="https://render.fused.io/ai.html">
 <meta property="og:image" content="https://render.fused.io/og-image.png">
 <meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1200">
@@ -1077,7 +1078,9 @@
   // ---- download links -------------------------------------------------
   // Same contract as index.html and ai.html: the buttons work before this
   // resolves and simply stay pointed at the releases page if it fails.
-  fetch("/latest.json", { cache: "no-cache" })
+  // Relative, not root-absolute: see the note in index.html -- the page is
+  // also proxied at www.fused.io/render/, where /latest.json is not ours.
+  fetch("latest.json", { cache: "no-cache" })
     .then(function (r) { return r.ok ? r.json() : null; })
     .then(function (m) {
       if (!m) return;

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -3,7 +3,7 @@
      partitioned hierarchy, dressed in the editorial variant's quiet monochrome
      paper-and-ink aesthetic. Content and hierarchy follow ai.html verbatim.
      Dark is home; light stays reachable via data-theme="light". Zero external requests:
-     system fonts, relative assets/*, same-origin /latest.json. -->
+     system fonts, relative assets/*, same-origin latest.json. -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -18,6 +18,8 @@
 <meta property="og:url" content="https://render.fused.io/">
 <meta property="og:image" content="https://render.fused.io/og-image.png">
 <meta name="twitter:card" content="summary_large_image">
+<!-- This page is also proxied at www.fused.io/render/; render.fused.io is canonical. -->
+<link rel="canonical" href="https://render.fused.io/">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><text y='26' font-size='28' fill='%23E5FF44'>%E2%9C%A6</text></svg>">
 <script type="application/fused-bundle">
 { "include": ["about.html", "ai.html", "assets/*.jpg", "assets/showcase/*.jpg", "assets/showcase/*.png"] }
@@ -1419,7 +1421,10 @@
   // ---- release manifest ----
   // The links already work before this resolves, and simply stay pointed at
   // the releases page if it never does.
-  fetch("/latest.json", { cache: "no-cache" })
+  // Relative, not root-absolute: the page is also proxied at
+  // www.fused.io/render/ (kgateway HTTPRoute -> this CDN), where a
+  // root-absolute /latest.json would hit the fused.io app instead.
+  fetch("latest.json", { cache: "no-cache" })
     .then(function (r) { if (!r.ok) throw new Error(String(r.status)); return r.json(); })
     .then(function (m) {
       var v = document.getElementById("version");


### PR DESCRIPTION
## Summary

- Makes the download page work when served under a path prefix, not just at the CDN root. `fusedlabs/application#7952` proxies `www.fused.io/render/` onto the same CloudFront distribution, and on that host the fused.io app owns `/latest.json`.
- `index.html` and `ai.html` fetched the manifest root-absolute, so under the prefix the request would be answered by the fused.io Next.js app: the version pill would stay hidden and every download button would stay pointed at the GitHub releases page. Both now fetch `latest.json` relative, which resolves correctly at `render.fused.io/` **and** at `www.fused.io/render/`.
- Adds `rel=canonical` to all three pages so the second live copy doesn't split SEO. `render.fused.io` stays canonical.
- Nothing else needed changing — `assets/*`, `about.html`, and `index.html` links were already relative.

## Visuals

The one link that broke under a prefix, and where it lands now:

```mermaid
flowchart TD
    P["page at /render/"] -->|"before: /latest.json"| A["fused.io Next.js app"]
    P -->|"after: latest.json"| M["/render/latest.json"]
    M --> C["CloudFront -> fused-render bucket"]
    A --> X["no manifest: empty version pill"]
```

## Usage

No new user-facing surface. The download buttons and version pill behave as before at `render.fused.io`, and now behave the same at `www.fused.io/render/` once the companion PR is applied.

## Test Plan

- [x] All three pages parse cleanly; no `src="/…"`, `href="/…"`, or `fetch("/…")` same-origin absolute references remain in `scripts/download_page/`
- [x] No test in `tests/` covers `scripts/download_page` (HTML-only change, nothing to update)
- [ ] Reviewer: serve `scripts/download_page/` with a `latest.json` present (`python3 -m http.server`), confirm the version pill fills in and the platform buttons point at the manifest URLs
- [ ] After the next release publishes to `s3://fused-render/`: `render.fused.io` still shows the version pill and real download links; once `fusedlabs/application#7952` is applied, same on `www.fused.io/render/`
