### PR TITLE
Tasks & AI Models polish: size right, tooltip scroll, list frame, Enter-to-instructions, file mark press, ring tour step

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,6 +60,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2007,6 +2008,7 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2251,6 +2253,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -3034,6 +3037,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3421,6 +3425,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
       "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4854,6 +4859,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4866,6 +4872,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5672,6 +5679,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5794,6 +5802,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5950,6 +5959,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/apps/ai_models/local/RecommendedCard.tsx
+++ b/frontend/src/apps/ai_models/local/RecommendedCard.tsx
@@ -151,8 +151,12 @@ function ModelCard({
           should be same".
           Id first, figure pinned to the right edge (2026-08-27: "move the size
           all the way to the right in the card"). */}
-      <div className="am-card-sub" data-hint={slug}>
-        <span className="am-card-slug cc-mono">{slug}</span>
+      {/* THE HINT IS ON THE ID, not the line (Akshil, 2026-08-27: "this tooltip
+          should only appear when I'm hovering on the ... model name text, not on
+          the empty space between model and size"). The line spans the card, so
+          a hint on it fired over the gap the figure's right-pin opened up. */}
+      <div className="am-card-sub">
+        <span className="am-card-slug cc-mono" data-hint={slug}>{slug}</span>
         <span className="am-card-size" data-hint={size.title}>
           {size.text}
         </span>

--- a/frontend/src/apps/ai_models/local/RecommendedCard.tsx
+++ b/frontend/src/apps/ai_models/local/RecommendedCard.tsx
@@ -149,12 +149,13 @@ function ModelCard({
           from the cached card drawn next to it in the same row — "why are they
           not the same? at least the name, the mlx-community thing and the size
           should be same".
-          Cost first, then the address of the thing it is the cost of. */}
+          Id first, figure pinned to the right edge (2026-08-27: "move the size
+          all the way to the right in the card"). */}
       <div className="am-card-sub" data-hint={slug}>
+        <span className="am-card-slug cc-mono">{slug}</span>
         <span className="am-card-size" data-hint={size.title}>
           {size.text}
         </span>
-        <span className="am-card-slug cc-mono">{slug}</span>
       </div>
       {what && <div className="am-card-what">{what}</div>}
       {progress}

--- a/frontend/src/apps/ai_models/local/RepoCard.tsx
+++ b/frontend/src/apps/ai_models/local/RepoCard.tsx
@@ -411,17 +411,12 @@ export function RepoCard({
             top-right corner whatever the name's length. */}
         <ModelInfoButton repo={repo} />
       </div>
-      {/* WHAT IT COSTS, THEN WHICH REPO IT IS — one line, directly under the
+      {/* WHICH REPO IT IS, THEN WHAT IT COSTS — one line, directly under the
           name (Akshil, 2026-08-25: "the size should not be after the model name
-          checkmark, it should be right below it").
-
-          The figure spent an hour up in the head, beside the name, on the
-          argument that the recommendation cards drawn next to these keep it
-          there. Those cards have no second line to put it on — their head IS
-          their only line — so matching them there bought consistency with a
-          card that had no choice, and cost the disk card the one arrangement
-          that reads as a caption: cost first, then the address of the thing it
-          is the cost of.
+          checkmark, it should be right below it"; 2026-08-27: "move the size
+          all the way to the right in the card"). The id continues the name
+          above it, and the figure sits pinned to the card's right edge, where
+          a column of cards lines its figures up against a shared margin.
 
           No separator between them: a middot in `--border` at 11px on a card
           wash is a mark nobody can see ("the dot here is barely visible, let's
@@ -431,13 +426,13 @@ export function RepoCard({
           with the whole thing on hover — a wrapped second line would set every
           card's height from the longest repo name in the section. */}
       <div className="am-card-sub" data-hint={repo.id}>
+        <span className="am-card-slug cc-mono">{repo.id}</span>
         <span
           className="am-card-size"
           data-hint={repo.mtime ? `Last changed ${formatMtimeFull(repo.mtime)}` : undefined}
         >
           {formatSize(repo.size)}
         </span>
-        <span className="am-card-slug cc-mono">{repo.id}</span>
       </div>
       {/* THE TWO TAGS THAT ARE STATE, not identity — and nothing else.
           This row held five chips (engine, task, parameters, quantization,

--- a/frontend/src/apps/ai_models/local/RepoCard.tsx
+++ b/frontend/src/apps/ai_models/local/RepoCard.tsx
@@ -425,8 +425,12 @@ export function RepoCard({
           Ellipsised on the id, which is the half that can be arbitrarily long,
           with the whole thing on hover — a wrapped second line would set every
           card's height from the longest repo name in the section. */}
-      <div className="am-card-sub" data-hint={repo.id}>
-        <span className="am-card-slug cc-mono">{repo.id}</span>
+      {/* THE HINT IS ON THE ID, not the line (Akshil, 2026-08-27: "this tooltip
+          should only appear when I'm hovering on the ... model name text, not on
+          the empty space between model and size"). The line spans the card, so
+          a hint on it fired over the gap the figure's right-pin opened up. */}
+      <div className="am-card-sub">
+        <span className="am-card-slug cc-mono" data-hint={repo.id}>{repo.id}</span>
         <span
           className="am-card-size"
           data-hint={repo.mtime ? `Last changed ${formatMtimeFull(repo.mtime)}` : undefined}

--- a/frontend/src/apps/ai_models/local/repoCardControls.test.ts
+++ b/frontend/src/apps/ai_models/local/repoCardControls.test.ts
@@ -253,8 +253,10 @@ describe("what the card's face keeps, and what the (i) takes", () => {
     // that tells them apart, and the name itself then ellipsises. The owner is
     // not lost — it leads the line directly below.
     expect(CARD).toContain("{modelName(repo.id)}");
-    expect(CARD).toContain('<div className="am-card-sub" data-hint={repo.id}>');
-    expect(CARD).toContain('<span className="am-card-slug cc-mono">{repo.id}</span>');
+    // The hint rides the ID, not the whole line: the line spans the card, and a
+    // hint on it fired over the empty space between id and size.
+    expect(CARD).toContain('<div className="am-card-sub">');
+    expect(CARD).toContain('<span className="am-card-slug cc-mono" data-hint={repo.id}>{repo.id}</span>');
     // The FIGURE ends that line, pinned to the card's right edge, and is NOT
     // in the head (Akshil, 2026-08-25: "the size should not be after the model
     // name checkmark, it should be right below it"; 2026-08-27: "move the size
@@ -378,7 +380,8 @@ describe("every card on the page has the same bones", () => {
 
   it("name, then a caption line of size + repo id, in that order", () => {
     // The shared skeleton draws it once for both of the not-on-disk cards.
-    expect(REC).toContain('<div className="am-card-sub" data-hint={slug}>');
+    expect(REC).toContain('<div className="am-card-sub">');
+    expect(REC).toContain('<span className="am-card-slug cc-mono" data-hint={slug}>{slug}</span>');
     const sub = REC.slice(REC.indexOf('<div className="am-card-sub"'));
     expect(sub.indexOf("am-card-slug")).toBeLessThan(sub.indexOf("{size.text}"));
     // Both callers hand it the same two things the disk card shows.

--- a/frontend/src/apps/ai_models/local/repoCardControls.test.ts
+++ b/frontend/src/apps/ai_models/local/repoCardControls.test.ts
@@ -255,18 +255,18 @@ describe("what the card's face keeps, and what the (i) takes", () => {
     expect(CARD).toContain("{modelName(repo.id)}");
     expect(CARD).toContain('<div className="am-card-sub" data-hint={repo.id}>');
     expect(CARD).toContain('<span className="am-card-slug cc-mono">{repo.id}</span>');
-    // The FIGURE leads that line and is NOT in the head: cost first, then the
-    // address of the thing it is the cost of (Akshil, 2026-08-25: "the size
-    // should not be after the model name checkmark, it should be right below
-    // it"). It sat in the head for an hour, matching the recommendation cards —
-    // which have no second line to put it on, so that was consistency with a
-    // card that had no choice.
+    // The FIGURE ends that line, pinned to the card's right edge, and is NOT
+    // in the head (Akshil, 2026-08-25: "the size should not be after the model
+    // name checkmark, it should be right below it"; 2026-08-27: "move the size
+    // all the way to the right in the card"). The id leads, continuing the
+    // name above it; `margin-left: auto` does the pinning.
     const head = CARD.slice(CARD.indexOf('<div className="cc-mdcard-head">'));
     expect(head.slice(0, head.indexOf('<div className="am-card-sub"'))).not.toContain(
       "{formatSize(repo.size)}",
     );
     const sub = CARD.slice(CARD.indexOf('<div className="am-card-sub"'));
-    expect(sub.indexOf("{formatSize(repo.size)}")).toBeLessThan(sub.indexOf("am-card-slug"));
+    expect(sub.indexOf("am-card-slug")).toBeLessThan(sub.indexOf("{formatSize(repo.size)}"));
+    expect(CSS).toMatch(/\.am-card-size\s*{[^}]*margin-left:\s*auto/);
     // And no separator between them — the middot was invisible at 11px on a
     // card wash.
     expect(CSS).not.toContain(".am-card-sub .am-card-size::after");
@@ -380,7 +380,7 @@ describe("every card on the page has the same bones", () => {
     // The shared skeleton draws it once for both of the not-on-disk cards.
     expect(REC).toContain('<div className="am-card-sub" data-hint={slug}>');
     const sub = REC.slice(REC.indexOf('<div className="am-card-sub"'));
-    expect(sub.indexOf("{size.text}")).toBeLessThan(sub.indexOf("am-card-slug"));
+    expect(sub.indexOf("am-card-slug")).toBeLessThan(sub.indexOf("{size.text}"));
     // Both callers hand it the same two things the disk card shows.
     expect(REC.match(/slug=\{model\.id\}/g)?.length).toBe(2);
     // The Hub result shows the model half of the id up top, like the others.

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -7,6 +7,7 @@ import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore, typ
 import { createPortal } from "react-dom";
 import {
   getAppEntry,
+  setAppPreview,
   getAppFileCloneTarget,
   cloneAppFile,
   rawUrl,
@@ -21,7 +22,7 @@ import {
   repairTemplateRegistry,
 } from "@platform/lib/api";
 import type { StatResult, TemplateEntry, RegistryEntryForPath } from "@platform/lib/api";
-import { exportAppFile } from "@platform/lib/appShot";
+import { captureAppPreview, exportAppFile } from "@platform/lib/appShot";
 import { navigate, navigateUrl, urlForFsPath, viewUrlForFsPath, replaceSearch, IS_EMBED, IS_FOREIGN_EMBED, IS_PREVIEW } from "@platform/lib/router";
 import { formatSize, formatMtimeFull, basename } from "@platform/lib/format";
 import {
@@ -522,6 +523,75 @@ function usePreviewFileMenu(
     });
   };
 
+  // IS THIS FILE AN APP'S FACE? The one shared entry rule, asked of the server
+  // (/api/apps/entry) exactly as ExportAppButton asks it — under the marker
+  // rule a filename says nothing. Only an entry gets "Set Current View as
+  // Preview": a preview.png beside a plain html file has no card to show it.
+  const [isAppEntry, setIsAppEntry] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    setIsAppEntry(false);
+    if (stat.is_dir) return;
+    const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
+    getAppEntry(parent)
+      .then((r) => {
+        if (alive) setIsAppEntry(r.entry != null && canon(r.entry) === fsPath);
+      })
+      .catch(() => {
+        /* indeterminate reads as "not an entry" — no verb for nothing */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [fsPath, parent, stat.is_dir]);
+
+  // "Set Current View as Preview" (Akshil, 2026-08-27): photograph what the
+  // frame is showing and write it as the folder's preview.png. Same capture
+  // the .fused export bakes in (appShot.captureAppPreview, tab capture cropped
+  // to the shown frame), so the same one-time share prompt.
+  //
+  // ORDER: the share prompt needs the click's own transient activation, which
+  // Chrome expires a few seconds out. The one thing awaited before it is a stat
+  // of preview.png (milliseconds) — and when that says a still already exists,
+  // the capture moves to the CONFIRM's click instead (Akshil: confirm before
+  // overwriting), which is a fresh activation of its own. Nothing is written
+  // until a frame is in hand: a dismissed prompt leaves the old file alone.
+  const shootPreview = async (replacing: boolean) => {
+    const name = basename(parent);
+    const blob = await captureAppPreview(fsPath, document.querySelector(".preview-frame.is-shown"));
+    if (!blob) {
+      pushToast({ msg: "Preview not captured — nothing was changed", tone: "info" });
+      return;
+    }
+    try {
+      await setAppPreview(parent, blob);
+      pushToast({
+        msg: (replacing ? "Preview replaced — " : "Preview saved — ") + name + "/preview.png",
+        tone: "info",
+      });
+    } catch (e) {
+      pushToast({ msg: "Could not save preview: " + (e as Error).message, tone: "error" });
+    }
+  };
+  const doSetPreview = () => {
+    statPath(join(parent, "preview.png")).then(
+      (s) => {
+        if (s.is_dir) {
+          pushToast({ msg: "preview.png here is a folder — move it first", tone: "error" });
+          return;
+        }
+        setDialog({
+          kind: "confirm",
+          title: "Replace preview?",
+          message: `"${basename(parent)}" already has a preview.png. Replace it with what the app shows now?`,
+          confirmLabel: "Replace",
+          onConfirm: () => void shootPreview(true),
+        });
+      },
+      () => void shootPreview(false),
+    );
+  };
+
   // The CRUMB BAR's menu for this file — deliberately not `buildMenu` above (see
   // lib/bar-menus for what it leaves out and why). The splits are offered on the
   // same condition TemplatePreview uses for its own split affordances: a single
@@ -533,6 +603,7 @@ function usePreviewFileMenu(
       onCopyPath: doCopyPath,
       onReveal: doReveal,
       onOpenInNewTab: () => window.open(urlForFsPath(fsPath), "_blank", "noopener"),
+      onSetPreview: isAppEntry ? doSetPreview : undefined,
       onSplit:
         !stat.is_dir && !IS_EMBED ? (dir) => enterPanel(fsPath, dir) : undefined,
     });

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -22,7 +22,7 @@ import {
   repairTemplateRegistry,
 } from "@platform/lib/api";
 import type { StatResult, TemplateEntry, RegistryEntryForPath } from "@platform/lib/api";
-import { captureAppPreview, exportAppFile } from "@platform/lib/appShot";
+import { captureAppPreview, cropRect, exportAppFile } from "@platform/lib/appShot";
 import { navigate, navigateUrl, urlForFsPath, viewUrlForFsPath, replaceSearch, IS_EMBED, IS_FOREIGN_EMBED, IS_PREVIEW } from "@platform/lib/router";
 import { formatSize, formatMtimeFull, basename } from "@platform/lib/format";
 import {
@@ -558,7 +558,20 @@ function usePreviewFileMenu(
   // until a frame is in hand: a dismissed prompt leaves the old file alone.
   const shootPreview = async (replacing: boolean) => {
     const name = basename(parent);
-    const blob = await captureAppPreview(fsPath, document.querySelector(".preview-frame.is-shown"));
+    // THE CURRENT VIEW OR NOTHING. appShot's export path falls back to a fresh
+    // full-viewport reload of the entry when the frame can't be cropped; that
+    // is not the view the user is looking at, so here it is refused up front
+    // (and `stage: false` refuses it again inside) rather than saved under a
+    // "Preview saved" toast (Bugbot, 2026-08-27).
+    const frame = document.querySelector(".preview-frame.is-shown");
+    if (!cropRect(frame)) {
+      pushToast({
+        msg: "Preview not captured — the app frame has to be fully on screen",
+        tone: "error",
+      });
+      return;
+    }
+    const blob = await captureAppPreview(fsPath, frame, { stage: false });
     if (!blob) {
       pushToast({ msg: "Preview not captured — nothing was changed", tone: "info" });
       return;

--- a/frontend/src/apps/explorer/lib/bar-menus.test.ts
+++ b/frontend/src/apps/explorer/lib/bar-menus.test.ts
@@ -127,3 +127,37 @@ test("fileBarMenu drops the splits AND their separator when it can't split", () 
   // something missing.
   expect(items[items.length - 1]).not.toBe("separator");
 });
+
+test("fileBarMenu offers Set Current View as Preview only on an app entry, in its own group", () => {
+  const base = {
+    onRename: () => {},
+    onOpenInClaude: () => {},
+    onCopyPath: () => {},
+    onReveal: () => {},
+    onOpenInNewTab: () => {},
+  };
+  // A plain file: no preview verb, and no orphan separator for it.
+  expect(labels(fileBarMenu(base))).not.toContain("Set Current View as Preview");
+  let shot = 0;
+  const items = fileBarMenu({ ...base, onSetPreview: () => shot++, onSplit: () => {} });
+  expect(labels(items)).toEqual([
+    "Rename…",
+    "—",
+    "Reveal in Finder",
+    "Open in New Tab",
+    "Copy Path",
+    "Copy Claude session command",
+    "—",
+    "Set Current View as Preview",
+    "—",
+    "Split right",
+    "Split down",
+  ]);
+  item(items, "Set Current View as Preview").onClick?.();
+  expect(shot).toBe(1);
+  // Without splits the preview group still closes the list cleanly.
+  expect(labels(fileBarMenu({ ...base, onSetPreview: () => {} })).slice(-2)).toEqual([
+    "—",
+    "Set Current View as Preview",
+  ]);
+});

--- a/frontend/src/apps/explorer/lib/bar-menus.ts
+++ b/frontend/src/apps/explorer/lib/bar-menus.ts
@@ -82,6 +82,10 @@ export interface FileBarActions {
   // split, and a directory's preview has no file to split on) — the separator
   // goes with it, so the menu never ends in a divider.
   onSplit?: (dir: SplitDir) => void;
+  // Only on an APP's entry page (Preview asks /api/apps/entry): photograph
+  // what the frame is showing and make it the folder's preview.png. Absent on
+  // a plain file — there is no card anywhere that would show the picture.
+  onSetPreview?: () => void;
 }
 
 // Right-click on the bar over a single open FILE. A short list on purpose: it
@@ -110,6 +114,15 @@ export function fileBarMenu(actions: FileBarActions): MenuEntry[] {
       icon: MenuIcons.openWith,
       onClick: actions.onOpenInClaude,
     },
+    // In its own group: the four above are about the FILE; this one is about
+    // the APP the file is the face of (Akshil, 2026-08-27: "if I right-click
+    // ... I want an option of add a preview").
+    ...(actions.onSetPreview
+      ? ([
+          "separator",
+          { label: "Set Current View as Preview", icon: MenuIcons.camera, onClick: actions.onSetPreview },
+        ] as MenuEntry[])
+      : []),
     ...(actions.onSplit ? (["separator", ...splitItems(actions.onSplit)] as MenuEntry[]) : []),
   ];
 }

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2045,6 +2045,27 @@ export function getBackgroundAppsRunning(): Promise<{ running: Record<string, bo
 // The folder's app entry page (its first top-level .html carrying
 // `<meta name="fused-app">`, resolved by the server's one copy of the rule) or
 // null. Feeds the explorer's "Open app" button.
+// Write (or replace) an app folder's authored still, `preview.png`, from a
+// capture of what the preview frame is showing (appShot.captureAppPreview).
+// The path-bar's "Set Current View as Preview". `replaced` says which verb it
+// was; the caller asks before the overwrite, not after.
+export async function setAppPreview(
+  dir: string,
+  preview: Blob,
+): Promise<{ path: string; replaced: boolean }> {
+  const form = new FormData();
+  form.set("path", dir);
+  form.set("preview", preview, "preview.png");
+  const res = await fetch("/api/apps/preview", {
+    method: "POST",
+    headers: { "X-Fused": "1" },
+    body: form,
+  });
+  const body = (await res.json().catch(() => ({}))) as { error?: string; path?: string; replaced?: boolean };
+  if (!res.ok) throw new Error(body.error || `HTTP ${res.status}`);
+  return { path: body.path ?? dir + "/preview.png", replaced: !!body.replaced };
+}
+
 export function getAppEntry(path: string): Promise<{ entry: string | null }> {
   return getJson<{ entry: string | null }>(
     `/api/apps/entry?path=${encodeURIComponent(path)}`,

--- a/frontend/src/platform/lib/appShot.ts
+++ b/frontend/src/platform/lib/appShot.ts
@@ -111,7 +111,7 @@ export async function exportAppFile(
 // of it is a picture of the app rather than a sliver of one. GEOMETRY ONLY —
 // whether the element has actually painted the app is the caller's promise
 // (see exportAppFile), because nothing in a bounding rect can answer it.
-function cropRect(el: Element | null | undefined): DOMRect | null {
+export function cropRect(el: Element | null | undefined): DOMRect | null {
   if (!el) return null;
   const r = el.getBoundingClientRect();
   if (r.width < MIN_CROP_CSS_PX.width || r.height < MIN_CROP_CSS_PX.height) return null;
@@ -209,12 +209,21 @@ async function capWidth(blob: Blob, maxWidth: number): Promise<Blob | undefined>
 export async function captureAppPreview(
   entryHtml: string,
   captureEl?: Element | null,
+  // `stage: false` — photograph the shown element or nothing. The caller is
+  // asking for THIS view (the explorer's "Set Current View as Preview"), and a
+  // fresh reload of the entry on a stage is a different picture than the one
+  // the user is looking at; silently saving it would be a lie with a success
+  // toast (Bugbot, 2026-08-27). The export path keeps the stage: any picture
+  // beats no thumbnail in a .fused.
+  opts: { stage?: boolean } = {},
 ): Promise<Blob | undefined> {
   let stage: HTMLDivElement | undefined;
   try {
     let source: Element;
     if (cropRect(captureEl)) {
       source = captureEl as Element;
+    } else if (opts.stage === false) {
+      return undefined;
     } else {
       // No usable thumb on screen — the stage: a scrim over the whole
       // viewport (so nothing of the page bleeds into the shot's margins) with

--- a/frontend/src/platform/lib/tours/registry.test.ts
+++ b/frontend/src/platform/lib/tours/registry.test.ts
@@ -190,17 +190,24 @@ describe("tasks tour", () => {
     // List row, board card, calendar grid — mutually exclusive on screen, so
     // presentSteps keeps exactly the one the user is looking at.
     expect(steps.map((s) => s.element)).toEqual([
+      ".tasks-row .tasks-rowmark .schedule-ring",
       ".tasks-row",
       ".schedule-tv-board .tasks-card-wrap",
       ".schedule-cal",
     ]);
+    // The ring step comes BEFORE the row step: the row's action leaves the
+    // page. It explains the one mark the list uses for read-state — a dot in
+    // the ring is unread, hollow is read — and is a plain pointer.
+    expect(steps[0].advanceOn).toBeUndefined();
+    expect(steps[0].popover?.description).toMatch(/dot inside/i);
+    expect(steps[0].popover?.description).toMatch(/hollow/i);
     // The row's press is the stretched link, not the row div — so that is what
     // the step waits for and what its action button clicks.
-    expect(steps[0].advanceOn).toBe(".tasks-rowlink");
-    expect(steps[0].actionText).toBe("Open it");
-    expect(steps[1].advanceOn).toBe(".schedule-tv-board .schedule-tv-card");
+    expect(steps[1].advanceOn).toBe(".tasks-rowlink");
+    expect(steps[1].actionText).toBe("Open it");
+    expect(steps[2].advanceOn).toBe(".schedule-tv-board .schedule-tv-card");
     // The calendar step is a plain pointer — a chip opens through a popover.
-    expect(steps[2].advanceOn).toBeUndefined();
+    expect(steps[3].advanceOn).toBeUndefined();
     // End of the chain.
     expect(chain?.followUp).toBeUndefined();
   });

--- a/frontend/src/platform/lib/tours/registry.test.ts
+++ b/frontend/src/platform/lib/tours/registry.test.ts
@@ -199,7 +199,7 @@ describe("tasks tour", () => {
     // page. It explains the one mark the list uses for read-state — a dot in
     // the ring is unread, hollow is read — and is a plain pointer.
     expect(steps[0].advanceOn).toBeUndefined();
-    expect(steps[0].popover?.description).toMatch(/dot inside/i);
+    expect(steps[0].popover?.description).toMatch(/dot in the ring/i);
     expect(steps[0].popover?.description).toMatch(/hollow/i);
     // The row's press is the stretched link, not the row div — so that is what
     // the step waits for and what its action button clicks.

--- a/frontend/src/platform/lib/tours/tasks.ts
+++ b/frontend/src/platform/lib/tours/tasks.ts
@@ -76,6 +76,21 @@ export const tasksTour: Tour = {
       trigger: ".schedule-save",
       steps: () => [
         {
+          // List, and BEFORE the row step: that one's action opens the task
+          // and leaves the page, so anything about reading the list has to be
+          // said first. The ring is the page's whole read-state vocabulary —
+          // there is no separate unread mark (tasks.css "Unread") — and a
+          // first-time reader has no way to know a hollow ring is a claim
+          // (Akshil, 2026-08-27: "if the status ring has a dot in between,
+          // that means it is unread ... add that to the tour").
+          element: ".tasks-row .tasks-rowmark .schedule-ring",
+          popover: {
+            title: "Read or unread",
+            description:
+              "The ring is the task's status. A dot inside it means there's output you haven't seen yet; once you've looked, the ring goes hollow.",
+          },
+        },
+        {
           // List. ROW ONE, not "the new one": rows sort by lane and then time
           // (tasks-lib.sortByLane), so an Upcoming task already on the page can
           // outrank the fresh one. The copy is true of whichever row this is.

--- a/frontend/src/platform/lib/tours/tasks.ts
+++ b/frontend/src/platform/lib/tours/tasks.ts
@@ -86,8 +86,9 @@ export const tasksTour: Tour = {
           element: ".tasks-row .tasks-rowmark .schedule-ring",
           popover: {
             title: "Read or unread",
-            description:
-              "The ring is the task's status. A dot inside it means there's output you haven't seen yet; once you've looked, the ring goes hollow.",
+            // ONE phrase (Akshil, screenshot, 2026-08-27: "too much wording ...
+            // one line max").
+            description: "A dot in the ring means unread; hollow means read.",
           },
         },
         {

--- a/frontend/src/platform/ui/MenuIcons.tsx
+++ b/frontend/src/platform/ui/MenuIcons.tsx
@@ -26,6 +26,13 @@ const svgProps = {
 // One entry per menu action. Kept as ready-made elements (not components) so
 // callers just drop `MenuIcons.copy` into an item's `icon` slot.
 export const MenuIcons: Record<string, ReactNode> = {
+  // Camera — a capture of what is on screen ("Set Current View as Preview").
+  camera: (
+    <svg {...svgProps}>
+      <path d="M4 8.5A1.5 1.5 0 0 1 5.5 7h2.3l1.4-2h5.6l1.4 2h2.3A1.5 1.5 0 0 1 20 8.5v9A1.5 1.5 0 0 1 18.5 19h-13A1.5 1.5 0 0 1 4 17.5z" />
+      <circle cx="12" cy="13" r="3.2" />
+    </svg>
+  ),
   // Open — arrow pointing up-and-out of a box.
   open: (
     <svg {...svgProps}>

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -3031,7 +3031,9 @@ export default function NewJobModal({
                 then and a live-looking hotkey on a dead button is a lie. */}
             {!busy && (
               <kbd className="schedule-save-key" aria-hidden>
-                {MOD_LABEL}{ENTER_LABEL}
+                <span>{MOD_LABEL}</span>
+                <span className="schedule-save-key-plus">+</span>
+                <span>{ENTER_LABEL}</span>
               </kbd>
             )}
           </button>

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -3127,11 +3127,13 @@ export default function NewJobModal({
             // NOT submit — a single-line field that fires Save on Enter would
             // create a task on the way to describing it. An IME composition's
             // Enter commits the candidate, not the line, and is left alone.
+            // A MODIFIED Enter is not this field's: ⌘↩ / Ctrl+Enter is the
+            // form's Save chord (the wrap's onKeyDown), and it must bubble there
+            // untouched rather than also walk the caret down (Bugbot).
             onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-                e.preventDefault();
-                askRef.current?.focus();
-              }
+              if (e.key !== "Enter" || e.nativeEvent.isComposing || isMod(e)) return;
+              e.preventDefault();
+              askRef.current?.focus();
             }}
             autoFocus
           />

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -25,6 +25,7 @@ import {
 import type { Config, RecurrenceRule, ScheduledMessage } from "@platform/lib/api";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { navigateUrl } from "@platform/lib/router";
+import { ENTER_LABEL, isMod, MOD_LABEL } from "@platform/lib/platform";
 import { describeRepeats, describeRule, repeatChoicesFor } from "./schedule-lib";
 import { ICON_CLOCK, ICON_FOLDER, ICON_PLUS } from "./ScheduleCalendar";
 // This card's own rules live in styles/new-task.css, imported from the
@@ -3023,11 +3024,37 @@ export default function NewJobModal({
           <button type="button" className="btn btn-primary schedule-save"
                   disabled={busy} aria-disabled={!ready} onClick={trySubmit}>
             {busy ? `${actionLabel === "Create" ? "Creating" : "Scheduling"}…` : actionLabel}
+            {/* THE HOTKEY, ON THE BUTTON (Akshil, 2026-08-27: "show that hotkey
+                on the schedule button as well"). ⌘↩ from any field submits —
+                see the form's onKeyDown — and a shortcut nobody is told about
+                is one nobody uses. Hidden while busy: the button is disabled
+                then and a live-looking hotkey on a dead button is a lie. */}
+            {!busy && (
+              <kbd className="schedule-save-key" aria-hidden>
+                {MOD_LABEL}{ENTER_LABEL}
+              </kbd>
+            )}
           </button>
         </>
       }
     >
-      <div className="schedule-form">
+      <div
+        className="schedule-form"
+        // ⌘↩ / Ctrl+Enter SUBMITS, from any field (Akshil, 2026-08-27). Plain
+        // Enter has a job in every box here — next line in the ask, next field
+        // from the title, a pick in the recents list — so the commit needs the
+        // modifier, and the modifier is the one every composer on the machine
+        // already uses for "send". Goes through trySubmit, not submit, so a form
+        // that cannot be saved answers the same way the button does: says which
+        // field, moves the caret. Left alone inside the folder explorer, whose
+        // own Enter picks a row, and while a save is already in flight.
+        onKeyDown={(e) => {
+          if (e.key !== "Enter" || !isMod(e) || busy) return;
+          if ((e.target as HTMLElement).closest(".schedule-explorer")) return;
+          e.preventDefault();
+          trySubmit();
+        }}
+      >
         {/* ONE WRITING SURFACE, not two controls (Akshil, 2026-08-17, reference
             image): the title and the description share a single borderless
             area running from the header rule to the rows below it, the title

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -3090,6 +3090,20 @@ export default function NewJobModal({
             placeholder={TITLE_PLACEHOLDER}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
+            // ENTER MOVES DOWN, into the instructions (Akshil, 2026-08-27: "when
+            // I am typing in the title, when I click enter, it should go to
+            // additional instructions"). The two fields are one message and the
+            // title is its first line, so Enter at the end of the first line
+            // means what it means in any editor: start the next one. It does
+            // NOT submit — a single-line field that fires Save on Enter would
+            // create a task on the way to describing it. An IME composition's
+            // Enter commits the candidate, not the line, and is left alone.
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                e.preventDefault();
+                askRef.current?.focus();
+              }
+            }}
             autoFocus
           />
 

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -2245,6 +2245,12 @@ function TaskNode({
               }
               activate();
             }}
+            // Middle-click never reaches onClick (it is `auxclick`), and on the
+            // <a> it is the browser's own new-tab; the mark owes the same
+            // (Bugbot, 2026-08-27).
+            onAuxClick={(e) => {
+              if (e.button === 1 && href) window.open(href, "_blank", "noopener");
+            }}
           >
             {ICON_FILE}
           </span>

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1464,6 +1464,15 @@ export function TaskList({
           reason. */}
       {pageNote && <p className="schedule-tv-note tasks-list-note">{pageNote}</p>}
       <div className="tasks-list" ref={listRef} onScroll={onScroll}>
+      {/* THE FRAME IS INSIDE THE SCROLLER, not the scroller itself. When the
+          bordered box was the thing that scrolled, its bar stood INSIDE the
+          border: a 10px column between the last row's edge and the frame, so
+          every hairline stopped short of the box it was meant to reach and the
+          rows read as cut off (Akshil, screenshot, 2026-08-27: "the scroll cuts
+          the item ... move the scroll UI outside"). Now the bar stands beside
+          the frame, and the frame scrolls with its rows like any other
+          content. */}
+      <div className="tasks-list-frame">
       {/* ORDERED BY STATUS, NOT GROUPED BY IT (tasks-lib.sortByLane): Upcoming,
           In Progress, Failed, Done, Archive — rank order, and inside each rank
           the time the rows themselves print (newest first; Upcoming soonest
@@ -1501,6 +1510,7 @@ export function TaskList({
           onSettleAll={settleAll}
         />
       ))}
+      </div>
       </div>
     </>
   );
@@ -2219,6 +2229,22 @@ function TaskNode({
             className="tasks-row-file"
             data-hint={tildePath(taskFile_, home)}
             aria-label={`This task is about ${basename(taskFile_)}`}
+            // A PRESS HERE IS A PRESS ON THE ROW (Akshil, 2026-08-27: "when I
+            // click on the whole task list item anywhere ... it opens the task
+            // for me, but when I click on the file icon, it does not"). The
+            // mark sits above the stretched link (`z-index: 2`, for its
+            // tooltip), which is exactly what made it the one dead pixel-run
+            // on the row. So it spends the same gesture the link spends — a
+            // modified press goes to a new tab, a plain one to `activate` —
+            // and nothing on the row has a private meaning.
+            onClick={(e) => {
+              if (!href) return;
+              if (opensElsewhere(e)) {
+                window.open(href, "_blank", "noopener");
+                return;
+              }
+              activate();
+            }}
           >
             {ICON_FILE}
           </span>

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -2249,7 +2249,14 @@ function TaskNode({
             // <a> it is the browser's own new-tab; the mark owes the same
             // (Bugbot, 2026-08-27).
             onAuxClick={(e) => {
-              if (e.button === 1 && href) window.open(href, "_blank", "noopener");
+              if (e.button !== 1 || !href) return;
+              e.preventDefault();
+              window.open(href, "_blank", "noopener");
+            }}
+            // …and the default a middle press STARTS is autoscroll, which the
+            // <a> never triggers and this span otherwise would (Bugbot).
+            onMouseDown={(e) => {
+              if (e.button === 1 && href) e.preventDefault();
             }}
           >
             {ICON_FILE}

--- a/frontend/src/styles/ai-models.css
+++ b/frontend/src/styles/ai-models.css
@@ -605,18 +605,15 @@
   border-radius: 3px;
 }
 
-/* -- the caption line: what it costs, then which repo it is -----------------
-   Directly under the name, cost first. The figure spent an hour in the head
-   beside the name, matching the recommendation cards drawn next to these — but
-   those cards have no second line to put it on, so matching them there bought
-   consistency with a card that had no choice and cost this one the arrangement
-   that actually reads as a caption.
-
-   No `margin-left: auto` on the figure any more either: the (i) claims the
-   head's free space now. Tabular, so a column of cards lines its figures up
-   even though each card sizes itself. */
+/* -- the caption line: which repo it is, then what it costs -----------------
+   Directly under the name. The figure is pinned to the card's RIGHT edge
+   (`margin-left: auto`) so a column of cards lines its figures up against a
+   shared margin — tabular for the same reason — while the id continues the
+   name it sits under (Akshil, 2026-08-27: "move the size all the way to the
+   right in the card"). */
 .am-card-size {
   flex: 0 0 auto;
+  margin-left: auto;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   white-space: nowrap;

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2462,14 +2462,24 @@ input.schedule-when-field {
   padding-right: 14px;
 }
 .schedule-save-key {
+  display: inline-flex;
+  align-items: center;
+  /* Glyph, plus, glyph — with air between them (Akshil, screenshot,
+     2026-08-27: "a little bit of space between these two icons and a plus
+     icon"). Set glyph-to-glyph the two read as one unfamiliar ligature. */
+  gap: 3px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
   line-height: 1;
-  padding: 3px 5px;
+  padding: 3px 6px;
   border-radius: 5px;
   background: color-mix(in srgb, currentColor 14%, transparent);
   color: inherit;
   opacity: 0.85;
+}
+.schedule-save-key-plus {
+  font-size: 9px;
+  opacity: 0.7;
 }
 
 /* The description hangs from a top-aligned icon (multi-line row), and grows

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2636,6 +2636,18 @@ input.schedule-when-field {
    overlaps something it is about, while above the first row of a scroller there
    is nothing but the scroller's own clipped edge.
 
+   BELOW only WHILE SHOWN, though. `visibility: hidden` keeps a box in layout,
+   and a hidden panel hanging under the mark is scrollable overflow: the List's
+   LAST row carried a tooltip-height of phantom scroll, so a four-task list wore
+   a scrollbar thumb over empty space (Akshil, screenshot, 2026-08-27: "when
+   there are less items there is a scroll bar that still appears"). At rest the
+   panel parks ON its own element — top-left, untranslated, inside the row it
+   already occupies — and takes the below-the-mark position as part of the
+   reveal. The geometry legs of the transition are 0s-with-a-delay bookkeeping,
+   not animation: on the way in the panel is seated before the fade starts, and
+   on the way out it holds that seat until the fade-out has finished rather than
+   snapping home mid-fade.
+
    Not a component, because this app has none — no tooltip primitive exists in
    src/platform/ui, and one built for two call sites would be a portal, a
    positioner and a state machine to say four characters. If a real one arrives,
@@ -2647,9 +2659,8 @@ input.schedule-when-field {
 [data-tip]:not([data-tip=""])::before {
   content: attr(data-tip);
   position: absolute;
-  top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
+  top: 0;
+  left: 0;
   z-index: 30;
   padding: 3px 7px;
   font-size: 11px;
@@ -2663,12 +2674,20 @@ input.schedule-when-field {
   box-shadow: 0 2px 8px var(--shadow-sm);
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.1s ease, visibility 0.1s ease;
+  transition:
+    opacity 0.1s ease,
+    visibility 0.1s ease,
+    top 0s 0.1s,
+    left 0s 0.1s,
+    transform 0s 0.1s;
   pointer-events: none;
 }
 
 [data-tip]:not([data-tip=""]):hover::before,
 [data-tip]:not([data-tip=""]):focus-visible::before {
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
   opacity: 1;
   visibility: visible;
   transition-delay: 0.3s;

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2452,6 +2452,26 @@ input.schedule-when-field {
   padding: 0 22px;
 }
 
+/* The ⌘↩ pill inside Save. Drawn in the button's own ink at a lower alpha so
+   it reads as a caption on the verb, not a second control; the right padding
+   is pulled in because the pill already ends the pill. */
+.schedule-save {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding-right: 14px;
+}
+.schedule-save-key {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 5px;
+  border-radius: 5px;
+  background: color-mix(in srgb, currentColor 14%, transparent);
+  color: inherit;
+  opacity: 0.85;
+}
+
 /* The description hangs from a top-aligned icon (multi-line row), and grows
    only by the user's hand. */
 .schedule-form-line--top {

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -48,9 +48,19 @@
 .tasks-list-frame {
   border: 1px solid var(--border);
   border-radius: 8px;
-  /* The scroller used to clip the row washes to the corners; now the frame
-     has to, or a hovered first row pokes square corners out of a round box. */
-  overflow: hidden;
+}
+/* The scroller used to clip the row washes to the corners. The frame must NOT
+   do it with `overflow: hidden`: the ring's unread-count tooltip hangs below
+   the last row, and a clipping frame cut it off (Bugbot, 2026-08-27). So the
+   END rows round their own outer corners instead — one px inside the frame's
+   8px so the wash meets the border's inner edge — and nothing is clipped. */
+.tasks-list-frame > .tasks-node:first-child > .tasks-row {
+  border-top-left-radius: 7px;
+  border-top-right-radius: 7px;
+}
+.tasks-list-frame > .tasks-node:last-child > .tasks-row {
+  border-bottom-left-radius: 7px;
+  border-bottom-right-radius: 7px;
 }
 
 /* Hairlines between TASKS only. A task and its thread are one thing, and a

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -58,7 +58,10 @@
   border-top-left-radius: 7px;
   border-top-right-radius: 7px;
 }
-.tasks-list-frame > .tasks-node:last-child > .tasks-row {
+/* The last node's LAST CHILD, not its row: an open task's row is not the
+   frame's bottom — its thread (or note, or loading line) is — and a curve on
+   the row there would sit mid-group over square frame corners (Bugbot). */
+.tasks-list-frame > .tasks-node:last-child > :last-child {
   border-bottom-left-radius: 7px;
   border-bottom-right-radius: 7px;
 }

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -40,9 +40,17 @@
   overscroll-behavior: contain;
 }
 
-.tasks-list {
+/* The border is on a FRAME inside the scroller, not on the scroller. A bordered
+   scroller wears its bar inside its own border, which leaves a bar-wide column
+   between the rows' edge and the frame — every hairline stopped 10px short of
+   the box (Akshil, screenshot, 2026-08-27). With the frame inside, the bar
+   stands beside the frame and the rows run edge to edge. */
+.tasks-list-frame {
   border: 1px solid var(--border);
   border-radius: 8px;
+  /* The scroller used to clip the row washes to the corners; now the frame
+     has to, or a hovered first row pokes square corners out of a round box. */
+  overflow: hidden;
 }
 
 /* Hairlines between TASKS only. A task and its thread are one thing, and a
@@ -644,7 +652,10 @@ button.tasks-caret,
   padding-left: 4px;
   margin-right: -4px;
 }
-.tasks-row-file:hover { opacity: 1; }
+/* NO HOVER SKIN OF ITS OWN (Akshil, 2026-08-27: "when I hover over the file
+   icon, it changes color and it feels like a button"). It is a caption on the
+   row, and a mark that brightens under the pointer promises a press the row's
+   press does not make. The row's own hover is the only hover here. */
 
 /* THE FOLDER CHIP AS A TAG (2026-08-23). A press filters the page to that
    folder, so on the List the chip is a real <button> — and it has to look like

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -59,7 +59,7 @@ import shutil
 import time
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Body, Header
+from fastapi import APIRouter, Body, File, Form, Header, UploadFile
 
 from fused_render import app_listing, schedule
 from fused_render.server.common import _error, _require_fused
@@ -372,6 +372,70 @@ def api_app_entry(path: str):
         return {"entry": app_listing.app_entry(path)}
     except OSError:
         return {"entry": None}
+
+
+# The authored thumbnail's cap and signature — the same two the .fused
+# export applies to a capture (appfile.py), because it is the same picture:
+# a card still, ~1280x800, and canvas.toBlob("image/png") is the only thing
+# that produces it.
+_PREVIEW_MAX_BYTES = 8 * 1024 * 1024
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+@router.post("/api/apps/preview")
+async def api_app_set_preview(
+    path: str = Form(default=""),
+    preview: UploadFile | None = File(default=None),
+    x_fused: str | None = Header(default=None),
+):
+    """Write (or replace) the app folder's authored still, ``preview.png``.
+
+    The explorer's path-bar menu offers "Set Current View as Preview" on an
+    app's entry page (Akshil, 2026-08-27): the page captures the pixels the
+    preview frame is showing (appShot.captureAppPreview — the same tab capture
+    the .fused export bakes in) and posts them here. The file lands under the
+    ONE name `app_listing.app_preview_image` reads, so a card shows it on its
+    next listing with no new plumbing.
+
+    Only an APP folder takes one — `app_listing.app_entry(path)` must resolve —
+    because a preview.png in a folder that is not an app is a stray file
+    nothing will ever read. Written to a sibling temp file and `os.replace`d so
+    an interrupted write never leaves the zero-length file `app_preview_image`
+    would (rightly) treat as absent while a real one sat there a moment ago.
+    ``replaced`` tells the caller which of the two verbs it just did.
+    """
+    from fused_render.index.ignore import MountGuard
+
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    if not path or not os.path.isabs(path):
+        return _error("path must be an absolute app folder path")
+    if MountGuard().blocks(path) or not os.path.isdir(path):
+        return _error("not a folder", status=404)
+    if app_listing.app_entry(path) is None:
+        return _error("not an app folder: no page carries the fused-app marker")
+    if preview is None:
+        return _error("preview.png is required")
+    raw = await preview.read(_PREVIEW_MAX_BYTES + 1)
+    if not raw or not raw.startswith(_PNG_MAGIC):
+        return _error("preview must be a PNG")
+    if len(raw) > _PREVIEW_MAX_BYTES:
+        return _error("preview is larger than 8 MiB")
+    target = os.path.join(path, app_listing.PREVIEW_IMAGE_NAME)
+    replaced = os.path.isfile(target)
+    tmp = os.path.join(path, f".{app_listing.PREVIEW_IMAGE_NAME}.{os.getpid()}.tmp")
+    try:
+        with open(tmp, "wb") as fh:
+            fh.write(raw)
+        os.replace(tmp, target)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return _error(f"could not write preview.png: {exc.strerror or exc}", status=500)
+    return {"path": target, "replaced": replaced}
 
 
 @router.get("/api/apps/recents")

--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -1174,3 +1174,51 @@ def test_rendering_an_external_marked_page_registers_the_folder(
     # ...and the folder now lists on the hub under the reserved tag.
     apps = {a["name"]: a for a in client.get("/api/apps").json()["apps"]}
     assert apps["myapp"]["tag"] == registered_apps.REGISTERED_TAG
+
+
+# ------------------------------------------------------------ set preview
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+def test_set_preview_writes_and_then_replaces_preview_png(client, workspace):
+    """The path-bar's "Set Current View as Preview": first call creates the
+    file under the one name the card reads, second call replaces it and says
+    so — the client's confirm-before-overwrite reads `replaced`."""
+    d = _app_dir(workspace, "lens")
+    r = client.post("/api/apps/preview", headers={"X-Fused": "1"},
+                    data={"path": str(d)}, files={"preview": ("preview.png", _PNG, "image/png")})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"path": str(d / "preview.png"), "replaced": False}
+    assert (d / "preview.png").read_bytes() == _PNG
+    assert app_listing.app_preview_image(str(d)) == str(d / "preview.png")
+    r = client.post("/api/apps/preview", headers={"X-Fused": "1"},
+                    data={"path": str(d)}, files={"preview": ("preview.png", _PNG + b"\x01", "image/png")})
+    assert r.json()["replaced"] is True
+    assert (d / "preview.png").read_bytes() == _PNG + b"\x01"
+    # No temp file left behind.
+    assert sorted(os.listdir(d)) == ["index.html", "preview.png"]
+
+
+def test_set_preview_refuses_non_apps_non_pngs_and_unguarded_calls(client, workspace, tmp_path):
+    d = _app_dir(workspace, "lens")
+    png = {"preview": ("preview.png", _PNG, "image/png")}
+    # A folder with no tagged page is not an app; nothing would read the file.
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "index.html").write_text("<html></html>")
+    r = client.post("/api/apps/preview", headers={"X-Fused": "1"}, data={"path": str(plain)}, files=png)
+    assert r.status_code == 400 and "not an app" in r.json()["error"]
+    assert not (plain / "preview.png").exists()
+    # Not a PNG.
+    r = client.post("/api/apps/preview", headers={"X-Fused": "1"}, data={"path": str(d)},
+                    files={"preview": ("preview.png", b"GIF89a....", "image/gif")})
+    assert r.status_code == 400 and "PNG" in r.json()["error"]
+    # Missing file, relative path, missing folder.
+    assert client.post("/api/apps/preview", headers={"X-Fused": "1"}, data={"path": str(d)}).status_code == 400
+    assert client.post("/api/apps/preview", headers={"X-Fused": "1"}, data={"path": "rel"}, files=png).status_code == 400
+    assert client.post("/api/apps/preview", headers={"X-Fused": "1"},
+                       data={"path": str(tmp_path / "gone")}, files=png).status_code == 404
+    # A write route: the X-Fused guard applies.
+    assert client.post("/api/apps/preview", data={"path": str(d)}, files=png).status_code != 200
+    assert not (d / "preview.png").exists()


### PR DESCRIPTION
## Summary
- **AI Models cards**: caption line reads repo id first, size pinned to the right edge (`margin-left: auto`).
- **Tasks tooltip**: `[data-tip]::before` no longer holds its below-the-mark geometry while hidden — kills the phantom scrollbar on short lists.
- **Tasks list frame**: border moved to an inner `.tasks-list-frame`; the scrollbar sits beside the frame, so row hairlines run edge to edge instead of stopping 10px short.
- **New task modal**: Enter in the title focuses Additional instructions (no submit; IME-safe).
- **File mark**: no hover skin; clicking it opens the row (⌘-click → new tab), matching the rest of the row.
- **Tasks tour**: new "Read or unread" step on the status ring — dot = unseen output, hollow = read — before the row step that navigates away.

- **Explorer**: right-click the path bar on an app entry → **Set Current View as Preview**: tab-captures the shown frame, `POST /api/apps/preview` writes `<app>/preview.png` atomically; confirm before replacing an existing one; only app entries get the item.
- **New task**: ⌘↩ / Ctrl+Enter submits from any field; Save reads `Create ⌘ + ↩`.

## Verification
- `tsc --noEmit` clean; `bun test` frontend: tours 21 pass, shell 918 pass
- cmux browser on the dev server: frame right edge = row right edge, bar outside; Enter in title lands focus on `.new-task-ask`; file-mark click navigates to the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a guarded file-write API for app previews plus several interaction changes in tasks and scheduling; validation is strict (app folder, PNG, size cap) but it is still new server-side persistence.
> 
> **Overview**
> This PR is mostly **UX polish** across Tasks, AI Models, and the new-task modal, plus one **end-to-end feature** for app folder thumbnails.
> 
> **AI Models** — On disk, recommended, and Hub cards, the caption line now shows **repo id first** and **size pinned to the right** (`margin-left: auto`). Full-id tooltips sit on the **slug span only**, so hovering the gap between id and size no longer shows the hint.
> 
> **Tasks** — The list **border moves to an inner** `.tasks-list-frame` so the scrollbar sits **beside** the frame and row dividers reach the edge. **`[data-tip]`** panels no longer reserve below-mark geometry while hidden, fixing a **phantom scrollbar** on short lists. The **file icon** opens the task like the rest of the row (incl. middle-click) and **drops its own hover** styling. The onboarding tour adds a **“Read or unread”** step on the status ring **before** the row step that navigates away.
> 
> **New task modal** — **Enter** in the title moves focus to additional instructions (not submit; IME-safe). **⌘↩ / Ctrl+Enter** submits from fields outside the folder explorer, with the shortcut shown on **Save/Create** when not busy.
> 
> **Explorer (app entries only)** — Path-bar menu **“Set Current View as Preview”** captures the visible preview frame (no silent reload fallback), confirms before overwriting `preview.png`, and **`POST /api/apps/preview`** writes PNG atomically on the server; client **`setAppPreview`**, exported **`cropRect`**, and **`captureAppPreview({ stage: false })`** support this flow.
> 
> Also: **`package-lock.json`** peer metadata flags only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be30f2fba01b3bd86b2e74468c8474cd8caecc7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->