### PR TITLE
Landing page: hide section subtitles for now

### DIFF
--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -159,7 +159,7 @@
     max-width: 26ch;
   }
   /* Section subtitles hidden for now; drop this rule to bring them back. */
-  .deck { display: none; }
+  .deck, .deck-list { display: none; }
   .deck {
     margin-top: 12px; max-width: 56ch;
     color: var(--ink-2); font-size: var(--t-md); line-height: 1.5;

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -158,8 +158,6 @@
     line-height: 1.1; letter-spacing: -0.03em; font-weight: 660;
     max-width: 26ch;
   }
-  /* Section subtitles hidden for now; drop this rule to bring them back. */
-  .deck, .deck-list { display: none; }
   .deck {
     margin-top: 12px; max-width: 56ch;
     color: var(--ink-2); font-size: var(--t-md); line-height: 1.5;
@@ -169,6 +167,8 @@
     margin-top: 12px;
     display: flex; flex-direction: column; gap: 7px;
   }
+  /* Section subtitles + bullet lists hidden for now; drop this rule to bring them back. */
+  .deck, .deck-list { display: none; }
   .deck-list li {
     position: relative; padding-left: 18px;
     font-size: var(--t-base); color: var(--ink-2); line-height: 1.5;

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -158,6 +158,8 @@
     line-height: 1.1; letter-spacing: -0.03em; font-weight: 660;
     max-width: 26ch;
   }
+  /* Section subtitles hidden for now; drop this rule to bring them back. */
+  .deck { display: none; }
   .deck {
     margin-top: 12px; max-width: 56ch;
     color: var(--ink-2); font-size: var(--t-md); line-height: 1.5;


### PR DESCRIPTION
## Summary
- Hide every section subtitle (`<p class="deck">`) under the landing-page h2s — "Connects with Python, Claude Code…", "No account, no API key, no per-token bill.", etc.
- Done with a single CSS rule so the copy stays in the markup; delete the rule to bring them back.

## Test plan
- [x] Served `scripts/download_page` locally: 0 of 8 `.deck` elements visible, headings spacing intact
- [ ] Reviewer: eyeball published page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational-only change to static marketing HTML; no auth, data, or app logic affected.
> 
> **Overview**
> The Fused Render download landing page (`scripts/download_page/index.html`) now hides explanatory copy under section headings without removing it from the HTML.
> 
> A single CSS rule sets **`display: none`** on **`.deck`** and **`.deck-list`**, which suppresses paragraph subtitles (e.g. under “Local Ecosystem”, “AI models run on your local machine”, the download block) and the bullet list under “One window for 100+ kinds of file.” A short comment notes the rule can be deleted to show them again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d4f5019576fdcbd721e37245ec9caeb2611a5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->