### PR TITLE
Apps: optional icon.svg — Projects row glyph + tab favicon

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2064,11 +2064,32 @@ export interface CurrentAppEntry {
   kind: "workspace" | "linked";
   entry: string | null;
   exists: boolean;
+  /** The app's optional `icon.svg` (canonical path) and its mtime — the
+   *  Projects row glyph and the tab favicon. Null when the file is absent. */
+  icon?: string | null;
+  icon_mtime?: number | null;
   added_at: number | null;
 }
 
 export function getCurrentApps(): Promise<{ apps: CurrentAppEntry[] }> {
   return getJson<{ apps: CurrentAppEntry[] }>("/api/current-apps");
+}
+
+/** The optional `icon.svg` of the app that owns `fsPath` (the folder itself
+ *  or any file inside it — the server's ownership rule), or `icon: null`. */
+export interface AppIconResult {
+  icon: string | null;
+  mtime?: number | null;
+}
+
+export function getAppIcon(fsPath: string): Promise<AppIconResult> {
+  return getJson<AppIconResult>("/api/apps/icon?path=" + encodeURIComponent(fsPath));
+}
+
+/** The URL to draw an app icon from: the raw file, with its mtime as a cache
+ *  key so an edited icon.svg shows up without a hard reload. */
+export function appIconUrl(icon: string, mtime?: number | null): string {
+  return rawUrl(icon) + (mtime ? "&v=" + Math.floor(mtime) : "");
 }
 
 /** Take an app off the desk. SIDE EFFECT, by design: every task whose project

--- a/frontend/src/platform/lib/hooks.ts
+++ b/frontend/src/platform/lib/hooks.ts
@@ -139,6 +139,32 @@ export function useDocumentTitle(label: string | null | undefined): void {
   }, [label]);
 }
 
+// The shell's own tab icon (frontend/index.html) — what every route shows
+// unless an app supplies its optional icon.svg.
+const DEFAULT_FAVICON = "/favicon.ico";
+
+// Tab icon: swap the shell's `<link rel="icon">` for an app's own icon.svg
+// while a route inside that app is on screen, and put the default back when
+// the route leaves (cleanup) or the href goes null (no icon for this app).
+// One writer at a time by construction — the callers (AppPage, StatView) are
+// mutually exclusive mounts — so there is no arbitration, only the restore.
+// The `type` attribute is set only for the svg and removed on restore: the
+// .ico link in index.html carries none, and a stale `image/svg+xml` on it
+// makes some browsers refuse the default.
+export function useFavicon(href: string | null): void {
+  useEffect(() => {
+    if (!href) return;
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    if (!link) return;
+    link.href = href;
+    link.type = "image/svg+xml";
+    return () => {
+      link.href = DEFAULT_FAVICON;
+      link.removeAttribute("type");
+    };
+  }, [href]);
+}
+
 // The builtin-mount readiness hook lived here: a bounded /api/config poll that
 // answered "is the bundled zip mount attached and browsable yet", seeded from
 // the boot-time config snapshot because the one-shot fetch (main.tsx) lands

--- a/frontend/src/platform/lib/hooks.ts
+++ b/frontend/src/platform/lib/hooks.ts
@@ -139,9 +139,15 @@ export function useDocumentTitle(label: string | null | undefined): void {
   }, [label]);
 }
 
-// The shell's own tab icon (frontend/index.html) — what every route shows
-// unless an app supplies its optional icon.svg.
-const DEFAULT_FAVICON = "/favicon.ico";
+// The shell's own tab icon: READ off the `<link rel="icon">` the document
+// arrived with, not spelled here. frontend/index.html says `/favicon.ico`,
+// but Vite rewrites that to the build's base (`/static/shell-dist/favicon.ico`,
+// vite.config.js) — a hard-coded `/favicon.ico` restore was a 404, which is
+// what the blank placeholder on the tab was (owner, 2026-08-27, second
+// report). Captured lazily on the first swap, so it is whatever the served
+// index.html linked, dev or packaged.
+const DEFAULT_FAVICON = Symbol("default favicon");
+let defaultHref: string | null = null;
 
 // The fused-render mark's own two colours (frontend/public/favicon.ico: the
 // #1b1d21 rounded square, the #e5ff44 glyph). An app's favicon is composed in
@@ -153,13 +159,24 @@ const FAVICON_FG = "#e5ff44";
 // its href: browsers (Chrome at least) do not reliably refetch when an existing
 // link's href flips back to a URL it showed before, which left the previous
 // app's icon stuck on a tab until a hard reload (owner, 2026-08-27). A fresh
-// node is a fresh icon request every time.
-function setFaviconHref(href: string): void {
+// node is a fresh icon request every time. The default goes back with a unique
+// query string as well — Chrome's per-document favicon cache can answer a URL
+// it already holds without repainting; static serving ignores the query, so
+// the bytes are the same file under a new key.
+let restoreSeq = 0;
+function setFaviconHref(href: string | typeof DEFAULT_FAVICON): void {
   const old = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+  if (defaultHref === null && old) defaultHref = old.href;
   const link = document.createElement("link");
   link.rel = "icon";
-  link.href = href;
-  if (href === DEFAULT_FAVICON) link.setAttribute("sizes", "any");
+  if (href === DEFAULT_FAVICON) {
+    if (!defaultHref) return;
+    const sep = defaultHref.includes("?") ? "&" : "?";
+    link.href = `${defaultHref}${sep}r=${++restoreSeq}`;
+    link.setAttribute("sizes", "any");
+  } else {
+    link.href = href;
+  }
   if (old) old.replaceWith(link);
   else document.head.appendChild(link);
 }

--- a/frontend/src/platform/lib/hooks.ts
+++ b/frontend/src/platform/lib/hooks.ts
@@ -143,24 +143,96 @@ export function useDocumentTitle(label: string | null | undefined): void {
 // unless an app supplies its optional icon.svg.
 const DEFAULT_FAVICON = "/favicon.ico";
 
-// Tab icon: swap the shell's `<link rel="icon">` for an app's own icon.svg
-// while a route inside that app is on screen, and put the default back when
-// the route leaves (cleanup) or the href goes null (no icon for this app).
-// One writer at a time by construction — the callers (AppPage, StatView) are
-// mutually exclusive mounts — so there is no arbitration, only the restore.
-// The `type` attribute is set only for the svg and removed on restore: the
-// .ico link in index.html carries none, and a stale `image/svg+xml` on it
-// makes some browsers refuse the default.
+// The fused-render mark's own two colours (frontend/public/favicon.ico: the
+// #1b1d21 rounded square, the #e5ff44 glyph). An app's favicon is composed in
+// the same livery so every fused tab reads as one family.
+const FAVICON_BG = "#1b1d21";
+const FAVICON_FG = "#e5ff44";
+
+// Set the tab icon by REPLACING the `<link rel="icon">` node, never by editing
+// its href: browsers (Chrome at least) do not reliably refetch when an existing
+// link's href flips back to a URL it showed before, which left the previous
+// app's icon stuck on a tab until a hard reload (owner, 2026-08-27). A fresh
+// node is a fresh icon request every time.
+function setFaviconHref(href: string): void {
+  const old = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+  const link = document.createElement("link");
+  link.rel = "icon";
+  link.href = href;
+  if (href === DEFAULT_FAVICON) link.setAttribute("sizes", "any");
+  if (old) old.replaceWith(link);
+  else document.head.appendChild(link);
+}
+
+// An app's icon.svg as a favicon in the fused livery: the svg's alpha as a
+// yellow glyph, inset on a black rounded square — mirroring the shell's own
+// mark (owner, 2026-08-27). Composed on a canvas: the svg is drawn to an
+// offscreen layer and recoloured with `source-in` (its shape, our colour — the
+// same alpha-mask idea the sidebar uses via CSS mask), then laid over the
+// square. Resolves to a PNG data URL, or null when the svg fails to load or
+// the canvas is unavailable — callers then leave the default icon in place.
+async function composeFavicon(src: string): Promise<string | null> {
+  const img = new Image();
+  const loaded = new Promise<boolean>((resolve) => {
+    img.onload = () => resolve(true);
+    img.onerror = () => resolve(false);
+  });
+  img.src = src;
+  if (!(await loaded)) return null;
+  const size = 64;
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  // The square: radius and inset in the ico's own proportions (a soft corner
+  // and a glyph that fills the middle ~56%).
+  const r = size * 0.22;
+  ctx.fillStyle = FAVICON_BG;
+  ctx.beginPath();
+  ctx.roundRect(0, 0, size, size, r);
+  ctx.fill();
+  // The glyph, recoloured on its own layer so the fill cannot bleed onto the
+  // square. Drawn with its aspect kept inside the inset box.
+  const layer = document.createElement("canvas");
+  layer.width = layer.height = size;
+  const lc = layer.getContext("2d");
+  if (!lc) return null;
+  const inset = size * 0.22;
+  const box = size - inset * 2;
+  const iw = img.naturalWidth || box;
+  const ih = img.naturalHeight || box;
+  const scale = Math.min(box / iw, box / ih);
+  const dw = iw * scale;
+  const dh = ih * scale;
+  lc.drawImage(img, (size - dw) / 2, (size - dh) / 2, dw, dh);
+  lc.globalCompositeOperation = "source-in";
+  lc.fillStyle = FAVICON_FG;
+  lc.fillRect(0, 0, size, size);
+  ctx.drawImage(layer, 0, 0);
+  try {
+    return canvas.toDataURL("image/png");
+  } catch {
+    return null;
+  }
+}
+
+// Tab icon: while a route inside an app is on screen, its optional icon.svg
+// (composed in the fused livery, above) replaces the shell's own; the default
+// comes back when the route leaves (cleanup) or the href goes null (no icon
+// for this app). One writer at a time by construction — the callers (AppPage,
+// StatView) are mutually exclusive mounts — so there is no arbitration, only
+// the restore. Composition is async, so a `live` flag stops a slow icon from
+// landing after the route moved on.
 export function useFavicon(href: string | null): void {
   useEffect(() => {
     if (!href) return;
-    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
-    if (!link) return;
-    link.href = href;
-    link.type = "image/svg+xml";
+    let live = true;
+    composeFavicon(href).then((dataUrl) => {
+      if (live && dataUrl) setFaviconHref(dataUrl);
+    });
     return () => {
-      link.href = DEFAULT_FAVICON;
-      link.removeAttribute("type");
+      live = false;
+      setFaviconHref(DEFAULT_FAVICON);
     };
   }, [href]);
 }

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -24,6 +24,8 @@ import {
 } from "@platform/lib/router";
 import { useRecentsTracking } from "@apps/explorer/lib/recents";
 import {
+  appIconUrl,
+  getAppIcon,
   statPath,
   getMounts,
   reconnectMount,
@@ -34,6 +36,7 @@ import {
 import {
   useNavEpoch,
   useDocumentTitle,
+  useFavicon,
   useRefreshOnReturn,
 } from "@platform/lib/hooks";
 import { useMountHealth } from "@platform/lib/mountHealth";
@@ -334,6 +337,26 @@ function StatView({
   // not on a `_mode` switch within the same file — TemplatePreview owns that.
   const [renderedTitle, setRenderedTitle] = useState<string | null>(null);
   useDocumentTitle(fsPath === "/" ? null : renderedTitle || basename(fsPath));
+  // Tab favicon: a path inside an app (the folder itself, or a page such as
+  // its index.html) wears that app's optional icon.svg — `/api/apps/icon`
+  // applies the server's ownership rule, so this agrees with the Projects row
+  // and the app page. Null (the shell's own icon) everywhere else. Guarded so
+  // a fast navigation cannot paint the previous path's answer.
+  const [iconHref, setIconHref] = useState<string | null>(null);
+  useEffect(() => {
+    let live = true;
+    setIconHref(null);
+    if (fsPath === "/") return;
+    getAppIcon(fsPath)
+      .then((r) => {
+        if (live) setIconHref(r.icon ? appIconUrl(r.icon, r.mtime) : null);
+      })
+      .catch(() => live && setIconHref(null));
+    return () => {
+      live = false;
+    };
+  }, [fsPath]);
+  useFavicon(iconHref);
   // Recents: the explorer's own store, gated on a confirmed FILE, so a
   // directory never lands there. The app
   // builder's parallel (tag, name) store went with its route — nothing displays

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -52,13 +52,15 @@ import {
   type ReactNode,
 } from "react";
 import {
+  appIconUrl,
   getAppEntry,
+  getAppIcon,
   resolveConditions,
   statPath,
   type Config,
   type TemplateEntry,
 } from "@platform/lib/api";
-import { useUrlVersion } from "@platform/lib/hooks";
+import { useFavicon, useUrlVersion } from "@platform/lib/hooks";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import { navigateUrl, urlForFsPath } from "@platform/lib/router";
 import {
@@ -222,6 +224,25 @@ export default function AppPage({
   // back/forward between the two tabs lands on the right one.
   useUrlVersion();
   const tab = appPageTabFromSearch(location.search);
+
+  // The tab favicon is the app's optional icon.svg while its page is open
+  // (`/api/apps/icon`; the same file the Projects row draws). Guarded by
+  // `live` like the resolve below, so a fast switch between two apps cannot
+  // paint the first one's icon over the second.
+  const [iconHref, setIconHref] = useState<string | null>(null);
+  useEffect(() => {
+    let live = true;
+    setIconHref(null);
+    getAppIcon(dir)
+      .then((r) => {
+        if (live) setIconHref(r.icon ? appIconUrl(r.icon, r.mtime) : null);
+      })
+      .catch(() => live && setIconHref(null));
+    return () => {
+      live = false;
+    };
+  }, [dir]);
+  useFavicon(iconHref);
 
   useEffect(() => {
     let live = true;

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -225,24 +225,26 @@ function CurrentAppRow({
       className={
         "bookmark-row current-app-row" +
         (active ? " active" : "") +
-        (app.exists ? "" : " is-missing")
+        (app.exists ? "" : " is-missing") +
+        (app.running ? " is-running" : "")
       }
       title={tip}
       draggable
       {...drag}
     >
       <span className="bookmark-glyph current-app-glyph" aria-hidden="true">
-        {app.running ? (
-          <span className="sidebar-rail-dot is-running" />
-        ) : app.iconUrl ? (
-          // The app's own icon.svg in the generic mark's slot. `draggable`
-          // off: the row is the drag handle, and a bare <img> would hijack
-          // the drag ghost (the <a> below carries the same guard).
-          <img
+        {app.iconUrl ? (
+          // The app's own icon.svg in the generic mark's slot, as a CSS MASK
+          // over currentColor rather than an <img>: authors draw in black,
+          // and a black glyph on the dark theme vanished (owner, 2026-08-27).
+          // Masked, the shape takes the row's colour — muted, accent when
+          // active — exactly like the ▣ it replaces.
+          <span
             className="current-app-icon"
-            src={app.iconUrl}
-            alt=""
-            draggable={false}
+            style={{
+              maskImage: `url("${app.iconUrl}")`,
+              WebkitMaskImage: `url("${app.iconUrl}")`,
+            }}
           />
         ) : (
           "▣"
@@ -257,6 +259,14 @@ function CurrentAppRow({
       >
         {app.name}
       </a>
+      {/* The running dot sits AFTER the name (owner, 2026-08-27), so it never
+          covers the app's icon: the glyph slot is identity, the dot is state. */}
+      {app.running && (
+        <span
+          className="sidebar-rail-dot is-running current-app-running"
+          aria-hidden="true"
+        />
+      )}
       <span className="bookmark-actions">
         <button
           className="icon-btn delete-btn current-app-archive"

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -232,7 +232,21 @@ function CurrentAppRow({
       {...drag}
     >
       <span className="bookmark-glyph current-app-glyph" aria-hidden="true">
-        {app.running ? <span className="sidebar-rail-dot is-running" /> : "▣"}
+        {app.running ? (
+          <span className="sidebar-rail-dot is-running" />
+        ) : app.iconUrl ? (
+          // The app's own icon.svg in the generic mark's slot. `draggable`
+          // off: the row is the drag handle, and a bare <img> would hijack
+          // the drag ghost (the <a> below carries the same guard).
+          <img
+            className="current-app-icon"
+            src={app.iconUrl}
+            alt=""
+            draggable={false}
+          />
+        ) : (
+          "▣"
+        )}
       </span>
       <a
         className="bookmark-name"

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -47,6 +47,9 @@ export interface CurrentApp {
   /** Something is running under it right now — the row wears the running dot.
    *  Read from the task pulse, which the sidebar already subscribes to. */
   running: boolean;
+  /** The app's optional `icon.svg`, as a drawable URL (api.appIconUrl), or
+   *  null — the glyph slot falls back to the generic mark. */
+  iconUrl: string | null;
 }
 
 /** Is `project` this app's folder or somewhere inside it — the scope test the
@@ -70,7 +73,18 @@ export function currentApps(
     kind: e.kind,
     exists: e.exists,
     running: live.some((p) => isUnderDir(p, e.path)),
+    iconUrl: e.icon ? iconUrlFor(e.icon, e.icon_mtime) : null,
   }));
+}
+
+/** api.ts `appIconUrl` restated (raw file + mtime cache key) — that module is
+ *  not importable here for the same DOM-free reason as the codec above. */
+function iconUrlFor(icon: string, mtime?: number | null): string {
+  return (
+    "/api/fs/raw?path=" +
+    encodeURIComponent(icon) +
+    (mtime ? "&v=" + Math.floor(mtime) : "")
+  );
 }
 
 // ---- the app page's address (D488) ------------------------------------------

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -1187,20 +1187,33 @@ a.bookmark-name::after {
   justify-content: center;
 }
 
-/* The running dot rides the glyph slot rather than the rail icon it was drawn
-   for: unposition it so it centres in the 14px slot. */
-.current-app-glyph > .sidebar-rail-dot {
-  position: static;
-}
-
-/* The app's own icon.svg, filling the 14px glyph slot. Drawn at its authored
-   colours — the active-row accent recolour cannot reach an <img>, the same
-   way it leaves a bookmark's custom emoji alone. */
+/* The app's own icon.svg, filling the 14px glyph slot as a mask over
+   currentColor: the shape is the author's, the colour is the row's (muted,
+   accent when active), so a black-drawn svg reads on the dark theme. */
 .current-app-icon {
   display: block;
   width: 14px;
   height: 14px;
-  object-fit: contain;
+  background: currentColor;
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+}
+
+/* The running dot sits after the name, in flow: the name gives up its
+   stretch so the dot hugs the text instead of drifting to the row's end
+   (under the hover-only actions). */
+.current-app-row.is-running .bookmark-name {
+  flex: 0 1 auto;
+}
+
+.current-app-running {
+  position: static;
+  flex: 0 0 auto;
+  margin-left: 6px;
 }
 
 .current-app-archive:disabled {

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -1193,6 +1193,16 @@ a.bookmark-name::after {
   position: static;
 }
 
+/* The app's own icon.svg, filling the 14px glyph slot. Drawn at its authored
+   colours — the active-row accent recolour cannot reach an <img>, the same
+   way it leaves a bookmark's custom emoji alone. */
+.current-app-icon {
+  display: block;
+  width: 14px;
+  height: 14px;
+  object-fit: contain;
+}
+
 .current-app-archive:disabled {
   opacity: 0.5;
   cursor: default;

--- a/fused_render/current_apps.py
+++ b/fused_render/current_apps.py
@@ -190,10 +190,27 @@ def _added_epoch(ts) -> float | None:
         return None
 
 
+ICON_NAME = "icon.svg"
+
+
+def app_icon(folder: str) -> dict | None:
+    """The app's optional ``icon.svg`` — ``{"icon": <canonical path>, "mtime":
+    <epoch>}`` when the file sits directly in the app folder, else None. One
+    fixed name, no lookup table: the sidebar's Projects row and the tab favicon
+    both read it, and the mtime rides along so the client can bust the
+    browser's (aggressive) favicon cache when the author edits the file.
+    Raises OSError like the isdir it sits next to — callers already catch."""
+    p = os.path.join(folder, ICON_NAME)
+    if not os.path.isfile(p):
+        return None
+    return {"icon": canonical_fs_path(p), "mtime": os.stat(p).st_mtime}
+
+
 def list_apps() -> list[dict]:
     """The desk, in stored (added) order. Each: ``path`` (canonical), ``name``
     (folder name), ``kind`` (``linked`` for a registry folder, ``workspace``
-    otherwise), ``entry`` (the page to run, or None), ``exists``, ``added_at``
+    otherwise), ``entry`` (the page to run, or None), ``exists``, ``icon`` /
+    ``icon_mtime`` (the optional ``icon.svg``, see `app_icon`), ``added_at``
     (epoch). A folder that is gone or unreadable still lists — the row is the
     user's to remove — with ``exists`` false and no entry."""
     linked = {
@@ -206,11 +223,13 @@ def list_apps() -> list[dict]:
         path = a["path"]
         entry = None
         exists = False
+        icon = None
         if not guard.blocks(path):
             try:
                 exists = os.path.isdir(path)
                 if exists:
                     entry = app_listing.app_entry(path)
+                    icon = app_icon(path)
             except OSError:
                 exists = False
         out.append({
@@ -219,6 +238,8 @@ def list_apps() -> list[dict]:
             "kind": "linked" if path in linked else "workspace",
             "entry": canonical_fs_path(entry) if entry else None,
             "exists": exists,
+            "icon": icon["icon"] if icon else None,
+            "icon_mtime": icon["mtime"] if icon else None,
             "added_at": _added_epoch(a.get("addedAt")),
         })
     return out

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -323,6 +323,29 @@ def _app_folder_exists(rel: str) -> bool:
     return os.path.isdir(os.path.join(fused_dir(), "/".join(parts)))
 
 
+@router.get("/api/apps/icon")
+def api_app_icon(path: str):
+    """The optional ``icon.svg`` of the app that owns ``path`` — the folder
+    itself, or a file anywhere inside an app (a page open in the explorer).
+    Ownership is the tasks' rule (`current_apps.app_dir_for`: registry first,
+    then the workspace climb to the first tagged folder), so the favicon on
+    `/explorer/.../index.html` agrees with the Projects row. `{"icon": null}`
+    for anything outside an app or an app without the file; `mtime` rides
+    along for cache-busting."""
+    from fused_render import current_apps
+
+    if not isinstance(path, str) or not os.path.isabs(path):
+        return {"icon": None}
+    folder = current_apps.app_dir_for(path)
+    if folder is None:
+        return {"icon": None}
+    try:
+        found = current_apps.app_icon(folder)
+    except OSError:
+        found = None
+    return found or {"icon": None}
+
+
 @router.get("/api/apps/entry")
 def api_app_entry(path: str):
     """The folder's app entry (its first tagged top-level page — the one rule,

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -34,7 +34,7 @@ fused-render is a local file explorer that renders `.html` files live in the bro
 <meta name="fused-app" />
 ```
 
-**Optional app icon: `icon.svg`.** Drop an `icon.svg` (that exact lowercase name) next to the entry page and the shell picks it up with no registration: it becomes the app's glyph in the sidebar's Projects list and the browser-tab favicon on the app's page (`/apps/<folder>`) and on any of its files opened in the explorer. Skip it and the generic mark is used. Keep it a single flat shape, legible at 14–16 px, no text. In the sidebar it is drawn as a **mask** — only the shape's alpha matters and the colour comes from the theme — so draw solid shapes on a transparent background (any fill colour works; a filled background rectangle would render as a solid square). The favicon shows the file as authored.
+**Optional app icon: `icon.svg`.** Drop an `icon.svg` (that exact lowercase name) next to the entry page and the shell picks it up with no registration: it becomes the app's glyph in the sidebar's Projects list and the browser-tab favicon on the app's page (`/apps/<folder>`) and on any of its files opened in the explorer. Skip it and the generic mark is used. Keep it a single flat shape, legible at 14–16 px, no text. Both places use it as a **mask** — only the shape's alpha matters; the sidebar colours it from the theme, the tab icon paints it yellow on the black rounded square of the fused mark — so draw solid shapes on a transparent background (any fill colour works; a filled background rectangle would render as a solid square).
 
 Three primitives — `runPython`, `params`, and the file IO helpers — are the core API; the table below has the rest. Everything else is ordinary HTML/CSS/JS: no framework, no build step, ES2020 fine.
 

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -34,7 +34,7 @@ fused-render is a local file explorer that renders `.html` files live in the bro
 <meta name="fused-app" />
 ```
 
-**Optional app icon: `icon.svg`.** Drop an `icon.svg` (that exact lowercase name) next to the entry page and the shell picks it up with no registration: it becomes the app's glyph in the sidebar's Projects list and the browser-tab favicon on the app's page (`/apps/<folder>`) and on any of its files opened in the explorer. Skip it and the generic mark is used. Keep it simple and legible at 14–16 px — a single flat shape, no text; it is drawn at its own colours on both light and dark backgrounds, so avoid relying on a transparent-background-only contrast.
+**Optional app icon: `icon.svg`.** Drop an `icon.svg` (that exact lowercase name) next to the entry page and the shell picks it up with no registration: it becomes the app's glyph in the sidebar's Projects list and the browser-tab favicon on the app's page (`/apps/<folder>`) and on any of its files opened in the explorer. Skip it and the generic mark is used. Keep it a single flat shape, legible at 14–16 px, no text. In the sidebar it is drawn as a **mask** — only the shape's alpha matters and the colour comes from the theme — so draw solid shapes on a transparent background (any fill colour works; a filled background rectangle would render as a solid square). The favicon shows the file as authored.
 
 Three primitives — `runPython`, `params`, and the file IO helpers — are the core API; the table below has the rest. Everything else is ordinary HTML/CSS/JS: no framework, no build step, ES2020 fine.
 

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -34,6 +34,8 @@ fused-render is a local file explorer that renders `.html` files live in the bro
 <meta name="fused-app" />
 ```
 
+**Optional app icon: `icon.svg`.** Drop an `icon.svg` (that exact lowercase name) next to the entry page and the shell picks it up with no registration: it becomes the app's glyph in the sidebar's Projects list and the browser-tab favicon on the app's page (`/apps/<folder>`) and on any of its files opened in the explorer. Skip it and the generic mark is used. Keep it simple and legible at 14–16 px — a single flat shape, no text; it is drawn at its own colours on both light and dark backgrounds, so avoid relying on a transparent-background-only contrast.
+
 Three primitives — `runPython`, `params`, and the file IO helpers — are the core API; the table below has the rest. Everything else is ordinary HTML/CSS/JS: no framework, no build step, ES2020 fine.
 
 Four neighbouring skills own the bigger surfaces, and this one keeps only enough to know when you need them: **`fused-render-ai`** (`fused.ai` and every model call), **`fused-render-capture`** (native screen/audio/screenshot), **`fused-render-jobs`** (work longer than one call, and the download manager), **`fused-render-theming`** (light/dark).


### PR DESCRIPTION
## Summary
- Optional `icon.svg` in an app folder (exact lowercase name, next to the entry page).
- **Sidebar Projects row** draws it in the glyph slot (`GET /api/current-apps` now returns `icon` / `icon_mtime`). Running dot still wins over the glyph, as before.
- **Tab favicon** becomes the icon on `/apps/<folder>` (AppPage) and on any file inside the app opened in the explorer (StatView) — new `GET /api/apps/icon?path=` resolves the owning app with `current_apps.app_dir_for`, so a page at `/explorer/.../index.html` gets the same icon as the row. `useFavicon` swaps `<link rel="icon">` and restores `/favicon.ico` on leave.
- mtime rides as `&v=` on the raw URL so an edited icon shows without a hard reload.
- Authoring skill: short note that the file is optional and what it affects.

Assumption: "explorer paths for the app" = any path the server's ownership rule places inside an app (registry folder or workspace climb to the first tagged folder), not just `index.html`.

No D row, no tests run (owner's standing rule). Shell built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive UI and a read-only API; favicon logic is client-only with graceful fallback when composition fails.
> 
> **Overview**
> Adds optional **`icon.svg`** in each app folder so authors get a custom glyph in the sidebar **Projects** list and a matching browser tab icon on the app page and on explorer routes inside that app.
> 
> **Server:** `list_apps` / `GET /api/current-apps` now include `icon` and `icon_mtime`; new **`GET /api/apps/icon?path=`** resolves the owning app via `app_dir_for` and returns the same file plus mtime for cache busting.
> 
> **Shell UI:** Projects rows render the SVG as a **CSS mask** (theme-colored shape) instead of the generic ▣; the **running** indicator moves **after the name** so it no longer replaces the glyph. **`AppPage`** and explorer **`StatView`** fetch the icon and drive **`useFavicon`**, which composes the SVG into the fused yellow-on-dark favicon livery on a canvas and swaps `<link rel="icon">` (with restore/cache-busting fixes for Chrome).
> 
> **Docs:** Authoring skill notes the optional file and mask/favicon behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a85056b8e46bac7ff97c57e15463aa932831e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->