### PR TITLE
New task attachments: viewer follows the live entry, undrawable uploads wear the glyph, blob thumbs revoked (bugbot on #915)

### DIFF
--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -2278,6 +2278,14 @@ export default function NewJobModal({
   // BEFORE the upload starts, which a state updater cannot do either.
   // `applyImages` writes the ref synchronously, then mirrors.
   const imagesRef = useRef<TaskImage[]>(images);
+  // Every `blob:` thumbnail is revoked when the form unmounts — Save and Close
+  // both drop the list without walking it, and with no count or size cap a
+  // folder of photos would otherwise stay pinned in memory for the rest of the
+  // session (bugbot, #915). The ref, not the state: it is the list as of the
+  // last write, and this runs once, after the final render.
+  useEffect(() => () => {
+    for (const i of imagesRef.current) if (i.thumb) URL.revokeObjectURL(i.thumb);
+  }, []);
   const applyImages = useCallback((fn: (prev: TaskImage[]) => TaskImage[]) => {
     imagesRef.current = fn(imagesRef.current);
     setImages(imagesRef.current);
@@ -2317,8 +2325,18 @@ export default function NewJobModal({
         thumb,
       }]);
       const pending: Promise<void> = uploadTaskShot(file)
-        .then((up) => applyImages((prev) => prev.map(
-          (i) => (i.key === key ? { ...i, path: up.path, kind: up.kind } : i))))
+        .then((up) => applyImages((prev) => prev.map((i) => {
+          if (i.key !== key) return i;
+          // The server's `kind` is trusted only where the PATH it stored can be
+          // drawn: a `.tif`/`.heic` whose transcode failed (no sips, Pillow
+          // without HEIF) comes back `kind: "image"` on the original bytes,
+          // and an <img> of those is the empty box DRAWABLE_EXTS exists to
+          // avoid — so it wears the glyph and the file viewer instead
+          // (bugbot, #915). The blob thumb is kept where the browser drew one.
+          const kind = up.kind === "image" && attachmentKindOf(up.path) === "image"
+            ? "image" : (i.thumb ? "image" : "file");
+          return { ...i, path: up.path, kind };
+        })))
         .catch((e) => {
           // A failed upload takes its chip with it — an attachment on the card
           // that would not reach the task is the lie to avoid.
@@ -2337,7 +2355,16 @@ export default function NewJobModal({
   // size (the zoom class) with the box scrolling; a FILE opens in its own
   // fused-render template, which is the only answer to "is this the right file"
   // that a name cannot give (D616).
-  const [viewer, setViewer] = useState<TaskImage | null>(null);
+  // The viewer holds a KEY and reads the entry out of `images` on every render,
+  // rather than holding the entry itself: an upload finishes AFTER the click
+  // that opened its chip, and it lands `path`/`kind` in the list only — a
+  // snapshot taken at click time would sit on "uploading…" for ever, and a
+  // TIFF that came back as a PNG would stay in the file dialog (bugbot, #915).
+  const [viewerKey, setViewerKey] = useState<number | null>(null);
+  const viewer = useMemo<TaskImage | null>(
+    () => (viewerKey === null ? null
+           : images.find((i) => i.key === viewerKey) ?? null),
+    [images, viewerKey]);
   const [viewerZoom, setViewerZoom] = useState(false);
   // A file's preview: the src once the stat has answered, null for every "no
   // preview" case (no template, a pruned copy, a declining server, an upload
@@ -2347,7 +2374,7 @@ export default function NewJobModal({
   const [previewSrc, setPreviewSrc] = useState<string | null>(null);
   const [previewWait, setPreviewWait] = useState(false);
   const [frameLoaded, setFrameLoaded] = useState(false);
-  const closeViewer = useCallback(() => setViewer(null), []);
+  const closeViewer = useCallback(() => setViewerKey(null), []);
   useEffect(() => {
     setPreviewSrc(null);
     setFrameLoaded(false);
@@ -2365,7 +2392,10 @@ export default function NewJobModal({
       .catch(() => { if (live) setPreviewSrc(null); })
       .finally(() => { if (live) setPreviewWait(false); });
     return () => { live = false; };
-  }, [viewer]);
+    // The three fields the stat depends on, not `viewer` itself: the object is
+    // re-derived on every `images` change (an upload landing on ANOTHER chip),
+    // and a re-stat of an unchanged file would blank a frame that was showing.
+  }, [viewer?.key, viewer?.kind, viewer?.path]);
 
   // Escape closes the VIEWER while it is up — captured at the document so the
   // modal chassis' own Escape (which would close the whole card) never sees it.
@@ -2374,7 +2404,7 @@ export default function NewJobModal({
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopPropagation();
-        setViewer(null);
+        setViewerKey(null);
       }
     };
     document.addEventListener("keydown", onKey, { capture: true });
@@ -3361,7 +3391,7 @@ export default function NewJobModal({
                   aria-label={img.kind === "image"
                     ? "View image" : "Preview " + img.name}
                   onClick={() => {
-                    setViewer(img);
+                    setViewerKey(img.key);
                     setViewerZoom(false);
                   }}
                 >
@@ -3381,7 +3411,7 @@ export default function NewJobModal({
                   onClick={() => {
                     if (img.thumb) URL.revokeObjectURL(img.thumb);
                     applyImages((prev) => prev.filter((i) => i.key !== img.key));
-                    setViewer((v) => (v?.key === img.key ? null : v));
+                    setViewerKey((k) => (k === img.key ? null : k));
                   }}
                 >
                   {ICON_X}

--- a/frontend/src/shell/new-task-images.test.ts
+++ b/frontend/src/shell/new-task-images.test.ts
@@ -242,9 +242,14 @@ describe("the wiring the pure tests cannot see", () => {
     expect(MODAL).not.toContain("readAsDataURL");
   });
 
-  it("the server's kind overrides the client's guess", () => {
+  it("the server's kind is trusted only where the stored path can be drawn", () => {
     // A .tif goes up as bytes no browser draws and comes back a PNG.
-    expect(MODAL).toContain("{ ...i, path: up.path, kind: up.kind }");
+    // a failed transcode hands back `kind: "image"` on a `.tif` nobody can draw
+    // — that chip wears the glyph and the file viewer, not an empty <img>
+    expect(MODAL).toContain(
+      'const kind = up.kind === "image" && attachmentKindOf(up.path) === "image"');
+    expect(MODAL).toContain('? "image" : (i.thumb ? "image" : "file");');
+    expect(MODAL).toContain("return { ...i, path: up.path, kind };");
   });
 
   it("a picture's thumbnail is a blob URL, revoked when the chip goes", () => {
@@ -315,7 +320,7 @@ describe("the wiring the pure tests cannot see", () => {
   it("Close, Escape and the scrim all take the frame down", () => {
     // The conditional render IS the unmount: one `viewer` clears them all.
     expect(MODAL).toContain('className="nt-shotview-scrim" onClick={closeViewer}');
-    expect(MODAL).toContain("const closeViewer = useCallback(() => setViewer(null), []);");
+    expect(MODAL).toContain("const closeViewer = useCallback(() => setViewerKey(null), []);");
     expect(MODAL).toContain('document.addEventListener("keydown", onKey, { capture: true })');
     expect(MODAL).toContain("e.stopPropagation();");
   });
@@ -326,7 +331,20 @@ describe("the wiring the pure tests cannot see", () => {
   });
 
   it("removing a chip also closes a viewer that was showing it", () => {
-    expect(MODAL).toContain("setViewer((v) => (v?.key === img.key ? null : v))");
+    expect(MODAL).toContain("setViewerKey((k) => (k === img.key ? null : k))");
+  });
+
+  it("the viewer follows the live entry, so an upload landing after the click reaches it", () => {
+    // a key, re-read from `images` each render — never a snapshot of the chip
+    expect(MODAL).toContain("const [viewerKey, setViewerKey] = useState<number | null>(null);");
+    expect(MODAL).toContain("images.find((i) => i.key === viewerKey) ?? null");
+    expect(MODAL).not.toContain("useState<TaskImage | null>");
+    // and the stat re-runs on the fields it depends on, not on object identity
+    expect(MODAL).toContain("}, [viewer?.key, viewer?.kind, viewer?.path]);");
+  });
+
+  it("every blob thumbnail is revoked when the form unmounts", () => {
+    expect(MODAL).toContain("useEffect(() => () => {\n    for (const i of imagesRef.current) if (i.thumb) URL.revokeObjectURL(i.thumb);\n  }, []);");
   });
 
   it("a failed upload takes its chip with it", () => {


### PR DESCRIPTION
Addresses the three Cursor Bugbot findings on #915, all in `frontend/src/shell/NewJobModal.tsx`.

## Fixes
- **Viewer ignores completed upload** — the viewer held a click-time snapshot of the chip; an upload landing afterwards wrote `path`/`kind` into the list only, so a file opened mid-upload stayed on "uploading…" and a TIFF that came back as PNG stayed in the file dialog. Now holds a **key** and re-reads the live entry from `images` each render; the stat effect keys off `key/kind/path`.
- **Empty box after failed transcode** — the server's `kind: "image"` was copied onto the chip even when the stored path was a `.tif`/`.heic` whose transcode failed (no `sips`, Pillow without HEIF). `kind` is now `"image"` only where the stored path is drawable (or the browser already drew a blob thumb), else `"file"` → glyph + file viewer.
- **Blob thumbnails leak on close** — `blob:` URLs were revoked only on ✕ / upload failure; Save and Close unmounted with every thumb alive. An unmount effect revokes them all off the list ref.

## Verified
- `tsc --noEmit` clean; `bun test` 2908 pass (the single failure, `appCardMenu.test.ts`, is a pre-existing isolation flake that reproduces on `origin/main`); `new-task-images.test.ts` 37 pass incl. 2 new pins
- Browser (cmux): `/api/schedule/shot` delayed 4 s → chip opened at t=0.5 s shows "uploading…", flips to the real path + mounts the template iframe at t=4.1 s without re-clicking; same for a PNG; close flow clean; 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to new-task attachment UI and client-side blob lifecycle; no API, auth, or scheduling payload contract changes beyond existing attachment metadata.
> 
> **Overview**
> Fixes three **New task** attachment issues in `NewJobModal.tsx` (Bugbot #915).
> 
> The **attachment viewer** no longer stores a click-time chip snapshot. It keeps a **`viewerKey`** and resolves the current row from **`images`** each render, so a chip opened mid-upload picks up **`path`/`kind`** when the upload finishes and transcoded files show the right UI. The file-preview **`statPath`** effect depends on **`viewer?.key/kind/path`** instead of the derived object identity, so updates on other chips do not blank an already-loaded preview.
> 
> After upload, **`kind: "image"`** from the server is applied only when **`attachmentKindOf(up.path)`** says the stored path is drawable; otherwise chips fall back to the doc glyph / file viewer (failed TIFF/HEIC transcode no longer renders an empty **`<img>`**).
> 
> On form unmount, a cleanup effect **revokes every `blob:` thumbnail** still on **`imagesRef`**, so Save/Close without removing chips does not leak object URLs. **`new-task-images.test.ts`** pins the new wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1edabcbb5b4b2a52c51921e44a17e3ac5db2e4e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->