### PR TITLE
Sweep orphan part files so a recipe-scoped repo stops reading partial

### DIFF
--- a/fused_render/ai/hub_cache.py
+++ b/fused_render/ai/hub_cache.py
@@ -1088,12 +1088,35 @@ def _unfinished_fetch(repo_dir: str) -> bool:
     So two facts, both of which are something that IS there:
 
     1. **A part file in `blobs/`.** Only an interrupted (or in-flight) fetch
-       leaves one: our own `finish()` renames the part over the blob and drops
-       its sidecar, hf does the same with `.incomplete`, and the one path that
-       abandons ours (`worker_base._clear_parts`, taken when a segmented fetch
-       falls back to hf) deletes them before handing the repo over. A cancel
-       does NOT go that way — `except Cancelled: raise` — which is exactly why
-       the bytes, and therefore this evidence, are still here.
+       leaves one — our own `finish()` renames the part over the blob and drops
+       its sidecar, hf does the same with `.incomplete` — and a live fetch keeps
+       rewriting it, so a part file's continued presence is either an in-flight
+       download or one nothing has finished cleaning up yet.
+
+       Two different things clean a part file up, on two different schedules,
+       and the distinction matters to why this predicate eventually stops
+       seeing a repo as partial rather than staying wrong forever.
+       `worker_base._clear_parts`, taken only when a segmented fetch gives up
+       and falls back to hf, drops OUR part files unconditionally and
+       immediately — hf is about to fetch those same names itself. Everything
+       else — a recipe whose `allow_patterns` permanently excludes a name an
+       earlier, wider fetch already left a part file for — is swept by
+       `worker_base._sweep_orphan_parts`, which runs after ANY scope's download
+       succeeds (the `_cached_path` fast path included, so a "Continue
+       downloading" retry that opens no connection still triggers it) and
+       removes any part file — ours or hf's — old enough (past
+       `_PART_GRACE_SECONDS`) that it cannot belong to the scope that just
+       finished. So a repo this predicate calls partial reads that way until
+       the NEXT download attempt of any scope over it succeeds and the
+       leftover part file has aged past the grace window — not forever, and not
+       on the first retry either, since a part file written moments before a
+       retry is presumed to be someone else's in-flight fetch rather than swept
+       out from under it.
+
+       A cancel does NOT go through either cleanup path —
+       `except Cancelled: raise` skips the fallback, and no download succeeded
+       to trigger a sweep — which is exactly why the bytes, and therefore this
+       evidence, are still here for a paused download to resume into.
     2. **No snapshot directory at all.** A folder with blobs and nothing to open,
        which is the state hub search has always called `partial` and the state a
        cancel before the first file lands leaves behind.

--- a/fused_render/ai/hub_cache.py
+++ b/fused_render/ai/hub_cache.py
@@ -1062,6 +1062,13 @@ def _refs_by_commit(repo_dir: str) -> dict[str, str]:
 #: pasted in — so the reading has to hold for repos this app never fetched.
 #: `test_ai_models_api.py` pins ours against the fetcher's own constant, so the
 #: two names cannot drift apart in silence.
+#:
+#: Deliberately NOT here: the sidecar's own `<etag>.fusedpart.json.tmp`
+#: (`worker_base._PART_MARKER` matches it, this does not). It adds no evidence
+#: this predicate lacks — it exists only in the narrow window `flush()` is
+#: writing it, or after a crash inside that window, and in both cases the
+#: `.fusedpart` file it is a sidecar FOR is still sitting right beside it and
+#: already trips this check on its own.
 _PART_SUFFIXES = (".fusedpart", ".incomplete")
 
 
@@ -1116,7 +1123,12 @@ def _unfinished_fetch(repo_dir: str) -> bool:
        A cancel does NOT go through either cleanup path —
        `except Cancelled: raise` skips the fallback, and no download succeeded
        to trigger a sweep — which is exactly why the bytes, and therefore this
-       evidence, are still here for a paused download to resume into.
+       evidence, are still here for a paused download to resume into. That
+       lasts only until some OTHER scope's download over the same repo
+       succeeds and the grace window passes: the sweep cannot tell a paused
+       download's resume state from any other orphan, and clears it too (see
+       `worker_base._sweep_orphan_parts`'s docstring for why that trade is
+       accepted rather than guarded against).
     2. **No snapshot directory at all.** A folder with blobs and nothing to open,
        which is the state hub search has always called `partial` and the state a
        cancel before the first file lands leaves behind.

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -2893,18 +2893,32 @@ def _clear_parts(folder):
     ever resumes into a part file whose blob already exists.
 
     **Ours only, and immediate — the opposite of `_sweep_orphan_parts` on both
-    counts, deliberately.** hf's own `.incomplete` is left alone, because it may
-    be genuine resume state from an EARLIER call into this same fallback (hf
-    resumes one of those by seeking to its length); clearing it here would turn
-    a resumable hf download into a fresh multi-gigabyte one. And there is no
-    grace window: the segmented fetch that just failed is definitely not
-    writing into its own part file any more, so age tells us nothing a
-    conditional check would add, only a reason to leave freshly-abandoned bytes
-    behind for one grace period.
+    counts, deliberately.** hf's own `.incomplete` is left alone here regardless
+    of age. In the huggingface_hub actually installed (1.29.0 in this venv;
+    upstream PR #4228), every attempt writes to a name unique to that attempt —
+    `<blob>.<8 hex chars>.incomplete` — and `_download_to_tmp_and_move` unlinks
+    it itself, in a `finally`, on any ordinary failure; a leftover `.incomplete`
+    is therefore evidence of a hard kill or crash, not of a resumable transfer,
+    and even then nothing will ever seek into it by that exact random name
+    again. Whether an older or future hf ever resumes by seeking into a shared
+    name is not a guarantee this file can make for every version it might run
+    against, so it takes the conservative position either way and never removes
+    hf's own leftovers here. Their eventual removal is entirely
+    `_sweep_orphan_parts`'s job, on ITS terms (a grace window, and only after
+    some scope's download has actually succeeded) — see there for why that is
+    the right call despite the cost.
 
-    So the resume story is honest about its scope. It covers the app being
-    killed, quit or crashed — the case that motivated it (AI-5e) — and not a
-    fetch that failed its way into the fallback, which re-downloads.
+    There is no grace window of its own here for the same reason age would add
+    nothing to a same-process check: the segmented fetch that just failed is
+    definitely not writing into its own part file any more.
+
+    So the resume story this function is party to is honest about its scope.
+    It removes only what THIS failed attempt was writing, and defers to
+    `_sweep_orphan_parts` for everything else in the repo — including anything
+    an app kill, quit or crash left behind (AI-5e), which is why a fetch that
+    fails its way into the fallback re-downloads rather than resumes: the part
+    files that would have let it resume are exactly the ones this function just
+    removed.
     """
     for dirpath, _dirs, files in os.walk(folder or ""):
         for name in files:
@@ -3547,6 +3561,19 @@ def _sweep_orphan_parts(folder):
     writing. No etag-to-filename mapping is needed to tell the two apart, and
     none is possible offline: the sidecar records only version/etag/size/
     segments, and hf's `.incomplete` carries no sidecar at all.
+
+    **The trade-off, stated plainly.** "Some OTHER fetch" includes a
+    `Cancelled` one — a paused download IS an out-of-scope part file with a
+    stale mtime, and its whole reason to exist is to be resumed later (AI-5i).
+    Once it is old enough and a sibling scope over the same repo succeeds,
+    this removes it same as any other orphan, and that sibling's success
+    restarts the paused download from zero the next time it is resumed. That
+    is accepted, not overlooked: the alternative is a card that can read
+    "partial" forever because the one thing standing in the way is resume
+    state for a download nobody is coming back to finish, and there is no way
+    from here to tell those two cases apart offline. A successful download
+    over a repo clears every OTHER scope's leftover resume state in that
+    repo — deliberately, as the cost of never leaving a card stuck.
 
     This is the fix for the recipe-scoped GGUF case: an earlier, unscoped fetch
     of a repo that later gains a `keep`-limited recipe leaves part files for

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -3501,24 +3501,34 @@ _NOT_CACHED = (OSError, ImportError)
 #: hf's own marker for a blob it is still writing. Ours is `PART_SUFFIX`.
 _HF_PART_SUFFIX = ".incomplete"
 
-#: Every part-file SHAPE a fetch can leave beside a blob: ours (`.fusedpart`
-#: and its offsets sidecar) and hf's own — the bare `<etag>.incomplete` older hf
-#: writes, and the `<etag>.<8 hex chars>.incomplete` newer hf writes so two
-#: concurrent attempts at one blob cannot collide on a single name.
+#: Every part-file SHAPE a fetch can leave beside a blob: ours — `.fusedpart`,
+#: its offsets sidecar, and the sidecar's own `.tmp` (`_FileFetch.flush` writes
+#: `<sidecar>.tmp` and `os.replace`s it over the sidecar; a crash between those
+#: two steps leaves the `.tmp` behind with nothing else ever removing it) — and
+#: hf's own `.incomplete`, unanchored on any prefix so it matches whether or
+#: not the installed hf version infixes a per-attempt random name before the
+#: suffix (`<etag>.incomplete` and `<etag>.<8 hex chars>.incomplete` both end
+#: in `.incomplete`, so one alternative covers both; there is no shape here
+#: that a narrower pattern would be catching that this one misses).
 _PART_MARKER = re.compile(
-    r"(?:" + re.escape(PART_SUFFIX) + r"(?:\.json)?"
-    r"|\.[0-9a-f]{8}" + re.escape(_HF_PART_SUFFIX) +
+    r"(?:" + re.escape(PART_SUFFIX) + r"(?:\.json(?:\.tmp)?)?"
     r"|" + re.escape(_HF_PART_SUFFIX) + r")$")
 
 #: How long `_sweep_orphan_parts` leaves a part file alone before it will treat
-#: it as dead weight. A LIVE download keeps its part file's mtime current —
-#: ours flushes its sidecar every `FLUSH_EVERY_S` (one second), and hf rewrites
-#: `.incomplete` on every chunk it appends — so anything genuinely in flight is
-#: seconds old. An orphan, the resume state for a file some scope no longer
-#: covers, is minutes to months old. Five minutes is enormous headroom over the
-#: flush cadence and nothing at all against how long a card has been stuck
-#: reading "partial".
-_PART_GRACE_SECONDS = 300
+#: it as dead weight, expressed against this module's own worst case rather
+#: than as an independent guess: `_Throttle.wait` (see `THROTTLE_TOTAL_MAX_S`)
+#: can park a segment on a 429 for up to that long without a single byte
+#: reaching the part file or its sidecar, and `_note_throttle` — not the
+#: mtime — is the only sign that fetch is still alive. So the grace window has
+#: to clear the stall ceiling with real headroom, not merely match the flush
+#: cadence: five extra minutes on top of the ten-minute ceiling is enormous
+#: against `FLUSH_EVERY_S` (one second) for anything actually moving bytes,
+#: and nothing at all against how long a card has been stuck reading
+#: "partial". Defined as an offset from `THROTTLE_TOTAL_MAX_S` rather than a
+#: second bare number so the two cannot drift back below each other in a
+#: future edit to either constant; `test_the_grace_window_clears_the_longest_a_fetch_can_stall`
+#: pins the relationship.
+_PART_GRACE_SECONDS = THROTTLE_TOTAL_MAX_S + 300
 
 
 def _sweep_orphan_parts(folder):
@@ -3561,10 +3571,19 @@ def _sweep_orphan_parts(folder):
     Never raises. A failed unlink is logged and skipped rather than swallowed —
     a cosmetic cleanup step must not be the thing that turns a successful
     download into a failed one, but it must not go silent either.
+
+    `folder` is `None` when `repo_folder` could not import
+    `huggingface_hub` (see its docstring) — checked explicitly, the same way
+    `bytes_on_disk` does, rather than folded into `os.path.join` with a `""`
+    fallback: `os.path.join("", "blobs")` is the RELATIVE path `"blobs"`, not
+    a no-op, and `os.scandir` would resolve it against this process's CWD —
+    unlinking anything part-shaped it happens to find in a `./blobs` there.
     """
+    if not folder:
+        return 0
     removed = 0
     try:
-        entries = list(os.scandir(os.path.join(folder or "", "blobs")))
+        entries = list(os.scandir(os.path.join(folder, "blobs")))
     except OSError:
         return removed
     now = time.time()

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -2883,13 +2883,24 @@ def _write_ref(folder, ref, commit):
 
 
 def _clear_parts(folder):
-    """Drop our partial files before handing the repo back to huggingface_hub.
+    """Drop OUR partial files, unconditionally, before handing the repo back to
+    huggingface_hub.
 
     Not because hf would misread them — the suffix exists precisely so it never
     sees them — but because hf is about to fetch those same files ITSELF. Kept,
     they would count towards the progress bar for a download nothing is writing,
     and then sit in the hub cache forever beside the blob hf finished: nothing
     ever resumes into a part file whose blob already exists.
+
+    **Ours only, and immediate — the opposite of `_sweep_orphan_parts` on both
+    counts, deliberately.** hf's own `.incomplete` is left alone, because it may
+    be genuine resume state from an EARLIER call into this same fallback (hf
+    resumes one of those by seeking to its length); clearing it here would turn
+    a resumable hf download into a fresh multi-gigabyte one. And there is no
+    grace window: the segmented fetch that just failed is definitely not
+    writing into its own part file any more, so age tells us nothing a
+    conditional check would add, only a reason to leave freshly-abandoned bytes
+    behind for one grace period.
 
     So the resume story is honest about its scope. It covers the app being
     killed, quit or crashed — the case that motivated it (AI-5e) — and not a
@@ -3490,6 +3501,92 @@ _NOT_CACHED = (OSError, ImportError)
 #: hf's own marker for a blob it is still writing. Ours is `PART_SUFFIX`.
 _HF_PART_SUFFIX = ".incomplete"
 
+#: Every part-file SHAPE a fetch can leave beside a blob: ours (`.fusedpart`
+#: and its offsets sidecar) and hf's own — the bare `<etag>.incomplete` older hf
+#: writes, and the `<etag>.<8 hex chars>.incomplete` newer hf writes so two
+#: concurrent attempts at one blob cannot collide on a single name.
+_PART_MARKER = re.compile(
+    r"(?:" + re.escape(PART_SUFFIX) + r"(?:\.json)?"
+    r"|\.[0-9a-f]{8}" + re.escape(_HF_PART_SUFFIX) +
+    r"|" + re.escape(_HF_PART_SUFFIX) + r")$")
+
+#: How long `_sweep_orphan_parts` leaves a part file alone before it will treat
+#: it as dead weight. A LIVE download keeps its part file's mtime current —
+#: ours flushes its sidecar every `FLUSH_EVERY_S` (one second), and hf rewrites
+#: `.incomplete` on every chunk it appends — so anything genuinely in flight is
+#: seconds old. An orphan, the resume state for a file some scope no longer
+#: covers, is minutes to months old. Five minutes is enormous headroom over the
+#: flush cadence and nothing at all against how long a card has been stuck
+#: reading "partial".
+_PART_GRACE_SECONDS = 300
+
+
+def _sweep_orphan_parts(folder):
+    """Remove every part file in `<folder>/blobs/` old enough to be provably
+    dead, and return how many were removed.
+
+    **The invariant this leans on.** Call this only after a download for some
+    SCOPE has succeeded — a full snapshot, one recipe's `allow_patterns`, one
+    named file, whether that success came off the network or off
+    `_cached_path`/`_cached_file` confirming the scope was already on disk. At
+    that moment every file the scope covers is a complete blob, by definition:
+    the fetch that just returned wrote it, or the cache check would not have
+    answered a hit. So a part file still sitting in `blobs/` cannot belong to
+    anything this download cared about — it is resume state for a file some
+    OTHER fetch, wider or narrower, earlier or concurrent-but-abandoned, was
+    writing. No etag-to-filename mapping is needed to tell the two apart, and
+    none is possible offline: the sidecar records only version/etag/size/
+    segments, and hf's `.incomplete` carries no sidecar at all.
+
+    This is the fix for the recipe-scoped GGUF case: an earlier, unscoped fetch
+    of a repo that later gains a `keep`-limited recipe leaves part files for
+    the files the recipe now permanently excludes, and nothing scoped to the
+    recipe ever looks at those names again to clean them up. Calling this after
+    that scope's own success — the `_cached_path` fast path included, since a
+    resume-button retry that changes nothing on the wire is exactly a repeat of
+    that same success — removes them, and `hub_cache._unfinished_fetch` stops
+    reading the repo as partial.
+
+    **Only `blobs/`, never a full walk.** Every part file this module writes
+    sits beside the blob it is filling (`_FileFetch.part`/`.sidecar`), and hf's
+    `.incomplete` markers live in the same directory — nothing in this cache
+    layout ever puts one anywhere else.
+
+    **The grace window is the only guard against sweeping a file that is still
+    being written.** There is no per-repo lock or in-flight registry here to
+    consult instead: two fetches over the same repo — different recipe scopes,
+    say — are two independent processes sharing nothing but the filesystem, so
+    freshness is the only signal available. See `_PART_GRACE_SECONDS`.
+
+    Never raises. A failed unlink is logged and skipped rather than swallowed —
+    a cosmetic cleanup step must not be the thing that turns a successful
+    download into a failed one, but it must not go silent either.
+    """
+    removed = 0
+    try:
+        entries = list(os.scandir(os.path.join(folder or "", "blobs")))
+    except OSError:
+        return removed
+    now = time.time()
+    for entry in entries:
+        if not _PART_MARKER.search(entry.name):
+            continue
+        try:
+            age = now - entry.stat().st_mtime
+        except OSError:
+            continue
+        if age < _PART_GRACE_SECONDS:
+            continue
+        try:
+            os.remove(entry.path)
+        except OSError as error:
+            sys.stderr.write(
+                f"[fused] could not remove orphan part file {entry.path}: "
+                f"{error.__class__.__name__}: {error}\n")
+            continue
+        removed += 1
+    return removed
+
 
 def _settled(path):
     """Whether the file at `path` is finished rather than mid-download.
@@ -3872,6 +3969,12 @@ def download_snapshot(model_id, allow_patterns=None, ignore_patterns=None, **kwa
         cached = _cached_path(model_id, local, allow=allow_patterns,
                               ignore=ignore_patterns)
         if cached:
+            # The most important call site of all: pressing "Continue
+            # downloading" on a repo whose recipe scope is already fully on
+            # disk lands exactly here, with zero connections opened. Without
+            # this the card stays "partial" forever no matter how many times
+            # the button is pressed — see `_sweep_orphan_parts`.
+            _sweep_orphan_parts(repo_folder(model_id))
             return cached
 
         # Our own mirror, for a suggested model, BEFORE the Hub is consulted at
@@ -3882,6 +3985,7 @@ def download_snapshot(model_id, allow_patterns=None, ignore_patterns=None, **kwa
         # manifest describes the whole repo at one commit and nothing else.
         mirrored = _mirror_snapshot(model_id, allow_patterns, ignore_patterns)
         if mirrored:
+            _sweep_orphan_parts(repo_folder(model_id))
             return mirrored
 
     # ONE listing, serving the bar's total, the list to fetch AND the revision
@@ -3955,6 +4059,7 @@ def download_snapshot(model_id, allow_patterns=None, ignore_patterns=None, **kwa
         # will not look up.
         _record_fetch(repo_folder(model_id), _commit_of(fetched), names, fetched,
                       allow=allow_patterns, ignore=ignore_patterns)
+        _sweep_orphan_parts(repo_folder(model_id))
         return fetched
     fell_back = hub(revision=sha)
     # Same rule as above, and the same reason it is checked rather than assumed:
@@ -3966,6 +4071,7 @@ def download_snapshot(model_id, allow_patterns=None, ignore_patterns=None, **kwa
     # what keeps a repo that ever fell back from being cold forever.
     _record_fetch(repo_folder(model_id), _commit_of(fell_back), names, fell_back,
                   allow=allow_patterns, ignore=ignore_patterns)
+    _sweep_orphan_parts(repo_folder(model_id))
     return fell_back
 
 
@@ -4158,6 +4264,12 @@ def download_file(repo_id, filename, detail=None, job=None, row=None):
     # download — see `_cached_file`.
     cached = _cached_file(repo_id, filename)
     if cached:
+        # Same rule as `download_snapshot`'s fast path — see
+        # `_sweep_orphan_parts` — one file wide: a "Continue downloading" retry
+        # on a GGUF quantization already on disk lands here with no connection
+        # opened, and has to be the moment any of this repo's other, out-of-
+        # scope leftovers get cleared too.
+        _sweep_orphan_parts(repo_folder(repo_id))
         return cached
 
     detail = detail or f"Fetching {filename}…"
@@ -4170,6 +4282,7 @@ def download_file(repo_id, filename, detail=None, job=None, row=None):
     # so `_mirror_snapshot` never sees a suggested text model on those platforms.
     mirrored = _mirror_file(repo_id, filename, detail=detail, job=job, row=row)
     if mirrored:
+        _sweep_orphan_parts(repo_folder(repo_id))
         return mirrored
 
     # One listing here too, for the revision as much as for the total: a GGUF
@@ -4197,9 +4310,11 @@ def download_file(repo_id, filename, detail=None, job=None, row=None):
             total=total, detail=detail, job=job, row=row, counter=ticker)
 
     if not sha:
-        return hub()
+        result = hub()
+        _sweep_orphan_parts(repo_folder(repo_id))
+        return result
     try:
-        return fetch_with_progress(
+        fetched = fetch_with_progress(
             repo_id,
             lambda: os.path.join(_segmented_fetch(repo_id, [filename], sha),
                                  filename),
@@ -4208,7 +4323,12 @@ def download_file(repo_id, filename, detail=None, job=None, row=None):
         raise
     except Exception as error:  # noqa: BLE001 - every failure degrades to hf's downloader
         _fallback(repo_id, error)
-    return hub()
+    else:
+        _sweep_orphan_parts(repo_folder(repo_id))
+        return fetched
+    result = hub()
+    _sweep_orphan_parts(repo_folder(repo_id))
+    return result
 
 
 # -------------------------------------------------------------------- bring-up

--- a/fused_render/ai/runners/worker_base.py
+++ b/fused_render/ai/runners/worker_base.py
@@ -4086,7 +4086,16 @@ def download_snapshot(model_id, allow_patterns=None, ignore_patterns=None, **kwa
         # revision, a local dir — and a fetch that quietly ignored one would
         # download the wrong thing. Ours honours exactly the two it knows about.
         # A listing with no sha is the same problem: nothing to pin to.
-        return hub()
+        #
+        # `files is None`/`not sha` is exactly the state a failed `_repo_files`
+        # listing above leaves — the same flaky-network case most likely to
+        # have left an orphan part file behind on an earlier attempt. Swept
+        # here too, same as every other successful return in this function,
+        # or a repo whose listing keeps failing stays "partial" forever no
+        # matter how many times hf itself completes it underneath.
+        result = hub()
+        _sweep_orphan_parts(repo_folder(model_id))
+        return result
     names = [name for name, _size in files]
     try:
         fetched = fetch_with_progress(

--- a/tests/test_ai_hub_fetch.py
+++ b/tests/test_ai_hub_fetch.py
@@ -1564,6 +1564,64 @@ def test_the_fallback_does_not_inherit_our_half_written_parts(base, monkeypatch,
     assert left == [], f"our part files were left for hf to trip over: {left}"
 
 
+def test_orphan_parts_outside_a_recipes_scope_are_swept_once_the_scope_succeeds(
+        base, monkeypatch, tmp_path, payload):
+    """A recipe that only ever asks for a subset of a repo (`allow_patterns`)
+    leaves an earlier, wider fetch's part files behind for names it will never
+    ask for again. Once THIS scope's own segmented fetch completes, those
+    leftovers are provably out of scope — the fetch just proved every IN-scope
+    file is a finished blob — and get swept."""
+    url, state = _start_server(payload)
+    folder = _wire(base, monkeypatch, tmp_path, url, len(payload))
+    monkeypatch.setattr(base, "report", lambda job=None, **fields: None)
+    monkeypatch.setattr(base, "_repo_files",
+                        lambda model_id, include=None, allow=None, ignore=None, revision="main":
+                        ("c0m", [("model.safetensors", len(payload))]))
+
+    orphan = os.path.join(folder, "blobs", "0ldetag.fusedpart")
+    os.makedirs(os.path.dirname(orphan), exist_ok=True)
+    with open(orphan, "wb") as handle:
+        handle.write(b"an earlier, wider fetch's leftovers")
+    stale = time.time() - base._PART_GRACE_SECONDS - 60
+    os.utime(orphan, (stale, stale))
+
+    base.download_snapshot("org/m", allow_patterns=["model.safetensors"])
+
+    assert state["log"], "the segmented route was never tried"
+    assert not os.path.exists(orphan), "the out-of-scope leftover was not swept"
+
+
+def test_a_cancelled_downloads_own_resume_state_is_never_swept(base, monkeypatch,
+                                                               tmp_path):
+    """A cancel must not trigger the sweep at all — the `.fusedpart` beside it
+    IS the resume state (AI-5i), not evidence of anything stale, even once it
+    is old enough that the sweep's own grace window would otherwise let it go.
+    No download succeeded, so nothing runs the sweep in the first place."""
+    folder = tmp_path / "models--org--m"
+    blobs = folder / "blobs"
+    blobs.mkdir(parents=True)
+    part = blobs / "e7ag.fusedpart"
+    part.write_bytes(b"half")
+    stale = time.time() - base._PART_GRACE_SECONDS - 60
+    os.utime(str(part), (stale, stale))
+    monkeypatch.setattr(base, "repo_folder",
+                        lambda model_id, repo_type="model": str(folder))
+    monkeypatch.setattr(base, "report", lambda job=None, **fields: None)
+    monkeypatch.setattr(base, "_repo_files",
+                        lambda model_id, include=None, allow=None, ignore=None, revision="main":
+                        ("c0m", [("model.safetensors", 10)]))
+
+    def cancelled(*args, **kwargs):
+        raise base.Cancelled()
+
+    monkeypatch.setattr(base, "_segmented_fetch", cancelled)
+
+    with pytest.raises(base.Cancelled):
+        base.download_snapshot("org/m")
+
+    assert part.exists(), "a cancelled download's resume state was swept away"
+
+
 @pytest.mark.parametrize("breaks", ["listing", "fetch"])
 def test_download_file_falls_back_like_the_snapshot_does(base, monkeypatch, tmp_path,
                                                          payload, breaks):

--- a/tests/test_ai_hub_fetch.py
+++ b/tests/test_ai_hub_fetch.py
@@ -1591,12 +1591,16 @@ def test_orphan_parts_outside_a_recipes_scope_are_swept_once_the_scope_succeeds(
     assert not os.path.exists(orphan), "the out-of-scope leftover was not swept"
 
 
-def test_a_cancelled_downloads_own_resume_state_is_never_swept(base, monkeypatch,
-                                                               tmp_path):
-    """A cancel must not trigger the sweep at all — the `.fusedpart` beside it
-    IS the resume state (AI-5i), not evidence of anything stale, even once it
-    is old enough that the sweep's own grace window would otherwise let it go.
-    No download succeeded, so nothing runs the sweep in the first place."""
+def test_a_cancel_never_triggers_the_sweep_itself(base, monkeypatch, tmp_path):
+    """A cancel must not trigger the sweep AT ALL, even once its own
+    `.fusedpart` — which IS the resume state, AI-5i — is old enough that the
+    sweep's grace window would otherwise let it go: `except Cancelled: raise`
+    skips `_clear_parts`'s fallback, and no download succeeded to trigger
+    `_sweep_orphan_parts` either. This is NOT a guarantee that a cancelled
+    download's resume state survives forever — a sibling scope's later
+    success still reaps it once it is stale enough, deliberately (see
+    `test_a_siblings_later_success_still_reaps_a_cancelled_downloads_resume_state`
+    below) — only that the cancelled attempt is never itself the trigger."""
     folder = tmp_path / "models--org--m"
     blobs = folder / "blobs"
     blobs.mkdir(parents=True)
@@ -1620,6 +1624,41 @@ def test_a_cancelled_downloads_own_resume_state_is_never_swept(base, monkeypatch
         base.download_snapshot("org/m")
 
     assert part.exists(), "a cancelled download's resume state was swept away"
+
+
+def test_a_siblings_later_success_still_reaps_a_cancelled_downloads_resume_state(
+        base, monkeypatch, tmp_path):
+    """The real guarantee is narrower than "a cancelled download's resume state
+    is never swept" — it holds only until some OTHER scope's download over the
+    same repo succeeds and the leftover ages past the grace window. There is
+    no signal on disk that tells a paused download's `.fusedpart` apart from
+    any other orphan (AI-5i's sidecar records offsets, not intent), so a
+    sibling success reaps it the same as it would any other leftover. That is
+    the accepted cost of `_sweep_orphan_parts` never leaving a card stuck —
+    see its docstring — not an oversight this test is pinning as a bug."""
+    folder = tmp_path / "models--org--m"
+    blobs = folder / "blobs"
+    blobs.mkdir(parents=True)
+    cancelled_part = blobs / "cance1ed.fusedpart"
+    cancelled_part.write_bytes(b"paused at 80%")
+    stale = time.time() - base._PART_GRACE_SECONDS - 60
+    os.utime(str(cancelled_part), (stale, stale))
+
+    snapshot = folder / "snapshots" / "c0m"
+    snapshot.mkdir(parents=True)
+    blob = blobs / "e7ag"
+    blob.write_bytes(b"weights")
+    (snapshot / "model.safetensors").symlink_to(blob)
+    base._record_fetch(str(folder), "c0m", ["model.safetensors"], str(snapshot))
+
+    monkeypatch.setattr(base, "repo_folder",
+                        lambda model_id, repo_type="model": str(folder))
+    monkeypatch.setattr(base, "_cached_path", lambda *a, **k: str(snapshot))
+
+    assert base.download_snapshot("org/m") == str(snapshot)
+    assert not cancelled_part.exists(), (
+        "a sibling scope's success did not reap a stale, cancelled "
+        "download's resume state")
 
 
 @pytest.mark.parametrize("breaks", ["listing", "fetch"])

--- a/tests/test_ai_models_api.py
+++ b/tests/test_ai_models_api.py
@@ -2121,12 +2121,17 @@ def test_a_dataset_is_never_partly_downloaded(client, hub):
 
 
 def test_the_part_suffix_is_the_fetchers_own(client):
-    """Two modules, one name. This module reads a cache the fetcher writes, and
-    the constant is duplicated deliberately (see `_PART_SUFFIXES`) — so the
-    duplication is pinned rather than trusted."""
+    """Two modules, one name — twice over. This module reads a cache the
+    fetcher writes, and both constants it pins against are duplicated
+    deliberately (see `_PART_SUFFIXES`), so the duplication is pinned rather
+    than trusted: ours (`PART_SUFFIX`) and hf's own (`_HF_PART_SUFFIX`), so the
+    two suffix sets cannot drift apart in silence."""
     from fused_render.ai.runners import worker_base
 
     assert worker_base.PART_SUFFIX in ai_models_mod._PART_SUFFIXES
+    assert worker_base._HF_PART_SUFFIX in ai_models_mod._PART_SUFFIXES
+    assert set(ai_models_mod._PART_SUFFIXES) == {
+        worker_base.PART_SUFFIX, worker_base._HF_PART_SUFFIX}
 
 
 @requires_symlinks

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -2373,11 +2373,25 @@ def _aged(path, seconds):
     os.utime(str(path), (then, then))
 
 
+def test_the_grace_window_clears_the_longest_a_fetch_can_stall(base):
+    """`_PART_GRACE_SECONDS` has to outlast `THROTTLE_TOTAL_MAX_S` — the most
+    wall clock a live segment can spend parked on a 429 without a single byte
+    reaching its part file, `_note_throttle` rather than the mtime being the
+    only sign it is still alive — and with real headroom, or the sweep can
+    delete a file a throttled fetch is still going to write into. Pinned so a
+    future edit that lets either constant drift back below the other fails
+    loudly here rather than as a corrupted multi-gigabyte download in the
+    field."""
+    assert base._PART_GRACE_SECONDS > base.THROTTLE_TOTAL_MAX_S
+    assert base._PART_GRACE_SECONDS - base.THROTTLE_TOTAL_MAX_S >= 120
+
+
 def test_sweep_removes_every_part_shape_once_it_is_old_enough(base, tmp_path):
-    """Ours (`.fusedpart` and its offsets sidecar) and both of hf's own
-    (`<etag>.incomplete` and `<etag>.<8 hex>.incomplete`) all count — a leftover
-    is a leftover regardless of which fetcher wrote it. A finished blob beside
-    them is left alone."""
+    """Ours (`.fusedpart`, its offsets sidecar, and the sidecar's own crashed
+    `.tmp`) and both of hf's own (`<etag>.incomplete` and
+    `<etag>.<8 hex>.incomplete`) all count — a leftover is a leftover
+    regardless of which fetcher wrote it. A finished blob beside them is left
+    alone."""
     folder = tmp_path / "models--org--m"
     blobs = folder / "blobs"
     blobs.mkdir(parents=True)
@@ -2385,18 +2399,20 @@ def test_sweep_removes_every_part_shape_once_it_is_old_enough(base, tmp_path):
     ours.write_bytes(b"half")
     sidecar = blobs / "e7ag.fusedpart.json"
     sidecar.write_bytes(b"{}")
+    sidecar_tmp = blobs / "e7ag.fusedpart.json.tmp"
+    sidecar_tmp.write_bytes(b"{")
     hf_old = blobs / "0ther.incomplete"
     hf_old.write_bytes(b"half")
     hf_new = blobs / "0ther.a1b2c3d4.incomplete"
     hf_new.write_bytes(b"half")
     finished = blobs / "f1n1shed"
     finished.write_bytes(b"weights")
-    for path in (ours, sidecar, hf_old, hf_new, finished):
+    for path in (ours, sidecar, sidecar_tmp, hf_old, hf_new, finished):
         _aged(path, base._PART_GRACE_SECONDS + 60)
 
     removed = base._sweep_orphan_parts(str(folder))
 
-    assert removed == 4
+    assert removed == 5
     assert sorted(p.name for p in blobs.iterdir()) == ["f1n1shed"]
 
 
@@ -2419,7 +2435,24 @@ def test_sweep_leaves_a_freshly_touched_part_file_alone(base, tmp_path):
 
 def test_sweep_on_a_never_fetched_folder_is_a_quiet_no_op(base, tmp_path):
     assert base._sweep_orphan_parts(str(tmp_path / "never-fetched")) == 0
+
+
+def test_sweep_on_a_falsy_folder_never_scans_a_relative_path(base, monkeypatch):
+    """`repo_folder` returns `None` when `huggingface_hub` cannot be imported
+    (see its docstring). `None or ""` joined with `"blobs"` is the RELATIVE
+    path `"blobs"`, not a no-op — `os.scandir` would resolve it against this
+    process's CWD, unlinking anything part-shaped it happens to find in a
+    `./blobs` there. Proven by making `scandir` explode if it is ever reached
+    at all, rather than trusting that no such directory exists in the pytest
+    CWD — the way this guard's absence used to pass by accident."""
+    def explodes(path):
+        raise AssertionError(
+            f"_sweep_orphan_parts scanned {path!r} for a falsy folder")
+
+    monkeypatch.setattr(base.os, "scandir", explodes)
+
     assert base._sweep_orphan_parts(None) == 0
+    assert base._sweep_orphan_parts("") == 0
 
 
 def test_a_failed_unlink_is_logged_rather_than_swallowed(base, tmp_path,

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -2363,6 +2363,124 @@ def test_a_part_file_for_an_UNRELATED_blob_does_not_disable_the_fast_path(
     assert hub.calls == [("snapshot", True)]
 
 
+# -- orphan part-file cleanup (`_sweep_orphan_parts`) --------------------------
+
+
+def _aged(path, seconds):
+    """Back-date a file's mtime so `_sweep_orphan_parts` reads it as older than
+    the grace window rather than as something still being written."""
+    then = time.time() - seconds
+    os.utime(str(path), (then, then))
+
+
+def test_sweep_removes_every_part_shape_once_it_is_old_enough(base, tmp_path):
+    """Ours (`.fusedpart` and its offsets sidecar) and both of hf's own
+    (`<etag>.incomplete` and `<etag>.<8 hex>.incomplete`) all count — a leftover
+    is a leftover regardless of which fetcher wrote it. A finished blob beside
+    them is left alone."""
+    folder = tmp_path / "models--org--m"
+    blobs = folder / "blobs"
+    blobs.mkdir(parents=True)
+    ours = blobs / "e7ag.fusedpart"
+    ours.write_bytes(b"half")
+    sidecar = blobs / "e7ag.fusedpart.json"
+    sidecar.write_bytes(b"{}")
+    hf_old = blobs / "0ther.incomplete"
+    hf_old.write_bytes(b"half")
+    hf_new = blobs / "0ther.a1b2c3d4.incomplete"
+    hf_new.write_bytes(b"half")
+    finished = blobs / "f1n1shed"
+    finished.write_bytes(b"weights")
+    for path in (ours, sidecar, hf_old, hf_new, finished):
+        _aged(path, base._PART_GRACE_SECONDS + 60)
+
+    removed = base._sweep_orphan_parts(str(folder))
+
+    assert removed == 4
+    assert sorted(p.name for p in blobs.iterdir()) == ["f1n1shed"]
+
+
+def test_sweep_leaves_a_freshly_touched_part_file_alone(base, tmp_path):
+    """A LIVE download keeps rewriting its part file; the grace window is what
+    stops a concurrent fetch's genuinely in-flight resume state from being
+    swept out from under it — there is no other guard, since two fetches over
+    the same repo share nothing but the filesystem."""
+    folder = tmp_path / "models--org--m"
+    blobs = folder / "blobs"
+    blobs.mkdir(parents=True)
+    live = blobs / "e7ag.fusedpart"
+    live.write_bytes(b"half")
+
+    removed = base._sweep_orphan_parts(str(folder))
+
+    assert removed == 0
+    assert live.exists()
+
+
+def test_sweep_on_a_never_fetched_folder_is_a_quiet_no_op(base, tmp_path):
+    assert base._sweep_orphan_parts(str(tmp_path / "never-fetched")) == 0
+    assert base._sweep_orphan_parts(None) == 0
+
+
+def test_a_failed_unlink_is_logged_rather_than_swallowed(base, tmp_path,
+                                                         monkeypatch, capsys):
+    """A cosmetic cleanup step must not go silent, and must not be the thing
+    that turns a successful download into a failed one either."""
+    folder = tmp_path / "models--org--m"
+    blobs = folder / "blobs"
+    blobs.mkdir(parents=True)
+    part = blobs / "e7ag.fusedpart"
+    part.write_bytes(b"half")
+    _aged(part, base._PART_GRACE_SECONDS + 60)
+
+    def boom(path):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(base.os, "remove", boom)
+
+    removed = base._sweep_orphan_parts(str(folder))
+
+    assert removed == 0
+    assert part.exists()
+    err = capsys.readouterr().err
+    assert "e7ag.fusedpart" in err
+    assert "Permission denied" in err
+
+
+def test_download_snapshot_fast_path_sweeps_so_the_card_stops_reading_partial(
+        base, monkeypatch, tmp_path):
+    """The bug this feature exists to fix, pinned at the boundary the AI Models
+    card actually reads: `_cached_path` answers a hit with no network call, so
+    "Continue downloading" jumping to 100% and stopping changed nothing on
+    retry. Once the fast path sweeps too, the same repo `hub_cache
+    ._unfinished_fetch` called partial reads complete."""
+    from fused_render.ai import hub_cache
+
+    folder = tmp_path / "models--org--m"
+    (folder / "blobs").mkdir(parents=True)
+    commit = "c0m"
+    snapshot = folder / "snapshots" / commit
+    snapshot.mkdir(parents=True)
+    blob = folder / "blobs" / "e7ag"
+    blob.write_bytes(b"weights")
+    (snapshot / "model.safetensors").symlink_to(blob)
+    base._record_fetch(str(folder), commit, ["model.safetensors"], str(snapshot))
+
+    orphan = folder / "blobs" / "0ldetag.fusedpart"
+    orphan.write_bytes(b"an earlier, wider fetch's leftovers")
+    _aged(orphan, base._PART_GRACE_SECONDS + 60)
+
+    assert hub_cache._unfinished_fetch(str(folder)) is True
+
+    monkeypatch.setattr(base, "repo_folder",
+                        lambda model_id, repo_type="model": str(folder))
+    monkeypatch.setattr(base, "_cached_path", lambda *a, **k: str(snapshot))
+
+    assert base.download_snapshot("org/m") == str(snapshot)
+    assert not orphan.exists()
+    assert hub_cache._unfinished_fetch(str(folder)) is False
+
+
 def test_a_local_answer_that_is_not_actually_THERE_is_not_trusted(
         base, monkeypatch, tmp_path):
     """The path comes from a call we did not make ourselves, so it is checked

--- a/tests/test_ai_worker_base.py
+++ b/tests/test_ai_worker_base.py
@@ -2608,6 +2608,31 @@ def test_download_snapshots_fallback_wires_a_byte_counter_through(
     assert len(seen_bars) == 1, "the fallback did not pass its own tqdm_class through"
 
 
+def test_download_snapshots_kwargs_fallback_sweeps_orphans_too(base, monkeypatch,
+                                                                tmp_path):
+    """An unrecognised keyword argument routes straight to `hub()` — same branch
+    `files is None`/`not sha` takes, which is exactly the state a failed
+    `_repo_files` listing leaves. `download_file`'s equivalent branch already
+    sweeps (SPEC AI-5l); this pins that `download_snapshot`'s does too, or a
+    repo whose caller passes an extra kwarg stays "partial" forever no matter
+    how many times hf completes it underneath."""
+    folder = _cache_folder(tmp_path)
+    orphan = folder / "blobs" / "0ldetag.fusedpart"
+    orphan.write_bytes(b"an earlier fetch's leftovers")
+    stale = time.time() - base._PART_GRACE_SECONDS - 60
+    os.utime(str(orphan), (stale, stale))
+
+    snapshot = _snapshot_dir(tmp_path, "config.json")
+    hub = _LocalHub(cached=[], snapshot=snapshot)
+    _local_hub(monkeypatch, base, hub, folder=folder)
+    monkeypatch.setattr(base, "_repo_files",
+                        lambda *a, **kw: (COMMIT, [("config.json", 7)]))
+    monkeypatch.setattr(base, "report", lambda job=None, **fields: None)
+
+    assert base.download_snapshot("u/x", revision="abc123") == snapshot
+    assert not orphan.exists(), "the kwargs fallback did not sweep orphan parts"
+
+
 def test_a_TORN_record_left_by_a_crashed_write_is_not_read_as_a_record(
         base, monkeypatch, tmp_path):
     """`_record_fetch` writes a per-writer temp and `os.replace`s it, so a crash


### PR DESCRIPTION
## Summary

- An AI model card could read **"partial" forever**, and pressing "Continue downloading" jumped straight to 100% without fixing it. Nothing in the codebase ever deleted the part files responsible.
- The cause is recipe-scoped fetches. `_GGUF_RECIPES` limits `black-forest-labs/FLUX.2-klein-4B` to a `keep` allow-list, so most of the base repo is deliberately never fetched. An earlier, wider fetch of that same repo leaves `.fusedpart`/`.incomplete` files for names the recipe now permanently excludes — and `hub_cache._unfinished_fetch` calls a repo partial on the mere presence of one. The only cleanup that existed, `_clear_parts`, fires from a single call site inside `_fallback()`, reached only when a fetch *raises*. The success path cleaned up nothing.
- Fixed on the downloader side, because it has to be: the checker runs in the server process, which structurally cannot import the runner venv (`formats.py` documents this precedent for `COMPONENT_REPOS`), so the server can never know a recipe's scope.
- New `_sweep_orphan_parts()` runs after any scope's download **succeeds** — the `_cached_path` fast path included, which is precisely the no-op retry case — and removes part files older than a five-minute grace window.

The insight that makes this cheap: **after a download for scope S succeeds, every file S covers is a complete blob by definition, so any part file still in `blobs/` is out of scope.** No etag-to-filename mapping is needed to identify orphans — which matters, because none is possible offline. Our sidecar records only `version/etag/size/segments`, and hf's `.incomplete` has no sidecar at all.

## Visuals

```mermaid
flowchart TD
    A[download_snapshot for scope S] --> B{Scope already on disk?}
    B -->|yes, fast path| C[sweep orphan parts]
    B -->|no| D[fetch]
    D -->|success| E[record fetch]
    E --> C
    D -->|Cancelled| F[raise, keep resume state]
    C --> G{Part file past grace window?}
    G -->|yes| H[remove: out of scope]
    G -->|no| I[keep: presumed in flight]
```

## Usage

Not directly user-invocable — it runs inside the model downloader. The user-visible effect is on the AI Models page: a card stuck on "partial" because of excluded-file leftovers now flips to "downloaded" the next time any download over that repo succeeds, including a "Continue downloading" press that opens no connection at all.

Note the two conditions, both deliberate: the repo reads partial until the *next* successful download over it, and a part file written moments before that retry is left alone as presumed in-flight.

## Test Plan

- [x] `tests/test_ai_worker_base.py` — unit coverage for `_sweep_orphan_parts`: all four part-file shapes removed once aged, fresh files preserved, no-op when `blobs/` is absent, failed unlink logged rather than swallowed. Plus end-to-end: `hub_cache._unfinished_fetch` flips `True` → `False` after the `download_snapshot` fast path runs. **127 passed**
- [x] `tests/test_ai_hub_fetch.py` — a real segmented fetch proving an out-of-scope orphan is swept once a recipe-scoped download completes, and a cancel test proving in-scope resume state survives even past the grace window. **131 passed**
- [x] `tests/test_ai_models_api.py` — `test_the_part_suffix_is_the_fetchers_own` strengthened to pin `hub_cache._PART_SUFFIXES` against both `worker_base.PART_SUFFIX` and `worker_base._HF_PART_SUFFIX`, so the two constants cannot drift. **169 passed**
- [x] `tests/test_ai_diffusers_worker.py` — recipe allow/ignore filtering unaffected. **17 passed**
- [ ] Full suite + CI — running now; PR stays draft until both are green.

### Reviewer note

One consequence worth a second opinion: because the sweep keys off "some scope succeeded", a **deliberately paused** wider download's resume state is removed if a narrower scope later succeeds over the same repo and the part file has aged past the grace window. That is the same mechanism that fixes the bug rather than a separate defect, and a cancel on its own still preserves resume state — but it is a real behaviour change for pause-then-fetch-something-else.
