### PR TITLE
Sidebar: collapsible Projects section with + New app row

### DIFF
--- a/frontend/src/apps/claude_config/ClaudeConfig.tsx
+++ b/frontend/src/apps/claude_config/ClaudeConfig.tsx
@@ -92,7 +92,7 @@ const PAGES = [...TABS, HISTORY];
 
 type SectionId = (typeof PAGES)[number]["id"];
 
-// The content column is capped at 900px everywhere by default (.cc-main) —
+// The content column is capped at 900px by default (.cc-main-capped, this page only) —
 // right for Preferences, whose label+doc column is itself capped near 60ch
 // for readability and should not stretch just because the page has room.
 // Wrong for the list-bearing tabs: at 1400px a 900px cap left roughly a
@@ -283,7 +283,9 @@ export default function ClaudeConfig() {
         </div>
       </div>
       <div className="cc-body">
-        <main className={"cc-main" + (WIDE_SECTIONS.has(active) ? " cc-main-wide" : "")}>
+        {/* cc-main-capped: the 900px cap is this page's, not the chassis' —
+            AI Models shares .cc-main and must not inherit it. */}
+        <main className={"cc-main cc-main-capped" + (WIDE_SECTIONS.has(active) ? " cc-main-wide" : "")}>
           {/* title= on the ROW, not on the note: the note itself is hidden on a
               narrow window, and the sentence should still be reachable there. */}
           <div className="cc-caption-row" title={TAGLINE}>

--- a/frontend/src/apps/explorer/sidebar/BookmarksSection.tsx
+++ b/frontend/src/apps/explorer/sidebar/BookmarksSection.tsx
@@ -902,11 +902,12 @@ export default function BookmarksSection() {
   return (
     <div className="sidebar-section sidebar-bookmarks">
       <div
-        className="sidebar-heading recents-heading"
+        className={"sidebar-heading recents-heading" + (sectionCollapsed ? " collapsed" : "")}
         title={sectionCollapsed ? "Show bookmarks" : "Hide bookmarks"}
         onClick={toggleSectionCollapsed}
       >
         Bookmarks
+        <span className="sidebar-heading-chevron" aria-hidden="true" />
         {/* `.sidebar-count-chip` is the shared skin every count in this sidebar
             wears — the folder rows' nested count and the Tasks entry's unread
             count are the same element (sidebar.css). */}

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -36,6 +36,7 @@ import {
 } from "react";
 import { getAppEntry, statPath, type Config } from "@platform/lib/api";
 import { useUrlVersion } from "@platform/lib/hooks";
+import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import { navigateUrl, urlForFsPath } from "@platform/lib/router";
 import { AppWindow, Files, ListTodo, type LucideIcon } from "lucide-react";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
@@ -162,6 +163,33 @@ export default function AppPage({
     return () => {
       live = false;
     };
+  }, [dir]);
+
+  // Left/Right step the tabs (owner, 2026-08-26), the sibling of the sidebar's
+  // Up/Down over its rows (sidebarArrowNav.ts): together the two axes make the
+  // app page steerable from the keyboard alone. Same ownership rule as there —
+  // only when nothing in particular is focused (<body>) or focus is in the
+  // sidebar, so a focused control, a text field, or the base-ui tab list's own
+  // arrow handling keeps its keys. Ends stop, no wrap.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      if (e.isComposing || e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      if (isOverlayOpen()) return;
+      const el = document.activeElement;
+      const onBody =
+        !el || el === document.body || el === document.documentElement;
+      const inSidebar = !!el && !!document.getElementById("sidebar")?.contains(el);
+      if (!onBody && !inSidebar) return;
+      const cur = appPageTabFromSearch(location.search);
+      const i = APP_PAGE_TABS.indexOf(cur) + (e.key === "ArrowRight" ? 1 : -1);
+      e.preventDefault();
+      if (i < 0 || i >= APP_PAGE_TABS.length) return;
+      navigateUrl(appPageUrl(dir, APP_PAGE_TABS[i], location.search));
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
   }, [dir]);
 
   const pickTab = (e: MouseEvent<HTMLAnchorElement>, next: AppPageTab) => {

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -38,7 +38,7 @@ import { getAppEntry, statPath, type Config } from "@platform/lib/api";
 import { useUrlVersion } from "@platform/lib/hooks";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import { navigateUrl, urlForFsPath } from "@platform/lib/router";
-import { AppWindow, Clock, Files, type LucideIcon } from "lucide-react";
+import { AppWindow, Files, ListTodo, type LucideIcon } from "lucide-react";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { Tabs, TabsList, TabsTrigger } from "@platform/shadcn/ui/tabs";
 import { SkeletonLines } from "@platform/ui/Skeleton";
@@ -99,7 +99,7 @@ const TAB_DEFS: Record<AppPageTab, TabDef> = {
   },
   tasks: {
     label: "Tasks",
-    Icon: Clock, // the sidebar's Tasks icon (GlobalSidebar SCHEDULED_ICON), so the two read as one thing
+    Icon: ListTodo, // the sidebar's Tasks icon too (GlobalSidebar SCHEDULED_ICON)
     render: ({ dir }) => <Scheduled scope={{ project: dir }} />,
   },
   files: {

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -38,7 +38,7 @@ import { getAppEntry, statPath, type Config } from "@platform/lib/api";
 import { useUrlVersion } from "@platform/lib/hooks";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import { navigateUrl, urlForFsPath } from "@platform/lib/router";
-import { AppWindow, Files, ListTodo, type LucideIcon } from "lucide-react";
+import { AppWindow, Clock, Files, type LucideIcon } from "lucide-react";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { Tabs, TabsList, TabsTrigger } from "@platform/shadcn/ui/tabs";
 import { SkeletonLines } from "@platform/ui/Skeleton";
@@ -99,7 +99,7 @@ const TAB_DEFS: Record<AppPageTab, TabDef> = {
   },
   tasks: {
     label: "Tasks",
-    Icon: ListTodo,
+    Icon: Clock, // the sidebar's Tasks icon (GlobalSidebar SCHEDULED_ICON), so the two read as one thing
     render: ({ dir }) => <Scheduled scope={{ project: dir }} />,
   },
   files: {

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -177,7 +177,16 @@ export default function AppPage({
       if (e.isComposing || e.defaultPrevented) return;
       if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
       if (isOverlayOpen()) return;
-      const el = document.activeElement;
+      const el = document.activeElement as HTMLElement | null;
+      // A text field keeps its caret keys — the sidebar holds one mid-rename
+      // (BookmarksSection's RenameInput), so "in the sidebar" is not enough.
+      if (
+        el &&
+        (el.tagName === "INPUT" ||
+          el.tagName === "TEXTAREA" ||
+          el.isContentEditable)
+      )
+        return;
       const onBody =
         !el || el === document.body || el === document.documentElement;
       const inSidebar = !!el && !!document.getElementById("sidebar")?.contains(el);

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -180,17 +180,22 @@ function CurrentAppRow({
   onRemoved: () => void;
 }) {
   const [busy, setBusy] = useState(false);
-  const href = appPageUrl(app.path);
+  // The destination keeps the TAB the user is on (owner, 2026-08-26): switching
+  // apps from the Files tab lands on the next app's Files tab, so the sidebar
+  // reads as "same view, other app". Only `_tab` rides along — a tab's own
+  // params (`?file=`, `?view=`) name things inside ONE app and are dropped.
+  // Off an app page the default tab it is. Read at render: the sidebar
+  // remounts on every navigation (App.tsx), so the href cannot go stale.
+  const onAppPage = appPathFromPath(location.pathname) !== null;
+  const tab = onAppPage ? appPageTabFromSearch(location.search) : undefined;
+  const href = appPageUrl(app.path, tab);
   const onOpen = (e: React.MouseEvent<HTMLAnchorElement>) => {
     // Middle/modified clicks keep the browser's own new-tab gesture on the href.
     if (opensElsewhere(e)) return;
     e.preventDefault();
-    // `active` is folder-only (the row lights up on either tab); the
-    // destination is the OVERVIEW, so from the Tasks tab the click still goes —
-    // it is how the sidebar gets back to the running app. Only a click that
-    // would land exactly where the page already is stays a no-op.
-    if (!active || appPageTabFromSearch(location.search) !== "overview")
-      navigateUrl(href);
+    // The row for the page already on screen, on the tab it already shows, is
+    // a no-op; the tab's own params would be the only thing the click cleared.
+    if (!active) navigateUrl(href);
   };
   const onRemove = async (e: React.MouseEvent) => {
     e.preventDefault();

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -396,11 +396,15 @@ export default function CurrentAppsSection() {
   return (
     <div className="sidebar-section sidebar-current-apps">
       <div
-        className="sidebar-heading recents-heading current-apps-heading"
+        className={
+          "sidebar-heading recents-heading current-apps-heading" +
+          (collapsed ? " collapsed" : "")
+        }
         title={collapsed ? "Show projects" : "Hide projects"}
         onClick={toggleCollapsed}
       >
         Projects
+        <span className="sidebar-heading-chevron" aria-hidden="true" />
         {collapsed && <span className="sidebar-count-chip">{apps.length}</span>}
       </div>
       {!collapsed && apps.map(render)}

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -53,6 +53,17 @@ import {
 // and is folder paths now, and a slug-shaped order would match nothing.
 export const ORDER_KEY = "fused-render:current-apps-order:v2";
 
+// The section fold, "1" when hidden — the Bookmarks section's own key pattern.
+export const COLLAPSED_KEY = "fused-render:current-apps-collapsed";
+
+function readCollapsed(): boolean {
+  try {
+    return localStorage.getItem(COLLAPSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
 // The last table this document fetched, kept at module level so the rows do not
 // blink empty on every per-navigation remount of the sidebar while the fetch
 // round-trips.
@@ -365,24 +376,54 @@ export default function CurrentAppsSection() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dragProps closes over `apps`
     [onPath, apps, refetch],
   );
-  // The + opens the /apps composer in a modal (D489). The section ALWAYS
-  // renders: a door to "make one" is exactly what an empty desk wants.
+  // The "+ New app" row at the foot of the list opens the /apps composer in a
+  // modal (D489). The section ALWAYS renders: a door to "make one" is exactly
+  // what an empty desk wants.
   const [composing, setComposing] = useState(false);
+  // Whole-section fold, the Bookmarks heading's pattern: local to this machine
+  // (localStorage) — sidebar layout, not desk data. The count chip carries the
+  // collapsed signal, no chevron.
+  const [collapsed, setCollapsed] = useState(readCollapsed);
+  const toggleCollapsed = () => {
+    const next = !collapsed;
+    try {
+      localStorage.setItem(COLLAPSED_KEY, next ? "1" : "0");
+    } catch {
+      // No store: the fold lasts as long as the page does.
+    }
+    setCollapsed(next);
+  };
   return (
     <div className="sidebar-section sidebar-current-apps">
-      <div className="sidebar-heading current-apps-heading">
-        Current apps
-        <button
-          type="button"
-          className="icon-btn current-apps-add"
-          title="New app"
-          aria-label="New app"
-          onClick={() => setComposing(true)}
-        >
-          +
-        </button>
+      <div
+        className="sidebar-heading recents-heading current-apps-heading"
+        title={collapsed ? "Show projects" : "Hide projects"}
+        onClick={toggleCollapsed}
+      >
+        Projects
+        {collapsed && <span className="sidebar-count-chip">{apps.length}</span>}
       </div>
-      {apps.map(render)}
+      {!collapsed && apps.map(render)}
+      {!collapsed && (
+        <div
+          className="bookmark-row current-app-row current-app-new"
+          role="button"
+          tabIndex={0}
+          title="New app"
+          onClick={() => setComposing(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              setComposing(true);
+            }
+          }}
+        >
+          <span className="bookmark-glyph current-app-glyph" aria-hidden="true">
+            +
+          </span>
+          <span className="bookmark-name">New app</span>
+        </div>
+      )}
       {composing && (
         // The SAME composer /apps and /home show (apps/builder/HomeHero.tsx):
         // it names, scaffolds and navigates into the new app's chat itself,

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -28,6 +28,7 @@ import { pulseTitle, runningLabel } from "@shell/tasks-lib";
 import { formatSize } from "@platform/lib/format";
 import BookmarksSection from "@apps/explorer/sidebar/BookmarksSection";
 import CurrentAppsSection from "@shell/CurrentAppsSection";
+import { useSidebarArrowNav } from "@shell/sidebarArrowNav";
 
 // House — the Home page (/home): search hero + the three recency strips.
 const HOME_ICON = (
@@ -360,6 +361,8 @@ const AI_MODELS_HOME = tabHref("playground", "");
 export default function GlobalSidebar({ config }: { config: Config }) {
   // Re-render on any nav/url change (active-item highlight).
   useUrlVersion();
+  // Up/Down step through the Projects + Bookmarks rows (sidebarArrowNav.ts).
+  useSidebarArrowNav();
 
   // No builtin-mount gate any more: the entries they guarded (Inbox, App
   // Basics) are gone from the sidebar — the learn content ships as a community

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -682,8 +682,9 @@ export default function GlobalSidebar({ config }: { config: Config }) {
             }
           />
         </div>
-        {/* Current apps (D487): the workspace apps with unfiled tasks, above the
-            permanent Bookmarks tree. Renders nothing when there are none. */}
+        {/* Projects (D487, "Current apps" until 2026-08-26): the apps on the
+            desk, above the permanent Bookmarks tree. Collapsible; always ends
+            in a "+ New app" row. */}
         <CurrentAppsSection />
         <BookmarksSection />
         <div className="sidebar-section sidebar-settings">

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -11,6 +11,7 @@
 // (SidebarFrame) and explorer-owned sections (Bookmarks), which only
 // the shell is allowed to import together (scripts/check-boundaries.mjs).
 import { useEffect, useRef, useState } from "react";
+import { ListTodo } from "lucide-react";
 import { SidebarFrame, NavItem } from "@platform/ui/sidebar/SidebarFrame";
 import UpdateBadge from "@platform/ui/UpdateBadge";
 import type { SidebarRailItem } from "@platform/ui/sidebar/SidebarFrame";
@@ -87,13 +88,11 @@ const MOUNTS_ICON = (
   </svg>
 );
 
-// A clock: scheduled messages are the one page about *when* something happens.
-const SCHEDULED_ICON = (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <circle cx="12" cy="12" r="9" />
-    <path d="M12 7v5l3.5 2" />
-  </svg>
-);
+// A to-do list (lucide ListTodo, sized like the hand-drawn icons around it):
+// Tasks is the page about work, and the app page's Tasks tab wears the same
+// glyph (shell/AppPage.tsx) so the two read as one thing. Was a clock while the
+// page was "Scheduled".
+const SCHEDULED_ICON = <ListTodo size={16} strokeWidth={2} aria-hidden="true" />;
 
 // Connected nodes: a canvas is a graph of UDFs.
 const CANVASES_ICON = (

--- a/frontend/src/shell/sidebarArrowNav.ts
+++ b/frontend/src/shell/sidebarArrowNav.ts
@@ -1,0 +1,94 @@
+// Arrow keys walk the sidebar's Projects and Bookmarks rows (owner, 2026-08-26):
+// Up/Down move to the previous/next row and OPEN it, so the sidebar behaves as
+// one list you can step through without the mouse. The "list" is every
+// navigable row link (`a.bookmark-name`) inside #sidebar in DOM order — Projects
+// first, then the bookmark tree as it is currently unfolded. Folder rows and
+// the "+ New app" row are not links and are stepped over.
+//
+// WHO OWNS THE ARROWS. The explorer's Listing drives its own selection with
+// Up/Down whenever focus sits on <body> (useListingSelection: `navActive`), and
+// two document listeners cannot negotiate order (App.tsx records why). So this
+// one claims the keys only where the listing cannot be in play:
+//   - focus is INSIDE the sidebar (a row was clicked or reached by Tab), or
+//   - focus is on <body> and the page is an app page (/apps/<folder>), whose
+//     main pane is the app's frame or its tasks/files — no listing to fight.
+// Anywhere else the keys stay with the page.
+//
+// STAYING IN THE CHAIN. Opening a row navigates, and the sidebar remounts on
+// every navigation (App.tsx), which drops focus to <body>. The mount hook below
+// puts focus back on the row that is now active — but only when the last step
+// was one of ours, so a mouse click never yanks focus into the sidebar.
+import { useEffect } from "react";
+import { isOverlayOpen } from "@platform/lib/ui-overlay";
+import { appPathFromPath } from "@shell/current-apps-lib";
+
+const ROW_LINKS = "#sidebar a.bookmark-name";
+
+// Set when an arrow step navigated; consumed by the next mount.
+let refocusPending = false;
+
+function rowLinks(): HTMLAnchorElement[] {
+  return Array.from(document.querySelectorAll<HTMLAnchorElement>(ROW_LINKS));
+}
+
+function inTextField(el: Element | null): boolean {
+  if (!el) return false;
+  const tag = el.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || (el as HTMLElement).isContentEditable;
+}
+
+/** The row to step FROM: the focused row link if one is focused, else the row
+ *  marked `.active` (the page on screen), else none. */
+function currentIndex(links: HTMLAnchorElement[]): number {
+  const el = document.activeElement;
+  const focused = links.findIndex((a) => a === el);
+  if (focused !== -1) return focused;
+  return links.findIndex((a) => a.closest(".bookmark-row")?.classList.contains("active"));
+}
+
+export function stepSidebarRow(e: KeyboardEvent): void {
+  if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+  if (e.isComposing || e.defaultPrevented) return;
+  if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+  if (isOverlayOpen()) return;
+  const el = document.activeElement;
+  if (inTextField(el)) return;
+  const sidebar = document.getElementById("sidebar");
+  if (!sidebar) return;
+  const inSidebar = !!el && sidebar.contains(el);
+  const onBody = !el || el === document.body || el === document.documentElement;
+  if (!inSidebar && !(onBody && appPathFromPath(location.pathname) !== null)) return;
+
+  const links = rowLinks();
+  if (!links.length) return;
+  const cur = currentIndex(links);
+  const down = e.key === "ArrowDown";
+  // Nothing current: Down starts at the top, Up at the bottom. Ends stop.
+  const next = cur === -1 ? (down ? 0 : links.length - 1) : cur + (down ? 1 : -1);
+  if (next < 0 || next >= links.length) {
+    e.preventDefault();
+    return;
+  }
+  e.preventDefault();
+  const target = links[next];
+  refocusPending = true;
+  target.focus();
+  // The row's own onClick does the navigation (and its active/no-op logic).
+  target.click();
+}
+
+/** Mounted once per GlobalSidebar: the document listener plus the refocus that
+ *  keeps the keyboard chain alive across the remount a navigation causes. */
+export function useSidebarArrowNav(): void {
+  useEffect(() => {
+    if (refocusPending) {
+      refocusPending = false;
+      const active = rowLinks().find((a) =>
+        a.closest(".bookmark-row")?.classList.contains("active"),
+      );
+      active?.focus({ preventScroll: false });
+    }
+    document.addEventListener("keydown", stepSidebarRow);
+    return () => document.removeEventListener("keydown", stepSidebarRow);
+  }, []);
+}

--- a/frontend/src/styles/claude-config.css
+++ b/frontend/src/styles/claude-config.css
@@ -257,11 +257,19 @@
   flex: 1 1 0%;
   width: 100%;
   min-width: 0;
-  max-width: 900px;
   box-sizing: border-box;
   overflow-x: hidden;
   overflow-y: auto;
   padding: 24px 28px 40px;
+}
+
+/* The cap is Claude Config's, NOT .cc-main's: that class is the shared chassis
+   the AI Models page stands on too (AiModelsPage.tsx), and a 900px cap there
+   squeezed the Playground into a column with the page background showing all
+   around it (owner, 2026-08-26). So the cap is an opt-in class ClaudeConfig.tsx
+   puts on its own <main>. */
+.cc-main-capped {
+  max-width: 900px;
 }
 
 /* The list-bearing tabs (see WIDE_SECTIONS in ClaudeConfig.tsx) get more room

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -637,6 +637,17 @@ button.sidebar-prefs-trigger {
   margin-bottom: 0;
 }
 
+/* Keyboard position: Up/Down walk the Projects + Bookmarks rows
+   (shell/sidebarArrowNav.ts) and land focus on the row's link, so the row
+   shows where the cursor is. `:has()` lifts the ring onto the row itself. */
+.bookmark-row:has(> a.bookmark-name:focus-visible) {
+  outline: 1.5px solid var(--accent, currentColor);
+  outline-offset: -1.5px;
+}
+.bookmark-row > a.bookmark-name:focus-visible {
+  outline: none;
+}
+
 /* The collapsed count sits at the row's far end, clear of the label+chevron. */
 .recents-heading > .sidebar-count-chip {
   margin-left: auto;

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -597,8 +597,7 @@ button.sidebar-prefs-trigger {
 
 /* Recents (SPEC §29): sits between the bookmark tree and the pinned footer.
    Rows reuse .bookmark-row/.bookmark-name/.bookmark-glyph for identical
-   metrics; heading click toggles the fold; the count pill carries the
-   collapsed signal — no chevron, matching D44's folder rows. */
+   metrics; heading click toggles the fold. */
 .sidebar-recents {
   flex: 0 0 auto;
   /* The bookmarks section above already ends in its own 8px padding — start
@@ -606,12 +605,41 @@ button.sidebar-prefs-trigger {
   padding-top: 0;
 }
 
+/* A foldable section heading (Projects, Bookmarks). Since 2026-08-26 it is set
+   in title case rather than the small-caps of the other headings, and the
+   label is followed by a chevron that says "this folds": pointing down when
+   open, right when collapsed. The count pill still rides the collapsed state. */
 .recents-heading {
   display: flex;
   align-items: center;
   gap: 6px;
   cursor: pointer;
   user-select: none;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 12px;
+}
+
+.sidebar-heading-chevron {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  margin: 0 1px 1px 2px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 120ms ease;
+  opacity: 0.8;
+}
+
+.recents-heading.collapsed .sidebar-heading-chevron {
+  transform: rotate(-45deg);
+  margin-bottom: 0;
+}
+
+/* The collapsed count sits at the row's far end, clear of the label+chevron. */
+.recents-heading > .sidebar-count-chip {
+  margin-left: auto;
 }
 
 /* The heading's collapsed count. No skin of its own since 2026-08-18: it wears

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -1130,16 +1130,16 @@ a.bookmark-name::after {
   cursor: pointer;
 }
 
-/* Current apps (D487): the workspace apps with unfiled tasks, above Bookmarks.
-   Rows reuse .bookmark-row/.bookmark-name/.bookmark-actions for identical
-   metrics; the hover cross archives every task under the app. Fixed height
-   like .sidebar-recents — the bookmark tree below is the one that scrolls. The
-   bookmarks heading's 18px sticky top padding assumed it sat first after the
-   nav group; with this section above it the gap would double, so the section
-   ends flush and lets that padding be the gap. */
+/* Projects (D487, "Current apps" until 2026-08-26): the apps on the desk, above
+   Bookmarks. Rows reuse .bookmark-row/.bookmark-name/.bookmark-actions for
+   identical metrics; the hover cross archives every task under the app. Fixed
+   height like .sidebar-recents — the bookmark tree below is the one that
+   scrolls. Keeps the section's own 8px bottom padding: with the bookmarks
+   heading's 18px sticky top padding that makes the gap to Bookmarks 26px — the
+   same 26px (8 + 8 + heading's 10) that separates the nav group from this
+   section, so the two seams read as one rhythm. */
 .sidebar-current-apps {
   flex: 0 0 auto;
-  padding-bottom: 0;
 }
 
 .current-app-glyph {
@@ -1166,25 +1166,26 @@ a.bookmark-name::after {
   text-decoration: line-through;
 }
 
-/* "Current apps" heading with its + (D489): the plus sits at the far end of the
-   heading row and only shows itself on hover, like the rows' own actions. */
-.current-apps-heading {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+/* The "+ New app" row (D489) closes the list: a row in the desk's own metrics,
+   muted so it reads as a door rather than another app, full colour on hover. */
+.current-app-new {
+  color: var(--fg-muted);
+  cursor: pointer;
+  user-select: none;
 }
 
-.current-apps-add {
-  margin-left: auto;
+.current-app-new .bookmark-name {
+  color: inherit;
+}
+
+.current-app-new .current-app-glyph {
   font-size: 14px;
   line-height: 1;
-  padding: 0 5px;
-  opacity: 0;
 }
 
-.current-apps-heading:hover .current-apps-add,
-.current-apps-add:focus-visible {
-  opacity: 1;
+.current-app-new:hover,
+.current-app-new:focus-visible {
+  color: var(--fg);
 }
 
 /* The composer, in the modal: the hero's bottom margin was spacing under a


### PR DESCRIPTION
## Summary
- Rename the sidebar's **Current apps** section to **Projects** and make it collapsible (heading click, persisted in localStorage like the Bookmarks fold; count chip when collapsed).
- Replace the hover-only `+` on the heading with a **+ New app** row at the end of the list; it opens the same new-app composer modal.
- Match the gap between Projects and Bookmarks to the gap between AI Models and Projects (26px both) by keeping the section's own bottom padding.

## Test plan
- [ ] Sidebar shows "Projects"; clicking heading folds/unfolds, survives reload.
- [ ] "+ New app" row sits last, opens the composer modal; keyboard Enter/Space work.
- [ ] Spacing above Bookmarks matches spacing above Projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, localStorage sidebar prefs, and client-side keyboard handlers with existing overlay/focus guards; layout change is scoped to Claude Config opt-in CSS.
> 
> **Overview**
> Renames **Current apps** to **Projects** and makes it collapsible like Bookmarks (localStorage, count chip when folded, chevron on both section headings). **+ New app** moves from a hover-only heading button to a list row at the bottom with keyboard support.
> 
> Adds **keyboard steering**: Up/Down in `sidebarArrowNav` walks Projects and Bookmarks link rows (with refocus after navigation); Left/Right on app pages steps Overview / Tasks / Files when focus is on the body or in the sidebar. Switching projects from the sidebar **keeps the active app tab** (`_tab` only; per-tab query params are not carried). Tasks uses the shared **ListTodo** icon in the global sidebar and on the app page.
> 
> Moves the **900px content cap** off shared `.cc-main` onto **`.cc-main-capped`** so Claude Config keeps the narrow default while AI Models can use full width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521717e826d3e2c9c75bd5a23d8eed9d69037103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->