### PR TITLE
Projects sidebar: pick an app's icon from the row glyph

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,7 +60,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2008,7 +2007,6 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2253,7 +2251,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -3037,7 +3034,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3425,7 +3421,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
       "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4859,7 +4854,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4872,7 +4866,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5679,7 +5672,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5802,7 +5794,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5959,7 +5950,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,6 +60,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2007,6 +2008,7 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2251,6 +2253,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -3034,6 +3037,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3421,6 +3425,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
       "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4854,6 +4859,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4866,6 +4872,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5672,6 +5679,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5794,6 +5802,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5950,6 +5959,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2169,6 +2169,34 @@ export function appIconUrl(icon: string, mtime?: number | null): string {
   return rawUrl(icon) + (mtime ? "&v=" + Math.floor(mtime) : "");
 }
 
+/** Write (or replace) the app folder's `icon.svg` — the Projects row glyph
+ *  and the tab favicon. `svg` is a complete standalone document; the sidebar's
+ *  icon picker wraps the chosen emoji in one. */
+export async function setAppIcon(
+  path: string,
+  svg: string,
+): Promise<{ path: string; replaced: boolean }> {
+  const r = await fetch("/api/apps/icon", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-Fused": "1" },
+    body: JSON.stringify({ path, svg }),
+  });
+  if (!r.ok) throw httpError(await r.json().catch(() => null), r.status);
+  return r.json();
+}
+
+/** Delete the app folder's `icon.svg` — back to the generic mark. */
+export async function removeAppIcon(
+  path: string,
+): Promise<{ removed: boolean }> {
+  const r = await fetch(`/api/apps/icon?path=${encodeURIComponent(path)}`, {
+    method: "DELETE",
+    headers: { "X-Fused": "1" },
+  });
+  if (!r.ok) throw httpError(await r.json().catch(() => null), r.status);
+  return r.json();
+}
+
 /** Take an app off the desk. SIDE EFFECT, by design: every task whose project
  *  is the folder or inside it is archived (the same gesture as
  *  `archiveTask`, per task — cancelled work, filed session, nothing destroyed). */

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2166,7 +2166,9 @@ export function getAppIcon(fsPath: string): Promise<AppIconResult> {
 /** The URL to draw an app icon from: the raw file, with its mtime as a cache
  *  key so an edited icon.svg shows up without a hard reload. */
 export function appIconUrl(icon: string, mtime?: number | null): string {
-  return rawUrl(icon) + (mtime ? "&v=" + Math.floor(mtime) : "");
+  // Full float mtime, not the floored second — a same-second replacement of
+  // icon.svg must still change the URL (current-apps-lib.iconUrlFor agrees).
+  return rawUrl(icon) + (mtime ? "&v=" + mtime : "");
 }
 
 /** Write (or replace) the app folder's `icon.svg` — the Projects row glyph

--- a/frontend/src/platform/ui/IconPicker.tsx
+++ b/frontend/src/platform/ui/IconPicker.tsx
@@ -166,11 +166,23 @@ interface IconPickerProps {
   onPick: (icon: string) => void;
   onRemove: () => void;
   onClose: () => void;
+  /** Selector for THIS picker's own trigger glyphs — an outside mousedown on
+   *  one of them is left to the host's click handler (the toggle), everything
+   *  else closes. Each host must scope it to its own glyphs: two sections
+   *  sharing a loose selector leave each other's pickers open (Bugbot,
+   *  2026-08-31). Defaults to the Bookmarks section's glyphs. */
+  toggleSelector?: string;
 }
 
 const GRID_COLS = 8;
 
-export default function IconPicker({ anchor, onPick, onRemove, onClose }: IconPickerProps) {
+export default function IconPicker({
+  anchor,
+  onPick,
+  onRemove,
+  onClose,
+  toggleSelector = ".bookmark-glyph:not(.folder-glyph):not(.current-app-glyph)",
+}: IconPickerProps) {
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const baseId = useId();
@@ -192,9 +204,11 @@ export default function IconPicker({ anchor, onPick, onRemove, onClose }: IconPi
     const onDocMouseDown = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
       if (rootRef.current && rootRef.current.contains(target)) return;
-      // Glyph clicks are the toggle — let the sidebar's click handler decide
-      // (closing here would make it reopen the picker immediately after).
-      if (target.closest(".bookmark-glyph:not(.folder-glyph)")) return;
+      // Clicks on this picker's own trigger glyphs are the toggle — let the
+      // host's click handler decide (closing here would make it reopen the
+      // picker immediately after). Anything else — another section's glyphs
+      // included — closes.
+      if (target.closest(toggleSelector)) return;
       onClose();
     };
     // Capture phase + stopPropagation so Escape closes only the picker — a
@@ -219,7 +233,7 @@ export default function IconPicker({ anchor, onPick, onRemove, onClose }: IconPi
       document.removeEventListener("keydown", onKeyDown, true);
       document.removeEventListener("scroll", onScroll, true);
     };
-  }, [onClose]);
+  }, [onClose, toggleSelector]);
 
   // Keep the popover on-screen: it opens below the glyph, flips above when it
   // would overflow the bottom edge.

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -26,9 +26,12 @@ import React, {
 } from "react";
 import {
   getCurrentApps,
+  removeAppIcon,
   removeCurrentApp,
+  setAppIcon,
   type CurrentAppEntry,
 } from "@platform/lib/api";
+import IconPicker from "@platform/ui/IconPicker";
 import { navigateUrl } from "@platform/lib/router";
 import { Modal } from "@platform/ui/modal/Modal";
 import { HeroComposer } from "@apps/builder/HomeHero";
@@ -52,6 +55,22 @@ import {
 // Bumped from `current-apps-order` with the redesign: the saved list was slugs
 // and is folder paths now, and a slug-shaped order would match nothing.
 export const ORDER_KEY = "fused-render:current-apps-order:v2";
+
+/** The picked emoji as a standalone icon.svg document — square viewBox, no
+ *  fixed size, transparent ground (a colour emoji carries its own colours, so
+ *  it reads on both themes; see skills/fused-render-app-icon). The same file
+ *  a hand-authored icon.svg would be, just generated. */
+function emojiIconSvg(emoji: string): string {
+  const safe = emoji
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">' +
+    '<text x="32" y="32" text-anchor="middle" dominant-baseline="central" ' +
+    `font-size="52">${safe}</text></svg>`
+  );
+}
 
 // The section fold, "1" when hidden — the Bookmarks section's own key pattern.
 export const COLLAPSED_KEY = "fused-render:current-apps-collapsed";
@@ -173,11 +192,13 @@ function CurrentAppRow({
   active,
   drag,
   onRemoved,
+  onGlyphClick,
 }: {
   app: CurrentApp;
   active: boolean;
   drag: RowDragProps;
   onRemoved: () => void;
+  onGlyphClick: (e: React.MouseEvent<HTMLSpanElement>, path: string) => void;
 }) {
   const [busy, setBusy] = useState(false);
   // The destination keeps the TAB the user is on (owner, 2026-08-26): switching
@@ -232,7 +253,14 @@ function CurrentAppRow({
       draggable
       {...drag}
     >
-      <span className="bookmark-glyph current-app-glyph" aria-hidden="true">
+      {/* The glyph is the icon picker's toggle — the Bookmarks pattern
+          (BookmarksSection.onBookmarkGlyphClick), except the pick lands on
+          disk as the folder's icon.svg rather than in the bookmarks tree. */}
+      <span
+        className="bookmark-glyph current-app-glyph"
+        title="Change icon"
+        onClick={(e) => onGlyphClick(e, app.path)}
+      >
         {app.iconUrl ? (
           // The app's own icon.svg in the generic mark's slot, drawn as is —
           // the author's colours, no mask or tint (owner, 2026-08-27). Not
@@ -390,6 +418,43 @@ export default function CurrentAppsSection() {
   });
 
   const refetch = useCallback(() => setRefreshEpoch((n) => n + 1), []);
+
+  // ---- the icon picker -------------------------------------------------------
+  // The glyph toggles the Bookmarks' emoji picker (IconPicker), anchored to
+  // itself. A pick is wrapped in a standalone svg and written to the folder's
+  // icon.svg (POST /api/apps/icon) — the file the row and the tab favicon
+  // already read — and the refetch brings back the new mtime, which is what
+  // busts the <img> cache. Remove deletes the file; the row falls back to the
+  // generic mark.
+  const [iconPicker, setIconPicker] = useState<{
+    path: string;
+    top: number;
+    left: number;
+  } | null>(null);
+  const onGlyphClick = useCallback(
+    (e: React.MouseEvent<HTMLSpanElement>, path: string) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const rect = e.currentTarget.getBoundingClientRect();
+      setIconPicker((cur) =>
+        cur?.path === path ? null : { path, top: rect.top, left: rect.left },
+      );
+    },
+    [],
+  );
+  const onPickIcon = async (icon: string | null) => {
+    const target = iconPicker;
+    setIconPicker(null);
+    if (!target) return;
+    try {
+      if (icon === null) await removeAppIcon(target.path);
+      else await setAppIcon(target.path, emojiIconSvg(icon));
+    } catch {
+      // A failed write leaves the old glyph; the refetch shows the truth.
+    }
+    refetch();
+  };
+
   const render = useCallback(
     (app: CurrentApp) => (
       <CurrentAppRow
@@ -398,10 +463,11 @@ export default function CurrentAppsSection() {
         active={app.path === onPath}
         drag={dragProps(app.path)}
         onRemoved={refetch}
+        onGlyphClick={onGlyphClick}
       />
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dragProps closes over `apps`
-    [onPath, apps, refetch],
+    [onPath, apps, refetch, onGlyphClick],
   );
   // The "+ New app" row at the foot of the list opens the /apps composer in a
   // modal (D489). The section ALWAYS renders: a door to "make one" is exactly
@@ -454,6 +520,14 @@ export default function CurrentAppsSection() {
           </span>
           <span className="bookmark-name">New app</span>
         </div>
+      )}
+      {iconPicker && (
+        <IconPicker
+          anchor={iconPicker}
+          onPick={(icon) => onPickIcon(icon)}
+          onRemove={() => onPickIcon(null)}
+          onClose={() => setIconPicker(null)}
+        />
       )}
       {composing && (
         // The SAME composer /apps and /home show (apps/builder/HomeHero.tsx):

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -256,8 +256,12 @@ function CurrentAppRow({
       {/* The glyph is the icon picker's toggle — the Bookmarks pattern
           (BookmarksSection.onBookmarkGlyphClick), except the pick lands on
           disk as the folder's icon.svg rather than in the bookmarks tree. */}
+      {/* `current-app-icon-toggle` marks the glyphs that toggle THIS
+          section's picker — the selector the IconPicker below whitelists.
+          The "+ New app" glyph deliberately lacks it, so a click there
+          closes an open picker instead of leaving it under the modal. */}
       <span
-        className="bookmark-glyph current-app-glyph"
+        className="bookmark-glyph current-app-glyph current-app-icon-toggle"
         title="Change icon"
         onClick={(e) => onGlyphClick(e, app.path)}
       >
@@ -537,6 +541,7 @@ export default function CurrentAppsSection() {
       {iconPicker && (
         <IconPicker
           anchor={iconPicker}
+          toggleSelector=".current-app-icon-toggle"
           onPick={(icon) => onPickIcon(icon)}
           onRemove={() => onPickIcon(null)}
           onClose={() => setIconPicker(null)}

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -273,7 +273,20 @@ function CurrentAppRow({
             draggable={false}
           />
         ) : (
-          "▣"
+          // The brand's four-point star (the app icon's sparkle) as the
+          // generic mark, on currentColor so it follows the glyph's tokens
+          // (muted at rest, accent on the active row) — the SidebarFrame
+          // cube's own posture.
+          <svg
+            className="current-app-star"
+            width="12"
+            height="12"
+            viewBox="0 0 64 64"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M32 2 C36.5 20.5 43.5 27.5 62 32 C43.5 36.5 36.5 43.5 32 62 C27.5 43.5 20.5 36.5 2 32 C20.5 27.5 27.5 20.5 32 2 Z" />
+          </svg>
         )}
       </span>
       <a

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -80,10 +80,11 @@ export function currentApps(
 /** api.ts `appIconUrl` restated (raw file + mtime cache key) — that module is
  *  not importable here for the same DOM-free reason as the codec above. */
 function iconUrlFor(icon: string, mtime?: number | null): string {
+  // The FULL float mtime as the cache key, not the floored second: picking a
+  // new icon twice inside one second must still change the URL, or the row
+  // keeps serving the browser's cached previous emoji (Bugbot, 2026-08-31).
   return (
-    "/api/fs/raw?path=" +
-    encodeURIComponent(icon) +
-    (mtime ? "&v=" + Math.floor(mtime) : "")
+    "/api/fs/raw?path=" + encodeURIComponent(icon) + (mtime ? "&v=" + mtime : "")
   );
 }
 

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -352,6 +352,85 @@ def api_app_icon(path: str):
     return found or {"icon": None}
 
 
+# A generated emoji glyph is a few hundred bytes; a hand-drawn one a few KB.
+# 64 KiB is headroom, not a target.
+_ICON_MAX_BYTES = 64 * 1024
+
+
+@router.post("/api/apps/icon")
+def api_app_set_icon(
+    path: str = Body(default="", embed=True),
+    svg: str = Body(default="", embed=True),
+    x_fused: str | None = Header(default=None),
+):
+    """Write (or replace) the app's ``icon.svg`` — the Projects row glyph and
+    the tab favicon (`current_apps.app_icon`). The sidebar's icon picker posts
+    here: the row hands over its folder path and the emoji the user picked,
+    wrapped client-side in a small standalone svg. Ownership is the same rule
+    the GET applies (`current_apps.app_dir_for`), so anything the row can show
+    an icon for can take one, linked apps included. The svg lands via a
+    sibling temp file and ``os.replace`` — the preview.png posture — so an
+    interrupted write never leaves a truncated file the favicon would serve.
+    """
+    from fused_render import current_apps
+
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    if not path or not os.path.isabs(path):
+        return _error("path must be an absolute app folder path")
+    folder = current_apps.app_dir_for(path)
+    if folder is None:
+        return _error("not an app folder", status=404)
+    body = svg.strip() if isinstance(svg, str) else ""
+    if not (body.startswith("<svg") or body.startswith("<?xml")):
+        return _error("icon must be an svg document")
+    if len(body.encode("utf-8")) > _ICON_MAX_BYTES:
+        return _error("icon is larger than 64 KiB")
+    target = os.path.join(folder, current_apps.ICON_NAME)
+    replaced = os.path.isfile(target)
+    tmp = os.path.join(folder, f".{current_apps.ICON_NAME}.{os.getpid()}.tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(body)
+        os.replace(tmp, target)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return _error(f"could not write icon.svg: {exc.strerror or exc}", status=500)
+    return {"path": target, "replaced": replaced}
+
+
+@router.delete("/api/apps/icon")
+def api_app_remove_icon(
+    path: str,
+    x_fused: str | None = Header(default=None),
+):
+    """Delete the app's ``icon.svg`` — the picker's "Remove", back to the
+    generic mark. A folder without the file is already there: ``removed``
+    false, not an error."""
+    from fused_render import current_apps
+
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    if not path or not os.path.isabs(path):
+        return _error("path must be an absolute app folder path")
+    folder = current_apps.app_dir_for(path)
+    if folder is None:
+        return _error("not an app folder", status=404)
+    target = os.path.join(folder, current_apps.ICON_NAME)
+    try:
+        os.unlink(target)
+    except FileNotFoundError:
+        return {"removed": False}
+    except OSError as exc:
+        return _error(f"could not remove icon.svg: {exc.strerror or exc}", status=500)
+    return {"removed": True}
+
+
 @router.get("/api/apps/entry")
 def api_app_entry(path: str):
     """The folder's app entry (its first tagged top-level page — the one rule,


### PR DESCRIPTION
Clicking a Projects row's glyph now opens the same emoji icon picker the Bookmarks section uses, anchored to the glyph. Picking an emoji wraps it client-side in a small standalone SVG (square viewBox, no fixed size, transparent ground — a colour emoji reads on both themes) and writes it to the app folder's `icon.svg`, the file the row glyph and the tab favicon already read. "Remove" deletes the file and the row falls back to the generic mark.

Server side, a new `POST /api/apps/icon` (and `DELETE` on the same route) does the write: ownership resolved by the GET's own rule (`current_apps.app_dir_for`, so linked apps take icons too), `X-Fused`-gated, content sniffed for an SVG document, capped at 64 KiB, and landed via sibling temp file + `os.replace` — the `POST /api/apps/preview` posture. The section refetches after the write; the new mtime in the listing busts the `<img>` cache so the row updates immediately.

Smoke pending — needs the live pick-an-emoji-and-see-the-row-update loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New mutating endpoints write/delete files under app folders, but they reuse existing ownership rules, X-Fused gating, and atomic replace — not auth, but real disk I/O on user-chosen paths.
> 
> **Overview**
> **Projects** rows can change their glyph from the sidebar: clicking the icon opens the shared **IconPicker**, and a chosen emoji is written as the app folder’s **`icon.svg`** (the same file the row and tab favicon already use). **Remove** deletes that file and the row falls back to a new generic **four-point star** mark instead of the old `▣` character.
> 
> The client adds **`setAppIcon`** / **`removeAppIcon`** and refetches current apps after each change. Icon URLs now use the **full `mtime` float** as the `&v=` cache key (not `Math.floor`), so rapid re-picks in the same second still bust the browser cache — mirrored in **`current-apps-lib.iconUrlFor`**.
> 
> **`IconPicker`** gains an optional **`toggleSelector`** so outside clicks only ignore *this* section’s trigger glyphs; Projects passes **`.current-app-icon-toggle`** so Bookmarks and Projects pickers do not leave each other open.
> 
> On the server, **`POST`** and **`DELETE`** **`/api/apps/icon`** validate absolute app paths via **`app_dir_for`**, require **`X-Fused`**, sniff SVG, cap size at 64 KiB, and write via temp file + **`os.replace`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad61d0f729d2fa42247b3a196936ff76a6fffe4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->