### PR TITLE
Migrate button reads "Migrate to new version"

### DIFF
--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -313,7 +313,7 @@ function MigrateAppButton({ fsPath }: { fsPath: string }) {
       disabled={busy}
     >
       {busy && <span className="mode-icon-spinner" />}
-      {busy ? "Creating task…" : "Migrate to API v" + info.to}
+      {busy ? "Creating task…" : "Migrate to new version"}
     </button>
   );
 }

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -448,7 +448,7 @@ export default function AppPage({
               <Button
                 size="sm"
                 className="app-page-migrate"
-                variant={inProgress ? "outline" : "default"}
+                variant="outline"
                 disabled={!inProgress && migrateState !== "idle"}
                 title={
                   inProgress

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -469,7 +469,7 @@ export default function AppPage({
                     ? "Creating task…"
                     : migrateState === "created"
                       ? "Migration task created"
-                      : `Migrate to API v${resolved.currentApiVersion}`}
+                      : "Migrate to new version"}
               </Button>
             )}
             {/* The app full-size in the explorer (its entry page), in a new tab


### PR DESCRIPTION
Both migration buttons (the app page at /apps/<path> and the explorer topbar) said "Migrate to API vN". A naive user has no idea what vN is. Both now read "Migrate to new version"; the from/to versions stay in the button tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label and button variant only; migration behavior and tooltips are unchanged.
> 
> **Overview**
> **Copy:** Both fused-API migration entry points—the explorer preview top bar (`Preview.tsx`) and the app page actions (`AppPage.tsx`)—no longer show **Migrate to API vN** on the button. Idle state label is now **Migrate to new version**. Declared vs runtime versions remain in the existing `title` tooltips.
> 
> **App page styling:** The migrate control on `/apps/<path>` always uses the **outline** button variant (previously **default** when idle, **outline** only while a migration was in progress).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ee56efef45a4e2b1fa72bd0af366b2505185abc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->