### PR TITLE
Test: landing-URL contract reads appLanding.ts, where #959 moved appLandingUrl

### DIFF
--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -980,13 +980,18 @@ def _repo_text(*parts):
 
 def test_home_navigates_into_the_claude_chat_for_the_started_run():
     home = _repo_text("frontend", "src", "apps", "builder", "HomeHero.tsx")
+    # The URL builder lives in platform (shared with the Migrate buttons, which
+    # make the same hop from the app page and the explorer topbar).
+    landing = _repo_text("frontend", "src", "platform", "lib", "appLanding.ts")
     # The scaffolding work is a TASK on the app's index.html now, and the chat
     # rides beside that page as a SIDE PANE rather than as a whole-page mode —
     # so the re-attach carries `_side=claude` plus the run to attach to.
-    assert '_side: "claude"' in home, "post-create nav must open the claude pane"
+    assert '_side: "claude"' in landing, "post-create nav must open the claude pane"
     assert "appLandingUrl(res.entry_html, res.task.run_id" in home, \
         "…on the app's entry html, carrying the task's run"
-    assert "run: runId" in home, "…and attach to the run the POST just started"
+    assert "run: runId" in landing, "…and attach to the run the POST just started"
+    assert "appLandingUrl" in home and "appLanding" in home, \
+        "the hero makes the hop through the shared builder"
     # the run_id is what gates it: no session (no prompt) -> the default view
     assert "if (res.task?.run_id) {" in home
 


### PR DESCRIPTION
Follow-up to #959, which merged before this fix was pushed.

`test_home_navigates_into_the_claude_chat_for_the_started_run` still scanned `HomeHero.tsx` for `_side: "claude"` and `run: runId`. Those spellings moved to `frontend/src/platform/lib/appLanding.ts` (shared with the Migrate buttons), so the test failed on main. It now reads them from `appLanding.ts` and keeps the HomeHero checks: the `appLandingUrl(res.entry_html, res.task.run_id` call, the `run_id` gate, and the import of the shared builder.

Assertions verified standalone against the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no runtime or API behavior is modified.
> 
> **Overview**
> Repairs **`test_home_navigates_into_the_claude_chat_for_the_started_run`** so it matches where the landing URL is built after **#959** moved that logic out of the home hero.
> 
> The contract for opening the Claude side pane (`_side: "claude"`) and attaching the new run (`run: runId`) is now asserted on **`frontend/src/platform/lib/appLanding.ts`**, the shared builder also used by Migrate. **`HomeHero.tsx`** is still checked for calling **`appLandingUrl(res.entry_html, res.task.run_id`**, importing the shared helper, and gating navigation on **`res.task?.run_id`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a8c2058efe8afaef3cd960083f3f541ffd01e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->