### PR TITLE
Landing: ecosystem captions say what each connection gives you

### DIFF
--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -1227,20 +1227,21 @@
         <div class="eco-row">
         <div class="eco-copy">
           <div class="eco-step" data-step="0">
-            <h3>Start a task</h3>
-            <p>Claude works on your machine and reports back.</p>
+            <h3>Use frontier models</h3>
+            <p>Delegates tasks to Claude &mdash; works with your existing Claude
+            Code subscription, no extra API costs.</p>
           </div>
           <div class="eco-step" data-step="1">
-            <h3>Run real code</h3>
-            <p>The page runs real Python on your machine.</p>
+            <h3>Runs code locally</h3>
+            <p>The Fused engine handles execution.</p>
           </div>
           <div class="eco-step" data-step="2">
             <h3>Models on device</h3>
-            <p>Text, images and transcription, all local.</p>
+            <p>Text, image and video generation, all local.</p>
           </div>
           <div class="eco-step" data-step="3">
-            <h3>Native reach</h3>
-            <p>Mic, screen and camera, straight from the app.</p>
+            <h3>Native support</h3>
+            <p>Can access the microphone, screen and camera.</p>
           </div>
         </div>
 


### PR DESCRIPTION
## What

Copy pass on the four Local Ecosystem captions — each now says what the connection actually gives you.

| Before | After |
| --- | --- |
| **Start a task** — Claude works on your machine and reports back. | **Use frontier models** — Delegates tasks to Claude — works with your existing Claude Code subscription, no extra API costs. |
| **Run real code** — The page runs real Python on your machine. | **Runs code locally** — The Fused engine handles execution. |
| **Models on device** — Text, images and transcription, all local. | **Models on device** — Text, image and video generation, all local. |
| **Native reach** — Mic, screen and camera, straight from the app. | **Native support** — Can access the microphone, screen and camera. |

Copy only: no layout, animation or contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static marketing copy in one HTML file only; no runtime or behavioral changes.
> 
> **Overview**
> Updates the **Local Ecosystem** scroll section on the download page so each of the four side captions states the **benefit** of that connection, not just what happens.
> 
> Headlines and body copy change for Claude (**Use frontier models**, Claude Code subscription / no extra API costs), execution (**Runs code locally**, Fused engine), on-device models (adds **video generation**, drops transcription wording), and native APIs (**Native support**, mic/screen/camera). **Models on device** keeps the same title with revised description.
> 
> **Copy only** in `scripts/download_page/index.html` — no CSS, SVG, or JS changes; `data-step` wiring and scroll animation stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8291bf4792bcebbae445287f50c3136981f5c92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->