### PR TITLE
App icon.svg: render as is in the sidebar and the tab

### DIFF
--- a/frontend/src/platform/lib/hooks.ts
+++ b/frontend/src/platform/lib/hooks.ts
@@ -153,11 +153,16 @@ let defaultHref: string | null = null;
 // its href: browsers (Chrome at least) do not reliably refetch when an existing
 // link's href flips back to a URL it showed before, which left the previous
 // app's icon stuck on a tab until a hard reload (owner, 2026-08-27). A fresh
-// node is a fresh icon request every time. The default goes back with a unique
-// query string as well — Chrome's per-document favicon cache can answer a URL
-// it already holds without repainting; static serving ignores the query, so
-// the bytes are the same file under a new key.
-let restoreSeq = 0;
+// node is a fresh icon request every time. EVERY href — the default and an
+// app's icon alike — also carries a unique query string: Chrome's per-document
+// favicon cache can answer a URL it already holds without repainting (the
+// app's raw URL is stable across visits, so it hits the same cache). The
+// server ignores the query, so the bytes are the same file under a new key.
+let faviconSeq = 0;
+function bust(url: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}r=${++faviconSeq}`;
+}
 function setFaviconHref(href: string | typeof DEFAULT_FAVICON): void {
   const old = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
   if (defaultHref === null && old) defaultHref = old.href;
@@ -165,11 +170,10 @@ function setFaviconHref(href: string | typeof DEFAULT_FAVICON): void {
   link.rel = "icon";
   if (href === DEFAULT_FAVICON) {
     if (!defaultHref) return;
-    const sep = defaultHref.includes("?") ? "&" : "?";
-    link.href = `${defaultHref}${sep}r=${++restoreSeq}`;
+    link.href = bust(defaultHref);
     link.setAttribute("sizes", "any");
   } else {
-    link.href = href;
+    link.href = bust(href);
   }
   if (old) old.replaceWith(link);
   else document.head.appendChild(link);

--- a/frontend/src/platform/lib/hooks.ts
+++ b/frontend/src/platform/lib/hooks.ts
@@ -149,12 +149,6 @@ export function useDocumentTitle(label: string | null | undefined): void {
 const DEFAULT_FAVICON = Symbol("default favicon");
 let defaultHref: string | null = null;
 
-// The fused-render mark's own two colours (frontend/public/favicon.ico: the
-// #1b1d21 rounded square, the #e5ff44 glyph). An app's favicon is composed in
-// the same livery so every fused tab reads as one family.
-const FAVICON_BG = "#1b1d21";
-const FAVICON_FG = "#e5ff44";
-
 // Set the tab icon by REPLACING the `<link rel="icon">` node, never by editing
 // its href: browsers (Chrome at least) do not reliably refetch when an existing
 // link's href flips back to a URL it showed before, which left the previous
@@ -181,76 +175,17 @@ function setFaviconHref(href: string | typeof DEFAULT_FAVICON): void {
   else document.head.appendChild(link);
 }
 
-// An app's icon.svg as a favicon in the fused livery: the svg's alpha as a
-// yellow glyph, inset on a black rounded square — mirroring the shell's own
-// mark (owner, 2026-08-27). Composed on a canvas: the svg is drawn to an
-// offscreen layer and recoloured with `source-in` (its shape, our colour — the
-// same alpha-mask idea the sidebar uses via CSS mask), then laid over the
-// square. Resolves to a PNG data URL, or null when the svg fails to load or
-// the canvas is unavailable — callers then leave the default icon in place.
-async function composeFavicon(src: string): Promise<string | null> {
-  const img = new Image();
-  const loaded = new Promise<boolean>((resolve) => {
-    img.onload = () => resolve(true);
-    img.onerror = () => resolve(false);
-  });
-  img.src = src;
-  if (!(await loaded)) return null;
-  const size = 64;
-  const canvas = document.createElement("canvas");
-  canvas.width = canvas.height = size;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  // The square: radius and inset in the ico's own proportions (a soft corner
-  // and a glyph that fills the middle ~56%).
-  const r = size * 0.22;
-  ctx.fillStyle = FAVICON_BG;
-  ctx.beginPath();
-  ctx.roundRect(0, 0, size, size, r);
-  ctx.fill();
-  // The glyph, recoloured on its own layer so the fill cannot bleed onto the
-  // square. Drawn with its aspect kept inside the inset box.
-  const layer = document.createElement("canvas");
-  layer.width = layer.height = size;
-  const lc = layer.getContext("2d");
-  if (!lc) return null;
-  const inset = size * 0.22;
-  const box = size - inset * 2;
-  const iw = img.naturalWidth || box;
-  const ih = img.naturalHeight || box;
-  const scale = Math.min(box / iw, box / ih);
-  const dw = iw * scale;
-  const dh = ih * scale;
-  lc.drawImage(img, (size - dw) / 2, (size - dh) / 2, dw, dh);
-  lc.globalCompositeOperation = "source-in";
-  lc.fillStyle = FAVICON_FG;
-  lc.fillRect(0, 0, size, size);
-  ctx.drawImage(layer, 0, 0);
-  try {
-    return canvas.toDataURL("image/png");
-  } catch {
-    return null;
-  }
-}
-
 // Tab icon: while a route inside an app is on screen, its optional icon.svg
-// (composed in the fused livery, above) replaces the shell's own; the default
-// comes back when the route leaves (cleanup) or the href goes null (no icon
-// for this app). One writer at a time by construction — the callers (AppPage,
-// StatView) are mutually exclusive mounts — so there is no arbitration, only
-// the restore. Composition is async, so a `live` flag stops a slow icon from
-// landing after the route moved on.
+// replaces the shell's own, AS IS — no recolouring, no livery (owner,
+// 2026-08-27: render the author's svg untouched). The default comes back when
+// the route leaves (cleanup) or the href goes null (no icon for this app). One
+// writer at a time by construction — the callers (AppPage, StatView) are
+// mutually exclusive mounts — so there is no arbitration, only the restore.
 export function useFavicon(href: string | null): void {
   useEffect(() => {
     if (!href) return;
-    let live = true;
-    composeFavicon(href).then((dataUrl) => {
-      if (live && dataUrl) setFaviconHref(dataUrl);
-    });
-    return () => {
-      live = false;
-      setFaviconHref(DEFAULT_FAVICON);
-    };
+    setFaviconHref(href);
+    return () => setFaviconHref(DEFAULT_FAVICON);
   }, [href]);
 }
 

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -235,8 +235,15 @@ function CurrentAppRow({
       <span className="bookmark-glyph current-app-glyph" aria-hidden="true">
         {app.iconUrl ? (
           // The app's own icon.svg in the generic mark's slot, drawn as is —
-          // the author's colours, no mask or tint (owner, 2026-08-27).
-          <img className="current-app-icon" src={app.iconUrl} alt="" />
+          // the author's colours, no mask or tint (owner, 2026-08-27). Not
+          // draggable: an <img> drags natively, and the glyph is the natural
+          // handle for the row reorder (same as the name's draggable={false}).
+          <img
+            className="current-app-icon"
+            src={app.iconUrl}
+            alt=""
+            draggable={false}
+          />
         ) : (
           "▣"
         )}

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -234,18 +234,9 @@ function CurrentAppRow({
     >
       <span className="bookmark-glyph current-app-glyph" aria-hidden="true">
         {app.iconUrl ? (
-          // The app's own icon.svg in the generic mark's slot, as a CSS MASK
-          // over currentColor rather than an <img>: authors draw in black,
-          // and a black glyph on the dark theme vanished (owner, 2026-08-27).
-          // Masked, the shape takes the row's colour — muted, accent when
-          // active — exactly like the ▣ it replaces.
-          <span
-            className="current-app-icon"
-            style={{
-              maskImage: `url("${app.iconUrl}")`,
-              WebkitMaskImage: `url("${app.iconUrl}")`,
-            }}
-          />
+          // The app's own icon.svg in the generic mark's slot, drawn as is —
+          // the author's colours, no mask or tint (owner, 2026-08-27).
+          <img className="current-app-icon" src={app.iconUrl} alt="" />
         ) : (
           "▣"
         )}

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -1187,20 +1187,13 @@ a.bookmark-name::after {
   justify-content: center;
 }
 
-/* The app's own icon.svg, filling the 14px glyph slot as a mask over
-   currentColor: the shape is the author's, the colour is the row's (muted,
-   accent when active), so a black-drawn svg reads on the dark theme. */
+/* The app's own icon.svg, filling the 14px glyph slot as is — the author's
+   shape AND colours, untouched (owner, 2026-08-27). */
 .current-app-icon {
   display: block;
   width: 14px;
   height: 14px;
-  background: currentColor;
-  mask-size: contain;
-  mask-repeat: no-repeat;
-  mask-position: center;
-  -webkit-mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-position: center;
+  object-fit: contain;
 }
 
 /* The running dot sits after the name, in flow: the name gives up its

--- a/skills/fused-render-app-icon/SKILL.md
+++ b/skills/fused-render-app-icon/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: fused-render-app-icon
+description: Design the optional icon.svg for a fused-render app — the file the shell shows as the app's sidebar glyph and browser-tab favicon. Use when the user asks for an app icon, logo, favicon or glyph, or wants to add, change or fix icon.svg.
+---
+
+# An app's icon.svg
+
+An app folder may carry an `icon.svg` (that exact lowercase name) next to its entry page. Nothing registers it — the shell finds it by name and uses it in two places:
+
+- the app's glyph in the sidebar's **Projects** list (a 14 px slot);
+- the **browser-tab favicon** on the app's page (`/apps/<folder>`) and on any of its files opened in the explorer (16 px in most browsers).
+
+Skip the file and the generic mark is used. Edit it and the new drawing shows on the next navigation — no reload of the shell.
+
+## It renders as is
+
+The svg is drawn **untouched**: no recolouring, no mask, no tint, no frame added. Whatever colours and background you draw are exactly what the user sees. Consequences:
+
+- **Own your background.** The icon lands on the sidebar (light or dark theme) and on a browser tab strip (light or dark, per the user's OS/browser). A transparent icon must read on BOTH; a black glyph vanishes on dark, a white one on light. The easy fix is to give the icon its own background — a filled rounded square or circle behind the glyph — so contrast is decided inside the file, not by whatever is behind it.
+- **If you go transparent**, use a mid-tone or saturated colour that holds on both white and near-black (a strong brand hue, not pure black/white/grey), or outline the shape in a contrasting stroke.
+- Nothing is clipped or inset for you. Fill the viewBox; leave only a small margin if the icon has its own background.
+
+## It renders very small
+
+14–16 px. Design for that, not for a hero image:
+
+- **One shape, one idea.** A single bold silhouette or a 1–2 letter monogram. No scenes, no text longer than two letters, no thin lines (under ~1/12 of the viewBox they blur to nothing).
+- **Two colours, maybe three.** Background + glyph is usually enough. Gradients, shadows and fine texture turn to mud.
+- **Square viewBox** (`viewBox="0 0 64 64"` or similar) so it fills the slot without letterboxing. Set no fixed `width`/`height`, or set them equal.
+- Check it: zoom the browser out until the svg is ~16 px on screen, on a light and a dark page. If you cannot tell what it is, simplify.
+
+## A serviceable default
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#1b1d21"/>
+  <circle cx="32" cy="32" r="16" fill="#e5ff44"/>
+</svg>
+```
+
+Dark rounded square, one bright glyph — reads on any background and at any size. Swap the glyph (a path, a monogram `<text>` at `font-size="34"` with `text-anchor="middle"`, a simple mark) and the two colours for the app's own.
+
+## Keep it a plain file
+
+- Inline everything: no external `<image>`, fonts or CSS `@import` — the favicon is fetched as a standalone document.
+- No scripts, no animation (favicons do not animate and the sidebar ignores it).
+- Small: a few KB. Optimise with `svgo` if exported from a design tool.

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fused-render-authoring
-description: Author .html views and .py data files for fused-render — the fused.runPython() bridge, URL-synced params, file IO, preview mode. Use when creating, editing or debugging a view, a data file or a preview template; when a view renders blank or shows a traceback overlay; or on any mention of fused.runPython/params/readFile/writeFile. Routes to the neighbouring fused-render-* skills for AI, capture, jobs and theming.
+description: Author .html views and .py data files for fused-render — the fused.runPython() bridge, URL-synced params, file IO, preview mode. Use when creating, editing or debugging a view, a data file or a preview template; when a view renders blank or shows a traceback overlay; or on any mention of fused.runPython/params/readFile/writeFile. Routes to the neighbouring fused-render-* skills for AI, capture, jobs, theming and the app icon.
 ---
 
 # Authoring fused-render views
@@ -34,11 +34,11 @@ fused-render is a local file explorer that renders `.html` files live in the bro
 <meta name="fused-app" />
 ```
 
-**Optional app icon: `icon.svg`.** Drop an `icon.svg` (that exact lowercase name) next to the entry page and the shell picks it up with no registration: it becomes the app's glyph in the sidebar's Projects list and the browser-tab favicon on the app's page (`/apps/<folder>`) and on any of its files opened in the explorer. Skip it and the generic mark is used. Keep it a single flat shape, legible at 14–16 px, no text. Both places use it as a **mask** — only the shape's alpha matters; the sidebar colours it from the theme, the tab icon paints it yellow on the black rounded square of the fused mark — so draw solid shapes on a transparent background (any fill colour works; a filled background rectangle would render as a solid square).
+**Optional app icon: `icon.svg`.** An `icon.svg` next to the entry page becomes the app's sidebar glyph and tab favicon, rendered as is. Designing one (own background, both themes, 14–16 px legibility) → **`fused-render-app-icon`**.
 
 Three primitives — `runPython`, `params`, and the file IO helpers — are the core API; the table below has the rest. Everything else is ordinary HTML/CSS/JS: no framework, no build step, ES2020 fine.
 
-Four neighbouring skills own the bigger surfaces, and this one keeps only enough to know when you need them: **`fused-render-ai`** (`fused.ai` and every model call), **`fused-render-capture`** (native screen/audio/screenshot), **`fused-render-jobs`** (work longer than one call, and the download manager), **`fused-render-theming`** (light/dark).
+Five neighbouring skills own the bigger surfaces, and this one keeps only enough to know when you need them: **`fused-render-ai`** (`fused.ai` and every model call), **`fused-render-capture`** (native screen/audio/screenshot), **`fused-render-jobs`** (work longer than one call, and the download manager), **`fused-render-theming`** (light/dark), **`fused-render-app-icon`** (the app's `icon.svg`).
 
 ## The Python side: `main()` contract
 


### PR DESCRIPTION
Removes the icon.svg recolouring from #887.

- Sidebar Projects row: `<img>` of the svg instead of a CSS mask over currentColor.
- Tab favicon: the raw icon URL as the `<link rel="icon">` href instead of a canvas-composed yellow-on-black PNG. `composeFavicon` and the livery constants are gone; the replace-the-node restore stays.

Shell rebuilt (`npm run build` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only favicon and sidebar icon behavior; no auth, data, or API changes.
> 
> **Overview**
> **App `icon.svg` is shown with the author’s colors everywhere** — the fused livery (yellow glyph on dark rounded square) and CSS `currentColor` masking are removed.
> 
> In the **Projects** sidebar, icons use a plain `<img>` instead of a masked span, with `draggable={false}` so row reorder still works. **Tab favicons** point at the raw SVG URL via `useFavicon`; the async canvas `composeFavicon` path and livery constants are deleted. Favicon swaps still replace the `<link rel="icon">` node, and **cache-busting** (`bust()`) now applies to both default and app URLs so Chrome repaints reliably.
> 
> Docs add **`fused-render-app-icon`** (background, contrast, small-size guidance) and **`fused-render-authoring`** now routes icon design there instead of describing mask/livery behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0847755a1282476baaa2d2bd8cc659c3bfc80674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->