### PR TITLE
Get test-python-windows green, and fix the scan-cancel bug it uncovered

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,9 +201,19 @@ jobs:
           sudo chmod +x /usr/local/bin/rclone
           rclone version
 
+      # `-q`, not `-v`: `-v` prints one line per test, and there are >11,000 of
+      # them, so it buried this job's actual output ~5:1 and pushed the log past
+      # what the Actions UI will render in one piece. It bought nothing that is
+      # not still here — pytest's own "short test summary info" names every
+      # failure by nodeid either way, and under `-n auto` the per-test lines
+      # arrive interleaved across workers, so they never read as a run order.
+      # The rest of the volume is the warnings summary, which is ~1,600 lines of
+      # `tests/x.py: N warnings` attribution for the 19 `@app.on_event`
+      # deprecations in server/app.py — fixed by migrating those to a lifespan
+      # handler, not by a pytest flag.
       - name: Run tests
         run: >
-          python -m pytest tests/ -v
+          python -m pytest tests/ -q
           --cov=fused_render --cov-report=term-missing --cov-report=xml --cov-report=html
 
       # One representative version avoids 4 duplicate reports/artifacts for
@@ -312,8 +322,10 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value $rcloneExe.DirectoryName
           & $rcloneExe.FullName version
 
+      # `-q` for the reason the Linux job above spells out: this job collects
+      # ~11,200 tests, and one `-v` line each is most of a 10k+ line log.
       - name: Run tests
-        run: python -m pytest tests/ -v
+        run: python -m pytest tests/ -q
 
   # The optional fused execution engine (D69) — the engine the migration plan
   # promotes to default, after which the built-in executor goes away. Until this

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -786,16 +786,24 @@ def cancel_all_scans() -> list:
     The one caller is `shell/prefs.py`'s `PUT /api/prefs`, when the indexing
     toggle flips to off: the contract is that a scan running at the moment of
     toggle-off is cancelled outright, not merely refused going forward. Lives
-    here rather than in the index layer because it needs `_live_runs`'
-    request-scoped cache and the same live-run enumeration `_scan_in_flight`
-    uses, and the index package cannot import the server (this module
-    already owns that seam for scan/cancel/status).
+    here rather than in the index layer because the index package cannot import
+    the server (this module already owns that seam for scan/cancel/status).
+
+    Listed through `runner.list_runs` directly rather than through
+    `_live_runs`. That helper is NOT request-scoped, whatever an earlier
+    version of this docstring said -- it is a 1.0s process-wide cache, held so
+    that ranking a keystroke does not re-fold every run directory. Reading a
+    toggle-off through it meant any ranked request in the preceding second --
+    and `/api/index/rank` fires on every keystroke in two search boxes --
+    answered from a listing taken before the running scan existed, so the scan
+    this exists to stop was never seen and never cancelled. Toggling indexing
+    off is a rare deliberate act; it can afford the fold a keystroke cannot.
 
     Returns the run ids actually cancelled — a run already told to stop is
     skipped, same as `active_run`'s own liveness rule."""
     cfg = load_config()
     cancelled = []
-    for r in _live_runs(cfg):
+    for r in runner.list_runs(cfg, limit=KEEP_RUNS)["runs"]:
         if not r.get("running"):
             continue
         rid = r.get("run_id")

--- a/tests/_big_files.py
+++ b/tests/_big_files.py
@@ -1,0 +1,68 @@
+"""Files that REPORT a size without spending it on the disk.
+
+A handful of tests here are about a number the app derives from how big a
+model file is — a budget-aware download picking a smaller quantisation, a
+cached repo's `size_gb`. What those tests need is a file whose `st_size` is
+multi-gigabyte; the bytes inside it are never read. Writing them for real
+costs both wall clock and disk (one 5GB `write_bytes` was 67s of the suite's
+295s, and repeated local runs filled the disk), so set the length instead of
+writing data: `ftruncate` is constant time and allocates nothing.
+
+That is also what a real download looks like on this disk. `worker_base`'s
+own docstring for `folder_bytes` spells it out: our segments write out of
+order, so a `.fusedpart` is created at its final size with `ftruncate` and
+filled sparsely.
+
+THE ONE PLACE THIS IS WRONG is a partial file — `.fusedpart` or hf's
+`.incomplete`. Download PROGRESS is deliberately measured by allocated
+BLOCKS rather than by length, for exactly the reason above: a sparse file's
+length is its eventual size, not what has arrived. A sparse `.fusedpart`
+would report zero bytes downloaded, so those fixtures have to write real
+bytes — which is fine, they are sized in megabytes rather than gigabytes.
+"""
+
+import ctypes
+import os
+import sys
+
+#: FSCTL_SET_SPARSE — see `_mark_sparse`.
+_FSCTL_SET_SPARSE = 0x000900C4
+
+
+def _mark_sparse(fd: int) -> None:
+    """Ask NTFS not to reserve the clusters. Best effort, never fatal.
+
+    A POSIX filesystem makes this sparse implicitly: extending the length
+    without writing allocates nothing at all. NTFS does not — it sets EOF
+    and reserves the space, so a 5GB fixture would still cost 5GB of a
+    Windows runner's rather small disk. It stays fast there either way (no
+    data is written), which is why failing to set the flag is not an error:
+    the worst case is the disk usage we already had before this helper.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import msvcrt
+
+        returned = ctypes.c_ulong(0)
+        ctypes.windll.kernel32.DeviceIoControl(
+            ctypes.c_void_p(msvcrt.get_osfhandle(fd)), _FSCTL_SET_SPARSE,
+            None, 0, None, 0, ctypes.byref(returned), None)
+    except Exception:
+        pass
+
+
+def sparse_file(path, size: int) -> None:
+    """Create `path` as a `size`-byte file holding no data.
+
+    `os.stat(path).st_size == size`, so every reader that sums or compares
+    lengths — `os.path.getsize`, `hub_cache`'s repo walk — sees `size`. Reads
+    return NUL bytes. Read the module docstring before reaching for this in a
+    partial-download fixture.
+    """
+    parent = os.path.dirname(os.fspath(path))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "wb") as f:
+        _mark_sparse(f.fileno())
+        f.truncate(size)

--- a/tests/test_ai_llamacpp_worker.py
+++ b/tests/test_ai_llamacpp_worker.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import pytest
 
+from _big_files import sparse_file
+
 WORKER_PATH = str(
     Path(__file__).resolve().parents[1]
     / "fused_render" / "ai" / "runners" / "llama_text.py"
@@ -338,7 +340,9 @@ def test_a_local_cache_hit_is_preferred_over_a_remote_listing(
     snapshot = folder / "snapshots" / "abc123"
     snapshot.mkdir(parents=True)
     curated_file = snapshot / "gemma-4-E4B-it-Q4_K_M.gguf"
-    curated_file.write_bytes(b"x" * (5 * 1024 ** 3))
+    # Sparse: only its `st_size` is ever read (`os.path.getsize`, below),
+    # and 5GB of real bytes was 67s of the suite. See `_big_files`.
+    sparse_file(curated_file, 5 * 1024 ** 3)
     local_file = snapshot / "gemma-4-E4B-it-Q2_K.gguf"
     local_file.write_bytes(b"x" * 1024)
     worker.worker_base.repo_folder = lambda model_id, repo_type="model": (

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -37,6 +37,7 @@ from fused_render.server.routers import ai_runtime
 # "every test stubs the Hub" is not the same claim as "no test reaches the
 # network".
 from test_ai_hub_fetch import no_egress  # noqa: F401
+from _big_files import sparse_file
 
 # os.geteuid is POSIX-only; a bare call below would crash collection of this
 # whole module on Windows, before any skipif could act on it.
@@ -9594,10 +9595,13 @@ def _text_repo(hub, repo_id, *, size=0):
 
     Safetensors, so a test using this needs the `safetensors_text_engine`
     fixture — see its docstring for why the ambient platform is not enough.
+
+    The weights file is sparse: `size` here exists to be read back as a
+    `size_gb`, and the scan that reads it sums `st_size`. See `_big_files`.
     """
     repo = _cached_repo(hub, repo_id, files=("model.safetensors",),
                         config={"architectures": ["LlamaForCausalLM"]})
-    (repo / "snapshots" / "c0ffee" / "model.safetensors").write_bytes(b"x" * size)
+    sparse_file(repo / "snapshots" / "c0ffee" / "model.safetensors", size)
     return repo
 
 
@@ -10200,7 +10204,7 @@ def test_a_second_revision_landing_in_an_EXISTING_repo_updates_its_size(
     assert _offered(client, registry.TEXT_GENERATION, "some-org/grows")["size_gb"] == 1.0
     blobs = repo / "blobs"
     blobs.mkdir(parents=True, exist_ok=True)
-    (blobs / "second-revision").write_bytes(b"x" * 2_000_000_000)
+    sparse_file(blobs / "second-revision", 2_000_000_000)
     assert _offered(client, registry.TEXT_GENERATION, "some-org/grows")["size_gb"] == 3.0
 
 

--- a/tests/test_app_fused_dir.py
+++ b/tests/test_app_fused_dir.py
@@ -88,6 +88,41 @@ def claude_store(tmp_path, monkeypatch):
     return projects, sessions
 
 
+def _absent_root() -> str:
+    """An absolute path that does not exist, on POSIX **and** on Windows.
+
+    `os.path.join(os.sep, "somewhere", ...)` is not enough. On Windows that is
+    `\\somewhere\\else\\demo` — drive-RELATIVE: `ntpath.isabs` says True, but
+    `splitdrive` returns no drive, so `os.path.abspath` prepends the current
+    drive and the string CHANGES. Every path function under test abspaths its
+    input (`claude_session_move.munge`, `_under`, `_path_rewrites`;
+    `workspace_migration._remap` documents that it requires it), so a fixture
+    seeded with the un-drived spelling never matches what production searches
+    for: the transcript's `cwd` is left unrewritten, and the assertions that
+    follow it fail — on Windows only.
+
+    Calling `abspath` here is what makes the fixture and production agree, and
+    is the same thing `test_file_history.py` does for its own absent path.
+    """
+    return os.path.abspath(os.path.join(os.sep, "somewhere", "else", "demo"))
+
+
+def test_the_absent_root_fixture_is_absolute_on_every_platform():
+    """The guard for the Windows-only breakage this file had.
+
+    `abspath(p) == p` is the contract every path function under test relies on,
+    and `os.path.isabs` is NOT that contract: on Windows it answers True for the
+    drive-relative `\\somewhere\\else\\demo`, which `abspath` then rewrites by
+    prepending a drive. A fixture whose spelling changes under `abspath` can
+    never match what production searches for — which is why these tests passed
+    on POSIX and failed on Windows. Assert the fixed point, not `isabs`.
+    """
+    root = _absent_root()
+    assert os.path.abspath(root) == root      # the load-bearing one
+    assert os.path.isabs(root)
+    assert not os.path.exists(root)           # still absent, or it is not a move
+
+
 def _transcript(projects, cwd, sid, extra_line=None):
     from fused_render.claude_session_move import munge
 
@@ -145,7 +180,7 @@ def test_a_moved_app_carries_its_claude_sessions_and_repoints_meta(app, claude_s
     projects, _ = claude_store
     app_fused_dir.ensure(str(app))
     meta_file = app / ".fused" / "meta.json"
-    old = os.path.join(os.sep, "somewhere", "else", "demo")
+    old = _absent_root()
     meta = json.loads(meta_file.read_text())
     meta["app_dir"] = old
     meta["custom"] = "kept"
@@ -201,7 +236,7 @@ def test_a_live_session_holds_the_move_back(app, claude_store):
     projects, sessions = claude_store
     app_fused_dir.ensure(str(app))
     meta_file = app / ".fused" / "meta.json"
-    old = os.path.join(os.sep, "somewhere", "else", "demo")
+    old = _absent_root()
     meta = json.loads(meta_file.read_text())
     meta["app_dir"] = old
     meta_file.write_text(json.dumps(meta))
@@ -221,8 +256,6 @@ def test_a_move_re_roots_bookmarks_and_app_stores(app, claude_store, tmp_path, m
     """The stores that name the old path by absolute path (bookmarks, the
     desk, the registered registry) or by workspace-relative key (app_recents)
     all follow the move; entries about OTHER apps are untouched."""
-    import urllib.parse
-
     home = tmp_path / "fused-home"
     home.mkdir()
     monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
@@ -231,10 +264,18 @@ def test_a_move_re_roots_bookmarks_and_app_stores(app, claude_store, tmp_path, m
     old = os.path.join(fused_dir(), "local", "demo-viz")
     new_root = os.path.abspath(str(app))  # tmp_path/Fused/local/demo
 
-    enc = "/".join(urllib.parse.quote(s, safe="!*'()")
-                   for s in (old.lstrip("/") + "/index.html").split("/"))
+    # The shell's own encoder, not a hand-rolled one: `old.lstrip("/")` and
+    # `.split("/")` assume forward slashes, so on Windows the whole backslashed
+    # path became ONE segment and `quote` turned it into
+    # `C%3A%5CUsers%5C...%5Cdemo-viz` — a spelling `_remap_url` cannot decode,
+    # so the bookmark was never re-rooted and only this test noticed.
+    # `view_url_path` canonicalises first, which is the form bookmarks.json
+    # actually holds on every platform.
+    from fused_render._view_url_codec import view_url_path
+
+    enc_url = view_url_path(os.path.join(old, "index.html"))
     (home / "bookmarks.json").write_text(json.dumps([
-        {"name": "mine", "url": "/explorer/view/" + enc + "?sel=index.html"},
+        {"name": "mine", "url": enc_url + "?sel=index.html"},
         {"name": "other", "url": "/explorer/view/Users/x/other/app.html"},
     ]))
     (home / "current_apps.json").write_text(json.dumps(
@@ -299,7 +340,7 @@ def test_a_second_move_before_the_live_session_ends_loses_nothing(app, claude_st
 
     projects, sessions = claude_store
     app_fused_dir.ensure(str(app))
-    old = os.path.join(os.sep, "somewhere", "else", "demo")
+    old = _absent_root()
     meta = json.loads((app / ".fused" / "meta.json").read_text())
     meta["app_dir"] = old
     (app / ".fused" / "meta.json").write_text(json.dumps(meta))

--- a/tests/test_app_fused_dir.py
+++ b/tests/test_app_fused_dir.py
@@ -207,11 +207,20 @@ def test_a_moved_app_carries_its_claude_sessions_and_repoints_meta(app, claude_s
     assert json.loads(moved[2])["cwd"] == new_root
     assert (dst / "aaaa-1" / "tool-results" / "x.txt").read_text() == "r"
     # The pane identity moved too — both spellings, nothing left of the old.
+    # Spelled as the FILE holds them, not as `os.path.join` returns them: these
+    # paths sit inside JSON strings, so on Windows their separators are escaped
+    # and the single-backslash form never appears in the raw bytes at all (the
+    # assertion could not pass there, however correct the rewrite).
+    # `json.dumps(p)[1:-1]` is precisely the spelling
+    # `claude_session_move._path_rewrites` rewrites, and is a no-op on POSIX.
     import urllib.parse
     body = (dst / "aaaa-1.jsonl").read_text()
-    assert os.path.join(new_root, "index.html") in body
-    assert urllib.parse.quote(os.path.join(new_root, "index.html"), safe="") in body
-    assert old not in body
+    entry = os.path.join(new_root, "index.html")
+    assert json.dumps(entry)[1:-1] in body
+    assert urllib.parse.quote(entry, safe="") in body
+    # The escaped spelling is the one that was there to remove — plain `old`
+    # never appears on Windows, so asserting it alone is vacuous there.
+    assert json.dumps(old)[1:-1] not in body
     sub = projects / munge(os.path.join(new_root, "sub", "deeper"))
     assert json.loads((sub / "bbbb-2.jsonl").read_text().splitlines()[1])["cwd"] == \
         os.path.join(new_root, "sub", "deeper")

--- a/tests/test_big_files.py
+++ b/tests/test_big_files.py
@@ -1,0 +1,71 @@
+"""`_big_files.sparse_file` keeps the one promise its callers rely on.
+
+Those callers assert about a `size_gb` or a quantisation pick derived from a
+file's length, so a helper that quietly produced the wrong length would turn
+them into tests of nothing. Pinned here rather than left implicit because the
+implementation is a `truncate` — plausible-looking and easy to "simplify"
+into something that no longer reports the right size on one platform.
+"""
+
+import os
+import sys
+
+import pytest
+
+from _big_files import _mark_sparse, sparse_file
+
+FIVE_GIB = 5 * 1024 ** 3
+
+
+def test_the_reported_length_is_the_length_that_was_asked_for(tmp_path):
+    path = tmp_path / "model.safetensors"
+    sparse_file(path, FIVE_GIB)
+    assert os.stat(path).st_size == FIVE_GIB
+    assert os.path.getsize(path) == FIVE_GIB      # what the callers call
+    assert path.stat().st_size == FIVE_GIB        # …and via pathlib
+
+
+def test_a_missing_parent_directory_is_created(tmp_path):
+    """`_text_repo` hands in a path several levels down a cache layout."""
+    path = tmp_path / "snapshots" / "c0ffee" / "model.safetensors"
+    sparse_file(path, 2048)
+    assert os.path.getsize(path) == 2048
+
+
+def test_zero_is_a_real_empty_file(tmp_path):
+    """`_text_repo`'s default size, which a couple of its callers take."""
+    path = tmp_path / "empty.bin"
+    sparse_file(path, 0)
+    assert path.is_file() and os.path.getsize(path) == 0
+
+
+def test_reads_come_back_as_nul_bytes(tmp_path):
+    """Nothing reads these fixtures today; this says what would be seen if
+    something started to, so a future reader is not surprised by `b"x"`."""
+    path = tmp_path / "holey.bin"
+    sparse_file(path, 4096)
+    assert path.read_bytes() == b"\0" * 4096
+
+
+@pytest.mark.skipif(not hasattr(os.stat_result, "st_blocks"),
+                    reason="st_blocks is POSIX-only")
+def test_nothing_is_allocated_on_the_disk(tmp_path):
+    """The half that makes it worth doing: 5GB of length, no 5GB of disk.
+
+    This is the assertion that fails if the helper regresses to writing real
+    bytes — the speed is a side effect of allocating nothing.
+    """
+    path = tmp_path / "model.safetensors"
+    sparse_file(path, FIVE_GIB)
+    assert os.stat(path).st_blocks * 512 < 1024 * 1024
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="the point is the branch NOT taken off windows")
+def test_the_windows_only_flag_is_skipped_rather_than_attempted(tmp_path):
+    """`ctypes.windll` exists only on Windows, so `_mark_sparse` has to return
+    on the platform check — an `except Exception` mopping up an
+    `AttributeError` on every POSIX call would work but would hide a real
+    Windows failure behind the same silence."""
+    with open(tmp_path / "x.bin", "wb") as f:
+        assert _mark_sparse(f.fileno()) is None

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -1017,6 +1017,19 @@ def test_the_run_listing_is_not_re_read_on_every_keystroke(home, tmp_path, monke
     monkeypatch.setattr(runner, "list_runs",
                         lambda cfg, limit=20: (calls.append(1), real(cfg, limit=limit))[1])
     index_routes._forget_runs()
+    # The shipped window has to be a real one, or the assertion below is a
+    # tautology — so it is checked rather than replaced…
+    assert index_routes.RUNS_CACHE_S >= 1.0
+    # …and then widened, because HOW MANY keystrokes fit inside it is a fact
+    # about the machine, not about the cache. `_live_runs` compares
+    # `time.monotonic()` against the window on every ranked request, so where
+    # five round trips take longer than RUNS_CACHE_S the entry expires
+    # mid-loop and this reads `assert 2 == 1`, `len([1, 1])`. That is what
+    # `test-python-windows` printed on two separate runs. What is under test
+    # is that a keystroke arriving INSIDE the window is served from the cache;
+    # `test_the_cached_run_listing_expires` below owns the other half, and
+    # forces the clock rather than waiting on it for the same reason.
+    monkeypatch.setattr(index_routes, "RUNS_CACHE_S", 3600.0)
     for q in ("a", "al", "alp", "alph", "alpha"):
         client.get("/api/index/rank", params={"root": root, "q": q})
     assert len(calls) == 1

--- a/tests/test_shell_prefs.py
+++ b/tests/test_shell_prefs.py
@@ -242,6 +242,40 @@ def test_turning_indexing_off_cancels_a_live_scan(tmp_path, monkeypatch):
     assert os.path.exists(os.path.join(run_dir, "cancel"))
 
 
+def test_a_live_scan_is_cancelled_even_with_the_run_listing_already_cached(
+        tmp_path, monkeypatch):
+    """The test above only catches this by luck, and on CI it stopped doing so.
+
+    `cancel_all_scans` enumerates live runs; the obvious way to do that is
+    `_live_runs`, the helper the ranking route uses. But that one is a 1.0s
+    PROCESS-WIDE cache, not a request-scoped one — so a listing taken before
+    the scan started answers the toggle, the running scan is not in it, and
+    nothing is cancelled. `/api/index/rank` fires on every keystroke in two
+    search boxes, so in the real app that cache is essentially always warm:
+    this was the common case, not the rare one.
+
+    Priming the cache first is what makes the failure deterministic rather
+    than a matter of which test ran a moment earlier in the same worker.
+    """
+    client, home = _client(tmp_path, monkeypatch)
+    from fused_render.index import runner
+    from fused_render.index.config import load_config
+    from fused_render.server.routers import index as index_routes
+
+    cfg = load_config()
+    index_routes._forget_runs()
+    index_routes._live_runs(cfg)  # …as any earlier ranked request would have
+    root = str(tmp_path / "proj")
+    os.makedirs(root, exist_ok=True)
+    run_id = runner.start(cfg, root)["run_id"]
+    run_dir = os.path.join(cfg.runs_dir, run_id)
+    assert not os.path.exists(os.path.join(run_dir, "cancel"))
+
+    client.put("/api/prefs", json={"indexing_enabled": False}, headers=FUSED)
+
+    assert os.path.exists(os.path.join(run_dir, "cancel"))
+
+
 def test_default_model_defaults_to_unset_and_round_trips(tmp_path, monkeypatch):
     client, home = _client(tmp_path, monkeypatch)
     # Unset is its own value — "" means "whatever each consumer's own default


### PR DESCRIPTION
`test-python-windows` had been red on `main` on every recent commit, taking the `Test Status` rollup — and therefore **every PR in the repo** — with it. This gets it green.

Chasing it turned up one real product bug, and two pieces of test overhead worth removing while they were in view. **All 13 checks pass on `9965ba2`, `test-python-windows` included.**

| | |
|---|---|
| Windows failures | 3 → **0** |
| Suite wall clock | 291.9s → **267.1s** (measured, 2 runs a side) |
| Disk written per run | **~11GB less** |
| CI log | ~25,000 → ~2,900 lines |
| Product bugs fixed | **1** (`cancel_all_scans`) |

---

## 1. A live scan was often not cancelled — `fused_render/server/routers/index.py`

**The only production change here, and it is a real user-facing bug.** Found by CI going red, not by looking for it.

Turning indexing off is documented to cancel a scan already in flight, not merely refuse the next one. `cancel_all_scans` enumerated live runs through `_live_runs`, and its own docstring justified that by calling it a *"request-scoped cache."* **It is not.** It is a 1.0s process-wide cache, held so that ranking a keystroke does not re-fold every run directory.

So any ranked request in the preceding second answered the toggle-off from a listing taken **before the running scan existed**. The scan was not in it, `cancel` was never written, and the scan kept going. `/api/index/rank` fires on every keystroke in two search boxes, so in a running app that cache is essentially always warm — **this was the common case, not the rare one.**

| `_runs_cache` state when the toggle arrives | `cancel` sentinel written? |
|---|---|
| cold | ✅ yes |
| primed < 1s earlier | ❌ **no** |

Fixed by listing through `runner.list_runs` directly — the same call `_live_runs` wraps, so the entry shape is unchanged and the ranking path keeps its cache. Toggling indexing off is a rare deliberate act; it can afford the fold a keystroke cannot.

The existing test passed only by luck, which is why this survived. The new one primes the cache first, making it deterministic. **Mutation checked**: it fails on the old enumeration, passes on the new.

## 2. The three Windows-only `test_app_fused_dir` failures

Two fixture bugs, both in the tests — `app_fused_dir`, `claude_session_move` and `workspace_migration` were behaving as documented.

**The fake "old" root was not absolute on Windows.** `os.path.join(os.sep, "somewhere", ...)` is `/somewhere/...` on POSIX but `\somewhere\...` on Windows — drive-*relative*. `ntpath.isabs` answers True anyway, but with no drive `abspath` prepends the current one and **the string changes**. Every path function under test abspaths its input, so the fixture seeded transcripts containing `\somewhere\else\demo` while `_path_rewrites` searched for `D:\somewhere\else\demo`. Now built by an `_absent_root()` helper, with a guard test asserting the contract that actually matters — `abspath(p) == p`, **not** `isabs`.

**The bookmark URL was hand-encoded with POSIX assumptions.** `lstrip("/")` and `.split("/")` left the whole backslashed path as one segment, producing `/explorer/view/C%3A%5CUsers%5C…` — verbatim what CI printed. Now built with the shell's own `_view_url_codec.view_url_path`. On POSIX the two constructions are identical.

## 3. One test wrote 5GB of real bytes; two more wrote 3GB each

Three tests build a model file solely so something can read its length back. The largest was `b"x" * (5 * 1024 ** 3)` — 5GB of RAM to build the string, 5GB written to disk, for a file nothing ever reads.

`tests/_big_files.sparse_file` sets the length with `ftruncate` instead. `st_size` is identical, which is what `os.path.getsize` and `hub_cache`'s repo walk both sum, and it allocates nothing. It also matches what a real download leaves on disk — `worker_base.folder_bytes` documents that our segments write out of order, so a `.fusedpart` is created at its final size and filled sparsely.

| test | before | after |
|---|---|---|
| `test_a_local_cache_hit_is_preferred_over_a_remote_listing` | 67.66s | 0.00s |
| `test_a_cached_entrys_size_is_its_real_measured_footprint` | 35.55s | 0.07s |
| `test_a_second_revision_landing_in_an_EXISTING_repo_updates_its_size` | 14.05s | 0.08s |

That is ~117s of worker time, which on 4 cores under `-n auto` is ~25s of wall clock — the other workers absorb most of it. The **~11GB of disk** is the part that may matter more on `windows-latest`.

Deliberately **not** applied to `test_fetched_bytes_reads_the_sidecar_not_the_part_files_length`: download progress is measured by allocated blocks precisely because a preallocated `.fusedpart`'s length is its eventual size rather than what has arrived, so a sparse one would describe a download that had not started. `tests/_big_files`'s docstring records that as the one place the helper is wrong.

## 4. A test that raced a 1.0s deadline

`test_index_search::test_the_run_listing_is_not_re_read_on_every_keystroke` fires five ranked requests and asserts `list_runs` ran once — which holds only if all five HTTP round trips fit inside `RUNS_CACHE_S`. On a loaded runner they do not, and it reads `assert 2 == 1`. It failed on two separate Windows runs before being fixed here.

It now asserts the shipped constant is a real window — so a regression to zero still fails — and then widens it for the loop. *How many round trips fit in a second* is a fact about the machine, not about the cache.

## 5. `-v` was ~89% of the CI log — `.github/workflows/test.yml`

Both full-suite jobs ran `pytest tests/ -v`. Measured on a 513-test sample, `-v` costs **2.00 extra lines per test**; at 11,383 collected tests that is **~22,800 lines** around ~2,900 lines of everything else, which is past what the Actions UI renders in one piece. Every other pytest job in the file already used `-q`.

Nothing is lost: pytest's "short test summary info" names every failure by nodeid without `-v`, and under `-n auto` the per-test lines interleave across four workers, so they never read as a run order.

**Not fixed here:** the remaining ~1,750 log lines are the warnings summary, ~1,580 of which are `tests/x.py: N warnings` attribution for the **19 `@app.on_event` deprecations** in `server/app.py`. Migrating those to a lifespan handler is the fix, and it changes how the server starts — it belongs in its own PR rather than riding along here.

---

## Verification

- **CI:** all 13 checks green on `9965ba2`, including `test-python-windows` (9m59s) and Cursor Bugbot.
- **Full suite, before and after the production change:** byte-identical failure lists. The 32 local failures are all pre-existing — 24 are missing `rasterio`/`shapely` in my container; the other 8 reproduce on a clean `origin/main` checkout.
- **Collected node ids diffed** across the change: exactly one new test, none dropped.
- The Windows path reasoning was driven on Linux with Windows-shaped strings before pushing, rather than guessed: the old hand-rolled URL reproduces the CI failure byte for byte, and `_remap` returns `None` for the drive-relative root and the right path for the absolute one.

## Reviewers

Commits 1–4 are test-only. **`9965ba2` is the one production change** and deserves its own look rather than riding along with the test fixes — happy to split it into a separate PR if that reads better.