### PR TITLE
Landing: isometric ecosystem board, zooming download closer, one-button installer

### DIFF
--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -479,13 +479,14 @@
   }
 
   /* ---------- download ---------- */
-  /* The download closer: the app inside a Mac window, its bottom fifth
-     dissolving into the page where the download buttons take over. */
-  #get { padding-top: var(--s5); border-top: 1px solid var(--rule); }
-  .macwrap { position: relative; max-width: 1020px; margin: var(--s5) auto 0; }
+  /* The download closer: the Mac window grows as you scroll, then hands
+     over to the headline and one detected-OS download button. */
+  #get { margin-top: var(--gap); padding-top: var(--s5); border-top: 1px solid var(--rule); }
+  .get-stage { display: flex; flex-direction: column; align-items: center; }
+  .macwrap { position: relative; width: min(1020px, 100%); }
   .mac {
-    border: 1px solid var(--rule-hi); border-bottom: none;
-    border-radius: 16px 16px 0 0;
+    border: 1px solid var(--rule-hi);
+    border-radius: 16px;
     background: var(--tile); overflow: hidden;
     box-shadow: 0 40px 120px rgba(0, 0, 0, 0.6);
   }
@@ -501,56 +502,81 @@
     font-size: 12.5px; color: var(--ink-3); pointer-events: none;
   }
   .mac-shot { display: block; width: 100%; height: auto; }
-  /* The fade that hands the screenshot over to the buttons. */
-  .macwrap::after {
-    content: ""; position: absolute; left: -1px; right: -1px; bottom: 0;
-    height: 62%;
-    background: linear-gradient(0deg, var(--paper) 34%, rgba(0, 0, 0, 0.55) 66%, rgba(0, 0, 0, 0) 100%);
-  }
-  .getbody {
-    position: relative; z-index: 1; text-align: center;
-    margin-top: clamp(-200px, -14vw, -110px);
-  }
+  .getbody { text-align: center; margin-top: var(--gap); }
   .getbody h2 { max-width: none; }
   .getbody .deck { margin: 8px auto 0; }
-  .getbody .oses { justify-content: center; margin-left: auto; margin-right: auto; }
-  .getbody .os { text-align: left; }
-  .oses {
-    display: grid; grid-template-columns: minmax(0, 1fr);
-    gap: 14px; margin-top: var(--s5); max-width: 780px;
-  }
-  .getcard .oses { margin-top: clamp(18px, 2vw, 28px); }
-  @media (min-width: 620px) { .oses { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
-  .os {
-    display: flex; flex-direction: column; gap: 3px;
-    padding: 19px 22px;
-    border: 1px solid var(--rule);
-    border-radius: var(--r);
-    background: var(--tile);
+  .dl { display: flex; flex-direction: column; align-items: center; gap: 16px; margin-top: clamp(22px, 2.6vw, 32px); }
+  .dl-btn {
+    display: inline-flex; align-items: center; gap: 12px;
+    min-height: 56px; padding: 0 36px; border-radius: 99px;
+    background: var(--accent-fill); color: var(--accent-on);
+    border: 1px solid var(--accent-edge);
+    font-size: 16.5px; font-weight: 640; letter-spacing: -0.01em;
     text-decoration: none;
-    transition: border-color 0.22s var(--ease), transform 0.22s var(--ease);
+    transition: transform 0.22s var(--ease);
   }
-  .os b { font-size: var(--t-base); font-weight: 640; letter-spacing: -0.015em;
-          display: flex; align-items: center; gap: 8px; }
-  .os b svg { width: 16px; height: 16px; flex: none; }
-  .os span { font-size: var(--t-sm); color: var(--ink-2); }
-  /* This section's single accent: the OS the visitor is actually on. */
-  .os.primary {
-    background: var(--accent-fill);
-    border-color: var(--accent-edge);
-    color: var(--accent-on);
+  .dl-btn:hover { transform: translateY(-1px); }
+  .dl-btn svg { width: 19px; height: 19px; }
+  .dl-others summary {
+    list-style: none; cursor: pointer;
+    display: inline-flex; align-items: center; gap: 7px;
+    font-size: var(--t-sm); color: var(--ink-3);
   }
-  .os.primary span { color: rgba(20, 21, 10, 0.72); }
-  .version {
-    display: inline-block; margin-top: var(--s3);
-    font: 500 var(--t-xs)/1 ui-monospace, SFMono-Regular, Menlo, monospace;
-    text-transform: uppercase; letter-spacing: 0.11em; color: var(--ink-3);
+  .dl-others summary::-webkit-details-marker { display: none; }
+  .dl-others summary::after {
+    content: ""; width: 8px; height: 8px;
+    border-right: 1.5px solid var(--ink-3); border-bottom: 1.5px solid var(--ink-3);
+    transform: rotate(45deg) translateY(-2px);
+    transition: transform 0.25s var(--ease);
   }
-  .version[hidden] { display: none; }
-
-
-
-
+  .dl-others[open] summary::after { transform: rotate(225deg) translateY(-1px); }
+  .dl-others summary:hover { color: var(--ink-2); }
+  .dl-others { position: relative; }
+  .dl-list {
+    position: absolute; bottom: calc(100% + 10px); left: 50%; transform: translateX(-50%);
+    z-index: 6; width: min(300px, 80vw);
+    display: flex; flex-direction: column;
+    padding: 5px; border-radius: var(--r-sm);
+    background: var(--tile); border: 1px solid var(--rule);
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.5);
+  }
+  .dl-list a {
+    display: flex; align-items: center; justify-content: space-between; gap: 16px;
+    padding: 9px 11px; border-radius: 8px;
+    text-decoration: none; color: var(--ink-2); font-size: var(--t-xs);
+    transition: background 0.18s var(--ease), color 0.18s var(--ease);
+  }
+  .dl-list a:hover { background: rgba(243, 242, 237, 0.05); color: var(--ink); }
+  .dl-list .nm { display: inline-flex; align-items: center; gap: 9px; font-weight: 600; }
+  .dl-list .nm svg { width: 13px; height: 13px; color: var(--ink-3); }
+  .dl-list .sub { color: var(--ink-4); }
+  .version { display: block; margin-top: 6px; font-size: var(--t-xs); color: var(--ink-4);
+             font-family: ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: 0.08em; }
+  /* The zoom: scroll grows the window past the page measure, then it fades
+     into the download block. Motion opts in under html.anim, desktop only. */
+  @media (min-width: 861px) {
+    html.anim .get-scroll { height: 165vh; }
+    html.anim .get-stage {
+      position: sticky; top: 0; height: 100vh;
+      justify-content: center; overflow: visible;
+    }
+    html.anim .macwrap { will-change: transform, opacity; }
+    /* the image stays behind: clear up top, sinking into black below */
+    html.anim .get-stage::after {
+      content: ""; position: absolute; top: 0; bottom: 0;
+      left: calc(50% - 50vw); width: 100vw; z-index: 1;
+      background: linear-gradient(0deg,
+        var(--paper) 10%, rgba(0, 0, 0, 0.82) 30%, rgba(0, 0, 0, 0.25) 52%, rgba(0, 0, 0, 0) 72%);
+      opacity: var(--gfade, 0); pointer-events: none;
+    }
+    html.anim .getbody {
+      position: absolute; inset: 0; z-index: 2;
+      display: flex; flex-direction: column; align-items: center; justify-content: flex-end;
+      padding-bottom: 7vh;
+      margin: 0; opacity: 0; pointer-events: none;
+    }
+    html.anim .getbody.on { pointer-events: auto; }
+  }
 
   /* ---------- §how : the how-it-works app's flow diagram, geometry copied
      verbatim, colours mapped onto the page tokens so both themes hold. ---------- */
@@ -693,39 +719,83 @@
   .track.back .head { left: -6px; border-right: 8px solid var(--accent-edge); }
   .bridge { text-align: center; color: var(--ink-3); font-size: 12px; margin-top: 16px; }
   .bridge code { color: var(--accent-text); }
-  .ecofig { margin: 0; display: flex; justify-content: center; }
-  .ecofig img { width: min(720px, 100%); height: auto; }
-  @media (max-width: 900px) {
-    .howrow.hub { grid-template-columns: 1fr; gap: 14px; }
-    .howconn { flex-direction: row; justify-content: center; }
-    .howarrow { width: 38%; }
-  }
-  @media (max-width: 680px) {
-    .howrow { grid-template-columns: 1fr; gap: 14px; }
-    .howconn { flex-direction: row; justify-content: center; padding: 0; }
-    .howarrow { width: 40%; }
+  /* thin page progress bar pinned to the very top */
+  .scrollbar {
+    position: fixed; top: 0; left: 0; height: 2px; width: 100%;
+    background: var(--accent-fill);
+    transform-origin: 0 50%; transform: scaleX(0);
+    z-index: 60; pointer-events: none;
   }
 
-
-  .node { position: relative; }
-  .node-models {
-    position: absolute; top: calc(100% + 8px); left: 50%;
-    transform: translateX(-50%);
-    display: flex; gap: 6px; white-space: nowrap;
+  /* ---------- ecosystem: isometric pipeline board, scroll-scrubbed ---------- */
+  /* Resting CSS is the finished page: without JS (or reduced motion) this is
+     a static isometric diagram with all four captions listed beside it. */
+  .eco-stage { display: flex; flex-direction: column; }
+  .eco-stage .sec-head { padding-bottom: clamp(18px, 2.4vw, 30px); }
+  .eco-row {
+    display: grid; grid-template-columns: minmax(230px, 300px) minmax(0, 1fr);
+    gap: clamp(20px, 3vw, 44px); align-items: center;
+    flex: 1; min-height: 0;
   }
-  .node-models > span {
-    display: inline-flex; align-items: center; gap: 5px;
-    padding: 4px 9px;
-    border: 1px solid var(--rule); border-radius: 99px;
-    background: var(--tile-2);
-    font: 500 10.5px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
-    letter-spacing: 0.04em; color: var(--ink-2);
+  .eco-copy { display: flex; flex-direction: column; gap: 12px; }
+  .eco-step {
+    padding: 4px 0 16px;
+    border-bottom: 2px solid var(--rule);
+    cursor: pointer;
+    transition: border-color 0.4s var(--ease), opacity 0.4s var(--ease);
   }
-  .node-models svg { width: 11px; height: 11px; color: var(--ink-3); }
-  .node-models .more { color: var(--ink-3); }
-
-  #claude h2 { max-width: none; }
-  #claude .deck { max-width: none; }
+  .eco-step:hover { border-bottom-color: var(--rule-hi); }
+  .eco-step h3 {
+    margin: 0 0 4px; font-size: var(--t-md); font-weight: 640;
+    letter-spacing: -0.018em;
+  }
+  .eco-step p { margin: 0; font-size: var(--t-sm); color: var(--ink-2); line-height: 1.5; }
+  .eco-svg { width: 100%; height: auto; display: block; }
+  .eco-groundg path { stroke: rgba(243, 242, 237, 0.05); stroke-width: 1; fill: none; }
+  /* 3D pipeline: a sunken channel in the ground plane */
+  .eco-pipe-bed { fill: #131312; }
+  .eco-pipe-edge { fill: none; stroke: rgba(243, 242, 237, 0.11); stroke-width: 1; }
+  .eco-pipe-core { fill: none; stroke: rgba(0, 0, 0, 0.55); stroke-width: 3; }
+  .eco-stream {
+    fill: none; stroke: var(--accent-fill); stroke-width: 3.5;
+    stroke-linecap: round; opacity: 0;
+  }
+  /* iso slabs */
+  .pad-t { fill: #191917; stroke: rgba(243, 242, 237, 0.1); stroke-width: 1; }
+  .pad-l { fill: #0c0c0b; } .pad-r { fill: #121211; }
+  .hubb-t { fill: #191917; stroke: rgba(243, 242, 237, 0.12); stroke-width: 1; }
+  .hubb-l { fill: #0b0b0a; } .hubb-r { fill: #111110; }
+  .hubg-t { fill: rgba(229, 255, 68, 0.07); stroke: rgba(229, 255, 68, 0.32); stroke-width: 1; }
+  .hubg-l { fill: rgba(229, 255, 68, 0.03); } .hubg-r { fill: rgba(229, 255, 68, 0.05); }
+  .eco-hubglow { fill: rgba(229, 255, 68, 0.22); }
+  .eco-hubmark { fill: var(--accent-fill); }
+  /* icons printed flat on the pads */
+  .eco-flat use { color: var(--ink-2); }
+  .eco-node { cursor: pointer; outline: none; }
+  .eco-node:hover .pad-t, .eco-node:focus-visible .pad-t { stroke: rgba(243, 242, 237, 0.24); }
+  .eco-node.live .pad-t { fill: var(--accent-wash); stroke: rgba(229, 255, 68, 0.45); }
+  .eco-node.live .eco-flat use { color: var(--ink); }
+  .eco-livelbl {
+    font: 600 13px ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: 0.08em; fill: var(--ink-2);
+  }
+  /* Motion opts in under html.anim only. */
+  html.anim .eco-scroll { height: 400vh; }
+  html.anim .eco-stage {
+    position: sticky; top: 0; height: 100vh;
+    box-sizing: border-box; padding: 4vh 0 3vh;
+  }
+  html.anim .eco-step { opacity: 0.35; }
+  html.anim .eco-step.on {
+    opacity: 1;
+    border-bottom-color: var(--accent-fill);
+  }
+  @media (max-width: 860px) {
+    .eco-row { grid-template-columns: minmax(0, 1fr); }
+    html.anim .eco-scroll { height: auto; }
+    html.anim .eco-stage { position: static; height: auto; padding: 0; }
+    html.anim .eco-step { opacity: 1; }
+  }
 
   /* ---------- §claude : the sessions list ---------- */
   .sess { padding: clamp(14px, 1.6vw, 20px); display: flex; flex-direction: column; }
@@ -928,7 +998,7 @@
   /* ---------- footer ---------- */
   footer {
     position: relative; overflow: hidden;
-    margin-top: var(--gap);
+    margin-top: var(--s4);
     border-top: 1px solid var(--rule);
     padding: var(--s5) 0 clamp(120px, 14vw, 200px);
   }
@@ -1064,9 +1134,14 @@
      <circle cx="7.5" cy="5.4" r="0.75" fill="currentColor"/></g>
   <g id="i-python-mark" transform="scale(0.8333)"><path fill="currentColor" d="M14.25.18l.9.2.73.26.59.3.45.32.34.34.25.34.16.33.1.3.04.26.02.2-.01.13V8.5l-.05.63-.13.55-.21.46-.26.38-.3.31-.33.25-.35.19-.35.14-.33.1-.3.07-.26.04-.21.02H8.77l-.69.05-.59.14-.5.22-.41.27-.33.32-.27.35-.2.36-.15.37-.1.35-.07.32-.04.27-.02.21v3.06H3.17l-.21-.03-.28-.07-.32-.12-.35-.18-.36-.26-.36-.36-.35-.46-.32-.59-.28-.73-.21-.88-.14-1.05-.05-1.23.06-1.22.16-1.04.24-.87.32-.71.36-.57.4-.44.42-.33.42-.24.4-.16.36-.1.32-.05.24-.01h.16l.06.01h8.16v-.83H6.18l-.01-2.75-.02-.37.05-.34.11-.31.17-.28.25-.26.31-.23.38-.2.44-.18.51-.15.58-.12.64-.1.71-.06.77-.04.84-.02 1.27.05zm-6.3 1.98l-.23.33-.08.41.08.41.23.34.33.22.41.09.41-.09.33-.22.23-.34.08-.41-.08-.41-.23-.33-.33-.22-.41-.09-.41.09zm13.09 3.95l.28.06.32.12.35.18.36.27.36.35.35.47.32.59.28.73.21.88.14 1.04.05 1.23-.06 1.23-.16 1.04-.24.86-.32.71-.36.57-.4.45-.42.33-.42.24-.4.16-.36.09-.32.05-.24.02-.16-.01h-8.22v.82h5.84l.01 2.76.02.36-.05.34-.11.31-.17.29-.25.25-.31.24-.38.2-.44.17-.51.15-.58.13-.64.09-.71.07-.77.04-.84.01-1.27-.04-1.07-.14-.9-.2-.73-.25-.59-.3-.45-.33-.34-.34-.25-.34-.16-.33-.1-.3-.04-.25-.02-.2.01-.13v-5.34l.05-.64.13-.54.21-.46.26-.38.3-.32.33-.24.35-.2.35-.14.33-.1.3-.06.26-.04.21-.02.13-.01h5.84l.69-.05.59-.14.5-.21.41-.28.33-.32.27-.35.2-.36.15-.36.1-.35.07-.32.04-.28.02-.21V6.07h2.09l.14.01zm-6.47 14.25l-.23.33-.08.41.08.41.23.33.33.23.41.08.41-.08.33-.23.23-.33.08-.41-.08-.41-.23-.33-.33-.23-.41-.08-.41.08z"/></g>
   <g id="i-github" transform="scale(0.8333)"><path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></g>
+  <g id="i-apple" transform="scale(0.8333)"><path fill="currentColor" d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/></g>
+  <g id="i-windows"><path fill="currentColor" d="M3 5.7l6.4-.9v4.7H3zM10.4 4.6L17 3.7v6.1h-6.6zM3 10.5h6.4v4.7L3 14.3zM10.4 10.5H17v6.2l-6.6-.9z"/></g>
+  <g id="i-linux" transform="scale(0.8333)"><path fill="currentColor" d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.132 1.884 1.071.771-.06 1.592-.536 2.257-1.306.631-.765 1.683-1.084 2.378-1.503.348-.199.629-.469.649-.853.023-.4-.2-.811-.714-1.376v-.097l-.003-.003c-.17-.2-.25-.535-.338-.926-.085-.401-.182-.786-.492-1.046h-.003c-.059-.054-.123-.067-.188-.135a.357.357 0 00-.19-.064c.431-1.278.264-2.55-.173-3.694-.533-1.41-1.465-2.638-2.175-3.483-.796-1.005-1.576-1.957-1.56-3.368.026-2.152.236-6.133-3.544-6.139zm.529 3.405h.013c.213 0 .396.062.584.198.19.135.33.332.438.533.105.259.158.459.166.724 0-.02.006-.04.006-.06v.105a.086.086 0 01-.004-.021l-.004-.024a1.807 1.807 0 01-.15.706.953.953 0 01-.213.335.71.71 0 00-.088-.042c-.104-.045-.198-.064-.284-.133a1.312 1.312 0 00-.22-.066c.05-.06.146-.133.183-.198.053-.128.082-.264.088-.402v-.02a1.21 1.21 0 00-.061-.4c-.045-.134-.101-.2-.183-.333-.084-.066-.167-.132-.267-.132h-.016c-.093 0-.176.03-.262.132a.8.8 0 00-.205.334 1.18 1.18 0 00-.09.4v.019c.002.089.008.179.02.267-.193-.067-.438-.135-.607-.202a1.635 1.635 0 01-.018-.2v-.02a1.772 1.772 0 01.15-.768c.082-.22.232-.406.43-.533a.985.985 0 01.594-.2zm-2.962.059h.036c.142 0 .27.048.399.135.146.129.264.288.344.465.09.199.14.4.153.667v.004c.007.134.006.2-.002.266v.08c-.03.007-.056.018-.083.024-.152.055-.274.135-.393.2.012-.09.013-.18.003-.267v-.015c-.012-.133-.04-.2-.082-.333a.613.613 0 00-.166-.267.248.248 0 00-.183-.064h-.021c-.071.006-.13.04-.186.132a.552.552 0 00-.12.27.944.944 0 00-.023.33v.015c.012.135.037.2.08.334.046.134.098.2.166.268.01.009.02.018.034.024-.07.057-.117.07-.176.136a.304.304 0 01-.131.068 2.62 2.62 0 01-.275-.402 1.772 1.772 0 01-.155-.667 1.759 1.759 0 01.08-.668 1.43 1.43 0 01.283-.535c.128-.133.26-.2.418-.2zm1.37 1.706c.332 0 .733.065 1.216.399.293.2.523.269 1.052.468h.003c.255.136.405.266.478.399v-.131a.571.571 0 01.016.47c-.123.31-.516.643-1.063.842v.002c-.268.135-.501.333-.775.465-.276.135-.588.292-1.012.267a1.139 1.139 0 01-.448-.067 3.566 3.566 0 01-.322-.198c-.195-.135-.363-.332-.612-.465v-.005h-.005c-.4-.246-.616-.512-.686-.71-.07-.268-.005-.47.193-.6.224-.135.38-.271.483-.336.104-.074.143-.102.176-.131h.002v-.003c.169-.202.436-.47.839-.601.139-.036.294-.065.466-.065zm2.8 2.142c.358 1.417 1.196 3.475 1.735 4.473.286.534.855 1.659 1.102 3.024.156-.005.33.018.513.064.646-1.671-.546-3.467-1.089-3.966-.22-.2-.232-.335-.123-.335.59.534 1.365 1.572 1.646 2.757.13.535.16 1.104.021 1.67.067.028.135.06.205.067 1.032.534 1.413.938 1.23 1.537v-.043c-.06-.003-.12 0-.18 0h-.016c.151-.467-.182-.825-1.065-1.224-.915-.4-1.646-.336-1.77.465-.008.043-.013.066-.018.135-.068.023-.139.053-.209.064-.43.268-.662.669-.793 1.187-.13.533-.17 1.156-.205 1.869v.003c-.02.334-.17.838-.319 1.35-1.5 1.072-3.58 1.538-5.348.334a2.645 2.645 0 00-.402-.533 1.45 1.45 0 00-.275-.333c.182 0 .338-.03.465-.067a.615.615 0 00.314-.334c.108-.267 0-.697-.345-1.163-.345-.467-.931-.995-1.788-1.521-.63-.4-.986-.87-1.15-1.396-.165-.534-.143-1.085-.015-1.645.245-1.07.873-2.11 1.274-2.763.107-.065.037.135-.408.974-.396.751-1.14 2.497-.122 3.854a8.123 8.123 0 01.647-2.876c.564-1.278 1.743-3.504 1.836-5.268.048.036.217.135.289.202.218.133.38.333.59.465.21.201.477.335.876.335.039.003.075.006.11.006.412 0 .73-.134.997-.268.29-.134.52-.334.74-.4h.005c.467-.135.835-.402 1.044-.7zm2.185 8.958c.037.6.343 1.245.882 1.377.588.134 1.434-.333 1.791-.765l.211-.01c.315-.007.577.01.847.268l.003.003c.208.199.305.53.391.876.085.4.154.78.409 1.066.486.527.645.906.636 1.14l.003-.007v.018l-.003-.012c-.015.262-.185.396-.498.595-.63.401-1.746.712-2.457 1.57-.618.737-1.37 1.14-2.036 1.191-.664.053-1.237-.2-1.574-.898l-.005-.003c-.21-.4-.12-1.025.056-1.69.176-.668.428-1.344.463-1.897.037-.714.076-1.335.195-1.814.12-.465.308-.797.641-.984l.045-.022zm-10.814.049h.01c.053 0 .105.005.157.014.376.055.706.333 1.023.752l.91 1.664.003.003c.243.533.754 1.064 1.189 1.637.434.598.77 1.131.729 1.57v.006c-.057.744-.48 1.148-1.125 1.294-.645.135-1.52.002-2.395-.464-.968-.536-2.118-.469-2.857-.602-.369-.066-.61-.2-.723-.4-.11-.2-.113-.602.123-1.23v-.004l.002-.003c.117-.334.03-.752-.027-1.118-.055-.401-.083-.71.043-.94.16-.334.396-.4.69-.533.294-.135.64-.202.915-.47h.002v-.002c.256-.268.445-.601.668-.838.19-.201.38-.336.663-.336zm7.159-9.074c-.435.201-.945.535-1.488.535-.542 0-.97-.267-1.28-.466-.154-.134-.28-.268-.373-.335-.164-.134-.144-.333-.074-.333.109.016.129.134.199.2.096.066.215.2.36.333.292.2.68.467 1.167.467.485 0 1.053-.267 1.398-.466.195-.135.445-.334.648-.467.156-.136.149-.267.279-.267.128.016.034.134-.147.332a8.097 8.097 0 01-.69.468zm-1.082-1.583V5.64c-.006-.02.013-.042.029-.05.074-.043.18-.027.26.004.063 0 .16.067.15.135-.006.049-.085.066-.135.066-.055 0-.092-.043-.141-.068-.052-.018-.146-.008-.163-.065zm-.551 0c-.02.058-.113.049-.166.066-.047.025-.086.068-.14.068-.05 0-.13-.02-.136-.068-.01-.066.088-.133.15-.133.08-.031.184-.047.259-.005.019.009.036.03.03.05v.02h.003z"/></g>
   <g id="i-folder"><path d="M2.6 5.4a1.4 1.4 0 011.4-1.4h3.2l1.6 2h7.2a1.4 1.4 0 011.4 1.4v7.2a1.4 1.4 0 01-1.4 1.4H4a1.4 1.4 0 01-1.4-1.4z"
      fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></g>
 </defs></svg>
+
+<div class="scrollbar" id="scrollbar" aria-hidden="true"></div>
 
 <div class="wrap">
 
@@ -1136,16 +1211,55 @@
   </section>
 
   <section id="how">
-    <div class="sec-head rule-top">
-      <h2>Local Ecosystem</h2>
-      <p class="deck">Connects with Python, Claude Code, local AI models and your
-      machine&rsquo;s own APIs.</p>
-    </div>
+    <div class="eco-scroll" id="eco-scroll">
+      <div class="eco-stage">
+        <div class="sec-head rule-top">
+          <h2>Local Ecosystem</h2>
+          <p class="deck">Connects with Python, Claude Code, local AI models and your
+          machine&rsquo;s own APIs.</p>
+        </div>
+        <div class="eco-row">
+        <div class="eco-copy">
+          <div class="eco-step" data-step="0">
+            <h3>Start a task</h3>
+            <p>Claude works on your machine and reports back.</p>
+          </div>
+          <div class="eco-step" data-step="1">
+            <h3>Run real code</h3>
+            <p>The page runs real Python on your machine.</p>
+          </div>
+          <div class="eco-step" data-step="2">
+            <h3>Models on device</h3>
+            <p>Text, images and transcription, all local.</p>
+          </div>
+          <div class="eco-step" data-step="3">
+            <h3>Native reach</h3>
+            <p>Mic, screen and camera, straight from the app.</p>
+          </div>
+        </div>
 
-    <figure class="ecofig">
-      <img src="assets/showcase/ecosystem.png" width="1344" height="768" loading="lazy" decoding="async"
-           alt="Fused Render at the center of a network, connected to Python, Claude, local AI models and macOS.">
-    </figure>
+        <svg class="eco-svg" viewBox="0 0 900 560" role="img" aria-label="Fused Render at the center of an isometric board, piping data to Claude Code, Python, local AI models and your Mac.">
+          <defs><filter id="f-soft" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="10"/></filter><radialGradient id="g-fade" cx="50%" cy="50%" r="52%"><stop offset="0%" stop-color="#fff"/><stop offset="72%" stop-color="#fff" stop-opacity="0.5"/><stop offset="100%" stop-color="#000"/></radialGradient><mask id="m-fade"><rect x="0" y="0" width="900" height="560" fill="url(#g-fade)"/></mask></defs>
+          <g class="eco-groundg" mask="url(#m-fade)"><path d="M -427.0 572.0 L 543.0 12.0"/><path d="M 543.0 572.0 L -427.0 12.0"/><path d="M -371.0 572.0 L 599.0 12.0"/><path d="M 599.0 572.0 L -371.0 12.0"/><path d="M -315.0 572.0 L 655.0 12.0"/><path d="M 655.0 572.0 L -315.0 12.0"/><path d="M -259.0 572.0 L 711.0 12.0"/><path d="M 711.0 572.0 L -259.0 12.0"/><path d="M -203.0 572.0 L 767.0 12.0"/><path d="M 767.0 572.0 L -203.0 12.0"/><path d="M -147.0 572.0 L 823.0 12.0"/><path d="M 823.0 572.0 L -147.0 12.0"/><path d="M -91.0 572.0 L 879.0 12.0"/><path d="M 879.0 572.0 L -91.0 12.0"/><path d="M -35.0 572.0 L 935.0 12.0"/><path d="M 935.0 572.0 L -35.0 12.0"/><path d="M 21.0 572.0 L 991.0 12.0"/><path d="M 991.0 572.0 L 21.0 12.0"/><path d="M 77.0 572.0 L 1047.0 12.0"/><path d="M 1047.0 572.0 L 77.0 12.0"/><path d="M 133.0 572.0 L 1103.0 12.0"/><path d="M 1103.0 572.0 L 133.0 12.0"/><path d="M 189.0 572.0 L 1159.0 12.0"/><path d="M 1159.0 572.0 L 189.0 12.0"/><path d="M 245.0 572.0 L 1215.0 12.0"/><path d="M 1215.0 572.0 L 245.0 12.0"/><path d="M 301.0 572.0 L 1271.0 12.0"/><path d="M 1271.0 572.0 L 301.0 12.0"/><path d="M 357.0 572.0 L 1327.0 12.0"/><path d="M 1327.0 572.0 L 357.0 12.0"/></g>
+          <g class="eco-pipe"><polygon class="eco-pipe-bed" points="458.0,273.8 458.0,115.5 442.0,115.5 442.0,273.8"/><path class="eco-pipe-edge" d="M 458.0 273.8 L 458.0 115.5"/><path class="eco-pipe-edge" d="M 442.0 273.8 L 442.0 115.5"/><path class="eco-pipe-core" id="p-claude" d="M 450.0 273.8 L 450.0 115.5"/><path class="eco-stream" id="st-claude" d="M 450.0 273.8 L 450.0 115.5"/></g>
+          <g class="eco-pipe"><polygon class="eco-pipe-bed" points="481.5,300.0 755.8,300.0 755.8,284.0 481.5,284.0"/><path class="eco-pipe-edge" d="M 481.5 300.0 L 755.8 300.0"/><path class="eco-pipe-edge" d="M 481.5 284.0 L 755.8 284.0"/><path class="eco-pipe-core" id="p-mac" d="M 481.5 292.0 L 755.8 292.0"/><path class="eco-stream" id="st-mac" d="M 481.5 292.0 L 755.8 292.0"/></g>
+          <g class="eco-pipe"><polygon class="eco-pipe-bed" points="458.0,310.2 458.0,468.5 442.0,468.5 442.0,310.2"/><path class="eco-pipe-edge" d="M 458.0 310.2 L 458.0 468.5"/><path class="eco-pipe-edge" d="M 442.0 310.2 L 442.0 468.5"/><path class="eco-pipe-core" id="p-brain" d="M 450.0 310.2 L 450.0 468.5"/><path class="eco-stream" id="st-brain" d="M 450.0 310.2 L 450.0 468.5"/></g>
+          <g class="eco-pipe"><polygon class="eco-pipe-bed" points="418.5,300.0 144.2,300.0 144.2,284.0 418.5,284.0"/><path class="eco-pipe-edge" d="M 418.5 300.0 L 144.2 300.0"/><path class="eco-pipe-edge" d="M 418.5 284.0 L 144.2 284.0"/><path class="eco-pipe-core" id="p-python" d="M 418.5 292.0 L 144.2 292.0"/><path class="eco-stream" id="st-python" d="M 418.5 292.0 L 144.2 292.0"/></g>
+          <g class="eco-hub">
+          <polygon class="hubb-l" points="338.0,292.0 450.0,348.0 450.0,368.0 338.0,312.0"/><polygon class="hubb-r" points="450.0,348.0 562.0,292.0 562.0,312.0 450.0,368.0"/><polygon class="hubb-t" points="450.0,236.0 562.0,292.0 450.0,348.0 338.0,292.0"/>
+          <polygon class="hubg-l" points="378.0,277.0 450.0,313.0 450.0,323.0 378.0,287.0"/><polygon class="hubg-r" points="450.0,313.0 522.0,277.0 522.0,287.0 450.0,323.0"/><polygon class="hubg-t" points="450.0,241.0 522.0,277.0 450.0,313.0 378.0,277.0"/>
+          <ellipse class="eco-hubglow" cx="450.0" cy="277.0" rx="58" ry="22" filter="url(#f-soft)"/>
+          <text class="eco-hubmark" transform="matrix(1 0 0 0.5 450.0 277.0)" x="0" y="22" text-anchor="middle" font-size="72">&#10022;</text>
+          </g>
+          <g class="eco-node" data-node="claude" tabindex="0"><polygon class="pad-l" points="372.0,110.0 450.0,149.0 450.0,162.0 372.0,123.0"/><polygon class="pad-r" points="450.0,149.0 528.0,110.0 528.0,123.0 450.0,162.0"/><polygon class="pad-t" points="450.0,71.0 528.0,110.0 450.0,149.0 372.0,110.0"/><g class="eco-flat" transform="matrix(1 0 0 0.5 450.0 109.0)"><g transform="translate(-24 -24) scale(2.4)"><use href="#i-claude"/></g></g></g>
+          <g class="eco-node" data-node="mac" tabindex="0"><polygon class="pad-l" points="687.2,292.0 765.2,331.0 765.2,344.0 687.2,305.0"/><polygon class="pad-r" points="765.2,331.0 843.2,292.0 843.2,305.0 765.2,344.0"/><polygon class="pad-t" points="765.2,253.0 843.2,292.0 765.2,331.0 687.2,292.0"/><g class="eco-flat" transform="matrix(1 0 0 0.5 765.2 291.0)"><g transform="translate(-24 -24) scale(2.4)"><use href="#i-apple"/></g></g></g>
+          <g class="eco-node" data-node="brain" tabindex="0"><polygon class="pad-l" points="372.0,474.0 450.0,513.0 450.0,526.0 372.0,487.0"/><polygon class="pad-r" points="450.0,513.0 528.0,474.0 528.0,487.0 450.0,526.0"/><polygon class="pad-t" points="450.0,435.0 528.0,474.0 450.0,513.0 372.0,474.0"/><g class="eco-flat" transform="matrix(1 0 0 0.5 450.0 473.0)"><g transform="translate(-24 -24) scale(2.4)"><use href="#i-brain"/></g></g></g>
+          <g class="eco-node" data-node="python" tabindex="0"><polygon class="pad-l" points="56.8,292.0 134.8,331.0 134.8,344.0 56.8,305.0"/><polygon class="pad-r" points="134.8,331.0 212.8,292.0 212.8,305.0 134.8,344.0"/><polygon class="pad-t" points="134.8,253.0 212.8,292.0 134.8,331.0 56.8,292.0"/><g class="eco-flat" transform="matrix(1 0 0 0.5 134.8 291.0)"><g transform="translate(-24 -24) scale(2.4)"><use href="#i-python-mark"/></g></g></g>
+          <text class="eco-livelbl" id="eco-live" x="450" y="548" text-anchor="middle"></text>
+          </svg>
+        </div>
+      </div>
+    </div>
   </section>
 
   <!-- Hidden for now: the illustrated set below (#models-alt) is live instead. -->
@@ -1365,32 +1479,48 @@
   <!-- ============ DOWNLOAD ============ -->
 
   <section id="get">
-    <div class="macwrap">
-      <div class="mac">
-        <div class="mac-bar" aria-hidden="true">
-          <span class="tl r"></span><span class="tl y"></span><span class="tl g"></span>
-          <span class="mac-title">Fused Render</span>
+    <div class="get-scroll" id="get-scroll">
+      <div class="get-stage">
+        <div class="macwrap" id="macwrap">
+          <div class="mac">
+            <div class="mac-bar" aria-hidden="true">
+              <span class="tl r"></span><span class="tl y"></span><span class="tl g"></span>
+              <span class="mac-title">Fused Render</span>
+            </div>
+            <img class="mac-shot" src="assets/showcase/app-home.jpg" width="3420" height="1970"
+                 loading="lazy" decoding="async" alt="The Fused Render home screen: apps, AI playground and Claude tasks.">
+          </div>
         </div>
-        <img class="mac-shot" src="assets/showcase/app-home.jpg" width="3420" height="1970"
-             loading="lazy" decoding="async" alt="The Fused Render home screen: apps, AI playground and Claude tasks.">
+        <div class="getbody" id="getbody">
+          <h2>Free, and it stays on your machine.</h2>
+          <p class="deck">One download. No account, no key, no card.</p>
+          <div class="dl">
+            <a class="dl-btn" id="dl-primary" rel="noopener" href="https://github.com/fusedio/fused-render/releases">
+              <svg viewBox="0 0 20 20" aria-hidden="true"><use id="dl-primary-icon" href="#i-apple"/></svg>
+              <span id="dl-primary-label">Download for macOS</span>
+            </a>
+            <details class="dl-others">
+              <summary>Other platforms</summary>
+              <div class="dl-list">
+                <a id="dmg" rel="noopener" href="https://github.com/fusedio/fused-render/releases">
+                  <span class="nm"><svg viewBox="0 0 20 20" aria-hidden="true"><use href="#i-apple"/></svg>macOS</span>
+                  <span class="sub">Apple silicon &middot; .dmg</span>
+                </a>
+                <a id="windows-exe" rel="noopener" href="https://github.com/fusedio/fused-render/releases">
+                  <span class="nm"><svg viewBox="0 0 20 20" aria-hidden="true"><use href="#i-windows"/></svg>Windows</span>
+                  <span class="sub">64-bit installer &middot; .exe</span>
+                </a>
+                <a id="linux-appimage" rel="noopener" href="https://github.com/fusedio/fused-render/releases">
+                  <span class="nm"><svg viewBox="0 0 20 20" aria-hidden="true"><use href="#i-linux"/></svg>Linux</span>
+                  <span class="sub">AppImage</span>
+                </a>
+              </div>
+            </details>
+            <span class="version" id="version" hidden></span>
+          </div>
+        </div>
       </div>
     </div>
-    <div class="getbody">
-      <h2>Free, and it stays on your machine.</h2>
-      <p class="deck">One download. No account, no key, no card.</p>
-      <div class="oses">
-        <a class="os primary" id="dmg" rel="noopener" href="https://github.com/fusedio/fused-render/releases">
-          <b><svg viewBox="0 0 20 20" aria-hidden="true"><use href="#i-down"/></svg>macOS</b><span>Apple silicon</span>
-        </a>
-        <a class="os" id="windows-exe" rel="noopener" href="https://github.com/fusedio/fused-render/releases">
-          <b><svg viewBox="0 0 20 20" aria-hidden="true"><use href="#i-down"/></svg>Windows</b><span>64-bit installer</span>
-        </a>
-        <a class="os" id="linux-appimage" rel="noopener" href="https://github.com/fusedio/fused-render/releases">
-          <b><svg viewBox="0 0 20 20" aria-hidden="true"><use href="#i-down"/></svg>Linux</b><span>AppImage</span>
-        </a>
-      </div>
-    </div>
-    <span class="version" id="version" hidden></span>
   </section>
 
   <!-- Hidden for now; the app's error screens deep-link here, so a
@@ -1547,17 +1677,19 @@
   var osCardId = { mac: "dmg", win: "windows-exe", linux: "linux-appimage" }[visitorOS];
   var osLabel = { mac: "macOS", win: "Windows", linux: "Linux" }[visitorOS];
 
-  // The visitor's own card leads, and carries the section's single accent.
-  Array.prototype.forEach.call(document.querySelectorAll(".os"), function (el) {
-    el.classList.toggle("primary", el.id === osCardId);
-  });
-
-  // Hero CTA: labelled for the visitor's OS, href mirroring the matching card
-  // (the releases page now, the direct artifact once the manifest lands).
+  // Hero CTA and the big download button both speak the visitor's OS,
+  // hrefs mirroring the matching accordion row (releases page until the
+  // manifest lands, the direct artifact after).
   var heroCta = document.getElementById("hero-cta");
+  var dlBtn = document.getElementById("dl-primary");
+  var osIcon = { mac: "#i-apple", win: "#i-windows", linux: "#i-linux" }[visitorOS];
   function syncCta() {
+    var href = document.getElementById(osCardId).href;
     heroCta.textContent = "Download for " + osLabel;
-    heroCta.href = document.getElementById(osCardId).href;
+    heroCta.href = href;
+    dlBtn.href = href;
+    document.getElementById("dl-primary-label").textContent = "Download for " + osLabel;
+    document.getElementById("dl-primary-icon").setAttribute("href", osIcon);
   }
   syncCta();
 
@@ -1654,13 +1786,185 @@
     });
   })();
 
+  // Page scroll progress bar.
+  (function () {
+    var bar = document.getElementById("scrollbar");
+    if (!bar) return;
+    function up() {
+      var max = document.documentElement.scrollHeight - innerHeight;
+      bar.style.transform = "scaleX(" + (max > 0 ? scrollY / max : 0) + ")";
+    }
+    addEventListener("scroll", up, { passive: true });
+    addEventListener("resize", up, { passive: true });
+    up();
+  })();
+
+  // Ecosystem board: scroll scrubs four chapters. A short lime stream runs
+  // through the pipeline to a pad, the pad's surface lights while it works,
+  // the stream runs home. Narration sits on one line under the board.
+  // Clicking a pad or a caption card scrubs to that chapter.
+  (function () {
+    var scroller = document.getElementById("eco-scroll");
+    if (!scroller || !document.documentElement.classList.contains("anim")) return;
+    if (matchMedia("(max-width: 860px)").matches) return;
+    var ORDER = ["claude", "python", "brain", "mac"];
+    var CH = {
+      claude: { out: "\u201cnew task \u2014 summarise my invoices\u201d", work: "claude is working\u2026", done: "task done \u2713" },
+      python: { out: "\u201crun the code\u201d", work: "python is running\u2026", done: "here\u2019s the result \u2713" },
+      brain:  { out: "\u201ctranscribe this recording\u201d", work: "local ai is transcribing\u2026", done: "transcript ready \u2713" },
+      mac:    { out: "\u201cuse the microphone\u201d", work: "recording\u2026", done: "recording saved \u2713" }
+    };
+    var STREAM = 52;
+    var stream = {}, lens = {};
+    ORDER.forEach(function (k) {
+      var el = document.getElementById("st-" + k);
+      stream[k] = el;
+      lens[k] = el.getTotalLength();
+      el.style.strokeDasharray = STREAM + " " + Math.ceil(lens[k] + STREAM * 2);
+    });
+    var live = document.getElementById("eco-live");
+    var nodes = {};
+    Array.prototype.slice.call(scroller.querySelectorAll(".eco-node")).forEach(function (n) {
+      nodes[n.dataset.node] = n;
+    });
+    var steps = Array.prototype.slice.call(scroller.querySelectorAll(".eco-step"));
+
+    var target = 0, cur = 0, shown = -1;
+    function measure() {
+      var r = scroller.getBoundingClientRect();
+      var span = r.height - innerHeight;
+      target = span > 0 ? Math.max(0, Math.min(1, -r.top / span)) : 0;
+    }
+    addEventListener("scroll", measure, { passive: true });
+    addEventListener("resize", measure, { passive: true });
+    measure();
+    var forced = /[?&]eco=([0-9.]+)/.exec(location.search);
+
+    function render(p) {
+      var ci = Math.min(3, Math.floor(p * 4));
+      var local = (p * 4) - ci;
+      var key = ORDER[ci];
+      var ch = CH[key];
+
+      if (shown !== ci) {
+        shown = ci;
+        steps.forEach(function (el, i) { el.classList.toggle("on", i === ci); });
+        ORDER.forEach(function (k) { if (k !== key) stream[k].style.opacity = 0; });
+      }
+      ORDER.forEach(function (k) {
+        nodes[k].classList.toggle("live", k === key && local >= 0.28 && local < 0.92);
+      });
+
+      // phases: 0-.3 stream out, .3-.6 working, .6-.9 stream home, .9-1 rest
+      var el = stream[key], len = lens[key];
+      function sweep(t) { el.style.strokeDashoffset = STREAM - t * (len + STREAM * 2); }
+      if (local < 0.3) {
+        el.style.opacity = 1; sweep(local / 0.3);
+        live.textContent = ch.out;
+      } else if (local < 0.6) {
+        el.style.opacity = 0;
+        live.textContent = ch.work;
+      } else if (local < 0.9) {
+        el.style.opacity = 1; sweep(1 - (local - 0.6) / 0.3);
+        live.textContent = ch.done;
+      } else {
+        el.style.opacity = 0;
+        live.textContent = ch.done;
+      }
+    }
+
+    function tick() {
+      if (forced) { render(parseFloat(forced[1])); return; }
+      if (play) {
+        var pt = (performance.now() - play.t0) / play.dur;
+        var eased = pt <= 0 ? 0 : (pt < 0.5 ? 2*pt*pt : 1 - Math.pow(-2*pt + 2, 2) / 2);
+        cur = (play.ci + 0.93 * Math.min(1, eased)) / 4;
+        render(cur);
+        if (pt >= 1) {
+          // park the page where the playhead ended, so scrolling resumes seamlessly
+          scrollTo({ top: play.end, behavior: "instant" });
+          play = null; measure(); cur = target;
+        }
+        requestAnimationFrame(tick);
+        return;
+      }
+      cur += (target - cur) * 0.14;
+      if (Math.abs(target - cur) < 0.0005) cur = target;
+      render(cur);
+      requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+
+    var play = null;
+    ["wheel", "touchstart", "keydown"].forEach(function (ev) {
+      addEventListener(ev, function () { play = null; }, { passive: true });
+    });
+    function goTo(ci) {
+      var top = scroller.getBoundingClientRect().top + scrollY;
+      var span = scroller.offsetHeight - innerHeight;
+      // park instantly at the chapter opening — one animation only: the story
+      // (behavior:"instant" beats the page's global scroll-behavior:smooth)
+      scrollTo({ top: top + span * (ci / 4 + 0.005), behavior: "instant" });
+      measure();
+      play = { ci: ci, t0: performance.now() + 250, dur: 3400,
+               end: top + span * (ci / 4 + 0.93 / 4) };
+    }
+    Object.keys(nodes).forEach(function (k) {
+      var n = nodes[k];
+      n.addEventListener("click", function () { goTo(ORDER.indexOf(k)); });
+      n.addEventListener("keydown", function (e) { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); goTo(ORDER.indexOf(k)); } });
+    });
+    steps.forEach(function (el, i) {
+      el.addEventListener("click", function () { goTo(i); });
+    });
+  })();
+
+  // Download closer: scrolling grows the Mac window past the measure, then
+  // crossfades it into the headline + download button.
+  (function () {
+    var scroller = document.getElementById("get-scroll");
+    if (!scroller || !document.documentElement.classList.contains("anim")) return;
+    if (matchMedia("(max-width: 860px)").matches) return;
+    var mac = document.getElementById("macwrap");
+    var body = document.getElementById("getbody");
+    var target = 0, cur = 0;
+    function measure() {
+      var r = scroller.getBoundingClientRect();
+      var span = r.height - innerHeight;
+      target = span > 0 ? Math.max(0, Math.min(1, -r.top / span)) : 0;
+    }
+    addEventListener("scroll", measure, { passive: true });
+    addEventListener("resize", measure, { passive: true });
+    measure();
+    var stage = scroller.querySelector(".get-stage");
+    function render(p) {
+      var grow = Math.min(1, p / 0.55);
+      var scale = 1 + 0.42 * (1 - Math.pow(1 - grow, 2));
+      var fade = Math.max(0, Math.min(1, (p - 0.42) / 0.22));
+      mac.style.transform = "scale(" + scale + ")";
+      // the window stays in view behind the gradient, only slightly dimmed
+      mac.style.opacity = 1 - 0.3 * fade;
+      stage.style.setProperty("--gfade", fade);
+      var reveal = Math.max(0, Math.min(1, (p - 0.5) / 0.26));
+      body.style.opacity = reveal;
+      body.style.transform = "translateY(" + (24 * (1 - reveal)) + "px)";
+      body.classList.toggle("on", reveal > 0.5);
+    }
+    (function tick() {
+      cur += (target - cur) * 0.16;
+      if (Math.abs(target - cur) < 0.0005) cur = target;
+      render(cur);
+      requestAnimationFrame(tick);
+    })();
+  })();
+
   // Scroll fade-ins: sections drift up as they enter the viewport.
   // Gated on html.anim; without JS or with reduced motion nothing is hidden.
   (function () {
     if (!document.documentElement.classList.contains("anim")) return;
     if (!("IntersectionObserver" in window)) return;
     var els = Array.prototype.slice.call(
-      document.querySelectorAll(".wrap > section:not([hidden])"));
+      document.querySelectorAll(".wrap > section:not([hidden]):not(#how)"));
     var io = new IntersectionObserver(function (entries) {
       entries.forEach(function (e) {
         if (e.isIntersecting) { e.target.classList.add("in"); io.unobserve(e.target); }

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -369,22 +369,28 @@
     font-weight: 620;
   }
 
-  /* format chips — one scrolling line beneath the panel, no tile */
-  .fmts {
-    display: flex; gap: 8px; margin-top: var(--s3);
-    overflow-x: auto; padding-bottom: 4px; scrollbar-width: none;
+  /* --- formats: a slow marquee band of extensions --- */
+  .fmt-band {
+    margin-top: var(--s3); padding: var(--s3) 0;
+    border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule);
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
   }
-  .fmts::-webkit-scrollbar { display: none; }
-  .fmts li {
-    flex: none;
-    font: var(--t-xs)/1 ui-monospace, SFMono-Regular, Menlo, monospace;
-    letter-spacing: 0.02em;
-    padding: 8px 11px;
-    border: 1px solid var(--rule);
-    border-radius: var(--r-sm);
-    color: var(--ink-2);
+  .fmt-track { display: flex; width: max-content; }
+  html.anim .fmt-track { animation: fmt-slide 48s linear infinite; }
+  .fmt-band:hover .fmt-track, .fmt-band:focus-within .fmt-track { animation-play-state: paused; }
+  @keyframes fmt-slide { to { transform: translateX(-50%); } }
+  .fmt-track ul { display: flex; align-items: center; }
+  .fmt-track li {
+    font: 500 var(--t-sm)/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3);
+    padding: 0 var(--s3); white-space: nowrap;
+    border-right: 1px solid var(--rule);
   }
-  .fmts .rest { border-color: transparent; color: var(--ink-4); padding-left: 2px; }
+  .fmt-track li.rest {
+    color: var(--ink-4); text-transform: none; letter-spacing: 0.04em;
+  }
 
   /* ---------- §2 : the model bento ---------- */
   .flow {
@@ -1416,11 +1422,22 @@
       </div>
     </div>
 
-    <ul class="fmts" aria-label="Some of the file types Fused Render previews">
-      <li>CSV</li><li>Parquet</li><li>PDF</li><li>XLSX</li><li>SQLite</li>
-      <li>ZIP</li><li>JSON</li><li>Markdown</li><li>GeoTIFF</li><li>NetCDF</li>
-      <li>Shapefile</li><li>GLB</li><li class="rest">and 100+ more</li>
-    </ul>
+    <!-- Marquee: doubled in markup so the loop is seamless with no JS. The
+         second copy is hidden from assistive tech. -->
+    <div class="fmt-band" role="group" aria-label="Some of the file types Fused Render previews">
+      <div class="fmt-track">
+        <ul>
+          <li>CSV</li><li>Parquet</li><li>PDF</li><li>XLSX</li><li>SQLite</li>
+          <li>ZIP</li><li>JSON</li><li>Markdown</li><li>GeoTIFF</li><li>NetCDF</li>
+          <li>Shapefile</li><li>GLB</li><li class="rest">and 100+ more</li>
+        </ul>
+        <ul aria-hidden="true">
+          <li>CSV</li><li>Parquet</li><li>PDF</li><li>XLSX</li><li>SQLite</li>
+          <li>ZIP</li><li>JSON</li><li>Markdown</li><li>GeoTIFF</li><li>NetCDF</li>
+          <li>Shapefile</li><li>GLB</li><li class="rest">and 100+ more</li>
+        </ul>
+      </div>
+    </div>
   </section>
 
   <section id="apps" hidden>
@@ -1956,6 +1973,64 @@
       render(cur);
       requestAnimationFrame(tick);
     })();
+  })();
+
+  // Scroll-reactive marquee: the format band drifts on its own and leans
+  // into the scroll — flick the page and the strip surges with you, then
+  // settles back to its base speed. One rAF owns the transform so the two
+  // motions never fight; it only runs while the band is on screen.
+  (function () {
+    var band = document.querySelector(".fmt-band");
+    var track = band && band.querySelector(".fmt-track");
+    if (!track || !document.documentElement.classList.contains("anim")) return;
+    if (!("IntersectionObserver" in window)) return;
+
+    var owned = false;
+    function takeOver() {
+      if (owned) return;
+      owned = true;
+      track.style.animation = "none";
+    }
+
+    var half = 0, x = 0, base = 26, boost = 0, last = 0, raf = 0, hovered = false;
+    var lastScroll = window.scrollY;
+    function measureBand() { half = track.scrollWidth / 2; }
+    measureBand();
+    addEventListener("resize", measureBand, { passive: true });
+    addEventListener("load", measureBand);
+
+    addEventListener("scroll", function () {
+      var y = window.scrollY;
+      var d = y - lastScroll;
+      lastScroll = y;
+      boost = Math.max(-900, Math.min(900, boost + d * 9));
+    }, { passive: true });
+    band.addEventListener("pointerenter", function () { hovered = true; });
+    band.addEventListener("pointerleave", function () { hovered = false; });
+
+    function frame(t) {
+      raf = requestAnimationFrame(frame);
+      if (!last) { last = t; return; }
+      var dt = Math.min(0.05, (t - last) / 1000);
+      last = t;
+      boost *= Math.pow(0.0016, dt);
+      if (Math.abs(boost) < 0.5) boost = 0;
+      if (!half) { measureBand(); return; }
+      takeOver();
+      x -= (hovered ? 0 : base) * dt + boost * dt;
+      if (x <= -half) x += half;
+      if (x > 0) x -= half;
+      track.style.transform = "translate3d(" + x.toFixed(2) + "px,0,0)";
+    }
+    function start() { if (!raf) { last = 0; raf = requestAnimationFrame(frame); } }
+    function stop() { if (raf) { cancelAnimationFrame(raf); raf = 0; } }
+    var io = new IntersectionObserver(function (e) {
+      e[0].isIntersecting && !document.hidden ? start() : stop();
+    }, { rootMargin: "120px 0px" });
+    io.observe(band);
+    document.addEventListener("visibilitychange", function () {
+      document.hidden ? stop() : (band.getBoundingClientRect().bottom > 0 && start());
+    });
   })();
 
   // Scroll fade-ins: sections drift up as they enter the viewport.

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -1972,7 +1972,31 @@
       if (Math.abs(target - cur) < 0.0005) cur = target;
       render(cur);
       requestAnimationFrame(tick);
-    })();
+  
+    // "Get the app" should land on the button, not the zoom's first frame:
+    // send #get arrivals to the revealed end of the closer.
+    function landAtButton(e) {
+      if (e) e.preventDefault();
+      var top = scroller.getBoundingClientRect().top + scrollY;
+      scrollTo({ top: top + (scroller.offsetHeight - innerHeight) * 0.995, behavior: "smooth" });
+    }
+    Array.prototype.forEach.call(document.querySelectorAll('a[href="#get"]'), function (a) {
+      a.addEventListener("click", landAtButton);
+    });
+    if (location.hash === "#get") setTimeout(function () { landAtButton(); }, 60);
+  })();
+
+    // "Get the app" should land on the button, not the zoom's first frame:
+    // send #get arrivals to the revealed end of the closer.
+    function landAtButton(e) {
+      if (e) e.preventDefault();
+      var top = scroller.getBoundingClientRect().top + scrollY;
+      scrollTo({ top: top + (scroller.offsetHeight - innerHeight) * 0.995, behavior: "smooth" });
+    }
+    Array.prototype.forEach.call(document.querySelectorAll('a[href="#get"]'), function (a) {
+      a.addEventListener("click", landAtButton);
+    });
+    if (location.hash === "#get") setTimeout(function () { landAtButton(); }, 60);
   })();
 
   // Scroll-reactive marquee: the format band drifts on its own and leans


### PR DESCRIPTION
## What

Two scroll-driven set pieces for the landing page, plus a rebuilt installer block. No dependencies added — all inline SVG/CSS/JS, and the page keeps its zero-external-requests contract.

### Local Ecosystem → interactive isometric board
- Fused Render's ✦ printed flat on a glowing center platform; Claude Code / Python / local AI / your Mac on four iso pads at the rhombus corners; sunken 3D pipeline channels between them; faint radially-fading iso grid.
- Scrolling scrubs four chapters: a lime data stream runs out through the pipe, the destination pad's whole surface lights while it works, the stream runs home. Narration in plain language on one line under the board ("new task — summarise my invoices" → "claude is working…" → "task done ✓").
- The section header rides inside the sticky stage. Captions are plain text with a lime underline on the active one; clicking a caption or pad parks at that chapter and plays the full round trip once, slowly (`behavior:"instant"` parks so the page's global smooth scrolling can't double-play it).

### Download closer
- Scrolling grows the Mac window past the page measure (transform scale, nothing clips), then a full-bleed bottom gradient rolls in and the headline + download button land near the bottom with the screenshot still showing through above.
- One detected-OS button (Apple/Windows/Linux mark + "Download for macOS/…"); "Other platforms" opens a compact dropdown holding the `#dmg` / `#windows-exe` / `#linux-appimage` rows — `latest.json` fill and OS detection unchanged, and opening it shifts no layout.

### Chrome
- 2px lime page-scroll progress bar fixed at the top.
- Spacing fix between the explorer section and the download separator.

All motion opts in under `html.anim` on desktop widths; reduced-motion, no-JS and mobile get finished static layouts. Verified: troubleshooting deep links, download ids, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-page HTML/CSS/JS only; download link IDs and manifest behavior are preserved, though the diff appears to register duplicate `#get` click handlers in the download-closer script.
> 
> **Overview**
> This PR turns the Fused Render **download landing page** (`scripts/download_page/index.html`) into a more cinematic marketing experience while keeping the same download IDs, `latest.json` wiring, and no-external-deps setup.
> 
> **Local Ecosystem** replaces the static `ecosystem.png` with an inline **isometric SVG board** (hub, four pads, piped “streams”). On desktop with `html.anim`, a tall scroll region scrubs four chapters: lime strokes animate out and back, pads highlight, captions sync, and live narration updates under the diagram; pads and caption rows are clickable to jump/play a chapter.
> 
> **Download (#get)** drops the three side-by-side OS cards for one **OS-detected primary pill** (Apple/Windows/Linux icons) plus an **“Other platforms”** `details` popover for macOS/Windows/Linux links. A scroll-driven **“closer”** scales the Mac screenshot, fades in a full-bleed gradient, and reveals the headline and CTA; `#get` nav links scroll to the revealed button state.
> 
> **Chrome and polish:** a fixed **2px scroll progress bar**; file-type chips become a **doubled-list marquee** (CSS loop, optional scroll-reactive rAF); footer spacing tweak; section fade-ins skip `#how` because it has its own motion.
> 
> Motion remains gated on `html.anim` / desktop width; reduced motion and no-JS still get static layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3466cf5e1244095bb0ee569d620359b5617026a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->