### PR TITLE
Add Content-Length support to download progress reporting

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -235,9 +235,12 @@ export interface UpdateStatus {
   // dmg: the app downloads and swaps its own bundle; none: not updatable.
   method: string;
   latest_version: string | null;
-  // Bytes downloaded so far (dmg method only) — the manifest carries no total
-  // size, so the UI shows MB downloaded rather than a percentage.
+  // Bytes downloaded so far (dmg method only).
   progress: number | null;
+  // Total bytes to download, from the download response's Content-Length —
+  // the manifest itself carries no size field. Null when the CDN omits that
+  // header, in which case the UI falls back to showing MB downloaded.
+  progress_total: number | null;
   error: string | null;
   // Set when the user must run the update themselves (brew-managed installs,
   // state "available") — shown with a copy button.

--- a/frontend/src/platform/ui/UpdateBadge.tsx
+++ b/frontend/src/platform/ui/UpdateBadge.tsx
@@ -18,9 +18,10 @@ import { getConfig, updateInstall, type UpdateStatus } from "@platform/lib/api";
 const POLL_IDLE_MS = 60_000;
 const POLL_BUSY_MS = 2_000;
 
-function formatMb(bytes: number | null): string {
-  if (!bytes) return "";
-  return `${Math.round(bytes / (1024 * 1024))} MB`;
+function formatProgress(done: number | null, total: number | null): string {
+  if (total) return `${Math.min(100, Math.round((100 * (done ?? 0)) / total))}%`;
+  if (!done) return "";
+  return `${Math.round(done / (1024 * 1024))} MB`;
 }
 
 export default function UpdateBadge() {
@@ -142,7 +143,7 @@ export default function UpdateBadge() {
           )}
           {status.state === "installing" && (
             <div className="update-badge-text">
-              Downloading… {formatMb(status.progress)}
+              Downloading… {formatProgress(status.progress, status.progress_total)}
             </div>
           )}
           {status.state === "error" && (

--- a/fused_render/update/common.py
+++ b/fused_render/update/common.py
@@ -107,7 +107,9 @@ def download_verified(manifest: dict, *, dir: str | None = None,
     while hashing it, and confirm its SHA-256 matches the signed value. The
     manifest signature (over version + sha256) is already verified in
     fetch_manifest; the URL is not signed, so require HTTPS. `progress`
-    (optional) is called with bytes downloaded so far after each chunk."""
+    (optional) is called with (bytes downloaded so far, total bytes or None)
+    after each chunk — the total comes from the response's Content-Length
+    header, which the manifest itself does not carry."""
     if urlopen_fn is None:
         urlopen_fn = urlopen
     url = manifest["url"]
@@ -115,19 +117,21 @@ def download_verified(manifest: dict, *, dir: str | None = None,
         raise ValueError("update manifest url is not https")
     sha256 = manifest["sha256"]
     digest = hashlib.sha256()
-    total = 0
+    done = 0
     fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=dir)
     ok = False
     try:
         with os.fdopen(fd, "wb") as out, urlopen_fn(url, DOWNLOAD_TIMEOUT_S) as resp:
+            content_length = resp.getheader("Content-Length")
+            size = int(content_length) if content_length is not None else None
             while chunk := resp.read(DOWNLOAD_CHUNK):
-                total += len(chunk)
-                if total > max_bytes:
+                done += len(chunk)
+                if done > max_bytes:
                     raise ValueError("update download exceeds the size limit")
                 digest.update(chunk)
                 out.write(chunk)
                 if progress is not None:
-                    progress(total)
+                    progress(done, size)
         if digest.hexdigest() != sha256:
             raise ValueError("downloaded file does not match the signed manifest")
         ok = True

--- a/fused_render/update/common.py
+++ b/fused_render/update/common.py
@@ -123,7 +123,10 @@ def download_verified(manifest: dict, *, dir: str | None = None,
     try:
         with os.fdopen(fd, "wb") as out, urlopen_fn(url, DOWNLOAD_TIMEOUT_S) as resp:
             content_length = resp.getheader("Content-Length")
-            size = int(content_length) if content_length is not None else None
+            try:
+                size = int(content_length) if content_length is not None else None
+            except ValueError:
+                size = None
             while chunk := resp.read(DOWNLOAD_CHUNK):
                 done += len(chunk)
                 if done > max_bytes:

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -130,6 +130,7 @@ class UpdateManager:
         self._error: str | None = None
         self._manual_command: str | None = None
         self._progress: float | None = None
+        self._progress_total: float | None = None
         self._install_thread: threading.Thread | None = None
 
     # -- status ---------------------------------------------------------------
@@ -151,6 +152,7 @@ class UpdateManager:
                 "method": self.method(),
                 "latest_version": self._latest["version"] if self._latest else None,
                 "progress": self._progress,
+                "progress_total": self._progress_total,
                 "error": self._error,
                 "manual_command": self._manual_command,
             }
@@ -273,6 +275,7 @@ class UpdateManager:
             self._error = None
             self._manual_command = None
             self._progress = 0.0
+            self._progress_total = None
             thread = threading.Thread(
                 target=self._install, args=(manifest,), daemon=True,
                 name="fused-render-update-install")
@@ -295,6 +298,7 @@ class UpdateManager:
         with self._lock:
             self._state = "installed"
             self._progress = None
+            self._progress_total = None
 
     # -- dmg path -------------------------------------------------------------
 
@@ -332,11 +336,13 @@ class UpdateManager:
         updates = self._updates_dir()
         self._check_disk_space(updates)
 
-        # Manifest carries no size field (schema 1), so progress is a raw byte
-        # count; the UI shows MB downloaded, not a percentage.
-        def on_bytes(done: int) -> None:
+        # The manifest itself carries no size field (schema 1); the total
+        # comes from the download response's Content-Length instead, so the
+        # UI can show a percentage when the CDN sends that header.
+        def on_bytes(done: int, size: int | None) -> None:
             with self._lock:
                 self._progress = float(done)
+                self._progress_total = float(size) if size is not None else None
 
         dmg = common.download_verified(
             manifest, dir=updates, prefix=_DOWNLOAD_PREFIX,

--- a/tests/test_win_supervisor_update.py
+++ b/tests/test_win_supervisor_update.py
@@ -149,6 +149,26 @@ def test_download_verified_progress_total_none_without_content_length(monkeypatc
     assert calls == [(len(installer), None)]
 
 
+def test_download_verified_progress_total_none_on_malformed_content_length(monkeypatch):
+    from fused_render.update import common
+
+    key = _install_key(monkeypatch)
+    installer = b"the real installer bytes"
+    sha256 = hashlib.sha256(installer).hexdigest()
+    manifest = {"schema": 1, "version": "0.4.0", "url": "https://x/setup.exe",
+                "sha256": sha256, "signature": _sign(key, "0.4.0", sha256)}
+
+    class _BadLengthResponse(_Response):
+        def getheader(self, name, default=None):
+            return "not-a-number" if name == "Content-Length" else default
+
+    calls = []
+    common.download_verified(
+        manifest, progress=lambda done, total: calls.append((done, total)),
+        urlopen_fn=lambda url, timeout: _BadLengthResponse(installer))
+    assert calls == [(len(installer), None)]
+
+
 def test_fetch_manifest_verifies_signature_before_returning(monkeypatch):
     # The version is only trusted after the signature checks out, so a bad
     # signature is rejected at fetch — before any "up to date"/prompt decision.

--- a/tests/test_win_supervisor_update.py
+++ b/tests/test_win_supervisor_update.py
@@ -22,9 +22,10 @@ from fused_render.supervisor._win32 import update
 
 
 class _Response:
-    def __init__(self, payload: bytes):
+    def __init__(self, payload: bytes, *, content_length: int | None = None):
         self._payload = payload
         self._done = False
+        self._content_length = content_length
 
     def __enter__(self):
         return self
@@ -39,6 +40,11 @@ class _Response:
             return b""
         self._done = True
         return self._payload
+
+    def getheader(self, name, default=None):
+        if name == "Content-Length" and self._content_length is not None:
+            return str(self._content_length)
+        return default
 
 
 def _sign(key: Ed25519PrivateKey, version: str, sha256: str) -> str:
@@ -111,6 +117,36 @@ def test_download_verified_roundtrip(monkeypatch):
     path = update._download_verified(manifest)
     with open(path, "rb") as f:
         assert f.read() == installer
+
+
+def test_download_verified_reports_progress_with_content_length(monkeypatch):
+    from fused_render.update import common
+
+    key = _install_key(monkeypatch)
+    installer = b"the real installer bytes"
+    sha256 = hashlib.sha256(installer).hexdigest()
+    manifest = {"schema": 1, "version": "0.4.0", "url": "https://x/setup.exe",
+                "sha256": sha256, "signature": _sign(key, "0.4.0", sha256)}
+    calls = []
+    common.download_verified(
+        manifest, progress=lambda done, total: calls.append((done, total)),
+        urlopen_fn=lambda url, timeout: _Response(installer, content_length=len(installer)))
+    assert calls == [(len(installer), len(installer))]
+
+
+def test_download_verified_progress_total_none_without_content_length(monkeypatch):
+    from fused_render.update import common
+
+    key = _install_key(monkeypatch)
+    installer = b"the real installer bytes"
+    sha256 = hashlib.sha256(installer).hexdigest()
+    manifest = {"schema": 1, "version": "0.4.0", "url": "https://x/setup.exe",
+                "sha256": sha256, "signature": _sign(key, "0.4.0", sha256)}
+    calls = []
+    common.download_verified(
+        manifest, progress=lambda done, total: calls.append((done, total)),
+        urlopen_fn=lambda url, timeout: _Response(installer))
+    assert calls == [(len(installer), None)]
 
 
 def test_fetch_manifest_verifies_signature_before_returning(monkeypatch):


### PR DESCRIPTION
## Summary
Enhanced the update download progress reporting to include total file size information when available from the HTTP response's Content-Length header. This allows the UI to display download progress as a percentage when the CDN provides the header, while gracefully falling back to showing MB downloaded when it doesn't.

## Key Changes
- **Test infrastructure**: Extended `_Response` mock class to support optional `content_length` parameter and added `getheader()` method to simulate HTTP response headers
- **Download progress API**: Modified `common.download_verified()` to extract Content-Length from response headers and pass both `done` and `total` bytes to the progress callback (previously only passed `done`)
- **macOS update handler**: Updated `mac.py` to track and expose `_progress_total` alongside `_progress`, passing both values through the progress callback
- **Status API**: Added `progress_total` field to `UpdateStatus` interface to communicate total download size to the frontend
- **UI progress display**: Refactored `formatProgress()` to show percentage when total is available, otherwise fall back to MB display
- **Documentation**: Updated docstrings and comments to clarify that total size comes from Content-Length header, not the manifest itself

## Implementation Details
- The manifest schema (v1) doesn't carry size information, so the total must come from the HTTP response
- Progress callback signature changed from `progress(done)` to `progress(done, total)` where `total` can be `None`
- The UI intelligently chooses display format: percentage (when total available), MB (when only done available), or empty string (when no progress yet)
- All changes maintain backward compatibility with servers that don't send Content-Length headers

https://claude.ai/code/session_01KxRgcKDEVRKhm17rccsntH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and optional progress reporting only; download verification and install logic are unchanged aside from reading a standard HTTP header.
> 
> **Overview**
> Self-update downloads now surface **total size** from the HTTP `Content-Length` header (the manifest still has no size field), so the UI can show a **percentage** during DMG installs instead of only megabytes downloaded.
> 
> `download_verified`’s optional progress callback is now `(done, total)` with `total` nullable when the header is missing or invalid. The macOS update manager stores `_progress_total`, exposes it on `UpdateStatus` as `progress_total`, and `UpdateBadge` uses `formatProgress()` to prefer `%` when total is known. Tests extend the mock response with `getheader` and cover present, absent, and malformed `Content-Length`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0660bb8b7c2d93b29064a300fdfe3d0a71f5cf98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->