### PR TITLE
App page polish: tabs, header, API curl + first-open, Overview full-screen

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,7 +60,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2008,7 +2007,6 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2253,7 +2251,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -3037,7 +3034,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3425,7 +3421,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
       "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4859,7 +4854,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4872,7 +4866,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5679,7 +5672,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5802,7 +5794,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5959,7 +5950,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -43,9 +43,10 @@ import { Button } from "@platform/shadcn/ui/button";
 import { Checkbox } from "@platform/shadcn/ui/checkbox";
 import { Input } from "@platform/shadcn/ui/input";
 import { Textarea } from "@platform/shadcn/ui/textarea";
-import { ChevronRight, FileCode2, Play, TriangleAlert } from "lucide-react";
+import { Check, ChevronRight, Copy, FileCode2, Play, TriangleAlert } from "lucide-react";
 import {
   collectParams,
+  curlCommand,
   defaultLabel,
   defaultText,
   endpointKind,
@@ -329,6 +330,16 @@ function EndpointRow({
   const crumb = cut >= 0 ? ep.rel.slice(0, cut + 1) : "";
   const name = ep.rel.slice(cut + 1);
   const bodyId = `app-api-body-${ep.rel.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+  // "Copy as curl": the form as it stands, or an empty body when it does not
+  // validate — a snippet with a blank required field is still worth pasting.
+  const [copied, setCopied] = useState(false);
+  const copyCurl = async () => {
+    const collected = collectParams(params, values);
+    const sent = collected.ok ? collected.params : {};
+    await navigator.clipboard.writeText(curlCommand(location.origin, ep.path, sent));
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
 
   return (
     <li className={cn("app-api-row group/row", open && "bg-muted/30")}>
@@ -462,6 +473,10 @@ function EndpointRow({
               >
                 <Play data-icon="inline-start" />
                 {run?.kind === "running" ? "Running…" : "Execute"}
+              </Button>
+              <Button size="sm" variant="outline" onClick={copyCurl}>
+                {copied ? <Check data-icon="inline-start" /> : <Copy data-icon="inline-start" />}
+                {copied ? "Copied" : "Copy as curl"}
               </Button>
               {run?.kind === "failed" && (
                 <span className="text-[12.5px] text-destructive">{run.message}</span>

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -108,7 +108,12 @@ export default function AppApi({
   folderHref: string;
 }) {
   useUrlVersion();
-  const openRel = safeRel(new URLSearchParams(location.search).get("ep"));
+  // Absent `ep` means "nothing chosen yet" — the first endpoint opens so the
+  // page lands on a form, not a list of closed rows (resolved below once the
+  // list is loaded). Present-but-empty `ep=` is the reader having closed
+  // that row: nothing open, and it stays that way.
+  const rawEp = new URLSearchParams(location.search).get("ep");
+  const chosenRel = safeRel(rawEp);
 
   const [load, setLoad] = useState<Load>({ kind: "loading" });
   // Per-endpoint scratch, keyed by rel: what the form holds, what the last run
@@ -130,7 +135,7 @@ export default function AppApi({
 
   const toggle = (rel: string) => {
     const next = new URLSearchParams(location.search);
-    if (openRel === rel) next.delete("ep");
+    if (openRel === rel) next.set("ep", "");
     else next.set("ep", rel);
     const q = next.toString();
     replaceSearch(location.pathname + (q ? "?" + q : ""));
@@ -172,6 +177,7 @@ export default function AppApi({
 
   const data = load.kind === "ok" ? load.data : null;
   const endpoints = data?.endpoints ?? [];
+  const openRel = rawEp === null ? (endpoints[0]?.rel ?? null) : chosenRel;
   const callable = endpoints.filter(isRunnable).length;
   // Three counts, not two: a file that will not parse or cannot be read is not
   // a helper module, and calling it one would hide exactly the files a reader

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -474,10 +474,6 @@ function EndpointRow({
                 <Play data-icon="inline-start" />
                 {run?.kind === "running" ? "Running…" : "Execute"}
               </Button>
-              <Button size="sm" variant="outline" onClick={copyCurl}>
-                {copied ? <Check data-icon="inline-start" /> : <Copy data-icon="inline-start" />}
-                {copied ? "Copied" : "Copy as curl"}
-              </Button>
               {run?.kind === "failed" && (
                 <span className="text-[12.5px] text-destructive">{run.message}</span>
               )}
@@ -487,6 +483,18 @@ function EndpointRow({
                   {formatMs(run.result.duration_ms ?? run.ms)}
                 </span>
               )}
+              {/* Far right and quiet, the way Swagger / Stripe docs park the
+                  snippet: a secondary door, not a second Execute. */}
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={copyCurl}
+                title="Copy this call as a curl command"
+                className="ml-auto text-muted-foreground hover:text-foreground"
+              >
+                {copied ? <Check data-icon="inline-start" /> : <Copy data-icon="inline-start" />}
+                {copied ? "Copied" : "curl"}
+              </Button>
             </div>
           )}
 

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -487,10 +487,10 @@ function EndpointRow({
                   snippet: a secondary door, not a second Execute. */}
               <Button
                 size="sm"
-                variant="ghost"
+                variant="outline"
                 onClick={copyCurl}
                 title="Copy this call as a curl command"
-                className="ml-auto text-muted-foreground hover:text-foreground"
+                className="ml-auto bg-transparent hover:bg-transparent"
               >
                 {copied ? <Check data-icon="inline-start" /> : <Copy data-icon="inline-start" />}
                 {copied ? "Copied" : "curl"}

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -68,6 +68,7 @@ import {
   Files,
   GitBranch,
   ListTodo,
+  Maximize2,
   Plug,
   Webhook,
   type LucideIcon,
@@ -137,11 +138,23 @@ const TAB_DEFS: Record<AppPageTab, TabDef> = {
     keepMounted: true,
     render: ({ slug, entry, folderHref }) =>
       entry ? (
-        <iframe
-          className="app-page-frame"
-          src={`/render?path=${encodeURIComponent(entry)}`}
-          title={`App: ${slug}`}
-        />
+        <div className="app-page-frame-wrap">
+          <iframe
+            className="app-page-frame"
+            src={`/render?path=${encodeURIComponent(entry)}`}
+            title={`App: ${slug}`}
+          />
+          {/* Floats over the frame's top-right: the app full-size in the
+              explorer, the same address the header path opens. */}
+          <a
+            className="app-page-fullscreen"
+            href={urlForFsPath(entry)}
+            title="Open full screen"
+            aria-label="Open full screen"
+          >
+            <Maximize2 />
+          </a>
+        </div>
       ) : (
         <p className="app-page-empty">
           This folder has no entry page yet.{" "}

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -398,7 +398,7 @@ export default function AppPage({
                 <TabsTrigger
                   key={id}
                   value={id}
-                  className="flex-none px-2 py-1.5"
+                  className="flex-none px-4 py-2.5"
                   // Base UI assumes a native <button> unless told otherwise:
                   // without this the anchor gets type="button" and Space
                   // does not activate it (Bugbot on #851).

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -373,9 +373,14 @@ export default function AppPage({
       <header className="app-page-head">
         <div className="app-page-title">
           <h1>{slug}</h1>
-          {/* The folder, as a link: the one door from this page into the
-              explorer, for when the files are the question. */}
-          <a className="app-page-folder" href={folderHref} title={dir}>
+          {/* Reads as the folder, opens the entry page (index.html) in the
+              explorer — the app itself, not its listing. Falls back to the
+              folder when there is no entry yet. */}
+          <a
+            className="app-page-folder"
+            href={entry ? urlForFsPath(entry) : folderHref}
+            title={entry ?? dir}
+          >
             {tildePath(dir, home)}
           </a>
         </div>

--- a/frontend/src/shell/app-api-lib.ts
+++ b/frontend/src/shell/app-api-lib.ts
@@ -146,3 +146,22 @@ export function safeRel(raw: string | null): string | null {
   if (parts.some((p) => !p || p === "." || p === "..")) return null;
   return raw;
 }
+
+/** Single-quote a string for a POSIX shell: the only unsafe byte inside single
+ *  quotes is the quote itself, which becomes '\'' (close, escaped quote, reopen). */
+function shQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+/** The curl equivalent of Execute: the same POST /api/run the page sends, with
+ *  the X-Fused header the server's write guard demands (without it: 403).
+ *  `origin` is passed in, not read from `location`, so this stays DOM-free. */
+export function curlCommand(origin: string, py: string, params: Record<string, unknown>): string {
+  const body = JSON.stringify({ py, params });
+  return [
+    `curl -X POST ${shQuote(origin + "/api/run")}`,
+    `  -H 'Content-Type: application/json'`,
+    `  -H 'X-Fused: 1'`,
+    `  -d ${shQuote(body)}`,
+  ].join(" \\\n");
+}

--- a/frontend/src/styles/app-page.css
+++ b/frontend/src/styles/app-page.css
@@ -124,29 +124,29 @@
    over whatever the app draws there, so it must bring its own backdrop. */
 .app-page-fullscreen {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 12px;
+  right: 12px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: 9px;
   background: var(--bg);
-  color: var(--fg-muted);
-  opacity: 0.75;
-  transition: opacity 120ms, color 120ms;
+  color: var(--fg);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  transition: background 120ms, border-color 120ms;
 }
 
 .app-page-fullscreen:hover {
-  opacity: 1;
-  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 8%, var(--bg));
+  border-color: var(--fg-muted);
 }
 
 .app-page-fullscreen svg {
-  width: 14px;
-  height: 14px;
+  width: 18px;
+  height: 18px;
 }
 
 /* The nested Tasks page brings its own 22px page padding and a 1050px column

--- a/frontend/src/styles/app-page.css
+++ b/frontend/src/styles/app-page.css
@@ -20,8 +20,11 @@
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  padding: 14px 22px 0;
-  border-bottom: 1px solid var(--border);
+  /* Same column as .app-page-body below, so the heading lines up with the
+     tab strip and the frame instead of hugging the window edge. */
+  width: min(1050px, calc(100% - 48px));
+  margin: 0 auto;
+  padding: 14px 0 0;
 }
 
 .app-page-title {

--- a/frontend/src/styles/app-page.css
+++ b/frontend/src/styles/app-page.css
@@ -101,6 +101,16 @@
   display: none;
 }
 
+/* The frame plus the button floating over it. The wrap takes the frame's flex
+   share so the iframe can fill it, and anchors the absolute button. */
+.app-page-frame-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 .app-page-frame {
   flex: 1 1 auto;
   min-height: 0;
@@ -108,6 +118,35 @@
   border: 1px solid var(--border);
   border-radius: 10px;
   background: var(--bg);
+}
+
+/* Full-screen door in the frame's top-right corner: quiet until hovered,
+   over whatever the app draws there, so it must bring its own backdrop. */
+.app-page-fullscreen {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg);
+  color: var(--fg-muted);
+  opacity: 0.75;
+  transition: opacity 120ms, color 120ms;
+}
+
+.app-page-fullscreen:hover {
+  opacity: 1;
+  color: var(--fg);
+}
+
+.app-page-fullscreen svg {
+  width: 14px;
+  height: 14px;
 }
 
 /* The nested Tasks page brings its own 22px page padding and a 1050px column


### PR DESCRIPTION
Small pass over `/apps/<path>`:

- **Tabs**: triggers go from `px-2 py-1.5` to `px-4 py-2.5` so the strip breathes.
- **Header**: rule under the heading removed; heading sits in the same 1050px column as the tab strip and frame instead of hugging the window edge.
- **Header path link**: opens the entry page (`index.html`) in the explorer rather than the folder; falls back to the folder when the app has no entry. Label unchanged.
- **API tab — first endpoint open by default**: no `?ep=` opens the first row so the page lands on a form; closing a row writes an explicit empty `?ep=` so the close sticks.
- **API tab — copy as curl**: outline button far right of the Execute row. `curlCommand()` in `app-api-lib.ts` (DOM-free) emits the same `POST /api/run` the page sends, with `Content-Type` and the `X-Fused: 1` header the write guard demands. Current form values as body; an invalid form copies an empty `params`.
- **Overview — full-screen button**: 36px floating button over the iframe's top-right, opens the entry page in the explorer (same address as the header path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)