### PR TITLE
Claude shots: prune at 30 days / 1000 files

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -141,9 +141,12 @@ SHOTS = os.path.join(os.path.dirname(RUNS), "shots")
 # reading a path out of one turn's message, so a crop stops mattering when its
 # conversation does. The TTL is generously longer than a session anyone would
 # keep scrolling back through, and the count is the backstop for a machine that
-# never idles long enough for the TTL to fire.
-SHOTS_TTL = 12 * 3600
-SHOTS_KEEP = 200
+# never idles long enough for the TTL to fire. Was 12h / 200: a restored turn
+# re-reads its shots through /api/fs/raw, and a picture gone from a week-old
+# conversation reads as a bug, so both were raised (2026-08-27) to 30 days /
+# 1000 files — still bounded, no longer visible in ordinary use.
+SHOTS_TTL = 30 * 24 * 3600
+SHOTS_KEEP = 1000
 
 # Claude Code's own data dir, and it must be the SAME one the CLI itself uses —
 # reading the wrong dir loses history and resume. CLAUDE_CONFIG_DIR wins where


### PR DESCRIPTION
Was 12h / 200 files. Screenshots referenced by restored conversations were disappearing within a day. Agreed with Sina: 30 days / 1000 files.

Only `SHOTS_TTL` / `SHOTS_KEEP` in `fused_render/templates/claude/agent.py` change; the pruner is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bounded temp-dir housekeeping only; increases disk use for screenshot crops but does not change security, auth, or pruner behavior.
> 
> **Overview**
> **Raises screenshot retention** for Claude chat annotation crops stored under the shared `shots` directory so older conversations can still load images via `/api/fs/raw`.
> 
> `SHOTS_TTL` moves from **12 hours** to **30 days** (`30 * 24 * 3600`), and `SHOTS_KEEP` from **200** to **1000** files. Comments document that restored turns re-read these paths and that shorter limits made week-old chats look broken. **`_prune_shots` is unchanged** — it already enforces TTL and count caps using these constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc3d6108a8ed10ced4d7b0e08ce7b5faccf0ec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->