### PR TITLE
Claude Code sign-in happens in the app, through the CLI's own browser flow

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -291,6 +291,34 @@ export function getClaudeInstall(): Promise<ClaudeInstallStatus> {
   return getJson<ClaudeInstallStatus>("/api/claude/install");
 }
 
+/** A browser sign-in, as the server holds it.
+
+    There is no `output` here, unlike the install record. The child's lines carry
+    the authorize URL's `state` and `code_challenge`, so the server keeps its
+    tail in memory and surfaces only the one derived sentence in `error`. */
+export interface ClaudeLoginStatus {
+  in_flight: boolean;
+  started_at: number | null;
+  /** The child's own diagnosis when a sign-in ended without signing in. */
+  error: string | null;
+}
+
+/** Start a browser sign-in. The CLI opens the page and completes on its own
+    loopback callback — no code is pasted, and none reaches the app. Rejects with
+    the server's sentence when one is already waiting. */
+export function startClaudeLogin(): Promise<ClaudeLoginStatus> {
+  return postJson<ClaudeLoginStatus>("/api/claude/login", {});
+}
+
+export function getClaudeLogin(): Promise<ClaudeLoginStatus> {
+  return getJson<ClaudeLoginStatus>("/api/claude/login");
+}
+
+export function cancelClaudeLogin(): Promise<ClaudeLoginStatus & { canceled: boolean }> {
+  return postJson<ClaudeLoginStatus & { canceled: boolean }>(
+    "/api/claude/login/cancel", {});
+}
+
 /** `claude doctor` on demand — what the CLI thinks of its own installation. */
 export function runClaudeDoctor(): Promise<{
   ok: boolean;

--- a/frontend/src/platform/lib/claude-health.test.ts
+++ b/frontend/src/platform/lib/claude-health.test.ts
@@ -345,6 +345,24 @@ test("the install command comes from the server, so Windows gets the Windows one
   expect(issueById(mac, "missing")?.command).toBe(CLAUDE_INSTALL_COMMAND);
 });
 
+test("a signed-out CLI offers to sign itself in, through the browser", () => {
+  // The row that was a sentence for longest, because `/login` is a TUI slash
+  // command. `claude auth login` is the other door: it opens the browser and
+  // finishes on its own loopback callback, so this is a button now.
+  const issue = issueById(healthy({ signed_in: false }), "signed-out");
+  expect(issue?.action).toEqual({ kind: "login", label: "Sign in" });
+});
+
+test("the signed-out row no longer sends anyone to a terminal", () => {
+  // The advice it replaced was "open a terminal, run `claude`, type /login".
+  // Leaving that text beside a button that does the whole thing would be the
+  // app telling the user to go and do the work it just did.
+  const issue = issueById(healthy({ signed_in: false }), "signed-out");
+  expect(issue?.detail).not.toContain("/login");
+  expect(issue?.detail).not.toContain("terminal");
+  expect(issue?.command).toBeUndefined();
+});
+
 test("a dead override still offers no button — we cannot edit a shell profile", () => {
   const issue = issueById(
     healthy({ found: false, source: "override", path: "/gone/claude" }),

--- a/frontend/src/platform/lib/claude-health.ts
+++ b/frontend/src/platform/lib/claude-health.ts
@@ -36,7 +36,7 @@ export interface ClaudeIssue {
    *  and its absence is meaningful: `unusable-override` has no action because
    *  the value lives in a shell profile we cannot edit, and offering a button
    *  that silently does nothing is worse than the sentence it replaced. */
-  action?: { kind: "install" | "update" | "doctor"; label: string };
+  action?: { kind: "install" | "update" | "doctor" | "login"; label: string };
 }
 
 /** `claude update`, the fix for an install that is merely old. Not in
@@ -186,8 +186,16 @@ export function claudeIssues(health: ClaudeHealth | null): ClaudeIssue[] {
     issues.push({
       id: "signed-out",
       title: "Claude Code isn't signed in",
-      detail: "Open a terminal, run `claude`, type /login and finish signing in.",
+      // NOT "run `claude`, type /login" any more. That was the only route
+      // through the TUI door, but `claude auth login` opens the browser itself
+      // and finishes on its own loopback callback — so this is a button, and
+      // the code never comes anywhere near the app. The sentence describes what
+      // pressing it does, because a browser window about to appear over the app
+      // is a thing to announce first.
+      detail: "Sign in with your browser — Claude Code opens the page and "
+        + "finishes on its own.",
       helpKind: "login",
+      action: { kind: "login", label: "Sign in" },
     });
   }
 

--- a/frontend/src/platform/ui/ClaudeHealthStrip.tsx
+++ b/frontend/src/platform/ui/ClaudeHealthStrip.tsx
@@ -20,14 +20,18 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
+  cancelClaudeLogin,
   getClaudeHealth,
   getClaudeInstall,
+  getClaudeLogin,
   refreshClaudeHealth,
   runClaudeDoctor,
   startClaudeInstall,
+  startClaudeLogin,
   type ClaudeDoctor,
   type ClaudeHealth,
   type ClaudeInstallStatus,
+  type ClaudeLoginStatus,
 } from "@platform/lib/api";
 import {
   claudeIssues,
@@ -85,6 +89,12 @@ function CopyCommand({ command }: { command: string }) {
     what reads as live rather than by cost. */
 const INSTALL_POLL_MS = 1200;
 
+/** How often to ask whether the browser sign-in has finished. Slower than the
+    install poll on purpose: nothing changes here until a person has finished
+    with a browser window, so a faster tick would only spend requests watching
+    someone read a consent screen. */
+const LOGIN_POLL_MS = 2000;
+
 /** `claude doctor`'s own words, or the installer's. Rendered verbatim and in a
  *  scroll box rather than summarised: the whole reason to surface either is
  *  that the exact string is what a user can search for and what an issue needs.
@@ -128,15 +138,19 @@ function DoctorReport({ doctor }: { doctor: ClaudeDoctor }) {
 function IssueRow({
   issue,
   install,
+  login,
   doctor,
   onAct,
+  onCancelLogin,
   busy,
   actionError,
 }: {
   issue: ClaudeIssue;
   install: ClaudeInstallStatus | null;
+  login: ClaudeLoginStatus | null;
   doctor: ClaudeDoctor | null;
   onAct: (issue: ClaudeIssue) => void;
+  onCancelLogin: () => void;
   busy: boolean;
   actionError: string | null;
 }) {
@@ -151,6 +165,13 @@ function IssueRow({
   const failed = Boolean(mine && install!.state === "error");
   const finished = Boolean(mine && install!.state === "done");
 
+  // The sign-in is tracked in its own record, for the reason it has its own
+  // endpoints: it waits on a person rather than running to completion, so a
+  // "Working…" that cannot be called off would be the app telling the user to
+  // wait for something only they can finish.
+  const signingIn = Boolean(issue.action?.kind === "login" && login?.in_flight);
+  const loginError = issue.action?.kind === "login" ? login?.error ?? null : null;
+
   return (
     <li className="claude-health-issue">
       <div className="claude-health-issue-title">{issue.title}</div>
@@ -162,10 +183,23 @@ function IssueRow({
             type="button"
             className="claude-health-action"
             onClick={() => onAct(issue)}
-            disabled={busy || running}
+            disabled={busy || running || signingIn}
           >
-            {running ? "Working…" : finished ? "Done" : issue.action.label}
+            {running || signingIn
+              ? "Working…"
+              : finished
+                ? "Done"
+                : issue.action.label}
           </button>
+          {signingIn && (
+            <button
+              type="button"
+              className="claude-health-action claude-health-action-quiet"
+              onClick={onCancelLogin}
+            >
+              Cancel
+            </button>
+          )}
           {/* What will actually run, before it runs. Piping a remote script
               into a shell on someone's behalf is a thing to disclose, not to
               do quietly behind a friendly label. */}
@@ -179,6 +213,18 @@ function IssueRow({
         <p className="claude-health-progress" role="status">
           {install!.detail || "Working…"}
         </p>
+      )}
+      {signingIn && (
+        <p className="claude-health-progress" role="status">
+          Finish signing in with the browser window that just opened.
+        </p>
+      )}
+      {/* The child's own diagnosis. `Login failed: Request failed with status
+          code 400` is the loopback exchange rejecting the code, and it is the
+          only diagnosis on offer — the server derives this one line and keeps
+          the rest of the output in memory. */}
+      {loginError && !signingIn && (
+        <p className="claude-health-error">{loginError}</p>
       )}
       {failed && (
         <OutputBlock
@@ -228,6 +274,10 @@ export function ClaudeHealthStrip() {
   // already holding would be the same do-our-work-for-us failure the shell
   // adoption exists to avoid.
   const [doctor, setDoctor] = useState<ClaudeDoctor | null>(null);
+  // The browser sign-in record, polled only while one is open. Its own state
+  // rather than a branch of `install`, because it is its own endpoint for its
+  // own reason: this one waits on a person and can be called off.
+  const [login, setLogin] = useState<ClaudeLoginStatus | null>(null);
   // A REFUSAL, shown verbatim. The one that matters is the 409 from an update
   // that would no-op: its text names the command that would actually work, and
   // rewording it would throw that away.
@@ -287,6 +337,22 @@ export function ClaudeHealthStrip() {
     );
   }, []);
 
+  // The same recovery for a sign-in, and it matters more: the browser window is
+  // in front of the user RIGHT NOW, so a remounted strip that showed "Sign in"
+  // again would invite a second press that can only earn a 409 for a window
+  // already open. Only an in-flight record is adopted; a finished one belongs to
+  // an attempt whose outcome the health snapshot already reflects.
+  useEffect(() => {
+    getClaudeLogin().then(
+      (rec) => {
+        if (rec.in_flight) setLogin(rec);
+      },
+      () => {
+        /* A recovery, not a prerequisite. */
+      },
+    );
+  }, []);
+
   // POLL ONLY WHILE SOMETHING IS RUNNING. An install outlives this component —
   // the user can navigate away and the download manager keeps showing it — so
   // the poll is tied to the record's state, not to the component's lifetime.
@@ -313,6 +379,32 @@ export function ClaudeHealthStrip() {
     };
   }, [install?.state, load]);
 
+  // POLL ONLY WHILE A SIGN-IN IS OPEN. The end of one is not a message the
+  // server can push, and it is not the child's exit code either: the CLI writes
+  // a credential this app never sees, so the only authority on whether it worked
+  // is `claude auth status`. When the record stops being in flight, re-probe —
+  // and let the strip close itself on the answer rather than on a guess.
+  useEffect(() => {
+    if (!login?.in_flight) return;
+    let alive = true;
+    const timer = window.setInterval(() => {
+      getClaudeLogin().then(
+        (next) => {
+          if (!alive) return;
+          setLogin(next);
+          if (!next.in_flight) load(true);
+        },
+        () => {
+          /* A failed poll is not a failed sign-in — keep what we last knew. */
+        },
+      );
+    }, LOGIN_POLL_MS);
+    return () => {
+      alive = false;
+      window.clearInterval(timer);
+    };
+  }, [login?.in_flight, load]);
+
   const act = useCallback(
     (issue: ClaudeIssue) => {
       if (!issue.action) return;
@@ -333,6 +425,22 @@ export function ClaudeHealthStrip() {
         });
         return;
       }
+      if (issue.action.kind === "login") {
+        startClaudeLogin().then(
+          (rec) => {
+            done();
+            setLogin(rec);
+          },
+          (e) => {
+            done();
+            // The server's own words. A 409 here means a browser window is
+            // already open and waiting — which is the thing the user needs to
+            // know, and a reworded "please wait" would hide it.
+            setActionError(String(e?.message || e));
+          },
+        );
+        return;
+      }
       startClaudeInstall(issue.action.kind).then(
         (rec) => {
           done();
@@ -348,6 +456,16 @@ export function ClaudeHealthStrip() {
     },
     [],
   );
+
+  // Calling off a sign-in. The server settles the record before answering, so
+  // what comes back is already not in flight and the poll stops on its own.
+  const cancelLogin = useCallback(() => {
+    setActionError(null);
+    cancelClaudeLogin().then(
+      (rec) => setLogin(rec),
+      () => setLogin(null),
+    );
+  }, []);
 
   const issues = claudeIssues(health);
   const showing = loaded && issues.length > 0 && !isDismissed(issues);
@@ -423,10 +541,12 @@ export function ClaudeHealthStrip() {
             key={issue.id}
             issue={issue}
             install={install}
+            login={login}
             // The report belongs to the row that can act on it, and only the
             // broken-install row can.
             doctor={issue.id === "broken" ? doctor : null}
             onAct={act}
+            onCancelLogin={cancelLogin}
             busy={acting}
             actionError={issue.action ? actionError : null}
           />

--- a/frontend/src/styles/dialogs.css
+++ b/frontend/src/styles/dialogs.css
@@ -333,6 +333,22 @@
   cursor: default;
 }
 
+/* Cancel, beside a sign-in that is waiting on a browser window. Quiet on
+   purpose: the affirmative control in that row is the one already pressed, and
+   two accent fills side by side would make calling it off look like the
+   next step rather than the way out. */
+.claude-health-action-quiet {
+  background: transparent;
+  color: var(--fg-muted);
+  border-color: var(--border);
+  font-weight: 500;
+}
+
+.claude-health-action-quiet:hover:not(:disabled) {
+  color: var(--fg);
+  filter: none;
+}
+
 /* What the button will run, beside the button. Disclosure, not decoration: this
    pipes a remote script into a shell, and doing that quietly behind a friendly
    label is the part that would not be OK. */

--- a/fused_render/claude_login.py
+++ b/fused_render/claude_login.py
@@ -206,13 +206,49 @@ def _drain(login: _Login) -> None:
         pass
 
 
+def _stop(login: _Login, force: bool) -> None:
+    """Stop the child — and on Windows the whole tree under it.
+
+    ON WINDOWS THE DIRECT CHILD MAY NOT BE CLAUDE. npm installs the CLI as a
+    `.cmd` shim, which only cmd.exe can run, so `_probe_cmd` hands us a command
+    string and the spawn is `shell=True`. `terminate()` and `kill()` are both
+    `TerminateProcess` on that cmd.exe and nothing else: the node process under
+    it keeps running, keeps the loopback listener, and keeps the write end of
+    our stdout pipe — so the drain never reaches EOF, the record never settles,
+    and `in_flight` stays true for the life of the app. Cancel and the watchdog
+    would both leave the button wedged, on precisely the install this button
+    exists to serve.
+
+    `taskkill /T` is what walks the tree. `/F` with it because there is no
+    graceful stop to prefer here: a console process is under no obligation to
+    act on the polite form, and a sign-in that will not close is the failure
+    being fixed. CREATE_NO_WINDOW so a packaged GUI app does not flash a
+    console. POSIX is unaffected — `shell=True` never happens there, so the
+    child IS the CLI and a signal reaches it.
+    """
+    proc = login.proc
+    if os.name == "nt":
+        try:
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                capture_output=True, timeout=30,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            return
+        except (OSError, subprocess.SubprocessError):
+            # taskkill missing or refused. Fall through: killing cmd.exe alone
+            # is worth less than nothing here, but it is better than not trying.
+            logger.warning("taskkill could not stop the Claude Code sign-in tree")
+    try:
+        proc.kill() if force else proc.terminate()
+    except OSError:
+        pass
+
+
 def _expire(login: _Login) -> None:
     """The watchdog body: end a sign-in nobody finished."""
     login.timed_out = True
-    try:
-        login.proc.kill()  # unblocks the drain, which then sees EOF
-    except OSError:
-        pass
+    _stop(login, force=True)  # unblocks the drain, which then sees EOF
 
 
 def _run(login: _Login) -> None:
@@ -235,10 +271,7 @@ def _run(login: _Login) -> None:
             # would label this a ten-minute login timeout in the record, when
             # what actually happened is a child that said its piece and would not
             # exit. Kill it and let its own last words explain it.
-            try:
-                login.proc.kill()
-            except OSError:
-                pass
+            _stop(login, force=True)
             code = -1
         except OSError:
             code = -1
@@ -254,10 +287,27 @@ def _run(login: _Login) -> None:
             login.error = None
         elif code != 0:
             login.error = _failure(login, code)
-        # A CLEAN EXIT IS NOT REPORTED AS SUCCESS, and that is not caution: the
-        # child exits 0 having written a credential this process never sees.
-        # Whether it worked is `claude auth status`'s answer, and the client asks
-        # the refresh endpoint for it.
+        else:
+            # THE RE-PROBE, the same one claude_install makes the point of: the
+            # child exited cleanly, so whatever it did to this machine's
+            # credentials has already happened, and the cached snapshot is now
+            # the stale claim that the user is signed out.
+            #
+            # SERVER-SIDE, AND BEFORE `settled`. Leaving it to the strip's own
+            # refresh made it conditional on the strip still being mounted and
+            # still polling — so a user who signed in and walked away came back
+            # to a mounted-fresh strip reading a 60-second-old "signed out" and
+            # offering to start a second browser flow. Doing it here also closes
+            # the gap on the polling path: by the time anything can observe
+            # `in_flight: false`, the snapshot behind it is already re-measured.
+            #
+            # A CLEAN EXIT IS STILL NOT REPORTED AS SUCCESS. This re-measures;
+            # it does not conclude. Whether the sign-in took is `claude auth
+            # status`'s answer, which is exactly what the re-probe goes and asks.
+            try:
+                claude_health.summary_refreshed()
+            except Exception:  # noqa: BLE001 - a failed probe is not a failed login
+                logger.warning("the sign-in finished but the re-probe failed")
     finally:
         # LAST, AND UNCONDITIONALLY. `error` must be readable the moment the
         # record stops saying "in flight", and a worker that died on the way out
@@ -346,10 +396,7 @@ def cancel() -> dict:
     if login is None:
         return {**status(), "canceled": False}
     login.canceled = True
-    try:
-        login.proc.terminate()
-    except OSError:
-        logger.debug("the Claude Code sign-in child was already gone")
+    _stop(login, force=False)
     if not login.settled.wait(CANCEL_GRACE_S):
         logger.warning("the Claude Code sign-in child did not stop when asked")
     return {**_record(login), "canceled": True}

--- a/fused_render/claude_login.py
+++ b/fused_render/claude_login.py
@@ -71,6 +71,11 @@ LOGIN_TIMEOUT_S = 600.0
 #: How long `cancel` waits for a terminated child before letting go of it.
 CANCEL_GRACE_S = 5.0
 
+#: How long to wait for a child to reap after its stdout has reached EOF. It has
+#: already said everything it is going to; this is only the gap between the pipe
+#: closing and the process record going away.
+REAP_TIMEOUT_S = 30.0
+
 #: How many of the child's lines to keep. Bounded, and IN MEMORY ONLY — see
 #: `_Login.tail`.
 _OUTPUT_TAIL_LINES = 40
@@ -265,7 +270,7 @@ def _run(login: _Login) -> None:
         watchdog.start()
         try:
             _drain(login)
-            code = login.proc.wait(30)
+            code = login.proc.wait(REAP_TIMEOUT_S)
         except subprocess.TimeoutExpired:
             # stdout is at EOF but the child has not reaped. NOT `_expire`: that
             # would label this a ten-minute login timeout in the record, when

--- a/fused_render/claude_login.py
+++ b/fused_render/claude_login.py
@@ -1,0 +1,362 @@
+"""Signing Claude Code in, by letting the CLI's own browser flow do the work.
+
+`claude_health.py` establishes that the CLI is installed and NOT signed in;
+`claude_install.py` repairs the two states that are a download away. This is the
+third repair, and it was the one that looked impossible: `/login` is a TUI slash
+command, so the advice the strip shipped with — open a terminal, run `claude`,
+type `/login` — really is the only route through that door.
+
+**There is a second door, and it does not need the code pasted anywhere.**
+`claude auth login` is a plain subcommand that runs TWO flows at once:
+
+* it opens the user's browser at ``http://localhost:<port>/callback``, a
+  loopback listener it binds itself, and completes the sign-in when the redirect
+  lands there; and
+* it PRINTS a different URL — ``https://platform.claude.com/oauth/code/callback``
+  — with a "Paste code here if prompted >" prompt, as the fallback for a machine
+  whose browser cannot reach it (ssh, headless, a browser on another device).
+
+Same authorization behind both: identical `state`, identical `code_challenge`,
+two redirect targets, whichever completes first. On a desktop app with the user's
+browser on the same machine the loopback path is the normal one — so THE APP
+NEVER HANDLES AN OAUTH CODE. That is the whole reason this module is small.
+
+**Do not read the printed URL and open it.** It is the paste URL; opening it
+forces the user into the manual flow for no reason. The loopback URL is never
+printed — the child hands it straight to the browser — so there is nothing here
+worth capturing, and the child opens the browser itself, which is the one thing
+that works on all three platforms (`BROWSER` is a POSIX convention; macOS and
+Windows shell out to `open`/`start` and ignore it).
+
+**Why this is not a third `claude_install` action.** Those two are machine time:
+they run to completion on their own, so the record is progress and the endpoint
+is fire-and-forget. This waits on a PERSON — it will sit at that prompt until the
+watchdog kills it — so it needs a cancel, and it must never occupy the shared
+install slot while it does. `canvases.py` already solved exactly this shape for
+`fused login` (a CLI that opens a browser and blocks on its own loopback
+callback) and the structure below is deliberately that one: a live child under a
+lock, a watchdog, and a client that polls until the health snapshot says signed
+in.
+
+**Success is never inferred from the exit code.** The child exits on failure too
+(`Login failed: …`). The authority on whether this worked is the one the rest of
+the module already defers to — `claude auth status`, reached through the refresh
+endpoint the strip calls anyway.
+"""
+from __future__ import annotations
+
+import codecs
+import collections
+import dataclasses
+import logging
+import os
+import re
+import subprocess
+import threading
+import time
+from typing import Optional
+
+from fused_render import claude_health, claude_install
+
+logger = logging.getLogger(__name__)
+
+#: How long a sign-in may stay open before the watchdog ends it. Matches
+#: canvases.LOGIN_CHILD_TIMEOUT, and for the same reason: this is a person
+#: finding a browser window, reading a consent screen and probably a password
+#: manager, not a machine doing work. The child itself never gives up — with no
+#: browser it sits at the paste prompt indefinitely — so this is the only thing
+#: that ends an abandoned attempt.
+LOGIN_TIMEOUT_S = 600.0
+
+#: How long `cancel` waits for a terminated child before letting go of it.
+CANCEL_GRACE_S = 5.0
+
+#: How many of the child's lines to keep. Bounded, and IN MEMORY ONLY — see
+#: `_Login.tail`.
+_OUTPUT_TAIL_LINES = 40
+
+#: Read granularity for the drain. Deliberately an `os.read` on the raw fd, and
+#: that is not a micro-optimisation — it is the only form that works here.
+#:
+#: Both buffered forms deadlock against this child. `for line in stdout` blocks
+#: holding the paste prompt, which never gets a newline; `stdout.read(n)` blocks
+#: until it has n CHARACTERS, and the child prints its ~700 and then waits on a
+#: human indefinitely. Either way the drain returns nothing until the child dies,
+#: which is exactly when its output has stopped being useful — the
+#: `Login failed: …` line would be captured only after the record had already
+#: fallen back to a generic sentence. `os.read` returns what one syscall got.
+_READ_CHUNK = 2048
+
+#: The child's stdin prompt, stripped out when deriving an error.
+#:
+#: STRIPPED, NOT SKIPPED, and that distinction was a bug. The prompt carries no
+#: newline, so whatever the child says next lands on the SAME line: a real
+#: failure arrives as `Paste code here if prompted > Login failed: Request failed
+#: with status code 400`. Dropping every line that mentions the prompt therefore
+#: threw away the diagnosis along with it, and the record fell back to quoting
+#: `Opening browser to sign in…` as the reason the sign-in failed.
+_PROMPT_RE = re.compile(r"Paste code here[^\n>]*>\s*")
+
+
+class LoginError(RuntimeError):
+    """A refusal with a sentence the strip can show as-is."""
+
+
+@dataclasses.dataclass
+class _Login:
+    proc: subprocess.Popen
+    started_at: float
+    #: The child's own words, capped. NOT mirrored into `jobs.py` and never
+    #: written to disk, which is the one place this module diverges from
+    #: claude_install deliberately. That module publishes every line into the
+    #: shared job registry because a verbatim installer error is the point. The
+    #: same lines here carry the authorize URL's `state` and `code_challenge`,
+    #: and phase 2 (the paste fallback) will put a live OAuth code on this
+    #: stream. So the tail stays in memory, dies with the process, and leaves it
+    #: only as the one derived sentence in `error`.
+    tail: collections.deque
+    error: Optional[str] = None
+    timed_out: bool = False
+    canceled: bool = False
+    #: Set once the worker has drained, reaped and written `error`.
+    #:
+    #: IN FLIGHT IS THIS, NOT `proc.poll()`, and the difference is a race the
+    #: user would see. The child dies the instant it fails, but its last line —
+    #: the only diagnosis there is — is still moving through the drain. A record
+    #: that went `in_flight: false` on the exit alone would be read by the strip
+    #: in the window before `error` was written, so the row would come back with
+    #: no explanation for why the sign-in did not take.
+    settled: threading.Event = dataclasses.field(default_factory=threading.Event)
+
+    def alive(self) -> bool:
+        return not self.settled.is_set()
+
+
+_LOCK = threading.Lock()
+_active: Optional[_Login] = None
+
+
+def _live() -> Optional[_Login]:
+    """The record, only while its child is still running. Callers hold no lock."""
+    with _LOCK:
+        return _active if _active is not None and _active.alive() else None
+
+
+def _failure(login: _Login, code: int) -> str:
+    """One sentence for a child that exited without signing in.
+
+    The child's own words where it gave any — `Login failed: Request failed with
+    status code 400` is the loopback exchange rejecting the code, and rewording
+    it would throw away the only diagnosis on offer.
+
+    LINES CARRYING A URL ARE NEVER USED. The authorize line is the bulk of this
+    child's output and it is not an error; excluding it by shape rather than by
+    position also keeps the `state` nonce out of the UI by construction.
+    """
+    for line in reversed(login.tail):
+        # The prompt is a PREFIX to strip, not a line to skip — see _PROMPT_RE.
+        cleaned = _PROMPT_RE.sub("", line).strip()
+        if not cleaned or "://" in cleaned:
+            continue
+        return cleaned
+    return f"the sign-in ended without signing in (exit code {code})"
+
+
+def _drain(login: _Login) -> None:
+    """Keep a bounded tail of the child's output, until EOF."""
+    stream = login.proc.stdout
+    if stream is None:
+        return
+    try:
+        fd = stream.fileno()
+    except (OSError, ValueError):
+        return
+    buffer = ""
+    # An INCREMENTAL decoder, because reads land on syscall boundaries rather
+    # than character ones: the CLI's own "Opening browser to sign in…" ends in a
+    # 3-byte ellipsis that a chunk edge can split in half. Decoding each chunk
+    # independently would turn that into replacement characters. Same encoding
+    # and errors as claude_health.SUBPROCESS_KWARGS, so a genuinely undecodable
+    # byte is still replaced rather than raising on a GUI-launched server that
+    # inherited no LANG.
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
+    try:
+        while True:
+            raw = os.read(fd, _READ_CHUNK)
+            if not raw:
+                break
+            buffer += decoder.decode(raw)
+            # Split on newlines but KEEP the trailing fragment: that fragment is
+            # usually the paste prompt, which never gets a newline of its own.
+            *lines, buffer = buffer.split("\n")
+            for line in lines:
+                if line.strip():
+                    login.tail.append(line.rstrip("\r"))
+    except (OSError, ValueError):
+        # A killed child closes the pipe under us. Not a failure of the sign-in.
+        pass
+    if buffer.strip():
+        login.tail.append(buffer.rstrip("\r"))
+    # Close the read end here rather than leaving it to the Popen's collection:
+    # the record is held until the NEXT sign-in replaces it, so an unclosed pipe
+    # is an fd kept for as long as the app runs, once per attempt.
+    try:
+        stream.close()
+    except OSError:
+        pass
+
+
+def _expire(login: _Login) -> None:
+    """The watchdog body: end a sign-in nobody finished."""
+    login.timed_out = True
+    try:
+        login.proc.kill()  # unblocks the drain, which then sees EOF
+    except OSError:
+        pass
+
+
+def _run(login: _Login) -> None:
+    """Drain, reap, and settle the record. Never raises out of the thread.
+
+    A TIMER, NOT A DEADLINE CHECKED IN THE READ LOOP — the same argument
+    `claude_install._run` makes. This child is silent for the whole time a human
+    spends in the browser, so a check that only ran when it spoke would never run
+    at all.
+    """
+    try:
+        watchdog = threading.Timer(LOGIN_TIMEOUT_S, _expire, args=(login,))
+        watchdog.daemon = True
+        watchdog.start()
+        try:
+            _drain(login)
+            code = login.proc.wait(30)
+        except subprocess.TimeoutExpired:
+            # stdout is at EOF but the child has not reaped. NOT `_expire`: that
+            # would label this a ten-minute login timeout in the record, when
+            # what actually happened is a child that said its piece and would not
+            # exit. Kill it and let its own last words explain it.
+            try:
+                login.proc.kill()
+            except OSError:
+                pass
+            code = -1
+        except OSError:
+            code = -1
+        finally:
+            watchdog.cancel()
+
+        if login.timed_out:
+            login.error = (f"the sign-in was not finished within "
+                           f"{int(LOGIN_TIMEOUT_S) // 60} minutes and was stopped")
+        elif login.canceled:
+            # Not a failure. The user said never mind, and inventing a sentence
+            # about it would put an error under a row they just dismissed.
+            login.error = None
+        elif code != 0:
+            login.error = _failure(login, code)
+        # A CLEAN EXIT IS NOT REPORTED AS SUCCESS, and that is not caution: the
+        # child exits 0 having written a credential this process never sees.
+        # Whether it worked is `claude auth status`'s answer, and the client asks
+        # the refresh endpoint for it.
+    finally:
+        # LAST, AND UNCONDITIONALLY. `error` must be readable the moment the
+        # record stops saying "in flight", and a worker that died on the way out
+        # must not wedge the button behind a sign-in nobody can finish.
+        login.settled.set()
+
+
+def _record(login: Optional[_Login]) -> dict:
+    """The record as the endpoint answers it.
+
+    `signed_in` is deliberately absent. This says whether a sign-in is in flight;
+    whether one WORKED belongs to the health snapshot, and putting a second
+    answer to that question here would be two sources of truth for the only fact
+    the strip acts on.
+    """
+    if login is None:
+        return {"in_flight": False, "started_at": None, "error": None}
+    return {"in_flight": login.alive(), "started_at": login.started_at,
+            "error": login.error}
+
+
+def status() -> dict:
+    """The current record. A cheap local read — no spawn, so no guard."""
+    with _LOCK:
+        return _record(_active)
+
+
+def start() -> dict:
+    """Open a browser sign-in, and return the opening record.
+
+    Refuses rather than queues, like `claude_install.start`: two sign-ins at once
+    means two loopback listeners and two authorizations racing, and the honest
+    answer to "sign in again while a sign-in is open" is that one is.
+    """
+    path, _source = claude_health.resolve()
+    if not path or not claude_health.executable(path):
+        raise LoginError("there is no Claude Code on this machine to sign in to")
+
+    # Through `_probe_cmd` for the reason the updater goes through it: npm
+    # installs `claude` as a .cmd shim that CreateProcess cannot run, and a
+    # signed-out npm install on Windows is exactly a machine this button is for.
+    cmd = claude_health._probe_cmd(path, "auth", "login")
+
+    global _active
+    with _LOCK:
+        if _active is not None and _active.alive():
+            raise LoginError(
+                "a Claude Code sign-in is already waiting in your browser")
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                shell=isinstance(cmd, str),
+                # A PIPE, NOT DEVNULL. Nothing is written to it on the loopback
+                # path — but closing stdin forecloses the paste fallback for a
+                # machine whose browser never opened, and buys nothing for it.
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                env=claude_install._child_env(),
+                **claude_health.SUBPROCESS_KWARGS,
+            )
+        except (OSError, ValueError) as exc:
+            raise LoginError(f"could not start the sign-in: {exc}") from exc
+        login = _Login(proc=proc, started_at=time.time(),
+                       tail=collections.deque(maxlen=_OUTPUT_TAIL_LINES))
+        _active = login
+        opening = _record(login)
+
+    thread = threading.Thread(target=_run, args=(login,), daemon=True)
+    thread.start()
+    return opening
+
+
+def cancel() -> dict:
+    """End a sign-in the user gave up on. Idempotent.
+
+    `terminate`, not `kill`: the child owns a loopback socket and is a step away
+    from a credential store, and asking it to stop is the difference between
+    closing those and orphaning them.
+
+    It waits briefly for the child to go, so the record the caller gets back is
+    the settled one — a cancel that returned `in_flight: true` would leave the
+    strip polling a sign-in the user just abandoned.
+    """
+    login = _live()
+    if login is None:
+        return {**status(), "canceled": False}
+    login.canceled = True
+    try:
+        login.proc.terminate()
+    except OSError:
+        logger.debug("the Claude Code sign-in child was already gone")
+    if not login.settled.wait(CANCEL_GRACE_S):
+        logger.warning("the Claude Code sign-in child did not stop when asked")
+    return {**_record(login), "canceled": True}
+
+
+def reset() -> None:
+    """Drop the record. For tests — production has `cancel`."""
+    global _active
+    with _LOCK:
+        _active = None

--- a/fused_render/claude_login.py
+++ b/fused_render/claude_login.py
@@ -107,6 +107,18 @@ class LoginError(RuntimeError):
     """A refusal with a sentence the strip can show as-is."""
 
 
+def _windows() -> bool:
+    """Whether to stop children the Windows way.
+
+    A function rather than an inline `os.name` check so a test can pin the
+    platform to ONE MODULE. Patching `os.name` itself would reach the whole
+    interpreter — pathlib, subprocess, tempfile — and on the Windows runner it
+    would also leave every test that reaches `_stop` firing a real
+    `taskkill /F /T /PID` at whatever process happens to hold a fake pid.
+    """
+    return os.name == "nt"
+
+
 @dataclasses.dataclass
 class _Login:
     proc: subprocess.Popen
@@ -232,18 +244,28 @@ def _stop(login: _Login, force: bool) -> None:
     child IS the CLI and a signal reaches it.
     """
     proc = login.proc
-    if os.name == "nt":
+    if _windows():
         try:
-            subprocess.run(
+            done = subprocess.run(
                 ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
                 capture_output=True, timeout=30,
                 creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
             )
-            return
+            if done.returncode == 0:
+                return
+            # NOT `check=True`, and the returncode is NOT ignorable. taskkill
+            # reports "process not found" and "access denied" by exiting
+            # non-zero, which raises nothing — so returning on the strength of
+            # having merely RUN it would skip the fallback in exactly the cases
+            # that need one, leaving the tree alive and the record in flight
+            # for good.
+            logger.warning("taskkill did not stop the Claude Code sign-in tree "
+                           "(exit %s)", done.returncode)
         except (OSError, subprocess.SubprocessError):
-            # taskkill missing or refused. Fall through: killing cmd.exe alone
-            # is worth less than nothing here, but it is better than not trying.
-            logger.warning("taskkill could not stop the Claude Code sign-in tree")
+            logger.warning("taskkill could not be run for the Claude Code sign-in")
+        # Fall through. Killing cmd.exe alone is worth little behind a shim, and
+        # on an already-dead pid it is a no-op, but neither is worse than
+        # walking away from a child we were asked to stop.
     try:
         proc.kill() if force else proc.terminate()
     except OSError:

--- a/fused_render/schedule.py
+++ b/fused_render/schedule.py
@@ -1601,7 +1601,10 @@ def _attachments_block(entry: dict) -> str:
         noun = "a picture" if len(shots) == 1 else "pictures"
     what = noun if len(shots) == 1 and noun.startswith("a ") \
         else f"{len(shots)} {noun}"
-    payload = json.dumps([{"kind": a["kind"], "view": a["path"],
+    # Forward slashes on the wire on every platform — the chat template's
+    # reader and the agent's Read rule both spell paths that way (agent.py
+    # `_wire_path`), and a stored Windows path still carries its backslashes.
+    payload = json.dumps([{"kind": a["kind"], "view": a["path"].replace("\\", "/"),
                            "name": a["name"], "viewNote": ""} for a in shots])
     # The chat's own two kind sentences, minus the two kinds a scheduled run
     # cannot have: "pane" and "overview" are pictures of a screen taken at send

--- a/fused_render/server/routers/claude_health.py
+++ b/fused_render/server/routers/claude_health.py
@@ -121,3 +121,57 @@ async def api_claude_doctor(x_fused: str | None = Header(default=None)):
         return {"ok": True, "doctor": report, "path": path}
 
     return await run_in_threadpool(_run)
+
+
+# --- signing in ---------------------------------------------------------------
+#
+# The third repair, and the one that needed a second door rather than more code:
+# `/login` is a TUI slash command, but `claude auth login` opens the browser and
+# completes on its own loopback callback, so the app can start a real sign-in
+# without ever handling an OAuth code. See fused_render/claude_login.py.
+#
+# These are separate endpoints rather than a third `/api/claude/install` action
+# because this one waits on a person: it needs a cancel, and it must not occupy
+# the install slot while a browser window sits open.
+
+
+@router.post("/api/claude/login")
+async def api_claude_login(x_fused: str | None = Header(default=None)):
+    """Start a browser sign-in, and return the opening record.
+
+    The X-Fused guard, like its neighbours: this spawns a process AND opens a
+    browser window on the user's desktop, which is not something a blind
+    cross-origin POST may do.
+    """
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    from fused_render import claude_login
+
+    try:
+        return await run_in_threadpool(claude_login.start)
+    except claude_login.LoginError as e:
+        # A refusal with a sentence the strip shows as-is — "a sign-in is
+        # already waiting in your browser" is the whole value of the 409, since
+        # the window the user needs is already open behind the app.
+        return _error(str(e), status=409)
+
+
+@router.get("/api/claude/login")
+async def api_claude_login_status():
+    """The current sign-in record. A read — no guard, no spawn."""
+    from fused_render import claude_login
+
+    return claude_login.status()
+
+
+@router.post("/api/claude/login/cancel")
+async def api_claude_login_cancel(x_fused: str | None = Header(default=None)):
+    """Stop a sign-in the user gave up on. Idempotent, and guarded because it
+    signals a process."""
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    from fused_render import claude_login
+
+    return await run_in_threadpool(claude_login.cancel)

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -1006,7 +1006,11 @@ def _attach_dirs(raw: str) -> list:
         # A root ("/", "C:/") has no parent to scope to — the rule would be the
         # whole disk. Also drops the shots dir if the page ever names it, since
         # its rule is unconditional.
-        if wired.rstrip("/").rstrip(":") in ("", "/"):
+        # Asked of the OS, not of the spelling: `os.path.dirname` of a root IS
+        # the root on every platform ("/" and "C:\\" alike), where a string
+        # strip of "C:/" left "C" and let the whole drive through on Windows.
+        normed = os.path.normpath(path)
+        if os.path.dirname(normed) == normed:
             continue
         if wired == _wire_path(SHOTS):
             continue

--- a/tests/test_claude_login.py
+++ b/tests/test_claude_login.py
@@ -40,7 +40,25 @@ def _clean(monkeypatch):
     """
     claude_login.reset()
     monkeypatch.setattr(claude_login, "_windows", lambda: False)
+    # AND STUB THE RE-PROBE. On a clean exit `_run` calls
+    # `claude_health.summary_refreshed()` from its worker thread, which spawns a
+    # real `claude auth status` through whatever `subprocess.Popen` is patched at
+    # that moment. A straggler thread from one test then lands in the NEXT test's
+    # fake and overwrites the kwargs it was about to assert on — seen as an
+    # intermittent `KeyError: 'stdin'`, roughly one run in six alongside the
+    # other claude_* files. The tests that are ABOUT the re-probe patch this
+    # themselves, and their patch wins by applying second.
+    monkeypatch.setattr(claude_health, "summary_refreshed", lambda: {})
     yield
+    # Settle the worker before the next test patches Popen again — the fixture
+    # tearing down is not the same thing as the thread having finished.
+    login = claude_login._active
+    if login is not None:
+        try:
+            login.proc.kill()
+        except Exception:  # noqa: BLE001 - a fake that refuses is still done with
+            pass
+        login.settled.wait(5)
     claude_login.reset()
 
 

--- a/tests/test_claude_login.py
+++ b/tests/test_claude_login.py
@@ -340,6 +340,105 @@ def test_an_abandoned_sign_in_is_killed_by_the_watchdog(monkeypatch):
     assert "not finished" in claude_login.status()["error"]
 
 
+def test_on_windows_the_whole_process_tree_is_stopped(monkeypatch):
+    """Behind a .cmd shim the direct child is cmd.exe, and TerminateProcess on
+    it leaves the node process holding the loopback listener and our stdout
+    pipe — so the drain never sees EOF and the record never settles. Cancel and
+    the watchdog would both wedge the button, on exactly the npm-on-Windows
+    install this button exists to serve."""
+    monkeypatch.setattr(claude_login.os, "name", "nt")
+    killed = []
+    monkeypatch.setattr(claude_login.subprocess, "run",
+                        lambda argv, **kw: killed.append(argv))
+    proc = _FakeProc(text=PROMPT, pid=9182)
+    claude_login._stop(claude_login._Login(proc=proc, started_at=0.0, tail=[]),
+                       force=False)
+    assert killed == [["taskkill", "/T", "/F", "/PID", "9182"]]
+    # And NOT the plain terminate, which is the thing that does not work here.
+    assert proc.terminated is False
+    proc.finish()
+
+
+def test_off_windows_the_child_itself_is_signalled(monkeypatch):
+    """`shell=True` never happens on POSIX, so the child IS the CLI and a
+    signal reaches it — no taskkill, and terminate stays the polite form."""
+    monkeypatch.setattr(claude_login.os, "name", "posix")
+    proc = _FakeProc(text=PROMPT)
+    login = claude_login._Login(proc=proc, started_at=0.0, tail=[])
+    claude_login._stop(login, force=False)
+    assert proc.terminated is True and proc.killed is False
+    proc2 = _FakeProc(text=PROMPT)
+    claude_login._stop(claude_login._Login(proc=proc2, started_at=0.0, tail=[]),
+                       force=True)
+    assert proc2.killed is True
+
+
+def test_a_clean_sign_in_re_probes_health_on_the_server(monkeypatch):
+    """Leaving the refresh to the strip made it conditional on the strip still
+    being mounted: sign in, walk away, come back to a fresh strip reading a
+    60-second-old "signed out" and offering a second browser flow."""
+    _found(monkeypatch)
+    probes = []
+    monkeypatch.setattr(claude_health, "summary_refreshed",
+                        lambda: probes.append(1) or {})
+    proc = _FakeProc(text=f"{AUTHORIZE_LINE}\n", code=0)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    assert probes == [1]
+
+
+def test_the_re_probe_happens_before_the_record_settles(monkeypatch):
+    """Ordering, not decoration: anything that can observe `in_flight: false`
+    must find the snapshot behind it already re-measured, or the polling client
+    reads the stale one in the gap."""
+    _found(monkeypatch)
+    seen = {}
+    monkeypatch.setattr(
+        claude_health, "summary_refreshed",
+        lambda: seen.setdefault("in_flight_during_probe",
+                                claude_login.status()["in_flight"]) or {})
+    proc = _FakeProc(text=f"{AUTHORIZE_LINE}\n", code=0)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    assert seen["in_flight_during_probe"] is True
+
+
+def test_a_failed_sign_in_does_not_re_probe(monkeypatch):
+    """Nothing changed about this machine's credentials, so spending a probe
+    would only be the app looking busy."""
+    _found(monkeypatch)
+    probes = []
+    monkeypatch.setattr(claude_health, "summary_refreshed",
+                        lambda: probes.append(1) or {})
+    proc = _FakeProc(text="Login failed: nope\n", code=1)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    assert probes == []
+
+
+def test_a_re_probe_that_itself_fails_does_not_wedge_the_record(monkeypatch):
+    """A failed probe is not a failed sign-in — and must never leave the button
+    stuck behind a record that never settles."""
+    _found(monkeypatch)
+
+    def boom():
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(claude_health, "summary_refreshed", boom)
+    proc = _FakeProc(text=f"{AUTHORIZE_LINE}\n", code=0)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    assert claude_login.status()["error"] is None
+
+
 def test_cancel_terminates_and_settles_the_record(monkeypatch):
     """`terminate`, not `kill`: the child owns a loopback socket and is a step
     from a credential store. And the record comes back settled, so the strip

--- a/tests/test_claude_login.py
+++ b/tests/test_claude_login.py
@@ -50,7 +50,8 @@ class _FakeProc:
     spoken and is now waiting, which is the resting state of a healthy sign-in.
     """
 
-    def __init__(self, text="", code=0, pid=4242):
+    def __init__(self, text="", code=0, pid=4242, ignore_stop=False):
+        self.ignore_stop = ignore_stop
         self._release = threading.Event()
         self._code = code
         self.pid = pid
@@ -70,6 +71,13 @@ class _FakeProc:
             raise subprocess.TimeoutExpired("claude", timeout)
         return self._code
 
+    def eof(self):
+        """Close stdout without exiting — a child that said its piece and stayed."""
+        try:
+            os.close(self._write_fd)
+        except OSError:
+            pass
+
     def _close(self):
         try:
             os.close(self._write_fd)
@@ -79,11 +87,13 @@ class _FakeProc:
 
     def terminate(self):
         self.terminated = True
-        self._close()
+        if not self.ignore_stop:
+            self._close()
 
     def kill(self):
         self.killed = True
-        self._close()
+        if not self.ignore_stop:
+            self._close()
 
     def finish(self):
         self._close()
@@ -437,6 +447,53 @@ def test_a_re_probe_that_itself_fails_does_not_wedge_the_record(monkeypatch):
     proc.finish()
     assert _settle(lambda: not claude_login.status()["in_flight"])
     assert claude_login.status()["error"] is None
+
+
+def test_taskkill_missing_falls_back_to_signalling_the_child(monkeypatch):
+    """Killing cmd.exe alone is worth little behind a shim, but it beats not
+    trying — and the fallback must not raise out of a cancel."""
+    monkeypatch.setattr(claude_login.os, "name", "nt")
+
+    def no_taskkill(*a, **k):
+        raise FileNotFoundError("taskkill")
+
+    monkeypatch.setattr(claude_login.subprocess, "run", no_taskkill)
+    proc = _FakeProc(text=PROMPT)
+    claude_login._stop(claude_login._Login(proc=proc, started_at=0.0, tail=[]),
+                       force=False)
+    assert proc.terminated is True
+    proc.finish()
+
+
+def test_a_child_that_will_not_reap_is_not_called_a_login_timeout(monkeypatch):
+    """stdout is at EOF but the process record has not gone. It said its piece,
+    so this is NOT the ten-minute watchdog and must not be labelled as one —
+    the record quotes the child's own last words instead."""
+    _found(monkeypatch)
+    monkeypatch.setattr(claude_login, "REAP_TIMEOUT_S", 0.05)
+    proc = _FakeProc(text="Login failed: nope\n", ignore_stop=True)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.eof()  # stdout closes; the child stays
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    error = claude_login.status()["error"]
+    assert error == "Login failed: nope"
+    assert "not finished within" not in error
+
+
+def test_a_cancel_the_child_ignores_is_reported_honestly(monkeypatch):
+    """It says it cancelled, because it asked. It does not claim the child is
+    gone when it is still there — the record keeps saying in flight, which is
+    the true thing and what keeps the poll alive."""
+    _found(monkeypatch)
+    monkeypatch.setattr(claude_login, "CANCEL_GRACE_S", 0.05)
+    proc = _FakeProc(text=PROMPT, ignore_stop=True)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    record = claude_login.cancel()
+    assert record["canceled"] is True
+    assert record["in_flight"] is True
+    proc.finish()
 
 
 def test_cancel_terminates_and_settles_the_record(monkeypatch):

--- a/tests/test_claude_login.py
+++ b/tests/test_claude_login.py
@@ -1,0 +1,421 @@
+"""Tests for fused_render/claude_login.py and the three sign-in endpoints.
+
+Like test_claude_install, this module RUNS THINGS — so the assertions cluster
+around what it will not do, and around the two properties that are wrong
+invisibly: that a failed sign-in keeps the child's own diagnosis, and that
+nothing the child printed is ever written down.
+
+Nothing below signs anything in. `subprocess.Popen` is faked at the module
+boundary, so what is under test is the state machine, the guards and the output
+discipline — not the OAuth flow.
+"""
+import os
+import subprocess
+import threading
+import time
+
+import pytest
+
+from fused_render import claude_health, claude_login
+
+# The authorize line the real CLI prints, trimmed. It is here because it is the
+# thing that must NOT come back out of this module: it carries the `state` nonce
+# and the PKCE challenge, and it is also the bulk of a healthy child's output.
+AUTHORIZE_LINE = (
+    "If the browser didn't open, visit: https://claude.com/cai/oauth/authorize"
+    "?code=true&client_id=9d1c250a&state=SECRETSTATE&code_challenge=SECRETPKCE"
+)
+PROMPT = "Paste code here if prompted > "
+_PROMPT = "Paste code here"
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    claude_login.reset()
+    yield
+    claude_login.reset()
+
+
+class _FakeProc:
+    """A child that prints `text`, then exits `code` when released.
+
+    Its stdout is A REAL OS PIPE, not a stub with a `read` method, and that is
+    load-bearing. A stub that hands back the whole string on the first call
+    passes against a drain that cannot actually work: `stdout.read(n)` on a
+    buffered stream waits for n CHARACTERS, so against the real CLI — which
+    prints ~700 and then waits on a human — it returns nothing until the child
+    dies. A real pipe reproduces that, so the fake cannot flatter the code.
+
+    The write end stays open until release, so the drain sees a child that has
+    spoken and is now waiting, which is the resting state of a healthy sign-in.
+    """
+
+    def __init__(self, text="", code=0, pid=4242):
+        self._release = threading.Event()
+        self._code = code
+        self.pid = pid
+        self.stdin = None
+        read_fd, self._write_fd = os.pipe()
+        if text:
+            os.write(self._write_fd, text.encode("utf-8"))
+        self.stdout = os.fdopen(read_fd, "r", encoding="utf-8", errors="replace")
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return self._code if self._release.is_set() else None
+
+    def wait(self, timeout=None):
+        if not self._release.wait(timeout if timeout is not None else 5):
+            raise subprocess.TimeoutExpired("claude", timeout)
+        return self._code
+
+    def _close(self):
+        try:
+            os.close(self._write_fd)
+        except OSError:
+            pass
+        self._release.set()
+
+    def terminate(self):
+        self.terminated = True
+        self._close()
+
+    def kill(self):
+        self.killed = True
+        self._close()
+
+    def finish(self):
+        self._close()
+
+
+def _found(monkeypatch, path="/usr/local/bin/claude"):
+    monkeypatch.setattr(claude_health, "resolve",
+                        lambda allow_shell=True: (path, "candidate"))
+    monkeypatch.setattr(claude_health, "executable", lambda p: True)
+
+
+def _spawn(monkeypatch, proc):
+    seen = {}
+
+    def fake_popen(cmd, **kw):
+        seen["cmd"] = cmd
+        seen["kw"] = kw
+        return proc
+
+    monkeypatch.setattr(claude_login.subprocess, "Popen", fake_popen)
+    return seen
+
+
+def _settle(predicate, timeout=5.0):
+    """Wait for the worker thread to reach a state. Threads, not sleeps."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# -- what it runs -------------------------------------------------------------
+
+
+def test_it_runs_auth_login_on_the_binary_we_resolved(monkeypatch):
+    """Not `claude` off PATH: the app's PATH is not the user's, which is the
+    whole reason claude_health resolves a path in the first place."""
+    _found(monkeypatch, "/opt/claude/claude")
+    proc = _FakeProc()
+    seen = _spawn(monkeypatch, proc)
+    claude_login.start()
+    assert seen["cmd"] == ["/opt/claude/claude", "auth", "login"]
+    proc.finish()
+
+
+def test_stdin_is_a_pipe_so_the_paste_fallback_stays_possible(monkeypatch):
+    """DEVNULL would close a door the loopback path does not need but the
+    headless one does, and buys nothing for it."""
+    _found(monkeypatch)
+    proc = _FakeProc()
+    seen = _spawn(monkeypatch, proc)
+    claude_login.start()
+    assert seen["kw"]["stdin"] is subprocess.PIPE
+    proc.finish()
+
+
+def test_the_child_gets_the_augmented_path(monkeypatch):
+    """The CLI has to find its own runtime, and a GUI-launched app's PATH is as
+    short of `node` as it is of `claude`."""
+    _found(monkeypatch)
+    monkeypatch.setattr(claude_health, "augmented_path", lambda: "/augmented")
+    proc = _FakeProc()
+    seen = _spawn(monkeypatch, proc)
+    claude_login.start()
+    assert seen["kw"]["env"]["PATH"] == "/augmented"
+    proc.finish()
+
+
+def test_it_goes_through_the_cmd_hop_behind_a_windows_shim(monkeypatch):
+    """npm installs `claude` as a .cmd shim CreateProcess cannot run — and a
+    signed-out npm install on Windows is exactly what this button is for."""
+    monkeypatch.setattr(claude_health.os, "name", "nt")
+    _found(monkeypatch, r"C:\npm\claude.cmd")
+    proc = _FakeProc()
+    seen = _spawn(monkeypatch, proc)
+    claude_login.start()
+    assert isinstance(seen["cmd"], str)
+    assert seen["kw"]["shell"] is True
+    proc.finish()
+
+
+# -- the refusals -------------------------------------------------------------
+
+
+def test_a_second_sign_in_is_refused_while_one_is_open(monkeypatch):
+    """Two loopback listeners and two authorizations racing. The honest answer
+    is that a browser window is already waiting."""
+    _found(monkeypatch)
+    proc = _FakeProc()
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    with pytest.raises(claude_login.LoginError, match="already waiting"):
+        claude_login.start()
+    proc.finish()
+
+
+def test_a_finished_sign_in_does_not_block_the_next_one(monkeypatch):
+    """The refusal is about a LIVE child, not about the record. A user whose
+    first attempt failed must be able to press the button again."""
+    _found(monkeypatch)
+    first = _FakeProc(text="Login failed: nope\n", code=1)
+    _spawn(monkeypatch, first)
+    claude_login.start()
+    first.finish()
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    _spawn(monkeypatch, _FakeProc())
+    claude_login.start()  # must not raise
+    assert claude_login.status()["in_flight"]
+
+
+def test_signing_in_with_no_cli_is_refused_in_words(monkeypatch):
+    monkeypatch.setattr(claude_health, "resolve",
+                        lambda allow_shell=True: (None, None))
+    with pytest.raises(claude_login.LoginError, match="no Claude Code"):
+        claude_login.start()
+
+
+def test_a_child_that_will_not_start_is_reported_not_raised_as_oserror(monkeypatch):
+    _found(monkeypatch)
+
+    def boom(*a, **k):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(claude_login.subprocess, "Popen", boom)
+    with pytest.raises(claude_login.LoginError, match="permission denied"):
+        claude_login.start()
+
+
+# -- how it ends --------------------------------------------------------------
+
+
+def test_output_is_captured_while_the_child_is_still_waiting(monkeypatch):
+    """THE REGRESSION. The drain must deliver lines from a child that has spoken
+    and is now blocked on a human — that is the state a sign-in spends all its
+    time in. A buffered `stdout.read(n)` waits for n characters and so captures
+    nothing until the child dies, by which point the record has already fallen
+    back to a generic sentence and the CLI's own diagnosis is gone. Caught
+    against the real CLI, which captured zero lines; pinned here.
+    """
+    _found(monkeypatch)
+    proc = _FakeProc(text=f"Opening browser to sign in…\n{AUTHORIZE_LINE}\n{PROMPT}")
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    live = claude_login._active
+    assert _settle(lambda: len(live.tail) >= 2), (
+        f"the drain saw {list(live.tail)} from a child that is still running")
+    assert proc.poll() is None, "the child must still be waiting, not exited"
+    # The trailing paste prompt is deliberately NOT here yet: it carries no
+    # newline, so it is held as a fragment and flushed at EOF. Phase 2 is what
+    # needs to see it before then, and will read the fragment rather than wait
+    # for a newline that never comes.
+    assert not any(_PROMPT in line for line in live.tail)
+    proc.finish()
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    assert any(_PROMPT in line for line in live.tail), (
+        "the held fragment must still be flushed once the child is done")
+
+
+def test_a_failed_sign_in_keeps_the_child_s_own_diagnosis(monkeypatch):
+    """`Login failed: Request failed with status code 400` is the loopback
+    exchange rejecting the code — the only diagnosis on offer."""
+    _found(monkeypatch)
+    proc = _FakeProc(
+        text=f"Opening browser to sign in…\n{AUTHORIZE_LINE}\n"
+             "Login failed: Request failed with status code 400\n",
+        code=1,
+    )
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: claude_login.status()["error"] is not None)
+    assert claude_login.status()["error"] == (
+        "Login failed: Request failed with status code 400")
+
+
+def test_the_authorize_url_never_leaves_the_module(monkeypatch):
+    """THE ONE THAT MATTERS. The tail is kept in memory to derive one sentence;
+    the line carrying the `state` nonce and the PKCE challenge is not a failure
+    and must never be surfaced as one. Excluded by shape, so a future line
+    ordering cannot leak it."""
+    _found(monkeypatch)
+    proc = _FakeProc(text=f"Opening browser to sign in…\n{AUTHORIZE_LINE}\n{PROMPT}",
+                     code=1)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: claude_login.status()["error"] is not None)
+    record = claude_login.status()
+    blob = repr(record)
+    assert "SECRETSTATE" not in blob
+    assert "SECRETPKCE" not in blob
+    assert "://" not in blob
+    # Nor is the record a place output is published at all.
+    assert "output" not in record
+
+
+def test_a_failure_printed_onto_the_prompt_line_is_still_found(monkeypatch):
+    """THE SHAPE THE REAL CLI PRODUCES. The prompt carries no newline, so the
+    failure the loopback exchange reports lands on the SAME line as it. Caught
+    live: skipping any line that mentioned the prompt threw the diagnosis away
+    with it, and the record blamed `Opening browser to sign in…` instead."""
+    _found(monkeypatch)
+    proc = _FakeProc(
+        text=f"Opening browser to sign in…\n{AUTHORIZE_LINE}\n"
+             f"{PROMPT}Login failed: Request failed with status code 400\n",
+        code=1,
+    )
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    assert claude_login.status()["error"] == (
+        "Login failed: Request failed with status code 400")
+
+
+def test_the_paste_prompt_is_never_mistaken_for_an_error(monkeypatch):
+    """It is where a HEALTHY child sits, so it is never why one failed."""
+    _found(monkeypatch)
+    proc = _FakeProc(text=PROMPT, code=1)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: claude_login.status()["error"] is not None)
+    assert "Paste code" not in claude_login.status()["error"]
+    assert "exit code 1" in claude_login.status()["error"]
+
+
+def test_a_clean_exit_reports_no_error_and_claims_no_success(monkeypatch):
+    """The child exits 0 having written a credential this process never sees.
+    Whether it worked is `claude auth status`'s answer, not this record's."""
+    _found(monkeypatch)
+    proc = _FakeProc(text=f"{AUTHORIZE_LINE}\n", code=0)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    proc.finish()
+    assert _settle(lambda: not claude_login.status()["in_flight"])
+    record = claude_login.status()
+    assert record["error"] is None
+    assert "signed_in" not in record
+
+
+def test_an_abandoned_sign_in_is_killed_by_the_watchdog(monkeypatch):
+    """The child never gives up on its own — with no browser it sits at the
+    prompt forever — so the timer is the only thing that ends this."""
+    _found(monkeypatch)
+    monkeypatch.setattr(claude_login, "LOGIN_TIMEOUT_S", 0.05)
+    proc = _FakeProc(text=PROMPT)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    assert _settle(lambda: proc.killed)
+    assert _settle(lambda: claude_login.status()["error"] is not None)
+    assert "not finished" in claude_login.status()["error"]
+
+
+def test_cancel_terminates_and_settles_the_record(monkeypatch):
+    """`terminate`, not `kill`: the child owns a loopback socket and is a step
+    from a credential store. And the record comes back settled, so the strip
+    stops polling a sign-in the user just abandoned."""
+    _found(monkeypatch)
+    proc = _FakeProc(text=PROMPT)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    record = claude_login.cancel()
+    assert proc.terminated is True
+    assert record["canceled"] is True
+    assert record["in_flight"] is False
+    # A cancel is not a failure — there is nothing to tell the user about it.
+    assert record["error"] is None
+
+
+def test_cancelling_nothing_is_not_an_error(monkeypatch):
+    record = claude_login.cancel()
+    assert record["canceled"] is False
+    assert record["in_flight"] is False
+
+
+# -- the endpoints ------------------------------------------------------------
+
+
+def _client():
+    from fastapi import FastAPI
+    from starlette.testclient import TestClient
+
+    from fused_render.server.routers.claude_health import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_login_endpoint_refuses_a_blind_cross_origin_post():
+    """It spawns a process AND opens a browser window on the user's desktop."""
+    resp = _client().post("/api/claude/login")
+    assert resp.status_code in (400, 403)
+
+
+def test_cancel_endpoint_refuses_a_blind_cross_origin_post():
+    resp = _client().post("/api/claude/login/cancel")
+    assert resp.status_code in (400, 403)
+
+
+def test_the_login_status_endpoint_is_a_read_and_needs_no_guard():
+    resp = _client().get("/api/claude/login")
+    assert resp.status_code == 200
+    assert resp.json()["in_flight"] is False
+
+
+def test_a_refused_second_sign_in_comes_back_as_409_with_the_reason(monkeypatch):
+    """The 409's text is the whole value: the window the user needs is already
+    open behind the app."""
+    _found(monkeypatch)
+    proc = _FakeProc(text=PROMPT)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    resp = _client().post("/api/claude/login", headers={"X-Fused": "1"})
+    assert resp.status_code == 409
+    assert "already waiting" in resp.text
+    proc.finish()
+
+
+def test_the_login_endpoint_does_not_share_the_install_slot(monkeypatch):
+    """A sign-in waits on a person. Parking it in the install record would block
+    a genuine install behind an open browser window, and would put the sign-in
+    in the download manager where it cannot be cancelled."""
+    from fused_render import claude_install
+
+    _found(monkeypatch)
+    proc = _FakeProc(text=PROMPT)
+    _spawn(monkeypatch, proc)
+    claude_login.start()
+    assert claude_install.status()["state"] == "idle"
+    assert claude_install.running() is False
+    proc.finish()

--- a/tests/test_claude_login.py
+++ b/tests/test_claude_login.py
@@ -30,8 +30,16 @@ _PROMPT = "Paste code here"
 
 
 @pytest.fixture(autouse=True)
-def _clean():
+def _clean(monkeypatch):
+    """Reset the record, and PIN THE PLATFORM.
+
+    Without the pin, every test that reaches `_stop` behaves differently on the
+    Windows runner: it would fire a real `taskkill /F /T /PID 4242` at whatever
+    process holds that pid on the runner, never close the fake child, and hang
+    to the grace period before failing. Tests about Windows opt in explicitly.
+    """
     claude_login.reset()
+    monkeypatch.setattr(claude_login, "_windows", lambda: False)
     yield
     claude_login.reset()
 
@@ -356,10 +364,12 @@ def test_on_windows_the_whole_process_tree_is_stopped(monkeypatch):
     pipe — so the drain never sees EOF and the record never settles. Cancel and
     the watchdog would both wedge the button, on exactly the npm-on-Windows
     install this button exists to serve."""
-    monkeypatch.setattr(claude_login.os, "name", "nt")
+    monkeypatch.setattr(claude_login, "_windows", lambda: True)
     killed = []
-    monkeypatch.setattr(claude_login.subprocess, "run",
-                        lambda argv, **kw: killed.append(argv))
+    monkeypatch.setattr(
+        claude_login.subprocess, "run",
+        lambda argv, **kw: killed.append(argv)
+        or subprocess.CompletedProcess(argv, 0))
     proc = _FakeProc(text=PROMPT, pid=9182)
     claude_login._stop(claude_login._Login(proc=proc, started_at=0.0, tail=[]),
                        force=False)
@@ -372,7 +382,6 @@ def test_on_windows_the_whole_process_tree_is_stopped(monkeypatch):
 def test_off_windows_the_child_itself_is_signalled(monkeypatch):
     """`shell=True` never happens on POSIX, so the child IS the CLI and a
     signal reaches it — no taskkill, and terminate stays the polite form."""
-    monkeypatch.setattr(claude_login.os, "name", "posix")
     proc = _FakeProc(text=PROMPT)
     login = claude_login._Login(proc=proc, started_at=0.0, tail=[])
     claude_login._stop(login, force=False)
@@ -449,10 +458,26 @@ def test_a_re_probe_that_itself_fails_does_not_wedge_the_record(monkeypatch):
     assert claude_login.status()["error"] is None
 
 
+def test_taskkill_failing_still_falls_back_to_signalling_the_child(monkeypatch):
+    """taskkill reports "process not found" and "access denied" by exiting
+    non-zero, and `subprocess.run` raises nothing for either. Returning on the
+    strength of having merely RUN it would skip the fallback in exactly the
+    cases that need one."""
+    monkeypatch.setattr(claude_login, "_windows", lambda: True)
+    monkeypatch.setattr(
+        claude_login.subprocess, "run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 128))
+    proc = _FakeProc(text=PROMPT)
+    claude_login._stop(claude_login._Login(proc=proc, started_at=0.0, tail=[]),
+                       force=False)
+    assert proc.terminated is True
+    proc.finish()
+
+
 def test_taskkill_missing_falls_back_to_signalling_the_child(monkeypatch):
     """Killing cmd.exe alone is worth little behind a shim, but it beats not
     trying — and the fallback must not raise out of a cancel."""
-    monkeypatch.setattr(claude_login.os, "name", "nt")
+    monkeypatch.setattr(claude_login, "_windows", lambda: True)
 
     def no_taskkill(*a, **k):
         raise FileNotFoundError("taskkill")

--- a/tests/test_schedule_images.py
+++ b/tests/test_schedule_images.py
@@ -602,7 +602,10 @@ def test_a_send_with_images_pre_allows_the_task_shots_dir(tmp_path, monkeypatch)
                     "session_id": "", "permission_mode": "auto",
                     "images": [shot]})
     assert seen["kw"]["extra_read_dirs"] == [schedule.shots_dir()]
-    assert shot in seen["prompt"]
+    # The wire spells the path with forward slashes on every platform (the
+    # template's reader and the Read rule both do), so a Windows join is
+    # compared in that spelling too.
+    assert shot.replace("\\", "/") in seen["prompt"]
 
 
 @pytest.mark.skipif(os.name == "nt",


### PR DESCRIPTION
The strip could already install and update Claude Code. A signed-out one was still a sentence: *"Open a terminal, run `claude`, type /login and finish signing in."* That was the only route through the TUI door — but `claude auth login` is a second door, and it does not need an OAuth code pasted anywhere.

## The finding this is built on

Run headless, `claude auth login` looks like a paste flow, and that is what its printed output shows — a URL on stdout and `Paste code here if prompted >`. **The URL it hands the browser is a different one.** Same authorization, identical `state` and `code_challenge`, two redirect targets:

| | `redirect_uri` |
|---|---|
| printed to stdout | `https://platform.claude.com/oauth/code/callback` (paste) |
| opened in the browser | `http://localhost:<port>/callback` (loopback) |

The CLI binds that loopback listener itself and completes when the redirect lands. On a desktop app with the user's browser on the same machine that is the normal path, so **the app never handles an OAuth code at all** — it spawns, waits, and re-probes `claude auth status`. The paste flow stays as the CLI's own fallback for a machine whose browser cannot reach it.

A consequence worth stating: do **not** read the printed URL and open it. That is the paste URL, and opening it forces the manual flow for no reason. The loopback URL is never printed, so the child opens the browser itself — which is also the only thing that works on all three platforms (`BROWSER` is a POSIX convention; macOS and Windows shell out to `open`/`start`).

## Shape

`fused_render/claude_login.py` is `canvases.py`'s `fused login` pattern rather than a third `claude_install` action: a live child under a lock, a watchdog, and a client that polls until the health snapshot says signed in. Install and update are machine time and run to completion; this waits on a person, so it needs a cancel and must not park in the install slot while a browser window sits open. Unlike `fused login` there is no PKCE driver to write — that file exists only to work around the Fused CLI's 30-second callback timeout, and Claude Code's listener has no such limit.

- `POST /api/claude/login` — X-Fused guarded (spawns a process *and* opens a browser window), single-flight, 409 with the reason
- `GET /api/claude/login` — cheap local read, no spawn. A separate record rather than a field on `/api/claude/health`, which is cached behind a fingerprint and a 60-second age gate; a live field inside a cached payload would read stale
- `POST /api/claude/login/cancel` — settles the record before answering, so the poll stops on its own

Success is never inferred from the exit code — the child exits on failure too. The authority stays `claude auth status`, via the refresh endpoint the strip already calls.

## Two bugs the fakes could not have caught

Both found by running it against the real CLI, not by the tests.

- **The drain returned nothing.** `stdout.read(n)` on a buffered stream waits for *n* characters, and this child prints ~700 then blocks on a human — so the tail stayed empty until the child died, which is after the record has already fallen back to a generic sentence. `os.read` on the raw fd returns what one syscall got. The test fake now uses a real `os.pipe()` so it cannot flatter the code again.
- **The failure line was discarded.** The prompt carries no newline, so the CLI writes its diagnosis onto the *same* line: `Paste code here if prompted > Login failed: Request failed with status code 400`. Skipping any line that mentioned the prompt threw the diagnosis away with it, and the record blamed `Opening browser to sign in…`. The prompt is stripped as a prefix now.

A third, quieter one: `in_flight` was computed from `proc.poll()`, so the strip could read a settled record in the window before `error` was written and show the row back with no explanation. It is now a `settled` event set after the worker has drained and reaped.

## Output discipline

The child's output is a bounded in-memory tail, never mirrored into `jobs.py` and never written to disk — it carries the authorize URL's `state` and PKCE challenge, and phase 2 (the paste fallback for headless machines) would put a live OAuth code on the same stream. Only one derived sentence leaves the module, and lines carrying a URL are excluded *by shape*, so the nonce cannot reach the UI by construction. Pinned by a test.

## Verification

Against Claude Code 2.1.250: both URLs captured in a single run, the loopback listener and its `/callback` route probed, output captured while the child is still waiting, and a driven failure surfacing the CLI's own words verbatim.

- `tests/test_claude_login.py` — 22 pass
- `test_claude_install.py` / `test_claude_health.py` / `test_trouble_parity.py` — 141 pass
- frontend: `tsc --noEmit` clean, boundaries clean, 2908 pass
- Full suites carry pre-existing failures unrelated to this change (map templates' geo deps, engine interpreter probes); each was confirmed failing identically on a clean tree.

**The success path is the one thing not verified end to end** — completing a sign-in needs a credential this container does not have. First thing to do on a real machine is confirm the child exits and `auth status` flips.

## Not in this PR

The paste fallback for headless boxes and browser-on-another-device. If no browser opens, loopback never fires and the child sits at the prompt until the watchdog. That is also the only place the OAuth-code handling applies — `stdin` is already a pipe rather than `DEVNULL` so the door stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLEX1vjpg3EgVp5trHLQoM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLEX1vjpg3EgVp5trHLQoM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and spawns processes that open the user’s browser, but OAuth secrets are filtered from API responses and success is verified via `claude auth status` rather than exit codes.
> 
> **Overview**
> Replaces the signed-out health strip’s terminal `/login` instructions with a **Sign in** action that starts the CLI’s own browser OAuth loopback flow—the app never receives an OAuth code.
> 
> **Backend:** New `fused_render/claude_login.py` runs `claude auth login` under a single-flight lock (separate from install), polls `in_flight` / derived `error`, supports cancel and a 10-minute watchdog, re-probes `claude auth status` after a clean exit, and uses `os.read` draining plus Windows `taskkill /T` so npm `.cmd` shims don’t wedge the UI. OAuth `state`/URLs stay in an in-memory tail only. Routes: `POST/GET /api/claude/login`, `POST /api/claude/login/cancel` (mutating calls X-Fused guarded).
> 
> **Frontend:** API helpers and `ClaudeHealthStrip` login state, slower polling while in flight, progress copy, **Cancel**, and recovery of an in-flight sign-in on remount.
> 
> **Smaller fixes:** Scheduled attachment JSON normalizes path separators to `/`; agent read-dir scoping skips filesystem roots via `os.path.dirname` instead of string stripping (fixes Windows drive roots).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfea75cb188d0cf94ccf2daaeadea98a34558407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->