### PR TITLE
Move the 19 on_event hooks to a lifespan handler (73,154 warnings → 4)

### DIFF
--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -376,6 +376,13 @@ def create_app(start_dir: str) -> FastAPI:
 
     app = FastAPI(title="fused-render",
                   lifespan=_lifespan(startup_handlers, shutdown_handlers))
+    # Exposed so the registry is inspectable — `on_event` kept its own on
+    # `app.router.on_startup`/`on_shutdown`, and losing that would mean the
+    # ORDER these run in, which is the contract, could only be checked by
+    # reading 450 lines of decorators. `tests/test_app_lifespan.py` asserts
+    # the exact sequence against what `on_event` produced.
+    app.state.startup_handlers = startup_handlers
+    app.state.shutdown_handlers = shutdown_handlers
     app.state.start_dir = start_dir
 
     # Shared keep-alive HTTP pool for the opt-in pooled /api/fs/raw proxy

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -20,6 +20,7 @@ import json
 import os
 import threading
 import time
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
@@ -302,6 +303,42 @@ def _export_bundled_uv_path() -> None:
     os.environ["PATH"] = (uv_dir + os.pathsep + path) if path else uv_dir
 
 
+def _lifespan(startup_handlers: list, shutdown_handlers: list):
+    """The startup/shutdown contract `on_event` used to provide.
+
+    Lifted out of `create_app` so it can be driven with fake handlers rather
+    than with the 19 real ones, which start schedulers and warm engines. The
+    lists are read when the app STARTS, not when this is called, so a handler
+    registered further down `create_app` is still picked up.
+
+    Two details are the whole reason this is not a one-liner, both taken from
+    what `on_event` actually did (fastapi/routing.py, `_startup`/`_shutdown`
+    and `_DefaultLifespan`):
+
+    * Both lists run in REGISTRATION order. Shutdown is **not** reversed — it
+      reads like it ought to be, and it never was, so reversing it here would
+      be a silent behaviour change wearing the clothes of a cleanup.
+    * Shutdown runs even when the served application raised, because
+      `__aexit__` ran regardless once `__aenter__` had returned. A bare
+      `yield` with no `finally` would quietly stop doing that. A startup that
+      raises still skips shutdown entirely, because `__aenter__` never
+      returned — which is why the `try` opens after the startup loop rather
+      than around it.
+    """
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        for handler in startup_handlers:
+            await handler()
+        try:
+            yield
+        finally:
+            for handler in shutdown_handlers:
+                await handler()
+
+    return lifespan
+
+
 def create_app(start_dir: str) -> FastAPI:
     # Engine (D69/D70 + SPEC §20): validate any FUSED_RENDER_ENGINE override
     # ONCE at startup — this raises on a bad value and fails loudly for
@@ -312,7 +349,33 @@ def create_app(start_dir: str) -> FastAPI:
     # and the page's "running" label never drifts from what actually runs.
     _forced_engine()
 
-    app = FastAPI(title="fused-render")
+    # Startup/shutdown work, collected here and run by `lifespan` below.
+    #
+    # These were 19 `on_event` hooks until FastAPI deprecated that decorator.
+    # The lists exist because a `lifespan` has to be handed to `FastAPI(...)`
+    # at construction, while the handlers are defined further down — several
+    # of them beside the routes they belong with. So the decorators keep
+    # working exactly where they are, and the lifespan reads the lists when
+    # the app is STARTED rather than when it is built.
+    #
+    # The ORDER is the contract, and it is deliberately the one `on_event`
+    # had (fastapi/routing.py, `_startup`/`_shutdown`): both lists run in
+    # REGISTRATION order. Shutdown is NOT reversed — it looks like it ought
+    # to be and it never was, so reversing it here would be a silent
+    # behaviour change wearing the clothes of a cleanup.
+    startup_handlers: list = []
+    shutdown_handlers: list = []
+
+    def on_startup(func):
+        startup_handlers.append(func)
+        return func
+
+    def on_shutdown(func):
+        shutdown_handlers.append(func)
+        return func
+
+    app = FastAPI(title="fused-render",
+                  lifespan=_lifespan(startup_handlers, shutdown_handlers))
     app.state.start_dir = start_dir
 
     # Shared keep-alive HTTP pool for the opt-in pooled /api/fs/raw proxy
@@ -320,20 +383,20 @@ def create_app(start_dir: str) -> FastAPI:
     # unhandled-exception/access-log middleware — bodies live in
     # _server_common.py / _server_ai.py; only the app-bound registration
     # stays here (an on_event hook needs the actual `app` it's attached to).
-    @app.on_event("startup")
+    @on_startup
     async def _startup_pooled_client():
         await open_pooled_client(app)
 
-    @app.on_event("shutdown")
+    @on_shutdown
     async def _shutdown_pooled_client():
         await close_pooled_client(app)
 
-    @app.on_event("startup")
+    @on_startup
     async def _startup_prewarm_ai():
         prewarm_ai()
 
     # Warm the fused engine off the request path (else the first /api/config pays the cold import).
-    @app.on_event("startup")
+    @on_startup
     async def _startup_warm_engine():
         from fused_render import engine
 
@@ -361,7 +424,7 @@ def create_app(start_dir: str) -> FastAPI:
     # docstring — for exactly the race a code review caught (2026-08-26).
     _background_apps_shutdown = threading.Event()
 
-    @app.on_event("startup")
+    @on_startup
     async def _startup_resurrect_background_apps():
         from fused_render import background_apps
 
@@ -369,7 +432,7 @@ def create_app(start_dir: str) -> FastAPI:
                          args=(_background_apps_shutdown,),
                          name="background-apps-resurrect", daemon=True).start()
 
-    @app.on_event("shutdown")
+    @on_shutdown
     async def _shutdown_background_apps_resurrection():
         _background_apps_shutdown.set()
 
@@ -385,7 +448,7 @@ def create_app(start_dir: str) -> FastAPI:
     # pre-bind path (D228). A startup event rather than the create_app body for
     # the usual reason — tests build apps without running lifespan, so they
     # never reach the user's real config.
-    @app.on_event("startup")
+    @on_startup
     async def _startup_sync_user_plugin():
         from fused_render import user_plugin
 
@@ -400,7 +463,7 @@ def create_app(start_dir: str) -> FastAPI:
     # The first tick is also the catch-up pass — it is what sends a message that
     # came due while the app was closed — so nothing here waits for a due time
     # that has already gone by.
-    @app.on_event("startup")
+    @on_startup
     async def _startup_schedule():
         from fused_render import schedule
 
@@ -411,13 +474,13 @@ def create_app(start_dir: str) -> FastAPI:
     # A startup event for the same reason as `_startup_schedule`: it is a
     # thread for the life of the process that reads the user's real ~/.claude,
     # and tests build apps without lifespan.
-    @app.on_event("startup")
+    @on_startup
     async def _startup_tasks_watch():
         from fused_render import tasks_watch
 
         tasks_watch.start()
 
-    @app.on_event("shutdown")
+    @on_shutdown
     async def _startup_shutdown_ai():
         await shutdown_ai_session()
 
@@ -427,7 +490,7 @@ def create_app(start_dir: str) -> FastAPI:
     # reason as `_startup_schedule` above: tests build apps with no lifespan,
     # and this starts a thread that lives for the process — building one per
     # test-constructed app would leak a thread per test.
-    @app.on_event("startup")
+    @on_startup
     async def _startup_ai_idle_reaper():
         from fused_render.ai import supervisor
 
@@ -443,7 +506,7 @@ def create_app(start_dir: str) -> FastAPI:
     # shape as the idle reaper above, not the create_app body: it fires one
     # probe immediately and then re-probes every few hours for the rest of
     # the process's life.
-    @app.on_event("startup")
+    @on_startup
     async def _startup_ai_hardware_refresh():
         from fused_render.ai import supervisor
 
@@ -457,7 +520,7 @@ def create_app(start_dir: str) -> FastAPI:
     # plain disk read), and this background thread is the sole writer,
     # mirroring the hardware-refresh hook immediately above for the
     # identical reason.
-    @app.on_event("startup")
+    @on_startup
     async def _startup_ai_hub_metadata_refresh():
         from fused_render.ai import supervisor
 
@@ -477,17 +540,17 @@ def create_app(start_dir: str) -> FastAPI:
     # event at all — a stale file there is exactly the case `resolve_origin()`
     # is required to connect-probe before trusting, so it is a correctness gap
     # this side does not need to close.
-    @app.on_event("shutdown")
+    @on_shutdown
     async def _shutdown_server_json():
         remove_server_json()
 
-    @app.on_event("shutdown")
+    @on_shutdown
     async def _shutdown_captures():
         from fused_render import capture
 
         capture.stop_all()
 
-    @app.on_event("shutdown")
+    @on_shutdown
     async def _shutdown_ai_workers():
         from fused_render.ai import supervisor
 
@@ -495,7 +558,7 @@ def create_app(start_dir: str) -> FastAPI:
 
     # Every managed engine dies with the app: template daemons and /api/engine
     # warm workers alike (stop_all clears both).
-    @app.on_event("shutdown")
+    @on_shutdown
     async def _shutdown_engines():
         from fused_render.server import engine_host
 
@@ -510,7 +573,7 @@ def create_app(start_dir: str) -> FastAPI:
     #
     # Best-effort like every other startup chore here: a home dir that cannot be
     # listed is a disk problem, not a reason to refuse to serve.
-    @app.on_event("startup")
+    @on_startup
     async def _startup_gc_project_venvs():
         from fused_render import projectenv
 
@@ -767,7 +830,7 @@ def create_app(start_dir: str) -> FastAPI:
     # of each root, so a reload loop does not queue scan after scan. First boot
     # takes seconds over a whole home; while it runs, the explorer's search
     # falls back to the live walk with no error state (SPEC server-api.md §2).
-    @app.on_event("startup")
+    @on_startup
     async def _startup_index_scan():
         await index_routes.startup_scan(start_dir)
         # ...and warm the corpus path the explorer's home search reads, on a

--- a/tests/test_app_lifespan.py
+++ b/tests/test_app_lifespan.py
@@ -1,0 +1,114 @@
+"""`create_app`'s startup/shutdown contract, after the move off `on_event`.
+
+FastAPI deprecated `@app.on_event`, and `app.py` had 19 of them. Replacing
+them is only safe if the replacement keeps what the old decorator actually
+did rather than what it looks like it did — so the two details that are easy
+to get wrong are pinned here rather than left to a reviewer's memory of
+`fastapi/routing.py`.
+
+Driven through `asyncio.run` rather than an async test: nothing else in this
+suite needs `pytest-asyncio`, and one file is a poor reason to add a plugin
+every test run then has to load.
+"""
+
+import asyncio
+
+import pytest
+
+from fused_render.server import create_app
+from fused_render.server.app import _lifespan
+
+
+def _drive(startup, shutdown, body=None):
+    """Enter and leave one lifespan, optionally raising inside it."""
+
+    async def go():
+        async with _lifespan(startup, shutdown)(app=None):
+            if body is not None:
+                body()
+
+    asyncio.run(go())
+
+
+def _recorder(log, name, boom=None):
+    async def handler():
+        log.append(name)
+        if boom is not None:
+            raise boom
+
+    return handler
+
+
+def test_startup_handlers_run_in_registration_order():
+    log = []
+    _drive([_recorder(log, "a"), _recorder(log, "b"), _recorder(log, "c")], [])
+    assert log == ["a", "b", "c"]
+
+
+def test_shutdown_handlers_run_in_registration_order_NOT_reversed():
+    """The one most likely to be "tidied up" by a future reader.
+
+    Teardown conventionally unwinds in reverse, and `on_event` did not:
+    `_shutdown` iterates `self.on_shutdown` forwards. Reversing it here would
+    change the order 7 real handlers close things in, while looking like a
+    cleanup — so it is asserted, with the reason attached.
+    """
+    log = []
+    _drive([], [_recorder(log, "a"), _recorder(log, "b"), _recorder(log, "c")])
+    assert log == ["a", "b", "c"]
+    assert log != ["c", "b", "a"], "shutdown was reversed; on_event never did that"
+
+
+def test_shutdown_still_runs_when_the_application_raised():
+    """`__aexit__` ran regardless once `__aenter__` had returned. A bare
+    `yield` with no `finally` would quietly stop doing this, and nothing else
+    in the suite would notice — the server would simply stop cleaning up
+    after a crash."""
+    log = []
+
+    def boom():
+        raise RuntimeError("the app fell over")
+
+    with pytest.raises(RuntimeError, match="fell over"):
+        _drive([_recorder(log, "up")], [_recorder(log, "down")], body=boom)
+    assert log == ["up", "down"]
+
+
+def test_a_failing_startup_skips_shutdown_entirely():
+    """The other side: `__aexit__` was never reached if `__aenter__` raised,
+    so a half-started app must not run teardown for things that never came
+    up. This is why the `try` opens after the startup loop, not around it."""
+    log = []
+    handlers = [
+        _recorder(log, "first"),
+        _recorder(log, "second", boom=RuntimeError("nope")),
+    ]
+    with pytest.raises(RuntimeError, match="nope"):
+        _drive(handlers, [_recorder(log, "down")])
+    assert log == ["first", "second"], "shutdown ran for an app that never started"
+
+
+def test_handlers_registered_after_the_app_is_built_are_still_picked_up():
+    """`create_app` hands the lifespan to `FastAPI(...)` at the top and then
+    registers handlers for another 450 lines. The lists are read at START,
+    which is what makes that work."""
+    log = []
+    startup: list = []
+    lifespan = _lifespan(startup, [])
+    startup.append(_recorder(log, "late"))  # …registered after the fact
+
+    async def go():
+        async with lifespan(app=None):
+            pass
+
+    asyncio.run(go())
+    assert log == ["late"]
+
+
+def test_create_app_registers_nothing_on_the_deprecated_path():
+    """The regression guard for the migration itself: one `@app.on_event`
+    creeping back in would re-open the deprecation and go unnoticed, since
+    the handler would still run."""
+    app = create_app(start_dir=".")
+    assert app.router.on_startup == []
+    assert app.router.on_shutdown == []

--- a/tests/test_app_lifespan.py
+++ b/tests/test_app_lifespan.py
@@ -105,6 +105,53 @@ def test_handlers_registered_after_the_app_is_built_are_still_picked_up():
     assert log == ["late"]
 
 
+#: Exactly what `@app.on_event` registered, in order, on the commit before the
+#: migration — read off `app.router.on_startup` / `.on_shutdown` there rather
+#: than transcribed from the decorators. This is the ground truth the move had
+#: to preserve, and the only thing that checks the real 19 handlers rather than
+#: the mechanism driving them.
+EXPECTED_STARTUP = [
+    "_startup_pooled_client",
+    "_startup_prewarm_ai",
+    "_startup_warm_engine",
+    "_startup_resurrect_background_apps",
+    "_startup_sync_user_plugin",
+    "_startup_schedule",
+    "_startup_tasks_watch",
+    "_startup_ai_idle_reaper",
+    "_startup_ai_hardware_refresh",
+    "_startup_ai_hub_metadata_refresh",
+    "_startup_gc_project_venvs",
+    "_startup_index_scan",
+]
+
+#: `_startup_shutdown_ai` is a SHUTDOWN handler despite the name — read the
+#: decorator, not the name. Kept as-is so this list stays a faithful record of
+#: what ran before rather than a tidied version of it.
+EXPECTED_SHUTDOWN = [
+    "_shutdown_pooled_client",
+    "_shutdown_background_apps_resurrection",
+    "_startup_shutdown_ai",
+    "_shutdown_server_json",
+    "_shutdown_captures",
+    "_shutdown_ai_workers",
+    "_shutdown_engines",
+]
+
+
+def test_every_handler_is_collected_in_the_order_on_event_had():
+    """The wiring, not the mechanism.
+
+    Every other test here drives `_lifespan` with fake handlers, which proves
+    the contract but not that the real hooks reach it. A decorator swapped to
+    the wrong collector, or a handler moved, would pass all of them and change
+    what the server does at startup.
+    """
+    app = create_app(start_dir=".")
+    assert [f.__name__ for f in app.state.startup_handlers] == EXPECTED_STARTUP
+    assert [f.__name__ for f in app.state.shutdown_handlers] == EXPECTED_SHUTDOWN
+
+
 def test_create_app_registers_nothing_on_the_deprecated_path():
     """The regression guard for the migration itself: one `@app.on_event`
     creeping back in would re-open the deprecation and go unnoticed, since


### PR DESCRIPTION
FastAPI deprecated `@app.on_event`, and `create_app` had **19** of them — 12 startup, 7 shutdown. Each warns on every app built, and pytest attributes every warning to every test file that triggered it.

This is the other half of the CI-log problem #939 started on: that PR removed `-v` (~22,800 lines); this removes the warnings summary.

| | before | after |
|---|---|---|
| warnings recorded | **73,154** | **4** |
| warnings-summary lines | 1,749 | **9** |
| full `-q` log | 2,883 lines | **1,160** |

Combined with #939's `-v` removal, the Windows CI log goes from **~25,000 lines to ~1,200**.

The four survivors are raised by the vendored `fused` package's own `_udf/decorators.py`, not by anything in this repo.

## What actually changed

**The handlers are untouched** — each keeps its body, its comment, and its position beside the routes it belongs with. Only the decorator changes, to one of two collectors:

```python
@on_startup                 # was: @app.on_event("startup")
async def _startup_prewarm_ai():
    prewarm_ai()
```

`_lifespan` reads those lists when the app **starts**, not when it is built. That is what lets a handler 450 lines below `FastAPI(...)` register with a lifespan that had to be passed at construction — and it is asserted, since it is the non-obvious part.

It is a module-level factory rather than a closure so its contract can be driven with fake handlers instead of the real 19, which start schedulers and warm engines.

## The two details worth reviewing

Both are taken from what `on_event` **did**, not what it looks like it did — `fastapi/routing.py`, `_startup`/`_shutdown` and `_DefaultLifespan`. (Worth noting: Starlette 1.6 removed `on_startup`/`on_shutdown` outright; FastAPI now carries its own copy, so that file is the only authority.)

**1. Shutdown runs in registration order, not reversed.**

```python
async def _shutdown(self) -> None:
    for handler in self.on_shutdown:      # forwards
```

Teardown conventionally unwinds in reverse, and this one never did. Reversing it here would change the order 7 real handlers close things in, while reading as a cleanup — so there is a test named for exactly that, with the reason attached.

**2. Shutdown runs even when the served application raised.**

`__aexit__` ran regardless once `__aenter__` had returned. A bare `yield` with no `finally` would quietly stop doing that, and nothing else in the suite would notice — the server would simply stop cleaning up after a crash. A startup that *raises* still skips shutdown entirely, because `__aenter__` never returned, which is why the `try` opens **after** the startup loop rather than around it.

## Verification

`tests/test_app_lifespan.py`, 6 tests, **mutation checked** — each failure mode is caught by exactly one test, so none of them is decorative:

| mutation | fails |
|---|---|
| `reversed(shutdown_handlers)` | `..._NOT_reversed` |
| drop the `try`/`finally` | `..._still_runs_when_the_application_raised` |
| reinstate one `@app.on_event` | `..._registers_nothing_on_the_deprecated_path` |

Full suite: **byte-identical failure list** to `main` (32, all pre-existing — 24 are missing `rasterio`/`shapely` in my container, 8 reproduce on a clean checkout). Wall clock 249s vs 267s, which is within run-to-run noise; the warnings were never the slow part.

Driven through `asyncio.run` rather than async test functions: nothing else in this suite needs `pytest-asyncio`, and one file is a poor reason to add a plugin every run then loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXDxeKbDsWkANaiDrzre3Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXDxeKbDsWkANaiDrzre3Y)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-wide startup/shutdown ordering for pooled HTTP, AI workers, engines, captures, and background threads; behavior is intended to be identical but mistakes in lifespan semantics would surface as subtle teardown or ordering bugs.
> 
> **Overview**
> Replaces deprecated `@app.on_event` with a custom **`lifespan`** on `create_app`, cutting CI deprecation noise (on the order of **73k warnings → 4** per the PR description) without changing what each hook does.
> 
> Handlers keep the same bodies and placement; only decorators switch to **`@on_startup`** / **`@on_shutdown`**, which append to lists read when the app **starts** (not at `FastAPI(...)` construction). **`_lifespan`** mirrors old FastAPI behavior: startup and shutdown run in **registration order** (shutdown is **not** reversed), shutdown runs in a **`finally`** after a successful startup even if the app raises, and a failing startup skips shutdown.
> 
> **`app.state.startup_handlers`** / **`shutdown_handlers`** expose the registry for tests. New **`tests/test_app_lifespan.py`** locks the contract and asserts all 12 startup + 7 shutdown hooks match the pre-migration order, with guards against reintroducing **`on_event`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd79b232ee2d0d96234d6583674a193254abc0f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->