### PR TITLE
Include brew update in the surfaced brew upgrade command

### DIFF
--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -9,10 +9,14 @@ Two methods, decided once per process:
 - "brew": the running bundle is Homebrew-managed. The app never runs brew
   itself — swapping the bundle behind brew's back would desync its
   bookkeeping (Caskroom metadata, `brew list`) permanently. Instead the
-  "available" state carries `manual_command` (`brew upgrade --cask
-  fused-render`) for the user to run in a terminal; POST /api/update/install
-  is a no-op. The next check() tick reads the bundle on disk and flips to
-  "installed" once the user's upgrade lands.
+  "available" state carries `manual_command` (`brew update && brew upgrade
+  --cask fused-render`) for the user to run in a terminal; POST
+  /api/update/install is a no-op. The `brew update` is required: the tap's
+  cask (fusedio/homebrew-tap) has no livecheck, so Homebrew only learns of a
+  version bump after refreshing its local clone of the tap — otherwise
+  `brew upgrade` reads the stale cached cask and reports nothing to do. The
+  next check() tick reads the bundle on disk and flips to "installed" once
+  the user's upgrade lands.
 - "dmg": download the signed DMG, verify, and swap the .app bundle in place.
   Replacing the bundle under a running process is the SUPPORTED existing flow
   (a manual DMG drag does exactly this): installed.installed_version() then
@@ -51,7 +55,7 @@ CASK_NAME = "fused-render"
 # GUI apps launch with a bare PATH, so brew is probed at its two fixed homes
 # (Apple Silicon, then Intel) rather than through the environment.
 BREW_PATHS = ("/opt/homebrew/bin/brew", "/usr/local/bin/brew")
-BREW_COMMAND = f"brew upgrade --cask {CASK_NAME}"
+BREW_COMMAND = f"brew update && brew upgrade --cask {CASK_NAME}"
 _DOWNLOAD_PREFIX = "FusedRender-"
 _DOWNLOAD_SUFFIX = ".dmg"
 # Keep a margin over the DMG itself: the download and the staged .app copy

--- a/tests/test_app_fused_dir.py
+++ b/tests/test_app_fused_dir.py
@@ -88,6 +88,41 @@ def claude_store(tmp_path, monkeypatch):
     return projects, sessions
 
 
+def _absent_root() -> str:
+    """An absolute path that does not exist, on POSIX **and** on Windows.
+
+    `os.path.join(os.sep, "somewhere", ...)` is not enough. On Windows that is
+    `\\somewhere\\else\\demo` — drive-RELATIVE: `ntpath.isabs` says True, but
+    `splitdrive` returns no drive, so `os.path.abspath` prepends the current
+    drive and the string CHANGES. Every path function under test abspaths its
+    input (`claude_session_move.munge`, `_under`, `_path_rewrites`;
+    `workspace_migration._remap` documents that it requires it), so a fixture
+    seeded with the un-drived spelling never matches what production searches
+    for: the transcript's `cwd` is left unrewritten, and the assertions that
+    follow it fail — on Windows only.
+
+    Calling `abspath` here is what makes the fixture and production agree, and
+    is the same thing `test_file_history.py` does for its own absent path.
+    """
+    return os.path.abspath(os.path.join(os.sep, "somewhere", "else", "demo"))
+
+
+def test_the_absent_root_fixture_is_absolute_on_every_platform():
+    """The guard for the Windows-only breakage this file had.
+
+    `abspath(p) == p` is the contract every path function under test relies on,
+    and `os.path.isabs` is NOT that contract: on Windows it answers True for the
+    drive-relative `\\somewhere\\else\\demo`, which `abspath` then rewrites by
+    prepending a drive. A fixture whose spelling changes under `abspath` can
+    never match what production searches for — which is why these tests passed
+    on POSIX and failed on Windows. Assert the fixed point, not `isabs`.
+    """
+    root = _absent_root()
+    assert os.path.abspath(root) == root      # the load-bearing one
+    assert os.path.isabs(root)
+    assert not os.path.exists(root)           # still absent, or it is not a move
+
+
 def _transcript(projects, cwd, sid, extra_line=None):
     from fused_render.claude_session_move import munge
 
@@ -145,7 +180,7 @@ def test_a_moved_app_carries_its_claude_sessions_and_repoints_meta(app, claude_s
     projects, _ = claude_store
     app_fused_dir.ensure(str(app))
     meta_file = app / ".fused" / "meta.json"
-    old = os.path.join(os.sep, "somewhere", "else", "demo")
+    old = _absent_root()
     meta = json.loads(meta_file.read_text())
     meta["app_dir"] = old
     meta["custom"] = "kept"
@@ -172,11 +207,20 @@ def test_a_moved_app_carries_its_claude_sessions_and_repoints_meta(app, claude_s
     assert json.loads(moved[2])["cwd"] == new_root
     assert (dst / "aaaa-1" / "tool-results" / "x.txt").read_text() == "r"
     # The pane identity moved too — both spellings, nothing left of the old.
+    # Spelled as the FILE holds them, not as `os.path.join` returns them: these
+    # paths sit inside JSON strings, so on Windows their separators are escaped
+    # and the single-backslash form never appears in the raw bytes at all (the
+    # assertion could not pass there, however correct the rewrite).
+    # `json.dumps(p)[1:-1]` is precisely the spelling
+    # `claude_session_move._path_rewrites` rewrites, and is a no-op on POSIX.
     import urllib.parse
     body = (dst / "aaaa-1.jsonl").read_text()
-    assert os.path.join(new_root, "index.html") in body
-    assert urllib.parse.quote(os.path.join(new_root, "index.html"), safe="") in body
-    assert old not in body
+    entry = os.path.join(new_root, "index.html")
+    assert json.dumps(entry)[1:-1] in body
+    assert urllib.parse.quote(entry, safe="") in body
+    # The escaped spelling is the one that was there to remove — plain `old`
+    # never appears on Windows, so asserting it alone is vacuous there.
+    assert json.dumps(old)[1:-1] not in body
     sub = projects / munge(os.path.join(new_root, "sub", "deeper"))
     assert json.loads((sub / "bbbb-2.jsonl").read_text().splitlines()[1])["cwd"] == \
         os.path.join(new_root, "sub", "deeper")
@@ -201,7 +245,7 @@ def test_a_live_session_holds_the_move_back(app, claude_store):
     projects, sessions = claude_store
     app_fused_dir.ensure(str(app))
     meta_file = app / ".fused" / "meta.json"
-    old = os.path.join(os.sep, "somewhere", "else", "demo")
+    old = _absent_root()
     meta = json.loads(meta_file.read_text())
     meta["app_dir"] = old
     meta_file.write_text(json.dumps(meta))
@@ -221,8 +265,6 @@ def test_a_move_re_roots_bookmarks_and_app_stores(app, claude_store, tmp_path, m
     """The stores that name the old path by absolute path (bookmarks, the
     desk, the registered registry) or by workspace-relative key (app_recents)
     all follow the move; entries about OTHER apps are untouched."""
-    import urllib.parse
-
     home = tmp_path / "fused-home"
     home.mkdir()
     monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
@@ -231,10 +273,18 @@ def test_a_move_re_roots_bookmarks_and_app_stores(app, claude_store, tmp_path, m
     old = os.path.join(fused_dir(), "local", "demo-viz")
     new_root = os.path.abspath(str(app))  # tmp_path/Fused/local/demo
 
-    enc = "/".join(urllib.parse.quote(s, safe="!*'()")
-                   for s in (old.lstrip("/") + "/index.html").split("/"))
+    # The shell's own encoder, not a hand-rolled one: `old.lstrip("/")` and
+    # `.split("/")` assume forward slashes, so on Windows the whole backslashed
+    # path became ONE segment and `quote` turned it into
+    # `C%3A%5CUsers%5C...%5Cdemo-viz` — a spelling `_remap_url` cannot decode,
+    # so the bookmark was never re-rooted and only this test noticed.
+    # `view_url_path` canonicalises first, which is the form bookmarks.json
+    # actually holds on every platform.
+    from fused_render._view_url_codec import view_url_path
+
+    enc_url = view_url_path(os.path.join(old, "index.html"))
     (home / "bookmarks.json").write_text(json.dumps([
-        {"name": "mine", "url": "/explorer/view/" + enc + "?sel=index.html"},
+        {"name": "mine", "url": enc_url + "?sel=index.html"},
         {"name": "other", "url": "/explorer/view/Users/x/other/app.html"},
     ]))
     (home / "current_apps.json").write_text(json.dumps(
@@ -299,7 +349,7 @@ def test_a_second_move_before_the_live_session_ends_loses_nothing(app, claude_st
 
     projects, sessions = claude_store
     app_fused_dir.ensure(str(app))
-    old = os.path.join(os.sep, "somewhere", "else", "demo")
+    old = _absent_root()
     meta = json.loads((app / ".fused" / "meta.json").read_text())
     meta["app_dir"] = old
     (app / ".fused" / "meta.json").write_text(json.dumps(meta))

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -174,7 +174,7 @@ def test_brew_available_carries_manual_command(monkeypatch):
     manager = _manager(monkeypatch, method="brew", available="9.9.9")
     status = manager.check()
     assert status["state"] == "available"
-    assert status["manual_command"] == "brew upgrade --cask fused-render"
+    assert status["manual_command"] == "brew update && brew upgrade --cask fused-render"
 
 
 def test_dmg_available_has_no_manual_command(monkeypatch):


### PR DESCRIPTION
## Summary
- Companion to [fusedio/homebrew-tap#4](https://github.com/fusedio/homebrew-tap/pull/4).
- For brew-managed installs, the update badge (`frontend/src/platform/ui/UpdateBadge.tsx`) shows a copy-paste terminal command sourced from `BREW_COMMAND` in `fused_render/update/mac.py`. It was just `brew upgrade --cask fused-render`.
- `fusedio/homebrew-tap`'s cask has `livecheck { skip ... }` (DMGs live in a private bucket), so Homebrew only learns of a version bump after `brew update` refreshes its local clone of the tap. A user who copies the old command straight from the badge — without a prior `brew update` — can hit a stale cached cask and see "already up to date" even after a newer release has shipped.
- This updates `BREW_COMMAND` to `brew update && brew upgrade --cask fused-render`, updates the docstring explaining why, and updates the matching assertion in `tests/test_mac_update.py`.

## Test plan
- [x] `uv run pytest tests/test_mac_update.py` — 24 passed (4 pre-existing errors unrelated to this change: `RuntimeError: React shell not built`, from the frontend not being built in this environment)
- [ ] Manually verify the update badge in a brew-managed install shows the new command with a working copy button

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UxfV5D7mxDvkR3yuPiUfb1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and user-facing terminal string only; no change to install logic, API behavior, or DMG update path.
> 
> **Overview**
> For **brew-managed** macOS installs, the in-app update badge’s copy-paste `manual_command` now runs **`brew update && brew upgrade --cask fused-render`** instead of upgrade-only.
> 
> Because the **fusedio/homebrew-tap** cask skips livecheck, Homebrew can keep a stale tap clone until `brew update`; upgrade-only could falsely report “already up to date” after a release. The module docstring documents that behavior, and **`tests/test_mac_update.py`** expects the new string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a84c731bd89faa8f87780509db28c83310aaa7d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->