### PR TITLE
AI workers: start with posix_spawn on macOS, and drop a worker whose process has died

### DIFF
--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -4314,6 +4314,43 @@ def build_server(generate, streaming=False, host="127.0.0.1"):
     return _Server((host, 0), _handler(generate, streaming))
 
 
+#: Where the supervisor wants this worker to run from, when it could not pass
+#: `cwd=` to Popen. Mirrors `supervisor.WORKER_CWD_ENV` — spelled here too because
+#: this module is imported from the runner's own interpreter, where
+#: `fused_render` is not importable.
+WORKER_CWD_ENV = "FUSED_AI_WORKER_CWD"
+
+
+def _adopt_spawn_shape():
+    """Do for ourselves the two things a `fork()`-based spawn used to do.
+
+    On macOS the supervisor starts workers with `posix_spawn` (see
+    `supervisor._spawn_kwargs` for the crash that forced it), and CPython only
+    takes that path for a Popen with no `cwd` and no `start_new_session`. So
+    the working directory arrives in an environment variable, and the worker
+    makes itself a session leader — which is what `_kill_tree`'s `killpg`
+    keys on, so an unload still takes the whole tree down.
+
+    Both are best-effort. A missing directory is the supervisor's fact to
+    report (the runner folder it named does not exist), not this worker's to
+    die on before it can say anything; and `setsid` fails with EPERM when the
+    process already leads a session, which is exactly the case on the
+    platforms that still spawn with `start_new_session=True`.
+    """
+    cwd = os.environ.get(WORKER_CWD_ENV)
+    if cwd:
+        try:
+            os.chdir(cwd)
+        except OSError:
+            pass
+    setsid = getattr(os, "setsid", None)
+    if setsid is not None:
+        try:
+            setsid()
+        except OSError:
+            pass
+
+
 def serve(download, load, generate, streaming=False, memory=None, peak_memory=None,
          argv=None):
     """Parse the supervisor's argv and run this worker. Does not return.
@@ -4328,6 +4365,7 @@ def serve(download, load, generate, streaming=False, memory=None, peak_memory=No
     """
     global JOB_ID, _measure, _measure_peak
 
+    _adopt_spawn_shape()
     _measure = memory
     _measure_peak = peak_memory
     parser = argparse.ArgumentParser()

--- a/fused_render/ai/supervisor.py
+++ b/fused_render/ai/supervisor.py
@@ -47,6 +47,7 @@ import secrets
 import shutil
 import signal
 import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -462,6 +463,55 @@ SPAWN_KWARGS = (
     if os.name == "nt" else {"start_new_session": True}
 )
 
+#: The worker's working directory, when the spawn cannot pass `cwd=` — see
+#: `_spawn_kwargs`. `worker_base.serve` reads it and `chdir`s first thing.
+WORKER_CWD_ENV = "FUSED_AI_WORKER_CWD"
+
+
+def _spawn_kwargs(cwd: str, env: dict) -> dict:
+    """The Popen keyword arguments for a worker — and the ONE place the
+    fork-versus-posix_spawn decision lives, because on macOS it decides whether
+    a worker can start at all.
+
+    **On macOS, workers are started with `posix_spawn`, never `fork()`.**
+    CPython picks `posix_spawn` only for a narrow Popen shape (3.12
+    `subprocess._execute_child`: no `cwd`, `close_fds=False`, no
+    `start_new_session`, no `preexec_fn`, every redirected fd above 2), and
+    falls back to `fork()` + `exec()` the moment any of those is set. The old
+    shape here set three of them, so every worker was forked — and a forked
+    child runs the parent's `pthread_atfork` child handlers before it ever
+    reaches `exec()`.
+
+    That is what killed the embeddings worker on a fresh machine, with
+    `the worker exited before it started (code -11)` and an EMPTY stderr:
+    the crash report shows the child dying in `do_fork_exec → fork →
+    _pthread_atfork_child_handlers → osgeo::proj::io::SQLiteHandleCache →
+    sqlite3Close → sqlite3_log → os_log_type_enabled → SIGSEGV`. PROJ (loaded
+    into THIS server process through pyproj/shapely the moment any geo page
+    renders) registers an atfork handler that closes its SQLite handles in
+    the child, SQLite logs while doing so, and `os_log` after `fork()` is the
+    documented macOS hazard. Nothing about the worker, its venv or MLX was at
+    fault — the same worker started fine from a shell, and the same server
+    could not start ANY worker once PROJ was resident. Reproduced exactly with
+    a deliberately crashing atfork handler: the fork shape dies -11 every
+    time, the `posix_spawn` shape never does.
+
+    `posix_spawn` runs no atfork handlers, so the worker gets its own process
+    with none of the parent's native state in the way. The two things the old
+    shape did for the child — `cwd` and a fresh session/process group for
+    `_kill_tree`'s `killpg` — the worker now does for itself, first thing in
+    `worker_base.serve`: `chdir` to `WORKER_CWD_ENV` and `os.setsid()`.
+    `close_fds=False` leaks only descriptors marked inheritable, which since
+    Python 3.4 (PEP 446) is none of this server's by default.
+
+    Linux and Windows keep the previous shape: glibc's fork is not where this
+    hazard lives, and Windows never forks.
+    """
+    if sys.platform == "darwin":
+        env[WORKER_CWD_ENV] = cwd
+        return {"close_fds": False}
+    return {"cwd": cwd, "close_fds": True, **SPAWN_KWARGS}
+
 #: Windows has no SIGKILL. Read through getattr so merely IMPORTING this module
 #: does not fail there — the image runner is cross-platform, so this code really
 #: does run on Windows.
@@ -796,15 +846,14 @@ def _spawn(runner: registry.Runner, worker: Worker, python: str) -> None:
 
     job = job_id_for(worker.model)
     log = _log_path(worker)
+    env = _child_env(worker.token, worker.model, worker.capability)
     proc = subprocess.Popen(
         [python, runner.worker, "--model", worker.model, "--status", status, "--job", job],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=open(log, "w"),
-        cwd=runner.folder,
-        env=_child_env(worker.token, worker.model, worker.capability),
-        close_fds=True,
-        **SPAWN_KWARGS,
+        env=env,
+        **_spawn_kwargs(runner.folder, env),
     )
     worker.pid = proc.pid
     worker.proc = proc
@@ -1175,11 +1224,12 @@ def _fetch_only(runner: registry.Runner, model: str, job: str) -> None:
         python = _ensure_venv(runner, stub, job)
         _report(job, detail="Fetching weights…")
         log = _log_path(stub)
+        env = _child_env(stub.token, model)
         proc = subprocess.Popen(
             [python, runner.worker, "--model", model, "--job", job, "--download-only"],
             stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=open(log, "w"),
-            cwd=runner.folder, env=_child_env(stub.token, model), close_fds=True,
-            **SPAWN_KWARGS,
+            env=env,
+            **_spawn_kwargs(runner.folder, env),
         )
         stub.pid = proc.pid
         stub.proc = proc
@@ -2063,6 +2113,40 @@ def busy_reason(model: str) -> str | None:
     return None
 
 
+def _drop_gone(worker: Worker) -> None:
+    """Forget a worker whose PROCESS has exited: an `error` row that says so,
+    and an empty slot the next request fills with a fresh load.
+
+    Shared by `refresh_memory()` (the sidebar's poll, which decides with
+    `_alive`) and `ready_worker()` (every generation request, which decides
+    with the stricter `_exited`) so the two agree on what "gone" leaves behind.
+    """
+    worker.state = "error"
+    worker.error = "the model process is gone"
+    with _lock:
+        if _workers.get(worker.capability) is worker:
+            del _workers[worker.capability]
+
+
+def _exited(worker: Worker) -> bool:
+    """True only when the worker's process has DEFINITELY exited: a Popen is
+    attached and `poll()` answered a real exit code.
+
+    Stricter than `not _alive(worker)` on purpose, because this is asked on the
+    request path. `_alive` reads a missing handle as dead — right for the
+    reaper, which is tidying a table — but here "cannot tell" must not cost a
+    caller its model: a worker planted without a Popen (every fixture in the
+    tests, an adopted process) has nothing to poll, and a test double whose
+    `poll()` returns a stand-in object is not reporting an exit code. Only an
+    `int` is.
+    """
+    proc = worker.proc
+    if proc is None:
+        return False
+    code = proc.poll()
+    return isinstance(code, int) and not isinstance(code, bool)
+
+
 def ready_worker(capability: str, model: str | None = None) -> Worker | None:
     """The resident, READY worker for a capability — what generation needs.
 
@@ -2092,6 +2176,18 @@ def ready_worker(capability: str, model: str | None = None) -> Worker | None:
             return None
         if model is not None and worker.model != model:
             return None
+    # **The 502-forever check.** A worker that died while idle — a SIGSEGV out
+    # of a native library, a memory kill — used to stay in the table as `ready`,
+    # so every request was proxied to a dead port and answered `the model
+    # process did not answer`, indefinitely: nothing re-checked the process, so
+    # nothing respawned it until an unload or the idle reaper cleared the slot.
+    # Measured at 46 seconds of 502s on a photo-search app before its caller
+    # gave up, against a ~10s respawn once somebody notices. Polling here turns
+    # that first failed request into the `ModelNotReady` callers already wait
+    # on. Outside `_lock`, like the resolution below: `poll()` is a syscall.
+    if _exited(worker):
+        _drop_gone(worker)
+        return None
     resolved = registry.for_capability(capability)
     if resolved is not None and resolved.code != worker.runner_code:
         evict_stale_engines()
@@ -2504,11 +2600,7 @@ def refresh_memory() -> None:
             continue
         if not _alive(worker):
             # The one thing the supervisor knows better than the worker does.
-            worker.state = "error"
-            worker.error = "the model process is gone"
-            with _lock:
-                if _workers.get(worker.capability) is worker:
-                    del _workers[worker.capability]
+            _drop_gone(worker)
             continue
         health = _health(worker)
         if health and isinstance(health.get("resident_bytes"), int):

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -3370,6 +3370,51 @@ def _idle_worker(monkeypatch, *, state="ready", last_activity, in_flight=0,
     return worker
 
 
+class _ExitedProc:
+    """A Popen whose process has already died — `poll()` answers its exit code."""
+
+    def __init__(self, returncode):
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+
+def test_a_ready_worker_whose_process_died_is_dropped_on_the_next_request(monkeypatch):
+    """The 502-forever bug. A worker that died while idle — a native SIGSEGV, a
+    memory kill — stayed in the table as `ready`, so every request was proxied
+    to a dead port and answered `the model process did not answer`, and
+    nothing ever respawned it. `ready_worker` now polls the process it is
+    about to hand out: gone means dropped, so this request gets
+    `ModelNotReady` (a fresh load) instead of a 502."""
+    worker = _idle_worker(monkeypatch, last_activity=time.monotonic())
+    worker.proc = _ExitedProc(-11)
+    assert supervisor.ready_worker(registry.TEXT_GENERATION, "org/idle") is None
+    assert registry.TEXT_GENERATION not in supervisor._workers
+    assert worker.state == "error"
+    assert "gone" in worker.error
+
+
+def test_a_ready_worker_with_a_live_process_is_still_served(monkeypatch):
+    """The other half: `poll()` returning None is alive, and the worker is
+    handed out exactly as before. The engine-match check below it is untouched,
+    so a fake runner code must resolve to nothing rather than to a mismatch."""
+    monkeypatch.setattr(registry, "for_capability", lambda capability: None)
+    worker = _idle_worker(monkeypatch, last_activity=time.monotonic())
+    worker.proc = _ExitedProc(None)
+    assert supervisor.ready_worker(registry.TEXT_GENERATION, "org/idle") is worker
+
+
+def test_a_ready_worker_with_no_process_handle_is_not_judged(monkeypatch):
+    """A worker planted without a Popen (every fixture in this file, an adopted
+    process) cannot be polled, and "cannot tell" must not read as "gone" on
+    the request path — the reaper's poll keeps its own stricter rule."""
+    monkeypatch.setattr(registry, "for_capability", lambda capability: None)
+    worker = _idle_worker(monkeypatch, last_activity=time.monotonic())
+    assert worker.proc is None
+    assert supervisor.ready_worker(registry.TEXT_GENERATION, "org/idle") is worker
+
+
 def test_a_non_ready_worker_is_exempt_from_the_reaper(monkeypatch):
     from fused_render.shell import prefs
     monkeypatch.setattr(prefs, "effective_ai_idle_unload_minutes", lambda: 10)
@@ -10215,6 +10260,54 @@ def test_an_operator_set_base_url_reaches_the_worker(monkeypatch, tmp_path):
 
     monkeypatch.delenv("FUSED_MODEL_MIRROR")
     assert "FUSED_MODEL_MIRROR" not in supervisor._child_env("t", _suggested_id())
+
+
+def test_on_macos_a_worker_is_spawned_in_the_posix_spawn_shape(monkeypatch):
+    """The fork-crash fix. CPython uses `posix_spawn` only for a Popen with no
+    `cwd`, `close_fds=False` and no `start_new_session`; anything else forks,
+    and a forked child runs the server's atfork handlers — which is how a
+    resident PROJ killed every worker with `code -11` and an empty stderr.
+    The directory travels in the environment instead."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    env = {}
+    kwargs = supervisor._spawn_kwargs("/runners/x", env)
+    assert kwargs == {"close_fds": False}
+    assert env[supervisor.WORKER_CWD_ENV] == "/runners/x"
+
+
+def test_elsewhere_a_worker_keeps_its_own_session_and_cwd(monkeypatch):
+    """Off macOS the shape is unchanged: `cwd` on the Popen, descriptors
+    closed, and the platform's own new-session/new-group flag — which is
+    `SPAWN_KWARGS` itself, so this reads the constant rather than naming
+    `start_new_session`: on a Windows runner that key is `creationflags`."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    env = {}
+    kwargs = supervisor._spawn_kwargs("/runners/x", env)
+    assert kwargs == {"cwd": "/runners/x", "close_fds": True, **supervisor.SPAWN_KWARGS}
+    assert supervisor.WORKER_CWD_ENV not in env
+
+
+def test_no_spawn_site_bypasses_the_spawn_shape_helper():
+    """Both Popen sites go through `_spawn_kwargs`, and neither passes `cwd`,
+    `close_fds` or the session flag directly — the arguments that silently
+    turn `posix_spawn` back into `fork()`. Checked on the source, because a
+    keyword added to one call is exactly the regression nobody would notice
+    until a geo page had rendered on someone's Mac."""
+    import ast
+    import inspect
+    tree = ast.parse(inspect.getsource(supervisor))
+    popens = [node for node in ast.walk(tree)
+              if isinstance(node, ast.Call) and ast.unparse(node.func) == "subprocess.Popen"]
+    assert len(popens) >= 2, f"{len(popens)} Popen sites, expected the two worker spawns"
+    forbidden = {"cwd", "close_fds", "start_new_session", "preexec_fn"}
+    for call in popens:
+        names = {kw.arg for kw in call.keywords if kw.arg is not None}
+        starred = [ast.unparse(kw.value) for kw in call.keywords if kw.arg is None]
+        assert not names & forbidden, (
+            f"Popen at line {call.lineno} sets {names & forbidden} directly — "
+            f"route it through _spawn_kwargs")
+        assert any(x.startswith("_spawn_kwargs(") for x in starred), (
+            f"Popen at line {call.lineno} does not spread _spawn_kwargs(...)")
 
 
 def test_neither_spawn_site_forgets_the_model(monkeypatch):

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -757,6 +757,34 @@ def test_resident_bytes_grows_the_rss_high_water_mark_but_never_shrinks_it(base,
     assert base._rss_peak == 5_000
 
 
+def test_serve_moves_into_the_directory_the_supervisor_names(base, monkeypatch, tmp_path):
+    """The posix_spawn half of the fork-crash fix (`supervisor._spawn_kwargs`):
+    with no `cwd=` on the Popen, the worker has to `chdir` itself, before
+    anything else in `serve` — a runner that opens a file by a relative path
+    must already be home. `setsid` is stubbed: under pytest this process leads
+    a session already, and the point here is the directory."""
+    class _FakeServer:
+        server_address = ("127.0.0.1", 0)
+
+        def serve_forever(self):
+            pass
+    calls = []
+    monkeypatch.setattr(base, "build_server", lambda *a, **kw: _FakeServer())
+    monkeypatch.setattr(base.os, "setsid", lambda: calls.append("setsid"), raising=False)
+    home = tmp_path / "runner_home"
+    home.mkdir()
+    monkeypatch.setenv(base.WORKER_CWD_ENV, str(home))
+    before = os.getcwd()
+    try:
+        base.serve(download=lambda m: None, load=lambda m, f: None,
+                  generate=lambda body: {},
+                  argv=["--model", "org/m", "--status", str(tmp_path / "status.json")])
+        assert os.path.realpath(os.getcwd()) == os.path.realpath(str(home))
+        assert calls == ["setsid"]
+    finally:
+        os.chdir(before)
+
+
 def test_serve_wires_peak_memory_into_the_peak_probe(base, monkeypatch, tmp_path):
     """`serve(peak_memory=...)` has to actually reach `peak_resident_bytes()`,
     not just be accepted and dropped — the same wiring `memory=` already gets


### PR DESCRIPTION
## What

Two supervisor fixes, found by running a downstream app (lens / photo search) as a brand-new user on a cold machine, where the embeddings worker would not start — and when it did, a dead one was never replaced.

### 1. Workers start with `posix_spawn` on macOS, never `fork()`

Every worker spawn died with `the worker exited before it started (code -11)` and an **empty** stderr. The crash report shows the forked child dying *before exec*, inside the parent's atfork child handlers:

```
do_fork_exec → fork → _pthread_atfork_child_handlers
  → osgeo::proj::io::SQLiteHandleCache::getHandle(...)::$_2::__invoke
  → sqlite3Close → sqlite3_log → os_log_type_enabled → _os_log_preferences_refresh → SIGSEGV
```

PROJ — loaded into the **server** process via pyproj/shapely the moment any geo page renders — registers a `pthread_atfork` handler that closes its SQLite handles in the child; SQLite logs on the way out, and `os_log` after `fork()` is the known macOS hazard. Nothing about the worker was at fault: the same worker started fine from a shell, and the same server could start *no* worker once PROJ was resident (`lsof` shows 16 pyproj handles). Reproduced exactly with a deliberately crashing atfork handler (ctypes `pthread_atfork`): the fork shape dies -11 four of four; the `posix_spawn` shape never does.

CPython takes `posix_spawn` only for a Popen with no `cwd`, `close_fds=False` and no `start_new_session` (3.12 `subprocess._execute_child`). So `_spawn_kwargs` is the one place that decides the shape, both spawn sites go through it, and the worker does for itself the two things the old shape did — `chdir` to `FUSED_AI_WORKER_CWD` and `os.setsid()`, first thing in `worker_base.serve`, so `_kill_tree`'s `killpg` still finds a group leader (verified: worker pid == pgid). Linux and Windows keep the previous shape. An AST test pins that no `Popen` bypasses the helper.

### 2. `ready_worker` drops a worker whose process has exited

A worker that died while idle stayed `ready` in the table, so every request was proxied to a dead port and answered 502 `the model process did not answer` — indefinitely, since nothing re-checked the process until an unload or the idle reaper cleared the slot. Measured: 46s of 502s before the caller gave up, against a ~10s respawn. `_exited` polls on the request path and trusts only a real integer exit code (fixtures without a Popen, and doubles whose `poll()` returns a stand-in, are not "gone"); the drop is shared with `refresh_memory`'s reaper.

## Verified

- Unit: 7 new tests (spawn shape per platform, AST guard on both Popen sites, `serve` honours the cwd env + calls `setsid`, dead/alive/handle-less worker cases for `ready_worker`).
- AI modules: 803 pass. Full suite: 11,146 pass; every failure reproduces identically on the unpatched tree (claude_health, ai_metrics, calls, joblib import, the `worker_base` chunked-transfer flake, map_raster).
- End to end on the downstream app, isolated `FUSED_RENDER_HOME`, PROJ resident in the server: cold start → results in 13s; `kill -9` the idle worker → results in 16s; evict → 13s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every AI worker is spawned on macOS and adds process polling on the hot `ready_worker` path; non-Darwin spawn shape is intentionally unchanged but both load and download-only spawns must stay routed through `_spawn_kwargs`.
> 
> **Overview**
> Fixes two supervisor/runtime issues seen on cold macOS installs: workers that never start after geo libraries load, and “ready” workers that keep serving 502s after the process dies.
> 
> **macOS spawn shape:** Worker `Popen` calls now go through `_spawn_kwargs`, which on Darwin avoids `cwd`, `start_new_session`, and `close_fds=True` so CPython uses `posix_spawn` instead of `fork()`—preventing child crashes from parent `pthread_atfork` handlers (e.g. PROJ/SQLite after a geo page). The runner folder is passed via `FUSED_AI_WORKER_CWD`; `worker_base.serve` runs `_adopt_spawn_shape()` first to `chdir` and `os.setsid()` so kill-tree behavior stays the same. Linux/Windows keep the previous Popen kwargs.
> 
> **Stale ready workers:** `ready_worker` now calls `_exited` (strict `poll()` → integer exit code) and `_drop_gone` before handing out a worker, so an idle crash becomes `ModelNotReady`/reload instead of endless proxy 502s. The same drop logic replaces duplicated cleanup in `refresh_memory`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8298d602b855a5f4f5bfa8fa30cee7d93ee9e3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->