### PR TITLE
App page Files tab: no sidebar plate, neutral selected row

### DIFF
--- a/frontend/src/styles/app-page.css
+++ b/frontend/src/styles/app-page.css
@@ -127,7 +127,8 @@
 
 /* ---- the Files tab (shell/AppFiles.tsx) ------------------------------------
    ONE bordered surface, the way an editor's workbench is one window: a tree
-   column on a quieter plate, a single rule, then the view. The frame inside
+   column, a single rule, then the view — both on the same ground, so the rule
+   alone divides them. The frame inside
    the view is flush — the surface carries the radius, so nothing is boxed
    inside a box. Two rows of chrome at the same height (the tree's eyebrow, the
    view's header) so the rule between the columns reads as one line across.
@@ -148,7 +149,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--bg-alt);
+  background: var(--bg);
   border-right: 1px solid var(--border);
 }
 
@@ -216,15 +217,22 @@
 }
 
 .app-files-row:hover {
-  background: var(--row-bg-hover);
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
 }
 
 .app-files-row.is-selected {
-  background: var(--row-bg-active);
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--fg);
 }
 
-/* The selected file wears the accent as a bar, the way the tab strip wears it
-   as an underline — one vocabulary for "this one, right now". */
+.app-files-row.is-selected:hover {
+  background: color-mix(in srgb, var(--fg) 11%, transparent);
+}
+
+/* Selection is a neutral tint, not the accent wash: a file list is read, not
+   acted on, so the loud colour would fight the view beside it. The accent
+   survives only as the 2px bar, the same mark the tab strip uses for "this
+   one, right now". */
 .app-files-row.is-selected::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
On \`/apps/<path>\` → Files:

1. Tree column no longer sits on a \`--bg-alt\` plate — both columns share \`--bg\`, the rule alone divides them.
2. Selected file row drops the accent (yellow) wash for a neutral 8% foreground tint (11% on hover). The 2px accent bar stays as the single "this one" mark. Hover row moved to the same neutral mix at 5% so the steps read on the new ground.

CSS only, \`frontend/src/styles/app-page.css\`. Shell rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only visual tweaks on the app Files tab; no logic, auth, or data paths change.
> 
> **Overview**
> On the app page **Files** tab, the file tree column now uses the same **`--bg`** as the preview pane instead of **`--bg-alt`**, so both sides read as one surface with only the vertical rule separating them.
> 
> File row **hover** and **selected** states no longer use **`--row-bg-hover`** / **`--row-bg-active`**; they use neutral **`color-mix`** tints on foreground (5% hover, 8% selected, 11% selected+hover), with explicit text color on selection. The **2px accent bar** on the selected row is unchanged—the accent wash on the row background was removed so selection stays readable next to the file view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e656eb6654fa3a0c449adfb49c2758ec24bc3d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->