### PR TITLE
Framed views inherit theme instead of racing matchMedia (.fused embed random dark/light)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,7 +26,34 @@
       var theme;
       if (pref === "light" || pref === "dark") {
         theme = pref;
-      } else {
+      }
+      if (!theme) {
+        /* FRAMED shell (an /explorer/embed pane, e.g. the fusedapp template's
+           entry iframe): inherit the nearest same-origin ancestor's resolved
+           theme instead of asking matchMedia. Inside an iframe the media query
+           answers with the parent iframe element's color-scheme, not the OS,
+           and this races the ancestor's own paint — with no change event when
+           it settles — which made a System-pref .fused app land dark or light
+           at random per refresh. Ancestors resolve pre-paint, before any of
+           their iframes exist, so the climb never reads an unset one. Mirrors
+           inheritedTheme() in static/runtime.js; lib/theme.ts follows the
+           same rule for post-boot re-applies. */
+        try {
+          var w = window;
+          while (w.parent !== w) {
+            w = w.parent;
+            var el = w.document.documentElement;
+            var t = el.getAttribute("data-theme") || el.style.colorScheme;
+            if (t === "light" || t === "dark") {
+              theme = t;
+              break;
+            }
+          }
+        } catch (e) {
+          /* cross-origin ancestor — resolve on our own below */
+        }
+      }
+      if (!theme) {
         try {
           theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
         } catch (e) {

--- a/frontend/src/platform/lib/theme.ts
+++ b/frontend/src/platform/lib/theme.ts
@@ -65,9 +65,35 @@ function saveThemePref(pref: ThemePref): void {
   }
 }
 
+// A FRAMED shell (an /explorer/embed pane) must not ask matchMedia: inside an
+// iframe the query reflects the parent iframe element's color-scheme, not the
+// OS, races the ancestor's paint, and Chrome fires no change event when the
+// inherited value settles — a System-pref .fused app landed dark or light at
+// random per refresh. Inherit the nearest same-origin ancestor's resolved
+// theme instead; ancestors resolve pre-paint, before their iframes exist, so
+// the climb never reads an unset one. Returns the resolving window too, so
+// subscribeThemePref can observe it for later flips. Mirrors inheritedTheme()
+// in static/runtime.js and the index.html bootstrap.
+function inheritedTheme(): { theme: Theme; win: Window } | null {
+  let w: Window = window;
+  try {
+    while (w.parent !== w) {
+      w = w.parent;
+      const el = w.document.documentElement;
+      const t = el.getAttribute("data-theme") || el.style.colorScheme;
+      if (t === "light" || t === "dark") return { theme: t, win: w };
+    }
+  } catch {
+    // cross-origin ancestor — resolve on our own
+  }
+  return null;
+}
+
 // The OS/browser preference. Defaults to dark when matchMedia is unavailable,
 // so a browser that can't answer keeps today's appearance.
 export function systemTheme(): Theme {
+  const inherited = inheritedTheme();
+  if (inherited) return inherited.theme;
   try {
     return window.matchMedia(DARK_QUERY).matches ? "dark" : "light";
   } catch {
@@ -114,10 +140,28 @@ function subscribeThemePref(onChange: () => void): () => void {
   } catch {
     media = null; // no matchMedia — pinned Light/Dark still works
   }
+  // A framed shell inherits its System theme (see inheritedTheme) — an OS
+  // flip only reaches the top-level document's matchMedia and raises no
+  // `storage` event, so follow the resolving ancestor's attribute writes;
+  // every frame does this, cascading the flip down one document at a time.
+  let observer: MutationObserver | null = null;
+  try {
+    const source = inheritedTheme();
+    if (source) {
+      observer = new MutationObserver(onChange);
+      observer.observe(source.win.document.documentElement, {
+        attributes: true,
+        attributeFilter: ["data-theme", "style"],
+      });
+    }
+  } catch {
+    observer = null; // cross-origin parent — matchMedia above is all we have
+  }
   return () => {
     window.removeEventListener(THEME_EVENT, onChange);
     window.removeEventListener("storage", onStorage);
     media?.removeEventListener("change", onChange);
+    observer?.disconnect();
   };
 }
 

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -341,7 +341,8 @@
   // before the document's own stylesheet, let alone its first paint.
   //
   // The theme is READ here rather than pushed in from the shell: reading the
-  // same localStorage key (same origin) plus this document's own matchMedia
+  // same localStorage key (same origin), a same-origin ancestor's resolved
+  // theme, or failing both this document's own matchMedia
   // means the shell never has to reach into a view, so a theme change is never
   // a re-render and can never remount or reload a live iframe. Cross-window
   // convergence rides the `storage` event, which fires in every other
@@ -353,6 +354,45 @@
   var THEME_KEY = "fused-render:theme";
   var DARK_QUERY = "(prefers-color-scheme: dark)";
 
+  // With the preference on System, only a TOP-LEVEL document may ask
+  // matchMedia. Inside an iframe, `prefers-color-scheme` is not the OS: the
+  // browser derives it from the computed `color-scheme` of the parent's
+  // <iframe> element (CSS Color Adjust §"preferred color scheme"). This
+  // script is parser-blocking at the very top of the child's <head>, so in a
+  // nested chain (embed shell → fusedapp template → entry page) it can run
+  // before an ancestor's own color-scheme has been applied — the query then
+  // answers with a transient default, and Chrome does not fire the matchMedia
+  // `change` event when the inherited value settles, so the wrong answer
+  // froze until the next refresh, winning or losing the race at random.
+  // Instead a framed document INHERITS the nearest same-origin ancestor's
+  // already-resolved theme (they run this same script, or are the shell whose
+  // index.html bootstrap sets `data-theme` pre-paint), and the mutation
+  // observer in startTheme keeps it following later flips.
+  // The inherit is race-free where matchMedia was not: an ancestor's copy of
+  // this script is parser-blocking at the top of ITS <head>, and its iframes
+  // are created by content that parses after it — so by the time this child
+  // document exists, every same-origin ancestor already carries `data-theme`
+  // or `style.colorScheme` (the embed shell sets `data-theme` in index.html's
+  // pre-paint bootstrap, likewise before any iframe mounts).
+  //
+  // Returns { theme, win } — `win` is the ancestor the value came from, so
+  // startTheme can observe THAT document for later flips (observing a nearer
+  // non-participating ancestor would freeze the theme on an OS flip).
+  function inheritedTheme() {
+    var w = window;
+    try {
+      while (w.parent !== w) {
+        w = w.parent;
+        var el = w.document.documentElement;
+        var t = el.getAttribute("data-theme") || el.style.colorScheme;
+        if (t === "light" || t === "dark") return { theme: t, win: w };
+      }
+    } catch (e) {
+      /* cross-origin ancestor — stop climbing, resolve on our own */
+    }
+    return null;
+  }
+
   function resolvedTheme() {
     var pref = null;
     try {
@@ -361,6 +401,8 @@
       /* private mode / blocked storage — fall through to the OS preference */
     }
     if (pref === "light" || pref === "dark") return pref;
+    var inherited = inheritedTheme();
+    if (inherited) return inherited.theme;
     try {
       return window.matchMedia(DARK_QUERY).matches ? "dark" : "light";
     } catch (e) {
@@ -412,6 +454,22 @@
       window.matchMedia(DARK_QUERY).addEventListener("change", apply);
     } catch (e) {
       /* no matchMedia — a pinned Light/Dark still works */
+    }
+    // Framed documents inherit their theme (see inheritedTheme) — but a
+    // System-mode OS flip only reaches the top-level document's matchMedia,
+    // and no `storage` event fires for it. Follow the resolving ancestor's
+    // theme by observing the attributes it writes; each frame does this, so
+    // the flip cascades down a nested chain one document at a time.
+    try {
+      var source = inheritedTheme();
+      if (source) {
+        new MutationObserver(apply).observe(source.win.document.documentElement, {
+          attributes: true,
+          attributeFilter: ["data-theme", "style"],
+        });
+      }
+    } catch (e) {
+      /* cross-origin parent — matchMedia above is all we have */
     }
   }
 


### PR DESCRIPTION
## Bug
Opening a `.fused` single-file app at `/explorer/embed/...` picked dark or light at random per refresh (System appearance pref).

## Mechanism (confirmed live on OpenSearch.fused)
Inside an iframe, `prefers-color-scheme` is not the OS — Chrome derives it from the computed `color-scheme` of the parent's `<iframe>` element. The .fused chain is the deepest nesting we have (embed shell → fusedapp template → entry page). The child's parser-blocking runtime.js could run before an ancestor's `color-scheme` had applied, capture the transient "light" answer, and Chrome never fires the matchMedia `change` event when the inherited value settles — frozen wrong until the next refresh. Per-frame probe on a wrong refresh: top and fusedapp frames `dark`/`matches:true`, inner frames `light` with `matches:false`.

## Fix
`runtime.js` only: with the pref on System, a framed document now inherits the nearest same-origin ancestor's already-resolved theme (`data-theme` / `style.colorScheme`) instead of asking matchMedia; only a top-level document consults matchMedia. Race-free because every ancestor writes those attributes parser-blocking/pre-paint, before any of its iframes can exist. OS flips cascade down via a MutationObserver on the resolving ancestor (no `storage` event fires for an OS flip, and the matchMedia change event is exactly what Chrome doesn't deliver here).

Amends D134's "this document's own matchMedia" wording — flagging in case that deserves a DECISIONS row (left out per standing call).

## Verify
Hard-refresh (cached runtime.js will look like no change): appearance System, reload `http://127.0.0.1:3777/explorer/embed/Users/vasu/Downloads/OpenSearch.fused` ~10×. Inner app should match OS every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme resolution only; behavior is scoped to iframe/embed System mode with cross-file sync already guarded by existing test_theme.py key pinning.
> 
> **Overview**
> Fixes **random dark/light flashes** when a `.fused` app runs under `/explorer/embed` with **System** appearance: nested iframes no longer rely on `matchMedia("(prefers-color-scheme: dark)")`, which can answer from the parent `<iframe>`’s `color-scheme`, race ancestor paint, and **never emit a `change` event** when the inherited value settles.
> 
> With no explicit **Light/Dark** `localStorage` pref, resolution now **walks same-origin parents** for `data-theme` or `style.colorScheme` before falling back to OS `matchMedia`. The same rule is applied in **`fused_render/static/runtime.js`**, the **`frontend/index.html` pre-paint bootstrap**, and **`frontend/src/platform/lib/theme.ts`** so first paint and post-boot updates stay aligned.
> 
> For ongoing **System** mode in framed shells, **`subscribeThemePref` / `startTheme`** add a **`MutationObserver`** on the resolving ancestor’s `<html>` so OS-driven theme flips propagate down nested frames (no `storage` event on an OS flip).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5728222faeea8acf7c6c2bae7bd28623e33bd6fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->