### PR TITLE
App page: MCP and Git tabs

### DIFF
--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -13,6 +13,18 @@
 //   Files     the folder's files as a tree, each rendered in one of its own
 //             templates (shell/AppFiles.tsx) — "what is in this app and what
 //             does each piece look like", without leaving the page.
+//   MCP       the folder's `mcp` template (templates/mcp) in a frame — the
+//             tool curation panel the explorer offers on an app folder, here
+//             as a tab. Offered whenever the template exists; the template's
+//             own empty state covers a folder that is not (yet) an app.
+//   Git       the folder's `git` template (templates/git) in a frame — the
+//             working-tree view. Offered ONLY when the folder is inside a
+//             work tree (the template's condition.py verdict, CT-12), so a
+//             plain folder never shows a Git tab that could only say "no".
+//
+// The two companion tabs render the EXISTING templates rather than a second
+// panel of their own: the templates are the mcp.toml / git contract's one
+// UI, and a rebuild here would be a second one to keep in step.
 //
 // Opened from the sidebar's "Current apps" rows and NOWHERE ELSE (owner's
 // brief): the hub's cards and the explorer keep opening the entry page as they
@@ -30,15 +42,29 @@
 import {
   useEffect,
   useMemo,
+  useRef,
   useState,
   type MouseEvent,
   type ReactNode,
 } from "react";
-import { getAppEntry, statPath, type Config } from "@platform/lib/api";
+import {
+  getAppEntry,
+  resolveConditions,
+  statPath,
+  type Config,
+  type TemplateEntry,
+} from "@platform/lib/api";
 import { useUrlVersion } from "@platform/lib/hooks";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import { navigateUrl, urlForFsPath } from "@platform/lib/router";
-import { AppWindow, Files, ListTodo, type LucideIcon } from "lucide-react";
+import {
+  AppWindow,
+  Files,
+  GitBranch,
+  ListTodo,
+  Plug,
+  type LucideIcon,
+} from "lucide-react";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { Tabs, TabsList, TabsTrigger } from "@platform/shadcn/ui/tabs";
 import { SkeletonLines } from "@platform/ui/Skeleton";
@@ -69,7 +95,25 @@ type TabCtx = {
   dir: string;
   entry: string | null;
   folderHref: string;
+  /** The folder's `mcp` / `git` template entries, when offered (null = not). */
+  mcpTpl: TemplateEntry | null;
+  gitTpl: TemplateEntry | null;
 };
+
+/** A folder template in a frame — the explorer's folder-peek shape
+ *  (`/render?path=<template>&_file=<folder>`), no `_preview`: a real open. */
+function templateFrame(dir: string, tpl: TemplateEntry, title: string) {
+  return (
+    <iframe
+      className="app-page-frame"
+      src={
+        `/render?path=${encodeURIComponent(tpl.path as string)}` +
+        `&_file=${encodeURIComponent(dir)}`
+      }
+      title={title}
+    />
+  );
+}
 
 type TabDef = {
   label: string;
@@ -111,6 +155,31 @@ const TAB_DEFS: Record<AppPageTab, TabDef> = {
       <AppFiles dir={dir} entry={entry} folderHref={folderHref} />
     ),
   },
+  mcp: {
+    label: "MCP",
+    Icon: Plug,
+    // Not keepMounted: the panel re-reads mcp.toml on return, which is the
+    // freshness a config surface wants after an edit elsewhere.
+    render: ({ dir, slug, mcpTpl }) =>
+      mcpTpl ? (
+        templateFrame(dir, mcpTpl, `MCP tools: ${slug}`)
+      ) : (
+        <p className="app-page-empty">The MCP template is not installed.</p>
+      ),
+  },
+  git: {
+    label: "Git",
+    Icon: GitBranch,
+    // Not keepMounted: a fresh `git status` on return is the point.
+    render: ({ dir, slug, gitTpl }) =>
+      gitTpl ? (
+        templateFrame(dir, gitTpl, `Git: ${slug}`)
+      ) : (
+        <p className="app-page-empty">
+          This folder is not inside a git repository.
+        </p>
+      ),
+  },
 };
 
 // What the folder turned out to be. `undefined` = still asking.
@@ -129,6 +198,13 @@ export default function AppPage({
 }) {
   const slug = useMemo(() => basename(dir) || dir, [dir]);
   const [resolved, setResolved] = useState<Resolved | undefined>(undefined);
+  // The folder's templates (from the same stat that checks it is a folder)
+  // and the gate verdicts for the conditional ones (CT-12: stat only marks
+  // them; the gates run on demand). `null` verdicts = still asking.
+  const [tpls, setTpls] = useState<TemplateEntry[]>([]);
+  const [verdicts, setVerdicts] = useState<Record<string, boolean> | null>(
+    null,
+  );
   // The tab is the `_tab` query param, re-read on every URL event so
   // back/forward between the two tabs lands on the right one.
   useUrlVersion();
@@ -137,12 +213,27 @@ export default function AppPage({
   useEffect(() => {
     let live = true;
     setResolved(undefined);
+    setTpls([]);
+    setVerdicts(null);
     (async () => {
       try {
         const st = await statPath(dir);
         if (!st.is_dir) {
           if (live) setResolved({ kind: "missing" });
           return;
+        }
+        if (live) {
+          const templates = st.templates ?? [];
+          setTpls(templates);
+          if (templates.some((t) => t.conditional)) {
+            // Shared in flight per path with any other asker (api.ts), so
+            // this costs nothing extra when the explorer asked first.
+            resolveConditions(dir)
+              .then((r) => live && setVerdicts(r.conditions))
+              .catch(() => live && setVerdicts({}));
+          } else {
+            setVerdicts({});
+          }
         }
       } catch {
         // A stat that fails is a folder that is not there (404) or a server
@@ -164,6 +255,30 @@ export default function AppPage({
       live = false;
     };
   }, [dir]);
+
+  const mcpTpl = tpls.find((t) => t.mode === "mcp" && t.path) ?? null;
+  const gitTplRaw = tpls.find((t) => t.mode === "git" && t.path) ?? null;
+  // Git is offered only where its gate says yes: a `conditional` entry waits
+  // for the verdict (pending reads as "not yet"), an unconditional one is in.
+  const gitAllowed =
+    !!gitTplRaw && (!gitTplRaw.conditional || verdicts?.git === true);
+  const gitTpl = gitAllowed ? gitTplRaw : null;
+  // The strip draws THESE; the route knows APP_PAGE_TABS. A tab that is not
+  // offered is still a valid address (a `?_tab=git` deep link opened before
+  // the verdict lands must not be rewritten away), so the panel logic below
+  // tolerates `tab` being outside this list and renders that tab's own
+  // empty state.
+  const visibleTabs = useMemo(
+    () =>
+      APP_PAGE_TABS.filter((id) => {
+        if (id === "mcp") return mcpTpl !== null;
+        if (id === "git") return gitAllowed;
+        return true;
+      }),
+    [mcpTpl, gitAllowed],
+  );
+  const visibleRef = useRef(visibleTabs);
+  visibleRef.current = visibleTabs;
 
   // Left/Right step the tabs (owner, 2026-08-26), the sibling of the sidebar's
   // Up/Down over its rows (sidebarArrowNav.ts): together the two axes make the
@@ -191,11 +306,14 @@ export default function AppPage({
         !el || el === document.body || el === document.documentElement;
       const inSidebar = !!el && !!document.getElementById("sidebar")?.contains(el);
       if (!onBody && !inSidebar) return;
+      // Over the VISIBLE tabs, through a ref so this [dir]-scoped listener
+      // never steps onto a hidden Git tab from a stale closure.
+      const tabs = visibleRef.current;
       const cur = appPageTabFromSearch(location.search);
-      const i = APP_PAGE_TABS.indexOf(cur) + (e.key === "ArrowRight" ? 1 : -1);
+      const i = tabs.indexOf(cur) + (e.key === "ArrowRight" ? 1 : -1);
       e.preventDefault();
-      if (i < 0 || i >= APP_PAGE_TABS.length) return;
-      navigateUrl(appPageUrl(dir, APP_PAGE_TABS[i], location.search));
+      if (i < 0 || i >= tabs.length) return;
+      navigateUrl(appPageUrl(dir, tabs[i], location.search));
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
@@ -240,7 +358,7 @@ export default function AppPage({
             aria-label="App page"
             className="h-auto w-full justify-start rounded-none border-b border-border p-0 pb-1"
           >
-            {APP_PAGE_TABS.map((id) => {
+            {visibleTabs.map((id) => {
               const { label, Icon } = TAB_DEFS[id];
               return (
                 <TabsTrigger
@@ -294,7 +412,7 @@ export default function AppPage({
                 role="tabpanel"
                 aria-hidden={!active}
               >
-                {def.render({ slug, dir, entry, folderHref })}
+                {def.render({ slug, dir, entry, folderHref, mcpTpl, gitTpl })}
               </section>
             );
           })}

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -92,8 +92,10 @@ export const APP_PAGE_PREFIX = "/apps/";
 /** Tab-strip order; the first is the default. THE list: the type below is
  *  derived from it, and AppPage.tsx's `TAB_DEFS` is a `Record` over that type,
  *  so adding a tab is one string here plus one entry there — the compiler
- *  refuses the second being forgotten. */
-export const APP_PAGE_TABS = ["overview", "tasks", "files"] as const;
+ *  refuses the second being forgotten. Not every tab is offered on every
+ *  folder: `git` shows only inside a work tree (AppPage's `visibleTabs`), so
+ *  the ROUTE knows five tabs while the strip may draw four. */
+export const APP_PAGE_TABS = ["overview", "tasks", "files", "mcp", "git"] as const;
 export type AppPageTab = (typeof APP_PAGE_TABS)[number];
 export const DEFAULT_APP_PAGE_TAB: AppPageTab = APP_PAGE_TABS[0];
 


### PR DESCRIPTION
## Summary
- Two new tabs on the `/apps/<path>` page: **MCP** and **Git**.
- Both render the existing folder templates (`templates/mcp`, `templates/git`) in an `app-page-frame` iframe via `/render?path=<template>&_file=<folder>` — no second panel to keep in step.
- **MCP** is offered whenever the mcp template is installed; the template's own empty state covers a folder that is not yet an app.
- **Git** is offered only when the folder's `condition.py` verdict is true (inside a work tree), per CT-12 — a plain folder gets no Git tab.
- Tab strip and ←/→ key navigation step over the *visible* tabs (ref-backed, no stale closure). A `?_tab=git` deep link opened before the verdict lands is left in the URL and shows the tab's empty state rather than being rewritten.
- `APP_PAGE_TABS` grows to five; `Record<AppPageTab, TabDef>` forces the two new defs.

## Test plan
- Open a current app inside a git repo: five tabs, Git shows `git status` view, MCP shows the curation panel.
- Open a linked app outside any repo: four tabs, no Git.
- ←/→ from Files lands on MCP (and Git when present), never on a hidden tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell UI-only changes reusing established template rendering and condition APIs; no auth or data-model changes.
> 
> **Overview**
> The `/apps/<folder>` page gains **MCP** and **Git** tabs alongside Overview, Tasks, and Files.
> 
> Both tabs embed the existing folder templates via `templateFrame` (`/render?path=…&_file=<folder>`), reusing the explorer’s MCP curation and git working-tree UIs instead of duplicating them. **MCP** appears when the `mcp` template is installed; **Git** appears only after `statPath` templates and `resolveConditions` (CT-12) confirm the folder is in a work tree. The tab strip uses `visibleTabs` so Git can be omitted; left/right keyboard navigation steps only visible tabs via a ref. Deep links like `?_tab=git` stay valid and show the tab’s empty state if Git isn’t offered yet.
> 
> `APP_PAGE_TABS` in `current-apps-lib.ts` expands to five entries; `TAB_DEFS` picks up matching defs and template context on `TabCtx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c33598a28846973240894c057dfbd1e2e12ed860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->