### PR TITLE
App file export: a .git that git rejects fails open, not the export

### DIFF
--- a/fused_render/appfile.py
+++ b/fused_render/appfile.py
@@ -171,11 +171,33 @@ class _IgnoreRoots:
         parent = self._by_dir.get(dirpath) or self._by_dir.get(
             os.path.dirname(dirpath), (None, False))
         root, in_repo = parent
-        if ".git" in names and dirpath != root:
+        if ".git" in names and dirpath != root and self._is_repo(dirpath):
             root, in_repo = dirpath, True
         elif not in_repo and root is None and ".gitignore" in names:
             root = dirpath
         self._by_dir[dirpath] = (root, in_repo)
+
+    def _is_repo(self, dirpath: str) -> bool:
+        """Whether a `.git` name at `dirpath` is a repository GIT accepts.
+
+        The NAME is not the fact. A `.git` directory with a HEAD git rejects
+        (a stub, a half-copied checkout, a folder someone named that) made
+        this re-root there and start an oracle git answers with "not a git
+        repository" — every query then read as the oracle breaking, and the
+        export refused a folder whose `.git` was going to be dropped by the
+        hidden-name rule anyway. So git is asked the same question the walk's
+        entry asks (`_repo_toplevel`, memoized), and a `.git` git will not
+        own leaves the parent's oracle in force: fail OPEN on the marker, as
+        an unreadable one always did, not closed on the export."""
+        from fused_render.server.gitignore import _repo_toplevel
+
+        top = _repo_toplevel(dirpath)
+        if top is None:
+            return False
+        try:
+            return os.path.realpath(top) == os.path.realpath(dirpath)
+        except OSError:
+            return False
 
     def ignored(self, dirpath: str, names: list[str]) -> set[str]:
         """Subset of `names` (children of `dirpath`) git ignores."""

--- a/tests/test_appfile.py
+++ b/tests/test_appfile.py
@@ -92,6 +92,32 @@ def test_export_skips_machinery_and_hidden(tmp_path):
     )
 
 
+def test_export_fails_open_on_a_git_dir_git_rejects(tmp_path):
+    """A `.git` whose HEAD git will not read (a stub, a half-copied checkout)
+    is not a repository, and must not become the ignore oracle's root: every
+    check-ignore against it answers 128, which read as "git stopped
+    answering" and refused the whole export (main was red on this from
+    #886). The marker fails open — the folder exports as a plain folder
+    would, the stub itself dropped by the hidden-name rule — while a REAL
+    ancestor .gitignore keeps being honored, because the parent's oracle
+    stays in force below the stub."""
+    root = tmp_path / "site"
+    root.mkdir()
+    (root / ".gitignore").write_text("*.log\n")
+    app = make_app(root)
+    (app / ".git").mkdir()
+    (app / ".git" / "HEAD").write_text("ref")  # not a ref git accepts
+    (app / "run.log").write_text("noise")
+    (app / "keep.txt").write_text("data")
+    out = tmp_path / "demo.fused"
+    appfile.export_app_file(str(app), str(out))
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+    assert "files/keep.txt" in names
+    assert "files/run.log" not in names
+    assert not any(".git" in n for n in names)
+
+
 def test_export_refuses_non_app_folder(tmp_path):
     d = tmp_path / "plain"
     d.mkdir()


### PR DESCRIPTION
## Summary
- `_IgnoreRoots.enter` re-rooted the ignore oracle on any dir with a `.git` name. A `.git` git rejects (stub `HEAD`, half-copied checkout) made every `check-ignore` answer 128 → read as "oracle broken" → export raised **"git check-ignore stopped answering"**.
- Since #886 this is `tests/test_appfile.py::test_export_skips_machinery_and_hidden` failing on **main** (`fused-engine`, `test-python-windows`), and every open PR inherits it via the merge ref.
- Fix: confirm the marker with git (`_repo_toplevel`, memoized) before re-rooting; a `.git` git won't own leaves the parent's oracle in force. New regression test: bogus `.git` + real ancestor `.gitignore` → export succeeds, `.gitignore` still honored.

## Verification
- `pytest tests/test_appfile.py` — 15 pass (was 1 failing locally on git 2.50 too)
- `tests/test_appfile_clone.py tests/test_gitignore*.py tests/test_exported_apps.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized export-walk gitignore logic; broadens fail-open behavior for invalid `.git` markers without changing auth or data handling.
> 
> **Overview**
> **`.fused` export no longer treats every `.git` folder as a nested repo.** During the app-folder walk, `_IgnoreRoots.enter` used to switch the gitignore oracle to any directory that merely *named* `.git`. Invalid stubs (bad `HEAD`, half-copied checkouts) made `git check-ignore` fail with exit 128, which surfaced as **"git check-ignore stopped answering"** and blocked export—even though those `.git` dirs would never ship (hidden-name rule).
> 
> The walk now calls new **`_is_repo`**, which uses the same **`_repo_toplevel`** check as elsewhere and only re-roots when git’s toplevel realpath matches that directory. Rejected markers **fail open**: the parent’s oracle stays active, export completes, and ancestor **`.gitignore`** rules still apply.
> 
> A regression test covers bogus app `.git` plus a real parent `*.log` ignore: export succeeds, `keep.txt` ships, `run.log` and `.git` do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8936a6f2d8ecd00ebf463e920a64b5985a4d88df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->