### PR TITLE
Fix main: 115 failing tests from #855's removed seam and new spawn kwargs

### DIFF
--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -13,8 +13,12 @@ not list — a page-less folder at depth 1 is a shelf of apps, not an app — so
 these assertions are unchanged by the walk becoming recursive. The depth rules
 are exercised directly in tests/test_app_listing.py.
 
-The spawn is stubbed at the module seam (_start_app_session) — no test here
-launches a real claude.
+The scaffolding task is stubbed at the module seam (_create_app_task) — no
+test here launches a real claude. A handful of tests further down exercise
+the fork-safe spawn discipline itself (claude_spawn.spawn_helper) directly,
+since apps.py no longer owns that seam — it goes through schedule.create /
+schedule.run_now instead, and the low-level posix_spawn contract is shared
+with scheduled messages.
 """
 import json
 import os
@@ -24,7 +28,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
-from fused_render import app_listing
+from fused_render import app_listing, claude_spawn
 from fused_render.server import create_app
 from fused_render.server.routers import apps as apps_mod
 
@@ -266,17 +270,18 @@ def test_new_app_requires_the_fused_header(client):
 
 def test_new_app_happy_path_no_prompt(client, workspace, monkeypatch):
     called = []
-    monkeypatch.setattr(apps_mod, "_start_app_session",
+    monkeypatch.setattr(apps_mod, "_create_app_task",
                         lambda entry, prompt, *rest:
-                        called.append((entry, prompt)) or ("r-1", None))
+                        called.append((entry, prompt)) or ({"id": "t-1", "run_id": "r-1"}, None))
     r = client.post("/api/apps/new", json={"name": "demo", "prompt": ""}, headers=HDRS)
     assert r.status_code == 200
     body = r.json()
     dest = workspace / "local" / "demo"
     assert body["path"] == str(dest)
     assert body["entry_html"] == str(dest / "index.html")
-    assert body["session_started"] is False
-    assert called == []  # empty prompt: no spawn attempt at all
+    assert body["task"] is None
+    assert body["task_error"] is None
+    assert called == []  # empty prompt: no task creation attempt at all
     assert (dest / "index.html").is_file()
     assert (dest / "CLAUDE.md").is_file()
     # the starter kit's entry is a valid single-entry app: it lists back
@@ -301,7 +306,7 @@ def test_new_app_has_no_dot_claude_and_publishes_the_plugin_root(
 
     claude_dir = tmp_path / "claude-config"
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_dir))
-    monkeypatch.setattr(apps_mod, "_start_app_session", lambda e, p, *rest: (None, "x"))
+    # prompt is empty, so _create_app_task is never called — nothing to stub
     client.post("/api/apps/new", json={"name": "demo", "prompt": ""}, headers=HDRS)
 
     assert not (workspace / "local" / "demo" / ".claude").exists()
@@ -314,23 +319,22 @@ def test_new_app_has_no_dot_claude_and_publishes_the_plugin_root(
 def test_new_app_with_prompt_starts_a_session(client, workspace, monkeypatch):
     seen = {}
 
-    def fake_start(app_dir, prompt, model="", effort=""):
-        seen["target"] = app_dir
+    def fake_create_task(entry_html, prompt, model="", effort=""):
+        seen["target"] = entry_html
         seen["prompt"] = prompt
         seen["model"] = model
         seen["effort"] = effort
-        return "run-42", None
+        return {"id": "t-1", "run_id": "run-42", "state": "sent", "error": ""}, None
 
-    monkeypatch.setattr(apps_mod, "_start_app_session", fake_start)
+    monkeypatch.setattr(apps_mod, "_create_app_task", fake_create_task)
     r = client.post("/api/apps/new",
                     json={"name": "demo", "prompt": "build a todo app"},
                     headers=HDRS)
-    assert r.json()["session_started"] is True
-    assert r.json()["session_error"] is None
-    assert r.json()["run_id"] == "run-42"   # the UI can attach to the live run
-    # The scaffolding session starts on the app FOLDER (claude agent),
-    # so its transcript lands where the split view lists sessions from.
-    assert seen["target"] == str(workspace / "local" / "demo")
+    assert r.json()["task"]["run_id"] == "run-42"   # the UI can attach to the live run
+    assert r.json()["task_error"] is None
+    # The scaffolding task targets the app's index.html FILE (not the folder),
+    # so _outgoing can name it in the transcript's first turn.
+    assert seen["target"] == str(workspace / "local" / "demo" / "index.html")
     assert seen["prompt"] == "build a todo app"
     # no pickers touched: "" both, i.e. no --model/--effort on the spawn, so the
     # session keeps whatever a chat opened by hand would have detected
@@ -340,12 +344,13 @@ def test_new_app_with_prompt_starts_a_session(client, workspace, monkeypatch):
 def test_the_composers_model_and_effort_reach_the_session(client, workspace,
                                                           monkeypatch):
     """The hero composer's two pickers are what the scaffolding turn runs
-    with, so they have to arrive at the spawn — a create that accepted them and
-    started a default session is the whole feature missing."""
+    with, so they have to arrive at the task creation — a create that accepted
+    them and started a default session is the whole feature missing."""
     seen = {}
-    monkeypatch.setattr(apps_mod, "_start_app_session",
+    monkeypatch.setattr(apps_mod, "_create_app_task",
                         lambda e, p, model="", effort="":
-                        seen.update(model=model, effort=effort) or ("r-1", None))
+                        seen.update(model=model, effort=effort) or
+                        ({"id": "t-1", "run_id": "r-1"}, None))
     r = client.post("/api/apps/new",
                     json={"name": "demo", "prompt": "build it",
                           "model": "opus", "effort": "xhigh"}, headers=HDRS)
@@ -368,8 +373,8 @@ def test_an_unknown_model_or_effort_is_a_400_not_a_substitution(client, workspac
     own UI can only send list values, so this only fires for a hand-rolled
     request. And nothing is created: the folder must not survive a rejected
     request any more than a bad name's does."""
-    monkeypatch.setattr(apps_mod, "_start_app_session",
-                        lambda *a, **k: pytest.fail("must not spawn"))
+    monkeypatch.setattr(apps_mod, "_create_app_task",
+                        lambda *a, **k: pytest.fail("must not create a task"))
     r = client.post("/api/apps/new",
                     json={"name": "demo", "prompt": "hi", **body}, headers=HDRS)
     assert r.status_code == 400
@@ -381,9 +386,9 @@ def test_an_empty_pick_means_no_flag_and_older_clients_still_work(
     """"" is a first-class value in both lists, not a rejected one — it is what
     the pickers' "Auto" option sends and what a client predating them omits."""
     seen = []
-    monkeypatch.setattr(apps_mod, "_start_app_session",
+    monkeypatch.setattr(apps_mod, "_create_app_task",
                         lambda e, p, model="", effort="":
-                        seen.append((model, effort)) or ("r-1", None))
+                        seen.append((model, effort)) or ({"id": "t-1", "run_id": "r-1"}, None))
     for body in ({"model": "", "effort": ""}, {}):
         client.post("/api/apps/new",
                     json={"name": f"demo{len(seen)}", "prompt": "hi", **body},
@@ -392,13 +397,12 @@ def test_an_empty_pick_means_no_flag_and_older_clients_still_work(
 
 
 def test_spawn_failure_does_not_fail_creation_and_says_why(client, workspace, monkeypatch):
-    monkeypatch.setattr(apps_mod, "_start_app_session",
+    monkeypatch.setattr(apps_mod, "_create_app_task",
                         lambda e, p, *rest: (None, "claude CLI not found"))
     r = client.post("/api/apps/new", json={"name": "demo", "prompt": "hi"}, headers=HDRS)
     assert r.status_code == 200
-    assert r.json()["session_started"] is False
-    assert r.json()["run_id"] is None
-    assert r.json()["session_error"] == "claude CLI not found"
+    assert r.json()["task"] is None
+    assert r.json()["task_error"] == "claude CLI not found"
     assert (workspace / "local" / "demo" / "index.html").is_file()
 
 
@@ -658,6 +662,15 @@ def test_home_falls_back_when_stale_recents_do_not_fill_the_row(
 
 
 # ---------------------------------------------------- the fork-safe spawn seam
+#
+# apps.py no longer calls claude_spawn.spawn_helper directly — the scaffolding
+# task goes through schedule.create/run_now, which is schedule.py's own seam
+# and calls spawn_helper with the same discipline. But claude_spawn.py itself
+# is unchanged by #855, is the seam BOTH features share, and carries no test
+# file of its own (schedule.py's own tests stub it away entirely rather than
+# exercising its internals). These tests are retargeted straight at
+# claude_spawn.spawn_helper so the fork-safety regression it guards against
+# stays covered rather than silently disappearing with _start_app_session.
 
 def test_spawn_runs_agent_start_in_a_helper_subprocess_not_in_process(
         tmp_path, workspace, monkeypatch):
@@ -666,12 +679,7 @@ def test_spawn_runs_agent_start_in_a_helper_subprocess_not_in_process(
     pthread_atfork handler; same crash test_worker_forksafe.py pins for the
     executor). The spawn must therefore happen via a helper subprocess — and
     that helper's own Popen must stay on the posix_spawn path (close_fds=False,
-    no cwd, no start_new_session) with the prompt on stdin, not argv.
-
-    The spawn itself now lives in fused_render/claude_spawn.py — shared with
-    scheduled messages, which need the identical discipline — so the subprocess
-    stub goes there. What stays this module's own is the policy asserted below:
-    permission mode "auto", and a fresh session."""
+    no cwd, no start_new_session) with the prompt on stdin, not argv."""
     entry = workspace / "app" / "index.html"
     entry.parent.mkdir()
     entry.write_text('<html><head><meta name="fused-app" /></head></html>')
@@ -683,17 +691,13 @@ def test_spawn_runs_agent_start_in_a_helper_subprocess_not_in_process(
         return type("R", (), {"returncode": 0,
                               "stdout": '{"run_id": "r-1"}', "stderr": ""})()
 
-    monkeypatch.setattr(apps_mod.claude_spawn.subprocess, "run", fake_run)
-    monkeypatch.setattr(apps_mod, "_claude_agent", lambda: None)
-    started_threads = []
-    monkeypatch.setattr(apps_mod.threading, "Thread",
-                        lambda **kw: type("T", (), {"start": lambda s: started_threads.append(kw)})())
+    monkeypatch.setattr(claude_spawn.subprocess, "run", fake_run)
 
-    run_id, err = apps_mod._start_app_session(str(entry), "secret prompt $(boom)")
-    assert (run_id, err) == ("r-1", None)
+    res = claude_spawn.spawn_helper(str(entry), "secret prompt $(boom)", "auto")
+    assert res == {"run_id": "r-1"}
 
     # a real python -c helper, not claude itself, and prompt over stdin only
-    assert seen["cmd"][0] == apps_mod.claude_spawn.sys.executable
+    assert seen["cmd"][0] == claude_spawn.sys.executable
     assert "secret prompt" not in " ".join(seen["cmd"])
     import json as jsonlib
     req = jsonlib.loads(seen["kwargs"]["input"])
@@ -718,7 +722,6 @@ def test_spawn_runs_agent_start_in_a_helper_subprocess_not_in_process(
     # model output) raised UnicodeDecodeError instead of returning a run_id.
     assert seen["kwargs"]["encoding"] == "utf-8"
     assert seen["kwargs"]["errors"] == "replace"
-    assert started_threads  # the session-recording poll thread was kicked off
 
 
 def test_the_picked_model_and_effort_reach_the_helper_request(tmp_path, workspace,
@@ -732,15 +735,12 @@ def test_the_picked_model_and_effort_reach_the_helper_request(tmp_path, workspac
                               "stdout": '{"run_id": "r-1"}', "stderr": ""})()
 
     seen = {}
-    monkeypatch.setattr(apps_mod.claude_spawn.subprocess, "run", fake_run)
-    monkeypatch.setattr(apps_mod, "_claude_agent", lambda: None)
-    monkeypatch.setattr(apps_mod.threading, "Thread",
-                        lambda **kw: type("T", (), {"start": lambda s: None})())
+    monkeypatch.setattr(claude_spawn.subprocess, "run", fake_run)
 
-    run_id, err = apps_mod._start_app_session("/x/index.html", "hi", "haiku", "low")
-    assert (run_id, err) == ("r-1", None)
+    res = claude_spawn.spawn_helper("/x/index.html", "hi", "auto",
+                                    model="haiku", effort="low")
+    assert res == {"run_id": "r-1"}
     assert (seen["model"], seen["effort"]) == ("haiku", "low")
-    # still the apps API's own policy, unchanged by the new args
     assert seen["permission_mode"] == "auto"
     assert seen["session_id"] == ""
 
@@ -750,10 +750,10 @@ def test_spawn_helper_failure_reports_why(tmp_path, workspace, monkeypatch):
         return type("R", (), {"returncode": 1, "stdout": "",
                               "stderr": "boom\nFileNotFoundError: claude"})()
 
-    monkeypatch.setattr(apps_mod.claude_spawn.subprocess, "run", fake_run)
-    run_id, err = apps_mod._start_app_session("/x/index.html", "hi")
-    assert run_id is None
-    assert "FileNotFoundError: claude" in err
+    monkeypatch.setattr(claude_spawn.subprocess, "run", fake_run)
+    res = claude_spawn.spawn_helper("/x/index.html", "hi", "auto")
+    assert res.get("run_id") is None
+    assert "FileNotFoundError: claude" in res["error"]
 
 
 def test_a_missing_claude_cli_reports_the_fix_not_a_traceback_tail(
@@ -770,11 +770,11 @@ def test_a_missing_claude_cli_reports_the_fix_not_a_traceback_tail(
                               "of the environment that launched fused-render. "
                               "Also looked in: /opt/foo"})()
 
-    monkeypatch.setattr(apps_mod.claude_spawn.subprocess, "run", fake_run)
-    run_id, err = apps_mod._start_app_session("/x/index.html", "hi")
-    assert run_id is None
-    assert "Claude Code isn't installed" in err
-    assert "render.fused.io/#troubleshooting-notfound" in err
+    monkeypatch.setattr(claude_spawn.subprocess, "run", fake_run)
+    res = claude_spawn.spawn_helper("/x/index.html", "hi", "auto")
+    assert res.get("run_id") is None
+    assert "Claude Code isn't installed" in res["error"]
+    assert "render.fused.io/#troubleshooting-notfound" in res["error"]
 
 
 @pytest.mark.skipif(os.name == "nt", reason="/bin/sh stub claude is POSIX-only")
@@ -782,7 +782,7 @@ def test_spawn_really_delivers_the_prompt_to_the_claude_process(
         tmp_path, workspace, monkeypatch):
     """The regression the mocked tests could never catch.
 
-    Everything below _start_app_session is real here — the helper subprocess,
+    Everything below spawn_helper is real here — the helper subprocess,
     agent._start, the detached spawn — with only `claude` itself replaced by a
     shell stub that records the argv and stdin it was handed. The live bug was
     precisely that this whole path produced nothing: the helper's absence meant
@@ -799,8 +799,8 @@ def test_spawn_really_delivers_the_prompt_to_the_claude_process(
     stub.chmod(0o755)
     monkeypatch.setenv("FUSED_RENDER_CLAUDE_BIN", str(stub))
 
-    run_id, err = apps_mod._start_app_session(str(entry), "hello from the test")
-    assert err is None and run_id, err
+    res = claude_spawn.spawn_helper(str(entry), "hello from the test", "auto")
+    assert res.get("error") is None and res.get("run_id"), res
 
     # the spawn is detached, so wait for the stub to finish writing
     deadline = time.monotonic() + 30
@@ -889,11 +889,12 @@ def test_agent_start_default_still_passes_message_in_argv(tmp_path, monkeypatch)
 # --------------------------- landing the creator in the running claude session
 
 # Creating an app with a prompt starts a session the user never sees unless the
-# post-create navigation opens the app FOLDER's chat attached to that run. Three
-# sources have to agree for that to work, and none of them can see the other two:
-# HomeHero.tsx builds the URL, registry.json makes "claude" a selectable
-# mode for the `/` key, and the chat template's boot re-attaches from the `run`
-# param. These tests pin the three ends of that contract.
+# post-create navigation opens the app's entry_html with the Claude pane
+# attached to that run. Three sources have to agree for that to work, and none
+# of them can see the other two: HomeHero.tsx builds the URL, registry.json
+# makes "claude" a selectable mode for the `/` key, and the chat template's
+# boot re-attaches from the `run` param. These tests pin the three ends of
+# that contract.
 
 def _repo_text(*parts):
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -902,15 +903,17 @@ def _repo_text(*parts):
 
 
 def test_home_navigates_into_the_claude_chat_for_the_started_run():
+    """File-first now: the scaffolding prompt is a TASK on the app's
+    index.html (schedule.create), not a session on the folder, so the
+    post-create nav lands on entry_html with the Claude pane (`_side=claude`)
+    attached to the run — not a folder-level claudeChatUrl."""
     home = _repo_text("frontend", "src", "apps", "builder", "HomeHero.tsx")
-    # Folder-first: the scaffolding session runs via the claude agent on
-    # the app FOLDER, so the re-attach must land there (same runs dir, same
-    # .claude-split.json sidecar) rather than on the entry html.
-    assert '_mode: "claude"' in home, "post-create nav must select the claude mode"
-    assert "claudeChatUrl(res.path" in home, "…on the app folder, not entry_html"
-    assert "run: runId" in home, "…and attach to the run the POST just started"
-    # the run_id is what gates it: no session (no prompt) -> the default view
-    assert "if (res.run_id) navigateUrl(claudeChatUrl(" in home
+    assert '_side: "claude", run: runId' in home, \
+        "the landing URL selects the claude pane and attaches to the run"
+    # the task's run_id is what gates it: no task, or one whose send hasn't
+    # produced a run id yet, lands on the bare page instead
+    assert "if (res.task?.run_id)" in home
+    assert "appLandingUrl(res.entry_html, res.task.run_id, model, effort)" in home
 
 
 def test_claude_is_the_selectable_chat_mode_for_html():
@@ -971,10 +974,11 @@ def test_poll_serves_a_run_started_by_the_server(tmp_path, workspace, monkeypatc
     stub.chmod(0o755)
     monkeypatch.setenv("FUSED_RENDER_CLAUDE_BIN", str(stub))
 
-    run_id, err = apps_mod._start_app_session(str(entry), "make it red")
-    assert err is None and run_id, err
+    res = claude_spawn.spawn_helper(str(entry), "make it red", "auto")
+    assert res.get("error") is None and res.get("run_id"), res
+    run_id = res["run_id"]
 
-    agent = apps_mod._claude_agent()
+    agent = claude_spawn.load_agent()
     deadline = time.monotonic() + 30
     data = {}
     while time.monotonic() < deadline:

--- a/tests/test_queue_dock.py
+++ b/tests/test_queue_dock.py
@@ -80,7 +80,7 @@ def client(tmp_path):
 def spawned(monkeypatch):
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         calls.append({"message": prompt, "session_id": session_id})
         return {"run_id": f"r-{len(calls)}"}
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -53,7 +53,7 @@ def spawned(monkeypatch):
     the entry lands in `sent`; a test wanting failure re-stubs this."""
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         calls.append({"target": target, "message": prompt,
                       "permission_mode": permission_mode,
                       "session_id": session_id})
@@ -345,7 +345,7 @@ def test_the_claim_is_written_before_the_spawn(target, monkeypatch):
     must already be out of `pending` so the next boot does not send it again."""
     seen = {}
 
-    def spawn_and_look(target_, prompt, mode, session_id=""):
+    def spawn_and_look(target_, prompt, mode, session_id="", **kwargs):
         # what the store says WHILE the helper is away
         seen["state"] = schedule.list_entries()[0]["state"]
         return {"run_id": "r-1"}
@@ -369,7 +369,7 @@ def test_only_the_message_in_flight_is_claimed(target, monkeypatch):
     are still sendable on the next tick or the next launch."""
     seen = []
 
-    def spawn_and_look(target_, prompt, mode, session_id=""):
+    def spawn_and_look(target_, prompt, mode, session_id="", **kwargs):
         # what the store says about EVERY entry while this one is away
         seen.append({e["message"]: e["state"] for e in schedule.list_entries()})
         return {"run_id": f"r-{len(seen)}"}
@@ -440,7 +440,7 @@ def test_one_bad_entry_does_not_stop_the_rest_of_the_tick(target, monkeypatch):
     other messages their send."""
     calls = []
 
-    def flaky(target_, prompt, mode, session_id=""):
+    def flaky(target_, prompt, mode, session_id="", **kwargs):
         calls.append(prompt)
         if prompt == "boom":
             raise RuntimeError("helper exploded")

--- a/tests/test_schedule_pane_state.py
+++ b/tests/test_schedule_pane_state.py
@@ -122,7 +122,7 @@ def test_the_send_carries_the_composed_message(target, monkeypatch):
     file, _ = target
     seen = {}
 
-    def fake_spawn(t, prompt, permission_mode, session_id=""):
+    def fake_spawn(t, prompt, permission_mode, session_id="", **kwargs):
         seen["prompt"] = prompt
         return {"error": "stop here"}
 

--- a/tests/test_schedule_queue.py
+++ b/tests/test_schedule_queue.py
@@ -72,7 +72,7 @@ def fresh_process():
 def spawned(monkeypatch):
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         calls.append({"message": prompt, "session_id": session_id})
         return {"run_id": f"r-{len(calls)}"}
 
@@ -518,7 +518,7 @@ def test_the_claim_is_still_written_before_the_spawn(target, monkeypatch):
     already out of `pending`."""
     seen = {}
 
-    def spawn_and_look(target_, prompt, mode, session_id=""):
+    def spawn_and_look(target_, prompt, mode, session_id="", **kwargs):
         seen["state"] = schedule.list_entries()[0]["state"]
         seen["queue"] = [e["id"] for e in schedule.queue()["queued"]]
         seen["running"] = [e["id"] for e in schedule.queue()["running"]]

--- a/tests/test_schedule_recurring.py
+++ b/tests/test_schedule_recurring.py
@@ -29,7 +29,7 @@ def no_real_wake(monkeypatch):
 def spawned(monkeypatch):
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         calls.append({"target": target, "message": prompt,
                       "permission_mode": permission_mode,
                       "session_id": session_id})

--- a/tests/test_schedule_resend.py
+++ b/tests/test_schedule_resend.py
@@ -80,7 +80,7 @@ def spawned(monkeypatch):
     than merely asserted about."""
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         claimed = [e["state"] for e in schedule._read()
                    if e.get("fired") and not e.get("run_id")]
         calls.append({"message": prompt, "session_id": session_id,

--- a/tests/test_schedule_rule.py
+++ b/tests/test_schedule_rule.py
@@ -79,7 +79,7 @@ def clock(monkeypatch):
 def spawned(monkeypatch):
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         calls.append({"target": target, "message": prompt})
         return {"run_id": f"r-{len(calls)}"}
 

--- a/tests/test_schedule_run_now.py
+++ b/tests/test_schedule_run_now.py
@@ -73,7 +73,7 @@ def nothing_is_live(monkeypatch):
 def spawned(monkeypatch):
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         calls.append({"message": prompt, "session_id": session_id})
         return {"run_id": f"r-{len(calls)}"}
 

--- a/tests/test_schedule_session_liveness.py
+++ b/tests/test_schedule_session_liveness.py
@@ -77,7 +77,7 @@ def projects_dir(tmp_path, monkeypatch):
 def spawned(monkeypatch):
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         calls.append({"message": prompt, "session_id": session_id})
         return {"run_id": f"r-{len(calls)}"}
 

--- a/tests/test_task_sync_matrix.py
+++ b/tests/test_task_sync_matrix.py
@@ -79,7 +79,7 @@ def spawned(monkeypatch):
     body is the right seam)."""
     calls = []
 
-    def fake_spawn(target, prompt, permission_mode, session_id=""):
+    def fake_spawn(target, prompt, permission_mode, session_id="", **kwargs):
         calls.append({"target": target, "message": prompt,
                       "session_id": session_id})
         return {"run_id": f"r-{len(calls)}"}


### PR DESCRIPTION
## Summary

`main` is red — **115 failing tests** locally, and CI failing on `fused-engine`, all four `test-python` lanes and `test-python-windows`. This is test-only repair. **No production code is touched.** It takes the suite from **115 failures to 12**, all pre-existing and environment-caused.

Both causes trace to **#855** (`4dce6d30`, *New app: create a task on index.html instead of spawning a session directly*), which merged without a green run — its CI shows `cancelled`, not `success`. So did #853 and #854.

**Cause 1 — 15 stale references (`test_apps_api.py`).** #855 removed `_start_app_session` from `fused_render/server/routers/apps.py` and replaced it with `_create_app_task`, but left 15 `monkeypatch.setattr(apps_mod, "_start_app_session", ...)` calls behind. Every one raised `AttributeError`.

**Cause 2 — 13 stub fixtures with fixed signatures (10 schedule/queue files).** Less obvious and more interesting: #855 also added `model=`/`effort=` kwargs to `schedule.py`'s `claude_spawn.spawn_helper` call. The `fake_spawn` / `spawn_and_look` / `flaky` stubs took fixed positional args with no `**kwargs`, so every spawn raised `TypeError` and entries landed in `error` instead of `sent`/`sending` — which is why `test_queue_dock`, `test_task_sync_matrix` and seven `test_schedule_*` files went red without ever naming the removed function.

## Visuals

```mermaid
flowchart TD
    A[#855 merges, CI cancelled] --> B[apps.py: _start_app_session removed]
    A --> C[schedule.py: spawn_helper gains model/effort]
    B --> D[15 monkeypatch sites: AttributeError]
    C --> E[13 stubs lack **kwargs: TypeError]
    D --> F[103 red in test_apps_api]
    E --> G[Schedule/queue suites red]
```

## Usage

Not user-invocable — repair only.

```bash
.venv/bin/python -m pytest tests/ -n auto -q
```

## Test Plan

- [x] Each of the 15 was classified **stale / obsolete / coverage gap** rather than blanket-renamed. A mechanical `_start_app_session` → `_create_app_task` rename would have compiled and asserted nothing, since the two have different contracts (direct spawn vs. task creation) — tests staying green over a path that never runs is a known recurring failure mode in this repo and is worse than an honest red.
- [x] All 15 came out **stale**; no obsolete case and no coverage gap. The `posix_spawn`/`close_fds` tests (guarding the historical fork SIGSEGV) were **retargeted at `claude_spawn.spawn_helper`** rather than deleted — that discipline still exists, it just moved out of `apps.py`'s ownership into `schedule.py`'s call path, and `schedule.py`'s own tests stub it away. Deleting them would have opened a real gap.
- [x] `test_home_navigates_into_the_claude_chat_for_the_started_run` rewritten against what `HomeHero.tsx` actually does now (`appLandingUrl(res.entry_html, res.task.run_id, …)` gated on `res.task?.run_id`).
- [x] Harness mutation-checked: `entry_html` target computation, `close_fds` discipline, and the frontend's `res.task?.run_id` gate were each broken in turn, the corresponding test confirmed red with a real diff, then reverted.
- [x] `test_canvases.py`'s similarly-shaped stub deliberately left alone — it stubs `canvases.py`'s own `spawn_helper` call, which never gained the kwargs.
- [x] Full suite: **115 → 12 failures**. The remaining 12 are pre-existing and environment-caused (`test_claude_health` needs a real `claude` install, plus `test_calls`, `test_capture_stream`, `test_ai_metrics`).
- [x] Diffed failure ID sets both ways against main. The only two not in main's older set are `test_theme.py::test_shell_css_has_no_colour_literals_outside_the_palettes` and a flaky `test_ai_worker_base` parametrization — neither file is in this diff, so both arrived with main advancing to `d99ae20e`. **`test_theme` looks like a separate regression worth its own look** (plausibly #860's landing-page CSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
