### PR TITLE
Fix red main: dev_shutdown is asked to reap a pid dev.sh no longer starts

### DIFF
--- a/tests/test_dev_sh_process_cleanup.py
+++ b/tests/test_dev_sh_process_cleanup.py
@@ -858,7 +858,12 @@ def test_shutdown_is_a_single_handler_reaping_every_background_pid():
     # character count: a fixed window spills into whatever follows, so the
     # assertions below could be satisfied by unrelated code further down.
     body = src[start : src.index("\n}\n", start)]
-    for var in ("WATCH_PID", "CORE_WATCH_PID", "OPENER_PID", "SERVER_PID"):
+    # `CORE_WATCH_PID` is deliberately absent: #945 removed the core_apps
+    # watcher along with the rest of the retired builtin-mount machinery, and
+    # dropped it from the roots list here. The script no longer starts that
+    # process, so requiring `dev_shutdown` to reap it asserts a pid that cannot
+    # exist. Every pid the script DOES background is still required below.
+    for var in ("WATCH_PID", "OPENER_PID", "SERVER_PID"):
         assert var in body, f"{var} is not reaped by dev_shutdown"
     # Every trap installs the same handler.
     traps = re.findall(r"^\s*trap\s+'([^']*)'\s+EXIT", src, re.M)


### PR DESCRIPTION
**`main` is red.** On `6151844`, `fused-engine` and the `test-python` matrix fail:

```
FAILED tests/test_dev_sh_process_cleanup.py::test_shutdown_is_a_single_handler_reaping_every_background_pid
AssertionError: CORE_WATCH_PID is not reaped by dev_shutdown
```

One line. **The script is right and the test is stale.**

## Cause

#945 ("Remove the retired sessions builtin zip mount (D627)") removed dev.sh's `core_apps` watcher along with the rest of the builtin-mount machinery. That commit correctly took out all three script-side pieces:

```diff
-CORE_WATCH_PID=""
-  local roots="$WATCH_PID $CORE_WATCH_PID $OPENER_PID $SERVER_PID"
-  CORE_WATCH_PID=$!
```

What it did not update is `tests/test_dev_sh_process_cleanup.py:861`, which still requires `dev_shutdown` to reap that pid. `CORE_WATCH_PID` now appears nowhere in `scripts/dev.sh`, so the assertion demands a process the script cannot start.

## The fix

`CORE_WATCH_PID` comes out of the list, with a note on why it is absent — so the next reader does not have to work out whether it was dropped deliberately or by accident.

The test keeps doing its real job. It exists so the two `trap` sites cannot drift apart again, and **every pid dev.sh actually backgrounds is still required**. Mutation checked: removing `$SERVER_PID` from the roots list still fails it with `SERVER_PID is not reaped by dev_shutdown`.

## Verification

- `tests/test_dev_sh_process_cleanup.py`: **28 passed** (fails on `main` without this).
- Confirmed by bisecting behaviour rather than reading alone: the test **passes** on `39b274e` (before #945) and **fails** on `6151844`.
- Swept the tree for the rest of #945's removal — this assertion is the only stale reference left. The one other `core_apps` mention is a historical note in `claude_config/__init__.py`'s docstring about where that module came from, which is accurate.

## Note

Found because it broke [#943](https://github.com/fusedio/fused-render/pull/943) — PR checks build a merge with current `main`, so main's breakage surfaced there on a diff that cannot cause it (`tests/test_canvases.py`, one `try/except`). This wants landing first; every open PR in the repo is red until it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXDxeKbDsWkANaiDrzre3Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXDxeKbDsWkANaiDrzre3Y)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only alignment with an already-landed dev.sh change; no runtime behavior changes.
> 
> **Overview**
> **Fixes red CI** on `test_shutdown_is_a_single_handler_reaping_every_background_pid`, which still expected `dev_shutdown` to reap `CORE_WATCH_PID` after #945 removed the core_apps watcher from `scripts/dev.sh`.
> 
> The structural test now only requires **`WATCH_PID`**, **`OPENER_PID`**, and **`SERVER_PID`** in `dev_shutdown`, with an inline note that `CORE_WATCH_PID` was intentionally dropped. The test’s purpose is unchanged: trap sites must stay aligned and every background pid the script actually starts must still be reaped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f551ee3059d970df8146aa3f247e3631041e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->