### PR TITLE
App page: "Open app" header button, folder path link, API "Copy as cURL" on the route line, MCP tab removed

### DIFF
--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -43,7 +43,14 @@ import { Button } from "@platform/shadcn/ui/button";
 import { Checkbox } from "@platform/shadcn/ui/checkbox";
 import { Input } from "@platform/shadcn/ui/input";
 import { Textarea } from "@platform/shadcn/ui/textarea";
-import { Check, ChevronRight, Copy, FileCode2, Play, TriangleAlert } from "lucide-react";
+import {
+  Check,
+  ChevronRight,
+  Copy,
+  FileCode2,
+  Play,
+  TriangleAlert,
+} from "lucide-react";
 import {
   collectParams,
   curlCommand,
@@ -64,7 +71,12 @@ type Load =
 
 type Run =
   | { kind: "running"; startedAt: number }
-  | { kind: "done"; result: RunResult; ms: number; sent: Record<string, unknown> }
+  | {
+      kind: "done";
+      result: RunResult;
+      ms: number;
+      sent: Record<string, unknown>;
+    }
   | { kind: "failed"; message: string };
 
 // What a row says about its kind, in words — only where the kind is unusual.
@@ -85,10 +97,20 @@ const KIND_NOTE: Record<EndpointKind, string | null> = {
  *  is the only colour on the list. */
 function KindGlyph({ kind }: { kind: EndpointKind }) {
   if (kind === "error" || kind === "unreadable") {
-    return <TriangleAlert aria-hidden className="size-4 flex-none text-destructive" />;
+    return (
+      <TriangleAlert
+        aria-hidden
+        className="size-4 flex-none text-destructive"
+      />
+    );
   }
   if (kind === "none") {
-    return <FileCode2 aria-hidden className="size-4 flex-none text-muted-foreground/60" />;
+    return (
+      <FileCode2
+        aria-hidden
+        className="size-4 flex-none text-muted-foreground/60"
+      />
+    );
   }
   return (
     <Play
@@ -119,7 +141,9 @@ export default function AppApi({
   const [load, setLoad] = useState<Load>({ kind: "loading" });
   // Per-endpoint scratch, keyed by rel: what the form holds, what the last run
   // said. Kept across open/close so a reader can compare two files' outputs.
-  const [values, setValues] = useState<Record<string, Record<string, string>>>({});
+  const [values, setValues] = useState<Record<string, Record<string, string>>>(
+    {},
+  );
   const [runs, setRuns] = useState<Record<string, Run>>({});
   const [invalid, setInvalid] = useState<Record<string, string | null>>({});
 
@@ -128,7 +152,10 @@ export default function AppApi({
     setLoad({ kind: "loading" });
     getAppPy(dir)
       .then((data) => live && setLoad({ kind: "ok", data }))
-      .catch((e) => live && setLoad({ kind: "error", message: (e as Error).message }));
+      .catch(
+        (e) =>
+          live && setLoad({ kind: "error", message: (e as Error).message }),
+      );
     return () => {
       live = false;
     };
@@ -143,7 +170,10 @@ export default function AppApi({
   };
 
   const setValue = (rel: string, name: string, v: string) => {
-    setValues((prev) => ({ ...prev, [rel]: { ...(prev[rel] ?? {}), [name]: v } }));
+    setValues((prev) => ({
+      ...prev,
+      [rel]: { ...(prev[rel] ?? {}), [name]: v },
+    }));
     setInvalid((prev) => (prev[rel] ? { ...prev, [rel]: null } : prev));
   };
 
@@ -152,7 +182,10 @@ export default function AppApi({
     const collected = collectParams(params, values[ep.rel] ?? {});
     if (!collected.ok) {
       setInvalid((prev) => ({ ...prev, [ep.rel]: collected.field }));
-      setRuns((prev) => ({ ...prev, [ep.rel]: { kind: "failed", message: collected.message } }));
+      setRuns((prev) => ({
+        ...prev,
+        [ep.rel]: { kind: "failed", message: collected.message },
+      }));
       return;
     }
     const startedAt = performance.now();
@@ -171,7 +204,10 @@ export default function AppApi({
     } catch (e) {
       setRuns((prev) => ({
         ...prev,
-        [ep.rel]: { kind: "failed", message: (e as Error).message || "request failed" },
+        [ep.rel]: {
+          kind: "failed",
+          message: (e as Error).message || "request failed",
+        },
       }));
     }
   };
@@ -191,7 +227,9 @@ export default function AppApi({
   // The project's declared dependencies are the FOLDER's, so every file reports
   // the same list; shown once, above the list, rather than on every row.
   const deps = useMemo(
-    () => endpoints.find((e) => e.dependencies && e.dependencies.length)?.dependencies ?? [],
+    () =>
+      endpoints.find((e) => e.dependencies && e.dependencies.length)
+        ?.dependencies ?? [],
     [endpoints],
   );
 
@@ -200,8 +238,12 @@ export default function AppApi({
   // scrolls here. The list inside hugs its rows (flex-none).
   return (
     <div className="app-api flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
-      {load.kind === "loading" && <SkeletonLines rows={3} label="Reading Python files" />}
-      {load.kind === "error" && <ErrorBanner>Could not read the folder: {load.message}</ErrorBanner>}
+      {load.kind === "loading" && (
+        <SkeletonLines rows={3} label="Reading Python files" />
+      )}
+      {load.kind === "error" && (
+        <ErrorBanner>Could not read the folder: {load.message}</ErrorBanner>
+      )}
 
       {data && (
         <>
@@ -214,7 +256,8 @@ export default function AppApi({
                 {callable === 0
                   ? "Nothing to run yet"
                   : `${callable} ${callable === 1 ? "endpoint" : "endpoints"} you can run`}
-                {helpers > 0 && ` · ${helpers} helper ${helpers === 1 ? "module" : "modules"}`}
+                {helpers > 0 &&
+                  ` · ${helpers} helper ${helpers === 1 ? "module" : "modules"}`}
                 {broken > 0 && (
                   <>
                     {" · "}
@@ -246,8 +289,9 @@ export default function AppApi({
               <FileCode2 className="size-7 opacity-60" aria-hidden />
               <p className="m-0">No Python files in this app yet.</p>
               <p className="m-0">
-                Add a <code className={MONO}>.py</code> with a <code className={MONO}>main()</code>{" "}
-                and it shows up here as an endpoint.
+                Add a <code className={MONO}>.py</code> with a{" "}
+                <code className={MONO}>main()</code> and it shows up here as an
+                endpoint.
               </p>
             </div>
           )}
@@ -336,7 +380,9 @@ function EndpointRow({
   const copyCurl = async () => {
     const collected = collectParams(params, values);
     const sent = collected.ok ? collected.params : {};
-    await navigator.clipboard.writeText(curlCommand(location.origin, ep.path, sent));
+    await navigator.clipboard.writeText(
+      curlCommand(location.origin, ep.path, sent),
+    );
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1500);
   };
@@ -344,72 +390,98 @@ function EndpointRow({
   return (
     <li className={cn("app-api-row group/row", open && "bg-muted/30")}>
       {/* The route line: a glyph for what the file is, its name, one sentence
-          about it, and — on hover — the invitation. The signature is NOT here:
-          types and defaults belong to the open form, and a wall of them made
-          the list read as code. */}
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={open}
-        aria-controls={bodyId}
-        className={cn(
-          "flex w-full items-center gap-3 border-0 bg-transparent px-4 py-3 text-left text-foreground",
-          "cursor-pointer hover:bg-muted/40 focus-visible:outline-2 focus-visible:outline-ring focus-visible:-outline-offset-2",
-          !runnable && "text-muted-foreground",
-        )}
-      >
-        <KindGlyph kind={kind} />
-        <span className="flex min-w-0 flex-1 flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-3">
-          <span
-            className={cn(MONO, "flex-none truncate", runnable && "font-medium")}
-            title={ep.path}
-          >
-            {crumb && <span className="text-muted-foreground">{crumb}</span>}
-            {name}
-          </span>
-          {kindNote && (
-            <span className="flex-none text-[11px] tracking-[0.04em] text-muted-foreground uppercase">
-              {kindNote}
-            </span>
-          )}
-          <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">
-            {summary || paramHint}
-          </span>
-        </span>
-        {runnable && !open && (
-          <span
-            className={cn(
-              "flex-none text-[12px] text-muted-foreground opacity-0 transition-opacity",
-              "group-hover/row:opacity-100 group-focus-within/row:opacity-100 motion-reduce:transition-none",
-            )}
-            aria-hidden
-          >
-            Try it
-          </span>
-        )}
-        <ChevronRight
-          aria-hidden
+          about it, and — on hover, or always once open — "Copy as cURL". The
+          signature is NOT here: types and defaults belong to the open form, and
+          a wall of them made the list read as code. The copy control is a
+          sibling of the toggle (a button cannot nest a button), floated over a
+          gap the toggle reserves for it. */}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={open}
+          aria-controls={bodyId}
           className={cn(
-            "size-3.5 flex-none text-muted-foreground/70 transition-transform duration-150 motion-reduce:transition-none",
-            open && "rotate-90",
+            "flex w-full items-center gap-3 border-0 bg-transparent px-4 py-3 text-left text-foreground",
+            "cursor-pointer hover:bg-muted/40 focus-visible:outline-2 focus-visible:outline-ring focus-visible:-outline-offset-2",
+            !runnable && "text-muted-foreground",
           )}
-        />
-      </button>
+        >
+          <KindGlyph kind={kind} />
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-3">
+            <span
+              className={cn(
+                MONO,
+                "flex-none truncate",
+                runnable && "font-medium",
+              )}
+              title={ep.path}
+            >
+              {crumb && <span className="text-muted-foreground">{crumb}</span>}
+              {name}
+            </span>
+            {kindNote && (
+              <span className="flex-none text-[11px] tracking-[0.04em] text-muted-foreground uppercase">
+                {kindNote}
+              </span>
+            )}
+            <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">
+              {summary || paramHint}
+            </span>
+          </span>
+          {/* Room for the floated "Copy as cURL" button. */}
+          {runnable && <span className="w-[124px] flex-none" aria-hidden />}
+          <ChevronRight
+            aria-hidden
+            className={cn(
+              "size-3.5 flex-none text-muted-foreground/70 transition-transform duration-150 motion-reduce:transition-none",
+              open && "rotate-90",
+            )}
+          />
+        </button>
+        {runnable && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={copyCurl}
+            title="Copy this call as a curl command"
+            className={cn(
+              "absolute top-1/2 right-[42px] -translate-y-1/2 bg-transparent transition-opacity",
+              "group-hover/row:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none",
+              open ? "opacity-100" : "opacity-0",
+            )}
+          >
+            {copied ? (
+              <Check data-icon="inline-start" />
+            ) : (
+              <Copy data-icon="inline-start" />
+            )}
+            {copied ? "Copied" : "Copy as cURL"}
+          </Button>
+        )}
+      </div>
 
       {open && (
-        <div id={bodyId} className="flex flex-col gap-4 border-t border-border px-4 pt-3 pb-4">
+        <div
+          id={bodyId}
+          className="flex flex-col gap-4 border-t border-border px-4 pt-3 pb-4"
+        >
           {fn && (
             <p className={cn(MONO, "m-0 text-muted-foreground")}>
               <Signature fn={fn} />
             </p>
           )}
           {kind === "error" && (
-            <pre className={cn(MONO, "m-0 whitespace-pre-wrap text-destructive")}>
+            <pre
+              className={cn(MONO, "m-0 whitespace-pre-wrap text-destructive")}
+            >
               Syntax error — {ep.parse_error}
             </pre>
           )}
           {kind === "unreadable" && (
-            <pre className={cn(MONO, "m-0 whitespace-pre-wrap text-destructive")}>
+            <pre
+              className={cn(MONO, "m-0 whitespace-pre-wrap text-destructive")}
+            >
               Could not read this file — {ep.read_error}
             </pre>
           )}
@@ -417,7 +489,9 @@ function EndpointRow({
           {(ep.module_docstring || fn?.docstring) && (
             <div className="flex flex-col gap-2 text-[13px] leading-relaxed text-foreground/85">
               {ep.module_docstring && (
-                <p className="m-0 whitespace-pre-wrap">{ep.module_docstring.trim()}</p>
+                <p className="m-0 whitespace-pre-wrap">
+                  {ep.module_docstring.trim()}
+                </p>
               )}
               {fn?.docstring && fn.docstring !== ep.module_docstring && (
                 <p className="m-0 whitespace-pre-wrap">{fn.docstring.trim()}</p>
@@ -427,16 +501,16 @@ function EndpointRow({
 
           {kind === "none" && (
             <p className="m-0 text-[12.5px] text-muted-foreground">
-              No <code className={MONO}>main()</code> here — a helper module, imported by the
-              others rather than called on its own. Define <code className={MONO}>main()</code> to
-              make it an endpoint.
+              No <code className={MONO}>main()</code> here — a helper module,
+              imported by the others rather than called on its own. Define{" "}
+              <code className={MONO}>main()</code> to make it an endpoint.
             </p>
           )}
 
           {kind === "result" && (
             <p className="m-0 text-[12.5px] text-muted-foreground">
-              Static script — assigns <code className={MONO}>result</code> at the top level, no
-              parameters.
+              Static script — assigns <code className={MONO}>result</code> at
+              the top level, no parameters.
             </p>
           )}
 
@@ -475,7 +549,9 @@ function EndpointRow({
                 {run?.kind === "running" ? "Running…" : "Execute"}
               </Button>
               {run?.kind === "failed" && (
-                <span className="text-[12.5px] text-destructive">{run.message}</span>
+                <span className="text-[12.5px] text-destructive">
+                  {run.message}
+                </span>
               )}
               {run?.kind === "done" && (
                 <span className="text-[12px] text-muted-foreground tabular-nums">
@@ -483,22 +559,12 @@ function EndpointRow({
                   {formatMs(run.result.duration_ms ?? run.ms)}
                 </span>
               )}
-              {/* Far right and quiet, the way Swagger / Stripe docs park the
-                  snippet: a secondary door, not a second Execute. */}
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={copyCurl}
-                title="Copy this call as a curl command"
-                className="ml-auto bg-transparent hover:bg-transparent"
-              >
-                {copied ? <Check data-icon="inline-start" /> : <Copy data-icon="inline-start" />}
-                {copied ? "Copied" : "curl"}
-              </Button>
             </div>
           )}
 
-          {run?.kind === "running" && <SkeletonLines rows={2} label="Running" />}
+          {run?.kind === "running" && (
+            <SkeletonLines rows={2} label="Running" />
+          )}
           {run?.kind === "done" && <Response run={run} py={ep.path} />}
         </div>
       )}
@@ -543,17 +609,31 @@ function ParamRow({
   const dflt = defaultLabel(p);
   return (
     <>
-      <label htmlFor={id} className={cn(MONO, "flex items-baseline gap-1 pt-1.5 leading-snug")}>
+      <label
+        htmlFor={id}
+        className={cn(MONO, "flex items-baseline gap-1 pt-1.5 leading-snug")}
+      >
         <span className="text-foreground">{p.name}</span>
         {required && (
-          <span className="text-destructive" title="required" aria-label="required">
+          <span
+            className="text-destructive"
+            title="required"
+            aria-label="required"
+          >
             *
           </span>
         )}
       </label>
-      <div className={cn(MONO, "flex flex-col gap-0.5 pt-1.5 text-[11.5px] leading-snug")}>
+      <div
+        className={cn(
+          MONO,
+          "flex flex-col gap-0.5 pt-1.5 text-[11.5px] leading-snug",
+        )}
+      >
         <span className="text-primary">{p.annotation ?? "any"}</span>
-        {dflt !== null && <span className="text-muted-foreground">= {dflt}</span>}
+        {dflt !== null && (
+          <span className="text-muted-foreground">= {dflt}</span>
+        )}
       </div>
       <div className="min-w-0">
         {kind === "bool" && (
@@ -623,13 +703,17 @@ function Response({
             className={cn(
               MONO,
               "h-[18px] rounded-md border-transparent px-1.5 text-[10.5px] font-semibold tracking-[0.06em]",
-              result.ok ? "bg-primary/10 text-primary" : "bg-destructive/10 text-destructive",
+              result.ok
+                ? "bg-primary/10 text-primary"
+                : "bg-destructive/10 text-destructive",
             )}
           >
             {result.ok ? "OK" : "ERROR"}
           </Badge>
           {!result.ok && result.error?.type && (
-            <span className={cn(MONO, "text-muted-foreground")}>{result.error.type}</span>
+            <span className={cn(MONO, "text-muted-foreground")}>
+              {result.error.type}
+            </span>
           )}
           <span className="ml-auto text-[11.5px] text-muted-foreground tabular-nums">
             {formatMs(result.duration_ms ?? run.ms)}
@@ -672,7 +756,12 @@ function Fold({
       <summary className="cursor-pointer select-none px-3 py-1.5 text-[12px] text-muted-foreground hover:text-foreground">
         {label}
       </summary>
-      <pre className={cn(MONO, "m-0 max-h-[280px] overflow-auto px-3 pb-2.5 leading-relaxed")}>
+      <pre
+        className={cn(
+          MONO,
+          "m-0 max-h-[280px] overflow-auto px-3 pb-2.5 leading-relaxed",
+        )}
+      >
         {children}
       </pre>
     </details>

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -446,7 +446,7 @@ function EndpointRow({
             onClick={copyCurl}
             title="Copy this call as a curl command"
             className={cn(
-              "absolute top-1/2 right-[42px] -translate-y-1/2 px-1 text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
+              "absolute top-1/2 right-[42px] -translate-y-1/2 border-border/60 px-1.5 text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
               "group-hover/row:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none",
               open ? "opacity-100" : "opacity-0",
             )}

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -446,7 +446,7 @@ function EndpointRow({
             onClick={copyCurl}
             title="Copy this call as a curl command"
             className={cn(
-              "absolute top-1/2 right-[42px] -translate-y-1/2 rounded-md border-border bg-transparent px-1.5 font-normal text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
+              "absolute inset-y-0 right-[42px] my-auto rounded-md border-border bg-transparent px-1.5 font-normal text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
               "group-hover/row:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none",
               open ? "opacity-100" : "opacity-0",
             )}

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -446,7 +446,7 @@ function EndpointRow({
             onClick={copyCurl}
             title="Copy this call as a curl command"
             className={cn(
-              "absolute top-1/2 right-[42px] -translate-y-1/2 text-muted-foreground transition-opacity",
+              "absolute top-1/2 right-[42px] -translate-y-1/2 px-1 text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
               "group-hover/row:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none",
               open ? "opacity-100" : "opacity-0",
             )}

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -430,7 +430,7 @@ function EndpointRow({
             </span>
           </span>
           {/* Room for the floated "Copy as cURL" button. */}
-          {runnable && <span className="w-[124px] flex-none" aria-hidden />}
+          {runnable && <span className="w-[104px] flex-none" aria-hidden />}
           <ChevronRight
             aria-hidden
             className={cn(
@@ -441,12 +441,12 @@ function EndpointRow({
         </button>
         {runnable && (
           <Button
-            size="sm"
-            variant="outline"
+            size="xs"
+            variant="ghost"
             onClick={copyCurl}
             title="Copy this call as a curl command"
             className={cn(
-              "absolute top-1/2 right-[42px] -translate-y-1/2 bg-transparent transition-opacity",
+              "absolute top-1/2 right-[42px] -translate-y-1/2 text-muted-foreground transition-opacity",
               "group-hover/row:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none",
               open ? "opacity-100" : "opacity-0",
             )}

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -447,8 +447,10 @@ function EndpointRow({
             title="Copy this call as a curl command"
             className={cn(
               "absolute inset-y-0 right-[42px] my-auto rounded-md border-border bg-transparent px-1.5 font-normal text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
-              "group-hover/row:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none",
-              open ? "opacity-100" : "opacity-0",
+              "group-hover/row:pointer-events-auto group-hover/row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 motion-reduce:transition-none",
+              // Hidden means hidden: no hit-testing, so a tap in the gap on a
+              // collapsed row (touch has no hover) reaches the toggle beneath.
+              open ? "opacity-100" : "pointer-events-none opacity-0",
             )}
           >
             {copied ? (

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -446,7 +446,7 @@ function EndpointRow({
             onClick={copyCurl}
             title="Copy this call as a curl command"
             className={cn(
-              "absolute top-1/2 right-[42px] -translate-y-1/2 rounded-md border-border px-1.5 font-normal text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
+              "absolute top-1/2 right-[42px] -translate-y-1/2 rounded-md border-border bg-transparent px-1.5 font-normal text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
               "group-hover/row:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none",
               open ? "opacity-100" : "opacity-0",
             )}

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -446,7 +446,7 @@ function EndpointRow({
             onClick={copyCurl}
             title="Copy this call as a curl command"
             className={cn(
-              "absolute top-1/2 right-[42px] -translate-y-1/2 border-border/60 px-1.5 text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
+              "absolute top-1/2 right-[42px] -translate-y-1/2 rounded-md border-border px-1.5 font-normal text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
               "group-hover/row:opacity-100 focus-visible:opacity-100 motion-reduce:transition-none",
               open ? "opacity-100" : "opacity-0",
             )}

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -390,9 +390,7 @@ export default function AppPage({
             size="sm"
             variant="outline"
             className="app-page-open"
-            render={
-              <a href={urlForFsPath(entry)} target="_blank" rel="noopener" />
-            }
+            onClick={() => window.open(urlForFsPath(entry), "_blank", "noopener")}
           >
             Open app
             <ExternalLink data-icon="inline-end" />

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -67,13 +67,14 @@ import {
   AppWindow,
   Files,
   GitBranch,
+  ExternalLink,
   ListTodo,
-  Maximize2,
   Plug,
   Webhook,
   type LucideIcon,
 } from "lucide-react";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
+import { Button } from "@platform/shadcn/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@platform/shadcn/ui/tabs";
 import { SkeletonLines } from "@platform/ui/Skeleton";
 import { basename } from "@platform/lib/format";
@@ -144,16 +145,6 @@ const TAB_DEFS: Record<AppPageTab, TabDef> = {
             src={`/render?path=${encodeURIComponent(entry)}`}
             title={`App: ${slug}`}
           />
-          {/* Floats over the frame's top-right: the app full-size in the
-              explorer, the same address the header path opens. */}
-          <a
-            className="app-page-fullscreen"
-            href={urlForFsPath(entry)}
-            title="Open full screen"
-            aria-label="Open full screen"
-          >
-            <Maximize2 />
-          </a>
         </div>
       ) : (
         <p className="app-page-empty">
@@ -386,17 +377,27 @@ export default function AppPage({
       <header className="app-page-head">
         <div className="app-page-title">
           <h1>{slug}</h1>
-          {/* Reads as the folder, opens the entry page (index.html) in the
-              explorer — the app itself, not its listing. Falls back to the
-              folder when there is no entry yet. */}
-          <a
-            className="app-page-folder"
-            href={entry ? urlForFsPath(entry) : folderHref}
-            title={entry ?? dir}
-          >
+          {/* Reads as the folder and IS the folder: opens its listing in the
+              explorer. The app itself is the "Open app" button opposite. */}
+          <a className="app-page-folder" href={folderHref} title={dir}>
             {tildePath(dir, home)}
           </a>
         </div>
+        {entry && (
+          /* The app full-size in the explorer (its entry page), in a new tab
+             so this page and its live frame stay put. */
+          <Button
+            size="sm"
+            variant="outline"
+            className="app-page-open"
+            render={
+              <a href={urlForFsPath(entry)} target="_blank" rel="noopener" />
+            }
+          >
+            Open app
+            <ExternalLink data-icon="inline-end" />
+          </Button>
+        )}
       </header>
 
       <div className="app-page-body">

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -17,18 +17,15 @@
 //   API       every .py in the folder as an endpoint, Swagger-style
 //             (shell/AppApi.tsx): entrypoint, parameters as a form, Execute,
 //             response — the api template's view, for the whole app at once.
-//   MCP       the folder's `mcp` template (templates/mcp) in a frame — the
-//             tool curation panel the explorer offers on an app folder, here
-//             as a tab. Offered whenever the template exists; the template's
-//             own empty state covers a folder that is not (yet) an app.
 //   Git       the folder's `git` template (templates/git) in a frame — the
 //             working-tree view. Offered ONLY when the folder is inside a
 //             work tree (the template's condition.py verdict, CT-12), so a
 //             plain folder never shows a Git tab that could only say "no".
 //
-// The two companion tabs render the EXISTING templates rather than a second
-// panel of their own: the templates are the mcp.toml / git contract's one
-// UI, and a rebuild here would be a second one to keep in step.
+// The Git tab renders the EXISTING template rather than a second panel of
+// its own: the template is the git contract's one UI, and a rebuild here
+// would be a second one to keep in step. (An MCP tab framed templates/mcp the
+// same way until 2026-08-27; the owner dropped it.)
 //
 // Opened from the sidebar's "Current apps" rows and NOWHERE ELSE (owner's
 // brief): the hub's cards and the explorer keep opening the entry page as they
@@ -69,7 +66,6 @@ import {
   GitBranch,
   ExternalLink,
   ListTodo,
-  Plug,
   Webhook,
   type LucideIcon,
 } from "lucide-react";
@@ -105,8 +101,7 @@ type TabCtx = {
   dir: string;
   entry: string | null;
   folderHref: string;
-  /** The folder's `mcp` / `git` template entries, when offered (null = not). */
-  mcpTpl: TemplateEntry | null;
+  /** The folder's `git` template entry, when offered (null = not). */
   gitTpl: TemplateEntry | null;
 };
 
@@ -173,18 +168,6 @@ const TAB_DEFS: Record<AppPageTab, TabDef> = {
     // Not keepMounted: the open row is in the URL (`?ep=`), and a return costs
     // one folder inspection — form values and responses are session scratch.
     render: ({ dir, folderHref }) => <AppApi dir={dir} folderHref={folderHref} />,
-  },
-  mcp: {
-    label: "MCP",
-    Icon: Plug,
-    // Not keepMounted: the panel re-reads mcp.toml on return, which is the
-    // freshness a config surface wants after an edit elsewhere.
-    render: ({ dir, slug, mcpTpl }) =>
-      mcpTpl ? (
-        templateFrame(dir, mcpTpl, `MCP tools: ${slug}`)
-      ) : (
-        <p className="app-page-empty">The MCP template is not installed.</p>
-      ),
   },
   git: {
     label: "Git",
@@ -294,7 +277,6 @@ export default function AppPage({
     };
   }, [dir]);
 
-  const mcpTpl = tpls.find((t) => t.mode === "mcp" && t.path) ?? null;
   const gitTplRaw = tpls.find((t) => t.mode === "git" && t.path) ?? null;
   // Git is offered only where its gate says yes: a `conditional` entry waits
   // for the verdict (pending reads as "not yet"), an unconditional one is in.
@@ -309,11 +291,10 @@ export default function AppPage({
   const visibleTabs = useMemo(
     () =>
       APP_PAGE_TABS.filter((id) => {
-        if (id === "mcp") return mcpTpl !== null;
         if (id === "git") return gitAllowed;
         return true;
       }),
-    [mcpTpl, gitAllowed],
+    [gitAllowed],
   );
   const visibleRef = useRef(visibleTabs);
   visibleRef.current = visibleTabs;
@@ -463,7 +444,7 @@ export default function AppPage({
                 role="tabpanel"
                 aria-hidden={!active}
               >
-                {def.render({ slug, dir, entry, folderHref, mcpTpl, gitTpl })}
+                {def.render({ slug, dir, entry, folderHref, gitTpl })}
               </section>
             );
           })}

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -109,7 +109,7 @@ export const APP_PAGE_PREFIX = "/apps/";
  *  refuses the second being forgotten. Not every tab is offered on every
  *  folder: `git` shows only inside a work tree (AppPage's `visibleTabs`), so
  *  the ROUTE knows six tabs while the strip may draw five. */
-export const APP_PAGE_TABS = ["overview", "tasks", "files", "api", "mcp", "git"] as const;
+export const APP_PAGE_TABS = ["overview", "tasks", "files", "api", "git"] as const;
 export type AppPageTab = (typeof APP_PAGE_TABS)[number];
 export const DEFAULT_APP_PAGE_TAB: AppPageTab = APP_PAGE_TABS[0];
 

--- a/frontend/src/styles/app-page.css
+++ b/frontend/src/styles/app-page.css
@@ -61,6 +61,14 @@
   text-decoration: underline;
 }
 
+/* "Open app" sits opposite the title, on the same baseline padding, so the
+   header's bottom rule reads as one line under both. */
+.app-page-open {
+  flex: 0 0 auto;
+  align-self: flex-end;
+  margin-bottom: 10px;
+}
+
 /* The gutter frame — the same width story as the playground's .pg-frame
    (ai-playground.css): one centered column, capped, with gutters either side
    below the cap. The tab strip, the app frame and the Tasks page all share it,
@@ -118,35 +126,6 @@
   border: 1px solid var(--border);
   border-radius: 10px;
   background: var(--bg);
-}
-
-/* Full-screen door in the frame's top-right corner: quiet until hovered,
-   over whatever the app draws there, so it must bring its own backdrop. */
-.app-page-fullscreen {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: 1px solid var(--border);
-  border-radius: 9px;
-  background: var(--bg);
-  color: var(--fg);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
-  transition: background 120ms, border-color 120ms;
-}
-
-.app-page-fullscreen:hover {
-  background: color-mix(in srgb, var(--fg) 8%, var(--bg));
-  border-color: var(--fg-muted);
-}
-
-.app-page-fullscreen svg {
-  width: 18px;
-  height: 18px;
 }
 
 /* The nested Tasks page brings its own 22px page padding and a 1050px column

--- a/frontend/src/styles/app-page.css
+++ b/frontend/src/styles/app-page.css
@@ -17,14 +17,14 @@
 .app-page-head {
   flex: 0 0 auto;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
   /* Same column as .app-page-body below, so the heading lines up with the
      tab strip and the frame instead of hugging the window edge. */
   width: min(1050px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 14px 0 0;
+  padding: 14px 0 10px;
 }
 
 .app-page-title {
@@ -32,7 +32,6 @@
   display: flex;
   align-items: baseline;
   gap: 12px;
-  padding-bottom: 10px;
 }
 
 .app-page-title h1 {
@@ -61,12 +60,9 @@
   text-decoration: underline;
 }
 
-/* "Open app" sits opposite the title, on the same baseline padding, so the
-   header's bottom rule reads as one line under both. */
+/* "Open app" sits opposite the title, centred on its line. */
 .app-page-open {
   flex: 0 0 auto;
-  align-self: flex-end;
-  margin-bottom: 10px;
 }
 
 /* The gutter frame — the same width story as the playground's .pg-frame


### PR DESCRIPTION
On `/apps/<path>` pages.

**Header / Overview**
- Removed the floating full-screen button over the Overview frame (and its CSS).
- New **Open app** outline button on the right of the header — opens the app's entry page in the explorer in a new tab. A real `<button>` + `window.open` (rendering the shadcn Button as an anchor picked up default link styling, since the shell runs Tailwind without preflight). Header centres title and button on one line.
- Header path link now navigates to the folder listing rather than `index.html` inside it.

**API tab**
- The "curl" button in the open form is gone; a **Copy as cURL** control sits on the route line where the "Try it" hint was ("Try it" removed).
- Hover-revealed like the hint was; pinned visible while the row is expanded.
- Floated beside the toggle (a button cannot nest a button) over a gap the toggle reserves.
- Styled like the outline badge: ghost xs, light border, muted text, no background at rest or on hover, `rounded-md`.

**MCP tab**
- Removed entirely: `mcp` dropped from `APP_PAGE_TABS` (route + strip), its tab def and template lookup deleted. `templates/mcp` itself is untouched — the explorer still offers it on a folder.

`tsc` + `vite build` clean; shell-dist not committed (build output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell-only navigation and API-tab UX; no backend, auth, or data-path changes. Deep links to `?_tab=mcp` may no longer match a tab.
> 
> **Overview**
> On `/apps/<path>`, the **app page header** is reworked: the folder caption now opens the **explorer folder listing** (not the entry page), and when an entry exists an **Open app** outline button opens the rendered app in a **new tab** via `window.open`. The Overview iframe **fullscreen overlay** is removed in favor of that header control; header CSS centers title and button on one line.
> 
> The **MCP tab** is removed from the tab strip and routing (`APP_PAGE_TABS`, tab defs, template lookup); Git and other tabs are unchanged. Explorer MCP tooling is unaffected.
> 
> On the **API tab**, **Copy as cURL** moves from the expanded Execute row to each **runnable route line** (replacing the hover **Try it** hint). It is a sibling button over reserved row space (no nested buttons), shows on row hover or while expanded, and uses `pointer-events-none` when hidden so collapsed rows still toggle on touch. The form-area curl control is removed; much of `AppApi.tsx` is formatting-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fc3f7216333c60774def97aae8c8342ad5e145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->