### PR TITLE
Update launcher.rc

### DIFF
--- a/windows/launcher/launcher.rc
+++ b/windows/launcher/launcher.rc
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <windows.h> 
 
 /* The Win11 "Open with" picker reads an .exe's own embedded icon, not the
  * Applications\<exe>\DefaultIcon registry value, so the app icon has to live


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Whitespace-only edit to a resource script with no functional or build impact.
> 
> **Overview**
> Adds a trailing space after the `#include <windows.h>` line in `windows/launcher/launcher.rc`. **No change** to the embedded `fused-render.ico` resource or build wiring; behavior of the Windows launcher exe and Win11 “Open with” icon embedding stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a34a13d51fbf51ff169ce048ff584ca031aeb37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->