### PR TITLE
AI Models Local tab polish: scrollbar, adaptive cards, tooltips, curated titles

### DIFF
--- a/frontend/src/apps/ai_models/local/Carousel.tsx
+++ b/frontend/src/apps/ai_models/local/Carousel.tsx
@@ -17,7 +17,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 
 /** The scrollable row, with its own "there is more" affordance.
  *
- *  Exact thirds took away the old signal — a card half in view — so the row has
+ *  Exact fractions took away the old signal — a card half in view — so the row has
  *  to SAY it scrolls. Each arrow exists only while there is content on its side
  *  (measured overflow, never a width threshold), floats over the row's edge so
  *  appearing and disappearing move no layout, and a click slides by one card so
@@ -39,15 +39,29 @@ export function Carousel({ children }: { children: ReactNode }) {
     setCanNext(row.scrollLeft + row.clientWidth < row.scrollWidth - 1);
   };
 
+  // Marks the row `is-scrolling` for the scrollbar thumb (ai-models.css) to
+  // key off, cleared 800ms after the last scroll event. A `:hover` reveal
+  // used to do this job, but the carousel IS the row — hovering any card in
+  // an overflowing capability painted the thumb and held it painted for as
+  // long as the pointer stayed anywhere in the row, which read as the bar
+  // popping in and out at random rather than announcing an actual scroll.
   useEffect(() => {
     const row = rowRef.current;
     if (!row) return;
-    row.addEventListener("scroll", measure, { passive: true });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onScroll = () => {
+      measure();
+      row.classList.add("is-scrolling");
+      clearTimeout(timer);
+      timer = setTimeout(() => row.classList.remove("is-scrolling"), 800);
+    };
+    row.addEventListener("scroll", onScroll, { passive: true });
     const ro = new ResizeObserver(measure);
     ro.observe(row);
     return () => {
-      row.removeEventListener("scroll", measure);
+      row.removeEventListener("scroll", onScroll);
       ro.disconnect();
+      clearTimeout(timer);
     };
   }, []);
   useEffect(measure);
@@ -64,7 +78,9 @@ export function Carousel({ children }: { children: ReactNode }) {
   };
 
   return (
-    <div className="am-carousel-wrap">
+    <div
+      className={`am-carousel-wrap${canPrev ? " has-prev" : ""}${canNext ? " has-next" : ""}`}
+    >
       {canPrev && (
         <button
           type="button"

--- a/frontend/src/apps/ai_models/local/LocalTab.tsx
+++ b/frontend/src/apps/ai_models/local/LocalTab.tsx
@@ -221,6 +221,18 @@ export function LocalTab({ scan }: { scan: CacheScan }) {
     ),
   );
 
+  // Repo id -> the curated `label` (AI-2c, catalog.py): a human display name is
+  // a CURATED field, never one derived by mechanically stripping a repo id at
+  // runtime — `modelName()` (RepoCard.tsx) is exactly that mechanical strip,
+  // kept only as the fallback for a repo the curation does not name. Keyed by
+  // the same `m.repo ?? m.id` as `repoById` above, since a card's `repo.id` is
+  // the disk-side address, not the curated id a llama.cpp GGUF is filed under.
+  const labelByRepoId = new Map<string, string>(
+    (catalog ?? []).flatMap((entry) =>
+      entry.models.map((m) => [m.repo ?? m.id, m.label] as const),
+    ),
+  );
+
   // The click is held until something ELSE can speak for the pull — the runtime
   // reporting it, `settling` carrying it through the walk, or the walk finding
   // it on disk (a "download" that was a cache hit and finished before any poll
@@ -421,6 +433,7 @@ export function LocalTab({ scan }: { scan: CacheScan }) {
       <RepoCard
         key={r.path}
         repo={r}
+        label={labelByRepoId.get(r.id)}
         recommended={curated.has(r.id)}
         loaded={loadedById.get(r.id)}
         job={jobByModel.get(r.id)}

--- a/frontend/src/apps/ai_models/local/RecommendedCard.tsx
+++ b/frontend/src/apps/ai_models/local/RecommendedCard.tsx
@@ -85,9 +85,13 @@ function ModelCard({
    *  NUMBER and so the one thing about these states a stylesheet cannot know. */
   style?: Record<string, string>;
   /** The card's own hover, where there is one thing to say about the whole of
-   *  it. Rendered as a title rather than as text because these cards sit in a
-   *  scrolling row: a sentence per card would set every card's height from the
-   *  longest one in the section. */
+   *  it. Rendered as a `data-hint` rather than as text because these cards sit
+   *  in a scrolling row: a sentence per card would set every card's height
+   *  from the longest one in the section. `data-hint`, not a native `title`,
+   *  so it doesn't double up with a child control's own hint — the app's one
+   *  tooltip system (`hints.ts`) walks up ancestors and lets the nearest
+   *  `data-hint` win, where two native titles on the same point would both
+   *  fire and show the browser's tooltip on top of the app's. */
   hoverNote?: string;
   /** For the one card that has to know whether it is on screen (see
    *  `HubResultCard`'s lazy size). */
@@ -119,7 +123,7 @@ function ModelCard({
     <div
       className={`cc-mdcard am-card ${variant}`}
       style={style}
-      title={hoverNote}
+      data-hint={hoverNote}
       ref={cardRef}
     >
       <div className="cc-mdcard-head">
@@ -333,7 +337,7 @@ export function RecommendedCard({
                filled the disk with weights nothing here reads would be the
                page contradicting its own card. */
             disabled={!runner?.available}
-            title={
+            data-hint={
               runner?.available
                 ? `Download ${model.id}${
                     size === null ? "" : ` (${size.approx ? "~" : ""}${size.text})`
@@ -539,7 +543,7 @@ export function HubResultCard({
       badges={
         <>
           {disk.state === "downloaded" && !busy && (
-            <span className="am-suggest-have" title={`${model.id} is already on this machine`}>
+            <span className="am-suggest-have" data-hint={`${model.id} is already on this machine`}>
               ✓ downloaded
             </span>
           )}
@@ -548,7 +552,7 @@ export function HubResultCard({
               and left a Download button beside it that would 403. Here the gate
               decides the action too — see the footer. */}
           {gate && (
-            <span className="am-card-gate" title={gate.title}>
+            <span className="am-card-gate" data-hint={gate.title}>
               {gate.pill}
             </span>
           )}
@@ -602,7 +606,7 @@ export function HubResultCard({
                 // path drops the mode, so a middle-click would land on the
                 // folder listing rather than the model card.
                 href={urlForFsPath(disk.path, "?_mode=model_card")}
-                title={`Explore ${model.id} here — ${disk.path}`}
+                data-hint={`Explore ${model.id} here — ${disk.path}`}
                 onClick={(e) => {
                   if (
                     e.defaultPrevented ||
@@ -630,7 +634,7 @@ export function HubResultCard({
                 href={model.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                title={gate.title}
+                data-hint={gate.title}
               >
                 {gate.action}
               </a>
@@ -648,7 +652,7 @@ export function HubResultCard({
                   type="button"
                   className="am-card-power"
                   disabled={!loadable}
-                  title={
+                  data-hint={
                     !loadable
                       ? `${model.id} cannot be loaded here: ${runner?.reason ?? "unavailable"}.`
                       : disk.state === "partial"

--- a/frontend/src/apps/ai_models/local/RepoCard.tsx
+++ b/frontend/src/apps/ai_models/local/RepoCard.tsx
@@ -129,7 +129,7 @@ function LoadedBadge({ loaded }: { loaded: AiLoadedModel }) {
   return (
     <span
       className="am-loaded-badge"
-      title={
+      data-hint={
         `${loaded.model} is loaded in memory` +
         (loaded.residentBytes ? ` — ${formatSize(loaded.residentBytes)} resident` : "")
       }
@@ -163,7 +163,7 @@ function DeviceNote({ device }: { device: string }) {
   return (
     <span
       className={"am-runtime-device" + (cpu ? " am-runtime-device-cpu" : "")}
-      title={
+      data-hint={
         cpu
           ? "This model is running on the processor, not a graphics card — it " +
             "works, but expect a few words a second rather than an instant " +
@@ -211,7 +211,7 @@ function RuntimeChip({
         {loaded.residentBytes ? (
           <span
             className="am-runtime-mem am-runtime-mem-lead"
-            title={
+            data-hint={
               "Resident memory of the model's process. Not the model's size: it " +
               "counts shared pages too and moves while it generates."
             }
@@ -226,7 +226,7 @@ function RuntimeChip({
   }
   if (loaded?.state === "error") {
     return (
-      <div className="am-card-runtime am-card-runtime-error" title={loaded.error ?? undefined}>
+      <div className="am-card-runtime am-card-runtime-error" data-hint={loaded.error ?? undefined}>
         Failed to load{loaded.error ? ` — ${loaded.error}` : ""}
       </div>
     );
@@ -236,6 +236,7 @@ function RuntimeChip({
 
 export function RepoCard({
   repo,
+  label,
   recommended,
   loaded,
   job,
@@ -251,6 +252,18 @@ export function RepoCard({
   onUnload,
 }: {
   repo: AiModelRepo;
+  /** The curated display name for the card's HEAD (AI-2c, catalog.py): a
+   *  human name is a curated field, never one mechanically derived from a
+   *  repo id at runtime. Looked up by the page (`LocalTab.tsx`'s
+   *  `labelByRepoId`) from `AiCatalogModel.label` — the unique, size/quant-
+   *  carrying field, not `nickname`, which deliberately collides within a
+   *  model family. `undefined` for a repo the curation does not name (most
+   *  engine-fetched repos, and anything outside the shortlist), in which
+   *  case the head falls back to `modelName(repo.id)` — the mechanical
+   *  strip this prop exists to avoid wherever a curated name IS available.
+   *  Every other identifier on the card (Load/Delete/Try hints, the subtitle
+   *  slug) keeps using `repo.id` — this prop only ever touches the head. */
+  label?: string;
   /** Whether the curation names this exact repo id — the tick beside the name.
    *  Decided by the page, which holds the catalog; a repo row itself has no
    *  opinion about whether we recommend it. */
@@ -393,9 +406,9 @@ export function RepoCard({
           href={hubUrl(repo)}
           target="_blank"
           rel="noopener noreferrer"
-          title={`Open ${repo.id} on the Hugging Face Hub`}
+          data-hint={`Open ${repo.id} on the Hugging Face Hub`}
         >
-          {modelName(repo.id)}
+          {label ?? modelName(repo.id)}
         </a>
         {recommended && <RecommendedMark />}
         {loaded?.state === "ready" && <LoadedBadge loaded={loaded} />}
@@ -472,7 +485,7 @@ export function RepoCard({
               className="am-card-engine am-card-engine-component"
               tabIndex={0}
               aria-label={`Part of ${repo.component.owner} — ${repo.component.what}`}
-              title={repo.component.what}
+              data-hint={repo.component.what}
             >
               part of {repo.component.owner}
             </span>
@@ -481,7 +494,7 @@ export function RepoCard({
               className="am-card-engine am-card-engine-partial"
               tabIndex={0}
               aria-label={`${PARTIAL_TAG} — ${partialNote(repo)}`}
-              title={partialNote(repo)}
+              data-hint={partialNote(repo)}
             >
               {PARTIAL_TAG}
             </span>
@@ -613,7 +626,7 @@ export function RepoCard({
               type="button"
               className="am-card-power am-card-power-on"
               disabled={busy}
-              title={`Unload ${repo.id} and give its memory back`}
+              data-hint={`Unload ${repo.id} and give its memory back`}
               onClick={onUnload}
             >
               Unload
@@ -623,7 +636,7 @@ export function RepoCard({
               type="button"
               className="am-card-power"
               disabled
-              title={`${repo.id} is loading into memory — the ✕ on the progress row stops it`}
+              data-hint={`${repo.id} is loading into memory — the ✕ on the progress row stops it`}
               aria-label={`${repo.id} is loading`}
             >
               Loading…
@@ -643,7 +656,7 @@ export function RepoCard({
               type="button"
               className="am-card-power am-card-power-discard"
               disabled={busy || !!inUse}
-              title={
+              data-hint={
                 inUse
                   ? `Cannot delete ${repo.id}: ${inUse}`
                   : `Delete ${repo.id} — ${
@@ -675,7 +688,7 @@ export function RepoCard({
               type="button"
               className="am-card-power"
               disabled={busy || fetching || !!job}
-              title={`Continue downloading ${repo.id} — it resumes from the ${formatSize(repo.fetchedBytes)} already here`}
+              data-hint={`Continue downloading ${repo.id} — it resumes from the ${formatSize(repo.fetchedBytes)} already here`}
               aria-label={`Continue downloading ${repo.id} — resume the unfinished download`}
               onClick={onDownload}
             >
@@ -687,12 +700,12 @@ export function RepoCard({
               type="button"
               className="am-card-power"
               disabled={busy || !!job || !!refusal}
-              title={refusal ?? `Load ${repo.id} into memory so it can answer`}
-              /* The reason again, in the accessible name. A `title` is a hover,
-                 and a disabled button is one a pointer user may never think to
-                 hover — while a screen reader reads the name and nothing else.
-                 It opens with the visible label so the name still contains
-                 what is on screen (WCAG 2.5.3). */
+              data-hint={refusal ?? `Load ${repo.id} into memory so it can answer`}
+              /* The reason again, in the accessible name. A hover-only hint is
+                 one a pointer user may never think to hover — while a screen
+                 reader reads the name and nothing else. It opens with the
+                 visible label so the name still contains what is on screen
+                 (WCAG 2.5.3). */
               aria-label={
                 refusal ? `Load ${repo.id} — unavailable: ${refusal}` : `Load ${repo.id}`
               }
@@ -733,7 +746,7 @@ export function RepoCard({
                  this card's. Anything else in the query is a stage setting
                  dialled in for a different model. */
               href={tryHref(repo)}
-              title={`Try ${repo.id} in the Playground`}
+              data-hint={`Try ${repo.id} in the Playground`}
               onClick={(e) => {
                 if (
                   e.defaultPrevented ||
@@ -761,7 +774,7 @@ export function RepoCard({
           <button
             type="button"
             className="cc-iconbtn cc-iconbtn-danger"
-            title={inUse ? `Cannot delete ${repo.id}: ${inUse}` : `Delete ${repo.id}`}
+            data-hint={inUse ? `Cannot delete ${repo.id}: ${inUse}` : `Delete ${repo.id}`}
             aria-label={`Delete ${repo.id}`}
             disabled={!!inUse}
             onClick={onDeleteRepo}
@@ -772,7 +785,7 @@ export function RepoCard({
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
-              strokeWidth="2"
+              strokeWidth="1.5"
               strokeLinecap="round"
               strokeLinejoin="round"
               aria-hidden="true"

--- a/frontend/src/apps/ai_models/local/repoCardControls.test.ts
+++ b/frontend/src/apps/ai_models/local/repoCardControls.test.ts
@@ -221,10 +221,15 @@ describe("Try is an outline, not a fill", () => {
     // sits on: Load is right next to it, and Load is the control that costs
     // memory. A lime plate beside it made the cheap navigation the loudest mark
     // on the card and the consequential button the quiet one.
+    // The border then softened again: a full-accent stroke repeated on every
+    // card out-shouted the one filled state (Loaded) that is supposed to be
+    // the loudest mark on the page, so it sits a third of the way between the
+    // plain border and the accent. The INK stays full accent — that is the
+    // "this goes somewhere else" signal.
     const body = block(CSS, ".am-card-try");
     expect(body).toContain("background: transparent");
     expect(body).toContain("color: var(--accent)");
-    expect(body).toContain("border: 1px solid var(--accent)");
+    expect(body).toContain("border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border))");
     expect(body).not.toContain("var(--on-accent)");
   });
 
@@ -252,7 +257,10 @@ describe("what the card's face keeps, and what the (i) takes", () => {
     // Six cards reading `mlx-community/…` spend their first third saying nothing
     // that tells them apart, and the name itself then ellipsises. The owner is
     // not lost — it leads the line directly below.
-    expect(CARD).toContain("{modelName(repo.id)}");
+    // The head prefers the CURATED label when the catalog names the repo
+    // (AI-2c: display names are curated, never derived at runtime), and the
+    // mechanical strip survives only as the fallback for uncatalogued repos.
+    expect(CARD).toContain("{label ?? modelName(repo.id)}");
     // The hint rides the ID, not the whole line: the line spans the card, and a
     // hint on it fired over the empty space between id and size.
     expect(CARD).toContain('<div className="am-card-sub">');

--- a/frontend/src/styles/ai-models.css
+++ b/frontend/src/styles/ai-models.css
@@ -286,14 +286,21 @@
 .am-subgroup-head {
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
   gap: 12px;
 }
 
 .am-section-head {
+  justify-content: space-between;
   border-bottom: 1px solid var(--border);
   padding-bottom: 6px;
   margin-bottom: var(--am-gap-head);
+}
+
+/* Flush left, not space-between: the size is a subtotal FOR the title beside
+   it, not a fact about the row's far edge, so it sits one gap after the name
+   instead of stranded ~800px away at the row's end. */
+.am-subgroup-head {
+  justify-content: flex-start;
 }
 
 .am-section-title {
@@ -387,6 +394,7 @@
    — a flick that reaches the end of one capability's row must not turn into the
    browser's back gesture. */
 .am-carousel {
+  --am-cpv: 3;
   display: flex;
   gap: var(--am-gap-card);
   overflow-x: auto;
@@ -425,10 +433,17 @@
    scrolls with its own prev/next arrows (rendered whenever there is overflow
    in that direction, not hover-gated — see Carousel.tsx), so the
    scrollbar's only job left is the drag handle, not the announcement. It
-   stays fully transparent at rest and only draws a thin thumb on
-   hover/focus, which also keeps macOS "always show scrollbars" from turning
-   it into a permanent dark stripe under every row — that setting still
-   paints track+thumb at rest, but a transparent thumb paints nothing.
+   stays fully transparent at rest and only draws a thin thumb while the row
+   is actually scrolling, or while keyboard focus is visible inside it — not
+   on hover. Hover was the first cut, but the carousel element IS the row: a
+   `:hover` reveal painted the thumb for as long as the pointer sat anywhere
+   over any card, so it popped in and out as the pointer wandered the page
+   rather than tracking an actual scroll. `Carousel.tsx` now stamps
+   `is-scrolling` on scroll and clears it 800ms after the last event, so the
+   thumb reads as "this row just moved," which also keeps macOS "always show
+   scrollbars" from turning it into a permanent dark stripe under every row —
+   that setting still paints track+thumb at rest, but a transparent thumb
+   paints nothing.
    `scrollbar-width: none` (or its `::-webkit-scrollbar { display: none }`
    equivalent) was ruled out for the same reason a standard-property mix was:
    it would remove the drag handle for anyone without a trackpad or scroll
@@ -448,50 +463,130 @@
   border-radius: 999px;
 }
 
-.am-carousel:hover::-webkit-scrollbar-thumb,
-.am-carousel:focus-within::-webkit-scrollbar-thumb {
+/* A second arm besides `is-scrolling`, so a keyboard user tabbing through
+   the row's cards can still see where the thumb is without ever scrolling
+   it. This used to be `:focus-within`, which matched on ANY focus inside the
+   row — including the one a mouse click leaves behind, since clicking Load,
+   Try, (i) or an arrow focuses that control — so the thumb stayed painted
+   until focus left the row entirely, long after the click that caused it.
+   `:has(:focus-visible)` only matches when the browser itself would draw a
+   focus ring in there, which is the keyboard case this arm is actually
+   for. */
+.am-carousel.is-scrolling::-webkit-scrollbar-thumb,
+.am-carousel:has(:focus-visible)::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--fg-muted) 40%, transparent);
   background-clip: padding-box;
   border: 2px solid transparent;
 }
 
-.am-carousel::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--fg-muted) 55%, transparent);
-  background-clip: padding-box;
+/* An EXACT FRACTION of the row per view, not a fixed card width, so every
+   card in a view is the same width and the eye learns one rhythm — a card
+   half in view reads as "there is more" rather than as a narrower card. The
+   fraction itself steps with the row's own width via `--am-cpv` (container
+   queries below): three cards on an ordinary window, more as the row grows,
+   so a card never stretches past ~480px on a wide monitor — a fixed third of
+   a 2200px row was pushing 720px, wider than a card has any business being.
+   The 360px floor is unchanged and still governs narrow windows, where even
+   the lowest count would crush the footer's buttons into each other; below
+   it the row shows fewer cards than `--am-cpv` and scrolls. */
+.am-carousel > .am-card {
+  flex: 0 0
+    max(
+      360px,
+      calc((100% - (var(--am-cpv) - 1) * var(--am-gap-card)) / var(--am-cpv))
+    );
+  scroll-snap-align: start;
 }
 
-/* THREE cards per view: the basis is a third of the row, so every card is the
-   same width whatever the window and the eye learns one rhythm — a card half in
-   view reads as "there is more" rather than as a narrower card. The 360px floor
-   is for narrow windows, where a true third would crush the footer's buttons
-   into each other; below it the row shows fewer than three and scrolls. */
-.am-carousel > .am-card {
-  flex: 0 0 max(360px, calc((100% - 2 * var(--am-gap-card)) / 3));
-  scroll-snap-align: start;
+/* Card count steps up with the WRAP's own width, not the viewport's — the
+   grid sits inside a sidebar-plus-content shell, so a container query keyed
+   to `.am-carousel-wrap` (below) answers "how wide is this row really" where
+   a media query would answer a different question. Breakpoints are picked so
+   a card's share of the row stays inside the ~360-480px band this design
+   calls a card's width: below 1480px three cards already sit under 480px;
+   above it a fourth keeps them there, and so on up to six. */
+@container am-carousel (min-width: 1480px) {
+  .am-carousel {
+    --am-cpv: 4;
+  }
+}
+
+@container am-carousel (min-width: 1880px) {
+  .am-carousel {
+    --am-cpv: 5;
+  }
+}
+
+@container am-carousel (min-width: 2280px) {
+  .am-carousel {
+    --am-cpv: 6;
+  }
 }
 
 /* The arrows live OUTSIDE the flow — absolutely placed over the row's edges —
    because their whole brief is "say the row scrolls without moving anything":
-   with exact thirds there is no half-visible card left to say it, and a control
+   with exact fractions there is no half-visible card left to say it, and a control
    that appears in the flow would shift the very cards it points at. Vertical
    centring is against the wrapper, so a click scrolls sideways and nothing on
    the page moves up or down. */
 .am-carousel-wrap {
   position: relative;
+  container: am-carousel / inline-size;
 }
 
-/* A full-height fade with the chevron in it, not a floating disc: the gradient
-   dissolves the edge card into the page background, which is itself the "there
-   is more" signal — the row visibly runs out of view instead of ending at a
-   crisp border. The strip stops above the scrollbar's lane (`bottom: 6px`
-   mirrors the row's padding) so the fade never sits on the bar it shares an
-   edge with. */
-.am-caro-btn {
+/* A full-height fade with the chevron over it, not a floating disc: the
+   gradient dissolves the edge card into the page background, which is itself
+   the "there is more" signal — the row visibly runs out of view instead of
+   ending at a crisp border. The strip stops above the scrollbar's lane
+   (`bottom: 6px` mirrors the row's padding) so the fade never sits on the bar
+   it shares an edge with.
+
+   The fade lives on the WRAP, as a `pointer-events: none` pseudo-element,
+   rather than on the button: a full-height, 56px-wide button covered a real
+   control (Load, trash) on whichever card ended up under it, stealing its
+   click. Only the chevron itself — a compact, vertically-centred hit target —
+   is a `<button>`; the fade beside it is decoration a click passes straight
+   through.
+
+   24px wide, not 32: even a vertically-centred button that width still
+   overlapped a Load button on the partially-visible edge card underneath.
+   24px sits inside the zone the fade has already made illegible (≥75%
+   opaque at that distance from the edge), so there is nothing legible left
+   to cover.
+
+   24px TALL too, not the fade's full 56px: the row itself is only ~134px
+   tall, so a 56px-tall centred button still reached down into the card
+   footer's Load button below it. 24px centred lands on the card's subtitle
+   line, which is text, not a control, so the button's hit area no longer
+   sits on anything the reader can click. */
+.am-carousel-wrap.has-prev::before,
+.am-carousel-wrap.has-next::after {
+  content: "";
   position: absolute;
   top: 0;
   bottom: 6px;
-  z-index: 1;
   width: 56px;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.am-carousel-wrap.has-prev::before {
+  left: 0;
+  background: linear-gradient(to left, transparent, var(--bg) 75%);
+}
+
+.am-carousel-wrap.has-next::after {
+  right: 0;
+  background: linear-gradient(to right, transparent, var(--bg) 75%);
+}
+
+.am-caro-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  width: 24px;
+  height: 24px;
   border: 0;
   background: transparent;
   color: var(--fg-muted);
@@ -508,12 +603,10 @@
 
 .am-caro-btn.prev {
   left: 0;
-  background: linear-gradient(to left, transparent, var(--bg) 75%);
 }
 
 .am-caro-btn.next {
   right: 0;
-  background: linear-gradient(to right, transparent, var(--bg) 75%);
 }
 
 /* Cards in a row are the SAME height, and their footers line up.
@@ -540,7 +633,7 @@
      the card beside it, and a row of four cards had four footers on three
      baselines. The height is the button's own: 12px text at 1.5, plus its 3px
      padding and 1px border on each side. */
-  min-height: 26px;
+  min-height: 28px;
 }
 
 /* The two destinations named in the page's captions: the cache directory this
@@ -588,6 +681,7 @@
    overflow the plate. */
 .am-card-name {
   min-width: 0;
+  font-size: 14px;
   color: inherit;
   text-decoration: none;
   white-space: normal;
@@ -702,7 +796,13 @@
   text-decoration: none;
   background: transparent;
   color: var(--accent);
-  border: 1px solid var(--accent);
+  /* Text stays full accent — that's the "this goes somewhere else" signal —
+     but the border used to match it stroke for stroke, and a border repeated
+     on every card in the grid out-shouted the one filled state (Loaded) that
+     is supposed to be the loudest mark on the page. Cut to a third of the
+     way to the plain border so the shape still reads as a button, not as a
+     second accent voice. */
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
 }
 
 /* Doubled selector to outrank `.cc-iconbtn:hover`, which is the same weight and
@@ -1710,7 +1810,7 @@
    opacity still dims it for a refused or busy card. */
 .am-card-power {
   flex: 0 0 auto;
-  padding: 3px 9px;
+  padding: 4px 10px;
   font: inherit;
   font-size: 12px;
   color: var(--fg);


### PR DESCRIPTION
## What

Four fixes to the AI Models Local tab (`/ai-models/local`), each verified live in the browser:

- **Sticky horizontal scrollbar fixed.** The carousel scrollbar revealed on hover anywhere in the row (the row *is* the hover target), so it appeared and stuck around near the text-generation section. It now reveals only while actually scrolling (a scroll-driven `is-scrolling` class, cleared 800ms after the last scroll event) or when a card inside has keyboard focus.
- **Adaptive cards-per-view.** Cards were stretched to a third of very wide windows. The carousel is now a container-query target: `--am-cpv` steps 3 → 4 → 5 → 6 at 1480/1880/2280px of row width, with a 360px per-card floor. Verified: 2171px row → 5 cards at 425px; 1417px → 3 at 464px (4 would violate the floor).
- **One tooltip system.** 21 native `title=` attributes inside cards (RepoCard, RecommendedCard) converted to the app's `data-hint` system — a native tooltip and the app's hint panel were both firing on the same hover (worst on the LTX card, whose whole surface carried a `title`). Verified live: 0 native titles remain inside cards.
- **Curated card titles (AI-2c).** Card heads now show the catalog's curated `label` ("Whisper large-v3 turbo (CT2)", "Gemma 4 E4B (Q4_K_M)") instead of the raw last path segment of the repo id, matching the Playground page. Uncatalogued repos (engine-fetched components, out-of-shortlist downloads) keep the mechanical fallback. The full repo id remains in the card subtitle.

## Verification

- `npm run build` (check-boundaries + tsc + vite) passes.
- Live-verified against the dev server with DOM probes and screenshots: scrollbar appears only during scroll; cpv breakpoints land where declared; zero native titles in cards; curated labels render with correct fallbacks.
- Rendered contrast pairs measured on the page (dark theme): all text passes WCAG AA (muted text 5.73–6.98, primary 12.5–15.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)