### PR TITLE
AI workers release their allocator pool after 30s idle

### DIFF
--- a/fused_render/ai/runners/faster_whisper/worker.py
+++ b/fused_render/ai/runners/faster_whisper/worker.py
@@ -651,5 +651,9 @@ def generate(body):
 
 
 if __name__ == "__main__":
+    # No `release=` (see `worker_base._release`'s docstring): the CTranslate2
+    # backend underneath faster-whisper exposes no cache-release call at all —
+    # there is nothing here in the shape of `mx.clear_cache()`/`torch.*.
+    # empty_cache()` to hand the idle timer to reach for.
     worker_base.serve(download=download, load=load, generate=generate,
                       streaming=False, memory=memory)

--- a/fused_render/ai/runners/llama_text.py
+++ b/fused_render/ai/runners/llama_text.py
@@ -1036,6 +1036,14 @@ def generate(body, write):
 
 
 def main():
-    """Serve, forever. The entry point `llamacpp_text/worker.py` calls."""
+    """Serve, forever. The entry point `llamacpp_text/worker.py` calls.
+
+    No `release=` (see `worker_base._release`'s docstring): llama.cpp's KV
+    context is a fixed-size allocation made once at `load()` time, sized for
+    the model's context window, and the weights themselves are mmap'd rather
+    than copied into a growable pool. There is no per-execution or per-idle
+    allocator cache here for a timer to hand back — the memory an idle worker
+    holds after this is exactly the memory it would need for its next call.
+    """
     worker_base.serve(download=download, load=load, generate=generate,
                       streaming=True, memory=memory)

--- a/fused_render/ai/runners/ltx_video/worker.py
+++ b/fused_render/ai/runners/ltx_video/worker.py
@@ -413,6 +413,31 @@ def peak_memory():
     return None
 
 
+def release():
+    """Hand MLX's allocator pool back to the OS — `mflux_image.release`'s own
+    probe, verbatim: `worker_base.serve(release=...)` fires this
+    `worker_base._RELEASE_IDLE_S` seconds after this worker's LAST execution
+    if nothing new started by then, never per-call (see `worker_base.
+    _release`'s docstring for why, and the measured numbers this whole
+    feature exists for).
+
+    Doubly relevant here: `DistilledPipeline(low_memory=True)` already frees
+    the transformer and text encoder BETWEEN STAGES of one render (see
+    `peak_memory`'s docstring), which is a real memory saving DURING a
+    render — but it is orthogonal to this. Freeing a stage still leaves its
+    buffers in MLX's own pool, not back with the OS, so a finished render can
+    still be sitting on the same "peak held, nothing active" pool `mflux_
+    image` was measured with. `getattr` because a real but older mlx wheel,
+    or this repo's stubbed `mlx.core` in tests, may not have `clear_cache` at
+    all — absence is a no-op.
+    """
+    import mlx.core as mx
+
+    clear = getattr(mx, "clear_cache", None)
+    if clear is not None:
+        clear()
+
+
 # ------------------------------------------------------------------ generation
 
 
@@ -568,4 +593,5 @@ def generate(body):
 
 if __name__ == "__main__":
     worker_base.serve(download=download, load=load, generate=generate,
-                      streaming=False, memory=memory, peak_memory=peak_memory)
+                      streaming=False, memory=memory, peak_memory=peak_memory,
+                      release=release)

--- a/fused_render/ai/runners/mflux_image/worker.py
+++ b/fused_render/ai/runners/mflux_image/worker.py
@@ -460,6 +460,33 @@ def peak_memory():
     return None
 
 
+def release():
+    """Hand MLX's allocator pool back to the OS — `worker_base.serve
+    (release=...)`, fired `worker_base._RELEASE_IDLE_S` after this worker's
+    LAST execution if nothing new has started by then, never per-call. See
+    `worker_base._release`'s docstring for the measured numbers this exists
+    for (a 34.4 GB machine holding "21 GB held" against "1.7 GB now" long
+    after a render finished) and why the reclaim is on a timer rather than
+    unconditional.
+
+    `mx.clear_cache()`, guarded the same way `_pin_stream` guards every MLX
+    API that might be missing: `getattr` rather than a bare attribute access,
+    because `tests/test_ai_mflux_worker.py` stubs `mlx.core` with a
+    `FakeMlxCore` that has no `clear_cache` at all, and a real but older mlx
+    wheel could equally lack it. Absence is a no-op, not a crash — there is
+    nothing to release on either.
+
+    Deliberately does NOT touch `set_cache_limit` or `set_memory_limit` — see
+    the module docstring's boundary: this reclaims what a finished render left
+    behind, it does not change what the NEXT render is allowed to cost.
+    """
+    import mlx.core as mx
+
+    clear = getattr(mx, "clear_cache", None)
+    if clear is not None:
+        clear()
+
+
 # ------------------------------------------------------------------ generation
 
 
@@ -701,4 +728,5 @@ def generate(body):
 
 if __name__ == "__main__":
     worker_base.serve(download=download, load=load, generate=generate,
-                      streaming=False, memory=memory, peak_memory=peak_memory)
+                      streaming=False, memory=memory, peak_memory=peak_memory,
+                      release=release)

--- a/fused_render/ai/runners/mlx_embed/worker.py
+++ b/fused_render/ai/runners/mlx_embed/worker.py
@@ -409,6 +409,32 @@ def peak_memory():
     return None
 
 
+def release():
+    """Hand MLX's allocator pool back to the OS — `mflux_image.release`'s own
+    probe, verbatim. `worker_base.serve(release=...)` fires this
+    `worker_base._RELEASE_IDLE_S` seconds after this worker's LAST embed call
+    if nothing new started in the meantime, not per call — an idle timer never
+    fires mid-batch, so the bulk loop this runner is actually used for (many
+    embeds in a row) is never the thing that trips it.
+
+    Matters here for the same stacking reason as `mlx_whisper.worker.release`:
+    the supervisor keeps ONE resident worker per capability, and this
+    machine's own recorded footprints put a vision embed model
+    (siglip2-so400m) at 5.68 GB — a pool that size sitting idle in its own
+    process, beside whatever text or image worker is also loaded, is exactly
+    the stacking this feature is for, not just the single-render case.
+
+    `getattr` because a real but older mlx wheel, or this repo's stubbed
+    `mlx.core` in tests, may not have `clear_cache` at all — absence is a
+    no-op, matching every other MLX runner's guard.
+    """
+    import mlx.core as mx
+
+    clear = getattr(mx, "clear_cache", None)
+    if clear is not None:
+        clear()
+
+
 # ------------------------------------------------------------------ embedding
 
 
@@ -562,7 +588,8 @@ def main():
     this engine installs — unlike `onnx_embed`, which has four, one per
     execution provider."""
     worker_base.serve(download=download, load=load, generate=generate,
-                      streaming=False, memory=memory, peak_memory=peak_memory)
+                      streaming=False, memory=memory, peak_memory=peak_memory,
+                      release=release)
 
 
 if __name__ == "__main__":

--- a/fused_render/ai/runners/mlx_text/worker.py
+++ b/fused_render/ai/runners/mlx_text/worker.py
@@ -359,8 +359,8 @@ def release():
     image, speech or embed worker is also loaded, each with its own idle
     pool — this is the runner most likely to be resident continuously through
     a whole session, which is exactly the case an idle-only release exists
-    for, as against the per-call design this shipped as originally and would
-    have thrashed a fast chat loop.
+    for, as against the per-call design this change's first cut used and
+    would have thrashed a fast chat loop.
 
     `getattr` because a real but older mlx wheel, or this repo's stubbed
     `mlx.core` in tests, may not have `clear_cache` at all — absence is a

--- a/fused_render/ai/runners/mlx_text/worker.py
+++ b/fused_render/ai/runners/mlx_text/worker.py
@@ -344,6 +344,35 @@ def peak_memory():
     return None
 
 
+def release():
+    """Hand MLX's allocator pool back to the OS — `mflux_image.release`'s own
+    probe, verbatim. `worker_base.serve(release=...)` fires this
+    `worker_base._RELEASE_IDLE_S` seconds after this worker's LAST generation
+    if nothing new started in the meantime, not per call: a chat exchanged in
+    a burst of turns, or a page issuing many short completions in a row, keeps
+    the allocator at full speed throughout — only a run of `_RELEASE_IDLE_S`
+    seconds with no new `/generate` at all actually clears it.
+
+    Matters for the same stacking reason as `mlx_whisper.worker.release` and
+    `mlx_embed.worker.release`: the supervisor keeps one resident worker PER
+    CAPABILITY, so a text model sits in its own process next to whatever
+    image, speech or embed worker is also loaded, each with its own idle
+    pool — this is the runner most likely to be resident continuously through
+    a whole session, which is exactly the case an idle-only release exists
+    for, as against the per-call design this shipped as originally and would
+    have thrashed a fast chat loop.
+
+    `getattr` because a real but older mlx wheel, or this repo's stubbed
+    `mlx.core` in tests, may not have `clear_cache` at all — absence is a
+    no-op, matching every other MLX runner's guard.
+    """
+    import mlx.core as mx
+
+    clear = getattr(mx, "clear_cache", None)
+    if clear is not None:
+        clear()
+
+
 # ------------------------------------------------------------------ generation
 
 
@@ -601,4 +630,5 @@ def generate(body, write):
 
 if __name__ == "__main__":
     worker_base.serve(download=download, load=load, generate=generate,
-                      streaming=True, memory=memory, peak_memory=peak_memory)
+                      streaming=True, memory=memory, peak_memory=peak_memory,
+                      release=release)

--- a/fused_render/ai/runners/mlx_whisper/worker.py
+++ b/fused_render/ai/runners/mlx_whisper/worker.py
@@ -341,6 +341,30 @@ def peak_memory():
     return None
 
 
+def release():
+    """Hand MLX's allocator pool back to the OS — `mflux_image.release`'s own
+    probe, verbatim. `worker_base.serve(release=...)` fires this
+    `worker_base._RELEASE_IDLE_S` seconds after this worker's LAST
+    transcription if nothing new started in the meantime, not per call — a
+    bulk batch of short recordings never triggers it mid-batch, only genuine
+    idleness does. See `worker_base._release`'s docstring for the measured
+    numbers (this machine's own recorded footprint has whisper-large-v3 at
+    3.66 GB) and why one resident whisper worker's idle pool matters even
+    though a single transcription is short: the supervisor keeps ONE worker
+    PER CAPABILITY, so this process can sit loaded alongside a text or image
+    worker for as long as the session runs, each holding its own pool.
+
+    `getattr` because a real but older mlx wheel, or this repo's stubbed
+    `mlx.core` in tests, may not have `clear_cache` at all — absence is a
+    no-op, matching every other MLX runner's guard.
+    """
+    import mlx.core as mx
+
+    clear = getattr(mx, "clear_cache", None)
+    if clear is not None:
+        clear()
+
+
 # ------------------------------------------------------------- audio, no ffmpeg
 
 
@@ -1559,4 +1583,5 @@ def generate(body):
 
 if __name__ == "__main__":
     worker_base.serve(download=download, load=load, generate=generate,
-                      streaming=False, memory=memory, peak_memory=peak_memory)
+                      streaming=False, memory=memory, peak_memory=peak_memory,
+                      release=release)

--- a/fused_render/ai/runners/onnx_embed.py
+++ b/fused_render/ai/runners/onnx_embed.py
@@ -1071,6 +1071,13 @@ def main():
 
     No `memory=`: see the module docstring on why RSS is the honest answer for
     an onnxruntime session.
+
+    No `release=` either (see `worker_base._release`'s docstring for the
+    feature this is opting out of): onnxruntime's memory arena is
+    `SessionOptions` config fixed when the session is CREATED, not a
+    per-execution or per-idle-timer allocation this process could hand back
+    without tearing the session down and rebuilding it — which is a much
+    bigger change than an idle reclaim is meant to be.
     """
     worker_base.serve(download=download, load=load, generate=generate,
                       streaming=False)

--- a/fused_render/ai/runners/torch_image.py
+++ b/fused_render/ai/runners/torch_image.py
@@ -266,6 +266,43 @@ def memory():
     return total or None
 
 
+def release():
+    """Hand the torch caching allocator's pool back to the OS — the non-MLX
+    analogue of `mlx_text.worker.release` and friends, one edit here covering
+    all three folders this file serves (CPU, CUDA, ROCm) per the module
+    docstring. `worker_base.serve(release=...)` fires this `worker_base.
+    _RELEASE_IDLE_S` seconds after this worker's LAST render if nothing new
+    started in the meantime — see `worker_base._release`'s docstring for the
+    measured numbers and why a timer rather than an unconditional per-call
+    clear.
+
+    `torch.mps.empty_cache()` on Apple Silicon, `torch.cuda.empty_cache()` on
+    an NVIDIA card — the CPU-only case (this file's own default install, see
+    the module docstring) has no allocator cache to speak of, so both calls
+    are simply absent there and this is a no-op. Both are guarded with
+    `hasattr`/`getattr` rather than a bare call: `torch.mps` did not gain
+    `empty_cache` until a later torch release than this app's floor, and
+    `torch.cuda.empty_cache` always exists on the module but is a no-op
+    itself when no CUDA device is available — checking `is_available()` first
+    avoids initialising a CUDA context on a machine that has none, the same
+    caution `_place`/`memory` above already take before touching either
+    backend.
+
+    Deliberately does NOT call `torch.cuda.reset_peak_memory_stats` or touch
+    anything upstream of the denoising loop — see the module boundary this
+    whole feature respects: reclaiming what a finished render left behind,
+    never changing what the next render is allowed to cost.
+    """
+    import torch
+
+    mps = getattr(torch, "mps", None)
+    empty_mps = getattr(mps, "empty_cache", None)
+    if empty_mps is not None:
+        empty_mps()
+    if torch.cuda.is_available() and hasattr(torch.cuda, "empty_cache"):
+        torch.cuda.empty_cache()
+
+
 def _sigma_after(pipeline, step):
     """The noise level the scheduler has ARRIVED at, after step index `step`.
 
@@ -420,4 +457,4 @@ def main():
     body is a path insert and a call to this.
     """
     worker_base.serve(download=download, load=load, generate=generate,
-                      streaming=False, memory=memory)
+                      streaming=False, memory=memory, release=release)

--- a/fused_render/ai/runners/torch_image.py
+++ b/fused_render/ai/runners/torch_image.py
@@ -276,17 +276,26 @@ def release():
     measured numbers and why a timer rather than an unconditional per-call
     clear.
 
-    `torch.mps.empty_cache()` on Apple Silicon, `torch.cuda.empty_cache()` on
-    an NVIDIA card — the CPU-only case (this file's own default install, see
-    the module docstring) has no allocator cache to speak of, so both calls
-    are simply absent there and this is a no-op. Both are guarded with
-    `hasattr`/`getattr` rather than a bare call: `torch.mps` did not gain
-    `empty_cache` until a later torch release than this app's floor, and
-    `torch.cuda.empty_cache` always exists on the module but is a no-op
-    itself when no CUDA device is available — checking `is_available()` first
-    avoids initialising a CUDA context on a machine that has none, the same
-    caution `_place`/`memory` above already take before touching either
-    backend.
+    **`torch.mps` is not a presence check.** An earlier version of this
+    function gated on `getattr(torch, "mps", None)` / `hasattr(mps,
+    "empty_cache")` — but `torch/__init__.py` imports `torch.mps`
+    unconditionally on every platform, and `empty_cache` is a plain Python
+    function that always exists on it; both those guards always pass. On a
+    CPU/CUDA/ROCm build the call still reaches `torch._C._mps_emptyCache()`
+    -> `MPSHooksInterface::emptyCache()`, which is `TORCH_CHECK(false,
+    "Cannot execute emptyCache() without MPS backend.")` — a `RuntimeError`,
+    raised BEFORE the CUDA branch below ever ran, so the one build that
+    actually has a caching allocator worth reclaiming (`diffusers_image_cuda`
+    /`_rocm`) got nothing at all. The correct presence check is the one
+    `_place()` above already uses: `torch.backends.mps.is_available()`.
+
+    Each backend's call is also its OWN `try/except`, independent of the
+    other's — the same shape `memory()` above uses for its two probes —
+    so a raise from one (an API this app's floor of torch does not yet have,
+    say) can never take the other one down with it the way the bug above did.
+    `RuntimeError`/`OSError` is the pair `memory()` already catches for the
+    same backends; anything else is a real bug and is left to surface via
+    `worker_base._fire_release`'s own swallow-and-log, not hidden twice here.
 
     Deliberately does NOT call `torch.cuda.reset_peak_memory_stats` or touch
     anything upstream of the denoising loop — see the module boundary this
@@ -295,12 +304,16 @@ def release():
     """
     import torch
 
-    mps = getattr(torch, "mps", None)
-    empty_mps = getattr(mps, "empty_cache", None)
-    if empty_mps is not None:
-        empty_mps()
-    if torch.cuda.is_available() and hasattr(torch.cuda, "empty_cache"):
-        torch.cuda.empty_cache()
+    if getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+        try:
+            torch.mps.empty_cache()
+        except (RuntimeError, OSError):
+            pass
+    if torch.cuda.is_available():
+        try:
+            torch.cuda.empty_cache()
+        except (RuntimeError, OSError):
+            pass
 
 
 def _sigma_after(pipeline, step):

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -175,6 +175,121 @@ def run_on_generate_thread(fn, *args, **kwargs):
         return payload
     raise payload
 
+
+#: How long a worker sits with NO new execution before it hands its allocator
+#: pool back to the OS (`_release`, `_arm_release_timer`, `_fire_release`
+#: below). A deliberate, named constant rather than a literal 30 scattered
+#: across the file — see those functions' docstrings for the mechanism.
+#:
+#: Chosen to match `supervisor._REAPER_TICK_S` (also 30.0) in spirit, not by
+#: coincidence: both exist because 30s is short enough that "idle" means
+#: something a user would recognise, and this timer is that reaper's much
+#: cheaper, purely in-process cousin. The reaper polls every 30s whether a
+#: worker has been unused for `prefs.effective_ai_idle_unload_minutes()` (10
+#: minutes by default) and, past that, KILLS THE PROCESS — losing the loaded
+#: weights entirely, the next request pays a full reload. This timer fires
+#: once, 30 SECONDS after the worker's own last execution, and only hands
+#: back the allocator's idle pool — the model stays resident and the next
+#: request is exactly as fast as this one, it just re-faults the working set
+#: from the pool it now has to grow again. Two different costs at two very
+#: different timescales, not one mechanism with two names.
+_RELEASE_IDLE_S = 30.0
+
+#: Guards `_release_timer`/`_release_generation` together, so arming a new
+#: timer and a just-fired old one checking whether it is still current can
+#: never interleave into a wrong answer.
+_release_lock = threading.Lock()
+
+#: The pending idle-release timer, or `None` between executions. Always
+#: `threading.Timer` in production; tests substitute a manually-fired stand-in
+#: (see `tests/test_ai_worker_base.py`) rather than sleeping 30 real seconds.
+_release_timer = None
+
+#: Bumped every time a timer is (re)armed. A fired timer compares the token it
+#: was armed with against this before calling `_release` — belt-and-braces
+#: alongside `Timer.cancel()` itself, for the window between a timer's wait
+#: elapsing and its callback actually running, during which a new execution
+#: could already have rearmed (see `_fire_release`).
+_release_generation = 0
+
+
+def _arm_release_timer():
+    """(Re)start the `_RELEASE_IDLE_S` idle timer — called once after every
+    completed execution, success, `Cancelled`, or any other exception alike,
+    since a render that already allocated its peak can still be the one the
+    user pressed Stop on.
+
+    Cancels whatever timer a PRIOR execution left pending first: a burst of
+    renders must not pay the re-fault cost of clearing and re-growing the
+    allocator pool between each one — only the LAST execution in a burst gets
+    to start the clock, which is the whole reason this is a timer and not the
+    unconditional `finally`-call this shipped as originally. Correctness in
+    the race between "the old timer's wait already elapsed" and "cancel just
+    ran" is `_fire_release`'s job, via the generation token.
+
+    A no-op when no `release` hook was supplied (`serve(release=...)` never
+    called) — nothing to ever arm for `mlx_text`, `llamacpp_text`, and the
+    rest of the runners this deliberately excludes.
+    """
+    global _release_timer, _release_generation
+    if _release is None:
+        return
+    with _release_lock:
+        if _release_timer is not None:
+            # A `Timer` whose wait already elapsed and is mid-callback cannot
+            # be stopped by `cancel()` — that race is exactly why
+            # `_fire_release` re-checks its token under this same lock rather
+            # than trusting cancellation alone.
+            _release_timer.cancel()
+        _release_generation += 1
+        token = _release_generation
+        timer = threading.Timer(_RELEASE_IDLE_S, _fire_release, args=(token,))
+        # Daemon: a pending release must never be what keeps the worker
+        # process alive. `serve_forever()`'s own thread and `os._exit(0)` in
+        # `/quit` are both how this process actually ends, and neither should
+        # have to know this timer exists in order to exit cleanly.
+        timer.daemon = True
+        _release_timer = timer
+    timer.start()
+
+
+def _fire_release(token):
+    """The idle timer's callback: reclaim the allocator pool, but only if
+    nothing has run since `token` was handed out.
+
+    `GENERATE_LOCK` FIRST, generation check second: acquiring the same lock
+    `_single`/`_stream` hold for the whole request guarantees this can never
+    run WHILE a generation is in flight (mid-render is the one moment this
+    must never fire — see `_arm_release_timer`), and once acquired, a
+    generation that started and finished entirely inside this timer's 30s
+    wait has already rearmed with a NEWER token by the time that lock frees
+    up — so the check below catches it even though `cancel()` came too late
+    to stop this callback from being scheduled at all.
+
+    Routed through `run_on_generate_thread`, same as `generate` itself: the
+    hook this exists for is `mx.clear_cache()`, an MLX allocator call, and
+    that function's docstring is the whole reason no MLX call is ever made
+    from a thread other than the one dedicated to them — a `Timer` callback
+    runs on yet another thread of its own, no different in kind from a
+    `ThreadingTCPServer` connection thread in that respect.
+
+    Never raises past this function. A `release` that throws must be a
+    no-op — there is no request waiting on this timer to fail loudly at, and
+    a broken reclaim must not take the timer thread down with it.
+    """
+    global _release_timer
+    with GENERATE_LOCK:
+        with _release_lock:
+            if token != _release_generation:
+                # Superseded: a later execution already rearmed a fresher
+                # timer, which owns clearing the cache from here.
+                return
+            _release_timer = None
+        try:
+            run_on_generate_thread(_release)
+        except Exception:  # noqa: BLE001 - see docstring: reclaim failures are silent
+            pass
+
 TOKEN = os.environ.get("FUSED_AI_WORKER_TOKEN", "")
 
 #: Bounds on the PRE-AUTH body drain (Handler._drain). 64 KiB is far above any
@@ -551,6 +666,58 @@ _measure_peak = None
 #: bytes` for the precedence between the two, and AI-16's `basis` for how that
 #: difference is carried outward to a reader.
 _rss_peak = None
+
+#: A runner's own "give it back to the OS" hook, when it has one. Set by
+#: `serve(release=...)` — the third optional hook beside `_measure`/`_measure_
+#: peak` above. Never called directly from a request: `_arm_release_timer`
+#: starts a `_RELEASE_IDLE_S` clock after every execution, and `_fire_release`
+#: is what actually calls this, once that clock runs out with nothing new
+#: having started.
+#:
+#: Why this exists: a live FLUX.2-Klein-4B-4bit render through `mflux-image`
+#: needed ~24.12 GB at its peak (`mx.get_peak_memory()`, the `_measure_peak`
+#: probe) but settles at 1.7 GB RSS once it is done — and yet the status bar
+#: kept showing "1.7 GB now (21 GB held)" (`os_footprint_bytes()`, D597) long
+#: after the render finished. MLX frees those buffers back to its OWN pool,
+#: never to the OS, and only reclaims the pool once it exceeds `mx.set_cache_
+#: limit`'s default — 1.5x the recommended working set, ~38.7 GB on the 34.4
+#: GB machine this was measured on, i.e. ABOVE physical RAM, so that condition
+#: can never fire on its own. `mx.clear_cache()` is the other side of that:
+#: hand the idle pool back once nothing has asked for it in a while.
+#:
+#: Why an IDLE TIMER rather than an unconditional call in `_single`/`_stream`'s
+#: `finally` (the first cut of this feature): a 24 GB working set is not free
+#: to re-fault, and clearing right after every execution makes a burst of five
+#: renders pay that cost five times over. Waiting `_RELEASE_IDLE_S` after the
+#: LAST execution keeps a burst at full allocator speed and still releases the
+#: moment the user actually walks away — see `_arm_release_timer` and
+#: `_fire_release` for the mechanism, which lives entirely in this process
+#: (no supervisor RPC, no new route: the worker already knows when its own
+#: last execution ended).
+#:
+#: Wired into all five MLX runners (`mflux_image`, `ltx_video`, `mlx_text`,
+#: `mlx_embed`, `mlx_whisper`) and the shared `torch_image` runner (MPS/CUDA).
+#: An idle timer changes the earlier per-call exclusion's arithmetic: it does
+#: not fire mid-loop, so a bulk run of embeds or a token stream is never
+#: interrupted by it, and the machine this was measured on can hold a speech
+#: model (whisper-large-v3, 3.66 GB measured) and a text model resident in
+#: SEPARATE PROCESSES at once — the supervisor keeps one worker per
+#: capability — each with its own idle pool, so the small-model case stacks
+#: rather than disappearing into rounding.
+#:
+#: Still nothing to wire for `llamacpp_text`/`llamacpp_text*` (a fixed KV
+#: context allocated up front, weights mmap'd — there is no reclaimable
+#: cache), `faster_whisper` (its CTranslate2 backend exposes no cache-release
+#: API), or `onnx_embed`/its cuda/directml/rocm shells (the arena is
+#: session-scoped `SessionOptions` config decided at session creation, not
+#: something a per-idle clear can touch).
+#:
+#: This only RECLAIMS memory after a run finishes — it must never be reached
+#: for by anything trying to lower the PEAK a render needs (tiled decode,
+#: `mx.eval()` boundaries, `set_cache_limit`/`set_memory_limit`): those are
+#: separate, unapproved changes to what an execution costs, not to what it
+#: leaves behind.
+_release = None
 
 
 def resident_bytes():
@@ -4266,6 +4433,13 @@ def _handler(generate, streaming):
                 except BaseException as e:  # noqa: BLE001 - must reach the client
                     traceback.print_exc(file=sys.stderr)
                     self._json({"ok": False, "error": describe_failure(e)})
+                finally:
+                    # Arms the idle-release timer on every outcome, not just
+                    # success: a cancelled or failed generation can still have
+                    # allocated its peak before it stopped, and this only
+                    # STARTS the clock — it does not clear anything itself.
+                    # See `_arm_release_timer`.
+                    _arm_release_timer()
 
         def _stream(self, body):
             """NDJSON, chunked. `{"type":"chunk"}` lines closed by
@@ -4296,6 +4470,13 @@ def _handler(generate, streaming):
                     write({"type": "done", "ok": False,
                            "error": describe_failure(e)})
                     traceback.print_exc(file=sys.stderr)
+                finally:
+                    # Same reasoning as `_single`'s finally — and note WHERE
+                    # this sits: after `run_on_generate_thread` has RETURNED,
+                    # i.e. after the whole token stream or transcription has
+                    # finished, not after its first chunk. The idle clock only
+                    # starts once the worker is actually idle again.
+                    _arm_release_timer()
             self.wfile.write(b"0\r\n\r\n")
             self.wfile.flush()
 
@@ -4315,7 +4496,7 @@ def build_server(generate, streaming=False, host="127.0.0.1"):
 
 
 def serve(download, load, generate, streaming=False, memory=None, peak_memory=None,
-         argv=None):
+         release=None, argv=None):
     """Parse the supervisor's argv and run this worker. Does not return.
 
     `--download-only` fills the cache and exits; the exit CODE is the answer
@@ -4325,11 +4506,18 @@ def serve(download, load, generate, streaming=False, memory=None, peak_memory=No
     `peak_memory` is `memory`'s sibling (SPEC AI-8c, D497) — a runner that can
     answer "what did this cost at its WORST", not just "right now". See
     `peak_resident_bytes` for what a runner without one gets instead.
+
+    `release` is a third, independent optional hook: not a measurement but an
+    action, armed to run `_RELEASE_IDLE_S` after the worker's last execution
+    (win, loss, or cancel alike) if nothing new has started by then — see
+    `_release`, `_arm_release_timer` and `_fire_release` for the mechanism and
+    why only some runners pass one.
     """
-    global JOB_ID, _measure, _measure_peak
+    global JOB_ID, _measure, _measure_peak, _release
 
     _measure = memory
     _measure_peak = peak_memory
+    _release = release
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", required=True)
     # Not required: a download-only run serves nothing, so it has no port to

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -212,6 +212,17 @@ _release_timer = None
 #: could already have rearmed (see `_fire_release`).
 _release_generation = 0
 
+#: The constructor `_arm_release_timer` calls to make its timer — a LOCAL
+#: seam, not `threading.Timer` used directly. A test that wants a manually-
+#: fired stand-in only has to monkeypatch THIS name, rather than
+#: `threading.Timer` itself — patching the real stdlib class would affect
+#: every `threading.Timer` created anywhere in the process for the duration
+#: of the test, including by daemon threads left running from an earlier
+#: test in the same worker, which is exactly the kind of cross-test flake
+#: this module's own generate-thread singleton (`_GENERATE_TASKS`) already
+#: has to be careful never to become an instance of.
+_new_timer = threading.Timer
+
 
 def _arm_release_timer():
     """(Re)start the `_RELEASE_IDLE_S` idle timer — called once after every
@@ -246,7 +257,7 @@ def _arm_release_timer():
             _release_timer.cancel()
         _release_generation += 1
         token = _release_generation
-        timer = threading.Timer(_RELEASE_IDLE_S, _fire_release, args=(token,))
+        timer = _new_timer(_RELEASE_IDLE_S, _fire_release, args=(token,))
         # Daemon: a pending release must never be what keeps the worker
         # process alive. `serve_forever()`'s own thread and `os._exit(0)` in
         # `/quit` are both how this process actually ends, and neither should

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -222,14 +222,17 @@ def _arm_release_timer():
     Cancels whatever timer a PRIOR execution left pending first: a burst of
     renders must not pay the re-fault cost of clearing and re-growing the
     allocator pool between each one — only the LAST execution in a burst gets
-    to start the clock, which is the whole reason this is a timer and not the
-    unconditional `finally`-call this shipped as originally. Correctness in
-    the race between "the old timer's wait already elapsed" and "cancel just
-    ran" is `_fire_release`'s job, via the generation token.
+    to start the clock, which is the whole reason this is a timer and not an
+    unconditional `finally`-call (the first cut of this change, before an
+    idle timer replaced it). Correctness in the race between "the old
+    timer's wait already elapsed" and "cancel just ran" is `_fire_release`'s
+    job, via the generation token.
 
     A no-op when no `release` hook was supplied (`serve(release=...)` never
-    called) — nothing to ever arm for `mlx_text`, `llamacpp_text`, and the
-    rest of the runners this deliberately excludes.
+    called) — see `_release`'s own docstring for exactly which runners that
+    is and why (six wired, several deliberately not); this docstring used to
+    keep its own, shorter list and it drifted out of date the moment
+    `mlx_text` was wired in, which is why it no longer tries to repeat it.
     """
     global _release_timer, _release_generation
     if _release is None:

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -275,7 +275,15 @@ def _fire_release(token):
 
     Never raises past this function. A `release` that throws must be a
     no-op — there is no request waiting on this timer to fail loudly at, and
-    a broken reclaim must not take the timer thread down with it.
+    a broken reclaim must not take the timer thread down with it. Still
+    LOGGED, though (`traceback.print_exc`, `_single`'s own pattern for an
+    error nobody is waiting on): a release that fails on every idle window
+    forever is otherwise invisible except as the footprint number this whole
+    feature exists to move never actually moving, and that is exactly the
+    silent-regression shape code review caught once already (a torch build
+    where the MPS branch always raised and quietly took the CUDA branch down
+    with it — see `torch_image.release`). The worker's own stderr lands in
+    `$TMPDIR/fused-render-<pid>.log`, where a broken reclaim is now visible.
     """
     global _release_timer
     with GENERATE_LOCK:
@@ -287,8 +295,8 @@ def _fire_release(token):
             _release_timer = None
         try:
             run_on_generate_thread(_release)
-        except Exception:  # noqa: BLE001 - see docstring: reclaim failures are silent
-            pass
+        except Exception:  # noqa: BLE001 - logged below, then swallowed: see docstring
+            traceback.print_exc(file=sys.stderr)
 
 TOKEN = os.environ.get("FUSED_AI_WORKER_TOKEN", "")
 

--- a/tests/test_ai_diffusers_worker.py
+++ b/tests/test_ai_diffusers_worker.py
@@ -407,6 +407,86 @@ def test_the_vae_CLASS_NAME_is_what_the_projection_table_is_keyed_by(monkeypatch
     assert worker._loaded["vae"] == "AutoencoderKLFlux2"
 
 
+# -- releasing the allocator on an idle timer (D597) -----------------------------
+
+
+def test_release_calls_cuda_even_when_the_mps_call_raises(monkeypatch, base):
+    """THE regression this locks down. `torch/__init__.py` imports `torch.mps`
+    unconditionally on every platform and `empty_cache` is a plain function
+    that always exists on it — so a presence check (`getattr`/`hasattr`)
+    always passes, even on a CPU/CUDA/ROCm build with no MPS backend at all.
+    Calling it anyway reaches `torch._C._mps_emptyCache()`, which raises
+    `RuntimeError("Cannot execute emptyCache() without MPS backend.")` — and
+    on an unconditional call (no per-backend try/except) that exception took
+    the CUDA branch down with it before it ever ran, on exactly the one build
+    (`diffusers_image_cuda`/`_rocm`) that has a caching allocator worth
+    reclaiming at all. `torch.backends.mps.is_available()` — `_place()`'s own
+    gate above — is what actually distinguishes the two cases; this test's
+    `mps.empty_cache` still raises even though `is_available()` correctly
+    says `False`, to prove the gate is what stops the call, not luck."""
+    torch = fake_torch()
+    calls = []
+
+    def raising_empty_cache():
+        raise RuntimeError("Cannot execute emptyCache() without MPS backend.")
+
+    torch.mps = types.SimpleNamespace(empty_cache=raising_empty_cache)
+    torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False))
+    torch.cuda = types.SimpleNamespace(
+        is_available=lambda: True,
+        empty_cache=lambda: calls.append("cuda"))
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    worker = load_worker(monkeypatch, base)
+    worker.release()  # must not raise, and must not skip the CUDA branch
+
+    assert calls == ["cuda"]
+
+
+def test_release_calls_mps_when_it_is_actually_available(monkeypatch, base):
+    """The other half: a real Apple Silicon build DOES get the call."""
+    torch = fake_torch()
+    calls = []
+    torch.mps = types.SimpleNamespace(empty_cache=lambda: calls.append("mps"))
+    torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: True))
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    worker = load_worker(monkeypatch, base)
+    worker.release()
+
+    assert calls == ["mps"]
+
+
+def test_release_survives_both_backends_raising(monkeypatch, base):
+    """Neither backend's failure reaches the caller — `_fire_release` already
+    swallows and logs a raising `release`, so a release that raises here would
+    only be double-handled, never a functional problem, but the whole point of
+    the per-backend try/except is that ONE of the two is still allowed to
+    succeed even when the other cannot, which this alone cannot show without
+    the mixed case above. This pins the belt-and-braces half: even if the gate
+    itself were ever wrong on some future torch build, this function still
+    cannot raise into `worker_base`."""
+    torch = fake_torch()
+
+    def raising_mps():
+        raise RuntimeError("boom")
+
+    def raising_cuda():
+        raise RuntimeError("boom")
+
+    torch.mps = types.SimpleNamespace(empty_cache=raising_mps)
+    torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: True))
+    torch.cuda = types.SimpleNamespace(is_available=lambda: True, empty_cache=raising_cuda)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    worker = load_worker(monkeypatch, base)
+    worker.release()  # must not raise
+
+
 def test_a_thumbnail_appears_from_the_SECOND_step_and_is_GONE_at_the_end(
         monkeypatch, base, tmp_path):
     """Step 1 has no predecessor, so it has no velocity and no estimate — and

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -687,26 +687,31 @@ def test_a_streaming_generates_writes_also_stay_off_the_connection_thread(base):
 # status bar kept reading "1.7 GB now (21 GB held)" long after the render
 # finished.
 #
-# It does NOT fire in the request's own `finally` — an earlier cut of this
-# did, and re-faulting a 24 GB working set on every single call would make a
-# burst of five renders pay that cost five times. Instead each completed
+# It does NOT fire in the request's own `finally` — this change's first cut
+# did that, and re-faulting a 24 GB working set on every single call would
+# make a burst of five renders pay that cost five times. Instead each completed
 # execution arms a `_RELEASE_IDLE_S`-second timer; a new execution inside
 # that window cancels the pending one and arms a fresh one, so only a
 # genuinely idle worker ever actually clears. These tests set `base._release`
 # directly (mirroring how `_measure_peak` is set on `base` above) because
 # `_serve` here calls `build_server` directly, the same seam `serve()` itself
 # assigns through — and they swap in `_ManualTimer` below for
-# `threading.Timer` so the 30s window is crossed by calling `.fire()`, never
-# by sleeping.
+# `worker_base._new_timer` so the 30s window is crossed by calling `.fire()`,
+# never by sleeping.
 
 
 class _ManualTimer:
     """Stands in for `threading.Timer`, fired by hand instead of by a real
-    30-second wait. `_arm_release_timer` calls `threading.Timer(...)`
-    directly, so patching the `Timer` NAME on the `threading` module (which
-    `base.threading` and the real stdlib module both are — one object)
-    intercepts every timer it creates for the rest of the test, with no seam
-    needed in the production code.
+    30-second wait. `_arm_release_timer` calls `worker_base._new_timer(...)`
+    — a local indirection to `threading.Timer` that exists FOR this seam —
+    rather than `threading.Timer` directly: patching the real stdlib class
+    would affect every `threading.Timer` created ANYWHERE in the process for
+    the duration of the test, including by daemon threads leaked from an
+    earlier test in the same xdist worker (a real cross-file flake shape in
+    this repo, not a hypothetical one), silently turning them into timers
+    that are never scheduled and never fire. Patching `base._new_timer`
+    instead only ever affects timers `_arm_release_timer` itself creates, in
+    THIS one fresh module.
 
     `cancel()` matches real `Timer` semantics: a cancelled timer's function
     never runs, even if `.fire()` is called on it afterwards — which is what
@@ -741,7 +746,7 @@ def manual_timers(base, monkeypatch):
     """Every `_ManualTimer` `_arm_release_timer` creates during this test, in
     order — `instances[-1]` is always the CURRENTLY pending one."""
     _ManualTimer.instances = []
-    monkeypatch.setattr(base.threading, "Timer", _ManualTimer)
+    monkeypatch.setattr(base, "_new_timer", _ManualTimer)
     return _ManualTimer.instances
 
 

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -947,6 +947,46 @@ def test_release_runs_on_the_generate_thread_not_the_connection_thread(base, man
         server.shutdown()
 
 
+def test_a_fired_release_cannot_run_while_a_generation_holds_the_lock(base, manual_timers):
+    """The safety-critical half of `_fire_release` that nothing above actually
+    exercises: acquiring `GENERATE_LOCK` FIRST is what makes firing mid-render
+    impossible, not just an assumption. `GENERATE_LOCK` is held here directly
+    from this thread, standing in for "a generation is in flight" without the
+    generation-token machinery (a real second execution would also CANCEL and
+    supersede this timer once it finishes, which is a different behaviour —
+    covered by `test_a_second_execution_inside_the_window_defers_the_pending_
+    release` above — and would make "does it fire" ambiguous here for the
+    wrong reason)."""
+    calls = []
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    base._release = lambda: calls.append("released")
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        timer = manual_timers[-1]
+    finally:
+        server.shutdown()
+
+    base.GENERATE_LOCK.acquire()
+    try:
+        firer = threading.Thread(target=timer.fire)
+        firer.start()
+        firer.join(timeout=0.2)
+        assert firer.is_alive(), (
+            "the release ran while GENERATE_LOCK was held by an in-flight "
+            "generation — the whole point of acquiring it first")
+        assert calls == []
+    finally:
+        base.GENERATE_LOCK.release()
+    firer.join(timeout=5)
+    assert not firer.is_alive()
+    assert calls == ["released"], (
+        "the pending release must still run once the lock is free again"
+    )
+
+
 def test_serve_wires_release_into_the_module_global(base, monkeypatch, tmp_path):
     """`serve(release=...)` has to actually reach the module global that
     `_arm_release_timer` reads — the same wiring `memory=`/`peak_memory=`

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -1561,27 +1561,39 @@ def test_every_runner_with_a_reclaimable_allocator_wires_the_idle_release():
     their executions. Source again, for the same reason as the peak-probe
     test above — mlx and a GPU-built torch do not import on this CI host.
 
+    The strings checked below are CODE, not prose: every one of these
+    `release()` docstrings also mentions `mx.clear_cache()`/`empty_cache()`
+    in its own explanation of what it does, so a naive `"clear_cache" in
+    source` (an earlier version of this test) would keep passing even with
+    the actual call deleted from the function body — a guard that cannot
+    fail is not a guard. `getattr(mx, "clear_cache", None)` and
+    `torch.{mps,cuda}.empty_cache()` are each the exact statement `release()`
+    executes, and each appears in these files exactly once, in the body, not
+    in a docstring — verified by hand: deleting the real call and re-running
+    this test does turn it red.
+
     `llamacpp_text`, `faster_whisper` and `onnx_embed` are deliberately
     absent from this list — see the comment beside each of their own
     `worker_base.serve(...)` calls for why each one has nothing here to
     release."""
     from fused_render.ai import registry
 
-    for code, clear_call in (
-        ("mlx-text", "clear_cache"),
-        ("mflux-image", "clear_cache"),
-        ("mlx-whisper", "clear_cache"),
-        ("mlx-embed", "clear_cache"),
-        ("ltx-video", "clear_cache"),
-        ("diffusers-image", "empty_cache"),
+    for code, clear_calls in (
+        ("mlx-text", ('getattr(mx, "clear_cache", None)',)),
+        ("mflux-image", ('getattr(mx, "clear_cache", None)',)),
+        ("mlx-whisper", ('getattr(mx, "clear_cache", None)',)),
+        ("mlx-embed", ('getattr(mx, "clear_cache", None)',)),
+        ("ltx-video", ('getattr(mx, "clear_cache", None)',)),
+        ("diffusers-image", ("torch.mps.empty_cache()", "torch.cuda.empty_cache()")),
     ):
         runner = registry.by_code(code)
         assert runner is not None, code
         source = _runner_source(runner)
         assert "def release(" in source, f"{code} has no release hook"
-        assert clear_call in source, (
-            f"{code}'s release() does not call {clear_call!r}"
-        )
+        for clear_call in clear_calls:
+            assert clear_call in source, (
+                f"{code}'s release() does not actually call {clear_call!r}"
+            )
         assert "release=release" in source, (
             f"{code} does not pass its release hook to serve(), so an idle "
             "worker here never hands its allocator pool back"

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -69,6 +69,25 @@ def _call(server, path, body=None, token="secret", method=None):
     return urllib.request.urlopen(request, timeout=5)
 
 
+def _settle(base):
+    """Block until the server-side request handler has FULLY finished —
+    including its `finally` — after a `_call(...)` the test already read the
+    response of.
+
+    A client that has received its response has no guarantee the SERVER
+    thread has finished running code AFTER it wrote those bytes: the network
+    is the only synchronisation point, and `_single`/`_stream` still have
+    their `finally` (arming or clearing the release timer) to run once
+    `self._json`/the last `write` returns. `GENERATE_LOCK` is held for the
+    whole handler, finally included, so acquiring and immediately releasing
+    it here is a barrier for exactly that gap — needed by every test in the
+    idle-release section below that inspects `base._release_timer` or
+    `manual_timers` right after a `_call(...).close()`.
+    """
+    with base.GENERATE_LOCK:
+        pass
+
+
 # -- the auth header ------------------------------------------------------------
 
 
@@ -659,6 +678,290 @@ def test_a_streaming_generates_writes_also_stay_off_the_connection_thread(base):
         server.shutdown()
 
 
+# -- releasing the allocator cache on a 30s IDLE TIMER (D597) -------------------
+#
+# `serve(release=...)` is the third optional hook beside `memory=`/`peak_
+# memory=` — an ACTION, not a measurement. Motivating numbers are on
+# `_release`'s docstring: a FLUX.2-Klein-4B-4bit render needs ~24 GB at its
+# peak but MLX never hands the idle pool back to the OS on its own, so the
+# status bar kept reading "1.7 GB now (21 GB held)" long after the render
+# finished.
+#
+# It does NOT fire in the request's own `finally` — an earlier cut of this
+# did, and re-faulting a 24 GB working set on every single call would make a
+# burst of five renders pay that cost five times. Instead each completed
+# execution arms a `_RELEASE_IDLE_S`-second timer; a new execution inside
+# that window cancels the pending one and arms a fresh one, so only a
+# genuinely idle worker ever actually clears. These tests set `base._release`
+# directly (mirroring how `_measure_peak` is set on `base` above) because
+# `_serve` here calls `build_server` directly, the same seam `serve()` itself
+# assigns through — and they swap in `_ManualTimer` below for
+# `threading.Timer` so the 30s window is crossed by calling `.fire()`, never
+# by sleeping.
+
+
+class _ManualTimer:
+    """Stands in for `threading.Timer`, fired by hand instead of by a real
+    30-second wait. `_arm_release_timer` calls `threading.Timer(...)`
+    directly, so patching the `Timer` NAME on the `threading` module (which
+    `base.threading` and the real stdlib module both are — one object)
+    intercepts every timer it creates for the rest of the test, with no seam
+    needed in the production code.
+
+    `cancel()` matches real `Timer` semantics: a cancelled timer's function
+    never runs, even if `.fire()` is called on it afterwards — which is what
+    lets a test tell "the pending release was deferred" from "it fired
+    anyway" without needing two clocks in flight at once.
+    """
+
+    instances = []
+
+    def __init__(self, interval, function, args=()):
+        self.interval = interval
+        self.function = function
+        self.args = args
+        self.daemon = None
+        self.cancelled = False
+        self.started = False
+        _ManualTimer.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def cancel(self):
+        self.cancelled = True
+
+    def fire(self):
+        if self.started and not self.cancelled:
+            self.function(*self.args)
+
+
+@pytest.fixture()
+def manual_timers(base, monkeypatch):
+    """Every `_ManualTimer` `_arm_release_timer` creates during this test, in
+    order — `instances[-1]` is always the CURRENTLY pending one."""
+    _ManualTimer.instances = []
+    monkeypatch.setattr(base.threading, "Timer", _ManualTimer)
+    return _ManualTimer.instances
+
+
+def test_a_completed_generate_arms_a_daemon_timer_for_the_idle_window(base, manual_timers):
+    """Armed with the named constant, not a bare literal, and marked daemon
+    so a pending release is never what keeps the worker process alive at
+    exit — `os._exit(0)` in `/quit` does not wait on it, and neither would a
+    normal interpreter shutdown."""
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    base._release = lambda: None
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        assert len(manual_timers) == 1
+        assert manual_timers[0].interval == base._RELEASE_IDLE_S
+        assert manual_timers[0].daemon is True
+        assert manual_timers[0].started is True
+    finally:
+        server.shutdown()
+
+
+def test_release_fires_after_the_idle_window_with_no_further_execution(base, manual_timers):
+    calls = []
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    base._release = lambda: calls.append("released")
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        assert calls == []  # not yet — only arming happens synchronously
+        manual_timers[-1].fire()
+        assert calls == ["released"]
+    finally:
+        server.shutdown()
+
+
+def test_a_second_execution_inside_the_window_defers_the_pending_release(base, manual_timers):
+    """The core of the redesign: a burst of renders must not clear between
+    each one. The FIRST timer is cancelled outright rather than left to fire
+    later — `fire()`'d directly here to prove it really is inert, not just
+    superseded."""
+    calls = []
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    base._release = lambda: calls.append("released")
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        first_timer = manual_timers[-1]
+        assert not first_timer.cancelled
+
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        assert first_timer.cancelled, "a second execution must cancel the first timer"
+        assert len(manual_timers) == 2, "the second execution must arm its own timer"
+
+        first_timer.fire()  # inert: cancelled timers never call their function
+        assert calls == []
+
+        manual_timers[-1].fire()
+        assert calls == ["released"]
+    finally:
+        server.shutdown()
+
+
+def test_a_stale_timer_that_already_escaped_cancel_still_checks_its_token(base, manual_timers):
+    """Belt-and-braces beside `cancel()`: the window between a real `Timer`'s
+    wait elapsing and its callback actually acquiring `GENERATE_LOCK` is where
+    a rearm can land AFTER `cancel()` was already too late to help. Exercised
+    directly here — `_ManualTimer.fire()` alone cannot reach this branch,
+    since it always honours `cancelled` — by calling `_fire_release` with a
+    token this test manufactures as already stale."""
+    calls = []
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    base._release = lambda: calls.append("released")
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        stale_token = base._release_generation
+        _call(server, "/generate", {}).close()  # bumps _release_generation past stale_token
+        _settle(base)
+        base._fire_release(stale_token)
+        assert calls == [], "a stale token must not clear the cache out from under a newer run"
+    finally:
+        server.shutdown()
+
+
+def test_a_streaming_execution_counts_as_active_for_its_whole_duration(base, manual_timers):
+    """The timer must only be armed once the STREAM ENDS, not once it starts
+    — a long token stream or transcription is exactly the case this matters
+    for, since `GENERATE_LOCK` is held throughout and arming happens in
+    `_stream`'s `finally`, after `run_on_generate_thread` returns."""
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    base._release = lambda: None
+    started = threading.Event()
+    finish = threading.Event()
+
+    def generate(body, write):
+        started.set()
+        finish.wait(timeout=5)
+        write({"type": "done", "ok": True})
+
+    server = _serve(base, generate, streaming=True)
+    try:
+        caller = threading.Thread(
+            target=lambda: _call(server, "/generate", {}).read())
+        caller.start()
+        assert started.wait(timeout=5)
+        # Mid-stream: nothing has been armed yet, because the execution has
+        # not finished — this is the assertion a per-call design could not
+        # make at all, since there IS no "mid-call" for it.
+        assert manual_timers == []
+        finish.set()
+        caller.join(timeout=5)
+        _settle(base)
+        assert len(manual_timers) == 1, "the timer arms once the stream actually ends"
+    finally:
+        finish.set()
+        server.shutdown()
+
+
+def test_no_release_hook_is_a_silent_no_op(base, manual_timers):
+    """Every runner that never calls `serve(release=...)` — `llamacpp_text`,
+    `faster_whisper`, `onnx_embed` and its shells — leaves `_release` at its
+    default `None`. Nothing is ever armed for them, and `/generate` behaves
+    exactly as it did before this hook existed."""
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+    assert base._release is None
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        with _call(server, "/generate", {}) as response:
+            assert json.loads(response.read())["ok"] is True
+        _settle(base)
+        assert manual_timers == []
+    finally:
+        server.shutdown()
+
+
+def test_a_raising_release_does_not_crash_the_timer_or_break_the_next_execution(base, manual_timers):
+    """The response this timer eventually fires for is long gone by the time
+    it runs — there is nobody left to hand a 500 to — so a `release` that
+    throws must be swallowed, and must not leave the timer machinery wedged
+    for the NEXT execution."""
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+
+    def boom():
+        raise RuntimeError("mlx.core has no attribute 'clear_cache'")
+
+    base._release = boom
+    server = _serve(base, lambda body: {"ok": True})
+    try:
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        manual_timers[-1].fire()  # must not raise out of this call
+        assert base._release_timer is None
+
+        # And a subsequent execution still arms cleanly.
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        assert len(manual_timers) == 2
+    finally:
+        server.shutdown()
+
+
+def test_release_runs_on_the_generate_thread_not_the_connection_thread(base, manual_timers):
+    """Routed through `run_on_generate_thread` like `generate` itself: the
+    hook this exists for is `mx.clear_cache()`, an MLX call, and that
+    function's docstring is the whole reason no MLX call is made from a
+    thread other than the one dedicated to them — a fired timer runs on yet
+    another thread of its own, no different in kind."""
+    generate_threads = []
+    release_threads = []
+    base.TOKEN = "secret"
+    base.set_state(state="ready")
+
+    def generate(body):
+        generate_threads.append(threading.current_thread())
+        return {}
+
+    base._release = lambda: release_threads.append(threading.current_thread())
+    server = _serve(base, generate)
+    try:
+        _call(server, "/generate", {}).close()
+        _settle(base)
+        manual_timers[-1].fire()
+        assert release_threads == generate_threads
+        assert release_threads[0] is not threading.current_thread()
+    finally:
+        server.shutdown()
+
+
+def test_serve_wires_release_into_the_module_global(base, monkeypatch, tmp_path):
+    """`serve(release=...)` has to actually reach the module global that
+    `_arm_release_timer` reads — the same wiring `memory=`/`peak_memory=`
+    already get, pinned by `test_serve_wires_peak_memory_into_the_peak_probe`
+    above."""
+    class _FakeServer:
+        server_address = ("127.0.0.1", 0)
+
+        def serve_forever(self):
+            pass
+
+    monkeypatch.setattr(base, "build_server", lambda *a, **kw: _FakeServer())
+    status = tmp_path / "status.json"
+    sentinel = lambda: None  # noqa: E731 - identity is what's under test
+    base.serve(download=lambda m: None, load=lambda m, f: None,
+              generate=lambda body: {}, release=sentinel,
+              argv=["--model", "org/m", "--status", str(status)])
+    assert base._release is sentinel
+
+
 # -- reporting ------------------------------------------------------------------
 
 
@@ -1243,6 +1546,40 @@ def test_every_MLX_runner_supplies_a_true_peak_probe():
         assert "peak_memory=peak_memory" in source, (
             f"{code} does not pass its peak probe to serve(), so /health "
             "reports no peak_resident_bytes at all"
+        )
+
+
+def test_every_runner_with_a_reclaimable_allocator_wires_the_idle_release():
+    """D597/the idle-release feature: every runner whose backend actually
+    exposes a cache-release call wires it to `serve(release=...)`, so
+    `worker_base._arm_release_timer` has something to arm after every one of
+    their executions. Source again, for the same reason as the peak-probe
+    test above — mlx and a GPU-built torch do not import on this CI host.
+
+    `llamacpp_text`, `faster_whisper` and `onnx_embed` are deliberately
+    absent from this list — see the comment beside each of their own
+    `worker_base.serve(...)` calls for why each one has nothing here to
+    release."""
+    from fused_render.ai import registry
+
+    for code, clear_call in (
+        ("mlx-text", "clear_cache"),
+        ("mflux-image", "clear_cache"),
+        ("mlx-whisper", "clear_cache"),
+        ("mlx-embed", "clear_cache"),
+        ("ltx-video", "clear_cache"),
+        ("diffusers-image", "empty_cache"),
+    ):
+        runner = registry.by_code(code)
+        assert runner is not None, code
+        source = _runner_source(runner)
+        assert "def release(" in source, f"{code} has no release hook"
+        assert clear_call in source, (
+            f"{code}'s release() does not call {clear_call!r}"
+        )
+        assert "release=release" in source, (
+            f"{code} does not pass its release hook to serve(), so an idle "
+            "worker here never hands its allocator pool back"
         )
 
 


### PR DESCRIPTION
## Summary

- **A worker that has sat idle for 30 seconds now hands its allocator pool back to the OS.** An MLX render keeps every buffer it touched: a FLUX.2-Klein-4B-4bit render peaks at ~24 GB (`mx.get_peak_memory()`), settles to 1.7 GB of live tensors — and the status bar keeps reading `1.7 GB now (21 GB held)` indefinitely, because MLX only reclaims its pool once it exceeds `set_cache_limit`, whose default is ~1.5x the recommended working set (≈38.7 GB on a 34.4 GB machine, i.e. above physical RAM, so the condition can never fire).
- **An idle timer, not a per-execution clear.** Clearing after every call makes a burst of five renders re-fault a 24 GB working set five times. Only the *last* execution in a burst starts the clock, so a chat loop, a bulk embed, or a batch of renders runs at full allocator speed and the pool comes back the moment the user walks away.
- **The model stays resident.** This is a much cheaper cousin of the supervisor's idle reaper, not a replacement: the reaper kills the process after `effective_ai_idle_unload_minutes()` (10 min default) and the next request pays a full reload. This releases only the idle pool after 30 s; the next request is exactly as fast.
- **Six runners wired:** all five MLX runners plus the shared `torch_image` (MPS/CUDA), which covers all three diffusers install shells. Three runners are explicitly opted out with a documented reason at the call site.
- **Nothing about a render's peak changes.** No tiled decode, no `mx.eval()` boundaries, no `set_cache_limit`/`set_memory_limit`. This reclaims what a finished execution left behind.

## Visuals

```mermaid
flowchart TD
    A[POST /generate] --> B[GENERATE_LOCK held]
    B --> C[finally: arm idle timer]
    C --> D{new execution<br/>within 30s?}
    D -->|yes| C
    D -->|no| E[timer fires]
    E --> F[take GENERATE_LOCK<br/>+ check token]
    F --> G[release on generate thread]
```

`release` runs on the worker's one persistent MLX thread, same as `generate`. Taking `GENERATE_LOCK` before it makes firing mid-execution impossible; the generation token catches a timer whose wait had already elapsed when `cancel()` was called.

| Runner | Hook |
|---|---|
| `mflux_image`, `ltx_video`, `mlx_text`, `mlx_embed`, `mlx_whisper` | `mx.clear_cache()` |
| `torch_image` (→ `diffusers_image`, `_cuda`, `_rocm`) | `torch.mps.empty_cache()` / `torch.cuda.empty_cache()` |
| `llamacpp_text` | none — fixed KV context allocated at load, weights mmap'd |
| `faster_whisper` | none — CTranslate2 exposes no cache-release API |
| `onnx_embed` (+ shells) | none — arena is session-scoped `SessionOptions` config |

## Usage

Not user-invocable and not configurable: there is no new route, no supervisor RPC, and no preference. The timer lives entirely inside each worker process, which already knows when its own last execution ended.

Observable in the status bar: run a model, wait 30 seconds idle, and the `(N GB held)` figure (`os_footprint_bytes()`, D597) drops toward the live-tensor number.

## Test Plan

- [x] `tests/test_ai_worker_base.py` — 11 new tests driven against the real HTTP handler, with `threading.Timer` monkeypatched by a manually-fired `_ManualTimer` (no real 30 s sleeps): arming with the named constant and the daemon flag; firing after the window; a second execution deferring the pending release; the stale-token guard; **a streaming execution counting as active for its whole duration, verified mid-stream**; no-op when no hook is supplied; a raising `release` neither crashing the timer nor wedging the next execution; generate-thread affinity; `serve(release=...)` wiring.
- [x] `test_every_runner_with_a_reclaimable_allocator_wires_the_idle_release` — source-grep test pinning that all six runners actually pass `release=`, so a new MLX runner can't silently ship without one.
- [x] Every touched runner's own test file re-run (mflux, ltx_video, mlx_text, mlx_embed, mlx_whisper, diffusers, llamacpp, onnx_embed, whisper, registry, runtime) — 1021 passed, 1 skipped. `test_ai_worker_base.py` repeated 5x for flakiness.
- [ ] **Manual, needs Metal + the model:** render with `mlx-community/FLUX.2-Klein-4B-4bit`, watch the status bar read `~1.7 GB now (21 GB held)`, wait 30 s idle, confirm the held figure drops. Then run two renders back to back and confirm no clear happens between them.
