### PR TITLE
AI job row: live elapsed clock, real cancellation, thinking-phase readout

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -289,7 +289,13 @@ const { text, model, usage } = await fused.ai(prompt, {
   behind another call's turn, `asyncio.Lock.acquire()` abandons the cancelled
   wait cleanly, so the ✕ frees the lock for whoever is next rather than making
   them wait out a turn nobody wants any more. It says when it is waiting its
-  turn behind another call rather than looking busy, and it heartbeats for as
+  turn behind another call rather than looking busy, it says "Thinking —
+  remote" for as long as the model is in an extended-thinking block rather
+  than writing the answer (probed against the real CLI: the block's own text
+  is always empty — `display` defaults to "omitted" on every effort-capable
+  model — so this is the fact of thinking, not a word count; a low-effort or
+  non-effort-capable call never sees the phase at all and reads "Claude —
+  remote" throughout, same as before), and it heartbeats for as
   long as the call runs (AI-5h) — without which any call slower than
   `STALE_AFTER_S` reported itself as no longer being reported.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -252,7 +252,10 @@ const { text, model, usage } = await fused.ai(prompt, {
   a structured error carrying `.type` — `"bad_request"` (empty prompt / bad options),
   `"ai_unavailable"` (claude binary not found or not runnable — the message names what
   to install/set), `"ai_error"` (the CLI exited nonzero, reported an error, or returned
-  an unexpected shape), or `"timeout"` (no answer within 600 s). `opts.effort`
+  an unexpected shape), `"timeout"` (no answer within 600 s), or `"cancelled"` (the
+  status bar's ✕ was pressed — see below; NOT counted toward AI-12's failure metric,
+  the same carve-out `model_loading` gets, since a deliberate stop is not evidence the
+  AI is broken). `opts.effort`
   (`"low" | "medium" | "high" | "xhigh"`, **default `low`**): `low` — and an
   omitted effort — means **no extended thinking**, enforced with a thinking-budget
   clamp that works on every model; `medium`/`high`/`xhigh` pass through to
@@ -278,8 +281,14 @@ const { text, model, usage } = await fused.ai(prompt, {
   **Visible while it runs**: each call opens one server-owned row in the status
   bar's Activity section (§36), titled with the prompt and detailed "Claude —
   remote" so remote work is tellable from a local model's, dropped the moment
-  the call succeeds. It is not cancellable (nothing in the relay polls the flag,
-  and a ✕ that does nothing is worse than none), it says when it is waiting its
+  the call succeeds. **Cancellable** (BG-4: this process owns the CLI and can
+  really stop it) — the beat that keeps the row's heartbeat also polls
+  `cancel_requested` every second, far more often than the 10s display tick, and
+  cancels the call's own asyncio task the moment it sees the ✕: mid-turn, that
+  discards the CLI process and rejects with `.type: "cancelled"`; still queued
+  behind another call's turn, `asyncio.Lock.acquire()` abandons the cancelled
+  wait cleanly, so the ✕ frees the lock for whoever is next rather than making
+  them wait out a turn nobody wants any more. It says when it is waiting its
   turn behind another call rather than looking busy, and it heartbeats for as
   long as the call runs (AI-5h) — without which any call slower than
   `STALE_AFTER_S` reported itself as no longer being reported.

--- a/frontend/src/platform/lib/jobs.test.ts
+++ b/frontend/src/platform/lib/jobs.test.ts
@@ -7,6 +7,7 @@ import {
   clearableCount,
   GRACE_MS,
   jobAmount,
+  jobElapsedLabel,
   jobFraction,
   jobsAfterClear,
   jobStatusLine,
@@ -93,6 +94,25 @@ test("seconds with no total still say how far in we are", () => {
 
 test("nothing reported reads as nothing, not as 0", () => {
   expect(jobAmount(job({ done: null, total: null }))).toBe("");
+});
+
+// ------------------------------------------------------------------ elapsed
+
+test("a running job reads its elapsed time as a clock, against the given clock", () => {
+  expect(jobElapsedLabel(job({ started_at: 1000 }), 1042_000)).toBe("0:42");
+  expect(jobElapsedLabel(job({ started_at: 0 }), 4530_000)).toBe("1:15:30");
+});
+
+test("a job that has not started yet by this clock reads as 0:00, not negative", () => {
+  // Server clock drift (a throttled/suspended tab's own `nowMs` running
+  // behind) must not print a negative clock.
+  expect(jobElapsedLabel(job({ started_at: 1000 }), 999_000)).toBe("0:00");
+});
+
+test("a finished job has no elapsed clock — that is not what this line is for", () => {
+  for (const state of ["done", "error", "cancelled"] as const) {
+    expect(jobElapsedLabel(job({ state, started_at: 0 }), 60_000)).toBe("");
+  }
 });
 
 // --------------------------------------------------------------- status line

--- a/frontend/src/platform/lib/jobs.ts
+++ b/frontend/src/platform/lib/jobs.ts
@@ -304,6 +304,27 @@ export function jobAmount(job: Job): string {
   return `${num(done, scale.div)} / ${num(total, scale.div)} ${scale.unit}`;
 }
 
+// How long a RUNNING job has been going, as a clock ("1:24"), or "" once it
+// is no longer running — an ended job's age is not what this line is for,
+// and `jobStatusLine` already has its own words for every terminal state.
+//
+// `nowMs` should be the SERVER's clock (`JobsSnapshot.now`, scaled to ms),
+// not the browser's own `Date.now()`: the two disagree after a tab throttle
+// or a suspend (the same reasoning `GET /api/jobs`'s own `now` field exists
+// for — see jobs.py `list_jobs`), and the visible symptom would be a call
+// that has been running for minutes reading as 0:00, or as negative.
+//
+// Every row gets this, not only the ones with no other numbers to show
+// (a download already prints bytes; a transcription already prints a
+// seconds-of-audio clock) — `started_at`/`now` were already being handed to
+// the client on every poll (SPEC BG-8) for exactly this measurement, and a
+// remote Claude call is the row that has NOTHING else: no bytes, no percent,
+// nothing but "Claude — remote" for as long as ten minutes.
+export function jobElapsedLabel(job: Job, nowMs: number): string {
+  if (!isRunning(job)) return "";
+  return clock(Math.max(0, nowMs / 1000 - job.started_at));
+}
+
 // The one line under the title. In priority order, because the states overlap:
 // an error's message beats everything (it is the thing to act on), a cancel
 // that has been asked for but not yet honored has to say so or the ✕ reads as

--- a/frontend/src/platform/ui/DownloadManager.test.tsx
+++ b/frontend/src/platform/ui/DownloadManager.test.tsx
@@ -84,13 +84,14 @@ function circleFilled(tree: ReactTestRendererJSON | null): boolean {
 // the PANEL contains and how the fold behaves — not about that default. Saying
 // so explicitly is what keeps them from silently inverting the next time the
 // default is revisited; the default itself has its own test.
-function renderCard(reported: Job[]): ReactTestRendererJSON | null {
+function renderCard(reported: Job[], nowMs?: number): ReactTestRendererJSON | null {
   return create(
     <DownloadManagerView
       reported={reported}
       initialCollapsed={false}
       refresh={() => {}}
       patch={() => {}}
+      nowMs={nowMs}
     />,
   ).toJSON() as ReactTestRendererJSON | null;
 }
@@ -704,9 +705,12 @@ test("a task row reads its phase and step count as one sentence", () => {
     total: 4,
     unit: "",
   };
-  const tree = renderCard([denoising]);
+  // nowMs pinned to `started_at` (BASE's own 0): a bare "0:00" elapsed clock,
+  // deterministic rather than however long the real Date.now() happens to be
+  // when the suite runs (this follow-up's own live-clock feature).
+  const tree = renderCard([denoising], 0);
   const row = findAll(tree, "dl-row")[0];
-  expect(text(findAll(row, "dl-status")[0])).toBe("Denoising · 0 / 4");
+  expect(text(findAll(row, "dl-status")[0])).toBe("Denoising · 0 / 4 · 0:00");
   // The amount is no longer its own element on the head line...
   expect(findAll(findAll(row, "dl-row-head")[0], "dl-amount")).toHaveLength(0);
   // ...but the percentage STAYS there, glanceable and aligned down the list.
@@ -728,12 +732,12 @@ test("a download row with NO phase text still shows its byte counts", () => {
     total: 10e9,
     unit: "bytes",
   };
-  const tree = renderCard([download]);
+  const tree = renderCard([download], 0); // pinned nowMs — see the test above
   const status = findAll(findAll(tree, "dl-row")[0], "dl-status");
   expect(status).toHaveLength(1);
-  // Bare amount, no leading separator — `filter(Boolean)` drops the empty part
-  // rather than joining onto nothing.
-  expect(text(status[0])).toBe(jobAmount(download));
+  // Bare amount plus the elapsed clock, no leading separator — `filter(Boolean)`
+  // drops the empty phase-text part rather than joining onto nothing.
+  expect(text(status[0])).toBe(`${jobAmount(download)} · 0:00`);
   expect(text(status[0]).startsWith(" · ")).toBe(false);
 });
 

--- a/frontend/src/platform/ui/DownloadManager.tsx
+++ b/frontend/src/platform/ui/DownloadManager.tsx
@@ -123,6 +123,7 @@ import {
   fetchJobs,
   isRunning,
   jobAmount,
+  jobElapsedLabel,
   jobFraction,
   jobRows,
   inFlightJobs,
@@ -171,10 +172,18 @@ function useJobs(): {
    *  pre-existing jobs as arrivals on load (D574 bug 2). */
   settled: boolean;
   jobs: Job[];
+  /** The SERVER's clock (ms) as of the last successful poll — for a live
+   *  elapsed-time clock on a running row (`jobElapsedLabel`), measured
+   *  against jobs.ts's own `now` rather than the browser's `Date.now()` for
+   *  the same reason `GET /api/jobs` sends it at all (a throttled/suspended
+   *  tab's own clock disagrees). Starts at `Date.now()` — a reasonable guess
+   *  until the first response corrects it. */
+  nowMs: number;
   refresh: () => void;
   patch: (fn: (jobs: Job[]) => Job[]) => void;
 } {
   const [jobs, setJobs] = useState<Job[]>([]);
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const [settled, setSettled] = useState(false);
   // Read by the scheduler without re-arming it: the poll loop re-reads the
   // cadence after every response, so `jobs` must not be in its dependency list
@@ -238,6 +247,7 @@ function useJobs(): {
         setSettled(true);
         if (at === epochRef.current) {
           setJobs(snapshot.jobs);
+          setNowMs(snapshot.now * 1000);
           scheduleFor(snapshot.jobs);
         } else {
           // Stale. Dropped rather than painted; `queued` is set (the mutation
@@ -294,7 +304,7 @@ function useJobs(): {
     setJobs(fn);
   }, []);
 
-  return { jobs, settled, refresh, patch };
+  return { jobs, settled, nowMs, refresh, patch };
 }
 
 function Bar({ job }: { job: Job }) {
@@ -413,12 +423,19 @@ export function JobRow({
   job,
   onChanged,
   onPatch,
+  nowMs = Date.now(),
   cancelFn = cancelJob,
   dismissFn = dismissJob,
 }: {
   job: Job;
   onChanged: () => void;
   onPatch: (fn: (jobs: Job[]) => Job[]) => void;
+  /** The clock a running row's elapsed time is measured against
+   *  (`jobElapsedLabel`) — the server's, ideally (`useJobs`'s own `nowMs`).
+   *  Defaults to the browser's own `Date.now()` so every existing caller
+   *  (this file's own tests included) keeps working unchanged; only
+   *  `useJobs`'s poll loop has anything better to hand in. */
+  nowMs?: number;
   /** Test seam only (D572's own failure-path test uses it) — every real
    *  caller gets the real `cancelJob`/`dismissJob` (@platform/lib/jobs) by
    *  default. Injectable rather than mocked so a rejected-request test does
@@ -446,6 +463,10 @@ export function JobRow({
   const fraction = jobFraction(job);
   const amount = jobAmount(job);
   const status = jobStatusLine(job);
+  // "" once the job is no longer running (`jobElapsedLabel`'s own doc) — a
+  // remote Claude call is the row this earns its keep for: no bytes, no
+  // percent, nothing but "Claude — remote" for as long as ten minutes.
+  const elapsed = jobElapsedLabel(job, nowMs);
   // THE PROGRESS FACTS TOGETHER, dot-joined (D598, user: "why isn't the step
   // count next to denoising?"). `0 / 4` is a progress fact, so it belongs with
   // the other progress facts rather than up beside the title, where it was a
@@ -468,7 +489,7 @@ export function JobRow({
   // `??` once, not twice: `join` returns "" rather than null for an empty
   // list, so a second `??` would be dead — the `&&` at the render site is what
   // handles the all-absent case.
-  const statusLine = failure ?? [status, amount].filter(Boolean).join(" · ");
+  const statusLine = failure ?? [status, amount, elapsed].filter(Boolean).join(" · ");
 
   // Two controls, one meaning each — because "stop this" and "take it off my
   // screen" read as the same gesture when both hide behind an identical ✕, and
@@ -693,6 +714,7 @@ export function DownloadManagerView({
   engines,
   refresh,
   patch,
+  nowMs = Date.now(),
 }: {
   reported: Job[];
   /** TEST SEAM ONLY — the fold's initial value. Every real caller omits it and
@@ -714,6 +736,11 @@ export function DownloadManagerView({
   engines?: EnginesSlot;
   refresh: () => void;
   patch: (fn: (jobs: Job[]) => Job[]) => void;
+  /** The clock a running row's elapsed time is measured against — see
+   *  `JobRow`'s own doc. Defaults to the browser's `Date.now()` so every
+   *  existing caller (this file's own tests included) keeps working
+   *  unchanged. */
+  nowMs?: number;
 }) {
   const [collapsed, setCollapsed] = useState(initialCollapsed ?? true);
   // Wraps the chip AND the panel — see dismissOnOutside.ts on why the whole
@@ -978,7 +1005,13 @@ export function DownloadManagerView({
                         <div className="dl-rows">
                           {queue?.rows}
                           {jobs.map((job) => (
-                            <JobRow key={job.id} job={job} onChanged={refresh} onPatch={patch} />
+                            <JobRow
+                              key={job.id}
+                              job={job}
+                              onChanged={refresh}
+                              onPatch={patch}
+                              nowMs={nowMs}
+                            />
                           ))}
                         </div>
                         {queue?.note}
@@ -1033,7 +1066,7 @@ export default function DownloadManager({
   queue?: QueueSlot;
   engines?: EnginesSlot;
 }) {
-  const { jobs: reported, settled, refresh, patch } = useJobs();
+  const { jobs: reported, settled, nowMs, refresh, patch } = useJobs();
   return (
     <DownloadManagerView
       reported={reported}
@@ -1042,6 +1075,7 @@ export default function DownloadManager({
       engines={engines}
       refresh={refresh}
       patch={patch}
+      nowMs={nowMs}
     />
   );
 }

--- a/frontend/src/platform/ui/JobRow.test.tsx
+++ b/frontend/src/platform/ui/JobRow.test.tsx
@@ -62,8 +62,10 @@ function text(node: ReactTestRendererJSON | string | null): string {
     .join("");
 }
 
-function renderRow(job: Job): ReactTestRendererJSON {
-  const tree = create(<JobRow job={job} onChanged={() => {}} onPatch={() => {}} />).toJSON();
+function renderRow(job: Job, nowMs?: number): ReactTestRendererJSON {
+  const tree = create(
+    <JobRow job={job} onChanged={() => {}} onPatch={() => {}} nowMs={nowMs} />,
+  ).toJSON();
   if (tree === null || Array.isArray(tree)) throw new Error("JobRow did not render a single root node");
   return tree;
 }
@@ -105,6 +107,24 @@ test("a model equal to the title draws no .dl-model suffix — a load row must n
   // suffix would otherwise repeat it verbatim right next to itself.
   const root = renderRow({ ...BASE, title: "org/model", model: "org/model" });
   expect(findAll(root, "dl-model")).toHaveLength(0);
+});
+
+test("a running row's status line carries a live elapsed clock, measured against the given nowMs", () => {
+  const root = renderRow({ ...BASE, started_at: 1000 }, 1042_000);
+  const status = findAll(root, "dl-status");
+  expect(status).toHaveLength(1);
+  // BASE's own detail/amount ("Denoising — step 2/4 · ~2s left" plus a 45/100
+  // amount) stays exactly what it was — the clock is APPENDED, not swapped in.
+  expect(text(status[0])).toBe("Denoising — step 2/4 · ~2s left · 45 / 100 · 0:42");
+});
+
+test("a done job carries no elapsed clock at all — an ended job's age is not this line's job", () => {
+  // `state: "done"` returns null from JobRow itself (see the test below), so
+  // this is checked on `cancelled` — the other terminal state that still
+  // draws a row.
+  const root = renderRow({ ...BASE, state: "cancelled", started_at: 1000 }, 1999_000);
+  const status = findAll(root, "dl-status");
+  expect(text(status[0])).not.toContain(":");
 });
 
 test("a done job draws nothing at all — success clears itself from the corner", () => {

--- a/fused_render/server/ai.py
+++ b/fused_render/server/ai.py
@@ -1483,7 +1483,7 @@ async def _ai_relay(body: dict):
                     proc = await _AI_SESSION.configure(
                         model, system_prompt, effort)
                     return await _ai_drive(proc, prompt, _AI_TIMEOUT_S,
-                                           on_delta=deliver)
+                                           on_delta=deliver, on_phase=on_phase)
                 except asyncio.CancelledError:
                     # Cancelled mid-retry: the respawned instance is left
                     # mid-reconfig/mid-turn. Discard it too, or the next

--- a/fused_render/server/ai.py
+++ b/fused_render/server/ai.py
@@ -127,6 +127,20 @@ _REMOTE_ROW_DETAIL = "Claude — remote"
 # that has not started, which "Claude — remote" alone would show as work in
 # progress. `supervisor._QUEUED_DETAIL`'s twin.
 _REMOTE_QUEUED_DETAIL = "Queued — another Claude call is in flight"
+# …and while the model is in an extended-thinking block rather than writing
+# the answer (AI-5h follow-up #1). Probed against the real CLI (2.1.252,
+# sonnet, effort xhigh vs. low): thinking blocks arrive, but their text is
+# always empty — `display` defaults to "omitted" on every effort-capable
+# model — so a word count is not an available signal, only the fact that
+# thinking is happening at all. Paired with the client's own elapsed clock
+# (jobs.ts `jobElapsedLabel`, which reads every running row's `started_at`
+# already) this alone renders as "Thinking — 1m 20s" with no new server-side
+# timer needed — the row's whole-call elapsed time is close enough to the
+# thinking phase's own, since thinking begins almost immediately after a
+# turn starts. A low-effort or non-effort-capable (haiku) call never sees
+# this at all: `on_phase` is simply never called with "thinking", and the
+# row reads `_REMOTE_ROW_DETAIL` for its whole life, same as before this.
+_REMOTE_THINKING_DETAIL = "Thinking — remote"
 # A reconfiguration step (/clear, set_model, effort) is local work; one that
 # takes longer than this means a wedged process — kill and respawn.
 _AI_CTRL_TIMEOUT_S = 10.0
@@ -670,15 +684,22 @@ class _AiSession:
 _AI_SESSION = _AiSession()
 
 
-async def _ai_drive(proc, prompt: str, timeout: float, on_delta=None) -> dict:
+async def _ai_drive(proc, prompt: str, timeout: float, on_delta=None,
+                    on_phase=None) -> dict:
     """Write the user message to a stream-json process and read events until
     the terminal `result` line; return it parsed.
 
-    `on_delta(text)` is called per text_delta when streaming (thinking_delta
-    and every other event type are skipped). The timeout covers message-write
-    to result. Raises asyncio.TimeoutError or _AiProcFailure (died/EOF/
-    garbage before a result — the process is reaped on EOF; the session
-    notices its death via returncode on the next request)."""
+    `on_delta(text)` is called per text_delta when streaming (every other
+    delta type, including thinking_delta, is skipped — its own text is
+    always empty; see `_REMOTE_THINKING_DETAIL`'s comment). `on_phase(phase)`
+    is called once per `content_block_start`, `phase` being `"thinking"` or
+    `"writing"` — the two block types this app's calls ever produce, since
+    `--tools=` rules out a tool_use block. Called regardless of streaming:
+    it is the row's OWN phase readout, not something only a page reading
+    deltas gets to see. The timeout covers message-write to result. Raises
+    asyncio.TimeoutError or _AiProcFailure (died/EOF/garbage before a
+    result — the process is reaped on EOF; the session notices its death
+    via returncode on the next request)."""
     message = json.dumps({"type": "user", "message": {
         "role": "user", "content": [{"type": "text", "text": prompt}]}})
     deadline = asyncio.get_running_loop().time() + timeout
@@ -716,15 +737,24 @@ async def _ai_drive(proc, prompt: str, timeout: float, on_delta=None) -> dict:
             continue
         if event.get("type") == "result":
             return event
-        if on_delta is not None and event.get("type") == "stream_event":
+        if event.get("type") == "stream_event":
             inner = event.get("event")
-            if isinstance(inner, dict) \
-                    and inner.get("type") == "content_block_delta":
+            if not isinstance(inner, dict):
+                continue
+            itype = inner.get("type")
+            if on_delta is not None and itype == "content_block_delta":
                 delta = inner.get("delta")
                 if isinstance(delta, dict) \
                         and delta.get("type") == "text_delta" \
                         and isinstance(delta.get("text"), str):
                     on_delta(delta["text"])
+            elif on_phase is not None and itype == "content_block_start":
+                block = inner.get("content_block")
+                block_type = block.get("type") if isinstance(block, dict) else None
+                if block_type == "thinking":
+                    on_phase("thinking")
+                elif block_type == "text":
+                    on_phase("writing")
 
 
 def _ai_result_payload(data: dict, requested_model: str):
@@ -1409,6 +1439,16 @@ async def _ai_relay(body: dict):
                 delivered = True
                 on_delta(text)
 
+        def on_phase(phase):
+            # The row's OWN readout of thinking vs. writing (AI-5h follow-up
+            # #1) — wired here, not threaded through `_ai_relay`'s two
+            # branches, because both would do exactly this and nothing else.
+            # Never touches `delivered`: a thinking phase with no text yet
+            # is not a delta reaching the client, so it must not forfeit the
+            # one-retry-on-fresh-spawn guarantee below.
+            _report_remote(detail=_REMOTE_THINKING_DETAIL if phase == "thinking"
+                                  else _REMOTE_ROW_DETAIL)
+
         # Contended: this call has not begun, and a row reading exactly like
         # one that is generating is the row lying by omission — the same fix
         # supervisor's `_QUEUED_DETAIL` is for the transcription queue, at the
@@ -1426,7 +1466,7 @@ async def _ai_relay(body: dict):
                 proc = await _AI_SESSION.configure(model, system_prompt,
                                                    effort)
                 return await _ai_drive(proc, prompt, _AI_TIMEOUT_S,
-                                       on_delta=deliver)
+                                       on_delta=deliver, on_phase=on_phase)
             except asyncio.CancelledError:
                 # Client went away mid-turn: the process is still emitting
                 # this turn's events, and a later request's /clear loop would

--- a/fused_render/server/ai.py
+++ b/fused_render/server/ai.py
@@ -107,6 +107,16 @@ _AI_TIMEOUT_S = 600.0
 # Well under 30s so a busy loop or a slow machine still leaves margin, and no
 # faster than it needs to be: nothing reads these ticks but the clock.
 _REMOTE_TICK_S = 10.0
+# How often the beat checks the row's ✕ (`cancel_requested`) while a call is
+# in flight — the same POLL-OFTEN/REPORT-RARELY split `schedule._await_turn`
+# and `supervisor._CANCEL_CHECK_INTERVAL_S` already make at the two other
+# places this app parks work behind a lock or a slow turn: a read
+# (`jobs.list_jobs()`, no write) rather than a `_report_remote()` tick, so
+# checking ten times as often as the display heartbeat does not also WRITE
+# ten times as often. `_REMOTE_TICK_S`'s own "no faster than it needs to be"
+# is about the write; this is the read, and a press sitting unnoticed for up
+# to `_REMOTE_TICK_S` would be a ✕ that reads as broken.
+_REMOTE_CANCEL_POLL_S = 1.0
 # The row's detail line. Says only that this is remote — the model rides its
 # own field (`jobs.py` `Job.model`, a dimmed suffix JobRow draws after the
 # title), so the one thing this line is for is the fact a local row's detail
@@ -1220,11 +1230,14 @@ async def _ai_relay(body: dict):
     # progress tick on the first) — with wording that says "remote" up
     # front, which is the whole point of adding it.
     #
-    # `cancellable=False`: JobRow renders a ✕ on any running, cancellable row
-    # (DownloadManager.tsx), and pressing it only sets jobs.py's
-    # `cancel_requested` flag for a reporter to notice on its next tick.
-    # Nothing in this relay polls that flag, so advertising a ✕ here would
-    # ship a button that visibly does nothing when pressed.
+    # `cancellable=True` (SPEC BG-4: a server-owned row's ✕ is an ACTION, not
+    # merely a request nobody reads back). `_start_remote_beat` below is what
+    # earns the claim: it polls `cancel_requested` far more often than the
+    # display tick and cancels this call's own asyncio task the moment it
+    # sees it, whether the task is mid-turn or still parked on
+    # `_AI_SESSION.lock` — `asyncio.Lock.acquire()` abandons a cancelled
+    # waiter cleanly, so a QUEUED call's ✕ frees the lock for whoever is next
+    # rather than making them wait out a turn nobody wants any more.
     #
     # NOT opened here, before the stream/non-stream fork: `ndjson()` below is
     # an async generator that Starlette only starts iterating once it
@@ -1237,10 +1250,21 @@ async def _ai_relay(body: dict):
     # with nothing yet committed to closing it.
     _remote_job = jobs.SERVER_ID_PREFIX + "ai-claude:" + uuid.uuid4().hex
     _remote_job_closed = False
+    # Set by the beat right before IT cancels `task` (the row's ✕) — the one
+    # thing that tells the branches below "this CancelledError is ours" apart
+    # from every other source of one. `task.cancelled()` cannot do this job:
+    # asyncio marks a Task cancelled whenever its coroutine raises
+    # CancelledError for ANY reason (an internal `_AiProcFailure` retry racing
+    # a real client disconnect, say), not only when something called
+    # `task.cancel()` — so reading `task.cancelled()` here would relabel a
+    # genuine disconnect as a user-pressed ✕.
+    _beat_cancelled_task = False
 
-    def _report_remote(**fields) -> None:
+    def _report_remote(**fields) -> dict | None:
         """One tick on the remote-Claude row, best-effort (never breaks the
-        call — same discipline as supervisor._report).
+        call — same discipline as supervisor._report). Returns the stored
+        record, or None if there was nothing to store (a late tick after the
+        row already closed) or the write itself failed.
 
         Catches EVERYTHING, like every other reporter here
         (`supervisor._report`, `schedule._report`, `claude_install._report`):
@@ -1255,12 +1279,12 @@ async def _ai_relay(body: dict):
         nonlocal _remote_job_closed
         if fields.get("state") in jobs.TERMINAL_STATES:
             if _remote_job_closed:
-                return
+                return None
             _remote_job_closed = True
         try:
-            jobs.upsert({"id": _remote_job, **fields}, server=True)
+            return jobs.upsert({"id": _remote_job, **fields}, server=True)
         except Exception:  # noqa: BLE001 — reporting is never authoritative
-            pass
+            return None
 
     def _open_remote_job() -> None:
         # Same title convention as the local rows (supervisor._start_render):
@@ -1274,7 +1298,21 @@ async def _ai_relay(body: dict):
         # say that a local row's detail never does.
         title = str(prompt or model).strip() or model
         _report_remote(title=title[:80], model=model, state="running", kind="task",
-                       cancellable=False, detail=_REMOTE_ROW_DETAIL)
+                       cancellable=True, detail=_REMOTE_ROW_DETAIL)
+
+    def _remote_cancel_requested() -> bool:
+        """Was the row's ✕ pressed? A READ (`jobs.list_jobs()`, like
+        `supervisor._cancel_state`), not a write — the beat calls this every
+        `_REMOTE_CANCEL_POLL_S`, far more often than the display tick, and a
+        poll that wrote on every call would turn "check the flag" into "spam
+        the registry". A closed or evicted row reads as "not requested": this
+        call is either already finished (nothing left to cancel) or its row
+        aged out from under it, and the belt-and-suspenders cancel in every
+        `finally` below is what a genuinely-missed press would still need."""
+        for record in jobs.list_jobs():
+            if record["id"] == _remote_job:
+                return bool(record.get("cancel_requested"))
+        return False
 
     def _finish_remote_job() -> None:
         """Success only: drop the row immediately rather than leaving it at
@@ -1287,29 +1325,55 @@ async def _ai_relay(body: dict):
         _report_remote(state="done")  # dismiss() refuses a still-running row
         jobs.dismiss(_remote_job)
 
-    def _start_remote_beat():
-        """Start the row's display heartbeat; returns the task that runs it.
+    def _start_remote_beat(task):
+        """Start the row's heartbeat AND cancel-watch; returns the task that
+        runs both. `task` is `run_once`'s own asyncio task — the one thing
+        this beat may cancel, and the only thing that makes `cancellable=True`
+        above an honest claim rather than a ✕ that does nothing.
 
-        `_REMOTE_TICK_S` says why a row with nothing new to report still has
-        to report. This carries NO FIELDS, which is the whole design of it:
-        `jobs.upsert` applies only the keys present, so an id and nothing else
-        is precisely "still here" and is incapable of saying anything more —
-        it cannot move a bar, cannot overwrite the detail `run_once` sets
-        while this call is parked in the queue, and is not an *opening* report
-        (jobs.py reopens a dismissed or forgotten id only for a report that
-        states `running` outright), so it can never blink a closed row back
-        onto the screen. `schedule._report` documents the same fieldless call
-        for the same registry.
+        Two cadences sharing one loop, the same split `schedule._await_turn`
+        and `supervisor._CANCEL_CHECK_INTERVAL_S` already make at the other
+        two places this app parks work behind a lock or a slow turn: POLLED
+        every `_REMOTE_CANCEL_POLL_S` (a read, `_remote_cancel_requested`),
+        REPORTED only every `_REMOTE_TICK_S` (the write, `_report_remote()`
+        with no fields — see that constant's own comment for why a row with
+        nothing new still has to say so).
 
-        A tick after the outcome is already reported is impossible rather than
-        merely unlikely: `_remote_job_closed` is set by the terminal report
-        itself, and is re-read here after every sleep."""
+        `jobs.upsert` applies only the keys present, so a fieldless tick is
+        precisely "still here": it cannot move a bar, cannot overwrite the
+        detail `run_once` sets while this call is parked in the queue, and is
+        not an *opening* report (jobs.py reopens a dismissed or forgotten id
+        only for a report that states `running` outright), so it can never
+        blink a closed row back onto the screen. `schedule._report`
+        documents the same fieldless call for the same registry.
+
+        A tick — or a cancel — after the outcome is already reported is
+        impossible rather than merely unlikely: `_remote_job_closed` is set
+        by the terminal report itself, and is re-read here after every sleep,
+        before either the poll or the report.
+
+        Cancelling `task` is enough on its own to stop a QUEUED call too:
+        `run_once` awaits `_AI_SESSION.lock` before it does anything else, and
+        `asyncio.Lock.acquire()` abandons a cancelled waiter cleanly rather
+        than acquiring on its way out — so a ✕ pressed while parked behind
+        another call's turn frees the lock for whoever is next, instead of
+        making them wait out a turn nobody wants any more (SPEC BG-4: the
+        server owns this process and can really stop it, queued or not)."""
         async def beat() -> None:
+            nonlocal _beat_cancelled_task
+            elapsed = 0.0
             while True:
-                await asyncio.sleep(_REMOTE_TICK_S)
+                await asyncio.sleep(_REMOTE_CANCEL_POLL_S)
                 if _remote_job_closed:
                     return
-                _report_remote()
+                if _remote_cancel_requested():
+                    _beat_cancelled_task = True
+                    task.cancel()
+                    return
+                elapsed += _REMOTE_CANCEL_POLL_S
+                if elapsed >= _REMOTE_TICK_S:
+                    elapsed = 0.0
+                    _report_remote()
 
         return asyncio.ensure_future(beat())
 
@@ -1392,10 +1456,26 @@ async def _ai_relay(body: dict):
 
     if not stream:
         _open_remote_job()
-        beat = _start_remote_beat()
+        # A TASK, not a bare `await`, so the beat can cancel `run_once` on its
+        # own — a ✕ press — without cancelling the request handler that is
+        # still holding a connection open for a client who is still there and
+        # still wants an answer, even a "cancelled" one.
+        task = asyncio.ensure_future(run_once())
+        beat = _start_remote_beat(task)
         try:
             try:
-                data = await run_once()
+                data = await task
+            except asyncio.CancelledError:
+                if not _beat_cancelled_task:
+                    # Some other source — a real client disconnect, most
+                    # likely. `finally` below reaps whatever `task` is still
+                    # doing.
+                    raise
+                # The beat's own cancel poll did this (the row's ✕). The
+                # client is still here, waiting on THIS response, so it gets
+                # a real answer rather than a dropped connection.
+                _report_remote(state="cancelled")
+                return _ai_error("cancelled", "the call was cancelled")
             except asyncio.TimeoutError:
                 _report_remote(state="error",
                                message=f"timed out after {_AI_TIMEOUT_S:.0f}s")
@@ -1436,9 +1516,19 @@ async def _ai_relay(body: dict):
             _report_remote(state="error", message="internal error")
             raise
         finally:
-            # The heartbeat first, so nothing is still ticking a row this
-            # block is about to close.
+            # The heartbeat first, so nothing is still ticking (or cancelling)
+            # a row this block is about to close.
             await _stop_remote_beat(beat)
+            if not task.done():
+                # A real client disconnect, reaped the same way the streaming
+                # branch's own `finally` does: `run_once`'s cancel branch
+                # (discard the now-mid-turn instance) has to actually run
+                # before this function returns.
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
             # Belt-and-suspenders: anything that reaches here without one of
             # the terminal reports above closes the row as cancelled rather
             # than leaving it running forever. A no-op once a real terminal
@@ -1459,10 +1549,10 @@ async def _ai_relay(body: dict):
         # sync: no code path can create a row without something guaranteed
         # to run also being on the hook to close it.
         _open_remote_job()
-        beat = _start_remote_beat()
         queue: asyncio.Queue = asyncio.Queue()
         task = asyncio.ensure_future(
             run_once(on_delta=queue.put_nowait))
+        beat = _start_remote_beat(task)
         try:
             while True:
                 get = asyncio.ensure_future(queue.get())
@@ -1480,6 +1570,22 @@ async def _ai_relay(body: dict):
                 break
             try:
                 data = task.result()
+            except asyncio.CancelledError:
+                if not _beat_cancelled_task:
+                    raise  # some other source — treat like any other bug/disconnect below
+                # The beat's own cancel poll did this (the row's ✕), not a
+                # client disconnect. The client is still reading this stream,
+                # so it gets a real done frame rather than a broken
+                # connection. NOT counted as an ai_metrics failure, same
+                # reasoning as `model_loading` (AI-12b): this call did exactly
+                # what its ✕ asked, and counting a deliberate stop beside a
+                # timeout or a missing binary would make "3 failed" mean "the
+                # user changed their mind" as often as "the AI is not working".
+                _report_remote(state="cancelled")
+                yield json.dumps({"type": "done", "ok": False, "error": {
+                    "type": "cancelled",
+                    "message": "the call was cancelled"}}) + "\n"
+                return
             except asyncio.TimeoutError:
                 ai_metrics.record_failure(model, "timeout")
                 _report_remote(

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -2863,7 +2863,7 @@
   // Ask an AI model: the shell runs the claude (Claude Code) CLI locally
   // (server.py /api/ai). Resolves with {text, model, usage}; rejects with an
   // Error carrying `.type` ("bad_request" | "ai_unavailable" | "ai_error" |
-  // "timeout"), mirroring runPython's rejection style. opts:
+  // "timeout" | "cancelled"), mirroring runPython's rejection style. opts:
   //   { systemPrompt, model, effort: "low"|"medium"|"high"|"xhigh", onChunk }
   // effort defaults to low = no extended thinking (fast, cheap); medium+
   // enables Claude Code's own effort/thinking semantics.
@@ -2872,7 +2872,11 @@
   // {text, model, usage} at the end. Without it the request/response is the
   // plain JSON exchange it always was.
   // No latest-wins channel: an AI call is never a scrub, and cancelling a
-  // half-billed completion buys nothing — calls run fully concurrent.
+  // half-billed completion buys nothing — calls run fully concurrent. The
+  // call IS cancellable, though, from the status bar's Activity row (its ✕,
+  // same as a model download's) rather than from this function — there is no
+  // `AbortSignal` here, and the row's cancel is what turns into `"cancelled"`
+  // above.
   function ai(prompt, opts) {
     opts = opts || {};
     if (typeof prompt !== "string" || !prompt.trim()) {

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -389,17 +389,16 @@ def test_relay_remote_job_row_title_is_truncated_to_80_chars(monkeypatch):
     assert row["title"] == "x" * 80
 
 
-def test_relay_remote_job_row_does_not_advertise_a_dead_cancel(monkeypatch):
+def test_relay_remote_job_row_is_cancellable(monkeypatch):
     # JobRow renders a ✕ Cancel affordance whenever cancellable=True on a
-    # running row. Nothing in the remote-Claude path polls cancel_requested,
-    # so a row claiming to be cancellable would ship a button that does
-    # nothing — the thing the brief explicitly forbids. Checked on the
-    # errored path for the same reason as the title test above: a success
-    # dismisses the row before anything could inspect it.
+    # running row (SPEC BG-4). This row earns the claim: the beat below
+    # actually polls cancel_requested and stops the call when it is set.
+    # Checked on the errored path for the same reason as the title test
+    # above: a success dismisses the row before anything could inspect it.
     _cli_ok(monkeypatch, lines=[], exit_code=1, stderr=b"boom")
     _relay({"prompt": "hello"})
     row = jobs.list_jobs()[0]
-    assert row["cancellable"] is False
+    assert row["cancellable"] is True
 
 
 def test_relay_remote_job_row_closes_on_cli_error(monkeypatch):
@@ -512,11 +511,12 @@ def test_relay_local_model_does_not_touch_the_claude_job_row_shape(monkeypatch):
 # rather than by waiting out the real 30s.
 
 
-def _tight_timers(monkeypatch, stale=0.4, tick=0.02, timeout=2.0):
+def _tight_timers(monkeypatch, stale=0.4, tick=0.02, timeout=2.0, cancel_poll=0.02):
     """The real ratio — a heartbeat comfortably inside the stale window —
     at a hundredth of the wall-clock. Returns nothing; every knob is a
     module global read at call time."""
     monkeypatch.setattr(_server_ai, "_REMOTE_TICK_S", tick)
+    monkeypatch.setattr(_server_ai, "_REMOTE_CANCEL_POLL_S", cancel_poll)
     monkeypatch.setattr(_server_ai, "_AI_TIMEOUT_S", timeout)
     monkeypatch.setattr(jobs, "STALE_AFTER_S", stale)
 
@@ -656,6 +656,114 @@ def test_a_call_waiting_its_turn_says_so_rather_than_looking_busy(monkeypatch):
     # rather than saying "queued" for the rest of its life.
     assert queued[-1]["detail"] == _server_ai._REMOTE_ROW_DETAIL
     assert not any(row["stalled"] for row in queued)
+
+
+# -- real cancellation -------------------------------------------------------
+#
+# The row is cancellable (SPEC BG-4): the beat that heartbeats it also polls
+# `cancel_requested` far more often than the display tick and cancels the
+# call's own asyncio task the moment it sees the ✕, whether the task is
+# mid-turn or still parked on `_AI_SESSION.lock`.
+
+
+def test_cancelling_a_running_call_stops_it_and_answers_cancelled(monkeypatch):
+    _cli_ok(monkeypatch, turn_delay=5.0)
+    _tight_timers(monkeypatch)
+
+    async def go():
+        relay = asyncio.ensure_future(_server_ai._ai_relay({"prompt": "hello"}))
+        # Wait for the row to exist, then press its ✕ — same call the
+        # dock's Cancel button makes (routers/jobs.py `api_jobs_cancel`).
+        while not jobs.list_jobs():
+            await asyncio.sleep(0.01)
+        row_id = jobs.list_jobs()[0]["id"]
+        jobs.request_cancel(row_id)
+        return await relay
+
+    resp = asyncio.run(go())
+    data = _data(resp)
+    assert data["ok"] is False
+    assert data["error"]["type"] == "cancelled"
+    row = jobs.list_jobs()[0]
+    assert row["state"] == "cancelled"
+    # The wedged/mid-turn instance must not be handed to the next request —
+    # same discipline as a genuine client disconnect (run_once's own
+    # CancelledError branch).
+    assert _server_ai._AI_SESSION._proc is None
+
+
+def test_cancelling_a_running_STREAMING_call_yields_a_cancelled_done_frame(
+        monkeypatch):
+    _cli_ok(monkeypatch, lines=[_delta_line("hi")], turn_delay=5.0)
+    _tight_timers(monkeypatch)
+
+    async def go():
+        resp = await _server_ai._ai_relay({"prompt": "hello", "stream": True})
+        frames = []
+
+        async def drain():
+            async for chunk in resp.body_iterator:
+                frames.extend(json.loads(l) for l in chunk.splitlines() if l)
+
+        pump = asyncio.ensure_future(drain())
+        while not jobs.list_jobs():
+            await asyncio.sleep(0.01)
+        jobs.request_cancel(jobs.list_jobs()[0]["id"])
+        await pump
+        return frames
+
+    frames = asyncio.run(go())
+    assert frames[-1]["ok"] is False
+    assert frames[-1]["error"]["type"] == "cancelled"
+    row = jobs.list_jobs()[0]
+    assert row["state"] == "cancelled"
+
+
+def test_cancelling_a_queued_call_frees_the_lock_without_waiting_its_turn(
+        monkeypatch):
+    """The case the follow-up called out as the one most worth cancelling: a
+    second call parked behind the first's `_AI_SESSION.lock` has not started
+    at all, so its ✕ should not have to wait out the first call's whole turn
+    — `asyncio.Lock.acquire()` abandons a cancelled waiter cleanly."""
+    _cli_ok(monkeypatch, turn_delay=1.0)
+    _tight_timers(monkeypatch)
+
+    async def go():
+        first = asyncio.ensure_future(_server_ai._ai_relay({"prompt": "one"}))
+        await asyncio.sleep(0.1)  # let it take the lock
+        second = asyncio.ensure_future(_server_ai._ai_relay({"prompt": "two"}))
+        # Wait for the QUEUED row specifically (there are two rows now).
+        while not any(j["title"] == "two" for j in jobs.list_jobs()):
+            await asyncio.sleep(0.01)
+        queued_id = next(j["id"] for j in jobs.list_jobs() if j["title"] == "two")
+        started = asyncio.get_running_loop().time()
+        jobs.request_cancel(queued_id)
+        second_resp = await second
+        elapsed = asyncio.get_running_loop().time() - started
+        first_resp = await first
+        return second_resp, elapsed, first_resp
+
+    second_resp, elapsed, first_resp = asyncio.run(go())
+    assert _data(second_resp)["error"]["type"] == "cancelled"
+    # Settled well inside the first call's own 1s turn — it never had to wait
+    # one out, because the ✕ aborted its own lock wait instead of the turn.
+    assert elapsed < 0.5
+    assert _data(first_resp)["ok"] is True
+
+
+def test_a_cancel_pressed_after_the_call_already_settled_is_a_no_op(
+        monkeypatch):
+    """A press that lands after the outcome was already reported — a slow
+    click racing a fast answer — must not resurrect or corrupt a row that is
+    already gone. `_remote_cancel_requested` reading a missing row as "not
+    requested" is what makes this safe."""
+    _cli_ok(monkeypatch, _CLI_RESULT)
+    _tight_timers(monkeypatch)
+    resp = _relay({"prompt": "hello"})
+    assert _data(resp)["ok"] is True
+    assert jobs.list_jobs() == []  # success dismisses its row immediately
+    # Nothing to press any more — this must not raise.
+    assert jobs.request_cancel("sys:ai-claude:doesnotexist") is None
 
 
 # -- happy path -----------------------------------------------------------------

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -1214,6 +1214,38 @@ def test_relay_instance_failing_midcall_retries_fresh_once(monkeypatch):
     assert wedged.killed  # the wedged instance was discarded, not kept
 
 
+def test_relay_retry_still_reports_the_thinking_phase(monkeypatch):
+    # Bugbot catch: the fresh-spawn retry call to `_ai_drive` did not carry
+    # `on_phase` (only `on_delta`) — a thinking block seen on the FIRST
+    # attempt (then lost when that instance died mid-turn) left the row
+    # stuck on "Thinking — remote" for the rest of the call, including the
+    # retry's own writing phase, because nothing on the retry path could
+    # ever flip it back.
+    procs = [
+        _FakeProc(turns=[[_block_start_line("thinking")]]),  # dies mid-thinking
+        _FakeProc(turns=[[_block_start_line("text")] + _result_lines(deltas=["hi"])]),
+    ]
+    fake = _FakeSpawn(factory=lambda: procs.pop(0))
+    monkeypatch.setattr(_server_ai, "_spawn_claude_stream", fake)
+    monkeypatch.setattr(_server_ai, "_AI_SESSION", _server_ai._AiSession())
+    monkeypatch.setattr(_server_ai.shutil, "which",
+                        lambda name: "/usr/local/bin/claude")
+    monkeypatch.delenv("FUSED_RENDER_CLAUDE_BIN", raising=False)
+    real = jobs.upsert
+    details = []
+
+    def upsert(body, **kwargs):
+        if "detail" in body:
+            details.append(body["detail"])
+        return real(body, **kwargs)
+
+    monkeypatch.setattr(jobs, "upsert", upsert)
+    resp = _relay({"prompt": "hello"})
+    assert _data(resp)["ok"] is True
+    assert len(fake.calls) == 2  # the first attempt, then the retry's respawn
+    assert details[-1] == _server_ai._REMOTE_ROW_DETAIL
+
+
 def test_relay_wedged_clear_kills_and_respawns(monkeypatch):
     # A /clear that never settles within the control timeout means a wedged
     # process: kill, respawn, retry the request.

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -79,6 +79,15 @@ def _delta_line(text):
         "delta": {"type": "text_delta", "text": text}}})
 
 
+def _block_start_line(block_type, text=""):
+    """A content_block_start for `block_type` ("thinking" or "text") — what
+    on_phase (_ai_drive/ai.py) reads. `text` matches the real CLI's own shape
+    (probed on 2.1.252): a thinking block's own text is always empty."""
+    return json.dumps({"type": "stream_event", "event": {
+        "type": "content_block_start",
+        "content_block": {"type": block_type, block_type: text}}})
+
+
 def _result_lines(payload=None, deltas=()):
     """Scripted stdout for one turn: stream_event deltas, then the result."""
     lines = [_delta_line(t) for t in deltas]
@@ -495,6 +504,85 @@ def test_relay_local_model_does_not_touch_the_claude_job_row_shape(monkeypatch):
                 "text": "hi", "model": model, "usage": None}}))
     _relay({"prompt": "hello", "model": "mlx-community/Qwen3-8B-4bit"})
     assert jobs.list_jobs() == []  # this path never touches jobs.py itself
+
+
+# -- the row's thinking-phase readout ---------------------------------------
+#
+# AI-5h follow-up #1, resolved by probing the real CLI (2.1.252, sonnet,
+# effort xhigh vs. low): thinking blocks arrive, but a block's own text is
+# always empty — `display` defaults to "omitted" on every effort-capable
+# model — so the row can say THAT the model is thinking, never how much it
+# has said. Detected the same way a real page tells the two apart:
+# `content_block_start`'s `content_block.type`, "thinking" or "text".
+
+
+def test_relay_row_says_thinking_during_a_thinking_block_then_reverts(monkeypatch):
+    _cli_ok(monkeypatch, lines=[
+        _block_start_line("thinking"),
+        _block_start_line("text"),
+        _delta_line("hi"),
+        json.dumps(_CLI_RESULT),
+    ])
+    real = jobs.upsert
+    details = []
+
+    def upsert(body, **kwargs):
+        if "detail" in body:
+            details.append(body["detail"])
+        return real(body, **kwargs)
+
+    monkeypatch.setattr(jobs, "upsert", upsert)
+    resp = _relay({"prompt": "hello", "effort": "xhigh"})
+    assert _data(resp)["ok"] is True
+    assert details == [
+        _server_ai._REMOTE_ROW_DETAIL,       # _open_remote_job's opening report
+        _server_ai._REMOTE_THINKING_DETAIL,  # the thinking block starts
+        _server_ai._REMOTE_ROW_DETAIL,       # the text block starts — writing
+    ]
+
+
+def test_relay_stream_row_says_thinking_too(monkeypatch):
+    # The row's phase readout is wired once, inside run_once — shared by both
+    # branches — but checked on the streaming path too since it has its own
+    # copy of everything else about this row's lifecycle.
+    _cli_ok(monkeypatch, lines=[
+        _block_start_line("thinking"),
+        _block_start_line("text"),
+        _delta_line("hi"),
+        json.dumps(_CLI_RESULT),
+    ])
+    real = jobs.upsert
+    details = []
+
+    def upsert(body, **kwargs):
+        if "detail" in body:
+            details.append(body["detail"])
+        return real(body, **kwargs)
+
+    monkeypatch.setattr(jobs, "upsert", upsert)
+    resp, frames = _stream({"prompt": "hello", "stream": True})
+    assert frames[-1]["ok"] is True
+    assert _server_ai._REMOTE_THINKING_DETAIL in details
+    assert details[-1] == _server_ai._REMOTE_ROW_DETAIL
+
+
+def test_relay_row_never_says_thinking_when_there_is_no_thinking_block(monkeypatch):
+    # The control: a call with no thinking block at all (a low-effort or
+    # non-effort-capable model) must never claim to be thinking — the row
+    # reads "Claude — remote" for its whole life, same as before this.
+    _cli_ok(monkeypatch, lines=_result_lines(deltas=["hi"]))
+    real = jobs.upsert
+    details = []
+
+    def upsert(body, **kwargs):
+        if "detail" in body:
+            details.append(body["detail"])
+        return real(body, **kwargs)
+
+    monkeypatch.setattr(jobs, "upsert", upsert)
+    _relay({"prompt": "hello"})
+    assert _server_ai._REMOTE_THINKING_DETAIL not in details
+    assert all(d == _server_ai._REMOTE_ROW_DETAIL for d in details)
 
 
 # -- the row's heartbeat ----------------------------------------------------


### PR DESCRIPTION
## Summary

Three follow-ups from #940 (remote-Claude heartbeat), all previously scoped but unstarted:

- **Live elapsed clock** — `GET /api/jobs` already hands the client `started_at` plus the server's own clock on every poll; `jobElapsedLabel` (jobs.ts) now renders that as a clock ("1:24") on every running row's status line, measured against the server's clock so a throttled/suspended tab doesn't misreport.
- **Real cancellation** — the row's ✕ now actually does something: the heartbeat beat polls `cancel_requested` every second (vs. its 10s display tick) and cancels the call's own asyncio task the moment it sees a press — mid-turn or still queued behind `_AI_SESSION.lock` (a queued call's ✕ frees the lock immediately rather than waiting out a turn nobody wants any more). Both response shapes gain a `"cancelled"` error type, not counted as an ai_metrics failure (same carve-out as `model_loading`).
- **Thinking-phase readout** — resolves the item that was blocked on a measurement: probed the real CLI (2.1.252, sonnet, effort xhigh vs. low) and confirmed thinking blocks arrive but their text is always empty (`display` defaults to `"omitted"`), so no word count is available — only the fact that thinking is happening. The row now says "Thinking — remote" while in a thinking block and reverts once real text starts; paired with the elapsed clock above, this renders as "Thinking — 1m 20s" with no new timer needed.

SPEC.md (RH-11, BG-4) and `runtime.js`'s `fused.ai()` doc comment updated to match.

## Test plan
- [x] `tests/test_server_ai.py` (95 tests, including new cancellation and thinking-phase coverage) and `tests/test_runtime_cancellation.py` pass
- [x] Frontend `jobs.test.ts` / `JobRow.test.tsx` / `DownloadManager.test.tsx` pass; `tsc --noEmit` clean
- [x] Thinking-phase behavior verified against the real `claude` CLI (not mocked) with both an xhigh and a low-effort arm as a control

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote AI relay lifecycle (task cancel, CLI discard, streaming vs JSON paths) and shared job UI polling; mistakes could leak rows, mis-handle disconnect vs user cancel, or break long-running Claude calls.
> 
> **Overview**
> Remote **Claude** activity rows in the status bar get three UX follow-ups: a **live elapsed clock** on every running job (via new `jobElapsedLabel`, using the server `now` from `/api/jobs` so throttled tabs don’t lie), **real cancellation** when ✕ is pressed, and a **thinking-phase** detail line during extended-thinking blocks.
> 
> On the server, remote rows are **`cancellable=True`**; the heartbeat loop polls `cancel_requested` every second (separate from the 10s stale tick), cancels the in-flight `run_once` task (including queued lock waits), discards the CLI session on abort, and answers JSON/NDJSON with **`error.type: "cancelled"`**—documented in SPEC/RH-11 and `runtime.js`, and excluded from AI failure metrics like `model_loading`. `_ai_drive` gains **`on_phase`** so the row flips between **"Thinking — remote"** and **"Claude — remote"** from `content_block_start` events.
> 
> The download manager threads **`nowMs`** from `useJobs` into `JobRow` and dot-joins the elapsed clock onto the status line beside existing phase/amount text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ac4bfb9ce8e2b6863c003732637fe374541bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->