### PR TITLE
Upgrade fused dependency to 2.9.3b8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,7 @@ bundled = [
     # The requirement string must stay byte-identical to `[fused]`'s — see the
     # comment there and
     # tests/test_bundle_contents.py::test_the_bundled_and_fused_extras_pin_the_same_wheel.
-    'fused==2.9.3b7 ; python_version >= "3.11"',
+    'fused==2.9.3b8 ; python_version >= "3.11"',
     # The engine's own `mcp[cli]>=1.0.0` floor admits mcp 2.x, where
     # `mcp.server.fastmcp` no longer exists (FastMCP moved to the standalone
     # `fastmcp` distribution) — so a fresh resolve gets a `fused` whose
@@ -309,7 +309,7 @@ app = [
 # (README, docs/usage.md) and CI's `fused-engine` job (`.[dev,fused]`), both of
 # which want the engine WITHOUT the ~650 MB scientific stack.
 fused = [
-    'fused==2.9.3b7 ; python_version >= "3.11"',
+    'fused==2.9.3b8 ; python_version >= "3.11"',
     # The engine's own `mcp[cli]>=1.0.0` floor admits mcp 2.x, where
     # `mcp.server.fastmcp` no longer exists (FastMCP moved to the standalone
     # `fastmcp` distribution) — so a fresh resolve gets a `fused` whose


### PR DESCRIPTION
## Summary

Bumps the pinned `fused` wheel from `2.9.3b7` to `2.9.3b8` across both the `[bundled]` and `[fused]` extras. Two lines, but it is the fix for a reported crash rather than routine dependency maintenance.

## The bug it fixes

Opening a simple sine wave generator app showed this where the page should have rendered, on a newly created macOS profile:

```
PermissionError: [Errno 13] Permission denied: '/tmp/exec/<uuid>'
  run.py line 13 in <module>
  handler.py line 650 in lambda_handler: os.makedirs(call_dir, exist_ok=True)
  <frozen os> line 225 in makedirs
```

`fused`'s Lambda handler opened every call with a hardcoded `f"/tmp/exec/{uuid4()}"`, and the **local** compute backend runs that same file verbatim — `compute_base.py` imports `_HANDLER_FILES, _HERE` straight from the AWS module and byte-copies them into a per-call temp dir, so nothing AWS-shaped is involved. On Lambda `/tmp` is the function's private scratch and a fixed path is correct; on a desktop it is machine-wide, so whichever account opened the app first created `/tmp/exec` under its own umask (`drwxr-xr-x <that user>`) and every other account on the box then failed **every** run.

The error was raised in the child, so a non-zero exit turned it into the run's `error`, `engine._split_error` read `PermissionError` off its last line, and the page's error overlay presented it as though the user's own script had raised it — which is why it read as an app bug rather than an environment one.

`2.9.3b8` carries [fusedio/fused#365](https://github.com/fusedio/fused/pull/365), which puts the call dir at `{tempdir}/openfused-exec-<uuid>` — no shared intermediate directory at all — and never touches `/tmp/exec`.

## Verification

The reported scenario, reproduced and then re-run with b8 installed: a second unprivileged account, with a hostile `/tmp/exec` owned by another user at `0755` still sitting there.

| | result |
|---|---|
| b7 | `PermissionError: [Errno 13] Permission denied: '/tmp/exec/<uuid>'` on every run |
| b8 | page runs on the **fused** engine (not degraded), correct result, `/tmp/exec` never touched |

- Confirmed the installed b8 wheel actually carries the fix (`_CALL_DIR_PREFIX = "openfused-exec-"`); its only remaining `/tmp/exec` mentions are historical prose in a comment block, with no live code path.
- Pin-parity and engine-dispatch tests: 114 passed. Real-backend engine suites against b8: 534 passed, with the same 5 pre-existing failures the fake-py2app-bundle tests produce on this container's 3.12 interpreter both before and after the bump (verified by name against a clean tree).

## Notes

Both requirement strings move together because `tests/test_bundle_contents.py::test_the_bundled_and_fused_extras_pin_the_same_wheel` pins them byte-identical — `[bundled]` is what the packaging derivation and the platform installers read, `[fused]` is the documented light install path. The `>= 2.9.3b7` floor asserted in the same file for `OPENFUSED_APP_SERVE_PYTHON` is satisfied unchanged.

This **supersedes a downstream guard** that was previously on this branch (~660 lines: `engine.EXEC_ROOT` / `exec_root_blocked`, which detected an unusable `/tmp/exec` and degraded to the built-in executor). Keeping it alongside b8 would have been worse than dead code — it is consulted on every engine resolve and *creates* `/tmp/exec` at `0o1777` when missing, so it would plant a world-writable directory on every user's machine to guard a path nothing uses any more. The implementation is archived at `claude/tmp-exec-guard-superseded` (`ed41478`) should the pin ever have to go back.

The fix only reaches users once a fused-render release carrying this pin ships.

https://claude.ai/code/session_01HXDxeKbDsWkANaiDrzre3Y