### PR TITLE
Boot wordmark: put display:none last so it actually wins the rule

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -89,7 +89,6 @@
     /* Hidden for now (Akshil, 2026-08-28): the pulsing "fused" wordmark is
        parked; the boot stays a plain themed ground until the shell paints. */
     #boot {
-      display: none;
       position: fixed;
       inset: 0;
       display: flex;
@@ -100,6 +99,8 @@
       color: #9aa0a6;
       animation: boot-pulse 1.4s ease-in-out infinite;
     }
+    /* Last word in the rule set: parks the wordmark (see above). */
+    #boot { display: none; }
     html[data-theme="light"] #boot { color: #61656c; }
     @keyframes boot-pulse { 50% { opacity: 0.45; } }
     @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
Follow-up to #913 (merged before this Bugbot fix landed). The `display: none` on `#boot` was declared *before* `display: flex` in the same rule, so it lost and an empty full-viewport overlay stayed until React mounted. The hide is now its own rule after the block, so it wins.

## Test plan
- [x] Served `index.html` on the dev server: `#boot` computed `display` is `none`
- [x] No test pins the `#boot` markup (checked frontend + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file inline CSS ordering fix with no auth, data, or API impact.
> 
> **Overview**
> Fixes a **CSS cascade bug** in `frontend/index.html` where the boot placeholder stayed visible until React mounted.
> 
> The `#boot` block still defines layout/animation (`display: flex`, etc.) for when the wordmark is re-enabled, but **`display: none` is now in a separate rule placed last** so it overrides `flex` instead of losing to it inside one rule. The boot overlay is hidden again while keeping the themed page background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ee782a9ac777fce5f156c2adc2917d4cddfd13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->