### PR TITLE
Sidebar: nav labels never wrap during the expand glide

### DIFF
--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -274,6 +274,12 @@ a.sidebar-rail-btn {
   text-decoration: none;
   cursor: pointer;
   font-size: 13.5px;
+  /* The expand glide lays these rows out at every width between the rail's
+     44px and the settled one; a label allowed to wrap ("AI Models") spends
+     those frames as two lines — a phantom extra row that flashes in and out
+     of the nav. Never wrap: mid-glide the text clips at the sidebar's edge
+     (overflow-x: hidden above) instead of reflowing. */
+  white-space: nowrap;
 }
 
 .sidebar-item:hover,


### PR DESCRIPTION
## What

One CSS line: `.sidebar-item { white-space: nowrap }`.

## Why

Reported as "the Canvases item flashes in the sidebar on collapse/expand even though the preference is off." Frame-by-frame analysis of a screen recording (904 native frames) showed **no Canvases node is ever rendered** — the flag gating is airtight in source and in every built bundle checked. The flash is a reflow: the expand glide animates the sidebar's width from the 44px rail to the settled width, and the expanded rows lay out at every width in between. "AI Models" wraps to two lines for ~5–8 frames, producing a phantom extra row exactly where a Canvases row would sit, then snaps back.

With nowrap, the label clips at the sidebar's edge mid-glide (`overflow-x: hidden` on `#sidebar` already handles the spill) instead of reflowing. Verified in a headless run: the AI Models row now holds 33px (one line) through the entire transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS property on nav row styling with no logic, data, or auth changes; long labels may clip briefly during resize animation rather than wrap.
> 
> **Overview**
> Fixes a **visual flash** during sidebar collapse/expand: while width animates between the 44px rail and full width, nav labels like **"AI Models"** could briefly wrap to two lines, creating a phantom extra row that looked like a flashing nav item (e.g. misreported as Canvases).
> 
> Adds **`white-space: nowrap`** on **`.sidebar-item`** so labels stay on one line during the transition; mid-animation text **clips** at the sidebar edge instead of reflowing, relying on existing **`overflow-x: hidden`** on **`#sidebar`**. Includes an inline comment explaining the expand-glide behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7d4a85ef6cb35b52d52ebcff90d8c12cb5f4e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->