### PR TITLE
Claude chat: the working line says what the run is doing, in plain words

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -2758,6 +2758,37 @@ def _segments_from_rows(rows: list) -> list:
     return out
 
 
+def _tool_detail(name, inp) -> str:
+    """The one short thing worth saying about a tool call on the status line.
+
+    Bash carries its own `description` (the model writes one per call); the
+    file tools name a file; Task/Agent describe the job. Anything else is just
+    its name. Kept to one line and ~80 chars — this rides inside "(47s · …)".
+    """
+    if not isinstance(inp, dict):
+        return ""
+    name = str(name or "")
+    if name == "Bash":
+        d = inp.get("description") or ""
+        if not d:
+            d = str(inp.get("command") or "").strip().splitlines()[:1]
+            d = d[0] if d else ""
+    elif name in ("Read", "Edit", "Write", "MultiEdit", "NotebookEdit"):
+        d = os.path.basename(str(inp.get("file_path") or inp.get("notebook_path") or ""))
+    elif name in ("Task", "Agent"):
+        d = inp.get("description") or inp.get("subagent_type") or ""
+    elif name in ("Grep", "Glob"):
+        d = inp.get("pattern") or ""
+    elif name == "Skill":
+        d = inp.get("skill") or ""
+    elif name in ("WebFetch", "WebSearch"):
+        d = inp.get("url") or inp.get("query") or ""
+    else:
+        d = ""
+    d = " ".join(str(d).split())
+    return d if len(d) <= 80 else d[:77] + "…"
+
+
 def _poll(run_id: str, file: str = "") -> dict:
     run_dir = os.path.join(RUNS, run_id)
     if _bad_id(run_id) or not os.path.isdir(run_dir):
@@ -2829,6 +2860,20 @@ def _poll(run_id: str, file: str = "") -> dict:
     retry_total = 0      # how many retries this run has seen at all
     retry_status = 0     # HTTP status of the last one (529 overloaded, 429 …)
     gave_up = None       # the retry still in flight when the run ended badly
+    # WHAT THE RUN IS DOING RIGHT NOW, beyond the verb. Every one of these is a
+    # thing the CLI already writes to out.jsonl and the page used to ignore, so
+    # a long quiet stretch — a minute of extended thinking, a Bash `sleep 30`,
+    # a 40 KB Write streaming its input, a slow Stop hook — sat under a frozen
+    # "Thinking… (47s)" that was indistinguishable from a hang (Akshil,
+    # 2026-08-28). See `_activity` for the wire shape.
+    tool_open = None       # {"id", "name", "detail"} of the tool block in flight
+    tool_input_bytes = 0   # input_json_delta bytes streamed for that block
+    tool_inputs = {}       # tool_use id -> finalized input (from `assistant` rows)
+    thinking_tokens = 0    # CLI's running estimate for the message in flight
+    hooks_open = {}        # hook_id -> hook_name, started and not yet responded
+    bg_tasks = {}          # task_id -> description, started and not yet finished
+    agent_rows = 0         # rows a subagent wrote (parent_tool_use_id set)
+    after_tool = False     # a tool_result landed and nothing has streamed since
     # Every row this poll managed to parse, handed to `_segments_from_rows` once
     # the loop is done. Collected rather than parsed a second time: the file is
     # re-read from scratch on every 400 ms tick, so a second `json.loads` pass
@@ -2870,16 +2915,75 @@ def _poll(run_id: str, file: str = "") -> dict:
             was_retrying, retry = retry, None
         else:
             was_retrying = None
+        # A subagent's rows come through the same stream tagged with the id of
+        # the Task/Agent call that spawned them (SDK contract; not yet seen in a
+        # local run, so counted rather than rendered). They must not move the
+        # main line's phase — the parent is still "running Agent".
+        if row.get("parent_tool_use_id"):
+            agent_rows += 1
+            continue
+        if t in ("stream_event", "assistant"):
+            after_tool = False
         if t == "system":
             new_session = row.get("session_id", new_session)
-            if row.get("subtype") == "api_retry":
+            sub = row.get("subtype")
+            if sub == "api_retry":
                 info = _retry_info(row)
                 if info is not None:
                     retry = info
                     retry_total += 1
                     retry_status = info["status"]
+            elif sub == "status":
+                # `{"status": "requesting"}` is the CLI saying the request is
+                # out and no token is back yet — the one gap the stream itself
+                # cannot describe, and the most common "what is it doing".
+                if row.get("status") == "requesting":
+                    phase = "requesting"
+                    after_tool = False
+            elif sub == "thinking_tokens":
+                est = row.get("estimated_tokens")
+                if isinstance(est, (int, float)):
+                    thinking_tokens = max(thinking_tokens, int(est))
+            elif sub == "hook_started" and row.get("hook_id"):
+                hooks_open[row["hook_id"]] = str(row.get("hook_name") or "hook")
+            elif sub == "hook_response":
+                hooks_open.pop(row.get("hook_id"), None)
+            elif sub == "task_started" and row.get("task_id"):
+                bg_tasks[row["task_id"]] = str(row.get("description") or "")
+            elif sub == "task_notification":
+                bg_tasks.pop(row.get("task_id"), None)
+            elif sub == "task_updated":
+                if (row.get("patch") or {}).get("status") in (
+                        "completed", "killed", "failed", "stopped"):
+                    bg_tasks.pop(row.get("task_id"), None)
+            elif sub == "background_tasks_changed":
+                # Authoritative list when the CLI sends one.
+                tasks = row.get("tasks")
+                if isinstance(tasks, list):
+                    bg_tasks = {
+                        str(x.get("task_id")): str(x.get("description") or "")
+                        for x in tasks if isinstance(x, dict) and x.get("task_id")}
         elif t == "assistant":
             skills += _skill_calls(row)
+            for blk in (row.get("message") or {}).get("content") or []:
+                if isinstance(blk, dict) and blk.get("type") == "tool_use" \
+                        and blk.get("id"):
+                    tool_inputs[blk["id"]] = blk.get("input") or {}
+                    if tool_open and tool_open["id"] == blk["id"]:
+                        tool_open["detail"] = _tool_detail(blk.get("name"),
+                                                           tool_inputs[blk["id"]])
+        elif t == "user":
+            # The tool's result went back in. From here until `status:
+            # requesting` (or the next delta) the run is packing the result
+            # into the next request — brief, but "Working" with no tool open
+            # was the lie this used to tell.
+            content = (row.get("message") or {}).get("content")
+            if isinstance(content, list) and any(
+                    isinstance(b, dict) and b.get("type") == "tool_result"
+                    for b in content):
+                tool_open = None
+                tool_input_bytes = 0
+                after_tool = True
         elif t == "stream_event":
             ev = row.get("event", {})
             et = ev.get("type")
@@ -2893,6 +2997,10 @@ def _poll(run_id: str, file: str = "") -> dict:
                     phase = "composing"
                 elif delta.get("type") == "thinking_delta":
                     phase = "thinking"
+                elif delta.get("type") == "input_json_delta":
+                    tool_input_bytes += len(delta.get("partial_json") or "")
+            elif et == "message_start":
+                thinking_tokens = 0
             elif et == "message_delta":
                 usage = ev.get("usage") or {}
                 tokens_current = usage.get("output_tokens", tokens_current)
@@ -2903,9 +3011,13 @@ def _poll(run_id: str, file: str = "") -> dict:
                 # break their texts concatenate mid-word ("orange.After").
                 pending_sep = bool(text_parts)
             elif et == "content_block_start":
-                block = (ev.get("content_block") or {}).get("type")
+                cb = ev.get("content_block") or {}
+                block = cb.get("type")
                 if block == "tool_use":
                     phase = "tooling"
+                    tool_open = {"id": cb.get("id") or "", "name": str(cb.get("name") or "tool"),
+                                 "detail": _tool_detail(cb.get("name"), tool_inputs.get(cb.get("id"), {}))}
+                    tool_input_bytes = 0
         elif t == "result":
             saw_result = True
             idle = True
@@ -2922,6 +3034,10 @@ def _poll(run_id: str, file: str = "") -> dict:
     # indistinguishable from a hang, which is what an overload used to look like.
     if retry is not None:
         phase = "retrying"
+    elif after_tool and phase == "tooling":
+        # Result in, nothing back yet, no `status` row (older CLI): the honest
+        # word is still "sending", not "Working" over a tool that has finished.
+        phase = "requesting"
 
     # Finished: a `result` with nothing after it (the turn ended and no wake has
     # started another), or a process that is simply gone (D415).
@@ -3069,6 +3185,14 @@ def _poll(run_id: str, file: str = "") -> dict:
             # schedule.py) left this page reporting the kill as a crash. See
             # `_cancel`, which writes the marker.
             "cancelled": os.path.exists(os.path.join(run_dir, "cancelled")),
+            "activity": {
+                "tool": tool_open,
+                "tool_input_bytes": tool_input_bytes if tool_open else 0,
+                "thinking_tokens": thinking_tokens if phase == "thinking" else 0,
+                "hook": next(reversed(hooks_open.values())) if hooks_open else "",
+                "tasks": [{"id": k, "description": v} for k, v in bg_tasks.items()],
+                "agent_rows": agent_rows,
+            },
             "segments": _segments_from_rows(parsed)}
 
 

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -2866,8 +2866,13 @@ def _poll(run_id: str, file: str = "") -> dict:
     # a 40 KB Write streaming its input, a slow Stop hook — sat under a frozen
     # "Thinking… (47s)" that was indistinguishable from a hang (Akshil,
     # 2026-08-28). See `_activity` for the wire shape.
-    tool_open = None       # {"id", "name", "detail"} of the tool block in flight
-    tool_input_bytes = 0   # input_json_delta bytes streamed for that block
+    # Tools in flight, BY ID and in start order. One assistant message can
+    # carry several tool_use blocks (parallel calls); their results come back
+    # as separate `user` rows, so "a result arrived" is not "the tool phase is
+    # over" — only the LAST open call's result is (Bugbot, PR #908). The line
+    # shows the most recently started call that has not returned.
+    tools_open = {}        # tool_use id -> {"id", "name", "detail"}
+    tool_input_bytes = 0   # input_json_delta bytes streamed for the newest block
     tool_inputs = {}       # tool_use id -> finalized input (from `assistant` rows)
     thinking_tokens = 0    # CLI's running estimate for the message in flight
     hooks_open = {}        # hook_id -> hook_name, started and not yet responded
@@ -2969,19 +2974,28 @@ def _poll(run_id: str, file: str = "") -> dict:
                 if isinstance(blk, dict) and blk.get("type") == "tool_use" \
                         and blk.get("id"):
                     tool_inputs[blk["id"]] = blk.get("input") or {}
-                    if tool_open and tool_open["id"] == blk["id"]:
-                        tool_open["detail"] = _tool_detail(blk.get("name"),
-                                                           tool_inputs[blk["id"]])
+                    if blk["id"] in tools_open:
+                        tools_open[blk["id"]]["detail"] = _tool_detail(
+                            blk.get("name"), tool_inputs[blk["id"]])
         elif t == "user":
             # The tool's result went back in. From here until `status:
             # requesting` (or the next delta) the run is packing the result
             # into the next request — brief, but "Working" with no tool open
             # was the lie this used to tell.
             content = (row.get("message") or {}).get("content")
-            if isinstance(content, list) and any(
-                    isinstance(b, dict) and b.get("type") == "tool_result"
-                    for b in content):
-                tool_open = None
+            results = [b for b in (content if isinstance(content, list) else [])
+                       if isinstance(b, dict) and b.get("type") == "tool_result"]
+            for b in results:
+                # Close the call this result answers. An id we never saw
+                # opened (older CLI, or a result whose start row was lost)
+                # falls back to closing the oldest open call, so a missing id
+                # can never leave a finished tool on the line forever.
+                tid = b.get("tool_use_id")
+                if tid in tools_open:
+                    del tools_open[tid]
+                elif tools_open:
+                    del tools_open[next(iter(tools_open))]
+            if results and not tools_open:
                 tool_input_bytes = 0
                 after_tool = True
         elif t == "stream_event":
@@ -3015,8 +3029,10 @@ def _poll(run_id: str, file: str = "") -> dict:
                 block = cb.get("type")
                 if block == "tool_use":
                     phase = "tooling"
-                    tool_open = {"id": cb.get("id") or "", "name": str(cb.get("name") or "tool"),
-                                 "detail": _tool_detail(cb.get("name"), tool_inputs.get(cb.get("id"), {}))}
+                    tid = cb.get("id") or ""
+                    tools_open[tid] = {
+                        "id": tid, "name": str(cb.get("name") or "tool"),
+                        "detail": _tool_detail(cb.get("name"), tool_inputs.get(tid, {}))}
                     tool_input_bytes = 0
         elif t == "result":
             saw_result = True
@@ -3034,7 +3050,7 @@ def _poll(run_id: str, file: str = "") -> dict:
     # indistinguishable from a hang, which is what an overload used to look like.
     if retry is not None:
         phase = "retrying"
-    elif after_tool and phase == "tooling":
+    elif after_tool and phase == "tooling" and not tools_open:
         # Result in, nothing back yet, no `status` row (older CLI): the honest
         # word is still "sending", not "Working" over a tool that has finished.
         phase = "requesting"
@@ -3186,8 +3202,9 @@ def _poll(run_id: str, file: str = "") -> dict:
             # `_cancel`, which writes the marker.
             "cancelled": os.path.exists(os.path.join(run_dir, "cancelled")),
             "activity": {
-                "tool": tool_open,
-                "tool_input_bytes": tool_input_bytes if tool_open else 0,
+                "tool": next(reversed(tools_open.values())) if tools_open else None,
+                "tools_open": len(tools_open),
+                "tool_input_bytes": tool_input_bytes if tools_open else 0,
                 "thinking_tokens": thinking_tokens if phase == "thinking" else 0,
                 "hook": next(reversed(hooks_open.values())) if hooks_open else "",
                 "tasks": [{"id": k, "description": v} for k, v in bg_tasks.items()],

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -1638,21 +1638,32 @@
      call leaves both sitting still while the run is perfectly healthy. A sweep
      across the label is motion the eye catches without being read.
      Gradient-over-text, so it costs no layout and no extra element. */
+  /* Claude orange (--accent), the same ink as the ✻ beside it, with the sweep
+     the top strip's "running" mark already uses (D453: a highlight sliding
+     across the word, 300% gradient, one animated property). The first cut
+     swept --fg over --faint — grey over grey — which read as a flat, static
+     word (Akshil, 2026-08-28: "not orange, not shimmering"). */
   .working .verb {
-    color: var(--fg);
-    background: linear-gradient(90deg, var(--fg) 35%, var(--faint) 50%, var(--fg) 65%);
-    background-size: 200% 100%;
+    color: var(--accent);
+    background-image: linear-gradient(
+      100deg,
+      var(--accent) 30%,
+      color-mix(in srgb, var(--accent) 55%, var(--fg)) 50%,
+      var(--accent) 70%
+    );
+    background-size: 300% 100%;
+    background-repeat: repeat;
     -webkit-background-clip: text;
     background-clip: text;
     -webkit-text-fill-color: transparent;
-    animation: skel-shimmer 2.2s linear infinite;
+    animation: claude-running-shimmer 2.2s linear infinite;
   }
   /* Awaiting approval is the one phase where nothing is running: the turn is
      blocked on the user, and a shimmer there would promise progress that only
      their click can produce. Stopping keeps it — the kill is still in flight. */
   .working.awaiting .verb {
     animation: none;
-    background: none;
+    background-image: none;
     -webkit-text-fill-color: var(--fg);
   }
   /* Reduced motion drops the sweep, and with it the transparent fill the
@@ -1660,11 +1671,22 @@
   @media (prefers-reduced-motion: reduce) {
     .working .verb {
       animation: none;
-      background: none;
-      -webkit-text-fill-color: var(--fg);
+      background-image: none;
+      -webkit-text-fill-color: var(--accent);
     }
   }
-  .working .meta { color: var(--faint); font-size: 12px; }
+  /* The brackets carry the detail (a Bash description, a file name) and are
+     the one part of the line whose length the page does not control. They give
+     way first: the verb and the stop button keep their width at any pane size,
+     and the detail truncates with an ellipsis rather than wrapping the line or
+     pushing the stop button off the column. */
+  .working .verb { white-space: nowrap; flex: 0 0 auto; }
+  .working .meta {
+    color: var(--faint); font-size: 12px;
+    flex: 1 1 auto; min-width: 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .working .stop { flex: 0 0 auto; }
   /* The stop control rides ON the working line, which exists for exactly as long
      as a run is interruptible — so the button cannot outlive what it cancels. */
   .working .stop {
@@ -12824,6 +12846,59 @@ function retryVerb(retry) {
 // line that reports a turn running OUTSIDE this app (D415's transcript-follow),
 // which has no process to kill and no phase to read, and where a "stop · esc"
 // that quietly does nothing would be the worst control on the page.
+// The verb for a run this page owns, from the poll's phase and `activity`. ONE
+// PLAIN SENTENCE a person who has never heard of tokens can read: what Claude
+// is doing right now, in everyday words. The specifics (which command, which
+// file) go in the brackets after it, and only one of them (see activityDetail).
+// An earlier cut of this line stacked tokens, input bytes, a thinking estimate,
+// a task count and a silence timer into the brackets — a dashboard, not a
+// status (Akshil, 2026-08-28). Everything that was a NUMBER is gone; what was
+// a number is now a word.
+//
+// `quietSecs` is how long the poll has reported nothing new. Past 20 s the
+// verb itself changes to say the wait is real — "Still waiting for a reply" —
+// instead of appending "quiet 86s" to a verb that still claims progress.
+function activityVerb(stats, thinkVerb, quietSecs) {
+  const act = stats.activity || {};
+  if (act.hook) return "Running project hooks";
+  if (stats.phase === "tooling") {
+    const t = act.tool;
+    if (!t) return "Reading the result";
+    const streaming = act.tool_input_bytes && !t.detail;
+    switch (t.name) {
+      case "Bash": return streaming ? "Preparing a command" : "Running a command";
+      case "Read": return "Reading a file";
+      case "Edit": case "MultiEdit": case "NotebookEdit": return "Editing a file";
+      case "Write": return "Writing a file";
+      case "Grep": case "Glob": return "Searching files";
+      case "Task": case "Agent": return "Running a helper agent";
+      case "Skill": return "Loading a skill";
+      case "WebFetch": case "WebSearch": return "Fetching from the web";
+      default: return "Using " + t.name;
+    }
+  }
+  // The model's turn: request out, thinking, or writing. A long silence here
+  // is the one ambiguity worth naming — and if a background command is still
+  // running, that is almost always what the wait is.
+  if (quietSecs >= 20) {
+    return act.tasks && act.tasks.length
+      ? "Waiting for a background command to finish"
+      : "Still waiting for a reply";
+  }
+  if (stats.phase === "requesting") return "Waiting for a reply";
+  if (stats.phase === "composing") return "Writing a reply";
+  return thinkVerb;
+}
+// The ONE thing that goes in the brackets beside the time: the command's
+// description, the file's name, the helper agent's job. Nothing while the model
+// itself is working — there is no useful noun for that.
+function activityDetail(stats) {
+  const act = stats.activity || {};
+  if (act.hook) return "";
+  if (stats.phase === "tooling" && act.tool && act.tool.detail) return act.tool.detail;
+  return "";
+}
+
 function addWorking(opts) {
   const fixedVerb = (opts && opts.verb) || "";
   const stoppable = !(opts && opts.stoppable === false);
@@ -12831,7 +12906,12 @@ function addWorking(opts) {
   d.className = "turn working";
   const thinkVerb = VERBS[Math.floor(Math.random() * VERBS.length)];
   const start = Date.now();
-  let stats = { tokens: 0, phase: "thinking", retry: null };
+  let stats = { tokens: 0, phase: "thinking", retry: null, activity: null };
+  // When the poll last told us something NEW. The stream rows carry no clock,
+  // so this is the page's own: a line whose facts have not moved for a while
+  // says so ("quiet 24s") instead of letting the timer imply progress.
+  let lastChange = Date.now();
+  let lastKey = "";
   let stopping = false;
   d.innerHTML = '<span class="star">✻</span> <span class="verb"></span><span class="meta"></span>'
     // The key rides on the label, not in a hint row: same reasoning as the
@@ -12848,20 +12928,21 @@ function addWorking(opts) {
     const secs = Math.round((Date.now() - start) / 1000);
     // A live retry outranks every phase but the user's own stop: it is the only
     // one of these that explains why nothing is happening.
+    const quiet = Math.round((Date.now() - lastChange) / 1000);
     verbEl.textContent = (stopping ? "Stopping" :
                           fixedVerb ? fixedVerb :
                           stats.retry ? retryVerb(stats.retry) :
                           stats.phase === "awaiting" ? "Waiting for your approval" :
-                          stats.phase === "composing" ? "Composing" :
-                          stats.phase === "tooling" ? "Working" : thinkVerb) + "…";
+                          activityVerb(stats, thinkVerb, quiet)) + "…";
     // The shimmer is the liveness signal (see .working .verb), so the one phase
     // that is NOT progress has to say so: awaiting approval is blocked on the
     // user, not on the model.
     d.classList.toggle("awaiting", !stopping && stats.phase === "awaiting");
-    const effort = curEffort();
+    // Time, and at most one detail. Nothing else: no token count, no byte
+    // count, no effort label — the numbers were the complaint.
     const parts = [secs + "s"];
-    if (stats.tokens) parts.push("↓ " + stats.tokens + " tokens");
-    if (stats.phase === "thinking" && effort) parts.push(effort + " effort");
+    const detail = stopping || fixedVerb ? "" : activityDetail(stats);
+    if (detail) parts.push(detail);
     meta.textContent = " (" + parts.join(" · ") + ")";
   };
   const timer = setInterval(draw, 1000);
@@ -12880,7 +12961,16 @@ function addWorking(opts) {
   followBottom();
   return {
     el: d,
-    setStats(tokens, phase, retry) { stats = { tokens, phase, retry: retry || null }; draw(); },
+    setStats(tokens, phase, retry, activity) {
+      stats = { tokens, phase, retry: retry || null, activity: activity || null };
+      // "New" = any fact on the line moved. Tokens tick during composing, the
+      // thinking estimate during thinking, input bytes during a Write — so a
+      // healthy run resets this every poll and only a genuinely silent one
+      // reaches the "quiet Ns" hint.
+      const key = JSON.stringify([tokens, phase, retry, activity]);
+      if (key !== lastKey) { lastKey = key; lastChange = Date.now(); }
+      draw();
+    },
     // Reversible: the kill can fail, and a run that is still streaming must not
     // be left wearing a "Stopping…" line it will never honour.
     setStopping(on) { stopping = on; if (stopBtn) stopBtn.disabled = on; draw(); },
@@ -14199,7 +14289,7 @@ async function pollLoop(run_id, gen = logGen) {
       if (tick++ % 8 === 0) pollArtifacts();
       // usage arrives only at message end; estimate from streamed text meanwhile
       const tokens = Math.max(data.tokens || 0, Math.round((data.text || "").length / 4));
-      w.setStats(tokens, data.phase || "thinking", data.retry);
+      w.setStats(tokens, data.phase || "thinking", data.retry, data.activity);
       syncPermissions(data.permissions, run_id, w, data.mode);
       noteSkills(data.skills, w);
       // Not awaited: a snapshot must never hold up the streaming reply, and the

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -1638,18 +1638,19 @@
      call leaves both sitting still while the run is perfectly healthy. A sweep
      across the label is motion the eye catches without being read.
      Gradient-over-text, so it costs no layout and no extra element. */
-  /* Claude orange (--accent), the same ink as the ✻ beside it, with the sweep
-     the top strip's "running" mark already uses (D453: a highlight sliding
-     across the word, 300% gradient, one animated property). The first cut
-     swept --fg over --faint — grey over grey — which read as a flat, static
-     word (Akshil, 2026-08-28: "not orange, not shimmering"). */
+  /* THE app's one running shimmer, on the verb: the same --status-progress
+     hue and the same D453 sweep the top strip's "running" mark and the
+     chat-row mark already use (100deg highlight, 300% gradient, 2.2 s, one
+     animated property). Not --fg over --faint (the first cut — grey over grey,
+     read as a static word) and not --accent (the second — a third colour for
+     "running" when the shell has settled on one). Two surfaces, one hue. */
   .working .verb {
-    color: var(--accent);
+    color: var(--status-progress);
     background-image: linear-gradient(
       100deg,
-      var(--accent) 30%,
-      color-mix(in srgb, var(--accent) 55%, var(--fg)) 50%,
-      var(--accent) 70%
+      var(--status-progress) 30%,
+      color-mix(in srgb, var(--status-progress) 65%, var(--fg)) 50%,
+      var(--status-progress) 70%
     );
     background-size: 300% 100%;
     background-repeat: repeat;
@@ -1667,12 +1668,13 @@
     -webkit-text-fill-color: var(--fg);
   }
   /* Reduced motion drops the sweep, and with it the transparent fill the
-     gradient stands in for — otherwise the label would be invisible. */
+     gradient stands in for — otherwise the label would be invisible. Same
+     fallback as the top strip: still says it, in the running colour. */
   @media (prefers-reduced-motion: reduce) {
     .working .verb {
       animation: none;
       background-image: none;
-      -webkit-text-fill-color: var(--accent);
+      -webkit-text-fill-color: var(--status-progress);
     }
   }
   /* The brackets carry the detail (a Bash description, a file name) and are

--- a/tests/test_claude_stream.py
+++ b/tests/test_claude_stream.py
@@ -408,7 +408,7 @@ def test_the_prompt_does_not_promise_a_path_the_fallback_may_not_send(agent, tmp
 def test_the_page_hands_the_live_retry_to_the_status_line(html):
     """Without the third argument the status line can only say "Thinking…",
     which is the bug this feature exists to fix."""
-    assert "w.setStats(tokens, data.phase || \"thinking\", data.retry)" in html
+    assert "w.setStats(tokens, data.phase || \"thinking\", data.retry, data.activity)" in html
 
 
 def test_the_page_announces_the_skills_the_poll_reports(html):

--- a/tests/test_claude_working_line.py
+++ b/tests/test_claude_working_line.py
@@ -1,0 +1,382 @@
+"""What the working line can say beyond a verb: `_poll`'s `activity` block.
+
+The status line used to read "Thinking… (47s)" with a frozen token count over
+a minute of extended thinking, a Bash `sleep 30`, a 40 KB Write streaming its
+input, or a slow hook — indistinguishable from a hang. Every one of those is a
+row the CLI already writes to out.jsonl (captured from real runs, 2026-08-28):
+
+  * `system`/`status {"status": "requesting"}` — request out, no token back.
+  * `system`/`thinking_tokens {estimated_tokens}` — thinking progress.
+  * `content_block_start tool_use` (name) + `input_json_delta` — a tool call
+    and its input streaming; the finalized `assistant` row carries the input.
+  * `user` row with `tool_result` — the tool finished.
+  * `system`/`hook_started` … `hook_response` — a hook running.
+  * `system`/`task_started` … `task_notification` / `background_tasks_changed`.
+  * `parent_tool_use_id` set — a subagent's rows (SDK contract; not yet seen
+    in a local run, so counted rather than rendered).
+
+Fixtures are shared with test_claude_stream.py by shape, not import: one file
+per concern keeps each self-contained.
+"""
+import importlib.util
+import json
+import os
+
+import pytest
+
+TEMPLATE_DIR = os.path.join("fused_render", "templates", "claude")
+
+
+def _load(name):
+    path = os.path.join(TEMPLATE_DIR, name + ".py")
+    spec = importlib.util.spec_from_file_location("claude_" + name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def agent():
+    return _load("agent")
+
+
+@pytest.fixture
+def run_dir(tmp_path):
+    d = tmp_path / "runs" / "run"
+    (d / "perm").mkdir(parents=True)
+    (d / "appstate").mkdir(parents=True)
+    return d
+
+
+def _poll(agent, run_dir, rows, alive=True):
+    agent.RUNS = str(run_dir.parent)
+    agent._alive = lambda _run_dir: alive
+    body = "".join(json.dumps(r) + "\n" if isinstance(r, dict) else r
+                   for r in rows)
+    (run_dir / "out.jsonl").write_text(body, encoding="utf-8")
+    return agent._poll("run")
+
+
+# ------------------------------------------------------------ row builders
+def _ev(event, **extra):
+    row = {"type": "stream_event", "event": event, "session_id": "s"}
+    row.update(extra)
+    return row
+
+
+def _delta(kind, _row=None, **fields):
+    d = {"type": kind}
+    d.update(fields)
+    return _ev({"type": "content_block_delta", "index": 0, "delta": d}, **(_row or {}))
+
+
+def _thinking(text="hm", **row):
+    return _delta("thinking_delta", row, thinking=text)
+
+
+def _text(text, **row):
+    return _delta("text_delta", row, text=text)
+
+
+def _tool_start(name, id="toolu_1"):
+    return _ev({"type": "content_block_start", "index": 1,
+                "content_block": {"type": "tool_use", "id": id, "name": name, "input": {}}})
+
+
+def _input_json(fragment):
+    return _delta("input_json_delta", partial_json=fragment)
+
+
+def _assistant_tool(name, inp, id="toolu_1"):
+    return {"type": "assistant", "session_id": "s", "message": {
+        "role": "assistant", "content": [
+            {"type": "tool_use", "id": id, "name": name, "input": inp}]}}
+
+
+def _tool_result(id="toolu_1", **extra):
+    row = {"type": "user", "session_id": "s", "parent_tool_use_id": None,
+           "message": {"role": "user", "content": [
+               {"type": "tool_result", "tool_use_id": id, "content": "ok"}]}}
+    row.update(extra)
+    return row
+
+
+def _status(status="requesting"):
+    return {"type": "system", "subtype": "status", "status": status, "session_id": "s"}
+
+
+def _thinking_tokens(total, delta=None):
+    return {"type": "system", "subtype": "thinking_tokens", "session_id": "s",
+            "estimated_tokens": total,
+            "estimated_tokens_delta": delta if delta is not None else total}
+
+
+def _sys(subtype, **fields):
+    row = {"type": "system", "subtype": subtype, "session_id": "s"}
+    row.update(fields)
+    return row
+
+
+def _message_start():
+    return _ev({"type": "message_start", "message": {"id": "m", "usage": {}}})
+
+
+# ----------------------------------------------------------------- phases
+
+def test_a_fresh_run_is_thinking_with_an_empty_activity(agent, run_dir):
+    data = _poll(agent, run_dir, [])
+    assert data["phase"] == "thinking"
+    assert data["activity"] == {"tool": None, "tool_input_bytes": 0,
+                                "thinking_tokens": 0, "hook": "", "tasks": [],
+                                "agent_rows": 0}
+
+
+def test_a_request_out_with_nothing_back_is_requesting(agent, run_dir):
+    """The most common "what is it doing": the CLI's own `status: requesting`
+    row, written when the request leaves and before any token returns."""
+    data = _poll(agent, run_dir, [_status()])
+    assert data["phase"] == "requesting"
+
+
+def test_the_first_delta_ends_requesting(agent, run_dir):
+    assert _poll(agent, run_dir, [_status(), _thinking()])["phase"] == "thinking"
+    assert _poll(agent, run_dir, [_status(), _text("a")])["phase"] == "composing"
+
+
+def test_thinking_progress_rides_the_cli_estimate(agent, run_dir):
+    """`message_delta` (the only token count the line had) arrives once, at
+    message end — so a minute of thinking showed a frozen counter. The CLI's
+    running `thinking_tokens` estimate is the number that moves."""
+    rows = [_message_start(), _thinking(), _thinking_tokens(50),
+            _thinking(), _thinking_tokens(120, 70)]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "thinking"
+    assert data["activity"]["thinking_tokens"] == 120
+
+
+def test_thinking_estimate_resets_per_message_and_hides_off_phase(agent, run_dir):
+    rows = [_message_start(), _thinking(), _thinking_tokens(400), _text("done"),
+            _message_start(), _thinking(), _thinking_tokens(30)]
+    assert _poll(agent, run_dir, rows)["activity"]["thinking_tokens"] == 30
+    # Composing: the estimate is not what the line is about any more.
+    rows = [_message_start(), _thinking(), _thinking_tokens(400), _text("x")]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "composing" and data["activity"]["thinking_tokens"] == 0
+
+
+# ------------------------------------------------------------------- tools
+
+def test_a_tool_call_is_named_the_moment_it_starts(agent, run_dir):
+    data = _poll(agent, run_dir, [_tool_start("Bash")])
+    assert data["phase"] == "tooling"
+    assert data["activity"]["tool"] == {"id": "toolu_1", "name": "Bash", "detail": ""}
+
+
+def test_streaming_input_is_measured_while_the_detail_is_unknown(agent, run_dir):
+    """A big Write streams its input for many seconds before the finalized
+    `assistant` row arrives with the whole thing. Bytes are the progress."""
+    rows = [_tool_start("Write"), _input_json('{"file_path": "/a/b/big.py", "con'),
+            _input_json('tent": "' + "x" * 3000)]
+    data = _poll(agent, run_dir, rows)
+    assert data["activity"]["tool"]["name"] == "Write"
+    assert data["activity"]["tool"]["detail"] == ""
+    assert data["activity"]["tool_input_bytes"] == len('{"file_path": "/a/b/big.py", "con') + len('tent": "') + 3000
+
+
+def test_the_finalized_row_fills_in_the_detail(agent, run_dir):
+    rows = [_tool_start("Bash"), _input_json("{}"),
+            _assistant_tool("Bash", {"command": "sleep 30", "description": "Wait for the deploy"})]
+    data = _poll(agent, run_dir, rows)
+    assert data["activity"]["tool"] == {"id": "toolu_1", "name": "Bash",
+                                        "detail": "Wait for the deploy"}
+    assert data["phase"] == "tooling"
+
+
+@pytest.mark.parametrize("name, inp, detail", [
+    ("Bash", {"command": "ls -la\npwd"}, "ls -la"),
+    ("Read", {"file_path": "/x/y/agent.py"}, "agent.py"),
+    ("Edit", {"file_path": "/x/template.html", "old_string": "a"}, "template.html"),
+    ("Write", {"file_path": "/x/new.md"}, "new.md"),
+    ("Grep", {"pattern": "def _poll"}, "def _poll"),
+    ("Task", {"description": "Map the phase machine", "subagent_type": "Explore"}, "Map the phase machine"),
+    ("Agent", {"subagent_type": "Explore"}, "Explore"),
+    ("Skill", {"skill": "brainstorming"}, "brainstorming"),
+    ("WebFetch", {"url": "https://example.com"}, "https://example.com"),
+    ("mcp__cmux__screenshot", {"x": 1}, ""),
+    ("Bash", {"description": "  spaces   and\nnewlines  "}, "spaces and newlines"),
+    ("Bash", {"description": "d" * 200}, "d" * 77 + "…"),
+    ("Bash", "not a dict", ""),
+])
+def test_tool_detail_is_one_short_line(agent, name, inp, detail):
+    assert agent._tool_detail(name, inp) == detail
+
+
+def test_a_finished_tool_clears_the_line(agent, run_dir):
+    """THE reported case: the tool ended, nothing has streamed, the line said
+    "Working…". A `tool_result` row means the tool is gone; until the CLI says
+    `requesting` (or streams), the phase is `requesting` — not `tooling`."""
+    rows = [_tool_start("Bash"), _assistant_tool("Bash", {"command": "sleep 30"}),
+            _tool_result()]
+    data = _poll(agent, run_dir, rows)
+    assert data["activity"]["tool"] is None
+    assert data["activity"]["tool_input_bytes"] == 0
+    assert data["phase"] == "requesting"
+
+
+def test_requesting_after_a_tool_then_thinking_again(agent, run_dir):
+    rows = [_tool_start("Bash"), _tool_result(), _status(), _message_start(), _thinking()]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "thinking" and data["activity"]["tool"] is None
+
+
+def test_a_second_tool_starts_clean(agent, run_dir):
+    rows = [_tool_start("Write", id="t1"), _input_json("x" * 500), _tool_result(id="t1"),
+            _status(), _tool_start("Read", id="t2")]
+    data = _poll(agent, run_dir, rows)
+    assert data["activity"]["tool"]["name"] == "Read"
+    assert data["activity"]["tool_input_bytes"] == 0
+
+
+def test_a_tool_that_finished_before_the_result_row_stays_open(agent, run_dir):
+    """`content_block_stop` and even the finalized assistant row do not mean the
+    tool has RUN — only the result row does. A Bash sleeping 30 s is exactly a
+    finalized call with no result yet."""
+    rows = [_tool_start("Bash"), _ev({"type": "content_block_stop", "index": 1}),
+            _assistant_tool("Bash", {"command": "sleep 30", "description": "Nap"})]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "tooling"
+    assert data["activity"]["tool"]["detail"] == "Nap"
+
+
+# ------------------------------------------------------------ hooks & tasks
+
+def test_a_hook_in_flight_is_named(agent, run_dir):
+    rows = [_sys("hook_started", hook_id="h1", hook_name="SessionStart:startup",
+                 hook_event="SessionStart")]
+    assert _poll(agent, run_dir, rows)["activity"]["hook"] == "SessionStart:startup"
+
+
+def test_a_hook_that_responded_is_gone(agent, run_dir):
+    rows = [_sys("hook_started", hook_id="h1", hook_name="SessionStart:startup"),
+            _sys("hook_response", hook_id="h1", hook_name="SessionStart:startup", output="")]
+    assert _poll(agent, run_dir, rows)["activity"]["hook"] == ""
+
+
+def test_the_newest_open_hook_wins(agent, run_dir):
+    rows = [_sys("hook_started", hook_id="h1", hook_name="A"),
+            _sys("hook_started", hook_id="h2", hook_name="B"),
+            _sys("hook_response", hook_id="h1", hook_name="A")]
+    assert _poll(agent, run_dir, rows)["activity"]["hook"] == "B"
+
+
+def test_background_tasks_are_listed_until_they_report(agent, run_dir):
+    rows = [_sys("task_started", task_id="b1", tool_use_id="toolu_1",
+                 description="Poll PR checks every 5 min", is_backgrounded=True,
+                 task_type="local_bash")]
+    data = _poll(agent, run_dir, rows)
+    assert data["activity"]["tasks"] == [{"id": "b1", "description": "Poll PR checks every 5 min"}]
+    rows.append(_sys("task_notification", task_id="b1", status="completed", summary="…"))
+    assert _poll(agent, run_dir, rows)["activity"]["tasks"] == []
+
+
+def test_task_updated_to_a_terminal_status_removes_it(agent, run_dir):
+    rows = [_sys("task_started", task_id="b1", description="x"),
+            _sys("task_updated", task_id="b1", patch={"status": "killed", "end_time": 1})]
+    assert _poll(agent, run_dir, rows)["activity"]["tasks"] == []
+    rows = [_sys("task_started", task_id="b1", description="x"),
+            _sys("task_updated", task_id="b1", patch={"status": "running"})]
+    assert len(_poll(agent, run_dir, rows)["activity"]["tasks"]) == 1
+
+
+def test_background_tasks_changed_is_authoritative(agent, run_dir):
+    rows = [_sys("task_started", task_id="b1", description="old"),
+            _sys("background_tasks_changed", tasks=[
+                {"task_id": "b2", "task_type": "local_bash", "description": "new"}])]
+    assert _poll(agent, run_dir, rows)["activity"]["tasks"] == [{"id": "b2", "description": "new"}]
+    rows.append(_sys("background_tasks_changed", tasks=[]))
+    assert _poll(agent, run_dir, rows)["activity"]["tasks"] == []
+
+
+# --------------------------------------------------------------- subagents
+
+def test_subagent_rows_are_counted_and_do_not_move_the_line(agent, run_dir):
+    """A subagent's stream comes tagged with the parent call's id. Its text
+    deltas must not flip the parent's line to "Composing" while the parent is
+    still "Running agent"."""
+    rows = [_tool_start("Agent"), _assistant_tool("Agent", {"description": "Map the code"}),
+            _text("child says hi", parent_tool_use_id="toolu_1"),
+            _thinking("child thinks", parent_tool_use_id="toolu_1")]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "tooling"
+    assert data["activity"]["tool"]["detail"] == "Map the code"
+    assert data["activity"]["agent_rows"] == 2
+    assert data["text"] == "", "a child's prose is not the parent's reply"
+
+
+# ------------------------------------------------------ precedence & legacy
+
+def test_a_retry_outranks_every_activity(agent, run_dir):
+    retry = {"type": "system", "subtype": "api_retry", "attempt": 1, "max_retries": 10,
+             "retry_delay_ms": 5, "error_status": 529, "error": "overloaded", "session_id": "s"}
+    rows = [_tool_start("Bash"), _tool_result(), retry]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "retrying"
+
+
+def test_a_parked_approval_outranks_a_tool(agent, run_dir):
+    rows = [_tool_start("Bash"), _assistant_tool("Bash", {"command": "rm x"})]
+    (run_dir / "perm" / "p1.req.json").write_text(json.dumps(
+        {"id": "p1", "tool": "Bash", "input": {"command": "rm x"}}), encoding="utf-8")
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "awaiting"
+
+
+def test_the_legacy_fields_are_untouched(agent, run_dir):
+    """`activity` is additive: text/tokens/done/segments are what they were."""
+    rows = [_message_start(), _thinking(), _thinking_tokens(9), _text("hi"),
+            _ev({"type": "message_delta", "usage": {"output_tokens": 7}}),
+            _ev({"type": "message_stop"}),
+            {"type": "result", "session_id": "s1", "result": "hi", "is_error": False}]
+    data = _poll(agent, run_dir, rows)
+    assert data["text"] == "hi" and data["tokens"] == 7 and data["done"]
+    assert [s["kind"] for s in data["segments"]] == ["thinking", "text"]
+
+
+def test_a_half_written_last_line_never_breaks_activity(agent, run_dir):
+    rows = [_tool_start("Bash"), '{"type": "system", "subtype": "thinking_to']
+    data = _poll(agent, run_dir, rows)
+    assert data["activity"]["tool"]["name"] == "Bash"
+
+
+def test_the_real_capture_replays_cleanly(agent, run_dir):
+    """A slice of a real out.jsonl (claude 2.1.x, 2026-08-27) in file order:
+    tool call → result → status → thinking → text → result."""
+    rows = [
+        _sys("init", cwd="/x", tools=["Bash"]),
+        _sys("hook_started", hook_id="h", hook_name="SessionStart:startup"),
+        _sys("hook_response", hook_id="h", hook_name="SessionStart:startup"),
+        _status(), _message_start(),
+        _ev({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
+        _thinking(), _thinking_tokens(50), _thinking(), _thinking_tokens(101, 51),
+        _delta("signature_delta", signature="sig"),
+        _ev({"type": "content_block_stop", "index": 0}),
+        _tool_start("Bash"), _input_json('{"command": "sleep 2", "description": "Nap"}'),
+        _ev({"type": "content_block_stop", "index": 1}),
+        _ev({"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 40}}),
+        _ev({"type": "message_stop"}),
+        _assistant_tool("Bash", {"command": "sleep 2", "description": "Nap"}),
+    ]
+    at_tool = _poll(agent, run_dir, rows)
+    assert at_tool["phase"] == "tooling" and at_tool["activity"]["tool"]["detail"] == "Nap"
+    assert at_tool["activity"]["hook"] == ""
+    rows.append(_tool_result(timestamp="2026-08-27T15:20:40.000Z", tool_use_result={"stdout": ""}))
+    assert _poll(agent, run_dir, rows)["phase"] == "requesting"
+    rows += [_status(), _message_start(), _thinking(), _thinking_tokens(20)]
+    mid = _poll(agent, run_dir, rows)
+    assert mid["phase"] == "thinking" and mid["activity"]["thinking_tokens"] == 20
+    rows += [_text("All done."),
+             _ev({"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 12}}),
+             _ev({"type": "message_stop"}),
+             {"type": "result", "session_id": "s", "result": "All done.", "is_error": False}]
+    end = _poll(agent, run_dir, rows)
+    assert end["done"] and end["text"] == "All done." and end["tokens"] == 52

--- a/tests/test_claude_working_line.py
+++ b/tests/test_claude_working_line.py
@@ -126,7 +126,7 @@ def _message_start():
 def test_a_fresh_run_is_thinking_with_an_empty_activity(agent, run_dir):
     data = _poll(agent, run_dir, [])
     assert data["phase"] == "thinking"
-    assert data["activity"] == {"tool": None, "tool_input_bytes": 0,
+    assert data["activity"] == {"tool": None, "tools_open": 0, "tool_input_bytes": 0,
                                 "thinking_tokens": 0, "hook": "", "tasks": [],
                                 "agent_rows": 0}
 
@@ -246,6 +246,46 @@ def test_a_tool_that_finished_before_the_result_row_stays_open(agent, run_dir):
     data = _poll(agent, run_dir, rows)
     assert data["phase"] == "tooling"
     assert data["activity"]["tool"]["detail"] == "Nap"
+
+
+def test_parallel_tools_stay_open_until_the_last_result(agent, run_dir):
+    """One message, two tool_use blocks, two separate result rows (Bugbot,
+    PR #908). The first result must not drop the line to "Waiting for a
+    reply" while the second command is still running."""
+    rows = [_tool_start("Bash", id="a"), _tool_start("Read", id="b"),
+            _assistant_tool("Bash", {"command": "sleep 30", "description": "Long one"}, id="a"),
+            _tool_result(id="b")]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "tooling"
+    assert data["activity"]["tools_open"] == 1
+    assert data["activity"]["tool"]["name"] == "Bash"
+    assert data["activity"]["tool"]["detail"] == "Long one"
+    rows.append(_tool_result(id="a"))
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "requesting"
+    assert data["activity"]["tool"] is None and data["activity"]["tools_open"] == 0
+
+
+def test_the_newest_open_tool_is_the_one_shown(agent, run_dir):
+    rows = [_tool_start("Bash", id="a"), _tool_start("Read", id="b")]
+    data = _poll(agent, run_dir, rows)
+    assert data["activity"]["tool"]["name"] == "Read"
+    assert data["activity"]["tools_open"] == 2
+
+
+def test_a_result_with_an_unknown_id_closes_the_oldest_call(agent, run_dir):
+    """A start row lost to a half-written line must not pin a finished tool
+    on the line for the rest of the turn."""
+    rows = [_tool_start("Bash", id="a"), _tool_result(id="zzz")]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "requesting" and data["activity"]["tool"] is None
+
+
+def test_a_result_row_with_no_tool_result_block_changes_nothing(agent, run_dir):
+    rows = [_tool_start("Bash", id="a"),
+            {"type": "user", "session_id": "s", "message": {"role": "user", "content": "plain text"}}]
+    data = _poll(agent, run_dir, rows)
+    assert data["phase"] == "tooling" and data["activity"]["tool"]["name"] == "Bash"
 
 
 # ------------------------------------------------------------ hooks & tasks


### PR DESCRIPTION
## What

The status line under a running turn used to read "Thinking… (47s)" with a frozen token count through a minute of extended thinking, a `sleep 30`, a large Write, or a slow hook — indistinguishable from a hang. The CLI already writes every one of those states to `out.jsonl`; `_poll` ignored them.

- `agent.py:_poll` returns an `activity` block: tool in flight (name + one-line detail), streamed input bytes, thinking-token estimate, open hook, live background tasks, subagent row count. New `requesting` phase from `system/status`; a `tool_result` row ends `tooling` (the line said "Working…" over a finished tool).
- `template.html`: one plain sentence + time + at most one detail. "Waiting for a reply…", "Running a command… (7s · Wait for the deploy to settle)", "Writing a file…", "Running a helper agent… (13s · List folder files)", "Running project hooks…". After 20 s of nothing new the verb changes to "Still waiting for a reply…" / "Waiting for a background command to finish…". No token/byte/effort/task counts in the brackets.
- Verb shimmers in the accent colour (D453 sweep) instead of grey-on-grey; brackets truncate with an ellipsis so verb + stop button never overflow.

## Verified

- `tests/test_claude_working_line.py` — 37 new tests over row shapes captured from real runs (phases, tools, hooks, tasks, subagents, precedence, legacy fields, a real-capture replay). Existing claude template suites: 409 pass; one string pin updated for the 4-arg `setStats`.
- Full suite: 11178 pass; the 38 failures are pre-existing/env (map geo deps, local CLI detection) and fail identically on the untouched checkout.
- Browser (cmux): 8 fixture runs + no-run page, three passes, at 420/768/1920 px, no console errors. Live through the dev server: Explore subagent (verb stays on the agent; `parent_tool_use_id` confirmed), long thinking, Bash-heredoc write.

## Not in this PR

A separate finding from the live pass: a turn that parks a backgrounded Bash command and ends loses it when the `claude -p` process exits — no wake, and Send is dead until reload. Touches the D415 wake path, not this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and poll parsing only; additive `activity` field and display logic with broad test coverage, no auth or data-path changes.
> 
> **Overview**
> **Replaces the frozen “Thinking… (47s)” status** with verbs and one optional detail drawn from CLI stream rows the poll used to ignore.
> 
> `_poll` in `agent.py` now tracks in-flight tools (with `_tool_detail` for Bash/file/agent labels), `requesting` from `system/status`, thinking-token estimates, hooks, background tasks, and parallel tool lifecycle until the last `tool_result`. It returns an **`activity`** block on each poll. The working line in `template.html` maps phase + activity to plain sentences (“Running a command…”, “Waiting for a reply…”), shows only **elapsed time · detail** in the brackets (no tokens/effort), switches verbs after ~20s of stale polls, and aligns the verb shimmer with `--status-progress` plus ellipsis truncation for long details.
> 
> **Tests:** new `tests/test_claude_working_line.py` (phases, tools, hooks, tasks, subagents); `test_claude_stream.py` updated for the four-arg `setStats`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f95ec8c54f0c23d8a7e8a0898d73d447faffdcfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->