### PR TITLE
Export preview: native screen shot replaces tab capture

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -9745,10 +9745,12 @@ experience and nothing else: no editor, no Claude, no explorer chrome.
   never extract fresh, never rebuild, never record recency; the entry iframe
   carries `_preview=1&_nofocus=1`). A never-opened file stays the empty
   thumb — a peek must not be the first run of a stranger's pages.
-  Export can BAKE one in: `exportAppFile` captures a tab screenshot
-  (getDisplayMedia with current-tab hints — the annotation shots' mechanism,
-  chosen over DOM serialization because canvas/WebGL apps rasterize blank)
-  when and only when the folder has no authored `preview.png`. The crop
+  Export can BAKE one in: `exportAppFile` takes a NATIVE screen shot of
+  the app's on-screen rect (`POST /api/capture/shot-region`, the §45 still
+  behind `fused.capture.screenshot()` pointed at a browser-measured rect,
+  PNG bytes back and no file in `<home>/recordings`; chosen over DOM
+  serialization because canvas/WebGL apps rasterize blank) when and only
+  when the folder has no authored `preview.png`. The crop
   source is the card's own thumbnail when it is on screen AND HAS PAINTED
   the app — a card without a preview.png renders the live app there, so
   nothing navigates or flashes, but only two card previews start at a time
@@ -9758,18 +9760,21 @@ experience and nothing else: no editor, no Claude, no explorer chrome.
   (`data-capture-ready`, set on the body iframe's load) because the surface
   that opens the context menu is not the one holding that state; the
   full-viewport stage is the fallback for a missing, off-screen or unpainted
-  thumb. **The share prompt goes up FIRST**, before the stage is mounted and
-  before anything is awaited: `getDisplayMedia` spends the click's transient
-  user activation, which expires seconds later, so asking after a stage
-  iframe's load-and-settle wait would lose the prompt for every app slower
-  than a beat — and lose it indistinguishably from a dismissal. A tab-capture
-  stream is continuous, so the stage mounts and settles against a stream
-  already running. The prompt itself cannot be silenced — that is
-  getDisplayMedia's contract. The
+  thumb, sized so its shot lands under the width cap at this DPR (so nothing
+  downscales). The browser reports the rect in its screen units
+  (`screenX` + chrome + the element's box) plus `devicePixelRatio`; the
+  backend's `locate` hook maps that onto ONE display in its own units
+  (points on macOS, physical pixels on Windows/Linux) and REFUSES a rect that
+  is not entirely on one display rather than clipping it — a sliver baked
+  in is a valid PNG nothing later can catch. No share prompt and nothing
+  hinging on the click's transient user activation (the earlier tab-capture
+  version's whole ordering problem); on a Mac without Screen Recording
+  granted the first shot raises the TCC dialog and that export ships plain.
+  The
   X-Fused `POST /api/appfile/export` variant writes it as
   `files/preview.png` (PNG magic + 8 MiB cap; the authored still always
-  wins; every capture failure — unsupported, prompt dismissed, blank,
-  over-cap — exports plain: the route drops a too-big screenshot rather than
+  wins; every capture failure — unsupported, permission denied, off-display,
+  blank, over-cap — exports plain: the route drops a too-big screenshot rather than
   failing the download, where `export_app_file` itself still raises for a
   caller that meant to supply a still). An injected preview extracts as a
   real file in the app's read-only extract dir like any other member.

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -295,17 +295,15 @@ function ExportAppButton({ fsPath }: { fsPath: string }) {
       // preview frame IS the app rendering, so it is the crop source — no
       // navigation, no flash. exportAppFile itself skips capture when the
       // folder carries an authored preview.png; the probe below is only so a
-      // pointless share prompt isn't raised for a capture the server would
-      // discard anyway (stat failure reads as "no authored still" — worst
-      // case is that redundant prompt, never a lost export).
+      // pointless native shot (and, on a Mac that has not granted Screen
+      // Recording, its permission dialog) isn't taken for a capture the
+      // server would discard anyway (stat failure reads as "no authored
+      // still" — worst case is that redundant shot, never a lost export).
       //
-      // ONE cheap local probe, and it must stay that: appShot raises the share
-      // prompt on this click's transient user activation, which Chrome expires
-      // a few seconds out, so anything slow awaited here spends the activation
-      // and loses the prompt. `.is-shown` satisfies appShot's crop-source
-      // contract (pixels that ARE the app, not a box it may fill): the class
-      // rides `shown`, which the frame swap only sets once that frame paints —
-      // the same guarantee `data-fused-annotate-target` below relies on.
+      // `.is-shown` satisfies appShot's crop-source contract (pixels that ARE
+      // the app, not a box it may fill): the class rides `shown`, which the
+      // frame swap only sets once that frame paints — the same guarantee
+      // `data-fused-annotate-target` below relies on.
       const authored = await statPath(dir + "/preview.png").then(
         (s) => !s.is_dir,
         () => false,

--- a/frontend/src/platform/lib/appCardMenu.ts
+++ b/frontend/src/platform/lib/appCardMenu.ts
@@ -75,8 +75,8 @@ export function appCardMenu(
             label: "Export App File",
             icon: MenuIcons.download,
             onClick: () => {
-              // exportAppFile also captures a tab screenshot into the file's
-              // preview.png when the folder has no authored one (D396).
+              // exportAppFile also bakes a native screen shot in as the
+              // file's preview.png when the folder has no authored one (D396).
               exportAppFile(app, captureEl).catch((e: Error) =>
                 pushToast({
                   msg: "Could not export " + app.name + ": " + e.message,

--- a/frontend/src/platform/lib/appShot.test.ts
+++ b/frontend/src/platform/lib/appShot.test.ts
@@ -1,12 +1,15 @@
-// The two things about the export capture that no screenshot and no unit call
-// can show, because both are about ORDER and about a promise made across files.
+// The one thing about the export capture that no screenshot and no unit call
+// can show, because it is a promise made across files: the crop source must
+// be PAINTED pixels. (The capture is a native screen shot now — an earlier
+// tab-capture version also pinned prompt ORDER here, against the click's
+// transient user activation; a native shot raises no prompt, so that
+// constraint and its tests are gone.)
 //
 // Source assertions, like ClaudeHealthStrip's in claude-health.test.ts and the
 // card's in tests/test_pane_no_autofocus.py: `bun test` has no DOM, so there is
-// no getDisplayMedia to stub and no iframe to load — but both failures below
-// are silent in the product (a share prompt that never appears; a thumbnail
-// that is a grey box) and permanent in the artifact, so they are worth pinning
-// where a refactor has to walk past them.
+// no screen to shoot and no iframe to load — but the failure below is silent
+// in the product (a thumbnail that is a grey box) and permanent in the
+// artifact, so it is worth pinning where a refactor has to walk past it.
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -21,44 +24,6 @@ const SHOT = read("appShot.ts");
 const CARD = read("..", "ui", "AppPreviewCard.tsx");
 const APPS = read("..", "..", "apps", "builder", "Apps.tsx");
 const PREVIEW = read("..", "..", "apps", "explorer", "Preview.tsx");
-
-// -- the prompt rides the click's activation ---------------------------------
-
-// getDisplayMedia needs transient user activation, which Chrome expires a few
-// seconds after the click. The stage waits for an iframe load (up to 10s) and
-// then settles (1.5s), so asking for the stream after that wait loses the
-// prompt for every app slower than a beat — silently, since a dismissed or
-// refused prompt and an expired one are the same rejection and the same
-// export-plain fallback. The stream is continuous, so the fix costs nothing:
-// ask first, mount the stage against a stream already running.
-test("getDisplayMedia is called before the stage is mounted or awaited", () => {
-  const prompt = SHOT.indexOf("getDisplayMedia({");
-  const mount = SHOT.indexOf("document.body.appendChild(stage)");
-  const settle = SHOT.indexOf("setTimeout(res, SETTLE_MS)");
-  expect(prompt).toBeGreaterThan(-1);
-  expect(mount).toBeGreaterThan(-1);
-  expect(settle).toBeGreaterThan(-1);
-  expect(prompt).toBeLessThan(mount);
-  expect(prompt).toBeLessThan(settle);
-});
-
-test("nothing is awaited between entering the capture and the prompt", () => {
-  // The body from the support check up to (not including) the prompt's own
-  // statement: a single `await` in there is the whole bug, whatever it awaits.
-  const start = SHOT.indexOf(
-    "if (!navigator.mediaDevices?.getDisplayMedia) return undefined;",
-  );
-  const promptStmt = SHOT.indexOf("stream = await navigator.mediaDevices");
-  expect(start).toBeGreaterThan(-1);
-  expect(promptStmt).toBeGreaterThan(start);
-  // Comments stripped: the prose in here says "awaited", and the assertion is
-  // about code.
-  const code = SHOT.slice(start, promptStmt)
-    .split("\n")
-    .filter((l) => !l.trim().startsWith("//"))
-    .join("\n");
-  expect(code).not.toContain("await");
-});
 
 // -- the crop source must be painted pixels ---------------------------------
 

--- a/frontend/src/platform/lib/appShot.ts
+++ b/frontend/src/platform/lib/appShot.ts
@@ -30,8 +30,9 @@
 //   2. A stage (scrim + fresh iframe of the entry under `_preview=1` /
 //      `_nofocus=1`), only when no usable thumb element was offered or it is
 //      off-screen/too small to be worth photographing. The frame is sized so
-//      its shot lands under MAX_SHOT_WIDTH at this DPR, which is why there is
-//      no downscale step anywhere: the server writes exactly the pixels asked.
+//      its shot lands under MAX_SHOT_WIDTH at this DPR; only a crop source
+//      that is itself wider than that (the explorer's preview pane) gets
+//      re-encoded down (`capWidth`).
 //
 // Every failure — no server, permission denied, the app failing to load, the
 // window straddling displays, an empty body — resolves to undefined, never a
@@ -63,7 +64,7 @@ const SETTLE_MS = 1500;
 // The captured PNG's width cap. A shot lands at the display's own pixel
 // scale — a 5k-wide preview.png inside every .fused is waste; card thumbs
 // render ~400px wide. The stage sizes its frame from this; a thumb crop is
-// always under it.
+// always under it; a wider crop source is scaled down to it (`capWidth`).
 const MAX_SHOT_WIDTH = 1600;
 
 // The stage frame's shape — the card thumb's own (appfile.MAX_PREVIEW_BYTES
@@ -133,11 +134,18 @@ function cropRect(el: Element | null | undefined): DOMRect | null {
 // stopPropagation in a menu cannot hide it).
 let viewportOrigin: { x: number; y: number } | undefined;
 if (typeof window !== "undefined") {
-  const learn = (e: MouseEvent) => {
-    viewportOrigin = { x: e.screenX - e.clientX, y: e.screenY - e.clientY };
-  };
-  window.addEventListener("pointerdown", learn, { capture: true, passive: true });
-  window.addEventListener("click", learn, { capture: true, passive: true });
+  // `pointerdown` only, never `click`: a keyboard-activated click is a real
+  // MouseEvent with screenX/clientX all ZERO, which would teach an origin of
+  // (0,0) and send viewport coordinates to the server as screen ones. No
+  // pointer ever produces a pointerdown, so a keyboard export falls through
+  // to the outer/inner arithmetic below instead.
+  window.addEventListener(
+    "pointerdown",
+    (e: PointerEvent) => {
+      viewportOrigin = { x: e.screenX - e.clientX, y: e.screenY - e.clientY };
+    },
+    { capture: true, passive: true },
+  );
 }
 
 // A viewport rect as the SCREEN sees it, in the browser's own screen units
@@ -155,13 +163,47 @@ function screenRect(r: DOMRect): [number, number, number, number] {
 }
 
 // Two frames, so whatever the click that reached here was tearing down — the
-// context menu over the thumb, the hover chip — has been painted away before
-// the screen is photographed. Tab capture never needed this: its grab came
-// long after the prompt; a native shot is immediate.
+// context menu over the thumb — has been painted away before the screen is
+// photographed. Tab capture never needed this: its grab came long after the
+// prompt; a native shot is immediate.
 function nextPaint(): Promise<void> {
   return new Promise((res) =>
     requestAnimationFrame(() => requestAnimationFrame(() => res())),
   );
+}
+
+// While a shot is being taken the body carries this attribute, and the
+// stylesheet hides the overlay UI that sits ON the thumb — the card's hover
+// export chip (`.app-pcard-export`, apps.css). Clicking that chip does not end
+// the hover, so without this the chip is in the pixels and becomes part of
+// the artifact's permanent thumbnail. An attribute rather than a class on
+// the card so any surface with overlay UI over its capture source can join
+// the same rule.
+const SHOOTING_ATTR = "data-capture-shooting";
+
+// A PNG wider than the cap, re-encoded narrower. The thumb and stage paths
+// never need this — a card thumb is ~400 CSS px and the stage is sized to
+// the cap — but the explorer's preview pane is the crop source there and
+// fills whatever the pane is; at 2x on a wide window that is a 4k-wide still,
+// which can cross the export route's 8 MiB cap and ship the .fused with no
+// preview at all. Decode → canvas → encode only in that case.
+async function capWidth(blob: Blob, maxWidth: number): Promise<Blob | undefined> {
+  const bitmap = await createImageBitmap(blob);
+  try {
+    if (bitmap.width <= maxWidth) return blob;
+    const scale = maxWidth / bitmap.width;
+    const canvas = document.createElement("canvas");
+    canvas.width = maxWidth;
+    canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return undefined;
+    ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+    return await new Promise<Blob | undefined>((res) =>
+      canvas.toBlob((b) => res(b ?? undefined), "image/png"),
+    );
+  } finally {
+    bitmap.close();
+  }
 }
 
 export async function captureAppPreview(
@@ -202,6 +244,7 @@ export async function captureAppPreview(
       await new Promise((res) => setTimeout(res, SETTLE_MS));
       source = frame;
     }
+    document.body.setAttribute(SHOOTING_ATTR, "");
     await nextPaint();
     // Re-read at shoot time: cheap insurance against layout shifting while
     // the stage settled.
@@ -218,12 +261,13 @@ export async function captureAppPreview(
     if (!res.ok) return undefined;
     const blob = await res.blob();
     if (!blob.size || !blob.type.startsWith("image/png")) return undefined;
-    return blob;
+    return await capWidth(blob, MAX_SHOT_WIDTH);
   } catch {
     // Server unreachable, frame refused — all the same outcome: export
     // without a preview.
     return undefined;
   } finally {
+    document.body.removeAttribute(SHOOTING_ATTR);
     stage?.remove();
   }
 }

--- a/frontend/src/platform/lib/appShot.ts
+++ b/frontend/src/platform/lib/appShot.ts
@@ -3,44 +3,44 @@
 // app actually looks like and downloadAppFile bakes it into the .fused as
 // `files/preview.png`.
 //
-// The mechanism is TAB CAPTURE — getDisplayMedia with the current-tab hints —
-// the same one the claude template's annotation shots use (annXO, D355), and
-// for the same reason it beats DOM serialization here: fused apps are
-// map/canvas/WebGL-heavy, and an SVG-foreignObject rasterization of those is
-// reliably blank (no external fetches, no WebGL readback), which baked into
-// the artifact would be a permanently wrong thumbnail. Live pixels have no
-// such failure mode. The cost is the browser's share prompt, once per capture.
+// The mechanism is a NATIVE SCREEN SHOT — `POST /api/capture/shot-region`, the
+// same ScreenCaptureKit / GDI / desktop-portal still behind
+// `fused.capture.screenshot()` (SPEC §45), pointed at the screen rect the
+// browser reports for an element. It replaced tab capture (getDisplayMedia
+// with current-tab hints) for three reasons: no share prompt, so nothing
+// hinges on the click's transient user activation any more; it works in
+// whatever browser `webbrowser.open` chose, where the Chromium-only tab hints
+// did not; and the pixels are the same live ones — DOM serialization was
+// never an option here because fused apps are map/canvas/WebGL-heavy and an
+// SVG-foreignObject rasterization of those is reliably blank, which baked
+// into the artifact would be a permanently wrong thumbnail.
 //
-// Tab capture photographs VISIBLE pixels only, so the app must be on screen.
-// Two sources, in preference order (owner call — no full-screen flash):
+// A screen shot photographs VISIBLE pixels only, so the app must be on screen
+// and the window must be fully on one display (the server refuses a rect that
+// is not — a sliver baked in as the permanent thumbnail is a valid PNG nothing
+// downstream can catch). Two sources, in preference order (owner call — no
+// full-screen flash):
 //
 //   1. The card's own thumbnail. A card without a preview.png already renders
 //      the live app in its thumb (AppPreviewCard's fallback chain), so the
-//      pixels the user is looking at ARE the app — capture the tab and crop
-//      to that rect. Nothing navigates, nothing flashes; the shot is thumb-
-//      sized (~card width × devicePixelRatio), which is exactly the size the
-//      card that will display it renders at.
-//   2. A full-viewport stage (scrim + fresh iframe of the entry under
-//      `_preview=1`/`_nofocus=1`), only when no usable thumb element was
-//      offered or it is off-screen/too small to be worth photographing.
+//      pixels the user is looking at ARE the app — shoot that rect. Nothing
+//      navigates, nothing flashes; the shot is thumb-sized (~card width ×
+//      devicePixelRatio), which is exactly the size the card that will display
+//      it renders at.
+//   2. A stage (scrim + fresh iframe of the entry under `_preview=1` /
+//      `_nofocus=1`), only when no usable thumb element was offered or it is
+//      off-screen/too small to be worth photographing. The frame is sized so
+//      its shot lands under MAX_SHOT_WIDTH at this DPR, which is why there is
+//      no downscale step anywhere: the server writes exactly the pixels asked.
 //
-// Every failure — no getDisplayMedia, the user dismissing the prompt, the
-// app failing to load, a zero-pixel frame — resolves to undefined, never a
+// Every failure — no server, permission denied, the app failing to load, the
+// window straddling displays, an empty body — resolves to undefined, never a
 // throw: the caller exports WITHOUT a preview, which is exactly what the
 // export did before this existed.
 //
-// ORDER IS LOAD-BEARING: the prompt goes up FIRST, before the stage is mounted
-// and before anything is awaited. `getDisplayMedia` requires transient user
-// activation, which the click that reached here is the only source of and which
-// Chrome expires ~5s later — so waiting for a stage iframe to load (up to 10s)
-// and then settle (1.5s) before asking would spend the activation on the wait
-// and lose the prompt for every app slower than a beat. Same lesson the
-// annotation shots already carry: "the click that armed the mode is the user
-// activation getDisplayMedia requires, where a later capture may have none"
-// (templates/claude/template.html, annXOStreamGet's caller). A tab-capture
-// stream is CONTINUOUS, so grabbing a frame long after the stream opened costs
-// nothing — the stage is mounted and settled against a stream already running,
-// and the frame we photograph is the one on screen at grab time.
+// On macOS the first shot on a machine that has not granted Screen Recording
+// raises the TCC dialog (capture._darwin: "the prompt rides the first real
+// capture"), and THAT export ships plain; the ones after it carry a preview.
 import { downloadAppFile } from "./api";
 import { thumbUrl } from "./thumb-frame";
 
@@ -60,10 +60,16 @@ export interface ExportableApp {
 // The thumb path pays none of this — its pixels are already painted.
 const SETTLE_MS = 1500;
 
-// The captured PNG's width cap. A crop captures at devicePixelRatio — a
-// 5k-wide preview.png inside every .fused is waste; card thumbs render
-// ~400px wide.
+// The captured PNG's width cap. A shot lands at the display's own pixel
+// scale — a 5k-wide preview.png inside every .fused is waste; card thumbs
+// render ~400px wide. The stage sizes its frame from this; a thumb crop is
+// always under it.
 const MAX_SHOT_WIDTH = 1600;
+
+// The stage frame's shape — the card thumb's own (appfile.MAX_PREVIEW_BYTES
+// comment: "a card thumbnail is ~1280x800"), so the baked preview fills the
+// slot it will be shown in.
+const STAGE_ASPECT = 16 / 10;
 
 // Below this on-screen size a thumb crop would be photographing noise —
 // take the stage instead.
@@ -76,12 +82,12 @@ function shotUrl(entryHtml: string): string {
 // The one export entry every card surface calls (the hover chip and the
 // context menu): capture only when there is something to gain — a renderable
 // page and no authored preview.png — then the ordinary download. A capture
-// that comes back undefined (unsupported, dismissed, blank) exports plain.
+// that comes back undefined (unsupported, refused, blank) exports plain.
 //
-// `captureEl` is the no-flash crop source above, and the CALLER'S CONTRACT on
-// it is narrow: an element whose pixels ARE the app *right now*. Not "the box
-// the app will render in" — a card thumb whose live iframe has not loaded is an
-// empty grey box, and cropping that bakes the empty box into the artifact as
+// `captureEl` is the no-flash source above, and the CALLER'S CONTRACT on it is
+// narrow: an element whose pixels ARE the app *right now*. Not "the box the
+// app will render in" — a card thumb whose live iframe has not loaded is an
+// empty grey box, and shooting that bakes the empty box into the artifact as
 // its permanent thumbnail (a valid PNG, so nothing downstream can catch it).
 // The /apps grid admits only two preview iframes at a time
 // (preview-start.createPreviewStartQueue(2)), so "mounted but not painted" is
@@ -100,7 +106,7 @@ export async function exportAppFile(
   return downloadAppFile(app.path, app.name, preview);
 }
 
-// Whether `el`'s box is fully inside the viewport and big enough that a crop
+// Whether `el`'s box is fully inside the viewport and big enough that a shot
 // of it is a picture of the app rather than a sliver of one. GEOMETRY ONLY —
 // whether the element has actually painted the app is the caller's promise
 // (see exportAppFile), because nothing in a bounding rect can answer it.
@@ -114,50 +120,61 @@ function cropRect(el: Element | null | undefined): DOMRect | null {
   return r;
 }
 
+// A viewport rect as the SCREEN sees it, in the browser's own screen units
+// (CSS pixels of the screen — points on macOS, DIPs elsewhere; the server
+// applies `dpr` where its display measures in physical pixels). The window's
+// chrome — tab strip, toolbar — is the difference between the outer and inner
+// sizes, assumed to sit on top and split evenly at the sides, which holds for
+// every mainstream browser in a normal window. Page zoom ≠ 100% or a docked
+// devtools panel break the arithmetic silently (a wrong crop, still a valid
+// PNG) — accepted: both are developer states, and the export is one click
+// away from a redo.
+function screenRect(r: DOMRect): [number, number, number, number] {
+  const chromeX = Math.max(0, (window.outerWidth - window.innerWidth) / 2);
+  const chromeY = Math.max(0, window.outerHeight - window.innerHeight);
+  return [
+    window.screenX + chromeX + r.left,
+    window.screenY + chromeY + r.top,
+    r.width,
+    r.height,
+  ];
+}
+
+// Two frames, so whatever the click that reached here was tearing down — the
+// context menu over the thumb, the hover chip — has been painted away before
+// the screen is photographed. Tab capture never needed this: its grab came
+// long after the prompt; a native shot is immediate.
+function nextPaint(): Promise<void> {
+  return new Promise((res) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => res())),
+  );
+}
+
 export async function captureAppPreview(
   entryHtml: string,
   captureEl?: Element | null,
 ): Promise<Blob | undefined> {
-  if (!navigator.mediaDevices?.getDisplayMedia) return undefined;
   let stage: HTMLDivElement | undefined;
-  let stream: MediaStream | undefined;
   try {
-    // Which source we photograph is decided BEFORE the prompt and with nothing
-    // awaited in between — see the ordering note in the module comment. Inside
-    // the try like everything else, so this function keeps its one promise to
-    // the export path: resolve to undefined, never throw.
-    const thumb = cropRect(captureEl);
-    // The prompt, on the click's own activation. Same current-tab hints as the
-    // annotation shots: preselect this tab, no switching, no monitors (ignored,
-    // not fatal, elsewhere).
-    stream = await navigator.mediaDevices.getDisplayMedia({
-      video: { displaySurface: "browser" },
-      audio: false,
-      // Chromium-only hints, absent from the lib.dom types — same cast the
-      // claude template's capture relies on.
-      ...({
-        preferCurrentTab: true,
-        selfBrowserSurface: "include",
-        surfaceSwitching: "exclude",
-        monitorTypeSurfaces: "exclude",
-      } as object),
-    });
-    let rectOf: () => DOMRect;
-    if (thumb) {
-      // Re-read at grab time: the share prompt scrolls nothing, but cheap
-      // insurance against layout shifting while it was up.
-      rectOf = () => cropRect(captureEl) ?? thumb;
+    let source: Element;
+    if (cropRect(captureEl)) {
+      source = captureEl as Element;
     } else {
-      // No usable thumb on screen — the full-viewport stage: scrim + the
-      // app's own page, visible because tab capture photographs the tab.
-      // Mounted only now, AFTER the prompt resolved: a dismissed prompt then
-      // costs no flash at all, and the scrim never sits under browser UI.
+      // No usable thumb on screen — the stage: a scrim over the whole
+      // viewport (so nothing of the page bleeds into the shot's margins) with
+      // the app's own page in a frame sized for the shot: as wide as the cap
+      // allows at this DPR, no wider than the viewport, thumb-shaped.
+      const dpr = window.devicePixelRatio || 1;
+      const width = Math.floor(Math.min(window.innerWidth, MAX_SHOT_WIDTH / dpr));
+      const height = Math.floor(Math.min(window.innerHeight, width / STAGE_ASPECT));
       stage = document.createElement("div");
       stage.style.cssText =
-        "position:fixed;inset:0;z-index:2147483000;background:#fff;";
+        "position:fixed;inset:0;z-index:2147483000;background:#fff;" +
+        "display:flex;align-items:center;justify-content:center;";
       const frame = document.createElement("iframe");
       frame.src = shotUrl(entryHtml);
-      frame.style.cssText = "width:100%;height:100%;border:0;display:block;";
+      frame.style.cssText =
+        `width:${width}px;height:${height}px;border:0;display:block;background:#fff;`;
       frame.tabIndex = -1;
       stage.appendChild(frame);
       document.body.appendChild(stage);
@@ -169,50 +186,32 @@ export async function captureAppPreview(
         setTimeout(res, 10_000);
       });
       await new Promise((res) => setTimeout(res, SETTLE_MS));
-      const s = stage;
-      rectOf = () => s.getBoundingClientRect();
+      source = frame;
     }
-    const video = document.createElement("video");
-    video.muted = true;
-    video.srcObject = stream;
-    await video.play();
-    // One PAINTED frame — play() resolving does not mean pixels arrived.
-    if ("requestVideoFrameCallback" in video) {
-      await new Promise((res) =>
-        (video as HTMLVideoElement & {
-          requestVideoFrameCallback: (cb: () => void) => void;
-        }).requestVideoFrameCallback(() => res(undefined)),
-      );
-    } else {
-      await new Promise((res) => setTimeout(res, 150));
-    }
-    if (!video.videoWidth || !video.videoHeight) return undefined;
-    // Crop the frame to the source rect (the captured frame is the whole tab
-    // at the capture's own resolution — window chrome differences, zoom and
-    // DPR all land in this one scale factor).
-    const sx = video.videoWidth / window.innerWidth;
-    const sy = video.videoHeight / window.innerHeight;
-    const r = rectOf();
-    const srcW = Math.max(1, r.width * sx);
-    const srcH = Math.max(1, r.height * sy);
-    const scale = Math.min(1, MAX_SHOT_WIDTH / srcW);
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.max(1, Math.round(srcW * scale));
-    canvas.height = Math.max(1, Math.round(srcH * scale));
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return undefined;
-    ctx.drawImage(video, r.left * sx, r.top * sy, srcW, srcH,
-      0, 0, canvas.width, canvas.height);
-    video.srcObject = null;
-    return await new Promise<Blob | undefined>((res) =>
-      canvas.toBlob((b) => res(b ?? undefined), "image/png"),
-    );
+    await nextPaint();
+    // Re-read at shoot time: cheap insurance against layout shifting while
+    // the stage settled.
+    const r = cropRect(source);
+    if (!r) return undefined;
+    const res = await fetch("/api/capture/shot-region", {
+      method: "POST",
+      headers: { "X-Fused": "1", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        rect: screenRect(r),
+        dpr: window.devicePixelRatio || 1,
+      }),
+    });
+    // Errors come back as the JSON `_error` shape (400 bad rect / off-display,
+    // 409 unsupported here, 500) — all the same outcome for an export.
+    if (!res.ok) return undefined;
+    const blob = await res.blob();
+    if (!blob.size || !blob.type.startsWith("image/png")) return undefined;
+    return blob;
   } catch {
-    // Prompt dismissed, capture unsupported, play() refused — all the same
-    // outcome: export without a preview.
+    // Server unreachable, frame refused — all the same outcome: export
+    // without a preview.
     return undefined;
   } finally {
-    stream?.getTracks().forEach((t) => t.stop());
     stage?.remove();
   }
 }

--- a/frontend/src/platform/lib/appShot.ts
+++ b/frontend/src/platform/lib/appShot.ts
@@ -207,13 +207,25 @@ export async function captureAppPreview(
     // the stage settled.
     const r = cropRect(source);
     if (!r) return undefined;
+    const rect = screenRect(r);
+    // What the browser sees vs what is asked for — the one place a wrong
+    // crop can be diagnosed from (DevTools console, verbose level): the
+    // window frame, the chrome the outer/inner split implies, the origin the
+    // click taught us, and the element's own box.
+    console.debug("[appShot] shot-region", {
+      window: [window.screenX, window.screenY, window.outerWidth, window.outerHeight],
+      viewport: [window.innerWidth, window.innerHeight],
+      chromeGuess: [(window.outerWidth - window.innerWidth) / 2,
+        window.outerHeight - window.innerHeight],
+      pointerOrigin: viewportOrigin ?? null,
+      element: [r.left, r.top, r.width, r.height],
+      dpr: window.devicePixelRatio,
+      rect,
+    });
     const res = await fetch("/api/capture/shot-region", {
       method: "POST",
       headers: { "X-Fused": "1", "Content-Type": "application/json" },
-      body: JSON.stringify({
-        rect: screenRect(r),
-        dpr: window.devicePixelRatio || 1,
-      }),
+      body: JSON.stringify({ rect, dpr: window.devicePixelRatio || 1 }),
     });
     // Errors come back as the JSON `_error` shape (400 bad rect / off-display,
     // 409 unsupported here, 500) — all the same outcome for an export.

--- a/frontend/src/platform/lib/appShot.ts
+++ b/frontend/src/platform/lib/appShot.ts
@@ -208,20 +208,6 @@ export async function captureAppPreview(
     const r = cropRect(source);
     if (!r) return undefined;
     const rect = screenRect(r);
-    // What the browser sees vs what is asked for — the one place a wrong
-    // crop can be diagnosed from (DevTools console, verbose level): the
-    // window frame, the chrome the outer/inner split implies, the origin the
-    // click taught us, and the element's own box.
-    console.debug("[appShot] shot-region", {
-      window: [window.screenX, window.screenY, window.outerWidth, window.outerHeight],
-      viewport: [window.innerWidth, window.innerHeight],
-      chromeGuess: [(window.outerWidth - window.innerWidth) / 2,
-        window.outerHeight - window.innerHeight],
-      pointerOrigin: viewportOrigin ?? null,
-      element: [r.left, r.top, r.width, r.height],
-      dpr: window.devicePixelRatio,
-      rect,
-    });
     const res = await fetch("/api/capture/shot-region", {
       method: "POST",
       headers: { "X-Fused": "1", "Content-Type": "application/json" },

--- a/frontend/src/platform/lib/appShot.ts
+++ b/frontend/src/platform/lib/appShot.ts
@@ -120,24 +120,38 @@ function cropRect(el: Element | null | undefined): DOMRect | null {
   return r;
 }
 
+// Where the viewport's origin sits on the screen, learned from POINTER EVENTS:
+// every MouseEvent carries both `screenX/Y` and `clientX/Y`, and their
+// difference IS the viewport origin in screen units — exact for any window
+// chrome layout. The arithmetic it replaced (`screenX` + half of
+// `outerWidth - innerWidth` per side) assumed chrome sits on top and splits
+// evenly at the sides, and a browser with a SIDE PANEL — Arc's sidebar,
+// Chrome's side panel, vertical tabs — puts all of it on one side: the shot
+// landed half a sidebar too far left, the shell's own sidebar baked into the
+// preview and the app cut off at the right. The export is always a click
+// away, and that click passes through here (capture phase, so a
+// stopPropagation in a menu cannot hide it).
+let viewportOrigin: { x: number; y: number } | undefined;
+if (typeof window !== "undefined") {
+  const learn = (e: MouseEvent) => {
+    viewportOrigin = { x: e.screenX - e.clientX, y: e.screenY - e.clientY };
+  };
+  window.addEventListener("pointerdown", learn, { capture: true, passive: true });
+  window.addEventListener("click", learn, { capture: true, passive: true });
+}
+
 // A viewport rect as the SCREEN sees it, in the browser's own screen units
 // (CSS pixels of the screen — points on macOS, DIPs elsewhere; the server
-// applies `dpr` where its display measures in physical pixels). The window's
-// chrome — tab strip, toolbar — is the difference between the outer and inner
-// sizes, assumed to sit on top and split evenly at the sides, which holds for
-// every mainstream browser in a normal window. Page zoom ≠ 100% or a docked
-// devtools panel break the arithmetic silently (a wrong crop, still a valid
-// PNG) — accepted: both are developer states, and the export is one click
-// away from a redo.
+// applies `dpr` where its display measures in physical pixels). The
+// outer/inner fallback is for a call no pointer event preceded (keyboard
+// activation) and keeps the top-chrome assumption only. Page zoom ≠ 100%
+// skews both silently (a wrong crop, still a valid PNG) — accepted.
 function screenRect(r: DOMRect): [number, number, number, number] {
-  const chromeX = Math.max(0, (window.outerWidth - window.innerWidth) / 2);
-  const chromeY = Math.max(0, window.outerHeight - window.innerHeight);
-  return [
-    window.screenX + chromeX + r.left,
-    window.screenY + chromeY + r.top,
-    r.width,
-    r.height,
-  ];
+  const origin = viewportOrigin ?? {
+    x: window.screenX + Math.max(0, (window.outerWidth - window.innerWidth) / 2),
+    y: window.screenY + Math.max(0, window.outerHeight - window.innerHeight),
+  };
+  return [origin.x + r.left, origin.y + r.top, r.width, r.height];
 }
 
 // Two frames, so whatever the click that reached here was tearing down — the

--- a/frontend/src/platform/ui/AppPreviewCard.tsx
+++ b/frontend/src/platform/ui/AppPreviewCard.tsx
@@ -396,7 +396,7 @@ export function AppPreviewCard({
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          // Also captures a tab screenshot into the file's preview.png when
+          // Also bakes a native screen shot in as the file's preview.png when
           // the folder has no authored one (appShot, D396). The thumb element
           // rides along as the crop source: a card without a preview.png is
           // already showing the live app there, so nothing has to flash —

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -302,6 +302,13 @@
   color: var(--fg);
   box-shadow: 0 2px 8px var(--shadow-sm);
 }
+/* While appShot photographs the screen, the chip must not be in the pixels:
+   clicking it does not end the hover, so it would sit in the baked
+   preview.png forever. No transition, so it is gone by the next frame. */
+body[data-capture-shooting] .app-pcard-export {
+  opacity: 0 !important;
+  transition: none;
+}
 
 .app-pcard-body {
   display: flex;

--- a/fused_render/capture/__init__.py
+++ b/fused_render/capture/__init__.py
@@ -82,10 +82,11 @@ def _backend():
     backend can ever be live in a process, so this is a module lookup and not an
     interface class standing in front of a single implementation.
 
-    Beyond the four calls, a backend may add three optional hooks —
+    Beyond the four calls, a backend may add four optional hooks —
     `ext(mode, spec)` for the container it is about to write,
-    `refuse(mode, spec)` for what it cannot honour, and `failure(handle)` for a
-    recording it has already lost. Everything platform-specific, INCLUDING the
+    `refuse(mode, spec)` for what it cannot honour, `failure(handle)` for a
+    recording it has already lost, and `locate(rect, dpr)` for mapping a
+    browser-measured screen rect onto one of its displays (`shot_region`). Everything platform-specific, INCLUDING the
     prose of a refusal, belongs there: a sentence naming System Settings is
     wrong on two of the three platforms, and this module cannot be the place it
     is written.
@@ -751,6 +752,63 @@ def screenshot(body: dict) -> dict:
     result = _describe(out)
     result.update(shot)
     return result
+
+
+def shot_region(body: dict) -> bytes:
+    """One frame of a SCREEN REGION, as PNG bytes — no file left behind.
+
+    The export path's capture (SPEC AF-11): the shell hands over the rect of an
+    element as the BROWSER measures it — `window.screenX` + chrome + the
+    element's box, in CSS pixels of the screen (DIPs) — plus the page's
+    `devicePixelRatio`, and gets back the pixels under it. It is not on the
+    `fused.capture` bridge because it answers a different question from
+    `screenshot()`: not "write a still to a path" but "what does this box look
+    like right now", where a file in `<home>/recordings` for every export
+    would be litter the user never asked for. So the backend still writes a
+    file — that is the one door it has — but into a temp path that is read and
+    unlinked before this returns.
+
+    Which display, and in which units, is the backend's knowledge (`locate`):
+    macOS measures displays in points, which ARE DIPs, so `dpr` is unused there;
+    Windows and Linux measure in physical pixels, so the rect is scaled. Each
+    backend also REFUSES a rect that is not fully inside one display rather
+    than clipping it — an export button on a half-off-screen window would
+    otherwise bake a sliver into the artifact as its permanent thumbnail, and
+    a valid PNG is something no later check can catch. Refusal is a
+    `CaptureError`, which the caller turns into "export without a preview".
+    """
+    import tempfile
+
+    rect = _rect(body.get("rect"))
+    if rect is None:
+        raise CaptureError("'rect' is required")
+    try:
+        dpr = float(body.get("dpr") or 1.0)
+    except (TypeError, ValueError):
+        raise CaptureError("'dpr' must be a number") from None
+    if not (0.25 <= dpr <= 8):
+        raise CaptureError(f"'dpr' is out of range: {dpr}")
+    backend = _backend()
+    locate = getattr(backend, "locate", None)
+    if locate is not None:
+        display, local = locate(rect, dpr)
+    else:
+        display, local = None, rect
+    fd, out = tempfile.mkstemp(prefix="fused-shot-", suffix=".png")
+    os.close(fd)
+    try:
+        spec = {"path": out, "rect": list(local)}
+        # Only when a backend named one: Linux refuses the key outright.
+        if display is not None:
+            spec["display"] = display
+        screenshot(spec)
+        with open(out, "rb") as fh:
+            return fh.read()
+    finally:
+        try:
+            os.remove(out)
+        except OSError:
+            pass
 
 
 # ------------------------------------------------------------------ teardown

--- a/fused_render/capture/_darwin.py
+++ b/fused_render/capture/_darwin.py
@@ -295,6 +295,35 @@ def _display(display_id) -> object:
     raise CaptureError(f"no such display: {wanted} (this machine has {known})")
 
 
+def locate(rect, dpr: float):
+    """`capture.shot_region`'s hook: which display a global rect sits on, and
+    the same rect in that display's own coordinates.
+
+    A browser's `screenX`/`getBoundingClientRect` are CSS pixels of the screen,
+    and on the Mac those are POINTS — the unit `CGDisplayBounds` reports and
+    the unit `sourceRect` wants — so `dpr` is deliberately unused here (the
+    panel's backing scale is `_configure`'s business, from the display mode).
+    Both spaces share the main display's top-left as origin, so the map is one
+    subtraction. A rect not entirely inside one display is REFUSED, not
+    clipped: the caller is about to bake the answer into an artifact.
+    """
+    from fused_render.capture import CaptureError
+
+    x, y, w, h = rect
+    err, ids, count = Quartz.CGGetActiveDisplayList(16, None, None)
+    if err != 0:                                          # pragma: no cover
+        raise RuntimeError("could not list displays")
+    for display_id in list(ids)[:count]:
+        b = Quartz.CGDisplayBounds(display_id)
+        bx, by = b.origin.x, b.origin.y
+        bw, bh = b.size.width, b.size.height
+        if bx <= x and by <= y and x + w <= bx + bw and y + h <= by + bh:
+            return int(display_id), (x - bx, y - by, w, h)
+    raise CaptureError(
+        "the region to photograph is not entirely on one display — move the "
+        "window fully on screen and export again")
+
+
 def _display_scale(display) -> int:
     """Backing pixels per point for this display — 2 on a Retina panel, 1 else."""
     mode = Quartz.CGDisplayCopyDisplayMode(display.displayID())

--- a/fused_render/capture/_linux.py
+++ b/fused_render/capture/_linux.py
@@ -157,6 +157,16 @@ def refuse(mode: str, spec: dict) -> str | None:
     return _sink_refuse(mode, spec)
 
 
+def locate(rect, dpr: float):
+    """`capture.shot_region`'s hook: the portal shoots the whole screen in
+    physical pixels, so a browser rect (DIPs from the screen origin) is scaled
+    by the page's `devicePixelRatio` and nothing else. No display to choose
+    (`refuse` says why), and no bounds to check against — `displays` is empty
+    here by design, so an off-screen rect surfaces later as Pillow's crop of
+    nothing rather than as a refusal."""
+    return None, tuple(float(n) * dpr for n in rect)
+
+
 # --------------------------------------------------------------------- still
 
 

--- a/fused_render/capture/_windows.py
+++ b/fused_render/capture/_windows.py
@@ -221,8 +221,8 @@ def _dip_layout(monitors: list[dict], dpr: float) -> list[tuple]:
 
     Chromium's rule (ScreenWin): the primary sits at the origin at its own
     scale; every other display is placed against the display it TOUCHES in
-    physical space, on that same edge, its offset along the edge scaled by its
-    own factor. Walked outward from the primary so a chain of monitors places
+    physical space, on that same edge, its offset along the edge scaled by the
+    PARENT's factor (the edge belongs to the parent). Walked outward from the primary so a chain of monitors places
     in order; one that touches nothing (a gap in the arrangement) falls back to
     physical/scale, which is exact whenever all scales are equal.
     """
@@ -248,14 +248,19 @@ def _dip_layout(monitors: list[dict], dpr: float) -> list[tuple]:
                 if dip[j] is None:
                     continue
                 p, (px, py, pw, ph) = monitors[j], dip[j]
+                # The offset ALONG the shared edge is a distance on the
+                # parent's edge, so it scales by the PARENT's factor
+                # (Chromium ScreenWin `ScaleOffset`: offset / parent_scale),
+                # not the child's.
+                ps = scale(p)
                 if m["x"] == p["x"] + p["width"]:            # right of p
-                    dip[i] = (px + pw, py + (m["y"] - p["y"]) / s, mw, mh)
+                    dip[i] = (px + pw, py + (m["y"] - p["y"]) / ps, mw, mh)
                 elif m["x"] + m["width"] == p["x"]:          # left of p
-                    dip[i] = (px - mw, py + (m["y"] - p["y"]) / s, mw, mh)
+                    dip[i] = (px - mw, py + (m["y"] - p["y"]) / ps, mw, mh)
                 elif m["y"] == p["y"] + p["height"]:         # below p
-                    dip[i] = (px + (m["x"] - p["x"]) / s, py + ph, mw, mh)
+                    dip[i] = (px + (m["x"] - p["x"]) / ps, py + ph, mw, mh)
                 elif m["y"] + m["height"] == p["y"]:         # above p
-                    dip[i] = (px + (m["x"] - p["x"]) / s, py - mh, mw, mh)
+                    dip[i] = (px + (m["x"] - p["x"]) / ps, py - mh, mw, mh)
                 else:
                     continue
                 changed = True

--- a/fused_render/capture/_windows.py
+++ b/fused_render/capture/_windows.py
@@ -96,7 +96,7 @@ def _monitors() -> list[dict]:
                                ctypes.POINTER(_RECT), ctypes.c_ssize_t)
     primary = (_u32().GetSystemMetrics(0), _u32().GetSystemMetrics(1))
 
-    def each(_handle, _dc, rect, _data):
+    def each(handle, _dc, rect, _data):
         box = rect.contents
         found.append({
             "id": len(found) + 1,
@@ -105,14 +105,33 @@ def _monitors() -> list[dict]:
             "width": int(box.right - box.left),
             "height": int(box.bottom - box.top),
             "main": bool(box.left == 0 and box.top == 0),
+            # This monitor's own DPI scale (1.0 at 96 dpi), for `locate`: on a
+            # mixed-DPI desk each monitor has its own, and the page's
+            # `devicePixelRatio` only describes the one the page is on.
+            "scale": _monitor_scale(handle),
         })
         return 1
 
     _u32().EnumDisplayMonitors(None, None, proto(each), 0)
     if not found:                                        # pragma: no cover
         found.append({"id": 1, "x": 0, "y": 0, "width": primary[0],
-                      "height": primary[1], "main": True})
+                      "height": primary[1], "main": True, "scale": 1.0})
     return found
+
+
+def _monitor_scale(handle) -> float:
+    """`GetDpiForMonitor(MDT_EFFECTIVE_DPI) / 96`, or 1.0 where shcore is
+    missing (pre-8.1) — the fallback that keeps `_monitors()` an answer."""
+    try:
+        dpi_x = ctypes.c_uint()
+        dpi_y = ctypes.c_uint()
+        if ctypes.windll.shcore.GetDpiForMonitor(
+                ctypes.c_void_p(handle), 0, ctypes.byref(dpi_x),
+                ctypes.byref(dpi_y)) == 0 and dpi_x.value:
+            return dpi_x.value / 96.0
+    except (AttributeError, OSError):                    # pragma: no cover
+        pass
+    return 1.0
 
 
 def _pick(display, monitors: list[dict]) -> dict:
@@ -166,25 +185,86 @@ def _region(monitor: dict, rect) -> tuple[int, int, int, int]:
 
 def locate(rect, dpr: float):
     """`capture.shot_region`'s hook: the monitor a browser-measured rect is on,
-    and the rect in that monitor's PHYSICAL pixels.
+    and the rect in that monitor's PHYSICAL pixels."""
+    return _locate(rect, _monitors(), dpr)
 
-    The browser measures in DIPs from the primary monitor's origin; this
-    process is per-monitor DPI aware and `_monitors()` reports physical pixels
-    from the same origin, so the scale is the page's `devicePixelRatio`. One
-    ratio for the whole rect is exact on the monitor the page is on and only
-    approximate where a window straddles monitors of different DPI — which
-    the containment test below refuses anyway.
+
+def _locate(rect, monitors: list[dict], dpr: float):
+    """The arithmetic behind `locate`, off-platform testable.
+
+    The browser measures in DIPs; `_monitors()` reports physical pixels. With
+    one DPI everywhere the map is one multiplication by the page's
+    `devicePixelRatio`. On a MIXED-DPI desk it is not: Chromium lays its DIP
+    desktop out per display — each monitor is its physical size divided by
+    ITS OWN scale, placed ADJACENT to the neighbour it touches (`_dip_layout`)
+    — so a window on a 100% external beside a 200% laptop panel reports DIPs
+    that, multiplied by the page's dpr, land inside the wrong monitor's
+    physical bounds and pass containment there. So containment runs in that
+    DIP layout, and the local rect is scaled by the matched monitor's scale,
+    not the page's. `dpr` stands in only for a monitor whose scale could not
+    be read.
     """
     from fused_render.capture import CaptureError
 
-    x, y, w, h = (float(n) * dpr for n in rect)
-    for m in _monitors():
-        if (m["x"] <= x and m["y"] <= y and x + w <= m["x"] + m["width"]
-                and y + h <= m["y"] + m["height"]):
-            return m["id"], (x - m["x"], y - m["y"], w, h)
+    x, y, w, h = (float(n) for n in rect)
+    for m, (dx, dy, dw, dh) in zip(monitors, _dip_layout(monitors, dpr)):
+        if dx <= x and dy <= y and x + w <= dx + dw and y + h <= dy + dh:
+            s = float(m.get("scale") or dpr or 1.0)
+            return m["id"], ((x - dx) * s, (y - dy) * s, w * s, h * s)
     raise CaptureError(
         "the region to photograph is not entirely on one monitor — move the "
         "window fully on screen and export again")
+
+
+def _dip_layout(monitors: list[dict], dpr: float) -> list[tuple]:
+    """Each monitor's bounds in the browser's DIP desktop, same order.
+
+    Chromium's rule (ScreenWin): the primary sits at the origin at its own
+    scale; every other display is placed against the display it TOUCHES in
+    physical space, on that same edge, its offset along the edge scaled by its
+    own factor. Walked outward from the primary so a chain of monitors places
+    in order; one that touches nothing (a gap in the arrangement) falls back to
+    physical/scale, which is exact whenever all scales are equal.
+    """
+    def scale(m):
+        return float(m.get("scale") or dpr or 1.0)
+
+    n = len(monitors)
+    dip: list = [None] * n
+    order = sorted(range(n), key=lambda i: not monitors[i].get("main"))
+    if n:
+        first = order[0]
+        m = monitors[first]
+        dip[first] = (0.0, 0.0, m["width"] / scale(m), m["height"] / scale(m))
+    changed = True
+    while changed:
+        changed = False
+        for i in range(n):
+            if dip[i] is not None:
+                continue
+            m, s = monitors[i], scale(monitors[i])
+            mw, mh = m["width"] / s, m["height"] / s
+            for j in range(n):
+                if dip[j] is None:
+                    continue
+                p, (px, py, pw, ph) = monitors[j], dip[j]
+                if m["x"] == p["x"] + p["width"]:            # right of p
+                    dip[i] = (px + pw, py + (m["y"] - p["y"]) / s, mw, mh)
+                elif m["x"] + m["width"] == p["x"]:          # left of p
+                    dip[i] = (px - mw, py + (m["y"] - p["y"]) / s, mw, mh)
+                elif m["y"] == p["y"] + p["height"]:         # below p
+                    dip[i] = (px + (m["x"] - p["x"]) / s, py + ph, mw, mh)
+                elif m["y"] + m["height"] == p["y"]:         # above p
+                    dip[i] = (px + (m["x"] - p["x"]) / s, py - mh, mw, mh)
+                else:
+                    continue
+                changed = True
+                break
+    for i in range(n):
+        if dip[i] is None:
+            m, s = monitors[i], scale(monitors[i])
+            dip[i] = (m["x"] / s, m["y"] / s, m["width"] / s, m["height"] / s)
+    return dip
 
 
 # ------------------------------------------------------------------- the probe

--- a/fused_render/capture/_windows.py
+++ b/fused_render/capture/_windows.py
@@ -164,6 +164,29 @@ def _region(monitor: dict, rect) -> tuple[int, int, int, int]:
     return (monitor["x"] + int(x), monitor["y"] + int(y), int(w), int(h))
 
 
+def locate(rect, dpr: float):
+    """`capture.shot_region`'s hook: the monitor a browser-measured rect is on,
+    and the rect in that monitor's PHYSICAL pixels.
+
+    The browser measures in DIPs from the primary monitor's origin; this
+    process is per-monitor DPI aware and `_monitors()` reports physical pixels
+    from the same origin, so the scale is the page's `devicePixelRatio`. One
+    ratio for the whole rect is exact on the monitor the page is on and only
+    approximate where a window straddles monitors of different DPI — which
+    the containment test below refuses anyway.
+    """
+    from fused_render.capture import CaptureError
+
+    x, y, w, h = (float(n) * dpr for n in rect)
+    for m in _monitors():
+        if (m["x"] <= x and m["y"] <= y and x + w <= m["x"] + m["width"]
+                and y + h <= m["y"] + m["height"]):
+            return m["id"], (x - m["x"], y - m["y"], w, h)
+    raise CaptureError(
+        "the region to photograph is not entirely on one monitor — move the "
+        "window fully on screen and export again")
+
+
 # ------------------------------------------------------------------- the probe
 
 

--- a/fused_render/server/routers/capture.py
+++ b/fused_render/server/routers/capture.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 
-from fastapi import (APIRouter, Body, Header, WebSocket,
+from fastapi import (APIRouter, Body, Header, Response, WebSocket,
                      WebSocketDisconnect)
 
 from fused_render import capture
@@ -101,6 +101,32 @@ def api_capture_screenshot(body: dict = Body(...),
         return _error(str(e), status=409)
     except Exception as e:                      # noqa: BLE001
         return _error(f"{e.__class__.__name__}: {e}".rstrip(": "), status=500)
+
+
+@router.post("/api/capture/shot-region")
+def api_capture_shot_region(body: dict = Body(...),
+                            x_fused: str | None = Header(default=None)):
+    """The pixels under a browser-measured screen rect, as a PNG body.
+
+    The shell's export capture (SPEC AF-11): `{rect: [x, y, w, h], dpr}` in
+    the browser's own screen units, bytes back — no file in `<home>/recordings`
+    and no `fused.capture` surface, because the caller is the shell baking a
+    thumbnail into a `.fused`, not a page keeping a still. Errors are the
+    ordinary JSON `_error` shape, so a caller branches on `res.ok` alone.
+    """
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    try:
+        png = capture.shot_region(body)
+    except capture.CaptureError as e:
+        return _error(str(e), status=400)
+    except capture.Unsupported as e:
+        return _error(str(e), status=409)
+    except Exception as e:                      # noqa: BLE001
+        return _error(f"{e.__class__.__name__}: {e}".rstrip(": "), status=500)
+    return Response(content=png, media_type="image/png",
+                    headers={"Cache-Control": "no-store"})
 
 
 @router.websocket("/api/capture/{cid}/stream")


### PR DESCRIPTION
## What

`exportAppFile`'s capture-on-export (D396 / SPEC AF-11) moves from browser tab capture (`getDisplayMedia` + current-tab hints) to the platform still behind `fused.capture.screenshot()`.

- **New route** `POST /api/capture/shot-region` `{rect: [x,y,w,h], dpr}` → `image/png` body. X-Fused guarded. Writes the still to a temp file and unlinks it — nothing lands in `<home>/recordings`.
- **`capture.shot_region`** + per-backend **`locate(rect, dpr)`** hook: maps the browser-measured screen rect (`screenX` + chrome + element box, in CSS screen px) onto one display in that backend's units — points on macOS (dpr unused), physical pixels on Windows/Linux (× dpr). A rect not entirely on one display is **refused, not clipped**, so a half-off-screen window can't bake a sliver in as the permanent thumbnail.
- **`appShot.ts`**: same two sources (painted card thumb, else a staged frame), no share prompt, no activation-ordering constraint. Stage frame is sized so the shot lands under `MAX_SHOT_WIDTH` at this DPR — the canvas downscale step is gone. Double-rAF before shooting so the closing context menu isn't photographed. Every failure still exports plain.
- Dropped the two `appShot.test.ts` source assertions that pinned prompt order (no prompt any more); the four paintedness tests stay verbatim.
- SPEC AF-11 amended in place; stale "tab screenshot"/activation prose in Preview.tsx, AppPreviewCard.tsx, appCardMenu.ts updated.

## Tradeoffs to know

- **macOS first run**: a machine without Screen Recording granted to FusedRender gets the TCC dialog on the first export, and *that* export ships without a preview. Worth one manual check whether the next export works without relaunching the app.
- A native shot photographs the **screen**: an overlapping window or notification over the card would bake in. Tab capture was immune to that. Off-screen is caught (refused); occlusion is not.
- Page zoom ≠ 100% or a docked devtools panel skew the chrome-offset arithmetic (wrong crop, valid PNG). Accepted.
- Win: no prompt, and it now works in Safari/Firefox as the default browser.

Out of scope: the claude template's annotation shots (annXO, D355) stay on tab capture.

## Verified

- `bun run build` (boundaries + tsc + vite) clean; `bun test appShot.test.ts` 4/4.
- Python smoke: route registered; `shot_region` rejects missing rect / bad dpr / off-display rects with `CaptureError`; `_darwin.locate` resolves the main display; `_windows.locate` arithmetic checked against fake monitors.
- Not run: a real end-to-end export (TCC on this terminal). Please smoke: export a preview-less app from `/apps` (thumb path) and from a card whose thumb hasn't painted (stage path); open the `.fused` and check `files/preview.png`. Thumb path via BOTH the hover chip and the context menu — confirm no chip/menu ghost in the baked preview (the shot is now ~2 frames after the click, where tab capture came seconds later; if a ghost shows, the fix is hiding the card's overlay UI for the shot or a short delay).
- Full `bun test`: 2753/2753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OS screen capture permissions and coordinate mapping across three platforms; wrong rects or occlusion bake into permanent `.fused` thumbnails, though failures generally fall back to export without preview.
> 
> **Overview**
> **Export-on-export preview capture** (D396 / SPEC AF-11) no longer uses browser tab capture (`getDisplayMedia`). It calls **`POST /api/capture/shot-region`** with a browser-measured screen rect and `devicePixelRatio`, reusing the same platform still stack as `fused.capture.screenshot()`. That removes the share prompt and the fragile “prompt before any await” ordering; macOS may still show **Screen Recording** TCC on the first shot, and that export can ship without a baked preview.
> 
> **Backend:** `capture.shot_region` writes a temp PNG and returns bytes (nothing in `<home>/recordings`). Per-platform **`locate(rect, dpr)`** maps CSS screen coordinates onto one display (points on macOS; physical pixels on Windows/Linux with mixed-DPI layout on Win). Rects **not fully on one display are refused** so half-off-screen exports cannot bake a sliver into the artifact.
> 
> **Frontend (`appShot.ts`):** Still prefers a painted card thumb, else a sized stage iframe. Adds **pointer-based viewport origin** (side-panel–safe), double-rAF before shooting, **`data-capture-shooting`** + CSS to hide the hover export chip from the shot, and **`capWidth`** when the explorer preview pane would exceed the PNG width cap. Source tests that pinned `getDisplayMedia` order are removed; paintedness contract tests remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd9c302d16492be7b083832c73a92a6b1c6187cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

