### PR TITLE
Image playground: ratio lock, typeable size boxes, steps max 28, seed pre-fill

### DIFF
--- a/frontend/src/apps/ai_models/lib/params.ts
+++ b/frontend/src/apps/ai_models/lib/params.ts
@@ -10,7 +10,15 @@
 // Nothing here knows what a model or a stage is: it is `location.search` in
 // and out. That is the whole reason it is in `lib/` rather than `playground/`
 // — the page shell reads `?cap=` through the same door (see routes.ts).
-import { replaceSearch } from "@platform/lib/router";
+import { navigateUrl, replaceSearch } from "@platform/lib/router";
+
+// How a rewrite lands in history. `replace` (the default) edits the current
+// entry — a slider drag must not stack entries. `push` adds one, so the Back
+// button undoes it: that is for a MODEL change, which is a move between
+// places rather than a tweak to the place one is in.
+export type WriteMode = "replace" | "push";
+const land = (url: string, mode: WriteMode) =>
+  mode === "push" ? navigateUrl(url) : replaceSearch(url);
 
 /** Read one query param off the CURRENT url. The second argument exists so
  *  tests can drive this without a `location`, the same three-argument trick
@@ -68,18 +76,24 @@ export function searchString(updates: Record<string, string | null>): string {
  *  name happens to collide and are dead weight in the URL if it does not.
  *  Naming what to keep, rather than what to clear, is the direction that does
  *  not go stale: a stage that adds a parameter tomorrow is covered. */
-export function resetParams(updates: Record<string, string | null>): void {
-  replaceSearch(location.pathname + searchString(updates));
+export function resetParams(
+  updates: Record<string, string | null>,
+  mode: WriteMode = "replace",
+): void {
+  land(location.pathname + searchString(updates), mode);
 }
 
-/** Rewrite query params in place — null deletes. `replaceSearch`, not
- *  navigate: model browsing and slider drags must not stack history entries. */
-export function writeParams(updates: Record<string, string | null>): void {
+/** Rewrite query params — null deletes. `replace` by default: slider drags
+ *  must not stack history entries. The model picker passes `push`. */
+export function writeParams(
+  updates: Record<string, string | null>,
+  mode: WriteMode = "replace",
+): void {
   const params = new URLSearchParams(location.search);
   for (const [key, value] of Object.entries(updates)) {
     if (value === null) params.delete(key);
     else params.set(key, value);
   }
   const search = params.toString();
-  replaceSearch(location.pathname + (search ? "?" + search : ""));
+  land(location.pathname + (search ? "?" + search : ""), mode);
 }

--- a/frontend/src/apps/ai_models/playground/ImageStage.tsx
+++ b/frontend/src/apps/ai_models/playground/ImageStage.tsx
@@ -108,14 +108,21 @@ const ASPECT_CHIPS = [
 // same functions decide which chip a saved size lights. A pair is a shape's if
 // EITHER side derives the other: a height edit writes `widthFor(h)`, whose
 // own `heightFor` can land one step off after rounding, and a link saved then
-// must reload with the lock it was showing.
+// must reload with the lock it was showing. Where the rail's edge clamped a
+// side, more than one shape can derive the same pair (16:9 and 4:3 both reach
+// 2048×1600), so the candidates are ranked by how close their true ratio is
+// to the pair's rather than by list order.
 const snap16 = (n: number) =>
   Math.min(SIZE_RANGE[1], Math.max(SIZE_RANGE[0], Math.round(n / 16) * 16));
 const heightFor = (width: number, a: Aspect) => snap16((width * a.rh) / a.rw);
 const widthFor = (height: number, a: Aspect) => snap16((height * a.rw) / a.rh);
-const aspectOf = (width: number, height: number) =>
-  ASPECTS.find((a) => heightFor(width, a) === height || widthFor(height, a) === width)?.value ??
-  CUSTOM;
+const aspectOf = (width: number, height: number) => {
+  const off = (a: Aspect) => Math.abs(Math.log(width / height) - Math.log(a.rw / a.rh));
+  const fits = ASPECTS.filter(
+    (a) => heightFor(width, a) === height || widthFor(height, a) === width,
+  ).sort((x, y) => off(x) - off(y));
+  return fits[0]?.value ?? CUSTOM;
+};
 
 // Eight authored examples — two pages of four (D465). Every one names a
 // subject AND a way of rendering it (medium, light, lens, texture), because

--- a/frontend/src/apps/ai_models/playground/ImageStage.tsx
+++ b/frontend/src/apps/ai_models/playground/ImageStage.tsx
@@ -105,13 +105,17 @@ const ASPECT_CHIPS = [
 
 // The locked axis, snapped to the nearest multiple of 16 and kept on the rail.
 // Reproduces every preset pair from its own width (480 → 272 for 16:9), so the
-// same function decides which chip a saved size lights.
+// same functions decide which chip a saved size lights. A pair is a shape's if
+// EITHER side derives the other: a height edit writes `widthFor(h)`, whose
+// own `heightFor` can land one step off after rounding, and a link saved then
+// must reload with the lock it was showing.
 const snap16 = (n: number) =>
   Math.min(SIZE_RANGE[1], Math.max(SIZE_RANGE[0], Math.round(n / 16) * 16));
 const heightFor = (width: number, a: Aspect) => snap16((width * a.rh) / a.rw);
 const widthFor = (height: number, a: Aspect) => snap16((height * a.rw) / a.rh);
 const aspectOf = (width: number, height: number) =>
-  ASPECTS.find((a) => heightFor(width, a) === height)?.value ?? CUSTOM;
+  ASPECTS.find((a) => heightFor(width, a) === height || widthFor(height, a) === width)?.value ??
+  CUSTOM;
 
 // Eight authored examples — two pages of four (D465). Every one names a
 // subject AND a way of rendering it (medium, light, lens, texture), because

--- a/frontend/src/apps/ai_models/playground/ImageStage.tsx
+++ b/frontend/src/apps/ai_models/playground/ImageStage.tsx
@@ -75,23 +75,43 @@ const DEFAULTS = { width: 480, height: 272, guidance: 1.0 };
 // The rail's slider bounds, in one place so a URL value and a dragged value
 // cannot disagree about what the control's scale is.
 const SIZE_RANGE = [256, 2048] as const;
-const STEPS_RANGE = [1, 100] as const;
+// Steps top out at the server's own 28: nothing in the shortlist gets better
+// past it, and the Max chip already says 28 — a rail running to 100 only made
+// the chip look like a mid-point.
+const STEPS_RANGE = [1, 28] as const;
 const GUIDANCE_RANGE = [0, 20] as const;
 
 // Multiple-of-16 pairs, all small by default. The chip writes its pair into the
-// same `w`/`h` params the custom sliders edit; a pair matching no chip lights
-// none of them — including a saved link from before 16:9 was re-footed onto the
-// default size, which now lights nothing rather than lying.
+// same `w`/`h` params the sliders edit, and then LOCKS the shape: moving width
+// re-derives height (and the other way round) until Custom is picked, so a
+// bigger 16:9 no longer means working out the second side by hand. A saved
+// link whose pair fits none of the shapes lights Custom.
 const ASPECTS = [
-  { value: "1:1", label: "1:1", title: "Square — 512×512", width: 512, height: 512 },
-  { value: "3:4", label: "3:4", title: "Portrait — 480×640", width: 480, height: 640 },
-  { value: "4:3", label: "4:3", title: "Landscape — 640×480", width: 640, height: 480 },
+  { value: "1:1", label: "1:1", title: "Square — 512×512", width: 512, height: 512, rw: 1, rh: 1 },
+  { value: "3:4", label: "3:4", title: "Portrait — 480×640", width: 480, height: 640, rw: 3, rh: 4 },
+  { value: "4:3", label: "4:3", title: "Landscape — 640×480", width: 640, height: 480, rw: 4, rh: 3 },
   // The default pair, so a fresh stage lights a chip rather than none. 480/272
   // is 1.76 rather than 1.778 — the nearest multiple-of-16 pair to the size
   // asked for, and the same rounding SDXL's own "16:9" bucket carries.
-  { value: "16:9", label: "16:9", title: "Wide — 480×272", width: 480, height: 272 },
-  { value: "9:16", label: "9:16", title: "Tall — 432×768", width: 432, height: 768 },
+  { value: "16:9", label: "16:9", title: "Wide — 480×272", width: 480, height: 272, rw: 16, rh: 9 },
+  { value: "9:16", label: "9:16", title: "Tall — 432×768", width: 432, height: 768, rw: 9, rh: 16 },
 ] as const;
+type Aspect = (typeof ASPECTS)[number];
+const CUSTOM = "custom";
+const ASPECT_CHIPS = [
+  ...ASPECTS.map(({ value, label, title }) => ({ value, label, title })),
+  { value: CUSTOM, label: "Custom", title: "Width and height move on their own" },
+];
+
+// The locked axis, snapped to the nearest multiple of 16 and kept on the rail.
+// Reproduces every preset pair from its own width (480 → 272 for 16:9), so the
+// same function decides which chip a saved size lights.
+const snap16 = (n: number) =>
+  Math.min(SIZE_RANGE[1], Math.max(SIZE_RANGE[0], Math.round(n / 16) * 16));
+const heightFor = (width: number, a: Aspect) => snap16((width * a.rh) / a.rw);
+const widthFor = (height: number, a: Aspect) => snap16((height * a.rw) / a.rh);
+const aspectOf = (width: number, height: number) =>
+  ASPECTS.find((a) => heightFor(width, a) === height)?.value ?? CUSTOM;
 
 // Eight authored examples — two pages of four (D465). Every one names a
 // subject AND a way of rendering it (medium, light, lens, texture), because
@@ -262,6 +282,9 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
   // control that lies about what will run.
   const [width, setWidth] = useState(() => numParam("w", DEFAULTS.width, ...SIZE_RANGE));
   const [height, setHeight] = useState(() => numParam("h", DEFAULTS.height, ...SIZE_RANGE));
+  // Which shape is locked — a chip value, or `custom` for two free sliders. Not
+  // a URL param: `w`/`h` round-trip and the chip is recovered from them.
+  const [aspect, setAspect] = useState<string>(() => aspectOf(width, height));
   const [steps, setSteps] = useState(() => numParam("steps", modelSteps, ...STEPS_RANGE));
   const [guidance, setGuidance] = useState(() =>
     numParam("guidance", DEFAULTS.guidance, ...GUIDANCE_RANGE),
@@ -516,7 +539,16 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
     return () => window.clearInterval(timer);
   }, [rendering]);
 
-  const aspect = ASPECTS.find((a) => a.width === width && a.height === height)?.value ?? null;
+  const locked = ASPECTS.find((a) => a.value === aspect) ?? null;
+  // The slider handlers: under a locked shape the other side follows.
+  const changeWidth = (w: number) => {
+    setWidth(w);
+    if (locked) setHeight(heightFor(w, locked));
+  };
+  const changeHeight = (h: number) => {
+    setHeight(h);
+    if (locked) setWidth(widthFor(h, locked));
+  };
   const speed = speedChips?.find((c) => c.steps === steps)?.value ?? null;
   // Is the size the PICTURE's? Only with a base image, and only until somebody
   // picks one themselves.
@@ -563,6 +595,10 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
         ...(seed.trim() !== "" ? { seed: Number(seed) } : {}),
       });
       setRun({ started, job: null, done: false, readFailed: false });
+      // The seed the server settled on — invented when the box was empty —
+      // lands in the box, so the render can be reproduced or nudged. Repeat
+      // Generates reuse it until the box is cleared.
+      setSeed(String(started.seed));
       try {
         const outcome = await watchJob(started.jobId, controller.signal, (job) =>
           setRun((r) => (r && r.started.jobId === started.jobId ? { ...r, job } : r)),
@@ -754,9 +790,10 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
               is also the way back to picking a size by hand. */}
           {!sizeIsTheImages && (
             <RailChips
-              options={ASPECTS.map(({ value, label, title }) => ({ value, label, title }))}
+              options={ASPECT_CHIPS}
               active={aspect}
               onPick={(value) => {
+                setAspect(value);
                 const pick = ASPECTS.find((a) => a.value === value);
                 if (pick) {
                   setWidth(pick.width);
@@ -797,13 +834,17 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
           <>
             <RailSlider
               label="Width"
-              hint="Snapped to a multiple of 16 by the server."
+              hint={
+                locked
+                  ? `Height follows to keep ${locked.label}. Pick Custom to move them apart.`
+                  : "Snapped to a multiple of 16 by the server."
+              }
               min={SIZE_RANGE[0]}
               max={SIZE_RANGE[1]}
               step={16}
               value={width}
               fallback={DEFAULTS.width}
-              onChange={setWidth}
+              onChange={changeWidth}
             />
             <RailSlider
               label="Height"
@@ -813,7 +854,7 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
               step={16}
               value={height}
               fallback={DEFAULTS.height}
-              onChange={setHeight}
+              onChange={changeHeight}
             />
           </>
         )}
@@ -964,8 +1005,8 @@ export function ImageStage({ model, entry }: { model: string; entry: AiCatalogMo
               </div>
             )}
             {/* Progress only. The settled parameters were dropped by request,
-                and D429's seed-reuse button with them: an invented seed is now
-                surfaced nowhere, so a random render cannot be reproduced. */}
+                and D429's seed-reuse button with them; the invented seed is
+                surfaced by pre-filling the Seed box instead. */}
             {busy && (
               <figcaption className="pg-image-caption">
                 <span>{job?.detail || "Starting — a cold model loads first…"}</span>

--- a/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
+++ b/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
@@ -137,9 +137,10 @@ export default function PlaygroundTab() {
   // lets the tick lapse on its own.
   const [copiedRepo, setCopiedRepo] = useState(false);
   const runtime = useAiRuntime();
-  // `useUrlVersion`, not `useNavEpoch`: the selection is written with
-  // `replaceSearch`, which fires only fused:urlchange — the nav epoch counts
-  // pushes and pops and would leave a click's own rewrite unread.
+  // `useUrlVersion`, not `useNavEpoch`: a model pick is PUSHED (so Back walks
+  // through the models tried) and the nav epoch would hear that, but the
+  // stages' own slider rewrites are `replaceSearch`, which fires only
+  // fused:urlchange — and this counter hears all three.
   const urlVersion = useUrlVersion();
 
   // One fetch per mount, then again when a download lands: `downloaded` on the
@@ -305,13 +306,16 @@ export default function PlaygroundTab() {
     const nextCapability = railRows.find((row) =>
       row.models.some((model) => model.id === id),
     )?.capability;
+    // Both writes PUSH a history entry: moving between models is moving between
+    // places, and Back should return to the one before — with the settings it
+    // had, since a stage's slider rewrites edit the entry it is on.
     if (nextCapability && selected && nextCapability !== selected.row.capability) {
-      resetParams({ model: id });
+      resetParams({ model: id }, "push");
       return;
     }
     // cap dies with the first explicit pick — leaving it would make a shared
     // URL claim a task the user has since clicked away from.
-    writeParams({ model: id, cap: null });
+    writeParams({ model: id, cap: null }, "push");
   };
 
   const residentRow = selected

--- a/frontend/src/apps/ai_models/playground/TextStage.tsx
+++ b/frontend/src/apps/ai_models/playground/TextStage.tsx
@@ -572,7 +572,7 @@ export function TextStage({
           hint="Lower is focused and repeatable; higher is varied and creative."
           min={LIMITS.temperature[0]}
           max={LIMITS.temperature[1]}
-          step={0.05}
+          step={0.1}
           value={temperature}
           fallback={DEFAULTS.temperature}
           onChange={setTemperature}

--- a/frontend/src/apps/ai_models/playground/controls.tsx
+++ b/frontend/src/apps/ai_models/playground/controls.tsx
@@ -219,7 +219,13 @@ export function RailSlider({
       setDraft(String(value));
       return;
     }
-    const clamped = Math.min(max, Math.max(min, next));
+    // Onto the rail's grid, then inside its bounds — a typed 500 on a step of
+    // 16 becomes 496, the same number the slider could have produced, so a
+    // value derived from it (the image stage's other side) stays on-grid too.
+    // The rounding keeps 0.1 steps from committing 0.30000000000000004.
+    const decimals = (String(step).split(".")[1] ?? "").length;
+    const stepped = Number((Math.round((next - min) / step) * step + min).toFixed(decimals));
+    const clamped = Math.min(max, Math.max(min, stepped));
     setDraft(String(clamped));
     if (clamped !== value) onChange(clamped);
   };

--- a/frontend/src/apps/ai_models/playground/controls.tsx
+++ b/frontend/src/apps/ai_models/playground/controls.tsx
@@ -181,7 +181,13 @@ export function CopyButton({ text, label }: { text: string; label: string }) {
 
 /** One continuous parameter: label row (name, live value, reset), slider,
  *  hint. The number is editable — research note: sliders alone hide the range
- *  and playgrounds pair them with a numeric input. */
+ *  and playgrounds pair them with a numeric input.
+ *
+ *  The input holds a DRAFT string and commits on blur or Enter. Clamping on
+ *  every keystroke made the box untypeable: "1" on the way to "1024" was
+ *  clamped to the 256 floor before the next digit landed, and clearing the box
+ *  read as 0. A caller that derives one value from another (the image stage's
+ *  ratio lock) also wants one commit per edit, not one per digit. */
 export function RailSlider({
   label,
   hint,
@@ -202,6 +208,21 @@ export function RailSlider({
   onChange: (value: number) => void;
 }) {
   const moved = value !== fallback;
+  const [draft, setDraft] = useState(String(value));
+  // A chip, a slider drag or a reset changed the value from outside the box.
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+  const commit = () => {
+    const next = Number(draft);
+    if (draft.trim() === "" || !Number.isFinite(next)) {
+      setDraft(String(value));
+      return;
+    }
+    const clamped = Math.min(max, Math.max(min, next));
+    setDraft(String(clamped));
+    if (clamped !== value) onChange(clamped);
+  };
   return (
     <Field className="gap-1.5">
       <div className="flex w-full items-center gap-2">
@@ -217,10 +238,14 @@ export function RailSlider({
           min={min}
           max={max}
           step={step}
-          value={value}
-          onChange={(e) => {
-            const next = Number(e.target.value);
-            if (Number.isFinite(next)) onChange(Math.min(max, Math.max(min, next)));
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            }
           }}
         />
       </div>


### PR DESCRIPTION
Isaac's report: could not pick 16:9 at a higher resolution without computing the other side, and could not type in the resolution boxes.

## Changes
- **Ratio lock.** Picking an aspect chip locks the shape: changing width re-derives height (and vice versa), snapped to the nearest multiple of 16 and kept inside the 256–2048 rail. A new **Custom** chip makes the two sliders independent again. Which chip a saved `w`/`h` lights is decided by the same derivation, so `1024×576` now lights 16:9 rather than nothing. Ratio is not a URL param — `w`/`h` already round-trip and the chip is recovered from them.
- **Typing fix** (`RailSlider`). The number box held a controlled value that was clamped on every keystroke, so typing `1` on the way to `1024` snapped to 256 and clearing the box read as 0. It now holds a draft and commits (clamped) on blur or Enter. This also fixes Steps, Guidance and the video stage's boxes.
- **Steps max 28** — `STEPS_RANGE = [1, 28]`, matching the Max chip and the server default. Stale URL values are clamped by `numParam`.
- **Seed pre-fill.** After a render starts, the server's settled seed (invented when the box was empty) is written into the Seed box. Side effect worth knowing: repeat Generates then reuse that seed until the box is cleared, which restores "Random each time".
- Slider step was already 16; the typing bug made it look broken.

No tests / no DECISIONS row per owner's 2026-08-26 guidance. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only playground and router URL helpers; no auth, API, or server behavior changes beyond UX and browser history.
> 
> **Overview**
> Improves the **image playground** UX: aspect chips now **lock ratio** (width/height stay snapped to 16px and in range) until **Custom** is chosen; saved `w`/`h` links recover the right chip via shared derivation logic. **Steps** slider max drops from 100 to **28** (aligned with server/Max chip). After generate starts, the **server-set seed** is written into the Seed field so renders can be reproduced; repeat runs reuse it until cleared.
> 
> **`RailSlider`** no longer clamps on every keystroke—it keeps a **draft** and commits on blur/Enter (step/grid clamp), fixing resolution typing and helping ratio-locked width/height updates. Text **temperature** step is **0.1** instead of 0.05.
> 
> **URL writes** gain optional **`WriteMode`**: slider/param tweaks still **replace** history; **model picks** in `PlaygroundTab` use **`push`** so Back walks prior models/settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba72b61302586fa21f501bcd016837f0e7efa41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->