### PR TITLE
Projects sidebar: right-click context menu on app rows

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2240,6 +2240,41 @@ export async function removeCurrentApp(
   return r.json();
 }
 
+/** Rename the app's FOLDER on disk. The server settles the move the same way
+ *  an out-of-band move is settled: stores repointed, Claude sessions carried
+ *  along. Answers the new canonical path. */
+export function renameCurrentApp(
+  path: string,
+  name: string,
+): Promise<{ ok: boolean; path: string }> {
+  return postJson<{ ok: boolean; path: string }>("/api/current-apps/rename", {
+    path,
+    name,
+  });
+}
+
+/** Mark every message of every task under the app's folder read — clears the
+ *  row's unread dot in one gesture. */
+export function readCurrentAppTasks(
+  path: string,
+): Promise<{ ok: boolean; marked: number; tasks: number }> {
+  return postJson<{ ok: boolean; marked: number; tasks: number }>(
+    "/api/current-apps/read",
+    { path },
+  );
+}
+
+/** Archive every task under the app's folder — the ✕'s task half without its
+ *  desk half: the row stays. */
+export function archiveCurrentAppTasks(
+  path: string,
+): Promise<{ ok: boolean; archived: number; cancelled: number }> {
+  return postJson<{ ok: boolean; archived: number; cancelled: number }>(
+    "/api/current-apps/archive",
+    { path },
+  );
+}
+
 // Scaffold a new app folder and (optionally) create ONE task on its index.html
 // carrying `prompt`, due now — the New task form's own path, so the app's
 // Tasks tab lists it and the scheduler spawns the session. 409 = name

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -35,7 +35,7 @@ import {
   type CurrentAppEntry,
 } from "@platform/lib/api";
 import IconPicker from "@platform/ui/IconPicker";
-import { navigate, navigateUrl } from "@platform/lib/router";
+import { navigateUrl, urlForFsPath } from "@platform/lib/router";
 import { pushToast } from "@platform/lib/toast";
 import ContextMenu, { type MenuEntry } from "@platform/ui/ContextMenu";
 import { MenuIcons } from "@platform/ui/MenuIcons";
@@ -502,9 +502,9 @@ export default function CurrentAppsSection() {
   };
 
   // ---- the row's right-click menu ---------------------------------------------
-  // The app-card vocabulary where it overlaps (appCardMenu.ts): "Open in
-  // Explorer" is the app's FOLDER in fused-render's own explorer. The rest are
-  // the desk's own verbs — the dot, the tasks, the row itself.
+  // "Open app" is the app page header's own button (AppPage.tsx) — the entry
+  // page in a new tab. The rest are the desk's own verbs — the dot, the
+  // tasks, the row itself.
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -566,10 +566,14 @@ export default function CurrentAppsSection() {
 
   const menuItems = (app: CurrentApp): MenuEntry[] => [
     {
-      label: "Open in Explorer",
-      icon: MenuIcons.folder,
-      disabled: !app.exists,
-      onClick: () => navigate(app.path, { isDir: true }),
+      // The app page header's own "Open app": the entry page full-size in the
+      // explorer, in a new tab so the current page stays put.
+      label: "Open app",
+      icon: MenuIcons.open,
+      disabled: !app.exists || !app.entry,
+      onClick: () => {
+        if (app.entry) window.open(urlForFsPath(app.entry), "_blank", "noopener");
+      },
     },
     {
       label: "Rename…",

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -539,20 +539,22 @@ export default function CurrentAppsSection() {
       const r = await renameCurrentApp(app.path, name);
       // Carry the row's SEQUENCE to the new path in memory, so the rename does
       // not reshuffle the list (assignSequences would put an unknown path on
-      // top). Deliberately NOT saved — the store is written by a drag and only
-      // by a drag (the cross-tab rule above).
+      // top). The OLD path's entry is left in place: the fetched table still
+      // names it until the refetch lands, and deleting it early hands the row
+      // a fresh top-of-list sequence in that window (Bugbot). The prune on the
+      // next assignment drops it. Deliberately NOT saved — the store is
+      // written by a drag and only by a drag (the cross-tab rule above).
       const seq = appOrder.get(app.path);
       if (seq !== undefined && !appOrder.has(r.path)) {
-        appOrder.delete(app.path);
         appOrder.set(r.path, seq);
       }
       setRenaming(null);
       pokeTasks();
-      // The renamed app's page, if we are on it, now lives at the new folder.
+      // Refetch UNCONDITIONALLY — the desk row changed either way. Then, if
+      // we are on the renamed app's page, follow it to the new folder.
+      refetch();
       if (app.path === onPath) {
         navigateUrl(appPageUrl(r.path, appPageTabFromSearch(location.search)));
-      } else {
-        refetch();
       }
     } catch (e) {
       pushToast({

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -25,14 +25,20 @@ import React, {
   useState,
 } from "react";
 import {
+  archiveCurrentAppTasks,
   getCurrentApps,
+  readCurrentAppTasks,
   removeAppIcon,
   removeCurrentApp,
+  renameCurrentApp,
   setAppIcon,
   type CurrentAppEntry,
 } from "@platform/lib/api";
 import IconPicker from "@platform/ui/IconPicker";
-import { navigateUrl } from "@platform/lib/router";
+import { navigate, navigateUrl } from "@platform/lib/router";
+import { pushToast } from "@platform/lib/toast";
+import ContextMenu, { type MenuEntry } from "@platform/ui/ContextMenu";
+import { MenuIcons } from "@platform/ui/MenuIcons";
 import { Modal } from "@platform/ui/modal/Modal";
 import { HeroComposer } from "@apps/builder/HomeHero";
 import { isDoneUnread, opensElsewhere } from "@shell/tasks-lib";
@@ -193,12 +199,14 @@ function CurrentAppRow({
   drag,
   onRemoved,
   onGlyphClick,
+  onMenu,
 }: {
   app: CurrentApp;
   active: boolean;
   drag: RowDragProps;
   onRemoved: () => void;
   onGlyphClick: (e: React.MouseEvent<HTMLSpanElement>, path: string) => void;
+  onMenu: (e: React.MouseEvent, app: CurrentApp) => void;
 }) {
   const [busy, setBusy] = useState(false);
   // The destination keeps the TAB the user is on (owner, 2026-08-26): switching
@@ -252,6 +260,7 @@ function CurrentAppRow({
       }
       title={tip}
       draggable
+      onContextMenu={(e) => onMenu(e, app)}
       {...drag}
     >
       {/* The glyph is the icon picker's toggle — the Bookmarks pattern
@@ -326,8 +335,8 @@ function CurrentAppRow({
       <span className="bookmark-actions">
         <button
           className="icon-btn delete-btn current-app-archive"
-          title="Remove from current apps (archives its tasks)"
-          aria-label={`Remove ${app.name} from current apps and archive its tasks`}
+          title="Hide from projects (archives its tasks)"
+          aria-label={`Hide ${app.name} from projects and archive its tasks`}
           disabled={busy}
           onClick={onRemove}
         >
@@ -492,6 +501,117 @@ export default function CurrentAppsSection() {
     refetch();
   };
 
+  // ---- the row's right-click menu ---------------------------------------------
+  // The app-card vocabulary where it overlaps (appCardMenu.ts): "Open in
+  // Explorer" is the app's FOLDER in fused-render's own explorer. The rest are
+  // the desk's own verbs — the dot, the tasks, the row itself.
+  const [menu, setMenu] = useState<{
+    x: number;
+    y: number;
+    app: CurrentApp;
+  } | null>(null);
+  const onRowMenu = useCallback((e: React.MouseEvent, app: CurrentApp) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setMenu({ x: e.clientX, y: e.clientY, app });
+  }, []);
+
+  // The rename dialog: prefilled with the folder's current name; submit renames
+  // the FOLDER on disk and the server carries the app's sessions and stores
+  // along (the D548 move settlement).
+  const [renaming, setRenaming] = useState<CurrentApp | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
+  const [renameBusy, setRenameBusy] = useState(false);
+  const startRename = (app: CurrentApp) => {
+    setRenameDraft(app.name);
+    setRenaming(app);
+  };
+  const submitRename = async () => {
+    const app = renaming;
+    const name = renameDraft.trim();
+    if (!app || renameBusy) return;
+    if (!name || name === app.name) {
+      setRenaming(null);
+      return;
+    }
+    setRenameBusy(true);
+    try {
+      const r = await renameCurrentApp(app.path, name);
+      // Carry the row's SEQUENCE to the new path in memory, so the rename does
+      // not reshuffle the list (assignSequences would put an unknown path on
+      // top). Deliberately NOT saved — the store is written by a drag and only
+      // by a drag (the cross-tab rule above).
+      const seq = appOrder.get(app.path);
+      if (seq !== undefined && !appOrder.has(r.path)) {
+        appOrder.delete(app.path);
+        appOrder.set(r.path, seq);
+      }
+      setRenaming(null);
+      pokeTasks();
+      // The renamed app's page, if we are on it, now lives at the new folder.
+      if (app.path === onPath) {
+        navigateUrl(appPageUrl(r.path, appPageTabFromSearch(location.search)));
+      } else {
+        refetch();
+      }
+    } catch (e) {
+      pushToast({
+        msg: "Could not rename " + app.name + ": " + (e as Error).message,
+        tone: "error",
+      });
+    } finally {
+      setRenameBusy(false);
+    }
+  };
+
+  const menuItems = (app: CurrentApp): MenuEntry[] => [
+    {
+      label: "Open in Explorer",
+      icon: MenuIcons.folder,
+      disabled: !app.exists,
+      onClick: () => navigate(app.path, { isDir: true }),
+    },
+    {
+      label: "Rename…",
+      icon: MenuIcons.rename,
+      disabled: !app.exists,
+      onClick: () => startRename(app),
+    },
+    "separator",
+    {
+      label: "Mark all tasks as read",
+      onClick: () => {
+        readCurrentAppTasks(app.path)
+          .catch(() => {})
+          .finally(() => pokeTasks());
+      },
+    },
+    {
+      label: "Archive all tasks",
+      icon: MenuIcons.compress,
+      onClick: () => {
+        archiveCurrentAppTasks(app.path)
+          .catch(() => {})
+          .finally(() => pokeTasks());
+      },
+    },
+    "separator",
+    // The ✕'s gesture, by name: off the desk, tasks archived with it.
+    {
+      label: "Hide from projects",
+      icon: MenuIcons.trash,
+      danger: true,
+      onClick: () => {
+        removeCurrentApp(app.path)
+          .catch(() => {})
+          .finally(() => {
+            pokeTasks();
+            refetch();
+          });
+      },
+    },
+  ];
+
   const render = useCallback(
     (app: CurrentApp) => (
       <CurrentAppRow
@@ -501,10 +621,11 @@ export default function CurrentAppsSection() {
         drag={dragProps(app.path)}
         onRemoved={refetch}
         onGlyphClick={onGlyphClick}
+        onMenu={onRowMenu}
       />
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dragProps closes over `apps`
-    [onPath, apps, refetch, onGlyphClick],
+    [onPath, apps, refetch, onGlyphClick, onRowMenu],
   );
   // The "+ New app" row at the foot of the list opens the /apps composer in a
   // modal (D489). The section ALWAYS renders: a door to "make one" is exactly
@@ -557,6 +678,61 @@ export default function CurrentAppsSection() {
           </span>
           <span className="bookmark-name">New app</span>
         </div>
+      )}
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          items={menuItems(menu.app)}
+          onClose={() => setMenu(null)}
+        />
+      )}
+      {renaming && (
+        <Modal
+          title={"Rename " + renaming.name}
+          busy={renameBusy}
+          onClose={() => setRenaming(null)}
+          width={420}
+          footer={
+            <>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                disabled={renameBusy}
+                onClick={() => setRenaming(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={renameBusy || !renameDraft.trim()}
+                onClick={submitRename}
+              >
+                {renameBusy ? "Renaming…" : "Rename"}
+              </button>
+            </>
+          }
+        >
+          <p>
+            Renames the app&apos;s folder on disk. Its tasks and Claude
+            sessions move with it.
+          </p>
+          <input
+            type="text"
+            className="field-control"
+            value={renameDraft}
+            autoFocus
+            onFocus={(e) => e.currentTarget.select()}
+            onChange={(e) => setRenameDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void submitRename();
+              }
+            }}
+          />
+        </Modal>
       )}
       {iconPicker && (
         <IconPicker

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -39,6 +39,10 @@ export interface CurrentApp {
   path: string;
   /** The folder name — the row's label. */
   name: string;
+  /** The page to run (canonical path), or null when the folder has none —
+   *  the context menu's "Open app", the same target as the app page's own
+   *  "Open app" button. */
+  entry: string | null;
   /** `linked` for a registry folder outside the workspace, else `workspace`. */
   kind: "workspace" | "linked";
   /** The folder is still on disk. A missing one still lists — removing it is
@@ -75,6 +79,7 @@ export function currentApps(
   return entries.map((e) => ({
     path: e.path,
     name: e.name,
+    entry: e.entry,
     kind: e.kind,
     exists: e.exists,
     running: live.some((p) => isUnderDir(p, e.path)),

--- a/fused_render/server/routers/current_apps.py
+++ b/fused_render/server/routers/current_apps.py
@@ -158,19 +158,27 @@ def api_current_apps_rename(patch: RenamePatch):
     if os.path.normcase(new) != os.path.normcase(folder) and os.path.exists(new):
         raise HTTPException(status_code=409, detail="a folder with that name "
                             "already exists")
+    from fused_render import app_fused_dir, app_state_move, claude_session_move
+
+    # Witness the OLD path before the move: `ensure` writes `.fused/meta.json`
+    # recording it (a no-op when one exists), so after the rename the settle
+    # below runs through `_after_move`'s full machinery — including recording
+    # a live session as PENDING so the next open retries it. Settling by hand
+    # has no place to keep that list.
+    app_fused_dir.ensure(folder)
     try:
         os.rename(folder, new)
     except OSError as e:
         raise HTTPException(status_code=400, detail=f"rename failed: {e}")
-    from fused_render import app_fused_dir, app_state_move, claude_session_move
-
     recorded = app_fused_dir.recorded_app_dir(new)
     if recorded and canonical_fs_path(
             os.path.abspath(recorded)).rstrip("/") == folder:
         # The witness fired: ensure settles the move — stores, sessions, meta.
         app_fused_dir.ensure(new)
     else:
+        # No witness could be written (read-only folder, mount-backed): settle
+        # best-effort. No meta means nowhere to record a pending live session,
+        # the same standing an out-of-band move of such a folder has.
         app_state_move.rewrite_stores(folder, new)
         claude_session_move.relocate(folder, new)
-        app_fused_dir.ensure(new)
     return {"ok": True, "path": new}

--- a/fused_render/server/routers/current_apps.py
+++ b/fused_render/server/routers/current_apps.py
@@ -9,13 +9,27 @@
   reverse — archiving tasks removing the app — is exactly what the redesign
   ended, so nothing here runs on an archive.
 
-There is no POST: the table is fed by the tasks listing (`current_apps.observe`,
-run inside `tasks._task_rows`) and by nothing else. An app arrives on the desk
-by having work started in it.
-"""
-from fastapi import APIRouter, HTTPException, Query
+The row's right-click menu adds three more verbs, all folder-scoped:
 
-from fused_render import current_apps
+* ``POST /api/current-apps/rename`` — rename the FOLDER on disk and settle the
+  move the way an out-of-band move is settled (D548): stores repointed, Claude
+  sessions carried along, `.fused/meta.json` repointed.
+* ``POST /api/current-apps/read`` — mark every message of every task under the
+  folder read, in one pass.
+* ``POST /api/current-apps/archive`` — the DELETE's task half without its desk
+  half: archive every task under the folder, keep the row.
+
+There is no POST that adds a row: the table is fed by the tasks listing
+(`current_apps.observe`, run inside `tasks._task_rows`) and by nothing else. An
+app arrives on the desk by having work started in it.
+"""
+import os
+import time
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from fused_render import current_apps, tasks_store, tasks_watch
 from fused_render._view_url_codec import canonical_fs_path
 from fused_render.server.routers import tasks as tasks_router
 
@@ -27,28 +41,136 @@ def api_current_apps():
     return {"apps": current_apps.list_apps()}
 
 
-@router.delete("/api/current-apps")
-def api_current_apps_remove(path: str = Query(...)):
+def _require_folder(path: str) -> str:
     folder = canonical_fs_path(path).rstrip("/")
     if not folder:
         raise HTTPException(status_code=400, detail="missing path")
-    removed = current_apps.remove(folder)
-    # Archive FIRST by collecting, then act: `_collect` is one pass over the
-    # transcripts and the schedule, and each task's project is what `_place`
-    # resolves for the listing — the same folder rule the observer used to
-    # put the app on the desk, so what the cross archives is what the app's
-    # Tasks tab showed.
-    archived = 0
-    cancelled = 0
-    tasks = tasks_router._collect()
-    for task in tasks.values():
+    return folder
+
+
+def _folder_tasks(folder: str) -> list[dict]:
+    """Every collected task whose project is `folder` or inside it — the same
+    one-pass collect + `_place` the DELETE has always run, shared now by the
+    read-all and archive-all verbs."""
+    matched = []
+    for task in tasks_router._collect().values():
         tasks_router._place(task)
         project = canonical_fs_path(task.get("project") or "")
-        if not project or not current_apps.is_under(project, folder):
-            continue
+        if project and current_apps.is_under(project, folder):
+            matched.append(task)
+    return matched
+
+
+def _archive_folder(folder: str) -> dict:
+    """Archive every task under `folder` — the gesture the DELETE has always
+    run, and the whole of the archive-all verb. `_collect` is one pass over
+    the transcripts and the schedule, and each task's project is what `_place`
+    resolves for the listing — the same folder rule the observer used to put
+    the app on the desk, so what gets archived is what the app's Tasks tab
+    showed."""
+    archived = 0
+    cancelled = 0
+    keys = set()
+    for task in _folder_tasks(folder):
         n, filed = tasks_router.archive_task(task)
         cancelled += n
         if filed or n:
             archived += 1
-    return {"ok": True, "removed": removed, "archived": archived,
-            "cancelled": cancelled}
+            keys.add(task["key"])
+    if keys:
+        tasks_watch.notify(keys)
+    return {"archived": archived, "cancelled": cancelled}
+
+
+@router.delete("/api/current-apps")
+def api_current_apps_remove(path: str = Query(...)):
+    folder = _require_folder(path)
+    removed = current_apps.remove(folder)
+    result = _archive_folder(folder)
+    return {"ok": True, "removed": removed, **result}
+
+
+class FolderPatch(BaseModel):
+    path: str
+
+
+@router.post("/api/current-apps/archive")
+def api_current_apps_archive(patch: FolderPatch):
+    """The cross's task half without its desk half: archive every task under
+    the folder, keep the row."""
+    folder = _require_folder(patch.path)
+    return {"ok": True, **_archive_folder(folder)}
+
+
+@router.post("/api/current-apps/read")
+def api_current_apps_read(patch: FolderPatch):
+    """Mark every message of every task under the folder read — the row's
+    green dot, cleared as one gesture. The per-task body is
+    `tasks._read_whole_task`'s, inlined over ONE collect rather than one per
+    task: ids come from the messages unread right now, so nothing pending is
+    swept in."""
+    folder = _require_folder(patch.path)
+    now = time.time()
+    marked = 0
+    keys = set()
+    for task in _folder_tasks(folder):
+        messages = tasks_router._thread(task, tasks_store.read_state(), now)
+        unread_ids = [m["message_id"] for m in messages if m["unread"]]
+        if not unread_ids:
+            continue
+        tasks_store.mark_read_many(task["key"], unread_ids)
+        marked += len(unread_ids)
+        keys.add(task["key"])
+    if keys:
+        tasks_watch.notify(keys)
+    return {"ok": True, "marked": marked, "tasks": len(keys)}
+
+
+class RenamePatch(BaseModel):
+    path: str
+    name: str
+
+
+@router.post("/api/current-apps/rename")
+def api_current_apps_rename(patch: RenamePatch):
+    """Rename the app's FOLDER on disk, then settle the move exactly as an
+    out-of-band move is settled (D548, app_fused_dir): the server's stores are
+    repointed (the desk row included) and the folder's Claude sessions are
+    carried to the new path. When the folder carries a `.fused/meta.json`
+    witnessing the old path, `ensure` runs the whole settlement itself;
+    otherwise the two halves are run directly. A live session in the folder is
+    left pending, retried on the next open — rename never blocks on it."""
+    folder = _require_folder(patch.path)
+    name = patch.name.strip()
+    if not name or name in (".", "..") or "/" in name or "\\" in name:
+        raise HTTPException(status_code=400, detail="invalid name")
+    if not os.path.isdir(folder):
+        raise HTTPException(status_code=404, detail="no such folder")
+    state = current_apps.read_state()
+    if not any(a["path"] == folder for a in state["apps"]):
+        raise HTTPException(status_code=404, detail="not a current app")
+    new = canonical_fs_path(
+        os.path.join(os.path.dirname(folder), name)).rstrip("/")
+    if new == folder:
+        return {"ok": True, "path": folder}
+    # Case-only renames (foo -> Foo) pass the exists check on a
+    # case-insensitive filesystem; os.rename handles them fine.
+    if os.path.normcase(new) != os.path.normcase(folder) and os.path.exists(new):
+        raise HTTPException(status_code=409, detail="a folder with that name "
+                            "already exists")
+    try:
+        os.rename(folder, new)
+    except OSError as e:
+        raise HTTPException(status_code=400, detail=f"rename failed: {e}")
+    from fused_render import app_fused_dir, app_state_move, claude_session_move
+
+    recorded = app_fused_dir.recorded_app_dir(new)
+    if recorded and canonical_fs_path(
+            os.path.abspath(recorded)).rstrip("/") == folder:
+        # The witness fired: ensure settles the move — stores, sessions, meta.
+        app_fused_dir.ensure(new)
+    else:
+        app_state_move.rewrite_stores(folder, new)
+        claude_session_move.relocate(folder, new)
+        app_fused_dir.ensure(new)
+    return {"ok": True, "path": new}


### PR DESCRIPTION
Right-click on a Projects row opens a context menu:

- **Open in Explorer** — the app's folder in fused-render's own explorer (the app-card menu's vocabulary).
- **Rename…** — modal with the folder name prefilled; renames the folder on disk, then settles the move the same way an out-of-band move is settled (D548): server stores repointed, Claude sessions carried along, `.fused/meta.json` repointed. A live session is left pending and retried on the next open. The row keeps its place in the list (its sequence is remapped in memory; the saved order is still written only by a drag).
- **Mark all tasks as read** — clears the row's green dot in one gesture; per-task body is `_read_whole_task`'s, inlined over one collect.
- **Archive all tasks** — the ✕'s task half without its desk half.
- **Hide from projects** — the ✕ button's gesture, now also named; the ✕'s tooltip is relabeled to match ("Hide from projects (archives its tasks)").

Backend: `POST /api/current-apps/{rename,read,archive}`; the DELETE's folder-archive loop extracted into `_archive_folder`/`_folder_tasks` and shared. Read/archive notify the tasks watch with the affected keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rename mutates the filesystem and repoints app/task stores and Claude sessions; mistakes could strand paths or sessions, though validation and existing move-settlement paths limit exposure.
> 
> **Overview**
> **Right-click on a Projects row** now opens a context menu with folder-scoped actions, and the row ✕ tooltip is relabeled to **Hide from projects**.
> 
> The menu adds **Open app** (entry page in a new tab via `urlForFsPath`), **Rename…** (modal that calls `POST /api/current-apps/rename`), **Mark all tasks as read**, **Archive all tasks** (tasks only—the row stays), and **Hide from projects** (same as the ✕). Rename keeps sidebar order by remapping the in-memory sequence to the new path, refetches the desk, and navigates if you were on that app’s page. Task read/archive actions `pokeTasks()` after the API call.
> 
> The client gains `renameCurrentApp`, `readCurrentAppTasks`, and `archiveCurrentAppTasks` in `api.ts`; `CurrentApp` now carries **`entry`** for the open action.
> 
> On the server, **`POST /api/current-apps/{rename,read,archive}`** are added. DELETE’s “archive everything under this folder” logic is extracted into **`_folder_tasks`** / **`_archive_folder`** (shared with archive-all and used by read-all). Rename performs **`os.rename`** then D548-style settlement (`app_fused_dir.ensure`, or fallback store/session rewrite). Read/archive notify **`tasks_watch`** for affected task keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9648921743ce5875c7b80e6d43e46a34edaeb5f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->