### PR TITLE
Current apps: green unread dot before the name

### DIFF
--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -247,7 +247,8 @@ function CurrentAppRow({
         "bookmark-row current-app-row" +
         (active ? " active" : "") +
         (app.exists ? "" : " is-missing") +
-        (app.running ? " is-running" : "")
+        (app.running ? " is-running" : "") +
+        (app.unread && !app.running ? " is-unread" : "")
       }
       title={tip}
       draggable
@@ -293,17 +294,6 @@ function CurrentAppRow({
           </svg>
         )}
       </span>
-      {/* The unread dot sits IN FRONT of the name (owner, 2026-08-31): a task
-          under this app finished and has not been read — the Tasks row's green,
-          worn per app. Yellow outranks green (one dot per row, the Tasks rule),
-          so it hides while anything runs; it clears when the task is read,
-          since it draws the raw doneUnread state, not a visit-stamped one. */}
-      {app.unread && !app.running && (
-        <span
-          className="sidebar-rail-dot is-unread current-app-unread"
-          aria-hidden="true"
-        />
-      )}
       <a
         className="bookmark-name"
         href={href}
@@ -318,6 +308,18 @@ function CurrentAppRow({
       {app.running && (
         <span
           className="sidebar-rail-dot is-running current-app-running"
+          aria-hidden="true"
+        />
+      )}
+      {/* The unread dot: a task under this app finished and has not been read —
+          the Tasks row's green, worn per app, in the running dot's own slot
+          after the name (owner, 2026-08-31). Yellow outranks green (one dot per
+          row, the Tasks rule), so it hides while anything runs; it clears when
+          the task is read, since it draws the raw doneUnread state, not a
+          visit-stamped one. */}
+      {app.unread && !app.running && (
+        <span
+          className="sidebar-rail-dot is-unread current-app-unread"
           aria-hidden="true"
         />
       )}

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -35,7 +35,7 @@ import IconPicker from "@platform/ui/IconPicker";
 import { navigateUrl } from "@platform/lib/router";
 import { Modal } from "@platform/ui/modal/Modal";
 import { HeroComposer } from "@apps/builder/HomeHero";
-import { opensElsewhere } from "@shell/tasks-lib";
+import { isDoneUnread, opensElsewhere } from "@shell/tasks-lib";
 import { pokeTasks, useTasksPulseRows } from "@shell/tasksPulse";
 import {
   appPageTabFromSearch,
@@ -293,6 +293,17 @@ function CurrentAppRow({
           </svg>
         )}
       </span>
+      {/* The unread dot sits IN FRONT of the name (owner, 2026-08-31): a task
+          under this app finished and has not been read — the Tasks row's green,
+          worn per app. Yellow outranks green (one dot per row, the Tasks rule),
+          so it hides while anything runs; it clears when the task is read,
+          since it draws the raw doneUnread state, not a visit-stamped one. */}
+      {app.unread && !app.running && (
+        <span
+          className="sidebar-rail-dot is-unread current-app-unread"
+          aria-hidden="true"
+        />
+      )}
       <a
         className="bookmark-name"
         href={href}
@@ -342,20 +353,27 @@ export default function CurrentAppsSection() {
     () => rows.filter((r) => r.status === "in_progress").map((r) => r.project || ""),
     [rows],
   );
+  // The projects with a finished-and-unread task — the raw doneUnread state
+  // the Tasks row's count chip reads, not the visit-stamped `unseen`: a dot
+  // per app clears by the task being READ, not by glancing at some page.
+  const unreadProjects = useMemo(
+    () => rows.filter(isDoneUnread).map((r) => r.project || ""),
+    [rows],
+  );
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const entries = useCurrentApps(keySignal, refreshEpoch);
   // A drop mutates `appOrder`, which React cannot see; this counter is what
   // turns that mutation into a render.
   const [orderEpoch, setOrderEpoch] = useState(0);
   const apps = useMemo(() => {
-    const found = currentApps(entries, runningProjects);
+    const found = currentApps(entries, runningProjects, unreadProjects);
     // Assigning during render is safe because it is idempotent: an app that
     // already has a sequence keeps it, so a double-invoked render (StrictMode)
     // or a re-run on the same rows cannot renumber anything.
     assignSequences(appOrder, found);
     return bySequence(found, appOrder);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- orderEpoch is the drag signal
-  }, [entries, runningProjects, orderEpoch]);
+  }, [entries, runningProjects, unreadProjects, orderEpoch]);
   // NOTHING is saved here. A new app, a removed one, a fetch landing — all of
   // those move rows on screen and write nothing to the store; the saved order is
   // an arrangement the user made, and only they can change it.

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -47,6 +47,9 @@ export interface CurrentApp {
   /** Something is running under it right now — the row wears the running dot.
    *  Read from the task pulse, which the sidebar already subscribes to. */
   running: boolean;
+  /** A task under it finished with something unread — the row wears the green
+   *  dot (unless running: yellow outranks green, the Tasks row's own rule). */
+  unread: boolean;
   /** The app's optional `icon.svg`, as a drawable URL (api.appIconUrl), or
    *  null — the glyph slot falls back to the generic mark. */
   iconUrl: string | null;
@@ -65,14 +68,17 @@ export function isUnderDir(project: string, dir: string): boolean {
 export function currentApps(
   entries: CurrentAppEntry[],
   runningProjects: Iterable<string>,
+  unreadProjects: Iterable<string> = [],
 ): CurrentApp[] {
   const live = [...runningProjects];
+  const fresh = [...unreadProjects];
   return entries.map((e) => ({
     path: e.path,
     name: e.name,
     kind: e.kind,
     exists: e.exists,
     running: live.some((p) => isUnderDir(p, e.path)),
+    unread: fresh.some((p) => isUnderDir(p, e.path)),
     iconUrl: e.icon ? iconUrlFor(e.icon, e.icon_mtime) : null,
   }));
 }

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -1199,21 +1199,16 @@ a.bookmark-name::after {
 /* The running dot sits after the name, in flow: the name gives up its
    stretch so the dot hugs the text instead of drifting to the row's end
    (under the hover-only actions). */
-.current-app-row.is-running .bookmark-name {
+.current-app-row.is-running .bookmark-name,
+.current-app-row.is-unread .bookmark-name {
   flex: 0 1 auto;
 }
 
-.current-app-running {
-  position: static;
-  flex: 0 0 auto;
-  margin-left: 6px;
-}
-
-/* The unread dot sits BEFORE the name (owner, 2026-08-31), never over the
-   glyph — the glyph slot is identity, the dot is state. */
+.current-app-running,
 .current-app-unread {
   position: static;
   flex: 0 0 auto;
+  margin-left: 6px;
 }
 
 .current-app-archive:disabled {

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -1209,6 +1209,13 @@ a.bookmark-name::after {
   margin-left: 6px;
 }
 
+/* The unread dot sits BEFORE the name (owner, 2026-08-31), never over the
+   glyph — the glyph slot is identity, the dot is state. */
+.current-app-unread {
+  position: static;
+  flex: 0 0 auto;
+}
+
 .current-app-archive:disabled {
   opacity: 0.5;
   cursor: default;


### PR DESCRIPTION
A current-apps row whose app has a finished task with something unread now wears the Tasks row's green dot in front of the name.

- `currentApps()` gains an `unreadProjects` input and an `unread` flag per row, matched with the same `isUnderDir` scope test as `running`.
- The sidebar section feeds it the pulse rows that pass `isDoneUnread` — the raw done+unread state the Tasks count chip reads, so the dot clears when the task is actually read, not on a page glance.
- One dot per row, the Tasks rule: yellow (running, after the name) outranks green (unread, before the name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar-only UI wired to existing task pulse and `isDoneUnread`; no API or auth changes.
> 
> **Overview**
> **Projects** rows in the sidebar now show the same **green unread** indicator as the Tasks entry when a finished task under that app still has unread output.
> 
> `currentApps()` takes **`unreadProjects`** and sets an **`unread`** flag per row using the existing **`isUnderDir`** scope (subfolders count). **`CurrentAppsSection`** derives those projects from the task pulse via **`isDoneUnread`**, so the dot clears when the task is marked read—not on a casual visit. **One dot per row**: the yellow **running** dot after the name still wins; the green dot only renders when **`!app.running`**. CSS reuses the in-flow dot layout already used for **running**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44cfe66907f9ee74141a73c0a03424c9d2f65ff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->