### PR TITLE
Authoring skill: preview mode, the `_` param namespace, and a split into focused skills

### DIFF
--- a/skills/fused-render-ai/SKILL.md
+++ b/skills/fused-render-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fused-render-ai
-description: Use when a fused-render page needs an AI model — calling fused.ai for text, streaming tokens, holding a conversation, generating an image with fused.ai.image, transcribing audio or video with fused.ai.transcribe, or driving local models with fused.ai.models (list/catalog/load/download/unload) and fused.ai.cancel. Also use when a .py data file or an external process wants the same calls via `import fused_ai`, when an AI call rejects with ai_unavailable, model_loading, unavailable, cancelled, timeout, or stalled, when a model download needs watching, or when a page (or a .py file) that calls AI must survive export.
+description: Call an AI model from a fused-render page or .py file — fused.ai text and streaming, .image, .video, .transcribe, .embed, .models, and `import fused_ai`. Use when a page needs a model, or an AI call rejects (ai_unavailable, model_loading, timeout, stalled).
 ---
 
 # AI in a fused-render Page
@@ -249,7 +249,7 @@ el.dataset.seed = img.seed;
 
 Resolves with `{jobId, path, url, previewUrl, previewPath, model, prompt, width, height, steps, guidance, seed}`, plus `image` (the resolved absolute path) when you passed one — the render that will actually happen, not the one you asked for.
 
-### Editing a base image: `{image}` — mflux only (D432)
+### Editing a base image: `{image}` — mflux only
 
 ```js
 const edited = await fused.ai.image({
@@ -584,10 +584,10 @@ Fifteen runners, five capabilities, taking **either** a Hugging Face repo id **o
 
 | Capability | Runners (default first) | Reality |
 |---|---|---|
-| `text-generation` | MLX, then llama.cpp (CPU), then llama.cpp (Vulkan) | **Everywhere.** MLX on Apple Silicon; **llama.cpp (CPU)** everywhere else, and as the Apple Silicon fallback — the same index's wheel links Metal, so it is on the GPU there too. The three Transformers rows that used to sit between them were withdrawn: llama.cpp reads a quantized GGUF of the same current-generation Qwen several times quicker, at roughly a third of the download and a third of the memory, so **local text ids are GGUF now** — the curated ones are the GGUF's own filename, and any other GGUF repo resolves generically once picked from Hub search or loaded by its bare repo id. A plain safetensors repo is loadable only by MLX, i.e. only on Apple Silicon. Vulkan is the one opt-in row: it needs a working loader AND driver ICD from the GPU vendor or the Load button refuses with a reason naming which is missing; once loaded, a model too large for the card degrades to partial or full CPU offload rather than failing the load. |
+| `text-generation` | MLX, then llama.cpp (CPU), then llama.cpp (Vulkan) | **Everywhere.** MLX on Apple Silicon; **llama.cpp (CPU)** everywhere else, and as the Apple Silicon fallback — the same index's wheel links Metal, so it is on the GPU there too. **Local text ids are GGUF**: the curated ones are the GGUF's own filename, and any other GGUF repo resolves generically once picked from Hub search or loaded by its bare repo id. A plain safetensors repo is loadable only by MLX, i.e. only on Apple Silicon. Vulkan is the one opt-in row: it needs a working loader AND driver ICD from the GPU vendor or the Load button refuses with a reason naming which is missing; once loaded, a model too large for the card degrades to partial or full CPU offload rather than failing the load. |
 | `text-to-image` | MLX FLUX, then Diffusers (CPU), then Diffusers (CUDA), then Diffusers (ROCm) | **Everywhere.** MLX FLUX takes Apple Silicon (quicker, smaller download, much more memory); Diffusers (CPU) serves everywhere else and is one Engines-tab switch away on a Mac — minutes per image rather than seconds. The CUDA and ROCm variants are opt-in and hardware-gated: offered only where the app sees a usable NVIDIA or AMD GPU, greyed out with the reason otherwise. |
 | `automatic-speech-recognition` | MLX Whisper, then Faster Whisper (CTranslate2) | **Everywhere.** MLX Whisper (GPU) is the Apple Silicon default; CTranslate2 serves both Mac architectures, Linux and Windows and is one Engines-tab switch away on a Mac. There is deliberately **no** GPU variant here off Apple Silicon, so transcription on an NVIDIA or AMD machine runs on the CPU. |
-| `embeddings` | MLX Embeddings, then ONNX Embeddings (CPU), then ONNX (DirectML), (CUDA), (ROCm) | **Everywhere.** MLX takes Apple Silicon; **ONNX Embeddings (CPU)** serves everywhere else and is the Apple Silicon fallback. Three Transformers rows used to sit here and were withdrawn: an embedding call is one forward pass over a short sequence or one image, so the compute was never the argument — the WHEEL was, at 0.2–5.9 GB of torch to run a model whose own weights are 1.5 GB, against tens of megabytes of `onnxruntime` producing the same vectors (there is a real-weights parity gate asserting ≥0.999 cosine). So **local embedding ids are ONNX exports now** on every machine but a Mac. The three accelerated rows are opt-in and hardware-gated; none of them is about speed, and `auto` never reaches one. |
+| `embeddings` | MLX Embeddings, then ONNX Embeddings (CPU), then ONNX (DirectML), (CUDA), (ROCm) | **Everywhere.** MLX takes Apple Silicon; **ONNX Embeddings (CPU)** serves everywhere else and is the Apple Silicon fallback, so **local embedding ids are ONNX exports** on every machine but a Mac (a parity gate asserts ≥0.999 cosine against the torch weights). The three accelerated rows — DirectML, CUDA, ROCm — are opt-in and hardware-gated; none of them is about speed, and `auto` never reaches one. |
 | `text-to-video` | LTX-2.3 (Apple Silicon) | **NOT everywhere — the first capability with no fallback row.** LTX-2.3 runs on `ltx-2-mlx`, which is MLX-only; there is no CPU, CUDA or ROCm engine for it. Off Apple Silicon, `catalog()` reports `default: null` and every call to `fused.ai.video` rejects `.type "unavailable"`. |
 
 Those five strings are the capability vocabulary — what `unload({capability})` and `cancel(capability)` take, and what `catalog()` groups by.
@@ -743,7 +743,7 @@ First failing = `ai_unavailable`, not your bug. `X-Fused: 1` is required on ever
 - **Reading progress as bytes or steps** → it is `unit: "s"`, seconds of audio.
 - **`fused.ai.cancel()` to stop a transcription** → it defaults to `"text-generation"`; name the capability or use the row's ✕.
 - **Loading `openai/whisper-large-v3`** → transformers format, which no shipping runner reads. Take the id from `catalog()`.
-- **Loading a plain safetensors text model such as `Qwen/Qwen3.5-9B`** → since the Transformers engines were withdrawn, only MLX reads safetensors, so this is loadable on Apple Silicon and nowhere else. Off a Mac take the GGUF id from `catalog()` — the same model, a quarter of the download.
+- **Loading a plain safetensors text model such as `Qwen/Qwen3.5-9B`** → only MLX reads safetensors, so it loads on Apple Silicon and nowhere else. Off a Mac take the GGUF id from `catalog()` — the same model, a quarter of the download.
 
 **Export**
 

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fused-render-authoring
-description: How to author HTML views and Python data files for fused-render (the local HTML explorer with a fused.runPython() bridge, URL-synced params, and file IO helpers). Use when creating, editing, or debugging an .html view, a .py data file, or a preview template; when a view renders blank, shows a traceback overlay, or params don't sync to the URL; or when the user mentions fused.runPython/params/readFile/writeFile or asks for "a view for <file/data>".
+description: Author .html views and .py data files for fused-render — the fused.runPython() bridge, URL-synced params, file IO, preview mode. Use when creating, editing or debugging a view, a data file or a preview template; when a view renders blank or shows a traceback overlay; or on any mention of fused.runPython/params/readFile/writeFile. Routes to the neighbouring fused-render-* skills for AI, capture, jobs and theming.
 ---
 
 # Authoring fused-render views
@@ -26,30 +26,17 @@ fused-render is a local file explorer that renders `.html` files live in the bro
    └─ fused.trackJob({...})         ← report long work to the shell's download manager
 ```
 
-**Mark every app entry page with `<meta name="fused-app" />`**, placed near the
-top of `<head>` (right after `<meta charset>` — detection reads only the first
-4 KiB of the file). The marker is **the only thing that makes a folder a fused
-app**: filenames — `index.html` included — declare nothing, so a page without
-the tag does not appear on the /apps hub, does not resolve as a folder's entry,
-and is never recorded/registered when rendered. The starter template already
-carries it; when authoring an entry page by hand, add it yourself.
-
-**Migrating an existing app** (one that predates the marker, or lives outside
-`~/Fused`): add the tag to the entry page's `<head>`:
+**Mark every app entry page with `<meta name="fused-app" />`**, near the top of `<head>` — detection reads only the first 4 KiB of the file. The marker is **the only thing that makes a folder a fused app**: filenames, `index.html` included, declare nothing. Without it the page never reaches the /apps hub, never resolves as a folder's entry, and is never registered when rendered. The starter template carries it; add it by hand to any entry page you author, and to any app you adopt from outside `~/Fused` (that one line is the whole migration — rendering the page then registers the folder automatically).
 
 ```html
 <head>
 <meta charset="utf-8" />
 <meta name="fused-app" />
-...
 ```
 
-Workspace apps were stamped automatically by a one-time migration at startup;
-apps anywhere else (external folders, cloned repos) are yours to stamp — this
-one line is the whole migration. Once tagged, rendering the page registers an
-external folder on the /apps hub automatically.
+Three primitives — `runPython`, `params`, and the file IO helpers — are the core API; the table below has the rest. Everything else is ordinary HTML/CSS/JS: no framework, no build step, ES2020 fine.
 
-Three primitives — `runPython`, `params`, and the file IO helpers — are the core API (plus `fused.ai` for asking an AI model — the claude CLI or a local one — and `fused.trackJob` for reporting long-running work — each gets its own section below — and two auxiliary members, `fused.env` and `fused.autoReload`, covered in the table). Everything else is ordinary HTML/CSS/JS (no framework, no build step, ES2020 fine).
+Four neighbouring skills own the bigger surfaces, and this one keeps only enough to know when you need them: **`fused-render-ai`** (`fused.ai` and every model call), **`fused-render-capture`** (native screen/audio/screenshot), **`fused-render-jobs`** (work longer than one call, and the download manager), **`fused-render-theming`** (light/dark).
 
 ## The Python side: `main()` contract
 
@@ -81,15 +68,15 @@ Rules that matter (each has a reason):
 
 ### Available Python libraries
 
-Write `main()` against **stdlib plus the supported library set** below — a folder with no `pyproject.toml` runs on the app's own interpreter, which ships exactly these with no download and no first-run wait. Dev installs get the same set via `pip install -e ".[bundled]"` (the authoritative list is the `[bundled]` extra in the repo's `pyproject.toml`, plus core deps):
+Write `main()` against **stdlib plus the bundled set** below — a folder with no `pyproject.toml` runs on the app's own interpreter, which ships exactly these with no download and no first-run wait. (Dev installs get the same via `pip install -e ".[bundled]"`; the authoritative list is that extra plus the core dependencies.)
 
 - **Data:** `numpy` `pandas` `pyarrow` `duckdb` `openpyxl` `msgpack`
 - **Images:** `pillow`
-- **Documents:** `python-pptx`
+- **Documents:** `python-pptx` `fpdf2` (its import name is *fpdf*)
 - **Network & cloud:** `requests` `httpx` `botocore` `google-auth`
 - **Logs:** `drain3`
 
-Anything outside this set is missing by default — including several packages the app used to ship and no longer does: **polars, matplotlib, scipy, geopandas, shapely, rasterio, rio-tiler, zarr, pymupdf, pikepdf**. They were 541.9 MB every user carried for a minority of pages, so they moved to per-folder declarations. **`fpdf2` is still bundled and still importable** — it is not in the table above only because that table is curated, and PDF export via `from fpdf import FPDF` needs no declaration and no install. Reaching for any of them (or for torch, sklearn, xarray, plotly) is a deliberate choice with a cost — a one-time install the user waits through — so prefer rewriting with the always-there set; when it genuinely cannot do the job, declare the folder's dependencies (next section).
+Anything else — polars, matplotlib, scipy, geopandas, shapely, rasterio, rio-tiler, zarr, pymupdf, pikepdf, torch, sklearn, xarray, plotly — must be declared in a folder `pyproject.toml`, and costs the user a one-time install they sit and wait through. Prefer rewriting against the bundled set; declare dependencies (next section) only when it genuinely cannot do the job.
 
 ### Declaring extra dependencies: `pyproject.toml`
 
@@ -109,8 +96,8 @@ package = false
 
 Four things to know before you write one:
 
-- **The declaration is the COMPLETE list.** The venv contains exactly what you name and nothing else — the bundled set above is *not* unioned in. Declare numpy if you import numpy, even though the app ships it.
-- **It is all-or-nothing per folder.** Adding a `pyproject.toml` to get one extra package means every import in every `.py` under that folder must be listed. A folder with no manifest runs on the app's own interpreter and gets the whole bundled set for free — which is why the supported set is still the better default.
+- **The declaration is the COMPLETE list.** The venv contains exactly what you name — the bundled set is *not* unioned in. Declare numpy if you import numpy, even though the app ships it.
+- **It is all-or-nothing per folder.** One extra package means every import in every `.py` under that folder must be listed. That is why a folder with no manifest — which gets the whole bundled set free — is still the better default.
 - **Only the project root counts.** That's the app folder, a template folder, or the *topmost* ancestor holding a `pyproject.toml`. One in a subfolder is inert; the inspector flags it.
 - **First render triggers an install.** The user sees a loader while `uv sync` runs, then the run is retried automatically. Commit the `uv.lock` it writes — that's what makes the folder resolve identically elsewhere.
 
@@ -118,24 +105,13 @@ Adding a dependency later is just an edit: save `pyproject.toml`, re-render, and
 
 **Per-file `# /// script` headers are not read.** A leftover block is an ordinary comment — silently ignored, not merged and not warned about. Never write one; if you see one, move its `dependencies` into the project root's `pyproject.toml` and delete it, because the packages it names are not being installed.
 
-Versions are not pinned — each install resolves its own. When a version matters (an API that changed between majors, a feature gated on a release), **probe the live environment** instead of guessing: `/api/run` executes in the exact interpreter that runs page code. Write a throwaway probe and POST it:
+Versions are not pinned — each install resolves its own. When a version matters, **probe the live environment** rather than guessing: `/api/run` executes in the exact interpreter that runs page code, so a throwaway `main()` returning `importlib.metadata.version(...)` for each name answers it. A `null` version means the package is missing from *this* environment — the same result an `import` would hit.
 
 ```bash
-cat > /tmp/probe.py <<'EOF'
-def main(names: str = "pandas,numpy"):
-    from importlib import metadata
-    out = {}
-    for n in names.split(","):
-        try: out[n] = metadata.version(n)
-        except Exception: out[n] = None
-    return out
-EOF
 curl -s -X POST http://127.0.0.1:1777/api/run -H 'X-Fused: 1' \
   -H 'Content-Type: application/json' \
   -d '{"py": "/tmp/probe.py", "params": {"names": "pandas,duckdb,geopandas"}}'
 ```
-
-A `null` version means the package is missing from *this* environment — the same result an `import` in `main()` would hit.
 
 ## The HTML side: `window.fused` API
 
@@ -143,29 +119,27 @@ The runtime is injected automatically when the explorer renders the page. Never 
 
 | Call | Behavior |
 |---|---|
-| `await fused.runPython(pyPath, params, opts?)` | Runs `main(**params)` of the file at `pyPath` — relative to **this html file's directory**, or absolute. Resolves with the return value; rejects with an `Error` carrying `.type`, `.message`, `.traceback`, `.stdout`. **Stale-request cancellation is on by default** (keyed by `pyPath`): a new call for a file aborts the prior in-flight call for that same file — so slider scrubs cancel the runs they move past. A superseded call's promise **never settles** (its `.then`/`await` just stops — nothing stale is drawn). `opts.key` regroups the channel (a string) or `opts.key: null` **opts out** (fully concurrent — use for polling loops, per-tile fetches, or writes that must finish); `opts.signal` is a standard `AbortSignal` that composes (an abort via *your* signal rejects with a benign `AbortError` the runtime swallows). |
-| `fused.params.get(k)` | Current value from the URL, as a **string** (or `undefined`). |
-| `fused.params.getAll()` | All non-reserved params as an object — plus `_file` (read-only) when the page was opened as a preview template, even though `_file` is otherwise a reserved key. |
-| `fused.params.set(k, v)` | Writes to the URL (replaceState — no history spam). **Throws unless `v` is a string** — do `String(n)` yourself. Then fires `onChange`. |
+| `await fused.runPython(pyPath, params, opts?)` | Runs `main(**params)` of the file at `pyPath` — relative to **this html file's directory**, or absolute. Resolves with the return value; rejects with an `Error` carrying `.type`, `.message`, `.traceback`, `.stdout`. **Stale-request cancellation is on by default**, keyed by `pyPath`: a new call for a file aborts the prior in-flight call for that same file, and the superseded promise **never settles** (its `.then`/`await` just stops, so nothing stale is drawn) — a slider drag therefore computes only the value it lands on, for free. Calls to *different* files are independent. `opts.key` regroups the channel, `opts.key: null` opts out into full concurrency (polling loops, per-tile fetches, a write that must finish), and `opts.signal` takes your own `AbortSignal` to cancel on something other than the next call. |
+| `fused.params.get(k)` | Current value from the URL, as a **string** (or `undefined`). `_`-prefixed keys return `undefined`; `_file` is the one exception — read-only, the target file a preview template was opened for. |
+| `fused.params.getAll()` | All non-reserved params as an object, plus `_file` when present. |
+| `fused.params.set(k, v)` | Writes to the URL (replaceState — no history spam), then fires `onChange`. **Throws** on a reserved `_` key, and unless `v` is a string — do `String(n)` yourself. |
 | `fused.params.onChange(cb)` | `cb(allParams)` after every applied `set`. Returns an unsubscribe function. |
-| `fused.params.get("_file")` | Read-only: the target file a **preview template** was opened for. Keys starting `_` are reserved — `set()` on them throws. |
 | `await fused.readFile(path)` | File contents as **text** (UTF-8). Rejects with an `Error` on failure. Use when a view just needs the bytes as a string — no reader `.py` required. |
-| `await fused.stat(path)` | Metadata object `{path, name, is_dir, size, mtime, writable, remote, templates}` (`templates` is the ordered mode-list array, usually irrelevant to page code; `writable` is false for read-only files — check it before offering an edit UI; `remote` is true for files on a mounted remote bucket — keep reads bounded there). May also carry `template_error` (a bad registry name). Use for size guards before reading big files, and to capture `mtime` before editing. |
-| `await fused.writeFile(path, content, opts?)` | Writes UTF-8 text **atomically** (never a half-written file). `opts.expectedMtime` arms an optimistic lock: if the file changed on disk since that mtime, rejects with an error whose `.type === "conflict"` (and `.mtime` = current on-disk value) instead of clobbering. A read-only file rejects with `.type === "readonly"` (check `stat().writable` first to avoid it). Omit `expectedMtime` to write unconditionally. `opts.create` writes only if the path is absent: an existing path rejects with `.type === "exists"` and nothing is written, which is how you create a file without a stat-then-write race. Resolves with a fresh stat object; keep its `.mtime` to re-arm the lock for the next save. |
-| `fused.rawUrl(path)` | **Sync**, returns a URL string serving the file's raw bytes. This is for embedding — `<img src>`, `<video src>`, `<embed>`, download links — where you need a URL, not text. |
-| `await fused.ai(prompt, opts?)` | Ask an AI model; resolves with `{text, model, usage}`. Runs the local `claude` (Claude Code) CLI; local-only. See the **"AI calls"** section below for the options, error types, and the worked pattern. |
-| `await fused.fileIndex.search({root, q, limit})` / `.query({sql, limit})` | Read the machine-wide **file index** — one folder's indexed corpus, or one read-only SQL statement over the `files`/`dirs` views (which is also how you get totals, per-extension breakdowns and path matches). Two methods, deliberately; scanning, roots/ignore config and the repos list are raw `fetch` + `X-Fused: 1`. Both resolve with `ready: {indexed, scanning, stale, reason}`, so an empty result can never be rendered as "no matches" when the truth is "no index yet". Use this instead of walking the filesystem in Python for anything machine-wide. For the readiness rule and the Python direct-parquet reader for bulk reads, read `skills/fused-render-index/SKILL.md`. |
-| `await fused.capture.screen(opts)` / `.audio(opts)` / `.screenshot(opts)` / `.sources()` | Record the screen, record the microphone, grab a still — **natively**, so the result is a FILE on this machine (`{path, url, …}`), not a `MediaRecorder` blob. `screen`/`audio` resolve **when the recording is running** with a handle `{id, path, url, state, stop(), cancel()}`: `stop()` resolves with the finished file, `cancel()` deletes it. The path is on the handle immediately, so `fused.ai.transcribe({path: rec.path})` is the next line. `screen({audio: "system"})` captures **system audio**, which `getDisplayMedia` cannot do on macOS at all. Call `sources()` first — it never prompts — and hide your record button when `available` is false: **local only**, and what is available differs per platform (macOS records natively with no picker; Windows and Linux open the browser's share dialog and refuse `display`/`rect`/`cursor` on `screen()`). See the **"Native capture"** section below. |
-| `fused.trackJob(spec)` | Report a long-running operation (a model download, a minutes-long generation) to the shell's **download manager**, so it stays visible after the user browses away from your page. Returns a handle; see the **"Long-running work"** section below. Never throws, never rejects. |
-| `fused.env` | String `"local"` (this local server) vs `"hosted"` (the exported/hosted runtime). Branch on it only if a view must behave differently when exported. |
-| `fused.autoReload(enabled)` | Toggle the automatic reload-on-file-change behavior for this page. Pass `false` to opt out (e.g. an in-page editor that manages its own saves and shouldn't reload under the user). |
+| `await fused.stat(path)` | `{path, name, is_dir, size, mtime, writable, remote, templates}`. Use it for a size guard before reading something big, to capture `mtime` before editing, to check `writable` before offering an edit UI, and to notice `remote` (a mounted remote bucket — keep reads bounded there). May also carry `template_error` (a bad registry name). |
+| `await fused.writeFile(path, content, opts?)` | Writes UTF-8 text **atomically** (never a half-written file). `opts.expectedMtime` arms an optimistic lock: a file changed on disk since that mtime rejects with `.type === "conflict"` (and `.mtime` = the current value) instead of clobbering. `opts.create` writes only if the path is absent — an existing path rejects with `.type === "exists"` and nothing is written, which is how you create a file without a stat-then-write race. A read-only file rejects with `.type === "readonly"`. Resolves with a fresh stat; keep its `.mtime` to re-arm the lock. |
+| `fused.rawUrl(path)` | **Sync**, returns a URL serving the file's raw bytes — for `<img src>`, `<video src>`, `<embed>`, download links. |
+| `await fused.ai(prompt, opts?)` | Ask an AI model; resolves with `{text, model, usage}`. Local-only. See **"AI calls"** below. |
+| `await fused.fileIndex.search({root, q, limit})` / `.query({sql, limit})` | Read the machine-wide **file index** — one folder's corpus, or one read-only SQL statement over the `files`/`dirs` views (totals, per-extension breakdowns, path matches). Both resolve with `ready: {indexed, scanning, stale, reason}`, so an empty result is never mistaken for "no matches" when the truth is "no index yet". Use this instead of walking the filesystem in Python. Details, and the Python direct-parquet reader for bulk reads: **`fused-render-index`**. |
+| `await fused.capture.screen(opts)` / `.audio(opts)` / `.screenshot(opts)` / `.sources()` | Record the screen, record the microphone, grab a still — **natively**, so the result is a FILE on this machine, not a `MediaRecorder` blob. See **`fused-render-capture`**. |
+| `fused.trackJob(spec)` | Report a long-running operation to the shell's **download manager**, so it stays visible after the user browses away. Returns a handle; see **`fused-render-jobs`**. Never throws, never rejects. |
+| `fused.env` | `"local"` (this server) vs `"hosted"` (the exported runtime). Branch on it only if a view must behave differently when exported. |
+| `fused.autoReload(enabled)` | Toggle reload-on-file-change for this page. Pass `false` from an in-page editor that manages its own saves and shouldn't reload under the user. |
 
 Notes:
-- **`_`-prefixed param names are the shell's.** `set()` throws on them, `get()`/`getAll()` hide them (except `_file`). Never invent one, never rewrite the URL query yourself, and read `_preview` only to skip work — see **"Reserved params and preview mode"** below.
+- **`_`-prefixed param names are the shell's**, and `_preview` is the one a page should read — only ever to do *less* work. See **"Reserved params and preview mode"**.
 - Params are **strings only, always**. Parse numbers yourself (`parseInt(fused.params.get("limit") || "50", 10)`), JSON-encode structure yourself if you need it.
-- Uncaught `runPython` rejections auto-show a red traceback overlay — good default for debugging; catch the rejection yourself when you want custom error UI.
-- **Stale requests to the same `.py` auto-cancel.** For the common slider/scrub case — a fast drag fires a request per intermediate value and only the last matters — you get this for free: a new `runPython("./x.py", …)` aborts any prior in-flight call to `./x.py`, and the superseded call's promise never settles (its continuation just stops, so nothing stale is drawn). Calls to **different** files are independent. When you genuinely need multiple concurrent calls to the **same** file to all finish — a polling loop, per-tile fetches, or a write that must complete — pass `{ key: null }` to opt out. Use a distinct `{ key: "…" }` to split one file into independent channels, or `{ signal }` (your own `AbortController`) to cancel on something other than the next call.
-- **Reach the filesystem only through these helpers**, never by fetching the server's `/api/fs/*` endpoints yourself — the helpers are the stable contract and carry required headers (writes are rejected without them).
+- Uncaught `runPython` rejections auto-show a red traceback overlay — a good debugging default; catch the rejection yourself when you want custom error UI.
+- **Reach the filesystem only through these helpers**, never by fetching `/api/fs/*` yourself — the helpers are the stable contract and carry required headers (writes are rejected without them).
 - `readFile`/`rawUrl` split: text you'll process → `readFile`; anything the browser should load itself (images, media, PDFs, download links) → `rawUrl`.
 
 The editing pattern (used by the built-in code editor template):
@@ -187,96 +161,17 @@ try {
 
 ## AI calls (`fused.ai`)
 
-`fused.ai(prompt, opts?)` asks an AI model. It resolves with **exactly** this shape (the server normalizes — no guarding needed):
+`await fused.ai(prompt, opts?)` resolves with **exactly** `{text, model, usage}` — the server normalizes, so no guarding is needed. `model` is the full id that actually ran; `usage` is `null` or `{input_tokens, output_tokens}` (Anthropic-style names — `prompt_tokens` reads `undefined`). The model id picks the destination: an id containing a `/` or ending in `.gguf` runs on **this machine**, anything else goes to the **`claude` (Claude Code) CLI** on the user's own login. Common options are `systemPrompt`, `model`, `effort` and `onChunk`.
 
-```json
-{
-  "text": "the completion text",
-  "model": "claude-haiku-4-5-20251001",
-  "usage": { "input_tokens": 544, "output_tokens": 73 }
-}
-```
+Three things decide whether a page using it behaves:
 
-- `text` — the completion (string).
-- `model` — the **full model id that actually ran**; an alias request (`"sonnet"`) echoes the resolved id.
-- `usage` — either `null` or exactly `{input_tokens, output_tokens}` (both integers). These are **Anthropic-style names** — there is NO `prompt_tokens`/`completion_tokens` (OpenAI names); reading those yields `undefined`.
+- **It is local-only, and the exporter enforces that textually.** Any page containing the string `fused.ai(` is rejected for export (SPEC RH-11) — an `if (fused.env === "local")` guard does not help. Keep AI out of a view that must export.
+- **Feed it aggregates, not the dataset.** Compute in Python, reduce to a compact summary, and hand the model that. A full table blows the token budget and drowns the signal.
+- **There is no stale-cancel channel.** Calls run fully concurrent, so a double-click fires two paid calls — disable the button while one is in flight.
 
-The page never talks to a model directly, and there are **two destinations** — the model id decides which. An id **containing a `/`** (a Hugging Face repo), or **ending in `.gguf`** (a llamacpp-text curated filename id — those are not repo ids, see **`fused-render-ai`**), runs on **this machine** (a resident worker process); anything else goes to the **`claude` (Claude Code) CLI**, where the user's Claude Code login is the credential (binary from `PATH`, overridable with `FUSED_RENDER_CLAUDE_BIN`).
+Rejections carry `.type`: `model_loading` (a local model is loading — `err.jobId` is the download it just started, not a failure), `ai_unavailable` (show a friendly state, not a raw overlay), `bad_request`, `ai_error`, `timeout`.
 
-Both are **local-only**: an exported/hosted page has neither, so the exporter rejects any page containing the string `fused.ai(` (SPEC RH-11) — a textual match, so an `if (fused.env === "local")` guard does not make the page exportable. Keep AI out of a view that must export.
-
-Core options:
-
-| Option | Meaning |
-|---|---|
-| `systemPrompt` | System message (string). Role + ground rules here; data + question in `prompt`. |
-| `model` | Model id. Default `claude-haiku-4-5-20251001` (or the user's configured default). A `/`, or a `.gguf` filename id, means a local model. |
-| `effort` | `"low"` \| `"medium"` \| `"high"` \| `"xhigh"`. Claude path only; default low = no extended thinking. |
-| `onChunk(text)` | Opts into streaming; the promise still resolves with the same `{text, model, usage}`. |
-
-`history`, `raw`, `temperature`, `topP` and `maxTokens` are **local-model only** and are **refused with a 400 on the Claude path**, not dropped.
-
-Rejections carry an `Error` with `.type`:
-
-| `.type` | Cause | UI response |
-|---|---|---|
-| `model_loading` | A local model isn't resident. The call **started the load**; `err.jobId` is it. | Not a failure — show the download, then retry. |
-| `ai_unavailable` | `claude` binary not found/runnable, or the local worker won't start. | Friendly "AI unavailable" state, not a raw overlay. |
-| `bad_request` | Empty prompt / bad options / a local-only option on the Claude path. | Fix the call; usually a bug in your page. |
-| `ai_error` | Ran but reported an error (bad model id, upstream failure). | Show `err.message`. |
-| `timeout` | No answer within 600 s. | Offer retry; suggest lower `effort`. |
-
-**There is more to the AI API than this call** — `fused.ai.models.*` (list/catalog/load/download/unload), `fused.ai.image()`, `fused.ai.cancel()`, and the rules for driving local models. For any of that → **`fused-render-ai`**.
-
-The canonical shape — compute data in Python, reduce it to **compact aggregates**, and hand the model those, never the raw dataset (a full table blows the token budget and drowns the signal):
-
-```js
-const data = await fused.runPython("./data.py", { days });   // full dataset for the UI
-const context = JSON.stringify({                              // aggregates only, for the model
-  total_revenue: data.total_revenue,
-  revenue_by_region: data.by_region,
-  daily_revenue: data.by_day,
-});
-
-async function ask(question) {
-  const btn = document.getElementById("go"), out = document.getElementById("answer");
-  btn.disabled = true;                    // fused.ai has NO stale-cancel — guard double-submits yourself
-  out.textContent = "Thinking…";
-  try {
-    const res = await fused.ai(
-      "Data (JSON):\n" + context + "\n\nQuestion: " + question,
-      {
-        systemPrompt: "You are a data analyst. Answer ONLY from the provided JSON data. " +
-                      "Cite figures. A few sentences at most.",
-        effort: "low",
-      }
-    );
-    out.textContent = res.text;           // res.model / res.usage available for a meta line
-  } catch (err) {
-    if (err.type === "ai_unavailable")      out.textContent = "AI unavailable — " + err.message;
-    else if (err.type === "bad_request")    out.textContent = "Bad request: " + err.message;
-    else                                    out.textContent = (err.type || "error") + ": " + err.message;
-  } finally {
-    btn.disabled = false;
-  }
-}
-```
-
-Two behaviors that differ from `runPython`, each for a reason:
-
-- **No stale-cancel channel.** An AI call is never a slider scrub — you asked a question and want the answer — so calls run fully concurrent. The flip side: nothing stops a double-click from firing two paid calls. Disable the button while a call is in flight (as above).
-- **The relay times out at 600 s** server-side (vs 60 s for `runPython`) — generation is slower than computation. A `high`-effort call on a big model can legitimately take a while; keep the loading state honest.
-
-When a call fails, check the CLI before blaming the page — same probe style as `/api/run`:
-
-```bash
-which claude && claude --version               # CLI installed? (or check $FUSED_RENDER_CLAUDE_BIN)
-curl -s -X POST http://127.0.0.1:1777/api/ai -H 'X-Fused: 1' \
-  -H 'Content-Type: application/json' \
-  -d '{"prompt": "Reply with exactly the word pong.", "effort": "low"}'
-```
-
-The first failing means the claude CLI isn't installed (that's `ai_unavailable`, not your bug); the second exercises the exact endpoint the page uses.
+Everything else — the full options and rejection tables, `fused.ai.models.*`, `.image()`, `.video()`, `.transcribe()`, `.embed()`, `.cancel()`, calling AI from Python, and diagnosing a failing call → **`fused-render-ai`**.
 
 ## The canonical wiring pattern
 
@@ -324,30 +219,19 @@ Why this shape:
 
 ### The `_` namespace is the shell's
 
-**Every query key starting with `_` belongs to the shell, not to your page.** The runtime enforces it: `fused.params.set("_x", …)` **throws**, `fused.params.get("_x")` returns `undefined`, and `getAll()` filters `_` keys out. The single exception is `_file` — readable, never writable.
+**Every query key starting with `_` belongs to the shell, not to your page.** The runtime enforces it: `set()` throws, `get()` returns `undefined`, `getAll()` filters them out — `_file` being the single readable exception. So:
 
-So:
-
-- **Never invent a `_`-prefixed param for your own state.** Names in use today include `_file`, `_mode`, `_preview`, `_nofocus`, `_layout`, `_side`, `_panel`, `_tab`, `_listing`, `_render`, `_rev` — and the set grows without notice. Squatting on one means the shell silently overwrites your state, or you overwrite the shell's. Page params get plain names: `limit`, `sort`, `offset`, `theme`.
-- **Never reach around the runtime to read one.** `new URLSearchParams(location.search).get("_whatever")` is going behind `fused.params` to read a value whose meaning is the shell's and can change under you. The one exception is `_preview`, below — and only ever to do *less* work.
-- **Never rewrite the URL's query yourself.** A `history.replaceState` (or a `location.search = …`) built from your own params drops the shell's `_` keys and breaks the pane/tab it is mounted in. Write through `fused.params.set` only.
+- **Name page params plainly** (`limit`, `sort`, `offset`, `theme`). The shell's set — `_file`, `_mode`, `_preview`, `_nofocus`, `_layout`, `_side`, `_panel`, `_tab`, `_listing`, `_render`, `_rev` — grows without notice, and squatting on one means the shell overwrites your state or you overwrite the shell's.
+- **Read `_` params only through `fused.params`.** Reaching around it with `new URLSearchParams(location.search)` reads a value whose meaning is the shell's and can change under you. `_preview` is the one exception, below.
+- **Write the URL only through `fused.params.set`.** A `history.replaceState` built from your own params drops the shell's `_` keys and breaks the pane or tab the page is mounted in.
 
 ### `_preview=1`: this render is a picture of the page, not a use of it
 
-The shell renders pages it was never asked to *open*: `/apps` cards, listing-pane peeks, hover previews. Those frames are stamped `_preview=1` (usually with `_nofocus=1`), they are mounted and unmounted as the pointer moves, and **many of them boot at once on a home/listing page** for apps the user has not opened and may never open.
+The shell renders pages nobody asked to *open*: `/apps` cards, listing-pane peeks, hover previews. Those frames are stamped `_preview=1` (usually with `_nofocus=1`), they mount and unmount as the pointer moves, and **many boot at once on a home or listing page** for apps the user has not opened and may never open. A page that boots identically in a preview turns that listing into N simultaneous cold starts — the most common way an app folder makes the home page unusable.
 
-A page that boots identically in a preview turns that listing into N simultaneous cold starts. This is the single most common way an app folder makes the home page unusable.
+**Read the flag at boot and return early**, rendering something cheap and static — a title, a cached thumbnail, an inert placeholder. Under preview, start none of: `runPython` calls that import something heavy, scan a directory or hit the network; model loads and downloads; daemon starts; `fused.capture.*`, `writeFile`, `trackJob`; polling loops, `setInterval`, websockets, EventSource; anything that records an "open", mutates state, or unpacks on first use.
 
-**Read the flag at boot and return early.** Under preview, render something cheap and static — a title, a cached thumbnail, an inert placeholder — and start none of:
-
-- `runPython` calls whose `main()` imports something heavy, scans a directory, or hits the network
-- model loads or downloads (`fused.ai`, `fused.ai.image`, `fused.ai.models.load`)
-- daemon starts (`fused.daemon.start` — already refused in preview, see below)
-- `fused.capture.*`, `writeFile`, `trackJob`
-- polling loops, `setInterval`, websockets, EventSource
-- anything that records an "open", mutates state, or unpacks/extracts on first use
-
-Read it by climbing, because the flag is **inherited**: your page may be framed by a template that was the one stamped, and only the ancestor's URL carries it. This mirrors the runtime's own `selfOrAncestorHasFlag`:
+Read it by climbing, because the flag is **inherited** — your page may be framed by a template that was the one stamped, and only the ancestor's URL carries it (this mirrors the runtime's own `selfOrAncestorHasFlag`):
 
 ```js
 function isPreview() {
@@ -378,50 +262,15 @@ boot();
 Two more rules:
 
 - **Forward the stamps to frames you mount yourself**: `frame.src = url + "?_preview=1&_nofocus=1"` when `PREVIEW`. Otherwise the inner page reads a clean URL and does the work you just skipped.
-- **A preview that *can* show real content should show a cached one, never compute one.** Ask for the already-extracted / already-cached artifact and fall back to the placeholder when it is absent; never let a peek be the thing that populates the cache.
+- **A preview that *can* show real content shows a cached one, never computes one.** Ask for the already-extracted artifact and fall back to the placeholder when it is absent; never let a peek be the thing that populates the cache.
 
-What the runtime already handles, so you don't have to: `fused.daemon.start/stop/restart/setAutostart/call` reject in a preview frame, and a preview never writes the shell's URL. **Everything else — your Python calls, AI calls, timers, fetches — runs exactly as it would in a real open unless you gate it.**
-
-`fused_render/templates/fusedapp/template.html` is the worked example: it reads `_preview`, asks the server for an existing extract only, live-renders it when there is one, and shows an inert "Open this file to unpack and run the app" card when there isn't.
+The runtime covers two of these for you — `fused.daemon.*` rejects in a preview frame, and a preview never writes the shell's URL. **Everything else — your Python calls, AI calls, timers, fetches — runs exactly as it would in a real open unless you gate it.** `fused_render/templates/fusedapp/template.html` is the worked example.
 
 ## Style and theming
 
-There is no imposed CSS — the iframe is a blank canvas, and by default **nothing is written into your document**: no class, no attribute, no stylesheet. But the explorer around it is not fixed. It follows the OS light/dark preference, with a Light/Dark override in Preferences → Appearance, so a hardcoded palette will sooner or later sit inside the opposite one.
+There is no imposed CSS — the iframe is a blank canvas, and nothing is written into your document by default. But the explorer around it follows the OS light/dark preference with a Light/Dark override in Preferences, so a hardcoded palette will sooner or later sit inside the opposite one. The quickest correct answer is `data-fused-theme="shell"` on your `<html>`: the runtime then writes `data-theme="light"`/`"dark"` on that element before your stylesheet is parsed and keeps it in step, so you author two `:root` token blocks and nothing else.
 
-Pick one of these and commit to it — the failure mode is picking none and half-following:
-
-**1. Fixed palette.** Fine for a view with its own strong look (a dark map, a photo grid). Just don't pretend to follow.
-
-**2. Follow the app** — one attribute, no JS. Put `data-fused-theme="shell"` on your `<html>` and the injected runtime resolves the app's setting, writes `data-theme="light"`/`"dark"` on that same element before your stylesheet is even parsed, and keeps it in step afterwards — including an in-app pin, an OS flip mid-session, and a change made in another window. Author against the attribute:
-
-```html
-<html data-fused-theme="shell">
-```
-```css
-:root       { color-scheme: dark;  --bg: #101318; --text: #dce2ea; --line: #2a303a; }
-:root[data-theme="light"]
-            { color-scheme: light; --bg: #f7f8fa; --text: #1a1f27; --line: #d8dce3; }
-body        { background: var(--bg); color: var(--text); }
-```
-
-This is what the built-in templates use (`SPEC.md` §30, AP-8/AP-9), and it is the only option that agrees with the app when the user pins Light or Dark.
-
-**3. Follow the desktop** — `@media (prefers-color-scheme: light)` around the second `:root`, same tokens, no attribute. Tracks the OS, which is what the app's default System mode tracks too, so the two agree for the setting almost nobody changes. It does *not* see an in-app pin.
-
-**4. Your own switcher.** Put the choice in a param (`fused.params.set("theme", …)`) so it is bookmarkable like the rest of your view state, and drive the same one `data-theme` attribute from it. **Don't combine this with option 2** — the runtime re-applies on every storage/OS event, so your button would silently lose to the app setting. That is exactly why the built-in log viewer dropped its own button.
-
-Whatever you pick, two rules make the second palette actually work:
-
-- **Every colour comes from a token.** Two blocks defining *the same token set*, and no colour literal anywhere else in the stylesheet. A stray `#1a1f27` in a rule is one the other mode cannot repaint — and it shows up as an unreadable smear, not an obvious bug.
-- **Colours you hand to JS don't follow.** Canvas fills, chart ramps, maplibre paint expressions — `var()` does not resolve inside a JS string. Read them at *draw* time and redraw when the attribute changes:
-
-  ```js
-  const token = (n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim();
-  new MutationObserver(() => redraw())
-    .observe(document.documentElement, { attributeFilter: ["data-theme"] });
-  ```
-
-Do not read the app's own `localStorage` key. It is private, it is not part of `window.fused`, and a view that reads it becomes a second copy of a resolution rule that will drift from the first — options 2 and 3 both get you the answer without one.
+The four strategies, when each is right, and the two rules that make a second palette work (every colour from a token; colours handed to canvas/charts/maplibre must be re-read on change) → **`fused-render-theming`**.
 
 ## Preview templates (views for a file format)
 
@@ -435,7 +284,7 @@ const page = await fused.runPython("./my_reader.py", { file, offset: fused.param
 
 A reader `.py` is only needed when Python adds value (parsing parquet/xlsx, paging, aggregation). Text formats can skip it entirely — `fused.stat` for a size guard, then `fused.readFile(file)` and render in JS (the markdown/JSON/code templates work this way); media formats just point a tag at `fused.rawUrl(file)`.
 
-Ship the reader `.py` next to the template html and call it with a relative path. Paging/sort/filter state goes in normal params (`offset`, `sort` …) exactly like any view. Built-in templates live one folder per template under `fused_render/templates/<name>/` and follow this pattern (see `templates/xlsx/template.html` + `templates/xlsx/reader.py` for a worked example); each extension maps to an **ordered list of mode names** (first = default) in the built-in registry `fused_render/templates/registry.json`. **User-owned** templates that override, reorder, or extend that list live under `~/.fused-render/` and are bound via `registry.json` — layout, the mode-list/registry grammar, and registration are covered by the `fused-render-custom-templates` skill (this skill still owns how the html/py themselves are written).
+Ship the reader `.py` next to the template html and call it with a relative path. Paging/sort/filter state goes in normal params (`offset`, `sort` …) exactly like any view. Built-in templates live one folder per template under `fused_render/templates/<name>/` — see `templates/xlsx/template.html` + `templates/xlsx/reader.py` — and each extension maps to an **ordered list of mode names** (first = default) in `fused_render/templates/registry.json`. **User-owned** templates that override, reorder or extend that list live under `~/.fused-render/`; the registry grammar and registration are covered by **`fused-render-custom-templates`** (this skill still owns how the html/py themselves are written).
 
 ## Testing in the browser: URL paths & modes
 
@@ -445,17 +294,15 @@ Verify a view by opening it in a real browser against the running server — do 
 |---|---|---|
 | `/` | Redirects to `/apps` (the app hub); `/explorer` is the file-explorer homepage. | Browse to a file by clicking. |
 | `/explorer/embed/<abs-path-without-leading-slash>` | **Embed mode**: the page chrome-free (no sidebar/breadcrumb/header). | **The default way to open and test a view** — you see just the view itself. |
-| `/explorer/view/<abs-path-without-leading-slash>` | **Full-shell mode**: the same page inside the explorer shell — sidebar, breadcrumb, preview header — with your page in an iframe. | Check how the view sits inside the explorer chrome, or when browsing. |
+| `/explorer/view/<abs-path-without-leading-slash>` | **Full-shell mode**: the same page inside the explorer shell, your page in an iframe. | Check how the view sits inside the chrome, or when browsing. |
 
-**Default to embed.** When you open a link to test a view or show it to the user, use `/explorer/embed/` — it renders the view alone, which is what you're iterating on. Reach for `/explorer/view/` only to inspect the surrounding chrome or when the user is browsing. (Legacy `/view/` and `/embed/` prefixes still redirect to the `/explorer/...` forms.)
+**Default to embed.** When you open a link to test a view or show it to the user, use `/explorer/embed/` — it renders the view alone, which is what you're iterating on. Reach for `/explorer/view/` only to inspect the surrounding chrome or when the user is browsing.
 
 Path encoding: the fs path rides in the URL after the prefix with its **leading slash dropped** and each segment URL-encoded. `/Users/me/proj/dash.html` → `http://127.0.0.1:1777/explorer/embed/Users/me/proj/dash.html`. A space becomes `%20`, etc.
 
 **View vs embed** is a fixed page-load mode (the prefix picks it; it cannot toggle without a full navigation). Both serve the same shell and route identically — embed just hides chrome. Params sync the same way in both; in nested embeds, param sync stops at each embed shell boundary so a tab's params stay tab-independent.
 
-**Preview templates** open at the target file's path (`/explorer/embed/<abs path to the data file>`) — the shell resolves the template by extension and hands it the file via the read-only `_file` param. To test a template's html directly, open it and pass the target yourself: `/explorer/embed/<abs path to template>.html?_file=<abs target path>`.
-
-**API endpoints** (`/api/config`, `/api/fs/stat|list|raw|events`, `/api/fs/write`, `/api/run`) back the runtime — reach them only through the `fused.*` helpers, never by hand (see the note above). They're listed here only so you recognize them in the network tab while debugging.
+**Preview templates** open at the *target file's* path (`/explorer/embed/<abs path to the data file>`) — the shell resolves the template by extension and hands it the file. To test a template's html directly, open it and pass the target yourself: `/explorer/embed/<abs path to template>.html?_file=<abs target path>`.
 
 Sanity loop: page renders → interact with a control → URL query updates → hard refresh → identical view. Python errors appear as the red overlay (with full traceback) and `print()` output in the browser console (prefixed `[python]`).
 
@@ -499,174 +346,36 @@ default, so treat the log as containing whatever your page passes around.
 
 ## Native capture (`fused.capture`)
 
-Three verbs: `screen()`, `audio()`, `screenshot()`. All three write a file this
-machine owns, which is the whole reason to use them over `getDisplayMedia` /
-`MediaRecorder`: the path is known before the recording ends, so it feeds
-`fused.ai.transcribe({path})` directly, and the recording survives your page
-being navigated away from (it is a download-manager job row).
+`fused.capture.screen()`, `.audio()` and `.screenshot()` record or grab **natively**, so the result is a file this machine owns — the path is known before a recording ends (it feeds `fused.ai.transcribe({path})` directly) and the recording survives your page being navigated away from. Call `fused.capture.sources()` first and draw your UI off the answer: it never prompts, and what is available differs per platform.
 
-**Ask first, and it never prompts.** What is possible differs per machine and
-per browser, so draw your UI off the answer rather than off a try/catch:
-
-```js
-const src = await fused.capture.sources();
-if (!src.video.available) { hideRecordButton(src.video.reason); return; }
-// src.displays -> [{id, width, height, main}], src.microphones -> [{id, name, default}]
-// `displays` is empty on Linux and on Wayland by design — nothing to name there.
-```
-
-**The one thing to design around: three platforms, one API, and deliberately no
-field telling you which you got.** Read the refusals and the `reason`s instead of
-sniffing the platform.
-
-| | macOS | Windows | Linux |
-|---|---|---|---|
-| screen recording | native, no picker | browser share picker | browser share picker |
-| survives a page reload | yes | no (file is kept) | no (file is kept) |
-| `display` / `rect` / `cursor` on `screen()` | honoured | refused | refused |
-| `display` / `rect` / `cursor` on `screenshot()` | honoured | honoured | `rect` only |
-| `device` on `audio()` | refused | honoured | honoured |
-| container | `.mov` / `.m4a` | `.mp4` or `.webm` | `.mp4` or `.webm` |
-
-So: do not hardcode an extension when you pass `path` — let the default name the
-file, or read `rec.path`. And if the recording matters, keep the page that
-started it open on Windows and Linux; a reload ends it (the file is kept and the
-row says so, but it is shorter than the user expected).
-
-Recording is a handle, not a promise that resolves at the end:
-
-```js
-const rec = await fused.capture.screen({
-  audio: "both",              // false | "mic" | "system" | "both" — "system" is
-                              // the one a browser cannot do on macOS at all
-  rect: [0, 0, 1200, 800],    // macOS only — refused where the browser's own
-                              // share picker chooses the region
-  path: "walkthrough.mov",    // optional; relative = beside THIS page. Omit it
-                              // unless you know the container (see the table)
-  maxSeconds: 600,            // default 30 min; hitting it STOPS (keeps the file)
-});
-// elapsed seconds come off the recording's job row — there is no onTick:
-fused.watchJob(rec.jobId).watch((row) => (label.textContent = row.done + "s"));
-// rec.path / rec.url are already usable here — the file is being written to them
-const out = await rec.stop();          // {path, url, mime, seconds, bytes}
-const words = await fused.ai.transcribe({ path: out.path, words: true });
-```
-
-- `rec.cancel()` stops **and deletes**. So does the ✕ on its download-manager
-  row — that is the one control left once your page is gone, so treat a cancel
-  as "the user does not want this recording", not as "stop".
-- `fused.capture.audio()` records the microphone alone. On macOS it uses the
-  system's current input and **refuses** a `device` (the error names the
-  alternative: a screen recording's `audio: "mic"` takes one); on Windows and
-  Linux a `device` from `sources().microphones` works. Those names are empty
-  until the browser's microphone permission has been granted once.
-- `fused.capture.list()` finds live recordings — including one your page started
-  before a reload — and `attach(id)` gives the handle back. Check it on load
-  instead of starting a second recording.
-- `screenshot({rect, cursor, path})` has no handle and no job row. The output
-  **filename** picks png or jpeg — there is no `format`, so a path and a format
-  cannot disagree about what was written. Native on **every** platform, so it
-  needs no readable document and raises no share prompt — which is what makes a
-  cross-origin pane shootable.
-- Rejections carry `.type`: `"unavailable"` (this machine cannot — show
-  `.message`, it names the reason), `"bad_request"` (your arguments).
+The per-platform matrix, the recording handle, and the rejection types → **`fused-render-capture`**.
 
 ## Long-running work and the 60 s timeout
 
-Every `fused.runPython` call runs `main()` in a fresh subprocess that the server **kills at 60 s** (`DEFAULT_TIMEOUT` in `fused_render/executor.py`). On timeout the call rejects with a `TimeoutError` — which, uncaught, becomes the red overlay. The `/api/run` route does not expose a per-call override, so you cannot raise the limit from the page; design around it instead:
+Every `fused.runPython` call runs `main()` in a fresh subprocess the server **kills at 60 s** (`DEFAULT_TIMEOUT` in `fused_render/executor.py`), and there is no per-call override — an uncaught timeout becomes the red overlay. Design around it: precompute and cache to disk, chunk behind an `offset` param, move a genuinely long build out of band into a separate process, and cut per-call import cost.
 
-- **Precompute and cache to disk.** Do the expensive work once, write the result next to the script (`.json`/`.parquet`), and have `main()` return the cached bytes when they're fresh (compare mtimes) — recompute only when the input changed. Reading a cached file is near-instant.
-- **Chunk / paginate.** Slice the work so each call stays well under 60 s, pass an `offset`/`page` param, and accumulate results in JS across several `runPython` calls. This also keeps the UI responsive.
-- **Move the heavy job out of band.** For a genuinely long build, run it as a separate process/script that writes an output file, and have the view just `fused.readFile`/`runPython` the finished result.
-- **Cut per-call cost.** Each call re-pays import cost (pandas ≈ 1 s); import lazily inside `main`, and debounce sliders (~150 ms) so a drag doesn't spawn a subprocess per tick.
+Work that outlives one call needs to be *visible* once the user browses away, because the shell replaces your page's frame: report it to the download manager with `fused.trackJob`, from the detached worker as well as from the page. The strategies, the job API, and the worker-side reporter → **`fused-render-jobs`**.
 
-### Show it in the download manager (`fused.trackJob`)
-
-The out-of-band pattern above leaves a hole: a detached worker pulling an 8GB model keeps running when the user browses to another file, and the shell replaces your page's frame the moment they do — so your in-page progress bar disappears and the download becomes invisible. Report it instead, and the shell shows it in the **download manager** at the bottom right for as long as it runs, whatever page the user is on:
-
-```js
-const job = fused.trackJob({
-  title: "FLUX.2-klein-4B",      // required — what is happening, in a few words
-  kind: "download",              // "download" | "task"
-  unit: "bytes",                 // "bytes" formats done/total as 1.2 / 8.1 GB
-  cancellable: true,             // shows a ✕; omit if you cannot honor it
-});
-
-// on each poll tick, from whatever your worker wrote:
-job.update({ done: s.bytes, total: s.size, detail: "transformer.gguf" });
-if (job.cancelRequested) await stopTheWorker();   // the manager's ✕ was clicked
-
-job.finish("Downloaded");        // or job.fail(err) / job.cancelled()
-```
-
-- **It cannot break your page.** Every method is fire-and-forget and never rejects; a failed report is swallowed. `await job.update(...)` only if you want to read `cancelRequested` at that exact point — the property is also readable synchronously between ticks.
-- **Cancel is a request you honor**, not something the shell can do — it has no idea which process is doing the work. The ✕ sets a flag; your poll loop notices it and stops the worker, then reports `job.cancelled()`. If you cannot stop the work, leave `cancellable` off and no ✕ is offered.
-- **Omit `total` while you don't know it.** A job with no total draws a travelling "indeterminate" bar, which is the honest picture; a total of `0` is treated the same way rather than painted as complete.
-- **Report the finish.** Without a terminal call the row goes "stalled" after 30 s and says the page that started it was closed — accurate if that is what happened, misleading if the work just ended. Report `finish`/`fail`/`cancelled` on every exit path of your poll loop.
-- **Report from the WORKER, not only the page — this is the one that bites.** The shell replaces your page's frame on every navigation, so a page-only reporter freezes the row at its last number and the manager declares it stalled ~30s later while the download carries on. Your detached worker outlives the page, so let it report too. It cannot `import fused_render` (it runs in its own venv), but the endpoint is plain JSON on the origin every spawned child inherits:
-
-  ```python
-  import json, os, urllib.error, urllib.request
-
-  class JobReport:
-      """Best-effort. Never raises: reporting must not break the work."""
-      def __init__(self, job_id, title):
-          self.url = (os.environ.get("FUSED_RENDER_ORIGIN") or "").rstrip("/") + "/api/jobs"
-          self.id, self.enabled, self.cancel_requested = job_id, self.url.startswith("http"), False
-          if self.enabled:
-              self.post(title=title, kind="download", state="running", cancellable=True)
-
-      def post(self, **fields):
-          if not self.enabled:
-              return None
-          fields["id"] = self.id
-          req = urllib.request.Request(self.url, data=json.dumps(fields).encode(),
-                                       headers={"Content-Type": "application/json", "X-Fused": "1"})
-          try:
-              with urllib.request.urlopen(req, timeout=3) as r:
-                  record = json.loads(r.read().decode())
-          except (urllib.error.URLError, OSError, ValueError):
-              return None
-          if isinstance(record, dict) and record.get("cancel_requested"):
-              self.cancel_requested = True   # the manager's ✕ — act on it here
-          return record
-  ```
-
-  Use the **same job id** on both sides (derive it from something both know — the job directory name, the model id) so the two reporters share ONE row instead of opening two for the same work. Keep the page reporting as well: it is the only thing alive during `uv run`'s first-run environment build, before your worker executes a line. Rate-limit the worker's posts to ~1/s — a download callback fires per chunk.
-
-  **The worker is also the only thing that can honor a cancel once the page is gone.** `cancel_requested` comes back in the reply to the tick you were already sending; check it in your progress callback and stop. If your long step is an opaque subprocess (`uv sync`), run a small daemon thread that posts a heartbeat, reads the flag, and kills the child — otherwise the ✕ does nothing for the minutes that matter most.
-
-- **One job per user-meaningful operation**, not per file: aggregate a multi-file download into one row (sum the bytes) and put the current filename in `detail`.
-- Reuse a **stable `id`** (`fused.trackJob({id: "flux:" + jobId, ...})`) when a page can be reloaded mid-work — the reopened page re-attaches to the existing row instead of opening a second one.
-- Exports fine: `fused.trackJob` is a no-op on a hosted page (there is no manager there), so unlike `fused.ai` it does not block export.
-
-Escape hatch: because fused-render runs your own trusted code on your own machine, you *can* raise `DEFAULT_TIMEOUT` in `fused_render/executor.py` — but that's editing the package, applies globally, and lets any view hang a worker that long. Prefer the caching/chunking patterns; reach for the constant only for a deliberate, local one-off.
-
-None of the above holds state indefinitely: `fused.engine(py)`, the warm variant of `runPython` that keeps a worker's imports and globals alive between calls, still idle-retires that worker after 15 minutes with no calls. A folder that genuinely needs to keep running past that — a poll loop, a held connection, a tray/menu-bar presence — wants a resident daemon instead: see **`fused-render-background-apps`**.
+Nothing here holds state indefinitely — even `fused.engine(py)`, the warm variant of `runPython`, idle-retires its worker after 15 minutes. A folder that must keep running past that wants a resident daemon: **`fused-render-background-apps`**.
 
 ## Pitfalls checklist
 
 - `fused.params.set("n", 5)` → **throws** (number). Use `String(5)`.
 - Reading `input.value` inside `draw()` instead of `fused.params.get()` → refresh loses state.
-- Naming a page param with a leading underscore (`_tab`, `_mode`, `_view`) → `params.set` throws, and if you route around it via `location.search` you collide with a shell param whose meaning changes under you. Drop the underscore.
-- Building the URL query yourself (`history.replaceState` with your own `URLSearchParams`) → silently drops the shell's `_layout`/`_side`/`_file` and breaks the pane the page is mounted in. Use `fused.params.set`.
-- Booting the full app under `_preview=1` → a listing/`/apps` page fires every card's cold start at once (heavy imports, model loads, extracts, daemons) for apps the user never opened. Gate boot on the preview flag and render a placeholder; see **"Reserved params and preview mode"**.
-- Reading `_preview` from `location.search` only → misses the inherited case where an outer template frame carries the stamp. Climb the same-origin ancestors (snippet in that section).
-- Mounting your own iframe in a preview without forwarding `?_preview=1&_nofocus=1` → the inner page does all the work you just skipped, and steals the keyboard from the listing.
+- Naming a page param with a leading underscore → `set()` throws, and routing around it collides with a shell param.
+- Building the URL query yourself (`history.replaceState`) → drops the shell's `_layout`/`_side`/`_file` and breaks the pane. Use `fused.params.set`.
+- Booting the full app under `_preview=1` → every card on a listing cold-starts at once for apps nobody opened. Gate boot on the flag.
+- Reading `_preview` off `location.search` alone → misses the inherited case where an outer frame carries the stamp. Climb the ancestors.
+- Mounting your own iframe in a preview without forwarding `?_preview=1&_nofocus=1` → the inner page does all the work you just skipped.
 - `main` returning a DataFrame / datetime / Decimal / numpy value → serialization error; convert to JSON-native first.
-- Missing annotation on a numeric param → `main` receives `"50"` (string) and comparisons silently misbehave.
+- Missing annotation on a numeric param → `main` receives `"50"` and comparisons silently misbehave.
 - Expecting module state to persist between `runPython` calls → each call is a fresh process.
-- Importing a library outside the supported set (torch, sklearn, xarray, plotly, ...) → `ModuleNotFoundError` in the packaged app; stick to the "Available Python libraries" list above.
+- Importing outside the bundled set without a folder `pyproject.toml` → `ModuleNotFoundError` in the packaged app.
 - Adding `<script src=".../runtime.js">` manually → double-injection; the explorer injects it.
-- Heavy import + slider wired without debounce → one full subprocess per tick; debounce inputs ~150 ms when `main` is slow.
-- Fetching `/api/fs/raw` (or POSTing `/api/fs/write`) directly instead of using the helpers → writes get rejected (missing required header) and you're coupled to internals.
-- `writeFile` without `expectedMtime` on an *existing* file → silently clobbers whatever is on disk now. For edits, arm the lock and handle `.type === "conflict"`; for "create this if it isn't there", pass `{create: true}` and handle `.type === "exists"` rather than stat-ing first (a stat that fails for any reason other than absence otherwise reads as "go ahead and write").
-- Using `readFile` for an image/video and stuffing bytes into the DOM → use `fused.rawUrl(path)` as the element's `src` instead.
-- Walking the filesystem (`os.walk`, `glob`, shelling out to `find`) to answer "how many / how big / where are all my X files" → the index already knows, without a single stat; use `fused.fileIndex.query()` or read its parquet directly (`fused-render-index`).
-- `fused.ai` rejecting with `.type === "ai_unavailable"` → the claude CLI isn't installed or found (the message says what to install or set); show that state in the UI instead of a raw overlay.
-- Dumping the full dataset into a `fused.ai` prompt → token blowout and a worse answer; reduce to compact aggregates first (see "AI calls" above).
-- Forgetting `fused.ai` has no stale-cancel → a double-click fires two concurrent calls; disable the button while one is in flight.
-- Calling `fused.ai` on a page meant for export → the exporter rejects it (SPEC RH-11); gate on `fused.env === "local"`.
-- Starting long work with `fused.trackJob` and never calling `finish`/`fail`/`cancelled` → the row sits there and goes "stalled" after 30 s, telling the user the page was closed when really the job just ended. Report a terminal state on every exit path of the poll loop.
-- Reporting progress ONLY from the page → the row freezes and goes "stalled" the moment the user opens another file, because the shell tears your frame down. Anything that outlives the page must report from the worker (see "Long-running work" above).
-- Reporting "I wrote the files, try it" as if it were verification → after the page has been opened, `fused-render calls --page <page>` says whether it actually ran (see "Verifying your work" above). Zero records means the page's JS died before it reached Python — a different bug from a failing `main()`, and they look identical without the log.
+- Heavy import + slider wired without debounce → one full subprocess per tick; debounce ~150 ms when `main` is slow.
+- Fetching `/api/fs/raw` or POSTing `/api/fs/write` directly → writes get rejected (missing header) and you're coupled to internals.
+- `writeFile` without `expectedMtime` on an *existing* file → silently clobbers what is on disk now. For edits arm the lock and handle `.type === "conflict"`; for "create if absent" pass `{create: true}` and handle `.type === "exists"` rather than stat-ing first (a stat that fails for any reason other than absence otherwise reads as "go ahead and write").
+- Using `readFile` for an image/video and stuffing bytes into the DOM → point the element's `src` at `fused.rawUrl(path)`.
+- Walking the filesystem (`os.walk`, `glob`, `find`) to answer "how many / how big / where are all my X files" → the index already knows; use `fused.fileIndex.query()` (`fused-render-index`).
+- Calling `fused.ai` on a page meant for export → the exporter rejects it textually (SPEC RH-11); a `fused.env` guard does not help.
+- Reporting "I wrote the files, try it" as verification → `fused-render calls --page <page>` says whether it actually ran. Zero records means the page's JS died before reaching Python — a different bug from a failing `main()`, and they look identical without the log.

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -161,6 +161,7 @@ The runtime is injected automatically when the explorer renders the page. Never 
 | `fused.autoReload(enabled)` | Toggle the automatic reload-on-file-change behavior for this page. Pass `false` to opt out (e.g. an in-page editor that manages its own saves and shouldn't reload under the user). |
 
 Notes:
+- **`_`-prefixed param names are the shell's.** `set()` throws on them, `get()`/`getAll()` hide them (except `_file`). Never invent one, never rewrite the URL query yourself, and read `_preview` only to skip work — see **"Reserved params and preview mode"** below.
 - Params are **strings only, always**. Parse numbers yourself (`parseInt(fused.params.get("limit") || "50", 10)`), JSON-encode structure yourself if you need it.
 - Uncaught `runPython` rejections auto-show a red traceback overlay — good default for debugging; catch the rejection yourself when you want custom error UI.
 - **Stale requests to the same `.py` auto-cancel.** For the common slider/scrub case — a fast drag fires a request per intermediate value and only the last matters — you get this for free: a new `runPython("./x.py", …)` aborts any prior in-flight call to `./x.py`, and the superseded call's promise never settles (its continuation just stops, so nothing stale is drawn). Calls to **different** files are independent. When you genuinely need multiple concurrent calls to the **same** file to all finish — a polling loop, per-tile fetches, or a write that must complete — pass `{ key: null }` to opt out. Use a distinct `{ key: "…" }` to split one file into independent channels, or `{ signal }` (your own `AbortController`) to cancel on something other than the next call.
@@ -318,6 +319,70 @@ Why this shape:
 - `draw()` reads **params, not the control**, so a bookmarked/refreshed URL renders identically before any interaction.
 - The control writes the param and nothing else; `onChange` is the single re-render path — no double-render logic, no drift between URL and UI.
 - Values passed to `runPython` can stay strings; annotations on `main` coerce them.
+
+## Reserved params and preview mode
+
+### The `_` namespace is the shell's
+
+**Every query key starting with `_` belongs to the shell, not to your page.** The runtime enforces it: `fused.params.set("_x", …)` **throws**, `fused.params.get("_x")` returns `undefined`, and `getAll()` filters `_` keys out. The single exception is `_file` — readable, never writable.
+
+So:
+
+- **Never invent a `_`-prefixed param for your own state.** Names in use today include `_file`, `_mode`, `_preview`, `_nofocus`, `_layout`, `_side`, `_panel`, `_tab`, `_listing`, `_render`, `_rev` — and the set grows without notice. Squatting on one means the shell silently overwrites your state, or you overwrite the shell's. Page params get plain names: `limit`, `sort`, `offset`, `theme`.
+- **Never reach around the runtime to read one.** `new URLSearchParams(location.search).get("_whatever")` is going behind `fused.params` to read a value whose meaning is the shell's and can change under you. The one exception is `_preview`, below — and only ever to do *less* work.
+- **Never rewrite the URL's query yourself.** A `history.replaceState` (or a `location.search = …`) built from your own params drops the shell's `_` keys and breaks the pane/tab it is mounted in. Write through `fused.params.set` only.
+
+### `_preview=1`: this render is a picture of the page, not a use of it
+
+The shell renders pages it was never asked to *open*: `/apps` cards, listing-pane peeks, hover previews. Those frames are stamped `_preview=1` (usually with `_nofocus=1`), they are mounted and unmounted as the pointer moves, and **many of them boot at once on a home/listing page** for apps the user has not opened and may never open.
+
+A page that boots identically in a preview turns that listing into N simultaneous cold starts. This is the single most common way an app folder makes the home page unusable.
+
+**Read the flag at boot and return early.** Under preview, render something cheap and static — a title, a cached thumbnail, an inert placeholder — and start none of:
+
+- `runPython` calls whose `main()` imports something heavy, scans a directory, or hits the network
+- model loads or downloads (`fused.ai`, `fused.ai.image`, `fused.ai.models.load`)
+- daemon starts (`fused.daemon.start` — already refused in preview, see below)
+- `fused.capture.*`, `writeFile`, `trackJob`
+- polling loops, `setInterval`, websockets, EventSource
+- anything that records an "open", mutates state, or unpacks/extracts on first use
+
+Read it by climbing, because the flag is **inherited**: your page may be framed by a template that was the one stamped, and only the ancestor's URL carries it. This mirrors the runtime's own `selfOrAncestorHasFlag`:
+
+```js
+function isPreview() {
+  const has = (s) => {
+    try { return new URLSearchParams(String(s).replace(/^\?/, "")).get("_preview") === "1"; }
+    catch (e) { return false; }
+  };
+  if (has(location.search)) return true;
+  try {
+    let w = window;
+    while (w.parent && w.parent !== w) {
+      w = w.parent;
+      if (has(w.location.search)) return true;
+    }
+  } catch (e) { /* cross-origin ancestor: the climb ends here */ }
+  return false;
+}
+
+const PREVIEW = isPreview();
+
+async function boot() {
+  if (PREVIEW) return renderPlaceholder();   // synchronous, no Python, no network
+  await loadEverything();                    // the real thing, only on a real open
+}
+boot();
+```
+
+Two more rules:
+
+- **Forward the stamps to frames you mount yourself**: `frame.src = url + "?_preview=1&_nofocus=1"` when `PREVIEW`. Otherwise the inner page reads a clean URL and does the work you just skipped.
+- **A preview that *can* show real content should show a cached one, never compute one.** Ask for the already-extracted / already-cached artifact and fall back to the placeholder when it is absent; never let a peek be the thing that populates the cache.
+
+What the runtime already handles, so you don't have to: `fused.daemon.start/stop/restart/setAutostart/call` reject in a preview frame, and a preview never writes the shell's URL. **Everything else — your Python calls, AI calls, timers, fetches — runs exactly as it would in a real open unless you gate it.**
+
+`fused_render/templates/fusedapp/template.html` is the worked example: it reads `_preview`, asks the server for an existing extract only, live-renders it when there is one, and shows an inert "Open this file to unpack and run the app" card when there isn't.
 
 ## Style and theming
 
@@ -583,6 +648,11 @@ None of the above holds state indefinitely: `fused.engine(py)`, the warm variant
 
 - `fused.params.set("n", 5)` → **throws** (number). Use `String(5)`.
 - Reading `input.value` inside `draw()` instead of `fused.params.get()` → refresh loses state.
+- Naming a page param with a leading underscore (`_tab`, `_mode`, `_view`) → `params.set` throws, and if you route around it via `location.search` you collide with a shell param whose meaning changes under you. Drop the underscore.
+- Building the URL query yourself (`history.replaceState` with your own `URLSearchParams`) → silently drops the shell's `_layout`/`_side`/`_file` and breaks the pane the page is mounted in. Use `fused.params.set`.
+- Booting the full app under `_preview=1` → a listing/`/apps` page fires every card's cold start at once (heavy imports, model loads, extracts, daemons) for apps the user never opened. Gate boot on the preview flag and render a placeholder; see **"Reserved params and preview mode"**.
+- Reading `_preview` from `location.search` only → misses the inherited case where an outer template frame carries the stamp. Climb the same-origin ancestors (snippet in that section).
+- Mounting your own iframe in a preview without forwarding `?_preview=1&_nofocus=1` → the inner page does all the work you just skipped, and steals the keyboard from the listing.
 - `main` returning a DataFrame / datetime / Decimal / numpy value → serialization error; convert to JSON-native first.
 - Missing annotation on a numeric param → `main` receives `"50"` (string) and comparisons silently misbehave.
 - Expecting module state to persist between `runPython` calls → each call is a fresh process.

--- a/skills/fused-render-background-apps/SKILL.md
+++ b/skills/fused-render-background-apps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fused-render-background-apps
-description: How to give a fused-render app folder its own long-running daemon that the server supervises — resident, exempt from idle-retire, killed with the server, resurrected at every server start while the user has explicitly opted it into autostart. Use when a folder needs to keep running after its page closes, hold a persistent connection or in-memory state across calls, poll something on a timer, or run native desktop UI (tray icon, menu-bar item); when the user mentions "background app", "daemon", `[tool.fused-render.app]`, `kind = "background"`, `fused.daemon.status/start/stop/restart/setAutostart/call`, or asks why a warm worker "keeps dying" after 15 minutes idle.
+description: Give a fused-render app folder a resident daemon the server supervises — exempt from idle-retire, opt-in autostart. Use when a folder must keep running after its page closes, hold a connection or native tray UI, or when a warm worker "keeps dying" after 15 minutes idle; covers [tool.fused-render.app] and fused.daemon.*.
 ---
 
 # Background apps: a folder's own long-running daemon
@@ -9,11 +9,11 @@ A background app is a **third** way a folder's Python runs alongside `/api/run` 
 
 | Path | Lifetime | State survives between calls? | Idle-retired? |
 |---|---|---|---|
-| `/api/run` (`fused.runPython`) | Fresh subprocess **per call**, killed at a 60 s timeout (`fused-render-authoring`'s "Long-running work") | No — nothing persists | N/A, it's already gone |
+| `/api/run` (`fused.runPython`) | Fresh subprocess **per call**, killed at a 60 s timeout | No — nothing persists | N/A, it's already gone |
 | Warm `/api/engine` worker | Persistent interpreter, spawned on first call | Yes — imports, globals, loaded models | **Yes, after 15 min idle** (`engine_host.APP_IDLE_RETIRE_S`) |
-| Background app | Resident daemon, spawned by `start()` and (only if opted in) at every server start | Yes — it's a whole separate process with its own lifecycle | **No** — that's the entire point |
+| Background app | Resident daemon, spawned by `start()` and (only if opted in) at every server start | Yes — a whole separate process with its own lifecycle | **No** — that's the entire point |
 
-Reach for a background app only when the warm worker's idle-retire is the actual problem: a websocket/poll server, something holding a device handle or a long-lived socket, a tray/menu-bar presence, or state that must survive an idle gap longer than 15 minutes. If your state just needs to survive between two calls that happen within a few minutes of each other, the warm worker (already zero-config — no manifest, no start step) is simpler and is what `/api/engine` already gives you for free.
+Reach for a background app only when the warm worker's idle-retire is the actual problem: a websocket/poll server, something holding a device handle or a long-lived socket, a tray/menu-bar presence, or state that must survive an idle gap longer than 15 minutes. State that only needs to survive between two calls a few minutes apart already has the warm worker, which is zero-config — no manifest, no start step.
 
 ## The manifest
 
@@ -25,49 +25,33 @@ kind = "background"
 daemon = "daemon.py"   # a filename, resolved inside this folder
 ```
 
-`background_apps.load_manifest` (`fused_render/background_apps.py`) reads this and **never raises** — a bad manifest just reads as "no manifest" rather than reaching `engine_host` as an opaque `python <folder>` bring-up failure. It rejects, silently:
+`background_apps.load_manifest` reads this and **never raises** — a bad manifest reads as "no manifest" rather than reaching `engine_host` as an opaque `python <folder>` bring-up failure. It rejects, silently:
 
 - `kind` anything other than `"background"`, or the table missing entirely.
 - `daemon` missing, not a string, or empty.
-- `daemon` resolving **outside** the folder — `daemon = "../elsewhere.py"` or a symlink that escapes, realpath-checked (the same containment guard `registered_apps.py` uses for its own folders).
-- `daemon` naming a **directory**, not a file (`daemon = "."` passes the containment check trivially — a folder is "inside" itself — so this needs its own `os.path.isfile` check).
+- `daemon` resolving **outside** the folder — `daemon = "../elsewhere.py"` or a symlink that escapes, realpath-checked (the same containment guard `registered_apps.py` uses).
+- `daemon` naming a **directory** (`daemon = "."` passes containment trivially — a folder is "inside" itself — so it needs its own `os.path.isfile` check).
 
-There's no error surfaced for a rejected manifest short of the folder just not showing a start option; check `GET /api/apps/background/status?html=<page>` if you're unsure whether yours parsed.
+No error is surfaced for a rejected manifest short of the folder simply not offering a start option; check `GET /api/apps/background/status?html=<page>` if you're unsure yours parsed.
 
 ## The daemon contract
 
-Your `daemon.py` is a plain script, run directly as `[interpreter, daemon.py, --status <path>, --cache <dir>, --version <str>]` (`engine_host._spawn`) — not imported, not run through `_child.py`, no framework to subclass. `tests/fixtures/background_app/daemon.py` is the minimal stdlib-only reference; read it in full before writing your own; this section only calls out what it does and *why*, so you don't cargo-cult past the reasoning:
+Your `daemon.py` is a plain script, run directly as `[interpreter, daemon.py, --status <path>, --cache <dir>, --version <str>]` (`engine_host._spawn`) — not imported, not run through `_child.py`, no framework to subclass. `tests/fixtures/background_app/daemon.py` is the minimal stdlib-only reference; read it in full before writing your own. What it does, and why:
 
 1. **Parse `--status`, `--cache`, `--version`** (argparse, all three `required=True`).
 2. **Bind `("127.0.0.1", 0)`** — port 0 asks the OS for a free port; never hardcode one.
-3. **Publish `{port, token, pid}` to the status file, atomically, BEFORE serving** — write to a temp file in the same directory, then `os.replace()` over the real path. This ordering is not a style choice: `_spawn` polls the status file in a loop, and binding-then-publishing-then-serving is *the only sequence with no race* — the parent can never observe a port that isn't yet accepting connections, because the file doesn't exist until after `bind()` succeeds. Publish before you call `serve_forever()`.
-4. **Generate a random token** (`secrets.token_urlsafe(32)` in the fixture) and require it on every request — `?t=<token>` in the fixture, checked with `secrets.compare_digest`. The parent proxies all traffic through the stable server origin (`/api/engines/<id>/proxy/...`); the browser never sees your port or token directly, but your daemon still has to enforce it, because it's listening on a loopback port any local process can otherwise reach.
-5. **Answer `GET /ping`** with `{"ok": true, "version": <the --version you were given>}`. `_spawn`'s bootstrap wait polls this after the status file lands, and `ensure_background`'s reuse check pings it on every subsequent call — a `/ping` that returns the wrong `version` string is treated as a stale child and respawned.
-6. **Answer `GET /quit`** by starting `shutdown()` on a separate thread (never call `server.shutdown()` from inside the request handler thread that's serving it — it deadlocks `ThreadingHTTPServer`). `stop()`/a respawn go through `engine_host`'s own SIGTERM→SIGKILL tree-kill (`_kill_tree`), not `/quit` — nothing in the shipped code calls it — but it costs nothing to implement and is a cleaner exit path for your own tooling.
+3. **Publish `{port, token, pid}` to the status file, atomically, BEFORE serving** — temp file in the same directory, then `os.replace()`. Not a style choice: `_spawn` polls the status file, and bind → publish → serve is *the only sequence with no race*, because the file cannot exist until `bind()` has succeeded. Publish before `serve_forever()`.
+4. **Generate a random token** (`secrets.token_urlsafe(32)`) and require it on every request — `?t=<token>`, checked with `secrets.compare_digest`. The parent proxies all traffic through the stable server origin (`/api/engines/<id>/proxy/...`) so the browser never sees your port or token, but you still enforce it: you are listening on a loopback port any local process can reach.
+5. **Answer `GET /ping`** with `{"ok": true, "version": <the --version you were given>}`. The bootstrap wait polls this, and every later reuse check pings it — a `/ping` returning the wrong `version` is treated as a stale child and respawned.
+6. **Answer `GET /quit`** by starting `shutdown()` on a separate thread (calling `server.shutdown()` from the handler thread serving it deadlocks `ThreadingHTTPServer`). Nothing shipped calls `/quit` — `stop()` and respawns go through `engine_host`'s SIGTERM→SIGKILL tree-kill — but it is a cleaner exit path for your own tooling.
 
-Everything else — what routes you serve, what state you hold, what background threads you run — is yours. The fixture also serves `POST /count` as a worked example of the request shape `fused.daemon.call()` actually sends (a JSON body, POST only — the runtime hardcodes the verb).
+Everything else — routes, state, threads — is yours. The fixture also serves `POST /count` as a worked example of the request shape `fused.daemon.call()` sends (JSON body, POST only; the runtime hardcodes the verb).
 
-## Calling the background-apps API about yourself (D505)
+## Asking the server about yourself, from inside the daemon
 
-Every `fused.daemon` method sends the caller's own page path as `html`, which
-the server turns into an app folder server-side. Your daemon has no page and
-no `html` path — so before D505 it had no way to ask the server anything
-about itself: not "am I running", not "stop me", not "am I set to autostart".
+Every `fused.daemon` method sends the caller's page path as `html`, which the server resolves to an app folder. Your daemon has no page — so it uses `templates/shared/background_app.py` instead, which reads the `FUSED_RENDER_APP_DIR` that `engine_host._spawn_env` exports into every `kind="background"` child.
 
-`engine_host._spawn_env` now exports `FUSED_RENDER_APP_DIR` (the app's own
-folder) into a `kind="background"` child's environment, and
-`templates/shared/background_app.py` is the stdlib-only client that uses it
-— but a bare `import background_app` does NOT work here the way it would
-under `/api/run` or the warm `/api/engine` worker. Those get `templates/shared`
-appended onto `sys.path` for free (`_child.py:68-69`); a background daemon
-is spawned as a plain script with no such seeding (see "Two things verified
-against the code" below) — a bare import raises `ModuleNotFoundError`.
-
-Bootstrap it off the same discovery file `server/app.py` writes at bind time
-(`write_server_json`, `fused_render/server/app.py:209`): `server.json`'s
-`shared` key names the exact `templates/shared` directory this server build
-ships, and `FUSED_RENDER_HOME_DIR` (branch-resolved for a dev worktree
-server, falling back to `~/.fused-render`) says where to find it:
+**A bare `import background_app` does not work here.** `/api/run` and the warm worker get `templates/shared` appended to `sys.path` for free (`_child.py`); a background daemon is spawned as a plain script with no such seeding, so the import raises `ModuleNotFoundError`. Bootstrap it off the discovery file `server/app.py` writes at bind time — `server.json`'s `shared` key names the exact `templates/shared` this server build ships, and `FUSED_RENDER_HOME_DIR` (branch-resolved for a dev worktree server, falling back to `~/.fused-render`) says where to find it:
 
 ```python
 import json, os, sys
@@ -90,35 +74,11 @@ background_app.set_autostart(True)  # persists the "come back at next launch" fl
 background_app.restart()            # respawns
 ```
 
-This is the production pattern, not a simplification of it — see
-`_bootstrap_fused_ai`/`_bootstrap_background_app` in the OpenWhisper tray's
-`menubar.py` for the shipping version (it also wraps this in a
-try/except so a missing or unreadable `server.json` degrades to `None`
-rather than crashing the daemon at import time).
+This is the production pattern, not a simplification — see `_bootstrap_fused_ai`/`_bootstrap_background_app` in the OpenWhisper tray's `menubar.py` for the shipping version, which wraps it in a try/except so an unreadable `server.json` degrades to `None` rather than crashing the daemon at import time.
 
-Calling `stop()` from inside your own daemon is exactly what a tray "Quit"
-should do instead of a raw self-`terminate`/`exit` — see "When does it come
-back?" below: an external kill leaves the `Child` registered and gets healed
-back to life by the next proxied call, while going through `stop()` pops it
-out first. `set_autostart(bool)` is separate and orthogonal (D511) — it
-never starts or stops the daemon, so a tray's "Start automatically" checkmark
-should call it directly rather than routing through `stop()`/`restart()`.
-Raises `background_app.NotUnderEngine` if `FUSED_RENDER_APP_DIR` isn't set
-(not running as an engine-spawned background daemon) and
-`background_app.ServerNotRunning`/`background_app.BackgroundAppError` for
-the same reasons `fused_ai`'s equivalents raise.
+A tray "Quit" should call `stop()` here rather than a raw self-`terminate`/`exit` — see "When does it come back?" below. `set_autostart(bool)` is separate and orthogonal: it never starts or stops anything, so a "Start automatically" checkmark calls it directly. Raises `NotUnderEngine` if `FUSED_RENDER_APP_DIR` isn't set (you are not an engine-spawned daemon), and `ServerNotRunning`/`BackgroundAppError` for the same reasons `fused_ai`'s equivalents do.
 
 ## Driving it from the page: `fused.daemon`
-
-The browser namespace is `fused.daemon` (D506) — the HTTP endpoints underneath
-it (`/api/apps/background/*`) and the Python modules (`background_apps.py`,
-`background_app.py`) still say "background". That split is deliberate, not a
-half-finished rename: "app" already means three other things here (an
-`fused-app`-tagged folder, `ensure_app`'s warm worker `Child.kind`, the
-`/apps` hub), so `fused.app.start()` read as "start this app" when it meant
-"install a resident daemon". `daemon` is the noun already used everywhere
-else — the manifest's `daemon = "daemon.py"` key, the file itself, and
-`engine_host`'s own vocabulary — so only the author-facing JS name changed.
 
 ```js
 await fused.daemon.start();                // spawn it now — does NOT touch autostart
@@ -130,95 +90,49 @@ await fused.daemon.setAutostart(true);      // ONLY thing that persists "bring t
 const unsubscribe = fused.daemon.watch((s) => {
   // s is the same shape status() resolves to. Fires on the initial read and
   // again whenever running/autostart/pid/version actually changes — NOT on
-  // every poll tick. Call this to reflect state that changed for a reason
+  // every poll tick. This is how you reflect state that changed for a reason
   // outside this page's own control, e.g. the tray's Quit.
 });
 ```
 
-Every method except `call` sends **this page's own path**, never a folder path — the server resolves which app folder the page belongs to server-side, the same `resolve_py` pattern `/api/run`/`/api/engine` already use, so there's no path-typed API to defend. `call(path, body)` reaches the daemon directly through `/api/engines/<engine_id>/proxy/<path>`, resolving `engine_id` from a cached `status()` call (fetching one first if none is cached yet) and rejecting client-side if the app isn't known to be running — call `start()` first.
+The JS namespace is `daemon` while the HTTP endpoints (`/api/apps/background/*`) and Python modules say "background": "app" already means three other things here (an `fused-app`-tagged folder, the warm worker's `Child.kind`, the `/apps` hub), and `daemon` is the noun the manifest, the file and `engine_host` already use.
 
-**Run state (`start`/`stop`/`restart`) and autostart (`setAutostart`) are two completely independent axes now (D511) — there is a test for exactly this shape (`test_api_start_calls_ensure_background_without_touching_autostart`, `test_api_autostart_sets_the_flag_without_starting_or_stopping_anything`, `tests/test_background_apps.py`):**
+Every method except `call` sends **this page's own path**, never a folder path — the server resolves which app folder the page belongs to, the same `resolve_py` pattern `/api/run` uses, so there is no path-typed API to defend. `call(path, body)` reaches the daemon through `/api/engines/<engine_id>/proxy/<path>`, resolving `engine_id` from a cached `status()` and rejecting client-side if the app isn't known to be running — call `start()` first.
 
-- `start()`/`stop()`/`restart()` change only whether the daemon is alive right now. None of them ever read or write the persisted autostart flag.
+**Run state and autostart are two independent axes** (pinned by `test_api_start_calls_ensure_background_without_touching_autostart` and `test_api_autostart_sets_the_flag_without_starting_or_stopping_anything`):
+
+- `start()`/`stop()`/`restart()` change only whether the daemon is alive right now. None of them read or write the persisted autostart flag.
 - `setAutostart(true|false)` changes only the persisted "bring this back at every launch" flag. It never starts or stops the daemon.
-- **Autostart is opt-in and defaults to off.** A folder nobody has ever called `setAutostart(true)` on reports `autostart: false` from `status()` forever, no matter how many times `start()` is called on it.
+- **Autostart is opt-in and defaults to off.** A folder nobody has called `setAutostart(true)` on reports `autostart: false` forever, no matter how many times `start()` is called.
 
-If your page conflates the two (e.g. assumes `start()` also makes the app come back at next launch, or that `stop()` also turns autostart off), the daemon either fails to survive a server restart the user expected it to survive, or comes back uninvited when the user only meant to stop it once.
+Conflate the two and the daemon either fails to survive a restart the user expected it to survive, or comes back uninvited when they only meant to stop it once.
 
-### When does it come back? Two questions, not one (D505, D511)
+### When does it come back? Two questions, not one
 
-There used to be one question here ("is it enabled?"); now there are two, and
-conflating them is the exact bug this decision fixes. Ask them separately:
+**Is it running right now?** `status().running`. That changes only through `start()`, `stop()`, `restart()`, or heal-on-proxy (below) — never through `setAutostart()`.
 
-**Is the daemon running right now?** Call `fused.daemon.status()` and read
-`running`. That fact changes only through `start()`, `stop()`, `restart()`,
-or heal-on-proxy (below) — never through `setAutostart()`.
+**Will it come back at the next server launch?** `status().autostart`. That changes ONLY through an explicit `setAutostart(bool)` (or server-side `background_apps.set_autostart`), and defaults to `false` for every folder.
 
-**Will it come back at the next server launch?** Call `status()` and read
-`autostart`. That fact changes ONLY through an explicit `setAutostart(bool)`
-call (or the server-side `background_apps.set_autostart`) — never as a side
-effect of `start()`, `stop()`, or `restart()`. It defaults to `false` for
-every folder until something explicitly turns it on.
+Given both facts, a stopped daemon comes back through exactly one of these — there is no other path:
 
-Given both facts, resurrection after the daemon stops running happens
-through exactly one of these — there is no other path:
+1. **Server start, but ONLY if autostart is on.** `_startup_resurrect_background_apps` walks `autostart_paths()` and brings each one up. A folder that was only ever `start()`ed is not in that list — the opt-in default in action, not an omission.
+2. **A page calling `start()` or `restart()`.** The deliberate path — unconditional, but never itself sets autostart.
+3. **Heal-on-proxy — the one that surprises people, and it is entirely about run state.** If the process was killed EXTERNALLY (a `kill`, a crash, a tray "Quit" that never talks to the server), the `Child` stays registered in `engine_host._children` — nothing popped it out. The next proxied call finds a `Child` that doesn't answer and heals by respawning it (`engine_forward.py`). **`stop()` does not have this problem**: it pops the child out of `_children` before killing it, so a later proxied call finds nothing registered, returns 409, and does not revive it. A raw external kill skips that pop, which makes it structurally the *weakest* way to end a background app — it leaves intact the one piece of bookkeeping that prevents an accidental revival.
+4. **Nothing else.** No heartbeat, no polling, no periodic sweep.
 
-1. **Server start, but ONLY if autostart is on.** `_startup_resurrect_background_apps`
-   (`server/app.py`) walks `autostart_paths()` and brings each one up. A
-   folder that was only ever `start()`ed, with `setAutostart` never called,
-   is NOT in that list and does not come back here — this is the opt-in
-   default in action, not an omission.
-2. **A page calling `start()` or `restart()`.** The documented, deliberate
-   path — unconditional, but never itself sets autostart.
-3. **Heal-on-proxy — the one that surprises people, and is entirely about run
-   state, not autostart.** If the process was killed EXTERNALLY (a `kill`, a
-   crash, a tray "Quit" that never talks to the server), the `Child` stays
-   registered in `engine_host._children` — nothing ever popped it out. The
-   next proxied call (`fused.daemon.call(...)`, `/api/engines/<id>/proxy/...`)
-   finds a `Child` that doesn't answer and heals by respawning it
-   (`engine_forward.py`). **`stop()` deliberately does not have this
-   problem**: it pops the child out of `_children` (`engine_host.stop`)
-   before killing it, so a proxied call after `stop()` finds nothing
-   registered, returns 409, and does NOT revive it. A raw external kill
-   skips that pop entirely — it is structurally the WEAKEST way to end a
-   background app's process, weaker than `stop()`, because it leaves the one
-   piece of bookkeeping that prevents an accidental revival intact. Anything
-   that quits a background app from outside the server's own API (a tray
-   menu doing `terminate:` directly, a shell `kill`, a crash) lands here, not
-   on `stop()`'s clean path — see the OpenWhisper tray for the concrete case
-   this bit.
-4. **Nothing else.** No heartbeat, no polling, no periodic sweep — resurrection
-   only ever happens as a *reaction* to one of the three triggers above, and
-   trigger 1 only fires at all if autostart is on.
+So anything letting a user "quit and stay off" from OUTSIDE a page (a tray icon, a CLI, a native menu item) must call `stop()` through the server's own API, never a raw process kill — otherwise it has built path 3 by accident and the app returns the moment anything pokes it. Whether it also stays off at the next launch depends on autostart, which `stop()` never touches: "stopped now AND never comes back automatically" is two calls for two facts.
 
-The practical consequence for anything that wants to let a user "quit and
-stay off" from OUTSIDE a page (a tray icon, a CLI, a native menu item): call
-`stop()` through the server's own API, never a raw process kill — otherwise
-you've built path 3 by accident, and the app comes back the moment anything
-pokes it. Whether it ALSO stays off at the next server launch depends
-entirely on autostart, which `stop()` never touches — if the user wants
-"stopped now AND never comes back automatically," that's `stop()` plus
-confirming (or setting) autostart off, two separate calls for two separate
-facts. `templates/shared/background_app.py` (above) is what a daemon uses to
-do the run-state half of that about itself.
+## Starting it — and opting into autostart — are the user's decisions
 
-## Starting it — and opting into autostart — are the user's decisions, not yours
-
-Opening a folder, or even the page loading and calling `fused.daemon.status()`, **never starts, stops, or persists anything**. `autostart_paths()` reads `<home_dir()>/background_apps.json` — the *only* thing "autostart" means — and the startup resurrection hook only resurrects folders already in that store. Your daemon comes up when something explicitly calls `POST /api/apps/background/start` (i.e. `fused.daemon.start()`), typically from a button the user clicks, never from page load. Do not call `start()` in an `onload`/init path — that would spawn a daemon on someone's machine the moment they open your folder, without them asking for it — and separately, do not call `setAutostart(true)` from page load either: that would make the daemon start surviving every future server launch, an even more surprising and more persistent version of the same mistake.
-
-## Authoring conventions: being one of many apps on a user's machine
-
-Everything above is mechanics — what the engine does. This section is what an app author has to get right so their app behaves as one of potentially many background apps sharing a user's machine, most of it a straight consequence of the mechanics already documented. None of this is enforced by a schema or a lint; the list at the end of this section says explicitly which parts the engine will not catch for you.
+Opening a folder, or a page calling `fused.daemon.status()`, **never starts, stops, or persists anything**. `autostart_paths()` reads `<home_dir()>/background_apps.json` — the *only* thing "autostart" means — and the startup hook only resurrects folders already in that store.
 
 ### Lead rule: never call `start()` (or `setAutostart(true)`) on page load
 
-An app going from off to running, or from "one-off" to "survives every server restart," is the user's decision, made by clicking something. A page whose script calls `fused.daemon.start()` unconditionally takes that decision away from them the moment its JS runs — which is not only "the user opened my folder."
+An app going from off to running, or from "one-off" to "survives every server restart", is the user's decision, made by clicking something. And "the page's JS ran" is a much wider event than "the user opened my folder": Home's "Fused Apps" strip and the `/apps` hub render a **live picture** of each app, mounting its own `entry_html` in an iframe (`AppPreviewCard`) once the card nears the viewport, and a card that has a `preview.png` still swaps to the live iframe on hover. That iframe's sandbox is `allow-scripts allow-same-origin` — your script runs, on a card someone merely scrolled past.
 
-**This was a live hazard, not a theoretical one.** The home page's "Fused Apps" strip and the `/apps` hub render a *live picture* of each app, not a static screenshot, whenever the app has no authored `preview.png`: `AppPreviewCard` mounts the app's own `entry_html` in an iframe (`frontend/src/platform/ui/AppPreviewCard.tsx`, the `liveSrc`/`wantsLive` logic) once the card is near the viewport, and even a card that *does* have a `preview.png` swaps to the same live iframe on hover. That iframe's sandbox is `"allow-scripts allow-same-origin"` (`frontend/src/platform/lib/frame-focus.ts:180-181`, `THUMB_SEAL`) — scripts run. So an app that called `enable()` (the predecessor of `start()` + autostart, before D511) on load used to get it called every time its card scrolled into view or was hovered in a listing — someone merely *browsing* apps, never opening one, silently installed a resident daemon that survived the page, outlived the session, and came back at every server start.
+**The runtime enforces this, it is not only a convention.** `_preview=1` reaches a card's live iframe reliably — `thumbFrame`/`withPreviewFlag` stamp it onto the `/render?path=...` URL that becomes the iframe's `src`, and `GET /render` serves the app's HTML at exactly that URL with no redirect, so the flag lands in the page's own `location.search`. `start()`, `restart()`, `call()`, `stop()` and `setAutostart()` all check it (this frame's URL, or any same-origin ancestor's) and reject before any POST is sent. `status()` is deliberately ungated: it is read-only.
 
-This was a real bug: `Sina/OpenWhisper/index.html`'s menu-bar control used to call `fused.daemon.enable()` unconditionally on load. The daemon came back every time the page rendered — including in a listing preview — which made the tray's "Turn Off" item effectively unreachable: the user turned it off, the page (or a preview of it) rendered again, and it was back. D511 splits WHY that happened into two separate, individually-fixable facts (run state and autostart, previously fused into one "enabled" concept) — but the underlying rule this section states is unchanged: neither fact may ever change as a side effect of rendering.
-
-**This is now enforced, not just documented (D507, SPEC.md §46).** The `_preview=1` flag reaches a card's live iframe reliably: `thumbFrame`/`withPreviewFlag` (`frontend/src/platform/lib/thumb-frame.ts`, `router.ts`) stamp it onto the `/render?path=...` URL that becomes the iframe's own `src`, and `fused_render/server/routers/render.py`'s `GET /render` serves the app's HTML at exactly that URL with no redirect — so the flag lands in the rendered page's own `location.search`, the same fact `runtime.js` already computed for the focus contract (`IS_THUMBNAIL`). `fused.daemon.start()`, `restart()`, `call()`, `stop()`, and `setAutostart()` now check it before doing anything: inside a preview thumbnail (this frame's own URL, or any same-origin ancestor's, carrying `_preview=1`), each rejects immediately with an `Error` naming the method and the rule — no POST is ever sent. See "How the guard rejects" below for the exact message. `status()` is the one method deliberately left ungated: it is read-only. `stop()` and `setAutostart()` are gated exactly like `start()`/`restart()`/`call()` (D508, 2026-08-26 code review) — leaving them open would let a preview do the one thing worse than starting a daemon: a card thumbnail mounts an app's own `entry_html` live with `allow-scripts`, so an app whose init path calls `setAutostart(true)` would persist a "come back forever" flag just because its card scrolled past, and unlike an unwanted `start()`, that survives a server restart.
+`setAutostart()` is gated for the same reason as `start()`, only more so — an unwanted `start()` dies with the server, while a persisted "come back forever" flag set by a card scrolling past survives every restart.
 
 ```js
 // Wrong: fires the instant this script runs, including inside a display-only
@@ -226,10 +140,9 @@ This was a real bug: `Sina/OpenWhisper/index.html`'s menu-bar control used to ca
 fused.daemon.start();
 fused.daemon.setAutostart(true);
 
-// Right: page load only reads and renders the current state. Starting the
-// daemon, and opting into autostart, are each something a control does, in
-// response to a click — two SEPARATE controls, since D511 made them two
-// separate facts.
+// Right: page load only reads and renders. Starting the daemon and opting into
+// autostart are each something a control does, in response to a click — two
+// SEPARATE controls, because they are two separate facts.
 async function refreshMenubar() {
   const st = await fused.daemon.status();     // {running, autostart, pid, ...}
   render(st);                                 // see "Render both facts" below
@@ -248,22 +161,21 @@ autostartCheckbox.addEventListener("change", async () => {
 });
 ```
 
-### What a page may do on load, and what it may not
+### What a page may do on load
 
 | On load | Allowed | Why |
 |---|---|---|
-| `fused.daemon.status()` | Yes | Read-only; does not spawn, persist, or kill anything. |
-| `fused.daemon.watch(callback)` | Yes — **but does one read and nothing more in a preview thumbnail** | `status()` underneath; never spawns, persists, or kills anything. In a live/hover preview iframe it does a single read and returns a no-op unsubscribe rather than leaving a poll loop or listeners running in a sandbox that gets mounted and unmounted on every hover. |
+| `fused.daemon.status()` | Yes | Read-only; spawns, persists and kills nothing. |
+| `fused.daemon.watch(cb)` | Yes — **one read and nothing more in a preview thumbnail** | `status()` underneath. In a live/hover preview it does a single read and returns a no-op unsubscribe rather than leaving a poll loop running in a sandbox that mounts and unmounts on every hover. |
 | Rendering the result | Yes | Pure display logic. |
-| `fused.daemon.start()` | No — **and refused in a preview thumbnail** | Spawns a daemon — see above. Called inside a card's live/hover iframe, it now rejects instead of spawning. |
-| `fused.daemon.restart()` | No — **and refused in a preview thumbnail** | Same spawn as `start()`; a page render is not a reason to bounce a daemon the user may be mid-use of. Same rejection as `start()` inside a preview. |
-| `fused.daemon.stop()` | No — **and refused in a preview thumbnail** | Turning something the user has running *off* on a page render is exactly as surprising as turning it on — a load is not a "turn it off" click either. |
-| `fused.daemon.setAutostart(bool)` | No — **and refused in a preview thumbnail** | Gated on the preview flag too (D508): a card thumbnail mounts an app's own `entry_html` live with `allow-scripts`, so an unguarded `setAutostart(true)` could persist a "come back forever" flag just because a card scrolled past — worse than an unwanted `start()`, since it survives a server restart. |
-| `fused.daemon.call(path, body)` | Only if it's a genuine read — **and refused in a preview thumbnail** | `call()` proxies straight to the daemon's own HTTP surface (`engine_forward.py`); the runtime itself won't spawn on your behalf for it (client-side rejects if the app isn't known to be running — see `fused.daemon` above), but `engine_forward.py`'s heal-on-proxy path (`_forward`, lines ~216-222) *will* respawn a dead-but-running child on any proxied call, so a preview render that calls `call()` against an app started elsewhere can resurrect its daemon exactly like `start()` would — the guard covers it for that reason. Beyond that, your daemon might still treat a given route as "start work" server-side, and nothing stops a page from calling that route on load outside a preview. Treat routes that kick off work the same as `start()`/`restart()`: gate them behind an explicit control, not a load path.
+| `start()` / `restart()` | No — **refused in a preview thumbnail** | Spawns a daemon; a page render is not a reason to start one, or to bounce one the user may be mid-use of. |
+| `stop()` | No — **refused in a preview thumbnail** | Turning something the user has running *off* on a page render is exactly as surprising as turning it on. |
+| `setAutostart(bool)` | No — **refused in a preview thumbnail** | Persists a flag that survives a server restart. |
+| `call(path, body)` | Only if it is a genuine read — **refused in a preview thumbnail** | `engine_forward.py`'s heal-on-proxy path respawns a dead-but-registered child on *any* proxied call, so a preview calling `call()` against an app started elsewhere can resurrect its daemon exactly like `start()` would. Beyond the preview case, your own daemon may treat a route as "start work" — gate those routes behind an explicit control too. |
 
 ### How the guard rejects
 
-`start()`, `restart()`, `stop()`, `setAutostart()`, and `call()` check the preview flag *before* making any request — a rejection is a plain `Error`, never a silent no-op, and it names the method and the rule so the author sees it immediately in the console rather than wondering later why the daemon they turned off keeps coming back:
+A rejection is a plain `Error`, never a silent no-op, and it names the method and the rule so the author sees it in the console instead of wondering later why the daemon they turned off keeps coming back:
 
 ```
 fused.daemon.start: refused — this page is rendering as a preview thumbnail
@@ -273,21 +185,23 @@ fused.daemon.status() on load to read state, and call start()/restart()
 only from an explicit user action, e.g. a button's click handler.
 ```
 
-This is a **client-side** guard (`fused_render/static/runtime.js`), not a server-side one, and that choice is deliberate: the flag reaches the app's own frame reliably (verified above — it's stamped directly onto the iframe's `src`, not merely inferred), so the check belongs where `start()`/`restart()`/`call()` themselves run, before any network request leaves the page. It protects against a *careless* app — the actual, verified hazard (OpenWhisper) — not a deliberately evasive one; nothing stops a page's own script from calling the underlying `fetch("/api/apps/background/start", ...)` directly and skipping `runtime.js` entirely, preview or not — that bypass exists independent of this guard, is not specific to preview rendering, and is out of scope for it (the iframe sandbox already grants arbitrary same-origin script execution; no guard on one function stops a page willing to route around it).
+The guard is **client-side** (`fused_render/static/runtime.js`), deliberately: the flag reaches the app's own frame reliably, so the check belongs where `start()` itself runs, before any request leaves the page. It protects against a careless app, not an evasive one — a page can always `fetch("/api/apps/background/start")` directly, a bypass that exists independent of preview rendering and is out of scope for this guard.
 
-### Render both facts honestly — running AND autostart are separate (D511)
+### Render both facts honestly
 
-`fused.daemon.status()` reports **`running`** (a live child right now) and **`autostart`** (will the server bring it back at the next launch) as two independent booleans — not one collapsed three-state enum any more, though most UIs still want to SHOW three states because the interesting cases are the same as before:
+`status()` reports **`running`** and **`autostart`** as two independent booleans. Most UIs still want to show three states:
 
-- **Running** — the daemon is up right now, regardless of what `autostart` says.
-- **Not running, but `autostart: true`** — "will come back" (at the next server launch, or on an explicit `start()`/`restart()`). Don't render this as broken or as an error; it's the ordinary state right after a `stop()` on an app that has autostart on, or after any external kill the heal-on-proxy path hasn't repaired yet.
-- **Not running, `autostart: false`** — the ordinary default for anyone who hasn't opted the app into autostart, whether or not they've ever `start()`ed it. Don't render this as an error, a missing dependency, or a disabled/unavailable feature — it's a valid, common, and often the *most* common state a background app is in (it's the default!). `Sina/OpenWhisper/index.html`'s `mbRender`/`refreshMenubar` (its "Menu bar active…" / "…stopped (starts automatically at next launch)" / "…off — click to turn on" labels, `.on`/`.pending` CSS classes, and a SEPARATE "Start automatically" checkbox in Settings for the autostart fact) is a worked example of rendering both facts — read it for the pattern, not as a finished reference.
+- **Running** — up right now, whatever `autostart` says.
+- **Not running, `autostart: true`** — "will come back" at the next launch or on an explicit `start()`. Not broken, not an error; it is the ordinary state right after a `stop()`, or after an external kill heal-on-proxy hasn't repaired yet.
+- **Not running, `autostart: false`** — the default for every folder, and often the most common state a background app is in. Do not render it as an error, a missing dependency, or a disabled feature.
 
-### Reflect state that changed for a reason outside this page — `fused.daemon.watch()`
+`Sina/OpenWhisper/index.html`'s `mbRender`/`refreshMenubar` is a worked example — three labels, `.on`/`.pending` classes, and a separate "Start automatically" checkbox for the autostart fact. Read it for the pattern, not as a finished reference.
 
-`status()` alone only tells you what's true right now, at the moment you called it. A page that calls `status()` once on load and otherwise only refreshes after its own `start()`/`stop()`/`restart()` calls has a silent blind spot: **the daemon's state can change for reasons that have nothing to do with this page** — the OpenWhisper tray's "Quit" (a native menu item, not a page action) routes through the exact same `POST /api/apps/background/stop` the page's own `stop()` button does, so the server knows the daemon died, but a page that only reflects its own actions never finds out. Its mic icon stayed "on" until the user manually reloaded — a real bug, not a hypothetical one.
+### Reflect state that changed outside this page — `fused.daemon.watch()`
 
-`fused.daemon.watch(callback)` closes that gap: it calls `callback(status)` on the initial read and again whenever `{running, autostart, pid, version}` changes, polling `status()` only while the tab is visible and refreshing immediately on `visibilitychange`→visible and window `focus` (the case that matters most — reaching for a tray or another window means this page was *not* focused when the state changed). Use it instead of hand-rolling your own poll loop, and use it as your app's ONE source of truth for `running`/`autostart` rather than tracking a local boolean your own button clicks flip:
+`status()` alone tells you what is true at the moment you called it. A page that reads once on load and otherwise refreshes only after its own `start()`/`stop()` has a blind spot: **the daemon's state changes for reasons that have nothing to do with this page.** A tray "Quit" routes through the same `POST /api/apps/background/stop` the page's own button does, so the server knows — but a page reflecting only its own actions leaves its icon "on" until someone reloads.
+
+`watch(callback)` closes that gap: it calls back on the initial read and whenever `{running, autostart, pid, version}` changes, polling only while the tab is visible and refreshing immediately on `visibilitychange`→visible and window `focus` — the case that matters most, since reaching for a tray means this page was *not* focused when the state changed.
 
 ```js
 const unsubscribe = fused.daemon.watch((s) => {
@@ -297,39 +211,37 @@ const unsubscribe = fused.daemon.watch((s) => {
 });
 ```
 
-The general convention this establishes: **an app should render from the server's actual state, not from an assumption that its own actions are the only source of change.** A button's own click handler updating local state directly (rather than waiting for the next `watch()` tick or re-deriving from a fresh `status()`) is fine for the calling page's own immediate feedback — but anything a *different* surface (a tray, another tab, the server's own startup resurrection) can also change should be read back from the server, not assumed static between polls.
+The convention this establishes: **render from the server's actual state, not from an assumption that your own actions are the only source of change.** Updating local state directly in a click handler is fine for immediate feedback; anything a *different* surface (a tray, another tab, startup resurrection) can also change gets read back from the server.
 
 ### Give the user a way to turn the app off from inside the app itself
 
-A background app that runs native desktop UI (a tray icon, a menu-bar item) needs its own off switch there too, not only on the page — a user who never has the page open still needs a way to quit it. Two things follow directly from the run-state/autostart split above:
+A background app running native desktop UI needs its own off switch there too — a user who never opens the page still needs a way to quit it. Two things follow from the run-state/autostart split:
 
-- A tray "Quit" item only needs to call `stop()` — it should NOT also try to turn autostart off, because "quit right now" and "never come back automatically" are different user intents (D511's whole point) and conflating them back together in the tray just re-creates the bug this decision fixed. Offer autostart as its own separate control (a checkmark item reflecting `status().autostart`, toggling it via `set_autostart()`) if you want the user to control it from the tray at all — see `menubar.py`'s `toggleAutostart_` for the shipped pattern.
-- Both controls must go through the server's own API — `fused.daemon.stop()`/`setAutostart()` from the page, or `background_app.stop()`/`set_autostart()` (`fused_render/templates/shared/background_app.py`) from inside the daemon itself — never a raw process kill (`terminate()`, `sys.exit()`, a bare `kill`) for the "stop it" half. A raw kill is the *weakest* way to end a background app: it skips the `_children` bookkeeping `stop()` pops, so the next proxied call heals the daemon back to life (resurrection path 3 in "When does it come back?" above). This is the exact mechanism behind the OpenWhisper tray bug this skill section exists for.
+- A tray "Quit" only needs `stop()`. It should NOT also turn autostart off: "quit right now" and "never come back automatically" are different intents, and conflating them in the tray re-creates the bug the split exists to fix. Offer autostart as its own checkmark item reflecting `status().autostart` (see `menubar.py`'s `toggleAutostart_`).
+- Both controls go through the server's API — `fused.daemon.stop()`/`setAutostart()` from the page, or `background_app.stop()`/`set_autostart()` from inside the daemon — never a raw kill for the "stop it" half, which skips the `_children` bookkeeping and lets the next proxied call heal the daemon back to life.
 
 ### The daemon is a guest process: assume nothing about its own continuity
 
-Three things follow from facts already established elsewhere in this skill, restated here as author obligations:
+- **It may be killed at any time**, by the server's tree-kill or by anything external. Never assume a clean shutdown path runs — persist anything that must survive under `background_apps.cache_dir_for(engine_id)` (never beside the user's code) with interrupt-safe writes: write-to-temp-then-`os.replace()`, the same pattern as the status-file publish.
+- **It is not a singleton across restarts.** Nothing replays state into a fresh child (see "reinit" below) — a respawned daemon starts new, with only what it reads back or rebuilds. Design `main()` for "I might be the fifth process this folder has run today".
+- **It must tolerate its own work being interrupted mid-request.** A `call()` can be answered by a daemon killed moments later; don't leave on-disk state half-written or a resource half-acquired across that boundary.
 
-- **It may be killed at any time**, by the server's own SIGTERM→SIGKILL tree-kill (`stop()`, a respawn) or by anything external (a crash, a manual `kill`, an OS reboot). Never assume a clean shutdown path runs — persist anything that must survive a restart (`background_apps.cache_dir_for(engine_id)`, never beside the user's code) with writes that are safe to interrupt mid-flight (write-to-temp-then-`os.replace()`, the same pattern the daemon's own status-file publish uses — see "The daemon contract" above).
-- **It is not a singleton across restarts.** Nothing replays state into a fresh child for you (see "Does `reinit()` replay apply to a background app? No" above) — a respawned daemon starts as a brand-new process with only what it reads back from its own persisted state or rebuilds from scratch. Design `main()` for "I might be the fifth process this folder has run today" rather than "I am the one true instance."
-- **It must tolerate its own work being interrupted mid-request.** A client-facing `call()` can be answered by a daemon that gets killed moments later; don't leave on-disk state half-written or a resource half-acquired across that boundary. This is the same interruption tolerance the venv-precondition and heal-on-proxy paths already assume of every background app, just stated as a requirement rather than a fact about the engine.
+### What the version digest expects from you
 
-### What the version-digest machinery expects from you
+`version_for` hashes your `pyproject.toml`'s bytes, your `daemon.py`'s mtime+size, and the interpreter's path+mtime+size into the `--version` string you are spawned with; the reuse check retires and respawns a running child the moment that digest changes.
 
-`version_for` (`fused_render/background_apps.py:116-163`) hashes your `pyproject.toml`'s bytes, your `daemon.py`'s mtime+size, and the interpreter's own path+mtime+size into the `--version` string your daemon is spawned with — and `ensure_background`'s reuse check retires and respawns a running child the moment that digest changes. Two consequences:
-
-- **You never bump a version yourself.** Editing `pyproject.toml` or `daemon.py` during development is enough — the next `start()`/`restart()`/reuse check sees a new digest and starts a fresh child; there's no manual step and no version field to remember to touch.
-- **Never hardcode your `/ping` response's `version` to a fixed string.** Echo back exactly the `--version` value you were spawned with (per "The daemon contract," step 5, above). Hardcoding it defeats the staleness check silently: `ensure_background` would see a `/ping` that always "matches," reuse the stale child forever, and the respawn-on-edit behavior the rest of this section relies on would stop working for your app specifically.
+- **You never bump a version yourself.** Editing `pyproject.toml` or `daemon.py` is enough — the next start or reuse check sees a new digest and spawns a fresh child.
+- **Never hardcode your `/ping` response's `version`.** Echo the `--version` you were given. Hardcoding defeats the staleness check silently: the reuse check always "matches", the stale child is kept forever, and respawn-on-edit stops working for your app specifically.
 
 ### Conventions the engine does not enforce
 
-Nothing below is checked by any code path — a careless app can still do the wrong thing, and no test or manifest rule will catch it. This is a deliberate list, not an oversight: enforcing any of these is a separate decision for the user to make, not something this documentation pass adds code for. (`start()`/`restart()`/`call()`/`stop()`/`setAutostart()` on page load used to be partly on this list — it's enforced now; see "How the guard rejects" above.)
+Nothing below is checked by any code path; no test or manifest rule will catch it.
 
-- Rendering both `status()` facts (`running`, `autostart`) honestly, and specifically not presenting `autostart: false` as an error or a missing feature — purely a UI choice.
-- Exposing an in-app off switch (tray/menu-bar or otherwise) at all — nothing requires a background app with native UI to offer one.
-- Routing that off switch through `stop()` (or `background_app.py`'s equivalent) instead of a raw process kill — the heal-on-proxy resurrection path exists precisely because the engine tolerates a raw kill; it does not forbid one.
-- The daemon persisting its own state safely across an unannounced kill, and not assuming it is the only instance a folder has ever spawned — both are properties of how the author writes `main()`, invisible to `background_apps.py`.
-- Echoing the real `--version` value from `/ping` rather than a hardcoded string — an author can defeat the staleness check and nothing will complain; the daemon just quietly stops picking up its own updates.
+- Rendering both `status()` facts honestly, and not presenting `autostart: false` as an error.
+- Exposing an in-app off switch at all.
+- Routing that off switch through `stop()` instead of a raw kill — heal-on-proxy exists precisely because the engine tolerates a raw kill; it does not forbid one.
+- Persisting daemon state safely across an unannounced kill, and not assuming it is the only instance the folder has spawned.
+- Echoing the real `--version` from `/ping` — defeat the staleness check and nothing complains; the daemon just quietly stops picking up its own updates.
 
 ## The venv precondition, its 409, and where the daemon actually runs
 
@@ -339,61 +251,49 @@ Nothing below is checked by any code path — a careless app can still do the wr
 {"error": "<folder> needs its project environment built before its background app can start; open it once (or call fused.runPython) to install it, then retry.", "status": 409}
 ```
 
-Building a venv can take minutes, and this endpoint won't do it inside a POST — open the page once, or call `fused.runPython`, to trigger the build, then retry `start()`. This is the identical stance `/api/engine`'s warm-worker dispatch already takes; see `fused-render-authoring` for the general venv-precondition rule and what "open it once" builds.
+Building a venv can take minutes and this endpoint won't do it inside a POST — open the page once, or call `fused.runPython`, then retry `start()`. Same stance `/api/engine`'s warm-worker dispatch takes.
 
-**The ordering trap specific to background apps (D503):** the daemon runs on **the folder's own declared environment**, resolved from the folder itself — never from an ancestor project. `background_apps.interpreter_for` calls `projectenv.has_project_env(folder)` on the app's own folder only; it does **not** walk upward the way a plain `.py` script's environment resolution does. If your folder declares no `[project]` deps of its own, your daemon runs on `sys.executable` (this app's own bundled interpreter) regardless of what any parent directory declares — `import fused_render` is **not** available there. And your folder's `[project]` dependency list (in its own `pyproject.toml`) is the **complete** list your daemon gets; nothing from this app's own bundled dependency set is unioned in. Declare everything your `daemon.py` imports, stdlib aside.
+**The ordering trap specific to background apps:** the daemon runs on **the folder's own declared environment**, resolved from the folder itself — never from an ancestor project. `background_apps.interpreter_for` calls `projectenv.has_project_env(folder)` on the app's own folder only; it does **not** walk upward the way a plain `.py` script's resolution does. A folder declaring no `[project]` deps of its own runs its daemon on `sys.executable` (the app's bundled interpreter) whatever a parent directory declares, and `import fused_render` is **not** available there. Its `[project]` dependency list is also the **complete** list the daemon gets — nothing bundled is unioned in. Declare everything `daemon.py` imports, stdlib aside.
 
-(A background app whose folder is nested deeper than `<fused_dir>/<tag>/<name>` may currently 409 forever on project-boundary resolution — that's a known bug being fixed elsewhere, not documented behavior. The rule above — the folder is the boundary — is what to build to.)
+(A background app nested deeper than `<fused_dir>/<tag>/<name>` may currently 409 forever on project-boundary resolution — a known bug being fixed elsewhere, not documented behavior. The rule above is what to build to.)
 
-## Two things verified against the code, not assumed
+## Two things that do not work the way `/api/run` does
 
-**Does a background daemon get `templates/shared` seeded onto `sys.path`? No.** `import fused_ai` does **not** work in a background daemon.
+**`templates/shared` is not on `sys.path`, so `import fused_ai` fails.** A `.py` under `/api/run` gets the seeding from `_child.py`; a background daemon is not spawned through `_child.py` at all — `engine_host._spawn` runs your script directly, and nothing appends `templates/shared`. Worse, a daemon on a project venv has `PYTHONPATH`/`PYTHONHOME`/`PYTHONEXECUTABLE`/`PYTHONSTARTUP` actively stripped by `_spawn_env` for venv hermeticity, so even an inherited `PYTHONPATH` would not survive. To use `fused_ai` or any other shared helper, bootstrap it off `server.json` (as "Asking the server about yourself" does) or copy the module in — the same "copy this reader" pattern `fused-render-index` uses.
 
-- A `.py` run under `/api/run` gets it: `fused_render/_child.py:68-69` explicitly does `sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates", "shared"))` before running the module — that's why `import fused_ai` works there and in the warm `/api/engine` worker (`engine_worker.py`, same pattern).
-- A background daemon is **not** spawned through `_child.py` at all. `engine_host._spawn` runs `[child.python, child.daemon, --status, ..., --cache, ..., --version, ...]` directly as the process's own `argv[0]` script — there is no import-and-seed step, and nothing in `engine_host.py` appends `templates/shared` to anything.
-- Worse, if your daemon runs on a project venv (not `sys.executable`), `_spawn_env` actively **strips** `PYTHONPATH`/`PYTHONHOME`/`PYTHONEXECUTABLE`/`PYTHONSTARTUP` from its environment (`engine_host.py:277-301`) for venv hermeticity — the same stripped-var set `_env_install_worker.py`'s `_STRIPPED_ENV_VARS` uses elsewhere. Even an inherited `PYTHONPATH` wouldn't survive.
-
-If you want `fused_ai` or any other `templates/shared` helper in your daemon, copy the module in (the same "copy this reader" pattern `fused-render-index` uses for its duckdb reader) rather than assuming an import will resolve.
-
-**Does `reinit()` replay apply to a background app? No — your daemon must survive its own restart on its own.**
-
-- `engine_host.reinit(engine_id, key, path, payload)` records a request so a **template daemon**'s restart can replay it into the fresh child before any retried request lands — that's what makes a map-tile daemon's death invisible to the page (`engine_host.py`'s module docstring, and `_replay`/`restart`).
-- Nothing in `fused_render/background_apps.py` or `server/routers/background_apps.py` ever calls `engine_host.reinit()` or `forget()` — grep confirms the only callers are in `server/routers/engines.py`, the template-daemon proxy path.
-- `engine_host.restart(engine_id)` still calls `_replay(child)` unconditionally for every kind, but for a `bg_*` engine_id `_reinit` was never populated, so replay is a no-op empty loop — there's nothing for it to replay even by accident.
-
-Practically: a background app is not one of the descriptors a page "registers" the way a template registers a viewport. If your daemon dies and gets respawned (`restart()`, or a fresh server launch), it starts with **whatever state its own startup code rebuilds** — nothing outside re-POSTs anything into it for you. Persist to disk under your own cache dir (`background_apps.cache_dir_for(engine_id)` — under `home_dir()`, never beside the user's code) or rebuild from scratch in your own `main()`, and design for the daemon dying and restarting as a normal event, not an exceptional one.
+**`reinit()` replay does not apply, so your daemon must survive its own restart.** `engine_host.reinit()` records a request so a *template daemon*'s restart can replay it into the fresh child before any retried request lands — that is what makes a map-tile daemon's death invisible to the page. Nothing in `background_apps.py` or its router ever calls it; `restart()` still calls `_replay(child)` for every kind, but a `bg_*` engine never populated `_reinit`, so it is a no-op empty loop. A respawned daemon starts with whatever its own startup code rebuilds — persist under your cache dir or rebuild in `main()`, and treat dying and restarting as a normal event.
 
 ## Cross-platform: native desktop work
 
-A daemon doing native desktop UI — a macOS menu-bar item, a Windows/Linux tray icon — will not run unmodified on another platform, and there's no cross-platform API in scope here to hand you one. Two facts to work from instead of building a fourth implementation:
+A daemon doing native desktop UI will not run unmodified on another platform, and there is no cross-platform API in scope to hand you one. Two facts to work from:
 
-- **fused-render already ships three tray/menu-bar backends.** `fused_render/supervisor/tray.py` is the platform-neutral seam (`TrayAction`, `_State`, `TrayHandle`, the retry-with-backoff `start()`), dispatching by `sys.platform` at call time to `fused_render/supervisor/_win32/tray.py` (pystray) or `fused_render/supervisor/_linux/tray.py` (StatusNotifierItem over D-Bus); `fused_render/menubar_pin.py` is the separate macOS AppKit/NSPopover implementation. Guard any platform-specific branch in your own daemon (`sys.platform`) rather than writing a fourth backend from scratch — read the existing one for your target platform as a reference before reinventing its retry/backoff or lifecycle handling.
-- **On macOS, `NSApplication.run()` cannot leave the main thread.** Every AppKit call in `menubar_pin.py` is documented "main thread only," and cross-thread work hops onto it with `PyObjCTools.AppHelper.callAfter(fn)` (used throughout `menubar_pin.py`, e.g. line 217, 260, 648) — the codebase's actual established hop, not merely a documented option. If your daemon's HTTP handler thread needs to touch AppKit state, post the work through `callAfter` (or `NSOperationQueue.mainQueue()`, the lower-level equivalent) rather than calling into AppKit directly from the handler thread.
+- **fused-render already ships three tray/menu-bar backends.** `fused_render/supervisor/tray.py` is the platform-neutral seam (`TrayAction`, `_State`, `TrayHandle`, the retry-with-backoff `start()`), dispatching by `sys.platform` to `supervisor/_win32/tray.py` (pystray) or `supervisor/_linux/tray.py` (StatusNotifierItem over D-Bus); `fused_render/menubar_pin.py` is the separate macOS AppKit/NSPopover implementation. Guard your own platform branch on `sys.platform` and read the existing backend for your target before reinventing its retry/backoff or lifecycle handling.
+- **On macOS, `NSApplication.run()` cannot leave the main thread.** Every AppKit call in `menubar_pin.py` is main-thread only, and cross-thread work hops onto it with `PyObjCTools.AppHelper.callAfter(fn)` — the codebase's established hop. If your HTTP handler thread needs to touch AppKit state, post it through `callAfter` (or `NSOperationQueue.mainQueue()`) rather than calling AppKit from the handler thread.
 
 ## Pitfalls checklist
 
-- Writing `daemon.py` to publish the status file AFTER calling `serve_forever()` → the parent's bootstrap poll never sees it in time, or worse, sees a port that isn't accepting connections yet; publish immediately after `bind()`, before serving.
-- Calling `server.shutdown()` from inside the request handler answering `/quit` → deadlocks `ThreadingHTTPServer`; shut down from a separate thread.
-- Expecting `fused.daemon.start()` from page load to be harmless → it spawns a daemon the user never asked for, and a display-only preview iframe (Home's app strip, the `/apps` hub) runs that same load path. Gate it behind an explicit user action; the runtime now refuses `start()`/`restart()`/`call()`/`stop()`/`setAutostart()` inside a preview thumbnail and throws a named error if you don't — see "How the guard rejects" above.
-- Assuming `start()` (or `stop()`) also changes whether the app comes back at the next server launch → it doesn't, ever (D511). Only `setAutostart(bool)` touches that flag; a test (`test_api_start_calls_ensure_background_without_touching_autostart`) fails if `start()` regresses this.
-- Calling `setAutostart(true)` from page load, or as a side effect of a "start it" click → it persists a flag surviving a server restart; gate it behind its OWN explicit control, separate from the run-state switch.
-- Ending a background app from a tray/menu-bar control with a raw process kill instead of `stop()` → the weakest way to quit it; skips the bookkeeping that keeps it from silently reviving on the next proxied call.
-- Rendering `autostart: true, running: false` or `autostart: false` as an error/broken state instead of an ordinary one → both are expected, common states, not failures — `autostart: false` is in fact the default for every folder.
-- Assuming a tray "Quit" should also turn autostart off (or that autostart on means "running") → they're independent facts now; conflating them back together re-creates the exact bug D511 exists to fix.
-- Assuming `import fused_ai` (or any `templates/shared` helper) works in a daemon because it works in `/api/run` → it doesn't; `_child.py`'s `sys.path` seeding never runs for a background daemon spawn. Copy the module in.
-- Expecting a daemon's descriptors to survive a restart the way a template's do → `reinit()`/`_replay` is never invoked for background apps; your daemon must rebuild or persist its own state.
-- Declaring a dependency only in this app's own environment and expecting it to reach the daemon → the folder's own `[project]` table is the complete dependency list; nothing bundled is unioned in.
-- Placing `daemon` outside the folder (`../daemon.py`) or naming a directory (`daemon = "."`) → both are silently rejected by `load_manifest`; the manifest reads as absent with no error surfaced to the page.
-- Calling `start()` before the folder's venv is built → 409; open the page once (or `fused.runPython`) first, per the same stance `/api/engine` already takes.
-- Reaching for a background app when the warm `/api/engine` worker's 15-minute idle-retire was never actually the problem → the manifest, start step, and daemon HTTP contract are all overhead a zero-config warm worker doesn't need.
-- Writing a fourth tray/menu-bar implementation instead of reading `supervisor/tray.py` (+ its `_win32`/`_linux` backends) or `menubar_pin.py` first.
-- Touching AppKit state from your daemon's HTTP handler thread on macOS → `NSApplication.run()` requires the main thread; hop with `PyObjCTools.AppHelper.callAfter`.
+- Publishing the status file AFTER `serve_forever()` → the parent's bootstrap poll never sees it in time, or sees a port not yet accepting connections. Publish right after `bind()`.
+- Calling `server.shutdown()` from inside the handler answering `/quit` → deadlocks `ThreadingHTTPServer`; shut down from a separate thread.
+- `fused.daemon.start()` on page load → spawns a daemon nobody asked for, and a display-only preview iframe runs that same load path. The runtime now refuses it (and `restart`/`call`/`stop`/`setAutostart`) inside a preview and throws a named error.
+- Assuming `start()` or `stop()` also changes whether the app comes back at the next launch → only `setAutostart(bool)` touches that flag.
+- `setAutostart(true)` from page load, or as a side effect of a "start it" click → it persists across restarts; give it its own control.
+- Ending the app from a tray control with a raw kill instead of `stop()` → skips the bookkeeping that keeps it from silently reviving on the next proxied call.
+- Rendering `autostart: false` (or `autostart: true, running: false`) as an error → both are ordinary, and `autostart: false` is the default.
+- Assuming a tray "Quit" should also turn autostart off, or that autostart on means running → independent facts.
+- Assuming `import fused_ai` works in a daemon because it works in `/api/run` → it doesn't; bootstrap off `server.json` or copy the module in.
+- Expecting a daemon's descriptors to survive a restart the way a template's do → `reinit()`/`_replay` is never invoked for background apps.
+- Declaring a dependency somewhere other than the folder's own `[project]` table and expecting the daemon to get it → that table is the complete list.
+- Placing `daemon` outside the folder (`../daemon.py`) or naming a directory (`daemon = "."`) → silently rejected; the manifest reads as absent with no error surfaced.
+- Calling `start()` before the folder's venv is built → 409; open the page once (or `fused.runPython`) first.
+- Reaching for a background app when the warm worker's 15-minute idle-retire was never the problem → the manifest, start step and HTTP contract are all overhead a zero-config warm worker doesn't need.
+- Writing a fourth tray/menu-bar implementation instead of reading `supervisor/tray.py` or `menubar_pin.py` first.
+- Touching AppKit state from the daemon's HTTP handler thread on macOS → hop with `PyObjCTools.AppHelper.callAfter`.
 
 ## When to switch skills
 
-- Writing or debugging the page's own `.html`/`.py` — `fused.runPython`, params, file IO, the venv-build precondition in general → **`fused-render-authoring`**.
-- The warm, zero-config `/api/engine` worker (persistent interpreter, 15-minute idle-retire, no manifest) instead of a resident daemon → **`fused-render-authoring`**'s "Long-running work" section.
-- Reading or querying the machine-wide file index from your daemon or page → **`fused-render-index`** (its "copy the reader, don't import fused_render" pattern is the same one this skill points you at for `templates/shared`).
-- Calling AI models, local or hosted, from a page or from Python → **`fused-render-ai`**.
-- Registering a preview template for a file extension (a different, page-rendering concept from a background daemon) → **`fused-render-custom-templates`**.
-- Just opening/running the app or a view → **`fused-render-usage`**.
+- The page's own `.html`/`.py` — `fused.runPython`, params, file IO, the venv-build precondition → **`fused-render-authoring`**.
+- The warm, zero-config worker, or any work longer than one call → **`fused-render-jobs`**.
+- Reading the machine-wide file index from your daemon or page → **`fused-render-index`** (its "copy the reader, don't import fused_render" pattern is the same one this skill points at for `templates/shared`).
+- Calling AI models from a page or from Python → **`fused-render-ai`**.
+- Registering a preview template for a file extension → **`fused-render-custom-templates`**.
+- Just opening or running the app → **`fused-render-usage`**.

--- a/skills/fused-render-capture/SKILL.md
+++ b/skills/fused-render-capture/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: fused-render-capture
+description: Record the screen, record the microphone, or grab a screenshot natively from a fused-render page — fused.capture.screen/audio/screenshot/sources. Use when a page records or captures anything, or a capture option is refused on this platform.
+---
+
+# Native capture (`fused.capture`)
+
+Three verbs: `screen()`, `audio()`, `screenshot()`. All three write a file this
+machine owns, which is the whole reason to use them over `getDisplayMedia` /
+`MediaRecorder`: the path is known before the recording ends, so it feeds
+`fused.ai.transcribe({path})` directly, and the recording survives your page
+being navigated away from (it is a download-manager job row).
+
+Local only — a hosted/exported page has no `fused.capture`.
+
+## Ask first, and it never prompts
+
+What is possible differs per machine and per browser, so draw your UI off the
+answer rather than off a try/catch:
+
+```js
+const src = await fused.capture.sources();
+if (!src.video.available) { hideRecordButton(src.video.reason); return; }
+// src.displays -> [{id, width, height, main}], src.microphones -> [{id, name, default}]
+// `displays` is empty on Linux and on Wayland by design — nothing to name there.
+```
+
+## Three platforms, one API, and deliberately no field telling you which you got
+
+Read the refusals and the `reason`s instead of sniffing the platform.
+
+| | macOS | Windows | Linux |
+|---|---|---|---|
+| screen recording | native, no picker | browser share picker | browser share picker |
+| survives a page reload | yes | no (file is kept) | no (file is kept) |
+| `display` / `rect` / `cursor` on `screen()` | honoured | refused | refused |
+| `display` / `rect` / `cursor` on `screenshot()` | honoured | honoured | `rect` only |
+| `device` on `audio()` | refused | honoured | honoured |
+| container | `.mov` / `.m4a` | `.mp4` or `.webm` | `.mp4` or `.webm` |
+
+So: do not hardcode an extension when you pass `path` — let the default name the
+file, or read `rec.path`. And if the recording matters, keep the page that
+started it open on Windows and Linux; a reload ends it (the file is kept and the
+row says so, but it is shorter than the user expected).
+
+## Recording is a handle, not a promise that resolves at the end
+
+```js
+const rec = await fused.capture.screen({
+  audio: "both",              // false | "mic" | "system" | "both" — "system" is
+                              // the one a browser cannot do on macOS at all
+  rect: [0, 0, 1200, 800],    // macOS only — refused where the browser's own
+                              // share picker chooses the region
+  path: "walkthrough.mov",    // optional; relative = beside THIS page. Omit it
+                              // unless you know the container (see the table)
+  maxSeconds: 600,            // default 30 min; hitting it STOPS (keeps the file)
+});
+// elapsed seconds come off the recording's job row — there is no onTick:
+fused.watchJob(rec.jobId).watch((row) => (label.textContent = row.done + "s"));
+// rec.path / rec.url are already usable here — the file is being written to them
+const out = await rec.stop();          // {path, url, mime, seconds, bytes}
+const words = await fused.ai.transcribe({ path: out.path, words: true });
+```
+
+`screen()` and `audio()` resolve **when the recording is running**, with a handle
+`{id, jobId, path, url, state, stop(), cancel()}`. `stop()` resolves with the
+finished file; `cancel()` deletes it.
+
+- `rec.cancel()` stops **and deletes**. So does the ✕ on its download-manager
+  row — that is the one control left once your page is gone, so treat a cancel
+  as "the user does not want this recording", not as "stop".
+- `fused.capture.audio()` records the microphone alone. On macOS it uses the
+  system's current input and **refuses** a `device` (the error names the
+  alternative: a screen recording's `audio: "mic"` takes one); on Windows and
+  Linux a `device` from `sources().microphones` works. Those names are empty
+  until the browser's microphone permission has been granted once.
+- `fused.capture.list()` finds live recordings — including one your page started
+  before a reload — and `attach(id)` gives the handle back. Check it on load
+  instead of starting a second recording.
+- `screenshot({rect, cursor, path})` has no handle and no job row. The output
+  **filename** picks png or jpeg — there is no `format`, so a path and a format
+  cannot disagree about what was written. Native on **every** platform, so it
+  needs no readable document and raises no share prompt — which is what makes a
+  cross-origin pane shootable.
+- Rejections carry `.type`: `"unavailable"` (this machine cannot — show
+  `.message`, it names the reason), `"bad_request"` (your arguments).
+
+## Two rules that catch most capture bugs
+
+- **A preview must not record.** A page rendered as a card thumbnail or listing
+  peek is stamped `_preview=1`; starting a capture there records the machine of
+  someone who was merely browsing. Gate boot on the flag — see "Reserved params
+  and preview mode" in **`fused-render-authoring`**.
+- **The recording outlives the page, so the job row is the real UI.** Progress
+  and cancellation live on the download-manager row, not in your DOM. For how
+  those rows work, and for reporting your own long work into them, see
+  **`fused-render-jobs`**.
+
+Related: **`fused-render-authoring`** (the rest of `window.fused`),
+**`fused-render-ai`** (`fused.ai.transcribe`, the usual next call after a
+recording).

--- a/skills/fused-render-custom-templates/SKILL.md
+++ b/skills/fused-render-custom-templates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fused-render-custom-templates
-description: How to create and register a custom preview template for fused-render — a user-owned template that overrides, reorders, or extends the built-in extension → template mode list, so opening a file of that extension renders the user's template (or offers it as a switchable mode) instead. Use this whenever the user wants a custom/own preview for a file extension (e.g. "my own parquet viewer", "add a mode for .xyz files", "render .xyz files with my template"), wants to override, add, reorder, or disable template modes, mentions ~/.fused-render, registry.json, or _mode, or asks to "register a template". For actually writing the template's html and py files, this skill delegates to the fused-render-authoring skill — read that one too.
+description: Register a custom preview template so files of an extension render with your own template — the ~/.fused-render layout, registry.json mode lists, and _mode. Use when the user wants their own viewer for a file type, or to override/reorder template modes.
 ---
 
 # Custom templates for fused-render
@@ -19,7 +19,7 @@ A custom template runs on every open of its extension, with the local server's p
 
 **In the reader `.py` / `condition.py`:**
 - ❌ Don't shell out — no `subprocess`, `os.system`, `os.popen`, or invoking system binaries (`gdalinfo`, `curl`, `ffmpeg`, …). They may not exist in the packaged app, run with the server's privileges, and pay a process-spawn cost on every preview.
-- ✅ Do the work in-process with the **bundled libraries** (numpy, pandas, pyarrow, duckdb, pillow, openpyxl, requests/httpx, … — the authoritative set is in `fused-render-authoring`, and it is smaller than it used to be: geopandas, rasterio, matplotlib, polars, pymupdf and friends now come from a folder `pyproject.toml`, not from the app). Reading local files with `open()` / `os.path` relative to your script is fine and idiomatic; spawning commands is not.
+- ✅ Do the work in-process with the **bundled libraries** (numpy, pandas, pyarrow, duckdb, pillow, openpyxl, requests/httpx, … — the authoritative set is in `fused-render-authoring`; anything else, geopandas and rasterio included, needs a folder `pyproject.toml`). Reading local files with `open()` / `os.path` relative to your script is fine and idiomatic; spawning commands is not.
 - ✅ In `condition.py`, **keep reads bounded** — sniff a footer/header/prefix, never `read()` a whole file, and never shell out. The gate runs for every file of the extension, some on remote mounts.
 
 **In `template.html`:**

--- a/skills/fused-render-index/SKILL.md
+++ b/skills/fused-render-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fused-render-index
-description: Read fused-render's machine-wide file index instead of walking the filesystem — the `fused.fileIndex.search/query` JS bridge, and a copy-paste duckdb reader for bulk Python. Use for a file search box, a disk-usage or file-type breakdown, a repos list, SQL over the filesystem, or any mention of the index, a scan, partitions.json or /api/index/*.
+description: Read fused-render's machine-wide file index instead of walking the filesystem — the fused.fileIndex.search/query bridge and a copy-paste duckdb reader for bulk Python. Use for a file search box, a disk-usage or file-type breakdown, or SQL over the filesystem.
 ---
 
 # Reading the fused-render file index
@@ -319,15 +319,15 @@ That is precisely why the repo list is a ROUTE and not a `fileIndex.query()` you
 
 When you need a *different* kind, the query is yours and `fileIndex.query()` is the tool — but the screening lesson is not optional, and a new kind that needs `junk_path`/`MountGuard` belongs in a server route beside `git_repos.py`, not in a page.
 
-## E. Migrating an app that carries its own index engine
+## E. Replacing an app's own index engine
 
-If an app ships its own scanner, it is now duplicating `fused_render/index/` — which was **ported from exactly such an app** (the `Ported from OpenIndex` docstrings in `fused_render/index/{store,scan,fsevents,query}.py`). The migration is a deletion, not a rewrite:
+An app shipping its own scanner is duplicating `fused_render/index/`, and the migration is a deletion, not a rewrite:
 
-- **Delete the scan engine wholesale** — the walk, the parquet sink, compaction, FSEvents replay, run bookkeeping (~1300 lines in the original) and the reader module beside it (~190). All of it is in `fused_render/index/` now, behind `/api/index/*`.
-- **The app becomes pure HTML + JS**, talking to `fused.fileIndex.*`. What was a `sql` action is now `fused.fileIndex.query()` — strictly better, because the original had *no allowlist and no read-only flag* and the port deliberately dropped it for that reason. A scan button becomes a raw `POST /api/index/scan` with `X-Fused: 1` (section C).
+- **Delete the scan engine wholesale** — the walk, the parquet sink, compaction, FSEvents replay, run bookkeeping, and the reader module beside it. All of it lives behind `/api/index/*` now.
+- **The app becomes pure HTML + JS** talking to `fused.fileIndex.*`. A `sql` action becomes `fused.fileIndex.query()` — which, unlike a hand-rolled one, is allowlisted and read-only. A scan button becomes a raw `POST /api/index/scan` with `X-Fused: 1` (section C).
 - **Anything genuinely bulk stays in Python**, using the direct reader in section B rather than a re-implemented store.
 
-One genuine gap, so nobody discovers it mid-migration: **relocating the index directory is not supported.** `IndexConfig.dir` is fixed to `home_dir()/index`, settable only via `FUSED_RENDER_HOME` at process start, with no runtime API — `POST /api/index/config` takes `roots` and `ignore`, not `location`. An app that let the user pick where the index lives loses that.
+One gap to know before you start: **the index directory cannot be relocated.** `IndexConfig.dir` is fixed to `home_dir()/index`, settable only via `FUSED_RENDER_HOME` at process start; `POST /api/index/config` takes `roots` and `ignore`, not `location`.
 
 ## Pitfalls checklist
 

--- a/skills/fused-render-jobs/SKILL.md
+++ b/skills/fused-render-jobs/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: fused-render-jobs
+description: Work that outlives one fused.runPython call — the 60 s executor timeout and the ways around it, plus fused.trackJob reporting into the shell's download manager from the page and from a detached worker. Use on a timeout, or when a progress row goes stalled.
+---
+
+# Long-running work and the 60 s timeout
+
+Every `fused.runPython` call runs `main()` in a fresh subprocess the server
+**kills at 60 s** (`DEFAULT_TIMEOUT` in `fused_render/executor.py`). On timeout
+the call rejects with a `TimeoutError` — uncaught, that becomes the red overlay.
+There is no per-call override, so design around it:
+
+- **Precompute and cache to disk.** Do the expensive work once, write the result next to the script (`.json`/`.parquet`), and have `main()` return the cached bytes when they're fresh (compare mtimes) — recompute only when the input changed.
+- **Chunk / paginate.** Slice the work so each call stays well under 60 s, pass an `offset`/`page` param, and accumulate in JS across several calls. This also keeps the UI responsive.
+- **Move the heavy job out of band.** For a genuinely long build, run it as a separate process that writes an output file, and have the view read the finished result.
+- **Cut per-call cost.** Each call re-pays import cost (pandas ≈ 1 s); import lazily inside `main`, and debounce sliders (~150 ms) so a drag doesn't spawn a subprocess per tick.
+
+State does not survive any of this: `fused.engine(py)`, the warm variant of
+`runPython` that keeps a worker's imports and globals alive between calls, still
+idle-retires that worker after 15 minutes with no calls. A folder that genuinely
+needs to keep running past that — a poll loop, a held connection, a tray or
+menu-bar presence — wants a resident daemon instead: see
+**`fused-render-background-apps`**.
+
+## Show it in the download manager (`fused.trackJob`)
+
+The out-of-band pattern leaves a hole: a detached worker pulling an 8 GB model
+keeps running when the user browses to another file, and the shell replaces your
+page's frame the moment they do — so your in-page progress bar disappears and the
+download becomes invisible. Report it instead, and the shell shows it in the
+**download manager** for as long as it runs, whatever page the user is on:
+
+```js
+const job = fused.trackJob({
+  title: "FLUX.2-klein-4B",      // required — what is happening, in a few words
+  kind: "download",              // "download" | "task"
+  unit: "bytes",                 // "bytes" formats done/total as 1.2 / 8.1 GB
+  cancellable: true,             // shows a ✕; omit if you cannot honor it
+});
+
+// on each poll tick, from whatever your worker wrote:
+job.update({ done: s.bytes, total: s.size, detail: "transformer.gguf" });
+if (job.cancelRequested) await stopTheWorker();   // the manager's ✕ was clicked
+
+job.finish("Downloaded");        // or job.fail(err) / job.cancelled()
+```
+
+- **It cannot break your page.** Every method is fire-and-forget and never rejects; a failed report is swallowed. `await job.update(...)` only if you want to read `cancelRequested` at that exact point — the property is also readable synchronously between ticks.
+- **Cancel is a request you honor**, not something the shell can do — it has no idea which process is doing the work. The ✕ sets a flag; your poll loop notices it, stops the worker, and reports `job.cancelled()`. If you cannot stop the work, leave `cancellable` off and no ✕ is offered.
+- **Omit `total` while you don't know it.** A job with no total draws a travelling "indeterminate" bar, which is the honest picture; a total of `0` is treated the same way rather than painted as complete.
+- **Report the finish.** Without a terminal call the row goes "stalled" after 30 s and says the page that started it was closed — accurate if that is what happened, misleading if the work just ended. Report `finish`/`fail`/`cancelled` on every exit path of your poll loop.
+- **One job per user-meaningful operation**, not per file: aggregate a multi-file download into one row (sum the bytes) and put the current filename in `detail`.
+- Reuse a **stable `id`** (`fused.trackJob({id: "flux:" + jobId, ...})`) when a page can be reloaded mid-work — the reopened page re-attaches to the existing row instead of opening a second one.
+- **Exports fine.** `fused.trackJob` is a no-op on a hosted page, so unlike `fused.ai` it does not block export.
+
+`fused.watchJob(id).watch(cb)` is the read side: it streams a row's updates to
+your page — used to show elapsed seconds for a `fused.capture` recording, or to
+follow a model download the runtime started for you.
+
+## Report from the WORKER, not only the page — this is the one that bites
+
+The shell replaces your page's frame on every navigation, so a page-only reporter
+freezes the row at its last number and the manager declares it stalled ~30 s later
+while the download carries on. Your detached worker outlives the page, so let it
+report too. It cannot `import fused_render` (it runs in its own venv), but the
+endpoint is plain JSON on the origin every spawned child inherits:
+
+```python
+import json, os, urllib.error, urllib.request
+
+class JobReport:
+    """Best-effort. Never raises: reporting must not break the work."""
+    def __init__(self, job_id, title):
+        self.url = (os.environ.get("FUSED_RENDER_ORIGIN") or "").rstrip("/") + "/api/jobs"
+        self.id, self.enabled, self.cancel_requested = job_id, self.url.startswith("http"), False
+        if self.enabled:
+            self.post(title=title, kind="download", state="running", cancellable=True)
+
+    def post(self, **fields):
+        if not self.enabled:
+            return None
+        fields["id"] = self.id
+        req = urllib.request.Request(self.url, data=json.dumps(fields).encode(),
+                                     headers={"Content-Type": "application/json", "X-Fused": "1"})
+        try:
+            with urllib.request.urlopen(req, timeout=3) as r:
+                record = json.loads(r.read().decode())
+        except (urllib.error.URLError, OSError, ValueError):
+            return None
+        if isinstance(record, dict) and record.get("cancel_requested"):
+            self.cancel_requested = True   # the manager's ✕ — act on it here
+        return record
+```
+
+Use the **same job id** on both sides — derive it from something both know (the
+job directory name, the model id) so the two reporters share ONE row instead of
+opening two. Keep the page reporting as well: it is the only thing alive during
+`uv run`'s first-run environment build, before your worker executes a line.
+Rate-limit the worker's posts to ~1/s — a download callback fires per chunk.
+
+**The worker is also the only thing that can honor a cancel once the page is
+gone.** `cancel_requested` comes back in the reply to the tick you were already
+sending; check it in your progress callback and stop. If your long step is an
+opaque subprocess (`uv sync`), run a small daemon thread that posts a heartbeat,
+reads the flag, and kills the child — otherwise the ✕ does nothing for the
+minutes that matter most.
+
+## Pitfalls
+
+- Never calling `finish`/`fail`/`cancelled` → the row goes "stalled" after 30 s and tells the user the page was closed when the work simply ended.
+- Reporting progress ONLY from the page → the row freezes the moment the user opens another file.
+- A page-started job under `_preview=1` → every card on a listing starts the work at once. Gate boot on the preview flag (**`fused-render-authoring`**).
+- One row per file in a multi-file download → a manager full of rows for one user-meaningful operation.
+
+Related: **`fused-render-authoring`** (the `runPython` contract these limits
+apply to), **`fused-render-background-apps`** (work that must outlive every
+page), **`fused-render-capture`** (recordings, which are job rows too),
+**`fused-render-ai`** (model downloads, which report themselves).

--- a/skills/fused-render-theming/SKILL.md
+++ b/skills/fused-render-theming/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: fused-render-theming
+description: Light/dark theming for a fused-render view — data-fused-theme="shell", the token rules, and colours handed to canvas/charts/maplibre. Use when a view must follow the app's appearance or looks wrong in the opposite one.
+---
+
+# Style and theming a view
+
+There is no imposed CSS — the iframe is a blank canvas, and by default nothing is
+written into your document: no class, no attribute, no stylesheet. But the
+explorer around it follows the OS light/dark preference, with a Light/Dark
+override in Preferences → Appearance, so a hardcoded palette will sooner or later
+sit inside the opposite one.
+
+Pick one of these and commit to it — the failure mode is picking none and
+half-following.
+
+**1. Fixed palette.** Fine for a view with its own strong look (a dark map, a
+photo grid). Just don't pretend to follow.
+
+**2. Follow the app** — one attribute, no JS. Put `data-fused-theme="shell"` on
+your `<html>` and the injected runtime resolves the app's setting, writes
+`data-theme="light"`/`"dark"` on that same element before your stylesheet is
+parsed, and keeps it in step afterwards — including an in-app pin, an OS flip
+mid-session, and a change made in another window. Author against the attribute:
+
+```html
+<html data-fused-theme="shell">
+```
+```css
+:root       { color-scheme: dark;  --bg: #101318; --text: #dce2ea; --line: #2a303a; }
+:root[data-theme="light"]
+            { color-scheme: light; --bg: #f7f8fa; --text: #1a1f27; --line: #d8dce3; }
+body        { background: var(--bg); color: var(--text); }
+```
+
+This is what the built-in templates use (`SPEC.md` §30, AP-8/AP-9), and it is the
+only option that agrees with the app when the user pins Light or Dark.
+
+**3. Follow the desktop** — `@media (prefers-color-scheme: light)` around the
+second `:root`, same tokens, no attribute. Tracks the OS, which is what the app's
+default System mode tracks too. It does *not* see an in-app pin.
+
+**4. Your own switcher.** Put the choice in a param
+(`fused.params.set("theme", …)`) so it is bookmarkable like the rest of your view
+state, and drive the same one `data-theme` attribute from it. Use it *instead of*
+option 2, never alongside: the runtime re-applies on every storage/OS event, so
+your button would silently lose to the app setting.
+
+## Two rules that make the second palette actually work
+
+- **Every colour comes from a token.** Two blocks defining *the same token set*,
+  and no colour literal anywhere else in the stylesheet. A stray `#1a1f27` in a
+  rule is one the other mode cannot repaint — and it shows up as an unreadable
+  smear, not an obvious bug.
+- **Colours you hand to JS don't follow.** Canvas fills, chart ramps, maplibre
+  paint expressions — `var()` does not resolve inside a JS string. Read them at
+  *draw* time and redraw when the attribute changes:
+
+  ```js
+  const token = (n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim();
+  new MutationObserver(() => redraw())
+    .observe(document.documentElement, { attributeFilter: ["data-theme"] });
+  ```
+
+Do not read the app's own `localStorage` key. It is private, it is not part of
+`window.fused`, and a view that reads it becomes a second copy of a resolution
+rule that will drift from the first — options 2 and 3 both get you the answer
+without one.
+
+Related: **`fused-render-authoring`** (everything else about writing the page).

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fused-render-usage
-description: How to run and use a fused-render project — open files and views in the FusedRender desktop app and browse the filesystem. Use this whenever the user wants to open, run, launch, start, show, or explore a fused-render project or its views/files; asks to "open this in fused-render", "run fused-render", "show me this view", "look at this file in the explorer"; or is orienting inside a fused-render repo without yet authoring code. For creating/editing/debugging an .html view or .py data file, use fused-render-authoring instead; for registering custom preview templates, use fused-render-custom-templates.
+description: Open and run a fused-render project — launching the FusedRender desktop app, opening files and views, browsing the filesystem. Use when the user wants to open, run or show a project or view rather than author one.
 ---
 
 # Using a fused-render project
@@ -33,7 +33,7 @@ The filesystem path rides in the URL after a **mode prefix**, with its **leading
 | `/explorer/view/<path>` | **Full-shell mode** — the page wrapped in explorer chrome (sidebar, breadcrumb, preview header). What the app opens when you hand it a path. |
 | `/explorer/embed/<path>` | **Embed mode** — the page chrome-free (no sidebar/breadcrumb/header). Best for opening a specific view on its own or for a screenshot. |
 
-Legacy prefixes `/view/<path>` and `/embed/<path>` (pre-rename) still redirect to the `/explorer/...` forms, so old links keep working — but write the new ones.
+`/view/<path>` and `/embed/<path>` still redirect to the `/explorer/...` forms, so old links keep working — but write the new ones.
 
 View vs embed is a fixed page-load mode set by the prefix — it can't toggle without a full navigation. Both serve the same page and sync URL params the same way; embed just hides the chrome.
 

--- a/tests/test_bundle_contents.py
+++ b/tests/test_bundle_contents.py
@@ -533,18 +533,14 @@ def test_excluded_distributions_are_not_forced_into_the_bundle():
 # must exist, which is itself asserted: a renamed anchor must break loudly
 # rather than silently narrow the section to nothing.
 #
-# One list now. There used to be three: `core_apps/learn/check_libs.py`'s
-# SUPPORTED (the one that RAN, and so the source of truth), the Learn page's
-# static table, and the skill's bullets — and this test pinned the copies to
-# SUPPORTED. The learn content left the app for the community catalog, so the
-# skill's list is what remains in the repo, and it is pinned directly to what
-# the bundle ships.
+# One list: the authoring skill's bullets, pinned directly to what the bundle
+# ships.
 _DOC_LIBRARY_LISTS = [
     # The authoring skill's list — what an agent writing a page reads.
     (
         os.path.join("skills", "fused-render-authoring", "SKILL.md"),
         "### Available Python libraries",
-        "Anything outside this set",
+        "Anything else",
         r"(?m)^- \*\*([^:*]+):\*\* (.*)$",
     ),
 ]
@@ -597,22 +593,19 @@ def test_the_documented_library_list_only_promises_what_ships(relpath, start, en
     )
 
 
-def test_no_doc_claims_a_shipped_package_was_removed():
-    """The other half of the promise: what a doc says is GONE must be gone.
+def test_no_doc_sends_a_shipped_package_to_a_folder_manifest():
+    """The other half of the promise: what a doc says is ABSENT must be absent.
 
-    `test_the_documented_library_list_matches_check_libs` pins the positive
-    list — what the app has. Nothing pinned the negative one, and that is
-    exactly where this rotted: two docs went on saying `fpdf2` had left
-    `[bundled]` after the removal was reversed, including
-    `fused-render-authoring`, which is what an agent reads to decide what it may
-    import. The consequence is not a broken build but a worse one — an agent
-    steered away from a package that is right there, or into declaring a folder
-    manifest it does not need, which is the precise outcome the reversal existed
-    to prevent.
+    `test_the_documented_library_list_only_promises_what_ships` pins the
+    positive list — what the app has. This pins the negative one: the sentence
+    naming what a page must declare in a folder `pyproject.toml` must not name
+    something the app already ships. Getting that wrong does not break a build;
+    it steers an agent away from a package that is right there, into a folder
+    manifest the page does not need and a first-run install the user waits
+    through.
 
-    Scanned as a set of names rather than by parsing prose: any distribution
-    `[bundled]` or the core dependencies actually ship must not appear in a
-    sentence claiming things were removed. Cheap, and it would have caught this.
+    Scanned as a set of names rather than by parsing prose: cheap, and it
+    catches the drift the moment a distribution moves between the two lists.
     """
     import re
 
@@ -620,7 +613,7 @@ def test_no_doc_claims_a_shipped_package_was_removed():
     offenders = {}
     for relpath, marker in [
         (os.path.join("skills", "fused-render-authoring", "SKILL.md"),
-         "no longer does:"),
+         "Anything else"),
     ]:
         with open(os.path.join(_REPO, relpath), encoding="utf-8") as f:
             text = f.read()
@@ -633,10 +626,10 @@ def test_no_doc_claims_a_shipped_package_was_removed():
         if wrong:
             offenders[relpath] = wrong
     assert not offenders, (
-        f"{offenders} are named as REMOVED but `[bundled]`/the core dependencies "
-        "still ship them, so the doc tells a reader (or an authoring agent) a "
-        "package is unavailable when it is importable with no declaration and no "
-        "install. Fix the doc, or remove the package for real."
+        f"{offenders} are named as needing a folder manifest, but `[bundled]`/the "
+        "core dependencies ship them — so the doc tells a reader (or an authoring "
+        "agent) a package is unavailable when it is importable with no declaration "
+        "and no install. Fix the doc, or drop the package for real."
     )
 
 


### PR DESCRIPTION
## Summary

Two things, both docs-only, both about `skills/`.

**1. Authored apps do full cold starts inside card thumbnails.** The shell renders pages nobody asked to *open* — `/apps` cards, listing-pane peeks, hover previews — and stamps those frames `_preview=1`. The authoring skill never mentioned it, so pages boot identically either way and a listing page fires every card's heavy imports, model loads, first-run extracts and daemon starts at once, for apps the reader never opened. A new section, **"Reserved params and preview mode"**, covers both halves of the `_` namespace: `_`-prefixed keys belong to the shell (never invent one, never read one off `location.search`, never rebuild the query yourself), and `_preview` is the single such key a page should read — only ever to do *less*. Its `isPreview()` snippet climbs same-origin ancestors, because reading `location.search` alone misses the inherited case where an outer template frame carries the stamp; it mirrors the runtime's own `selfOrAncestorHasFlag`. The section also names what the runtime already covers (`fused.daemon.*` rejects in a preview; a preview writes no URL) so a reader does not mistake that for coverage of their own `runPython`, `fused.ai` calls and timers, which run unless gated.

**2. A pass over all nine skills: split, condense, de-archaeologise.** Three surfaces that were being loaded to answer *any* authoring question became their own skills, each leaving a two-line stub behind:

| New skill | What moved | Lines |
|---|---|---|
| `fused-render-capture` | `fused.capture.*`, the per-platform refusal matrix, the recording handle | 101 |
| `fused-render-jobs` | the 60 s executor timeout and the ways around it, `trackJob`, the worker-side reporter | 118 |
| `fused-render-theming` | the four theme strategies and the token rules | 70 |

`fused.ai`'s section shrank the same way — `fused-render-ai` already carried the full option and rejection tables, and a second copy could only drift. **Authoring: 672 → 381 lines.**

**Archaeology removed throughout.** A skill is read by an agent deciding what to write *now*, so "this used to be bundled and was removed", "there used to be one question here", and "the three Transformers rows that used to sit between them were withdrawn" cost attention to say nothing about the present. Also gone: the naming rationale for `fused.daemon`, the OpenWhisper bug retold in three places, the port history in the index skill's section E. Every rule those passages justified is unchanged — just stated in the present tense. **Background-apps: 399 → 299 lines.**

**Descriptions** are always-loaded context, so each is now one short sentence plus its triggers (the AI skill's was 600+ characters of trigger list). Authoring's stays longest deliberately — it is the entry point that routes to the rest.

| Skill | Description | Body |
|---|---|---|
| fused-render-authoring | 415 ch | 381 lines |
| fused-render-ai | 257 ch | 758 lines |
| fused-render-background-apps | 321 ch | 299 lines |
| fused-render-index | 259 ch | 357 lines |
| fused-render-custom-templates | 253 ch | 122 lines |
| fused-render-jobs | 256 ch | 118 lines |
| fused-render-capture | 240 ch | 101 lines |
| fused-render-theming | 218 ch | 70 lines |
| fused-render-usage | 213 ch | 57 lines |

New skills need no registration — `scripts/hatch_build.py::_canonical_skills` discovers every `skills/<name>/SKILL.md`, and `skill_sources.skill_names()` is the same scan.

## Visuals

The behavioural delta is the boot gate the skill now teaches — one read, taken before anything expensive starts. Previously there was no `B`: every render took the `C` path.

```mermaid
flowchart TD
    A[Page boots in a frame] --> B{"_preview=1 here<br/>or on an ancestor?"}
    B -->|no| C[Real open: full boot]
    B -->|yes| D[Cheap placeholder<br/>or cached artifact]
    C --> E[runPython, AI, daemons,<br/>timers, writes]
    D --> F[Nothing started]
```

## Usage

Read by an agent authoring a fused-render app. The pattern the authoring skill now prescribes:

```js
function isPreview() {
  const has = (s) => {
    try { return new URLSearchParams(String(s).replace(/^\?/, "")).get("_preview") === "1"; }
    catch (e) { return false; }
  };
  if (has(location.search)) return true;
  try {
    let w = window;
    while (w.parent && w.parent !== w) {
      w = w.parent;
      if (has(w.location.search)) return true;
    }
  } catch (e) { /* cross-origin ancestor: the climb ends here */ }
  return false;
}

const PREVIEW = isPreview();

async function boot() {
  if (PREVIEW) return renderPlaceholder();   // synchronous, no Python, no network
  await loadEverything();
}
boot();
```

`fused_render/templates/fusedapp/template.html` is cited as the worked example — it reads the flag, asks the server for an existing extract only, and shows an inert card when there is none.

The three new skills are loaded the same way as the existing ones; `fused-render-authoring` routes to them by name from its intro and from the stubs it left behind.

## Test Plan

Two test anchors moved with the doc, in `tests/test_bundle_contents.py`, which parses the authoring skill's library section by literal markers:

- The section-end marker `"Anything outside this set"` → `"Anything else"`, which the check confirmed is unique in the file. The first candidate, `"Everything else"`, also appears in the intro — and the second test does a bare `find()`, so it would have silently scanned the wrong sentence and passed vacuously.
- `test_no_doc_claims_a_shipped_package_was_removed` existed because a doc kept claiming `fpdf2` had left `[bundled]`. The doc no longer claims anything was removed, so it is renamed `test_no_doc_sends_a_shipped_package_to_a_folder_manifest` — same guard, present-tense subject: a package the doc sends to a folder manifest must not be one the app already ships.

- [ ] **pytest was not run.** This worktree has no `.venv`, and the system Python lacks `httpx`, so `conftest`'s server import fails before collection. CI is what confirms the suite.
- [ ] **Verified by hand instead**, replicating each doc-anchored assertion against the edited files: both `test_bundle_contents.py` anchors resolve and their sets come back empty; `test_index_skill_reader.py`'s description-length, bridge-surface, route, section-letter, generation-guard and reader-compiles assertions all hold; `test_ai_runtime.py`'s `## Images:` heading and every reply field it greps for are intact; every skill's frontmatter `name` matches its directory; and no `` `fused-render-*` `` cross-reference in any skill points at a skill that does not exist.
- [ ] **Reviewer check — the preview facts are pinned to code, not prose.** `_preview` is read at `fused_render/static/runtime.js` (`PREVIEW_PARAM`, `selfOrAncestorHasFlag`, `IS_THUMBNAIL`); the daemon refusals it claims are the `IS_THUMBNAIL` guards on `start/stop/restart/setAutostart/call`; the reserved-key behaviour is `isReserved` in the same file (`set` throws, `get`/`getAll` skip, `_file` excepted). The listed shell params (`_file`, `_mode`, `_preview`, `_nofocus`, `_layout`, `_side`, `_panel`, `_tab`, `_listing`, `_render`, `_rev`) come from a grep of `frontend/src` + `runtime.js`.
- [ ] **Reviewer check — the split is content-preserving.** The moved sections are the same prose, and each stub names the surface and the skill that owns it. Worth a skim of `fused-render-authoring` end to end, since it is the file that changed shape.
