### PR TITLE
Rewrite plugin skills terse: pointers over prose, tested code stays tested

### DIFF
--- a/fused_render/app_starter/CLAUDE.md
+++ b/fused_render/app_starter/CLAUDE.md
@@ -1,68 +1,16 @@
 # fused-render app
 
-This folder is a **fused-render app** — a self-contained folder rendered by
-the fused-render explorer. `index.html` is the app's entry view; it was
-scaffolded from the starter kit, so edit it in place (don't create a second
-top-level `.html` next to it — one entry file is what makes the folder open
-as an app). Keep the `<meta name="fused-app" />` tag near the top of its
-`<head>`: the marker is the ONLY thing that identifies this page as a fused
-app's entry — without it the app disappears from the apps hub (detection reads
-only the first 4 KiB of the file, so keep the tag near the top). Right after
-it sits `<meta name="fused-api-version" content="N" />` — the version of the
-`fused` page API this app was written against. Leave it as is; the app page
-offers a "Migrate" task that updates the code and the tag together when the
-API moves on. A page without the tag is version 0.
+Folder = **fused-render app**, rendered by fused-render explorer. `index.html` = entry view; edit in place (no second top-level `.html` — one entry file makes folder open as app). Keep `<meta name="fused-app" />` near top of `<head>`: ONLY marker identifying app entry — detection reads first 4 KiB only; without it app vanishes from apps hub. Right after: `<meta name="fused-api-version" content="N" />` — fused page API version app written against. Leave as is; app page's "Migrate" task updates code + tag together. No tag = version 0.
 
-The page runs inside the explorer, which injects a `fused` runtime bridge:
-`fused.params` (URL-synced view state), `fused.runPython("./file.py", args)`
-(compute in Python files beside this one), `fused.readFile` / `fused.rawUrl`,
-and more. There is no network at runtime and no build step.
+Page runs inside explorer, which injects `fused` bridge: `fused.params` (URL-synced view state), `fused.runPython("./file.py", args)` (compute in Python beside page), `fused.readFile` / `fused.rawUrl`, more. No network at runtime, no build step.
 
-Before non-trivial changes, invoke the **`fused-render-authoring`** skill —
-the full contract for `.html` views and `.py` data files: the `fused` bridge,
-params-as-state wiring, file IO, theming, and debugging blank views /
-traceback overlays.
+Before non-trivial changes, invoke **`fused-render-authoring`** skill — full contract for `.html` views + `.py` data files: bridge, params wiring, file IO, `.fused/data` vs `.fused/cache` rules, theming, debugging blank views / traceback overlays.
 
-## Where this app keeps its stuff: `.fused/`
+## `.fused/`
 
-Every app folder gets a hidden `.fused/` at its root, created for you:
+Hidden `.fused/` at app root, created for you: `data/` = state app owns, can't rebuild; `cache/` = derived bytes, deletable anytime; `meta.json` = where app was set up (mismatched `app_dir` → folder moved/copied → distrust absolute-path keys).
 
-```
-.fused/
-  data/       state the app owns and cannot rebuild
-  cache/      derived bytes the app can rebuild — deletable at any time
-  meta.json   {"version": 1, "app_dir": "<absolute path>", "created_at": "<iso>"}
-```
-
-**Write persistent state to `.fused/data/`, and nowhere else.** Not a JSON file
-beside `index.html` (that is authored content, and it lands in git history),
-not a folder under the user's home, not the system temp dir. Reach it from a
-`.py` as `os.path.join(os.path.dirname(__file__), ".fused", "data")` — relative
-paths in a `.py` resolve next to that file, so a script at the app root can
-just use `./.fused/data/`. From the page, go through a `.py`.
-
-**Cache anything slow into `.fused/cache/`, and cache more than feels
-necessary.** Every `fused.runPython` call is a fresh subprocess: no globals
-survive, no import cost is amortised, and a 60 s timeout is waiting for
-anything that recomputes work it already did. A network fetch, a parsed large
-file, a rendered tile, a model response, an expensive aggregation — key it by a
-hash of its inputs, write the result under `.fused/cache/`, and return the
-cached copy on the next call. Nothing sweeps this folder automatically, so if a
-cache can grow without bound, give it your own cap or TTL.
-
-The split between the two folders is a promise, not a naming preference:
-**everything in `cache/` must be reconstructible from `data/` plus the outside
-world.** Deleting `cache/` entirely must cost the user nothing but time. If it
-would lose something, it is data.
-
-`meta.json` records where the app was set up. Nothing rewrites it, so if its
-`app_dir` no longer matches where the app actually is, the folder was moved or
-copied — the moment to distrust anything you keyed by absolute path. What to do
-about that is the app's call; there is no automatic repair.
-
-`.fused/` is machine-local. It is gitignored, and it is not included when the
-app is exported as a `.fused` app file — so never put anything there that the
-app needs in order to work on a fresh machine.
+**Persistent state → `.fused/data/` only** (not JSON beside index.html, not home dir, not temp). **Cache slow work → `.fused/cache/`, aggressively** — each `runPython` = fresh subprocess, 60 s timeout. Promise: everything in `cache/` reconstructible from `data/` + outside world. `.fused/` is machine-local: gitignored, excluded from `.fused` app exports — never put anything there the app needs on fresh machine.
 
 ## Version control
 
@@ -82,15 +30,6 @@ Use short imperative subjects ("Add dark theme toggle", "Fix param sync").
 Don't push, don't add remotes, don't rewrite history, don't touch paths
 outside this folder — the repo is purely local undo history for the apps.
 
-If the app reads the machine-wide **file index** — a file search box, a
-disk-usage or file-type breakdown, a repos list, SQL over the filesystem —
-invoke **`fused-render-index`** as well: `fused.fileIndex.search/query` and their
-readiness envelope, plus the direct-parquet reader for bulk Python.
+App reads machine-wide **file index** (search box, disk-usage/file-type breakdown, repos list, SQL over filesystem)? Invoke **`fused-render-index`**: `fused.fileIndex.search/query`, readiness envelope, direct-parquet reader for bulk Python.
 
-fused-render supplies those skills (and their siblings, `fused-render-usage`
-and `fused-render-custom-templates`) to every chat it launches, as a plugin loaded
-for that session, so it is available here by name with no install step. It
-also keeps a copy in Claude Code's user-level skills directory for sessions
-fused-render didn't start — a plain `claude` in this folder, say. If the skill
-isn't listed in one of those, start (or restart) fused-render once; it
-refreshes both on startup.
+fused-render supplies these skills (plus `fused-render-usage`, `fused-render-custom-templates`) to every chat it launches as session plugin — available by name, no install. Also keeps copy in Claude Code user-level skills dir for sessions fused-render didn't start (plain `claude` here). Skill missing from both → start/restart fused-render once; refreshes both on startup.

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -324,7 +324,7 @@
  *     stats/lookup calls did, and readiness rides on every response, so a
  *     `status` method was surface without capability. Scanning, editing
  *     roots/ignore and the repos derivation stay raw fetch + `X-Fused: 1`
- *     (section C of skills/fused-render-index) — managing the index is a shell
+ *     (documented in skills/fused-render-index) — managing the index is a shell
  *     action, not a render path, and so are /api/index/delete (wipes the whole
  *     store) and /api/index/ask (spends AI credits per call).
  *     Both resolve with the endpoint's own payload PLUS a normalized

--- a/fused_render/template_starter/CLAUDE.md
+++ b/fused_render/template_starter/CLAUDE.md
@@ -1,20 +1,8 @@
 # fused-render preview template
 
-This folder is one **fused-render preview template** — a self-contained folder
-that renders a file (or directory) in the preview pane. It was scaffolded from
-the starter kit; edit it in place. Two skills carry the full contract — invoke
-them before non-trivial changes:
+Folder = one **fused-render preview template** — renders a file (or dir) in preview pane. Scaffolded from starter kit; edit in place. Two skills carry full contract — invoke before non-trivial changes:
 
-- **`fused-render-authoring`** — writing `template.html` and the optional
-  `reader.py`, plus the injected `fused` runtime bridge (`params`, `runPython`,
-  `readFile`, `rawUrl`, …).
-- **`fused-render-custom-templates`** — registering the template: registry keys,
-  binding rules, `condition.py`, and `icon.svg`.
+- **`fused-render-authoring`** — writing `template.html` + optional `reader.py`, injected `fused` bridge (`params`, `runPython`, `readFile`, `rawUrl`, …).
+- **`fused-render-custom-templates`** — registering: registry keys, binding rules, `condition.py`, `icon.svg`.
 
-fused-render supplies both (and `fused-render-usage` / `fused-render-index`,
-the latter for reading the machine-wide file index) to every chat it
-launches, as a plugin loaded for that session, so they are available here by
-name with no install step. It also keeps a copy in Claude Code's user-level
-skills directory for sessions fused-render didn't start — a plain `claude` in
-this folder, say. If a skill isn't listed in one of those, start (or restart)
-fused-render once; it refreshes both on startup.
+fused-render supplies both (plus `fused-render-usage` / `fused-render-index` — latter for machine-wide file index) to every chat it launches as session plugin — available by name, no install. Also keeps copy in Claude Code user-level skills dir for sessions fused-render didn't start (plain `claude` here). Skill missing from both → start/restart fused-render once; refreshes both on startup.

--- a/skills/fused-render-ai/SKILL.md
+++ b/skills/fused-render-ai/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: fused-render-ai
-description: Use when a fused-render page or .py calls fused.ai (text/image/video/transcribe/embed), picks a model or provider, or an AI call rejects (model_loading, ai_unavailable, bad_request, timeout).
+description: Use when page or .py calls fused.ai (text/image/video/transcribe/embed), picks model/provider, or AI call rejects.
 ---
 
 # fused.ai
 
-Five verbs, one options object each, one shared result frame. `fused.ai(prompt)` / `fused.ai.text("hi")` do not exist — always `fused.ai.text({prompt})`.
+Five verbs, one options object each, one shared result frame. `fused.ai(prompt)` / `fused.ai.text("hi")` don't exist — always `fused.ai.text({prompt})`.
 
-Result frame on every verb: `{<payload>, provider, finishReason, warnings, usage, response: {id, modelId, timestamp}, providerMetadata}`. Read `response.modelId` (no top-level `model`), `usage.inputTokens` (camelCase, or null), `providerMetadata.local` for seed/sizes/paths — never echo your request as the caption.
+Result frame, every verb: `{<payload>, provider, finishReason, warnings, usage, response: {id, modelId, timestamp}, providerMetadata}`. Read `response.modelId` (no top-level `model`), `usage.inputTokens` (camelCase, or null), `providerMetadata.local` for seed/sizes/paths. Never echo own request as caption.
 
 | Verb | Required | Payload |
 |---|---|---|
@@ -19,57 +19,59 @@ Result frame on every verb: `{<payload>, provider, finishReason, warnings, usage
 
 Universal rules:
 
-- **Options are closed** — unknown key rejects `bad_request` before any request.
+- **Options closed** — unknown key rejects `bad_request` before any request.
 - `provider`, `model`, `abortSignal` everywhere; `onChunk` = streaming (text, transcribe); `onProgress(job)` = job row (image, video, transcribe).
-- Relative file paths resolve beside the page.
-- Rejections: Error with `.type` (+ `.jobId` when a job existed) — table below.
+- Relative file paths resolve beside page.
+- Rejections: Error with `.type` (+ `.jobId` when job existed) — table below.
 - Calls run concurrent — disable buttons in flight (image/video/transcribe serialize silently server-side).
-- Local-only; export refuses pages containing the literal text `fused.ai.text(` — an `fused.env` guard does NOT help. Other verbs pass the check then fail hosted. Keep AI in a local-only companion page.
+- Local-only. Export refuses pages containing literal text `fused.ai.text(` — `fused.env` guard does NOT help. Other verbs pass check, then fail hosted. Keep AI in local-only companion page.
 
 ## Provider / model
 
-Two tiers. `provider: "local" | "claude"` pins; omitted, model shape decides: id with `/` or `.gguf` → local; `"sonnet"`/`"opus"`/`claude-*`/omitted → Claude CLI (text only). image/video/transcribe/embed are local-only. **Take local ids from `fused.ai.models.catalog()` and treat as opaque** — never hardcode, never `split("/")`.
+Two tiers. `provider: "local" | "claude"` pins; omitted → model shape decides: id with `/` or `.gguf` → local; `"sonnet"`/`"opus"`/`claude-*`/omitted → Claude CLI (text only; default tier haiku unless configured). image/video/transcribe/embed = local-only. **Take local ids from `fused.ai.models.catalog()`, treat as opaque** — never hardcode, never `split("/")`.
 
 `catalog()` → `{capabilities: [{capability, available, reason, default, models[], videoTraits?}], unsupported, ramGb}`. Capabilities: `text-generation`, `text-to-image`, `text-to-video`, `automatic-speech-recognition`, `embeddings`. Model flags: `downloaded, loaded, recommended, size_gb, acceptsImage, acceptsPaths, promptScheme`.
 
-`fused.ai.models`: `list()`, `load(id, {capability})` / `download(id, {capability})` → `{jobId}` (**always pass capability** — wrong runner otherwise), `unload({capability})` (by capability, not id), `fused.ai.cancel(capability?)` (defaults to text-generation — name the capability to stop anything else).
+`fused.ai.models`: `list()`, `load(id, {capability})` / `download(id, {capability})` → `{jobId}` (**always pass capability** — wrong runner otherwise), `unload({capability})` (by capability, not id), `fused.ai.cancel(capability?)` (default text-generation — name capability to stop anything else).
 
-## Per-verb notes
+## Text and cold start
 
-**text** — options: `prompt, provider, model, systemPrompt, effort (Claude), history, raw, images (local-only, reject on Claude), temperature/maxTokens/topP (dropped on Claude w/ warning), onChunk, abortSignal`. Feed aggregates, not datasets (compute in Python first). Structured output: demand strict JSON, strip fences, `JSON.parse` in try/catch. Vision: `images` on a local model with `acceptsImage`.
+**text** options: `prompt, provider, model, systemPrompt, effort (Claude; default "low" = no extended thinking — ask for more explicitly), history, raw, images (local-only, rejects on Claude), temperature/maxTokens/topP (dropped on Claude w/ warning), onChunk, abortSignal`. Feed aggregates, not datasets — compute in Python first. Structured output: demand strict JSON, strip fences, `JSON.parse` in try/catch. Vision: `images` on local model with `acceptsImage`.
 
-**Cold start**: first text/embed call naming a non-resident local model rejects `model_loading` — the download already started, `err.jobId` is it. Watch `fused.watchJob(err.jobId)`, then retry. Not a failure. Image/video/transcribe load inside their own job instead (`done`/`total` null while weights arrive — guard the division).
-
-**transcribe** — `language, task ("transcribe"|"translate"), initialPrompt, vad, diarize, speakers, words, onChunk (per segment), onProgress (seconds)`. Default model = smallest; pass bigger for accuracy. Output persisted under `~/.fused-render/ai/transcripts/` (paths in `providerMetadata.local`). Failed long run keeps `err.outputPartial` (.partial.jsonl). Word timings ±200 ms — don't cut clips on them; `translate` returns no words. One at a time, second queues.
-
-**embed** — `texts` OR `paths` (≤64), `kind: "query"|"document"`. Prose encoder: `kind`, no paths. Dual encoder (CLIP/SigLIP): `paths`, no kind. Index with `"document"`, search with `"query"` — mixing silently drops recall. **Store `response.modelId` with vectors and compare before searching** — cross-model cosine is plausible garbage; dimensions don't catch it.
+**Cold start**: first text/embed call naming non-resident local model rejects `model_loading` — download already started, `err.jobId` = it. `fused.watchJob(err.jobId)`, then retry. Not a failure. Image/video/transcribe load inside own job instead (`done`/`total` null while weights arrive — guard division).
 
 ## Images: `fused.ai.image({prompt, ...})`
 
-Options: `width`/`height` (1024, 256–2048, snapped down to /16), `steps` (28), `guidance` (4.0), `seed` (random; always returned — re-render with it), `image` (page-relative edit base — only some engines: check `acceptsImage`, else `bad_request` naming the engine; defaults become the file's size, steps 4, guidance 1.0), `onProgress`, `abortSignal`. No negative prompt / batch / LoRA / strength.
+Options: `width`/`height` (1024, 256–2048, snapped down to /16), `steps` (28), `guidance` (4.0), `seed` (random; always returned — re-render with it), `image` (page-relative edit base — only some engines: check `acceptsImage`, else `bad_request` naming engine; defaults become file's size, steps 4, guidance 1.0), `onProgress`, `abortSignal`. No negative prompt / batch / LoRA / strength.
 
-Resolves with `images: [{path, url, mediaType: "image/png"}]`, `usage: {imagesGenerated: 1}`, `response.id` = job id, and the render that happened in `providerMetadata.local: {seed, width, height, steps, guidance, prompt, previewPath}` (+ `image` on edits). Read sizes off the reply. `onProgress` job carries `done/total` (denoising steps) and `previewUrl` (~32px thumb, null on last tick — swap to `images[0].url`). One PNG per call; 900 s cap; renders serialize silently.
+Resolves `images: [{path, url, mediaType: "image/png"}]`, `usage: {imagesGenerated: 1}`, `response.id` = job id, actual render in `providerMetadata.local: {seed, width, height, steps, guidance, prompt, previewPath}` (+ `image` on edits). Read sizes off reply. `onProgress` job carries `done/total` (denoising steps) + `previewUrl` (~32px thumb, null on last tick — swap to `images[0].url`). One PNG per call; 900 s cap; renders serialize silently.
 
 ## Video: `fused.ai.video({prompt, ...})`
 
-Apple Silicon only, no fallback — before drawing UI check the `catalog()` `text-to-video` row's `available` and take limits from its `videoTraits`. Options: `width`/`height` (704/480, snapped /32), `frames` (97; `1+8n` grid, rounded **up**), `steps` (8), `seed`, `image` (conditions frame 0; only if `videoTraits.supportsImage`), `onProgress`, `abortSignal`. No guidance, no preview.
+Apple Silicon only, no fallback — before drawing UI check `catalog()` `text-to-video` row `available`, take limits from its `videoTraits`. Options: `width`/`height` (704/480, snapped /32), `frames` (97; `1+8n` grid, rounded **up**), `steps` (8), `seed`, `image` (conditions frame 0; only if `videoTraits.supportsImage`), `onProgress`, `abortSignal`. No guidance, no preview.
 
-Resolves with `videos: [{path, url, mediaType: "video/mp4"}]`, `usage: {videosGenerated: 1}`, `response.id` = job id, `providerMetadata.local: {seed, width, height, frames, steps, prompt, image?}`. Up to 2 h; serializes; `fused.ai.cancel("text-to-video")` keeps the model warm.
+Resolves `videos: [{path, url, mediaType: "video/mp4"}]`, `usage: {videosGenerated: 1}`, `response.id` = job id, `providerMetadata.local: {seed, width, height, frames, steps, prompt, image?}`. Up to 2 h; serializes; `fused.ai.cancel("text-to-video")` keeps model warm.
+
+## Transcribe and embed
+
+**transcribe** — `language, task ("transcribe"|"translate"), initialPrompt, vad, diarize, speakers, words, onChunk (per segment), onProgress (seconds)`. Default model = smallest; pass bigger for accuracy. Output persisted under `~/.fused-render/ai/transcripts/` (paths in `providerMetadata.local`). Failed long run keeps `err.outputPartial` (.partial.jsonl) — rows there are RAW `{start, end, text}`, not the resolved `startSecond`/`endSecond` shape. Word timings ±200 ms — don't cut clips on them; `translate` returns no words. One at a time, second queues.
+
+**embed** — `texts` OR `paths` (≤64), `kind: "query"|"document"`. Prose encoder: `kind`, no paths. Dual encoder (CLIP/SigLIP): `paths`, no kind. Index with `"document"`, search with `"query"` — mixing silently drops recall. **Store `response.modelId` with vectors, compare before searching** — cross-model cosine = plausible garbage; dimensions don't catch it.
 
 ## From Python
 
-`import fused_ai` works in any server-run `.py`, no path setup. Same option names, blocking; all verbs except video. `fused_ai.text(prompt, ...)` → str; `stream(...)` yields; others return the frame (dict). `wait=False`, `on_progress=`, `timeout=` on job-backed calls. Catch `ServerNotRunning` and `AiError` (`.type`). Outside the server: `sys.path.insert(0, server.json["shared"])`. Don't route live UI through it — `runPython` returns once, no streaming.
+`import fused_ai` works in any server-run `.py`, no path setup. Same option names, blocking; all verbs except video. `fused_ai.text(prompt, ...)` → str; `stream(...)` yields; others return frame (dict). `wait=False`, `on_progress=`, `timeout=` on job-backed calls. Catch `ServerNotRunning`, `AiError` (`.type`). Outside server: `sys.path.insert(0, server.json["shared"])`. No live UI through it — `runPython` returns once, no streaming.
 
 ## Errors
 
 | `.type` | Meaning |
 |---|---|
-| `model_loading` | Not resident; load started, watch `err.jobId`, retry |
+| `model_loading` | Not resident; load started — watch `err.jobId`, retry |
 | `ai_unavailable` | claude CLI missing / local worker won't start — friendly state, not overlay |
-| `unavailable` | This machine can't (no runner, needs Apple Silicon, claude on non-text verb) |
-| `bad_request` | Your call is wrong — read `.message` |
-| `ai_error` | Ran and failed (bad id, OOM, crash, render past cap) |
+| `unavailable` | Machine can't (no runner, needs Apple Silicon, claude on non-text verb) |
+| `bad_request` | Call wrong — read `.message` |
+| `ai_error` | Ran, failed (bad id, OOM, crash, render past cap) |
 | `timeout` | Text, 600 s |
 | `cancelled` | abortSignal / cancel / row ✕ — not a failure |
 
-Debug the machine (not the page): `which claude`; `GET /api/ai/runtime`; `POST /api/ai` with `X-Fused: 1` header (required on every POST).
+Debug machine (not page): `which claude`; `GET /api/ai/runtime`; `POST /api/ai` with `X-Fused: 1` (required on every POST).

--- a/skills/fused-render-ai/SKILL.md
+++ b/skills/fused-render-ai/SKILL.md
@@ -36,7 +36,7 @@ Two tiers. `provider: "local" | "claude"` pins; omitted → model shape decides:
 
 ## Text and cold start
 
-**text** options: `prompt, provider, model, systemPrompt, effort (Claude; default "low" = no extended thinking — ask for more explicitly), history, raw, images (local-only, rejects on Claude), temperature/maxTokens/topP (dropped on Claude w/ warning), onChunk, abortSignal`. Feed aggregates, not datasets — compute in Python first. Structured output: demand strict JSON, strip fences, `JSON.parse` in try/catch. Vision: `images` on local model with `acceptsImage`.
+**text** options: `prompt, provider, model, systemPrompt, effort ("low"|"medium"|"high"|"xhigh", Claude only; default "low" = no extended thinking — ask for more explicitly), history, raw, images, temperature/maxTokens/topP, onChunk, abortSignal`. Tier split: `history`/`raw`/`images` local-only, **reject `bad_request` on Claude**; `temperature`/`maxTokens`/`topP` on Claude and `effort` on local dropped with `warnings[]` entry, call succeeds. `history` = `[{role: "user"|"assistant", content}]` — push user+assistant pair after each turn. Feed aggregates, not datasets — compute in Python first. Structured output: demand strict JSON, strip fences, `JSON.parse` in try/catch. Vision: `images` on local model with `acceptsImage`.
 
 **Cold start**: first text/embed call naming non-resident local model rejects `model_loading` — download already started, `err.jobId` = it. `fused.watchJob(err.jobId)`, then retry. Not a failure. Image/video/transcribe load inside own job instead (`done`/`total` null while weights arrive — guard division).
 
@@ -75,3 +75,5 @@ Resolves `videos: [{path, url, mediaType: "video/mp4"}]`, `usage: {videosGenerat
 | `cancelled` | abortSignal / cancel / row ✕ — not a failure |
 
 Debug machine (not page): `which claude`; `GET /api/ai/runtime`; `POST /api/ai` with `X-Fused: 1` (required on every POST).
+
+Full option semantics + edge cases: `fused_render/static/runtime.js` header comment (SPEC §40 refs); Python signatures: `fused_render/templates/shared/fused_ai.py`.

--- a/skills/fused-render-ai/SKILL.md
+++ b/skills/fused-render-ai/SKILL.md
@@ -24,7 +24,7 @@ Universal rules:
 - Relative file paths resolve beside page.
 - Rejections: Error with `.type` (+ `.jobId` when job existed) — table below.
 - Calls run concurrent — disable buttons in flight (image/video/transcribe serialize silently server-side).
-- Local-only. Export refuses pages containing literal text `fused.ai.text(` — `fused.env` guard does NOT help. Other verbs pass check, then fail hosted. Keep AI in local-only companion page.
+- Needs a local runtime, so it depends on WHICH export. **Hosted** export refuses any page containing the literal text `fused.ai.text(` — `fused.env` guard does NOT help; other verbs pass the check, then fail served. Only there is a local-only companion page the answer. A **`.fused` app file** deliberately allows `fused.ai.text(` (D388): it opens inside the recipient's own fused-render, and one without claude or a local model just gets the `ai_unavailable` rejection you already handle.
 
 ## Provider / model
 
@@ -71,7 +71,7 @@ Resolves `videos: [{path, url, mediaType: "video/mp4"}]`, `usage: {videosGenerat
 | `unavailable` | Machine can't (no runner, needs Apple Silicon, claude on non-text verb) |
 | `bad_request` | Call wrong — read `.message` |
 | `ai_error` | Ran, failed (bad id, OOM, crash, render past cap) |
-| `timeout` | Text, 600 s |
+| `timeout` | Text: 600 s on Claude, 900 s local (image 900 s, video 2 h, transcribe far longer) — size a UI timeout off the tier you're calling, not off 600 |
 | `cancelled` | abortSignal / cancel / row ✕ — not a failure |
 
 Debug machine (not page): `which claude`; `GET /api/ai/runtime`; `POST /api/ai` with `X-Fused: 1` (required on every POST).

--- a/skills/fused-render-ai/SKILL.md
+++ b/skills/fused-render-ai/SKILL.md
@@ -1,416 +1,75 @@
 ---
 name: fused-render-ai
-description: Use fused.ai from a fused-render page or .py file — text (Claude or a local model), image, video, transcription, embeddings, and the local model catalog. Load when a page needs a model, when picking a model or provider, or when an AI call rejects (model_loading, ai_unavailable, unavailable, bad_request, timeout, cancelled).
+description: Use when a fused-render page or .py calls fused.ai (text/image/video/transcribe/embed), picks a model or provider, or an AI call rejects (model_loading, ai_unavailable, bad_request, timeout).
 ---
 
-# fused.ai — building with models in a fused-render page
+# fused.ai
 
-`window.fused.ai` is injected into every rendered page. Five verbs, one options object each, one result frame for all of them. Learn the shape once, then reach for the recipes below.
+Five verbs, one options object each, one shared result frame. `fused.ai(prompt)` / `fused.ai.text("hi")` do not exist — always `fused.ai.text({prompt})`.
 
-```js
-const r = await fused.ai.text({ prompt: "Three words about rain." });
-r.text;               // the payload — one verb-named key per verb
-r.provider;           // "claude" | "local" — the tier that answered
-r.response.modelId;   // the model that actually ran (no top-level `model`)
-r.usage;              // { inputTokens, outputTokens, totalTokens } | null
-r.finishReason;       // "stop" | "length" | "cancelled"
-r.warnings;           // [] or [{ type: "unsupported-setting", setting, message }]
-r.providerMetadata;   // { local: {...} } — seed, sizes, file paths, seconds: read it, never echo your request
-```
+Result frame on every verb: `{<payload>, provider, finishReason, warnings, usage, response: {id, modelId, timestamp}, providerMetadata}`. Read `response.modelId` (no top-level `model`), `usage.inputTokens` (camelCase, or null), `providerMetadata.local` for seed/sizes/paths — never echo your request as the caption.
 
-| Verb | Required | Payload keys on the frame |
+| Verb | Required | Payload |
 |---|---|---|
-| `fused.ai.text({prompt})` | `prompt` | `text` |
-| `fused.ai.image({prompt})` | `prompt` | `images: [{path, url, mediaType}]` |
-| `fused.ai.video({prompt})` | `prompt` | `videos: [{path, url, mediaType}]` |
-| `fused.ai.transcribe({path})` | `path` | `text`, `segments: [{text, startSecond, endSecond, speaker?, words?}]`, `language`, `durationInSeconds` |
-| `fused.ai.embed({texts})` | `texts` or `paths` | `embeddings: number[][]`, `values` |
+| `text({prompt})` | prompt | `text` |
+| `image({prompt})` | prompt | `images: [{path, url, mediaType}]` |
+| `video({prompt})` | prompt | `videos: [...]` |
+| `transcribe({path})` | path | `text`, `segments: [{text, startSecond, endSecond, speaker?, words?}]`, `language`, `durationInSeconds` |
+| `embed({texts})` | texts or paths | `embeddings: number[][]` (unit-length → cosine = dot) |
 
-Rules that hold on every verb:
+Universal rules:
 
-- **Options are closed.** A key the verb does not take rejects `bad_request` naming it, before any request. Typos never silently do nothing. The exact lists are in each section below.
-- **`provider`, `model`, `abortSignal`** mean the same thing everywhere. `onChunk` is the streaming callback (text, transcribe); `onProgress(job)` is the job-row callback (image, video, transcribe).
-- **Relative file paths resolve beside the calling page.** `"photo.png"` means the file next to this `.html`. Nothing is uploaded; the server opens the file.
-- **Every rejection is an `Error` with `.type`** (table at the end) and, when a job existed, `.jobId`.
-- **Calls run concurrently.** Nothing stops a double-click firing two calls. Disable the button while one is in flight.
-- **`fused.ai` never works on an exported page.** See "Export" before you ship.
+- **Options are closed** — unknown key rejects `bad_request` before any request.
+- `provider`, `model`, `abortSignal` everywhere; `onChunk` = streaming (text, transcribe); `onProgress(job)` = job row (image, video, transcribe).
+- Relative file paths resolve beside the page.
+- Rejections: Error with `.type` (+ `.jobId` when a job existed) — table below.
+- Calls run concurrent — disable buttons in flight (image/video/transcribe serialize silently server-side).
+- Local-only; export refuses pages containing the literal text `fused.ai.text(` — an `fused.env` guard does NOT help. Other verbs pass the check then fail hosted. Keep AI in a local-only companion page.
 
-## Choosing provider and model
+## Provider / model
 
-Two tiers, fixed order. `provider` pins one; omitted, the model's shape decides.
+Two tiers. `provider: "local" | "claude"` pins; omitted, model shape decides: id with `/` or `.gguf` → local; `"sonnet"`/`"opus"`/`claude-*`/omitted → Claude CLI (text only). image/video/transcribe/embed are local-only. **Take local ids from `fused.ai.models.catalog()` and treat as opaque** — never hardcode, never `split("/")`.
 
-| `provider` | `model` | Runs on |
-|---|---|---|
-| omitted | omitted | Claude, the user's default (haiku unless configured) |
-| omitted | `"sonnet"`, `"opus"`, a `claude-*` id | Claude Code CLI, the user's login. Text only. |
-| omitted | contains `/` or ends in `.gguf` | this machine, a resident local worker |
-| `"claude"` | alias or omitted | Claude. A repo id here is `bad_request` |
-| `"local"` | repo id or omitted | this machine; omitted = the catalog's default text model |
+`catalog()` → `{capabilities: [{capability, available, reason, default, models[], videoTraits?}], unsupported, ramGb}`. Capabilities: `text-generation`, `text-to-image`, `text-to-video`, `automatic-speech-recognition`, `embeddings`. Model flags: `downloaded, loaded, recommended, size_gb, acceptsImage, acceptsPaths, promptScheme`.
 
-`.image`, `.video`, `.transcribe`, `.embed` are local-only today: omitted means `"local"`, `"claude"` rejects `unavailable`.
+`fused.ai.models`: `list()`, `load(id, {capability})` / `download(id, {capability})` → `{jobId}` (**always pass capability** — wrong runner otherwise), `unload({capability})` (by capability, not id), `fused.ai.cancel(capability?)` (defaults to text-generation — name the capability to stop anything else).
 
-**Take local ids from `fused.ai.models.catalog()` and treat them as opaque.** Ids are backend-specific (MLX on Apple Silicon, GGUF/ONNX elsewhere) and not always `org/name` — a curated GGUF id is a bare filename. A hard-coded id is an unusable download on the next machine. Never `id.split("/")`.
+## Per-verb notes
 
-```js
-const cat = await fused.ai.models.catalog();       // { capabilities: [row...], unsupported, ramGb }
-const row = cat.capabilities.find(r => r.capability === "text-generation");
-row.available;   // false → nothing here serves it; row.reason says why
-row.default;     // the id a bare call uses — null when there is no recommendation
-row.models;      // [{ id, label, size_gb, downloaded, loaded, recommended, source, ... }]
-```
+**text** — options: `prompt, provider, model, systemPrompt, effort (Claude), history, raw, images (local-only, reject on Claude), temperature/maxTokens/topP (dropped on Claude w/ warning), onChunk, abortSignal`. Feed aggregates, not datasets (compute in Python first). Structured output: demand strict JSON, strip fences, `JSON.parse` in try/catch. Vision: `images` on a local model with `acceptsImage`.
 
-Capability strings: `"text-generation"`, `"text-to-image"`, `"text-to-video"`, `"automatic-speech-recognition"`, `"embeddings"`.
+**Cold start**: first text/embed call naming a non-resident local model rejects `model_loading` — the download already started, `err.jobId` is it. Watch `fused.watchJob(err.jobId)`, then retry. Not a failure. Image/video/transcribe load inside their own job instead (`done`/`total` null while weights arrive — guard the division).
 
-## Text
+**transcribe** — `language, task ("transcribe"|"translate"), initialPrompt, vad, diarize, speakers, words, onChunk (per segment), onProgress (seconds)`. Default model = smallest; pass bigger for accuracy. Output persisted under `~/.fused-render/ai/transcripts/` (paths in `providerMetadata.local`). Failed long run keeps `err.outputPartial` (.partial.jsonl). Word timings ±200 ms — don't cut clips on them; `translate` returns no words. One at a time, second queues.
 
-Options: `prompt`, `provider`, `model`, `systemPrompt`, `effort` (`"low"|"medium"|"high"|"xhigh"`, Claude only), `history`, `raw`, `images`, `temperature`, `maxTokens`, `topP`, `onChunk`, `abortSignal`.
-
-Tier split: `history`, `raw`, `images` are **local-only and reject 400 on Claude** — dropping them would answer a different question. `temperature`/`maxTokens`/`topP` on Claude and `effort` on local are **dropped with a `warnings[]` entry**; the call succeeds. Default `effort` is `"low"` (no extended thinking).
-
-### Ask, stream, and show what ran
-
-```js
-const res = await fused.ai.text({
-  prompt,
-  systemPrompt: "Answer in one paragraph.",
-  onChunk: (delta) => { out.textContent += delta; },   // optional — same frame resolves either way
-});
-out.textContent = res.text;
-meta.textContent = `${res.provider} · ${res.response.modelId}`;
-if (res.finishReason === "length") meta.textContent += " · truncated";
-```
-
-### Feed aggregates, not the dataset
-
-Compute in Python, reduce to a few numbers, hand the model those. A raw table blows the token budget and drowns the signal.
-
-```js
-const data = await fused.runPython("./data.py", { days });      // full data for the chart
-const context = JSON.stringify({ total: data.total, byRegion: data.by_region });
-const res = await fused.ai.text({
-  prompt: `Data (JSON):\n${context}\n\nQuestion: ${q}`,
-  systemPrompt: "You are a data analyst. Answer only from the JSON. Cite figures.",
-});
-```
-
-### Structured output
-
-Ask for JSON, parse defensively, never trust the fence.
-
-```js
-const res = await fused.ai.text({
-  prompt: `Classify each title. Reply with ONLY a JSON array of {"title","tag"}.\n${titles.join("\n")}`,
-  systemPrompt: "Output strict JSON. No prose, no code fences.",
-});
-const json = res.text.replace(/^```(?:json)?\s*|\s*```$/g, "");
-let rows; try { rows = JSON.parse(json); } catch { rows = []; }    // retry or degrade, never crash
-```
-
-### Chat with memory, and vision — local models
-
-```js
-const history = [];                                    // [{role: "user"|"assistant", content}]
-async function turn(userText) {
-  const res = await fused.ai.text({ prompt: userText, history, model: chatModelId });
-  history.push({ role: "user", content: userText }, { role: "assistant", content: res.text });
-  return res.text;
-}
-// A vision-language model takes base images for THIS turn, beside the page:
-await fused.ai.text({ prompt: "What is in this chart?", images: ["chart.png"], model: visionModelId });
-```
-
-`chatModelId` must be a local id (`history` and `images` are refused on Claude). Pick one from `catalog()`; a model's `acceptsImage` flag says whether `images` will work.
-
-### A stop button
-
-```js
-const ctl = new AbortController();
-stopBtn.onclick = () => ctl.abort();
-try {
-  await fused.ai.text({ prompt, onChunk, abortSignal: ctl.signal });
-} catch (err) {
-  if (err.type !== "cancelled") throw err;           // a stop is not a failure
-}
-```
-
-Works on every verb. On image/video/transcribe it cancels the job — the same as the ✕ on its row.
-
-### The cold-start handler — write it once
-
-The first text or embed call naming a local model that is not resident rejects `model_loading` **having already started the download**. Watch it, then retry.
-
-```js
-async function withModel(call) {
-  try { return await call(); }
-  catch (err) {
-    if (err.type !== "model_loading") throw err;
-    status.textContent = "Loading model…";
-    await fused.watchJob(err.jobId).watch((job) => {
-      if (job.total) status.textContent = `Loading… ${Math.round(100 * job.done / job.total)}%`;   // bytes
-    });
-    return call();                                   // resident now
-  }
-}
-const res = await withModel(() => fused.ai.text({ prompt, model: localId }));
-```
-
-Image, video and transcribe do **not** throw this: they load the model inside their own job (`done`/`total` are `null` while the weights arrive — guard the division).
+**embed** — `texts` OR `paths` (≤64), `kind: "query"|"document"`. Prose encoder: `kind`, no paths. Dual encoder (CLIP/SigLIP): `paths`, no kind. Index with `"document"`, search with `"query"` — mixing silently drops recall. **Store `response.modelId` with vectors and compare before searching** — cross-model cosine is plausible garbage; dimensions don't catch it.
 
 ## Images: `fused.ai.image({prompt, ...})`
 
-Options: `prompt`, `model`, `provider`, `width`, `height`, `steps`, `guidance`, `seed`, `image`, `onProgress`, `abortSignal`.
+Options: `width`/`height` (1024, 256–2048, snapped down to /16), `steps` (28), `guidance` (4.0), `seed` (random; always returned — re-render with it), `image` (page-relative edit base — only some engines: check `acceptsImage`, else `bad_request` naming the engine; defaults become the file's size, steps 4, guidance 1.0), `onProgress`, `abortSignal`. No negative prompt / batch / LoRA / strength.
 
-| Option | Default | Range | Notes |
-|---|---|---|---|
-| `width` / `height` | 1024 | 256–2048 | clamped, snapped down to a multiple of 16 |
-| `steps` | 28 | 1–100 | clamped |
-| `guidance` | 4.0 | 0–20 | clamped |
-| `seed` | random | 0–2147483647 | always returned, so a render can be re-requested |
-| `image` | — | one page-relative file | edit this base image instead of rendering from scratch; defaults become the file's size, `steps` 4, `guidance` 1.0 |
-
-No negative prompt, batch, LoRA or `strength`. One prompt, one PNG, one row. Resolves with `images: [{path, url, mediaType: "image/png"}]`, `usage: {imagesGenerated: 1}`, `response.id` = the job id, and the render that actually happened under `providerMetadata.local`: `seed, width, height, steps, guidance, prompt, previewPath`, plus `image` when you passed one. **Read sizes off the reply**, never echo your request as the caption.
-
-### Generate with a live preview
-
-```js
-el.onerror = () => { el.hidden = true; };             // early ticks have no frame yet
-const img = await fused.ai.image({
-  prompt,
-  onProgress: (job) => {
-    if (job.total) bar.value = job.done / job.total;  // denoising steps, not bytes
-    if (job.previewUrl) { el.src = job.previewUrl; el.hidden = false; }   // ~32px thumbnail, already cache-busted — blur it in CSS
-  },
-});
-el.src = img.images[0].url;                           // previewUrl is null on the last tick: swap here
-seedLabel.textContent = img.providerMetadata.local.seed;
-```
-
-### Edit a photo, and degrade when the engine cannot
-
-Only some engines edit. The picked model's `acceptsImage` flag in `catalog()` says so up front; the call says so again as a `bad_request` naming the engine.
-
-```js
-try {
-  const edited = await fused.ai.image({ prompt: "make the sky stormy", image: "photo.png" });
-} catch (err) {
-  if (err.type === "bad_request" && /engine/i.test(err.message)) showPlainRenderInstead();   // only the Apple Silicon engine edits
-  else throw err;
-}
-```
-
-Renders take minutes on CPU, are capped at 900 s (past that: `ai_error`), and **serialize**: a second render waits with no queue message on its row. Keep default sliders modest; disable the button.
+Resolves with `images: [{path, url, mediaType: "image/png"}]`, `usage: {imagesGenerated: 1}`, `response.id` = job id, and the render that happened in `providerMetadata.local: {seed, width, height, steps, guidance, prompt, previewPath}` (+ `image` on edits). Read sizes off the reply. `onProgress` job carries `done/total` (denoising steps) and `previewUrl` (~32px thumb, null on last tick — swap to `images[0].url`). One PNG per call; 900 s cap; renders serialize silently.
 
 ## Video: `fused.ai.video({prompt, ...})`
 
-Options: `prompt`, `model`, `provider`, `width`, `height`, `frames`, `steps`, `seed`, `image`, `onProgress`, `abortSignal`. No `guidance`, no preview.
+Apple Silicon only, no fallback — before drawing UI check the `catalog()` `text-to-video` row's `available` and take limits from its `videoTraits`. Options: `width`/`height` (704/480, snapped /32), `frames` (97; `1+8n` grid, rounded **up**), `steps` (8), `seed`, `image` (conditions frame 0; only if `videoTraits.supportsImage`), `onProgress`, `abortSignal`. No guidance, no preview.
 
-Apple Silicon only, no fallback. **Check before you draw the button:**
+Resolves with `videos: [{path, url, mediaType: "video/mp4"}]`, `usage: {videosGenerated: 1}`, `response.id` = job id, `providerMetadata.local: {seed, width, height, frames, steps, prompt, image?}`. Up to 2 h; serializes; `fused.ai.cancel("text-to-video")` keeps the model warm.
 
-```js
-const row = (await fused.ai.models.catalog()).capabilities.find(r => r.capability === "text-to-video");
-if (!row.available || !row.default) { panel.hidden = true; note.textContent = row.reason; return; }
-const t = row.videoTraits;    // { defaultWidth, defaultHeight, defaultFrames, defaultSteps, minFrames, maxFrames, framesStep, supportsImage }
-```
+## From Python
 
-| Option | Default | Range | Notes |
-|---|---|---|---|
-| `width` / `height` | 704 / 480 | 256–1344, `w*h ≤ 768*1344` | snapped down to a multiple of 32 |
-| `frames` | 97 (~4 s at 24 fps) | 9–169 on a `1 + 8n` grid | rounded **up** to the grid: 100 → 105 |
-| `steps` | 8 | 2–50 | clamped |
-| `seed` | random | 0–2147483647 | returned |
-| `image` | — | one page-relative file | conditions frame 0; sizes default from the image. Offer it only if `videoTraits.supportsImage` |
-
-```js
-const vid = await fused.ai.video({ prompt, onProgress: (job) => { if (job.total) bar.value = job.done / job.total; } });
-video.src = vid.videos[0].url;                        // mp4 with audio muxed in
-```
-
-Resolves with `videos: [{path, url, mediaType: "video/mp4"}]`, `usage: {videosGenerated: 1}`, `response.id` = the job id, `providerMetadata.local: {seed, width, height, frames, steps, prompt, image?}`. Renders can take up to 2 hours and serialize. `fused.ai.cancel("text-to-video")` or `abortSignal` stops one and keeps the model warm.
-
-## Transcription: `fused.ai.transcribe({path, ...})`
-
-Options: `path`, `model`, `provider`, `language` (omit = auto-detect), `task` (`"transcribe"` | `"translate"` into English), `initialPrompt`, `vad` (default `true`), `diarize`, `speakers`, `words`, `onProgress`, `onChunk`, `abortSignal`.
-
-Progress `done`/`total` are **seconds of audio**. The transcript is written to `~/.fused-render/ai/transcripts/` and outlives the tab; paths are under `providerMetadata.local` (`output`, `outputText`, `outputPartial`, `url`). `model` omitted loads the **smallest** model — pass a larger one from `catalog()` when accuracy matters.
-
-### Live transcript, then the whole thing
-
-```js
-const rec = await fused.ai.transcribe({
-  path: "meeting.m4a",
-  onChunk: (s) => addCue(s.startSecond, s.endSecond, s.text),   // every segment, in order, exactly once, during the run
-  onProgress: (job) => { if (job.total) bar.value = job.done / job.total; },
-});
-// rec.segments is the same list, whole. rec.text is the joined transcript.
-```
-
-### Who said it
-
-```js
-const rec = await fused.ai.transcribe({ path, diarize: true });           // speakers: 3 fixes the count; omitted = estimated
-const labels = rec.providerMetadata.local.speakers;                        // ["Speaker 1", ...] for a colour map
-rec.segments.forEach(s => paint(s.speaker));                              // null where words were heard but no voice segmented
-rec.providerMetadata.local.estimatedSpeakers;                              // present only when it had to guess — show it, offer a re-run
-```
-
-### Click-a-word player
-
-```js
-const rec = await fused.ai.transcribe({ path, words: true });
-for (const s of rec.segments)
-  for (const w of s.words || [])                     // best-effort: some engines return no words — always `|| []`
-    addWord(w.word, w.startSecond, w.endSecond);    // `word` keeps its leading space; join("") rebuilds s.text
-```
-
-Word timings follow along fine for a highlight; roughly half land >200 ms off on conversational audio, so do not cut clips on them. `task: "translate"` returns no words.
-
-### Salvage a failed long run
-
-The worker flushes each segment to `outputPartial` (`.partial.jsonl`). It is deleted on success and cancel, kept on failure:
-
-```js
-try { await fused.ai.transcribe({ path }); }
-catch (err) {
-  if (err.type === "ai_error" && err.outputPartial) {
-    const segs = (await fused.readFile(err.outputPartial)).split("\n").filter(Boolean).map(JSON.parse);   // raw worker rows: {start, end, text}
-  }
-}
-```
-
-One transcription runs at a time; a second **queues** and says so on its row.
-
-## Embeddings: `fused.ai.embed({texts, ...})`
-
-Options: `texts` **or** `paths` (never both, ≤ 64 items), `model`, `kind` (`"query"` | `"document"`), `provider`, `abortSignal`. Not job-backed: the reply is the result. Vectors are **unit-length**, so cosine is a plain dot product.
-
-Two model shapes serve this capability, and two options are per-model: a **prose encoder** takes `kind` and refuses `paths`; a **dual encoder** (SigLIP/CLIP) takes `paths` and refuses `kind`. Read the flags off `catalog()` before drawing a control: `acceptsPaths === true` for an image affordance, `promptScheme !== null` for a query/document toggle.
-
-### Semantic search over a folder
-
-```js
-// Index once. kind:"document" here, kind:"query" at search time — using one side for both silently costs recall.
-const r = await fused.ai.embed({ texts: chunks, kind: "document" });
-await fused.writeFile("index.json", JSON.stringify({
-  model: r.response.modelId,                          // the space these vectors live in — store it
-  chunks, embeddings: r.embeddings,
-}));
-
-// Search.
-const index = JSON.parse(await fused.readFile("index.json"));
-const q = await fused.ai.embed({ texts: [question], kind: "query" });
-if (q.response.modelId !== index.model)
-  throw new Error(`index built with ${index.model}; rebuild before searching with ${q.response.modelId}`);
-const dot = (a, b) => a.reduce((s, x, i) => s + x * b[i], 0);
-const hits = index.embeddings.map((v, i) => [dot(v, q.embeddings[0]), index.chunks[i]])
-                             .sort((a, b) => b[0] - a[0]).slice(0, 5);
-```
-
-Two models produce two spaces. A cosine between them is a meaningless number that **looks** ranked and plausible, and a dimension check does not catch it — several unrelated models are 768-dim. Storing and comparing `response.modelId` is the only guard.
-
-### Search photos with a sentence
-
-```js
-const m = row.models.find(m => m.acceptsPaths === true);          // a dual encoder
-const imgs = await fused.ai.embed({ paths: photoPaths, model: m.id });   // page-relative or absolute
-const txt  = await fused.ai.embed({ texts: ["a dog on a beach"], model: m.id });   // no `kind` on this model
-```
-
-## The model picker: `fused.ai.models`
-
-| Call | Returns |
-|---|---|
-| `catalog()` | `{capabilities: [{capability, available, reason, default, models[], videoTraits?}], unsupported, ramGb}` |
-| `list()` | `{loaded: [...], downloading, runners: [{code, capability, available, active, ...}], totalResidentBytes, memoryCeilingBytes}` |
-| `load(id, {capability})` / `download(id, {capability})` | `{jobId}` — a job, not a model. Watch with `fused.watchJob(jobId)` |
-| `unload({capability})` | `{stopped, ...}` |
-| `fused.ai.cancel(capability?)` | `boolean` — stops generation, keeps weights. Defaults to `"text-generation"` |
-
-```js
-const row = cat.capabilities.find(r => r.capability === cap);
-for (const m of row.models) {                        // render ALL of them — filtering to curated hides what the user downloaded
-  const state = m.loaded ? "ready" : m.downloaded ? "instant load" : `${m.size_gb} GB download`;
-  addOption(m.id, `${m.label || m.id} — ${state}`, { recommended: m.recommended, isDefault: m.id === row.default });
-}
-```
-
-- **Always pass `{capability}` to `load`/`download`.** Without it an undownloaded whisper or diffusion repo is guessed as a text model and fails inside the wrong runner.
-- **Unload by capability, not id.** The resident model may not be the one your dropdown shows; `unload({capability: cap})` releases whatever is there.
-- Lists are smallest-first and `default` is the smallest curated entry, so a bare call gets the quickest model, not the best. Offer `recommended` ones for quality.
-- Switching engines on the AI Models page evicts the resident model; your next call sees `model_loading` again. The cold-start handler already covers it.
-
-## From Python: `import fused_ai`
-
-Same option names, blocking by default; every verb except `video`. Any `.py` the server runs can `import fused_ai` with no path setup.
-
-```python
-import fused_ai
-
-def main(path: str = "meeting.m4a"):
-    rec = fused_ai.transcribe(path=path)                         # blocks until done; same frame as the JS side
-    summary = fused_ai.text("Summarise:\n" + rec["text"], model="sonnet")   # returns str
-    vecs = fused_ai.embed(texts=[rec["text"]], kind="document")  # frame: vecs["embeddings"], vecs["response"]["modelId"]
-    return {"summary": summary, "speakers": rec["providerMetadata"]["local"].get("speakers")}
-```
-
-- `fused_ai.text(prompt, model=, effort=, system_prompt=, provider=)` → `str`; `fused_ai.stream(...)` yields chunks. `transcribe`/`image`/`embed` return the frame.
-- Job-backed calls take `wait=False` (get `{jobId}` back), `on_progress=` (each job row), `timeout=`.
-- Catch `fused_ai.ServerNotRunning` (nothing to call) separately from `fused_ai.AiError` (`.type`, `.message`, same types as JS plus `stalled`).
-- Outside the server (a script, a notebook): `~/.fused-render/server.json` has `"shared"`; `sys.path.insert(0, that)` then import.
-- **Do not route a UI through it.** `runPython()` returns once, so a `fused_ai` call behind it cannot stream tokens or move a progress bar. For anything live, call `fused.ai` from JavaScript.
+`import fused_ai` works in any server-run `.py`, no path setup. Same option names, blocking; all verbs except video. `fused_ai.text(prompt, ...)` → str; `stream(...)` yields; others return the frame (dict). `wait=False`, `on_progress=`, `timeout=` on job-backed calls. Catch `ServerNotRunning` and `AiError` (`.type`). Outside the server: `sys.path.insert(0, server.json["shared"])`. Don't route live UI through it — `runPython` returns once, no streaming.
 
 ## Errors
 
-```js
-try { ... } catch (err) {
-  switch (err.type) {
-    case "model_loading": /* watch err.jobId, retry */ break;
-    case "cancelled":     /* user asked; not a failure */ break;
-    case "unavailable":   /* this machine cannot: show err.message */ break;
-    case "ai_unavailable":/* claude CLI missing or worker won't start: friendly state */ break;
-    case "bad_request":   /* your call is wrong: read err.message */ break;
-    case "timeout":       /* offer retry */ break;
-    default:              /* ai_error: show err.message */
-  }
-}
-```
+| `.type` | Meaning |
+|---|---|
+| `model_loading` | Not resident; load started, watch `err.jobId`, retry |
+| `ai_unavailable` | claude CLI missing / local worker won't start — friendly state, not overlay |
+| `unavailable` | This machine can't (no runner, needs Apple Silicon, claude on non-text verb) |
+| `bad_request` | Your call is wrong — read `.message` |
+| `ai_error` | Ran and failed (bad id, OOM, crash, render past cap) |
+| `timeout` | Text, 600 s |
+| `cancelled` | abortSignal / cancel / row ✕ — not a failure |
 
-| `.type` | Meaning | From |
-|---|---|---|
-| `model_loading` | Local model not resident; the load already started, `err.jobId` is it | text, embed |
-| `ai_unavailable` | `claude` CLI not found, or the local worker will not start | text |
-| `unavailable` | A fact about this machine: no runner, needs Apple Silicon, `"claude"` on a non-text verb | image, video, transcribe, embed, models |
-| `bad_request` | Unknown option, missing/empty required field, local-only option on Claude, unusable value | all |
-| `ai_error` | Ran and failed: bad model id, OOM, worker crash, transcript unreadable, or a render past its cap (image 900 s, video 2 h — "the … process did not answer") | all |
-| `timeout` | No answer within 600 s | text |
-| `cancelled` | `abortSignal`, `fused.ai.cancel`, or the row's ✕ | all |
-
-## Export
-
-The exporter refuses any page containing the text `fused.ai.text(` — matched literally, so `if (fused.env === "local")` does not help. The other verbs **pass the check and then fail hosted** (no worker, no `/api/fs/raw`). To ship an exportable view, keep AI in a separate local-only companion page, or gate every AI feature on `fused.env === "local"` and keep `fused.ai.text(` out of the file entirely. `import fused_ai` is not copied into an export either.
-
-## Debugging
-
-```bash
-which claude && claude --version                      # Claude tier present?
-curl -s http://127.0.0.1:1777/api/ai/runtime          # what is resident locally
-curl -s -X POST http://127.0.0.1:1777/api/ai -H 'X-Fused: 1' -H 'Content-Type: application/json' \
-  -d '{"prompt": "Reply with exactly the word pong."}'
-```
-
-`X-Fused: 1` is required on every POST; without it the rejection looks like a broken endpoint. If the curl fails, it is the machine, not your page.
-
-## Pitfalls
-
-- `fused.ai(prompt)` and `fused.ai.text("hi")` → gone. One options object: `fused.ai.text({ prompt })`.
-- `res.model`, `usage.input_tokens`, `seg.start` → `undefined`. Use `response.modelId`, `usage.inputTokens`, `startSecond`.
-- Reading `res.url` / `res.seed` on an image → `images[0].url`, `providerMetadata.local.seed`.
-- Treating `model_loading` as a failure → it is a download you asked for. Watch and retry.
-- Dividing by `job.total` on an image job while the model loads → `NaN`. Guard it.
-- Hard-coding a model id → wrong format on the next machine. Read `catalog()`.
-- `load(id)` without `{capability}` for a non-text repo → fails in the wrong runner.
-- `unload(selectedId)` → often a no-op. `unload({capability})`.
-- `fused.ai.cancel()` to stop an image or transcription → only stops text. Name the capability or use `abortSignal`.
-- `embed` without `kind` on a retrieval model → recall quietly drops. `"document"` to index, `"query"` to search.
-- Mixing vectors from two models → plausible garbage. Store and compare `response.modelId`.
-- Firing two renders → they serialize silently. Disable the button.
-- Gating on `fused.env` and expecting export to pass → textual match. Move the call to a companion page.
+Debug the machine (not the page): `which claude`; `GET /api/ai/runtime`; `POST /api/ai` with `X-Fused: 1` header (required on every POST).

--- a/skills/fused-render-api-migration/SKILL.md
+++ b/skills/fused-render-api-migration/SKILL.md
@@ -1,52 +1,24 @@
 ---
 name: fused-render-api-migration
-description: Migrate a fused-render app from an older version of the `fused` page API to the current one. Use when a task says to migrate an app, when the app page's Migrate button created the task, when an entry page's `<meta name="fused-api-version">` is behind (or missing), or when an app breaks with "fused.ai is not a function" or an unexpected result shape after a fused-render upgrade. Self-contained — reads the per-version notes under docs/ and does the whole migration.
+description: Use when migrating a fused-render app to the current fused page API — a Migrate task, a behind/missing fused-api-version meta tag, or "fused.ai is not a function" after an upgrade.
 ---
 
-# Migrating an app across fused API versions
+# API migration
 
-Every fused-render app declares which shape of the `fused` runtime it was written against, in its entry page's `<head>`, right after the app marker:
+Entry pages declare their API version in `<head>`: `<meta name="fused-api-version" content="N" />` (right after `<meta name="fused-app" />`, inside the first 4 KiB). No tag = version 0. Each breaking change is one note `docs/vN.md` beside this SKILL.md; **the current version is the highest vN.md** — no other registry (the server reads this folder too: `fused_render/fused_api_version.py`). Migrating A → B = apply `v{A+1}.md` … `v{B}.md` in order.
 
-```html
-<meta name="fused-app" />
-<meta name="fused-api-version" content="1" />
-```
+## Procedure (one pass, self-contained)
 
-A page **without** the tag is **version 0** (authored before versioning existed). The runtime moves on with breaking changes from time to time; each change is written up once, as one file under `docs/` beside this skill:
+1. **FROM**: read the entry page's meta tag (task target = the page with `fused-app`); no tag = 0. Task text naming versions wins.
+2. **TO**: highest `docs/vN.md` here. FROM ≥ TO → ensure the tag is present and correct, stop.
+3. **Read every note in (FROM, TO], oldest first, all before editing** — a symbol renamed twice must land on its final name.
+4. **Sweep the whole folder** (subfolders; skip `.fused/`, `node_modules/`): `fused.*` in html, `import fused_ai`/`fused_ai.*` in py, direct `fetch("/api/ai…")`. Rewrite call shapes AND result readers per the notes. Verify what each site actually calls first — leave already-current sites alone. No restyling beyond what the notes ask.
+5. **Declare**: set `content="TO"` on the meta tag (add/replace, directly after `fused-app`).
+6. **Check**: re-grep for every OLD spelling the notes list; none should remain outside obvious non-call strings.
+7. **Report**: FROM → TO, files changed, anything deliberately left and why.
 
-```
-docs/v1.md    what changed in version 1 over version 0
-docs/v2.md    what changed in version 2 over version 1
-...
-```
+Diagnosing only ("fused.ai is not a function", `res.model` undefined): read the note that introduced the shape — `docs/v1.md` covers the fused.ai namespace + result frame.
 
-**The current API version is the highest `docs/vN.md` that exists.** There is no other registry. Migrating from A to B means applying `docs/v{A+1}.md` … `docs/v{B}.md`, **in order** — v2 → v5 reads v3, v4, v5.
+## Maintainers: shipping a new version
 
-## Procedure
-
-Do all of it in one pass; the task that invoked you does not add anything beyond this file.
-
-1. **Find the entry page and its declared version.** The task's target file is the entry page (it carries `<meta name="fused-app">`). Read its head. `content="N"` on `<meta name="fused-api-version">` is the FROM version; no tag = 0. If the task text names the versions ("from 0 to 1"), trust that.
-2. **Find the current version.** List `docs/` beside this SKILL.md; the highest `vN.md` is the TO version. If FROM ≥ TO, the app is already current: make sure the tag is present and correct (step 5) and stop.
-3. **Read every note in `(FROM, TO]`, oldest first.** Each note is self-contained: what changed, old spelling → new spelling, and a checklist. Read all of them before editing so a symbol renamed in v3 and again in v4 lands on its final name.
-4. **Sweep the whole app folder, not just the entry page.** Every `.html` and `.py` in the folder (subfolders included, `.fused/` and `node_modules/` excluded) that touches the runtime: `fused.*` in pages, `import fused_ai` / `fused_ai.*` in Python, and direct `fetch("/api/ai…")` calls. For each site, apply the notes' rewrites — the call shape AND every reader of its result (`res.model`, `usage.input_tokens`, `res.url`, callback field names, …). **Verify what the code actually calls before changing it**: a page may already be on newer shapes without declaring so — leave those sites alone. Do not restyle, restructure or "improve" anything the notes do not ask for.
-5. **Declare the new version.** In the entry page, place `<meta name="fused-api-version" content="TO" />` directly after `<meta name="fused-app" />` (replace an existing `fused-api-version` tag). Both tags stay inside the first 4 KiB of the file — detection reads only the head.
-6. **Check it.** Re-grep the folder for every OLD spelling listed in the notes you applied (`fused.ai(`, `.input_tokens`, `onSegment`, …); none should remain except in strings that are clearly not runtime calls. If the app has a `.py` that the page calls through `fused.runPython`, read it once more for result-shape readers.
-7. **Report.** One short summary: FROM → TO, which files changed, anything you deliberately left (a site you could not confidently rewrite — name it and say why).
-
-## Which notes to read
-
-| Situation | Read |
-|---|---|
-| Tag missing, or `content="0"` | every `docs/vN.md`, ascending |
-| `content="K"` | `docs/v{K+1}.md` … highest, ascending |
-| Only diagnosing ("fused.ai is not a function", `res.model` undefined) | the note that introduced the shape — `docs/v1.md` covers the `fused.ai` namespace and result-frame break |
-
-## Maintainers: shipping a new API version
-
-When a fused-render PR breaks the page API:
-
-1. add `docs/v{N}.md` here — what changed over v{N-1}, old → new, and a checklist a migrating session can act on;
-2. bump `content="N"` on the starter's `<meta name="fused-api-version">` (`fused_render/app_starter/index.html`).
-
-Nothing else: the server reads the current version off this `docs/` folder (`fused_render/fused_api_version.py`), the app page's Migrate button compares against it, and the task it creates invokes this skill.
+1. Add `docs/v{N}.md` here (what changed, old → new, checklist). 2. Bump `content="N"` in `fused_render/app_starter/index.html`. Nothing else — the server, the Migrate button and its task all key off this folder.

--- a/skills/fused-render-api-migration/SKILL.md
+++ b/skills/fused-render-api-migration/SKILL.md
@@ -1,24 +1,24 @@
 ---
 name: fused-render-api-migration
-description: Use when migrating a fused-render app to the current fused page API — a Migrate task, a behind/missing fused-api-version meta tag, or "fused.ai is not a function" after an upgrade.
+description: Use when migrating app to current fused page API — Migrate task, stale/missing fused-api-version meta, "fused.ai is not a function" after upgrade.
 ---
 
 # API migration
 
-Entry pages declare their API version in `<head>`: `<meta name="fused-api-version" content="N" />` (right after `<meta name="fused-app" />`, inside the first 4 KiB). No tag = version 0. Each breaking change is one note `docs/vN.md` beside this SKILL.md; **the current version is the highest vN.md** — no other registry (the server reads this folder too: `fused_render/fused_api_version.py`). Migrating A → B = apply `v{A+1}.md` … `v{B}.md` in order.
+Entry page declares API version in `<head>`: `<meta name="fused-api-version" content="N" />` (right after `<meta name="fused-app" />`, inside first 4 KiB). No tag = version 0. Each breaking change = one note `docs/vN.md` beside this SKILL.md; **current version = highest vN.md** — no other registry (server reads this folder too: `fused_render/fused_api_version.py`). Migrate A → B = apply `v{A+1}.md` … `v{B}.md` in order.
 
 ## Procedure (one pass, self-contained)
 
-1. **FROM**: read the entry page's meta tag (task target = the page with `fused-app`); no tag = 0. Task text naming versions wins.
-2. **TO**: highest `docs/vN.md` here. FROM ≥ TO → ensure the tag is present and correct, stop.
-3. **Read every note in (FROM, TO], oldest first, all before editing** — a symbol renamed twice must land on its final name.
-4. **Sweep the whole folder** (subfolders; skip `.fused/`, `node_modules/`): `fused.*` in html, `import fused_ai`/`fused_ai.*` in py, direct `fetch("/api/ai…")`. Rewrite call shapes AND result readers per the notes. Verify what each site actually calls first — leave already-current sites alone. No restyling beyond what the notes ask.
-5. **Declare**: set `content="TO"` on the meta tag (add/replace, directly after `fused-app`).
-6. **Check**: re-grep for every OLD spelling the notes list; none should remain outside obvious non-call strings.
-7. **Report**: FROM → TO, files changed, anything deliberately left and why.
+1. **FROM**: read entry page's meta tag (task target = page with `fused-app`); no tag = 0. Task text naming versions wins.
+2. **TO**: highest `docs/vN.md` here. FROM ≥ TO → ensure tag present + correct, stop.
+3. **Read every note in (FROM, TO], oldest first, ALL before editing** — symbol renamed twice must land on final name.
+4. **Sweep whole folder** (subfolders; skip `.fused/`, `node_modules/`): `fused.*` in html, `import fused_ai`/`fused_ai.*` in py, direct `fetch("/api/ai…")`. Rewrite call shapes AND result readers per notes. Verify what each site actually calls first — already-current sites stay. No restyling beyond notes.
+5. **Declare**: set `content="TO"` on meta tag (add/replace, directly after `fused-app`).
+6. **Check**: re-grep every OLD spelling notes list; none remain outside obvious non-call strings.
+7. **Report**: FROM → TO, files changed, anything left + why.
 
-Diagnosing only ("fused.ai is not a function", `res.model` undefined): read the note that introduced the shape — `docs/v1.md` covers the fused.ai namespace + result frame.
+Diagnosing only ("fused.ai is not a function", `res.model` undefined): read note that introduced shape — `docs/v1.md` covers fused.ai namespace + result frame.
 
-## Maintainers: shipping a new version
+## Maintainers: shipping new version
 
-1. Add `docs/v{N}.md` here (what changed, old → new, checklist). 2. Bump `content="N"` in `fused_render/app_starter/index.html`. Nothing else — the server, the Migrate button and its task all key off this folder.
+1. Add `docs/v{N}.md` here (what changed, old → new, checklist). 2. Bump `content="N"` in `fused_render/app_starter/index.html`. Nothing else — server, Migrate button, task all key off this folder.

--- a/skills/fused-render-app-icon/SKILL.md
+++ b/skills/fused-render-app-icon/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: fused-render-app-icon
-description: Use when adding, changing or fixing an app's icon.svg — the sidebar glyph and browser-tab favicon.
+description: Use when adding/changing/fixing app's icon.svg — sidebar glyph, browser-tab favicon.
 ---
 
 # icon.svg
 
-`icon.svg` (exact lowercase name) beside the entry page. Nothing registers it — found by name; edits show on next navigation. Used at 14 px (sidebar Projects) and 16 px (favicon). Skip it → generic mark.
+`icon.svg` (exact lowercase name) beside entry page. Nothing registers it — found by name; edits show next navigation. Used 14 px (sidebar Projects), 16 px (favicon — also for plain files opened in explorer). Skip → generic mark.
 
 Rules:
 
-- **Rendered as is** — no tinting, masking or framing. It lands on light AND dark surfaces, so own your background: filled rounded square/circle behind the glyph. Going transparent → mid-tone/saturated colour or contrasting outline, never pure black/white/grey.
-- **Design for 16 px**: one bold shape or 1–2 letter monogram; no scenes, no thin lines (< ~1/12 viewBox blurs away); 2–3 colours, no gradients/shadows/texture. Verify by zooming out to ~16 px on a light and a dark page.
-- **Square viewBox**, fill it (small margin only if it has its own background); no fixed width/height (or equal).
-- **Plain standalone file**: everything inline — no external images/fonts/CSS imports (favicon is fetched standalone), no scripts/animation. A few KB; `svgo` if exported from a tool.
+- **Rendered as is** — no tinting/masking/framing. Lands on light AND dark surfaces → own your background: filled rounded square/circle behind glyph. Transparent → mid-tone/saturated colour or contrasting outline, never pure black/white/grey.
+- **Design for 16 px**: one bold shape or 1–2 letter monogram; no scenes, no thin lines (< ~1/12 viewBox blurs); 2–3 colours, no gradients/shadows/texture. Verify: zoom to ~16 px on light + dark page.
+- **Square viewBox**, fill it (small margin only if own background); no fixed width/height (or equal).
+- **Plain standalone file**: everything inline — no external images/fonts/CSS imports (favicon fetched standalone), no scripts/animation. Few KB; `svgo` if tool-exported.
 
-Serviceable default: dark rounded `<rect rx>` + one bright glyph (path, or centred `<text>` monogram); swap glyph and colours for the app's own.
+Serviceable default: dark rounded `<rect rx>` + one bright glyph (path, or centred `<text>` monogram); swap glyph + colours for app's own.

--- a/skills/fused-render-app-icon/SKILL.md
+++ b/skills/fused-render-app-icon/SKILL.md
@@ -1,47 +1,17 @@
 ---
 name: fused-render-app-icon
-description: Design the optional icon.svg for a fused-render app — the file the shell shows as the app's sidebar glyph and browser-tab favicon. Use when the user asks for an app icon, logo, favicon or glyph, or wants to add, change or fix icon.svg.
+description: Use when adding, changing or fixing an app's icon.svg — the sidebar glyph and browser-tab favicon.
 ---
 
-# An app's icon.svg
+# icon.svg
 
-An app folder may carry an `icon.svg` (that exact lowercase name) next to its entry page. Nothing registers it — the shell finds it by name and uses it in two places:
+`icon.svg` (exact lowercase name) beside the entry page. Nothing registers it — found by name; edits show on next navigation. Used at 14 px (sidebar Projects) and 16 px (favicon). Skip it → generic mark.
 
-- the app's glyph in the sidebar's **Projects** list (a 14 px slot);
-- the **browser-tab favicon** on the app's page (`/apps/<folder>`) and on any of its files opened in the explorer (16 px in most browsers).
+Rules:
 
-Skip the file and the generic mark is used. Edit it and the new drawing shows on the next navigation — no reload of the shell.
+- **Rendered as is** — no tinting, masking or framing. It lands on light AND dark surfaces, so own your background: filled rounded square/circle behind the glyph. Going transparent → mid-tone/saturated colour or contrasting outline, never pure black/white/grey.
+- **Design for 16 px**: one bold shape or 1–2 letter monogram; no scenes, no thin lines (< ~1/12 viewBox blurs away); 2–3 colours, no gradients/shadows/texture. Verify by zooming out to ~16 px on a light and a dark page.
+- **Square viewBox**, fill it (small margin only if it has its own background); no fixed width/height (or equal).
+- **Plain standalone file**: everything inline — no external images/fonts/CSS imports (favicon is fetched standalone), no scripts/animation. A few KB; `svgo` if exported from a tool.
 
-## It renders as is
-
-The svg is drawn **untouched**: no recolouring, no mask, no tint, no frame added. Whatever colours and background you draw are exactly what the user sees. Consequences:
-
-- **Own your background.** The icon lands on the sidebar (light or dark theme) and on a browser tab strip (light or dark, per the user's OS/browser). A transparent icon must read on BOTH; a black glyph vanishes on dark, a white one on light. The easy fix is to give the icon its own background — a filled rounded square or circle behind the glyph — so contrast is decided inside the file, not by whatever is behind it.
-- **If you go transparent**, use a mid-tone or saturated colour that holds on both white and near-black (a strong brand hue, not pure black/white/grey), or outline the shape in a contrasting stroke.
-- Nothing is clipped or inset for you. Fill the viewBox; leave only a small margin if the icon has its own background.
-
-## It renders very small
-
-14–16 px. Design for that, not for a hero image:
-
-- **One shape, one idea.** A single bold silhouette or a 1–2 letter monogram. No scenes, no text longer than two letters, no thin lines (under ~1/12 of the viewBox they blur to nothing).
-- **Two colours, maybe three.** Background + glyph is usually enough. Gradients, shadows and fine texture turn to mud.
-- **Square viewBox** (`viewBox="0 0 64 64"` or similar) so it fills the slot without letterboxing. Set no fixed `width`/`height`, or set them equal.
-- Check it: zoom the browser out until the svg is ~16 px on screen, on a light and a dark page. If you cannot tell what it is, simplify.
-
-## A serviceable default
-
-```svg
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="14" fill="#1b1d21"/>
-  <circle cx="32" cy="32" r="16" fill="#e5ff44"/>
-</svg>
-```
-
-Dark rounded square, one bright glyph — reads on any background and at any size. Swap the glyph (a path, a monogram `<text>` at `font-size="34"` with `text-anchor="middle"`, a simple mark) and the two colours for the app's own.
-
-## Keep it a plain file
-
-- Inline everything: no external `<image>`, fonts or CSS `@import` — the favicon is fetched as a standalone document.
-- No scripts, no animation (favicons do not animate and the sidebar ignores it).
-- Small: a few KB. Optimise with `svgo` if exported from a design tool.
+Serviceable default: dark rounded `<rect rx>` + one bright glyph (path, or centred `<text>` monogram); swap glyph and colours for the app's own.

--- a/skills/fused-render-app-icon/SKILL.md
+++ b/skills/fused-render-app-icon/SKILL.md
@@ -5,7 +5,7 @@ description: Use when adding/changing/fixing app's icon.svg — sidebar glyph, b
 
 # icon.svg
 
-`icon.svg` (exact lowercase name) beside entry page. Nothing registers it — found by name; edits show next navigation. Used 14 px (sidebar Projects), 16 px (favicon — also for plain files opened in explorer). Skip → generic mark.
+`icon.svg` (exact lowercase name) beside entry page. Nothing registers it — found by name; edits show next navigation. Used tiny: sidebar Projects glyph + favicon (favicon also for plain files opened in explorer). Skip → generic mark.
 
 Rules:
 

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: fused-render-authoring
-description: Use when creating, editing or debugging a fused-render .html view or .py data file — fused.runPython, params, readFile/writeFile, preview mode, blank views, traceback overlays.
+description: Use when writing or debugging fused-render .html view or .py data file — runPython, params, preview mode, blank views, traceback overlays.
 ---
 
 # Authoring fused-render views
 
-A view = sibling pair: `.html` (UI) + `.py` (data). The explorer renders the html in an iframe, injects `window.fused` (never `<script src>` a runtime), and the page calls local Python via `fused.runPython`. UI state lives in URL params → refresh-proof, bookmarkable. Plain HTML/CSS/JS, no framework, no build step.
+View = sibling pair: `.html` (UI) + `.py` (data). Explorer renders html in iframe, injects `window.fused` (never `<script src>` runtime), page calls local Python via `fused.runPython`. UI state lives in URL params → refresh-proof, bookmarkable. Plain HTML/CSS/JS. No framework, no build step.
 
 ## App markers (entry page `<head>`, first 4 KiB)
 
@@ -14,19 +14,19 @@ A view = sibling pair: `.html` (UI) + `.py` (data). The explorer renders the htm
 <meta name="fused-api-version" content="N" />
 ```
 
-- `fused-app` is the ONLY thing that makes a folder an app. No marker = never in /apps, never registered.
+- `fused-app` = ONLY thing making folder an app. No marker → never in /apps, never registered.
 - `fused-api-version`: copy N from `fused_render/app_starter/index.html`. Missing tag = version 0. Migration → `fused-render-api-migration`.
 - Optional `icon.svg` beside entry page = sidebar glyph + favicon → `fused-render-app-icon`.
 
 ## Python side: `main()`
 
-One plain function `main(**params)`. Rules:
+One plain fn `main(**params)`. Rules:
 
-- **Annotate params** — they arrive as URL strings; annotations coerce (`limit: int`, `bool` accepts "true/1/yes/on"). Unannotated = raw string.
+- **Annotate params** — arrive as URL strings; annotations coerce (`limit: int`, `bool` accepts "true/1/yes/on"). Unannotated = raw string.
 - **Default every param** unless truly required.
 - **Return JSON-native only** (dict/list/str/int/float/bool/None). DataFrame → `df.to_dict("records")`; datetime/Decimal/numpy → cast.
-- Relative paths resolve beside the `.py`.
-- **Fresh subprocess per call.** No globals survive. Import cost repaid every call (pandas ≈ 1 s). Killed at **60 s** (`DEFAULT_TIMEOUT`, `fused_render/executor.py`) — no override. Longer work → `fused-render-jobs`.
+- Relative paths resolve beside `.py`.
+- **Fresh subprocess per call.** No globals survive. Import cost paid every call (pandas ≈ 1 s). Killed at **60 s** (`DEFAULT_TIMEOUT`, `fused_render/executor.py`), no override. Longer work → `fused-render-jobs`.
 - `print()` → browser console as `[python]`.
 
 ### Available Python libraries
@@ -39,103 +39,104 @@ No `pyproject.toml` in folder → app interpreter: stdlib plus exactly this bund
 - **Network & cloud:** `requests` `httpx` `botocore` `google-auth`
 - **Logs:** `drain3`
 
-Anything else needs a folder `pyproject.toml` (project root only; add `[tool.uv] package = false`). Facts:
+Anything else needs folder `pyproject.toml` (project root only; add `[tool.uv] package = false`). Facts:
 
-- The dependency list is **complete** — bundled set is NOT unioned in. Import numpy → declare numpy.
-- All-or-nothing per folder; only the topmost `pyproject.toml` counts.
+- Dependency list **complete** — bundled set NOT unioned in. Import numpy → declare numpy.
+- All-or-nothing per folder; only topmost `pyproject.toml` counts.
 - First render installs (loader, auto-retry). Non-PyPI sources / custom indexes → consent prompt. No-wheel deps stop with "install anyway". Commit `uv.lock`.
-- Never run `uv sync` by hand — it skips the readiness marker and consent (`fused_render/projectenv.py`).
-- `# /// script` headers are IGNORED. Delete them; move deps into `pyproject.toml`.
-- Version question? Probe the live env via `POST /api/run` with a throwaway `main()` returning `importlib.metadata.version(...)` — don't guess.
+- Never run `uv sync` by hand — skips readiness marker + consent (`fused_render/projectenv.py`).
+- `# /// script` headers IGNORED. Delete; move deps into `pyproject.toml`.
+- Version question? Probe live env: `POST /api/run` with throwaway `main()` returning `importlib.metadata.version(...)`. Don't guess.
 
 ## App state: `.fused/`
 
-Created automatically at app root. Convention, no helper API — build paths yourself off `os.path.dirname(os.path.abspath(__file__))`:
+Auto-created at app root. Convention, no helper API — build paths off `os.path.dirname(os.path.abspath(__file__))`:
 
-- `.fused/data/` — state the app owns, cannot rebuild. NOT beside index.html, NOT `~/.myapp`, NOT tmp.
-- `.fused/cache/` — rebuildable derived bytes. Deleting it must cost only time. No auto-sweep — cap it yourself.
-- `.fused/meta.json` — `{version, app_dir, created_at}`. `app_dir` ≠ actual path → folder was moved; distrust absolute paths stored in state.
-- Machine-local: gitignored, excluded from export. Nothing required-on-fresh-machine goes here.
+- `.fused/data/` — state app owns, cannot rebuild. NOT beside index.html, NOT `~/.myapp`, NOT tmp.
+- `.fused/cache/` — rebuildable derived bytes. Deleting must cost only time. No auto-sweep — cap yourself.
+- `.fused/meta.json` — `{version, app_dir, created_at}`. `app_dir` ≠ actual path → folder moved; distrust stored absolute paths.
+- Machine-local: gitignored, excluded from export. Nothing required-on-fresh-machine here.
 
-**Cache aggressively.** Fresh subprocess + 60 s kill means: memoize fetches/parses/aggregations to `.fused/cache/`. Key = hash of all inputs **with a version segment** (bump on shape change). Write atomically (`os.replace` a temp file — calls overlap). Treat unreadable entry as miss. Cache the expensive step, not `main()` wholesale. Bytes (PNG/parquet) → cache file, hand page `fused.rawUrl(path)`.
+**Cache aggressively.** Fresh subprocess + 60 s kill → memoize fetches/parses/aggregations to `.fused/cache/`. Key = hash of all inputs **with version segment** (bump on shape change). Write atomic (`os.replace` temp file — calls overlap). Unreadable entry = miss. Cache expensive step, not `main()` wholesale. Bytes (PNG/parquet) → cache file, hand page `fused.rawUrl(path)`.
 
 ## HTML side: `window.fused`
 
 | Call | Notes |
 |---|---|
-| `await fused.runPython(py, params, opts?)` | Runs `main(**params)`; path relative to the html. Rejects with Error carrying `.type/.message/.traceback/.stdout`. **Stale-cancel by default**, keyed per pyPath: new call aborts prior in-flight one, superseded promise never settles. `opts.key` regroups; `opts.key: null` = full concurrency; `opts.signal` = your AbortSignal. |
-| `fused.params.get/getAll/set/onChange` | Strings only — `set("n", 5)` THROWS, do `String(n)`. `set` uses replaceState then fires `onChange`. `_`-prefixed keys are the shell's: `set` throws, `get` returns undefined (`_file` readable exception). |
+| `await fused.runPython(py, params, opts?)` | Runs `main(**params)`; path relative to html. Rejects with Error carrying `.type/.message/.traceback/.stdout`. **Stale-cancel by default**, keyed per pyPath: new call aborts prior in-flight one, superseded promise never settles. `opts.key` regroups; `opts.key: null` = full concurrency; `opts.signal` = own AbortSignal. |
+| `fused.params.get/getAll/set/onChange` | Strings only — `set("n", 5)` THROWS, do `String(n)`. `set` = replaceState then `onChange`. `_`-prefixed keys are shell's: `set` throws, `get` undefined (`_file` readable exception). |
 | `await fused.readFile(path)` | UTF-8 text. |
-| `await fused.stat(path)` | `{path, name, is_dir, size, mtime, writable, remote, templates}` (+ `template_error`). Size-guard before big reads; capture `mtime` before edits; check `remote`. |
+| `await fused.stat(path)` | `{path, name, is_dir, size, mtime, writable, remote, templates}` (+ `template_error`). Size-guard big reads; grab `mtime` before edits; check `remote`. |
 | `await fused.writeFile(path, text, opts?)` | Atomic. `opts.expectedMtime` → rejects `.type==="conflict"` on stale disk; `opts.create` → rejects `.type==="exists"` (race-free create); readonly → `.type==="readonly"`. Resolves with fresh stat — keep its mtime. |
-| `fused.rawUrl(path)` | Sync URL for raw bytes — img/video/embed/download. Also resolves relative sibling assets (see pitfall below). |
+| `fused.rawUrl(path)` | Sync URL for raw bytes — img/video/embed/download. Also resolves relative sibling assets (pitfall below). |
 | `fused.ai.*` | → `fused-render-ai`. |
-| `fused.fileIndex.search/query` | Machine-wide file index — use instead of walking the fs → `fused-render-index`. |
+| `fused.fileIndex.search/query` | Machine-wide file index — use instead of walking fs → `fused-render-index`. |
 | `fused.capture.*` | Native screen/mic/screenshot → `fused-render-capture`. |
 | `fused.trackJob(spec)` | Report long work to download manager; never rejects → `fused-render-jobs`. |
 | `fused.daemon.*` | Folder's warm worker / resident daemon → `fused-render-background-apps`. |
 | `fused.env` | `"local"` vs `"hosted"` (exported). |
-| `fused.autoReload(false)` | Disable reload-on-file-change (in-page editors). |
+| `fused.autoReload(false)` | Kill reload-on-file-change (in-page editors). |
 
 - Uncaught `runPython` rejection → red traceback overlay (good default). Catch for custom UI.
 - Filesystem ONLY via these helpers — never fetch `/api/fs/*` yourself (writes rejected, unstable contract).
-- Page is served at `/render?path=...`, NOT its own dir: bare `<script src="./app.js">` 404s **silently** (no overlay, page inert). Use `fused.rawUrl("app.js")`. Blank view doing nothing → check console for 404 first.
-- Editing pattern (stat → readFile → writeFile with expectedMtime, handle conflict/readonly): see the built-in code editor template.
+- Page served at `/render?path=...`, NOT own dir: bare `<script src="./app.js">` 404s **silently** (no overlay, page inert). Use `fused.rawUrl("app.js")`. Blank dead view → check console for 404 first.
+- Editing pattern (stat → readFile → writeFile with expectedMtime, handle conflict/readonly): see built-in code editor template.
 
 ## Canonical wiring
 
-Params ARE the state. Controls write params; `onChange` is the single re-render path; `draw()` reads params (never the control), so refresh/bookmark reproduces the view. Values passed to `runPython` stay strings — annotations coerce. Worked example: `fused_render/templates/fusedapp/template.html`.
+Params ARE state. Controls write params; `onChange` = single re-render path; `draw()` reads params (never control) → refresh/bookmark reproduces view. Values to `runPython` stay strings — annotations coerce. Worked example: `fused_render/templates/fusedapp/template.html`.
 
 ## Preview mode (`_preview=1`)
 
-Shell renders pages nobody opened: /apps cards, listing peeks, hovers — stamped `_preview=1` (+`_nofocus=1`), many boot at once. Ungated boot = N cold starts on the home page.
+Shell renders pages nobody opened: /apps cards, listing peeks, hovers — stamped `_preview=1` (+`_nofocus=1`), many boot at once. Ungated boot = N cold starts on home page.
 
-- Read the flag AND climb parent frames (it's inherited; only an ancestor URL may carry it). Copy `isPreview()` from `fused_render/templates/fusedapp/template.html`.
-- Under preview: render cheap static placeholder. NO runPython, network, model loads, daemon starts, capture, writeFile, trackJob, timers, websockets, state mutation, dependency installs.
-- Forward `?_preview=1&_nofocus=1` to iframes you mount yourself.
-- A preview may SHOW a cached artifact, never compute one.
-- `_noopen=1` ≠ preview — it's a real interactive surface that just shouldn't count as an "open". Ignore it in `isPreview()`.
-- Runtime covers only `fused.daemon.*` rejection + URL writes; everything else is yours to gate.
+- Read flag AND climb parent frames (inherited; only ancestor URL may carry it). Copy `isPreview()` from `fused_render/templates/fusedapp/template.html`.
+- Under preview: cheap static placeholder. NO runPython, network, model loads, daemon starts, capture, writeFile, trackJob, timers, websockets, state mutation, dependency installs.
+- Forward `?_preview=1&_nofocus=1` to iframes you mount.
+- Param sync stops at each embed shell boundary — nested embeds keep params independent (tabs don't share state).
+- Preview may SHOW cached artifact, never compute one.
+- `_noopen=1` ≠ preview — real interactive surface, just not counted as "open". Ignore in `isPreview()`.
+- Runtime covers only `fused.daemon.*` rejection + URL writes; rest is yours to gate.
 
 ## Theming
 
-Iframe is a blank canvas, but the shell follows OS/pref light-dark. Quick answer: `data-fused-theme="shell"` on `<html>`, author two `:root` token blocks against `data-theme`. Full rules → `fused-render-theming`.
+Iframe = blank canvas; shell follows OS/pref light-dark. Quick answer: `data-fused-theme="shell"` on `<html>`, two `:root` token blocks against `data-theme`. Full rules → `fused-render-theming`.
 
 ## Preview templates
 
-Same html, opened FOR a target file: read-only `_file` param carries the path. Reader `.py` only when Python adds value; text → `readFile`, media → `rawUrl`. Built-ins: `fused_render/templates/<name>/` (see `xlsx/`). Extension → mode list: `fused_render/templates/registry.json`. User overrides → `fused-render-custom-templates`.
+Same html, opened FOR target file: read-only `_file` param carries path. Reader `.py` only when Python adds value; text → `readFile`, media → `rawUrl`. Built-ins: `fused_render/templates/<name>/` (see `xlsx/`). Extension → mode list: `fused_render/templates/registry.json`. User overrides → `fused-render-custom-templates`.
 
 ## Testing
 
-Open in a real browser against the running server (`fused-render --port 1777 --no-browser`):
+Real browser against running server (`fused-render --port 1777 --no-browser`):
 
 - `/explorer/embed/<abs path, leading slash dropped, segments URL-encoded>` — chrome-free. **Default for testing.**
 - `/explorer/view/<path>` — full shell chrome.
-- Templates: open the TARGET file's path; or template html directly with `?_file=<abs target>`.
+- Templates: open TARGET file's path; or template html directly with `?_file=<abs target>`.
 
 Loop: render → interact → URL updates → hard refresh → identical view.
 
-## Verifying: the call log
+## Verifying: call log
 
-You cannot execute the page's JS from a terminal. After the user opens it:
+Cannot run page JS from terminal. After user opens page:
 
 ```
 fused-render calls --page <abs html> --since 15m   # --failed, --json, --follow
 ```
 
-Read the digest. Zero records + visible placeholder = preview-gated, fine. Zero records + blank page = JS died pre-boot (look for `page error` = window.onerror). `error` = Python raised (traceback + params in record). Way more calls than interactions = onChange/set render loop. High `stale` = normal for slider drags only. Raw store: `~/.fused-render/logs/<app>/*.calls.jsonl`.
+Read digest. Zero records + visible placeholder = preview-gated, fine. Zero records + blank page = JS died pre-boot (look for `page error` = window.onerror). `error` = Python raised (traceback + params in record). Way more calls than interactions = onChange/set render loop. High `stale` = normal for slider drags only. Raw store: `~/.fused-render/logs/<app>/*.calls.jsonl`.
 
 ## Pitfalls
 
-- `params.set` with non-string → throws. `_`-prefixed page param → throws/collides.
-- Own `history.replaceState` → drops shell `_` keys, breaks the pane.
+- `params.set` non-string → throws. `_`-prefixed page param → throws/collides.
+- Own `history.replaceState` → drops shell `_` keys, breaks pane.
 - Ungated boot under `_preview` / not climbing ancestors / not forwarding to own iframes.
 - Non-JSON return, unannotated numeric param, expecting state across calls.
 - Plain `open(...,"w")` cache write; unversioned cache key; irreplaceable bytes in `cache/`.
-- Import outside bundled set with no `pyproject.toml`.
-- Slider + heavy import without ~150 ms debounce = subprocess per tick.
+- Import outside bundled set, no `pyproject.toml`.
+- Slider + heavy import, no ~150 ms debounce → subprocess per tick.
 - `writeFile` on existing file without `expectedMtime` = silent clobber; create-if-absent = `{create: true}`, not stat-then-write.
 - `readFile` for media → use `rawUrl`.
-- Walking the fs for counts/sizes → `fused.fileIndex.query` (`fused-render-index`).
-- `fused.ai` in an exportable page → exporter rejects textually; env guard doesn't help (`fused-render-ai`).
-- Claiming "done" without `fused-render calls` — blank-JS and failing-Python look identical without the log.
+- Walking fs for counts/sizes → `fused.fileIndex.query` (`fused-render-index`).
+- `fused.ai` in exportable page → exporter rejects textually; env guard no help (`fused-render-ai`).
+- Claiming "done" without `fused-render calls` — blank-JS and failing-Python look identical without log.

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -90,7 +90,21 @@ Params ARE state. Controls write params; `onChange` = single re-render path; `dr
 
 Shell renders pages nobody opened: /apps cards, listing peeks, hovers — stamped `_preview=1` (+`_nofocus=1`), many boot at once. Ungated boot = N cold starts on home page.
 
-- Read flag AND climb parent frames (inherited; only ancestor URL may carry it). Copy `isPreview()` from `fused_render/templates/fusedapp/template.html`.
+- Read flag AND climb parent frames — inherited, and only an ANCESTOR URL may carry it. Reading `location.search` alone answers `false` for a framed page and boots it. Copy this (the runtime's own `selfOrAncestorHasFlag`, `fused_render/static/runtime.js`):
+
+```js
+function isPreview() {
+  if (new URLSearchParams(location.search).get("_preview") === "1") return true;
+  try {
+    let w = window;
+    while (w.parent && w.parent !== w) {
+      w = w.parent;
+      if (new URLSearchParams(w.location.search).get("_preview") === "1") return true;
+    }
+  } catch (e) { /* cross-origin ancestor: the climb ends here */ }
+  return false;
+}
+```
 - Under preview: cheap static placeholder. NO runPython, network, model loads, daemon starts, capture, writeFile, trackJob, timers, websockets, state mutation, dependency installs.
 - Forward `?_preview=1&_nofocus=1` to iframes you mount.
 - Param sync stops at each embed shell boundary — nested embeds keep params independent (tabs don't share state).
@@ -138,5 +152,5 @@ Read digest. Zero records + visible placeholder = preview-gated, fine. Zero reco
 - `writeFile` on existing file without `expectedMtime` = silent clobber; create-if-absent = `{create: true}`, not stat-then-write.
 - `readFile` for media → use `rawUrl`.
 - Walking fs for counts/sizes → `fused.fileIndex.query` (`fused-render-index`).
-- `fused.ai` in exportable page → exporter rejects textually; env guard no help (`fused-render-ai`).
+- `fused.ai.text(` in a page meant for HOSTED export → exporter rejects textually, env guard no help. A `.fused` app file allows it (`fused-render-ai`).
 - Claiming "done" without `fused-render calls` — blank-JS and failing-Python look identical without log.

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -31,7 +31,7 @@ One plain fn `main(**params)`. Rules:
 
 ### Available Python libraries
 
-No `pyproject.toml` in folder → app interpreter: stdlib plus exactly this bundled set (authoritative: `[bundled]` extra in repo `pyproject.toml`). Prefer it — zero install.
+No `pyproject.toml` in folder → app interpreter: stdlib plus exactly this bundled set (authoritative: repo `pyproject.toml` — `[bundled]` extra, plus `pyarrow`/`duckdb`/`httpx` from core `[project]` deps). Prefer it — zero install.
 
 - **Data:** `numpy` `pandas` `pyarrow` `duckdb` `openpyxl` `msgpack`
 - **Images:** `pillow`
@@ -104,7 +104,7 @@ Iframe = blank canvas; shell follows OS/pref light-dark. Quick answer: `data-fus
 
 ## Preview templates
 
-Same html, opened FOR target file: read-only `_file` param carries path. Reader `.py` only when Python adds value; text → `readFile`, media → `rawUrl`. Built-ins: `fused_render/templates/<name>/` (see `xlsx/`). Extension → mode list: `fused_render/templates/registry.json`. User overrides → `fused-render-custom-templates`.
+Same html, opened FOR target file: read-only `_file` param carries path. Reader `.py` only when Python adds value; text → `readFile`, media → `rawUrl`. Built-in sources: `fused_render/templates/<name>/` (see `xlsx/`; server serves staged copy `~/.fused-render/.core-templates/`). Extension → mode list: `fused_render/templates/registry.json`. User overrides → `fused-render-custom-templates`.
 
 ## Testing
 

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -1,472 +1,141 @@
 ---
 name: fused-render-authoring
-description: Author .html views and .py data files for fused-render — the fused.runPython() bridge, URL-synced params, file IO, preview mode. Use when creating, editing or debugging a view, a data file or a preview template; when a view renders blank or shows a traceback overlay; or on any mention of fused.runPython/params/readFile/writeFile. Routes to the neighbouring fused-render-* skills for AI, capture, jobs, theming and the app icon.
+description: Use when creating, editing or debugging a fused-render .html view or .py data file — fused.runPython, params, readFile/writeFile, preview mode, blank views, traceback overlays.
 ---
 
 # Authoring fused-render views
 
-fused-render is a local file explorer that renders `.html` files live in the browser and lets them call local Python for data. A "view" is usually a **pair of sibling files**: an `.html` page (UI) and a `.py` file (data). The user opens the html in the explorer; the page fetches data through Python and stores its UI state in URL params so any view is refresh-proof and bookmarkable.
+A view = sibling pair: `.html` (UI) + `.py` (data). The explorer renders the html in an iframe, injects `window.fused` (never `<script src>` a runtime), and the page calls local Python via `fused.runPython`. UI state lives in URL params → refresh-proof, bookmarkable. Plain HTML/CSS/JS, no framework, no build step.
 
-## Mental model
-
-```
-.html file (rendered in an iframe)
-   │  window.fused  ← injected runtime, do NOT <script src> anything for it
-   │
-   ├─ fused.runPython("./data.py", {limit: "50"})   ← executes main() of the .py
-   │        └─ returns a Promise of main()'s JSON return value
-   │
-   ├─ fused.params            ← string key/values mirrored into the browser URL
-   │        └─ ?limit=50      ← refresh/bookmark restores exact view state
-   │
-   ├─ fused.readFile / writeFile / stat / rawUrl   ← direct file IO, no Python needed
-   │
-   ├─ fused.ai.text({prompt})  ← the claude CLI, or a local model; {text, ...result frame}
-   │
-   └─ fused.trackJob({...})         ← report long work to the shell's download manager
-```
-
-**Mark every app entry page with `<meta name="fused-app" />`**, near the top of `<head>` — detection reads only the first 4 KiB of the file. The marker is **the only thing that makes a folder a fused app**: filenames, `index.html` included, declare nothing. Without it the page never reaches the /apps hub, never resolves as a folder's entry, and is never registered when rendered. The starter template carries it; add it by hand to any entry page you author, and to any app you adopt from outside `~/Fused` (that one line is the whole migration — rendering the page then registers the folder automatically).
+## App markers (entry page `<head>`, first 4 KiB)
 
 ```html
-<head>
-<meta charset="utf-8" />
 <meta name="fused-app" />
-<meta name="fused-api-version" content="1" />
+<meta name="fused-api-version" content="N" />
 ```
 
-**Declare the fused API version beside it: `<meta name="fused-api-version" content="N" />`** — copy the value from the starter's `index.html`, which always carries the current one. It records which shape of the `fused` runtime the page was authored against. A page without the tag is version 0. When the API changes in a breaking way, the app page shows a **Migrate** button that opens a task on the entry page; that task invokes **`fused-render-api-migration`**, which reads the per-version notes (`docs/v{N}.md` beside that skill), updates the code and bumps the tag. Authoring a new page: use the current version. Adding a breaking change to the runtime: add a `docs/vN.md` to that skill and bump the starter's tag — the procedure is in its SKILL.md.
+- `fused-app` is the ONLY thing that makes a folder an app. No marker = never in /apps, never registered.
+- `fused-api-version`: copy N from `fused_render/app_starter/index.html`. Missing tag = version 0. Migration → `fused-render-api-migration`.
+- Optional `icon.svg` beside entry page = sidebar glyph + favicon → `fused-render-app-icon`.
 
-**Optional app icon: `icon.svg`.** An `icon.svg` next to the entry page becomes the app's sidebar glyph and tab favicon, rendered as is. Designing one (own background, both themes, 14–16 px legibility) → **`fused-render-app-icon`**.
+## Python side: `main()`
 
-Three primitives — `runPython`, `params`, and the file IO helpers — are the core API; the table below has the rest. Everything else is ordinary HTML/CSS/JS: no framework, no build step, ES2020 fine.
+One plain function `main(**params)`. Rules:
 
-Five neighbouring skills own the bigger surfaces, and this one keeps only enough to know when you need them: **`fused-render-ai`** (`fused.ai` and every model call), **`fused-render-capture`** (native screen/audio/screenshot), **`fused-render-jobs`** (work longer than one call, and the download manager), **`fused-render-theming`** (light/dark), **`fused-render-app-icon`** (the app's `icon.svg`).
-
-## The Python side: `main()` contract
-
-A data file exposes **one plain function named `main`**. No decorator, no import, no registration:
-
-```python
-def main(path: str = ".", limit: int = 50, min_size: float = 0.0):
-    import os
-    entries = []
-    for name in os.listdir(path):
-        full = os.path.join(path, name)
-        if os.path.isfile(full):
-            size = os.path.getsize(full)
-            if size >= min_size:
-                entries.append({"name": name, "size": size})
-    entries.sort(key=lambda e: -e["size"])
-    return {"entries": entries[:limit], "total": len(entries)}
-```
-
-Rules that matter (each has a reason):
-
-- **Type-annotate parameters.** Params arrive as strings (they live in URLs). Annotations drive coercion: `limit: int` receives `int("50")`; `bool` accepts `"true"/"1"/"yes"/"on"`. Unannotated args get the raw string — a classic source of `"50" < 10` bugs.
-- **Give every parameter a default** unless it is genuinely required; missing required args become an error shown to the page.
-- **Return JSON-native values only** (dict / list / str / int / float / bool / None). A DataFrame or bytes return is an error — convert first: `df.to_dict("records")`. Non-JSON scalars inside structures (datetime, Decimal, numpy types) also break serialization — stringify or cast them (`str(ts)`, `float(x)`).
-- **Relative paths in your code resolve next to the .py file** (the working directory is set there). `open("./data.csv")` next to your script just works.
-- **Each call is a fresh subprocess.** Edits to the .py apply on the next call — but so does full import cost (pandas ≈ 1 s per call). No state survives between calls; don't cache in globals.
-- **`print()` output goes to the browser console** (prefixed `[python]`) — use it freely for debugging; it cannot corrupt the result.
-- **Calls time out at 60 s** and errors return `{type, message, traceback}` to the page.
+- **Annotate params** — they arrive as URL strings; annotations coerce (`limit: int`, `bool` accepts "true/1/yes/on"). Unannotated = raw string.
+- **Default every param** unless truly required.
+- **Return JSON-native only** (dict/list/str/int/float/bool/None). DataFrame → `df.to_dict("records")`; datetime/Decimal/numpy → cast.
+- Relative paths resolve beside the `.py`.
+- **Fresh subprocess per call.** No globals survive. Import cost repaid every call (pandas ≈ 1 s). Killed at **60 s** (`DEFAULT_TIMEOUT`, `fused_render/executor.py`) — no override. Longer work → `fused-render-jobs`.
+- `print()` → browser console as `[python]`.
 
 ### Available Python libraries
 
-Write `main()` against **stdlib plus the bundled set** below — a folder with no `pyproject.toml` runs on the app's own interpreter, which ships exactly these with no download and no first-run wait. (Dev installs get the same via `pip install -e ".[bundled]"`; the authoritative list is that extra plus the core dependencies.)
+No `pyproject.toml` in folder → app interpreter: stdlib plus exactly this bundled set (authoritative: `[bundled]` extra in repo `pyproject.toml`). Prefer it — zero install.
 
 - **Data:** `numpy` `pandas` `pyarrow` `duckdb` `openpyxl` `msgpack`
 - **Images:** `pillow`
-- **Documents:** `python-pptx` `fpdf2` (its import name is *fpdf*)
+- **Documents:** `python-pptx` `fpdf2` (import name *fpdf*)
 - **Network & cloud:** `requests` `httpx` `botocore` `google-auth`
 - **Logs:** `drain3`
 
-Anything else — polars, matplotlib, scipy, geopandas, shapely, rasterio, rio-tiler, zarr, pymupdf, pikepdf, torch, sklearn, xarray, plotly — must be declared in a folder `pyproject.toml`, and costs the user a one-time install they sit and wait through. Prefer rewriting against the bundled set; declare dependencies (next section) only when it genuinely cannot do the job.
+Anything else needs a folder `pyproject.toml` (project root only; add `[tool.uv] package = false`). Facts:
 
-### Declaring extra dependencies: `pyproject.toml`
+- The dependency list is **complete** — bundled set is NOT unioned in. Import numpy → declare numpy.
+- All-or-nothing per folder; only the topmost `pyproject.toml` counts.
+- First render installs (loader, auto-retry). Non-PyPI sources / custom indexes → consent prompt. No-wheel deps stop with "install anyway". Commit `uv.lock`.
+- Never run `uv sync` by hand — it skips the readiness marker and consent (`fused_render/projectenv.py`).
+- `# /// script` headers are IGNORED. Delete them; move deps into `pyproject.toml`.
+- Version question? Probe the live env via `POST /api/run` with a throwaway `main()` returning `importlib.metadata.version(...)` — don't guess.
 
-A `.py`'s environment is decided by **the folder it belongs to**, never by anything written in the file. Put a `pyproject.toml` at the project root and every `.py` under it shares one venv:
+## App state: `.fused/`
 
-```toml
-[project]
-name = "my-view"
-version = "0.1.0"
-requires-python = ">=3.12"
-dependencies = ["xarray", "netCDF4"]
+Created automatically at app root. Convention, no helper API — build paths yourself off `os.path.dirname(os.path.abspath(__file__))`:
 
-# This folder is a set of scripts, not a distribution to build and install.
-[tool.uv]
-package = false
-```
+- `.fused/data/` — state the app owns, cannot rebuild. NOT beside index.html, NOT `~/.myapp`, NOT tmp.
+- `.fused/cache/` — rebuildable derived bytes. Deleting it must cost only time. No auto-sweep — cap it yourself.
+- `.fused/meta.json` — `{version, app_dir, created_at}`. `app_dir` ≠ actual path → folder was moved; distrust absolute paths stored in state.
+- Machine-local: gitignored, excluded from export. Nothing required-on-fresh-machine goes here.
 
-Four things to know before you write one:
+**Cache aggressively.** Fresh subprocess + 60 s kill means: memoize fetches/parses/aggregations to `.fused/cache/`. Key = hash of all inputs **with a version segment** (bump on shape change). Write atomically (`os.replace` a temp file — calls overlap). Treat unreadable entry as miss. Cache the expensive step, not `main()` wholesale. Bytes (PNG/parquet) → cache file, hand page `fused.rawUrl(path)`.
 
-- **The declaration is the COMPLETE list.** The venv contains exactly what you name — the bundled set is *not* unioned in. Declare numpy if you import numpy, even though the app ships it.
-- **It is all-or-nothing per folder.** One extra package means every import in every `.py` under that folder must be listed. That is why a folder with no manifest — which gets the whole bundled set free — is still the better default.
-- **Only the project root counts.** That's the app folder, a template folder, or the *topmost* ancestor holding a `pyproject.toml`. One in a subfolder is inert; the inspector flags it.
-- **First render triggers an install** — unless the render is a preview thumbnail, which never installs at all; see "Reserved params and preview mode" below. An all-PyPI manifest installs straight away with no prompt: the user sees a loader while `uv sync` runs, then the run is retried automatically. A dependency that will not arrive as a released version from the default index — a `[tool.uv.sources]` git/url/path pin, a PEP 508 direct URL, a workspace member, or a custom index (`[tool.uv]`/`uv.toml`, `find-links`) — raises a consent prompt naming those dependencies before anything installs. A dependency with no matching wheel stops rather than running its build backend, offering an explicit "install anyway" retry; one whose wheels exist only for another platform stops with that explained and no retry offered. Commit the `uv.lock` it writes — that's what makes the folder resolve identically elsewhere.
+## HTML side: `window.fused`
 
-Adding a dependency later is just an edit: save `pyproject.toml`, re-render, and the environment is reconciled. Never run `uv sync` by hand in the folder — a hand-run sync writes no readiness marker and no digest sidecar (`envinstall.READY_MARKER`, `.fused-source.json`; see `projectenv.state_digest`), so the app's own install flow can't tell it already ran; it also skips the consent prompt for a non-PyPI dependency, and runs a source build the app's own install would instead refuse by default (`--no-build`).
-
-**Per-file `# /// script` headers are not read.** A leftover block is an ordinary comment — silently ignored, not merged and not warned about. Never write one; if you see one, move its `dependencies` into the project root's `pyproject.toml` and delete it, because the packages it names are not being installed.
-
-Versions are not pinned — each install resolves its own. When a version matters, **probe the live environment** rather than guessing: `/api/run` executes in the exact interpreter that runs page code, so a throwaway `main()` returning `importlib.metadata.version(...)` for each name answers it. A `null` version means the package is missing from *this* environment — the same result an `import` would hit.
-
-```bash
-curl -s -X POST http://127.0.0.1:1777/api/run -H 'X-Fused: 1' \
-  -H 'Content-Type: application/json' \
-  -d '{"py": "/tmp/probe.py", "params": {"names": "pandas,duckdb,geopandas"}}'
-```
-
-## Where an app keeps state: the `.fused/` folder
-
-An app folder is authored content — the entry page, its `.py` files, assets. Anything the app *accumulates while running* goes in one hidden folder at the app's root, created for you the first time the app is opened (you never `makedirs` it, and apps written before this convention have one too):
-
-```
-<app>/.fused/
-  data/       state the app owns and cannot rebuild
-  cache/      derived bytes the app can rebuild — deletable at any time
-  meta.json   {"version": 1, "app_dir": "<absolute path>", "created_at": "<iso>"}
-```
-
-There is no `fused.dataDir` and no Python helper: the paths are a **convention**, so you build them yourself.
-
-```python
-import os
-
-APP = os.path.dirname(os.path.abspath(__file__))   # a .py at the app root
-DATA = os.path.join(APP, ".fused", "data")
-CACHE = os.path.join(APP, ".fused", "cache")
-```
-
-(A `.py` in a subfolder walks up to the folder containing `.fused` — or, more simply, doesn't: keep the two or three lines above in one module at the app root and import it.) From the page side there is no direct access; go through a `.py`.
-
-**Persistent state goes in `data/`.** Not a JSON file beside `index.html` — that is authored content and it lands in the app's git history. Not `~/.myapp`, not the system temp dir. A saved list, user settings, an accumulated log, a small SQLite/DuckDB file: `data/`.
-
-**The split is a promise, not a naming preference.** Everything under `cache/` must be reconstructible from `data/` plus the outside world, so that deleting `cache/` outright costs the user nothing but time. If deleting it would lose something, it is data. Nothing sweeps `cache/` automatically — an unbounded cache needs your own cap or TTL.
-
-**`meta.json` records where the app was set up, and nothing ever rewrites it.** So when its `app_dir` disagrees with where the app actually is, the folder was moved or copied since its state was created — the moment to distrust anything keyed by an absolute path. Read it and decide; there is no automatic repair.
-
-```python
-import json, os
-meta = json.load(open(os.path.join(APP, ".fused", "meta.json")))
-if os.path.abspath(meta["app_dir"]) != APP:
-    ...  # moved or copied: repoint stored paths, or drop the cache
-```
-
-`.fused/` is **machine-local**: gitignored, and excluded from a `.fused` app-file export. Never put something there that the app needs in order to work on a fresh machine — that belongs in the folder proper.
-
-### Cache heavy work — more than feels necessary
-
-Every `runPython` call is a fresh subprocess. No globals survive, no import cost is amortised, and the 60 s kill is waiting for anything that recomputes what it already computed. Caching to `.fused/cache/` is the single highest-leverage thing a data-heavy page does, and the bar for "worth caching" is far lower than it looks: a network fetch, a parsed multi-MB file, an aggregation over a large table, a rendered tile, a model response, a geocode.
-
-Key by a hash of everything the result depends on, and treat a corrupt or unreadable entry as a miss:
-
-```python
-import hashlib, json, os
-
-def cached(key: str, compute):
-    """Return compute()'s JSON result, memoised on disk under .fused/cache/."""
-    name = hashlib.sha256(key.encode()).hexdigest()[:32] + ".json"
-    path = os.path.join(CACHE, name)
-    try:
-        with open(path, encoding="utf-8") as f:
-            return json.load(f)
-    except (OSError, ValueError):
-        pass                       # absent, unreadable or truncated: recompute
-    value = compute()
-    tmp = path + f".{os.getpid()}.tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(value, f)
-    os.replace(tmp, path)          # atomic: a concurrent reader never sees half
-    return value
-
-
-def main(city: str = "Berlin", days: int = 7):
-    return cached(f"forecast/v1/{city}/{days}",
-                  lambda: fetch_forecast(city, days))
-```
-
-Three things that decide whether a cache helps or hurts:
-
-- **Version the key.** `forecast/v1/…` above — bump the `v` when the shape of what you store changes, so an old entry becomes a miss instead of feeding the page a value it can no longer read. Never rely on deleting the folder by hand.
-- **Write atomically** (`os.replace`, as above). Calls overlap: a slider drag can have two subprocesses writing the same key, and a half-written file read by the next call is a `ValueError` at best and wrong data at worst.
-- **Cache the expensive part, not the request.** Memoising `main()` wholesale defeats the URL-param wiring the page depends on; memoise the fetch, the parse, the aggregation.
-
-For bytes rather than JSON — a rendered PNG, a Parquet extract — the same shape applies: hashed filename under `cache/`, `os.replace` into place, and hand the page a `fused.rawUrl()` of the cached file instead of loading it through Python.
-
-## The HTML side: `window.fused` API
-
-The runtime is injected automatically when the explorer renders the page. Never add a script tag for it; just use the global.
-
-| Call | Behavior |
+| Call | Notes |
 |---|---|
-| `await fused.runPython(pyPath, params, opts?)` | Runs `main(**params)` of the file at `pyPath` — relative to **this html file's directory**, or absolute. Resolves with the return value; rejects with an `Error` carrying `.type`, `.message`, `.traceback`, `.stdout`. **Stale-request cancellation is on by default**, keyed by `pyPath`: a new call for a file aborts the prior in-flight call for that same file, and the superseded promise **never settles** (its `.then`/`await` just stops, so nothing stale is drawn) — a slider drag therefore computes only the value it lands on, for free. Calls to *different* files are independent. `opts.key` regroups the channel, `opts.key: null` opts out into full concurrency (polling loops, per-tile fetches, a write that must finish), and `opts.signal` takes your own `AbortSignal` to cancel on something other than the next call. |
-| `fused.params.get(k)` | Current value from the URL, as a **string** (or `undefined`). `_`-prefixed keys return `undefined`; `_file` is the one exception — read-only, the target file a preview template was opened for. |
-| `fused.params.getAll()` | All non-reserved params as an object, plus `_file` when present. |
-| `fused.params.set(k, v)` | Writes to the URL (replaceState — no history spam), then fires `onChange`. **Throws** on a reserved `_` key, and unless `v` is a string — do `String(n)` yourself. |
-| `fused.params.onChange(cb)` | `cb(allParams)` after every applied `set`. Returns an unsubscribe function. |
-| `await fused.readFile(path)` | File contents as **text** (UTF-8). Rejects with an `Error` on failure. Use when a view just needs the bytes as a string — no reader `.py` required. |
-| `await fused.stat(path)` | `{path, name, is_dir, size, mtime, writable, remote, templates}`. Use it for a size guard before reading something big, to capture `mtime` before editing, to check `writable` before offering an edit UI, and to notice `remote` (a mounted remote bucket — keep reads bounded there). May also carry `template_error` (a bad registry name). |
-| `await fused.writeFile(path, content, opts?)` | Writes UTF-8 text **atomically** (never a half-written file). `opts.expectedMtime` arms an optimistic lock: a file changed on disk since that mtime rejects with `.type === "conflict"` (and `.mtime` = the current value) instead of clobbering. `opts.create` writes only if the path is absent — an existing path rejects with `.type === "exists"` and nothing is written, which is how you create a file without a stat-then-write race. A read-only file rejects with `.type === "readonly"`. Resolves with a fresh stat; keep its `.mtime` to re-arm the lock. |
-| `fused.rawUrl(path)` | **Sync**, returns a URL serving the file's raw bytes — for `<img src>`, `<video src>`, `<embed>`, download links. |
-| `await fused.ai.text({prompt, ...opts})` | Ask an AI model; resolves with `text` plus the result frame every `fused.ai` verb shares (`provider, finishReason, warnings, usage, response, providerMetadata`). Every verb takes `abortSignal`. Local-only. See **"AI calls"** below. |
-| `await fused.fileIndex.search({root, q, limit})` / `.query({sql, limit})` | Read the machine-wide **file index** — one folder's corpus, or one read-only SQL statement over the `files`/`dirs` views (totals, per-extension breakdowns, path matches). Both resolve with `ready: {indexed, scanning, stale, reason}`, so an empty result is never mistaken for "no matches" when the truth is "no index yet". Use this instead of walking the filesystem in Python. Details, and the Python direct-parquet reader for bulk reads: **`fused-render-index`**. |
-| `await fused.capture.screen(opts)` / `.audio(opts)` / `.screenshot(opts)` / `.sources()` | Record the screen, record the microphone, grab a still — **natively**, so the result is a FILE on this machine, not a `MediaRecorder` blob. See **`fused-render-capture`**. |
-| `fused.trackJob(spec)` | Report a long-running operation to the shell's **download manager**, so it stays visible after the user browses away. Returns a handle; see **`fused-render-jobs`**. Never throws, never rejects. |
-| `fused.env` | `"local"` (this server) vs `"hosted"` (the exported runtime). Branch on it only if a view must behave differently when exported. |
-| `fused.autoReload(enabled)` | Toggle reload-on-file-change for this page. Pass `false` from an in-page editor that manages its own saves and shouldn't reload under the user. |
+| `await fused.runPython(py, params, opts?)` | Runs `main(**params)`; path relative to the html. Rejects with Error carrying `.type/.message/.traceback/.stdout`. **Stale-cancel by default**, keyed per pyPath: new call aborts prior in-flight one, superseded promise never settles. `opts.key` regroups; `opts.key: null` = full concurrency; `opts.signal` = your AbortSignal. |
+| `fused.params.get/getAll/set/onChange` | Strings only — `set("n", 5)` THROWS, do `String(n)`. `set` uses replaceState then fires `onChange`. `_`-prefixed keys are the shell's: `set` throws, `get` returns undefined (`_file` readable exception). |
+| `await fused.readFile(path)` | UTF-8 text. |
+| `await fused.stat(path)` | `{path, name, is_dir, size, mtime, writable, remote, templates}` (+ `template_error`). Size-guard before big reads; capture `mtime` before edits; check `remote`. |
+| `await fused.writeFile(path, text, opts?)` | Atomic. `opts.expectedMtime` → rejects `.type==="conflict"` on stale disk; `opts.create` → rejects `.type==="exists"` (race-free create); readonly → `.type==="readonly"`. Resolves with fresh stat — keep its mtime. |
+| `fused.rawUrl(path)` | Sync URL for raw bytes — img/video/embed/download. Also resolves relative sibling assets (see pitfall below). |
+| `fused.ai.*` | → `fused-render-ai`. |
+| `fused.fileIndex.search/query` | Machine-wide file index — use instead of walking the fs → `fused-render-index`. |
+| `fused.capture.*` | Native screen/mic/screenshot → `fused-render-capture`. |
+| `fused.trackJob(spec)` | Report long work to download manager; never rejects → `fused-render-jobs`. |
+| `fused.daemon.*` | Folder's warm worker / resident daemon → `fused-render-background-apps`. |
+| `fused.env` | `"local"` vs `"hosted"` (exported). |
+| `fused.autoReload(false)` | Disable reload-on-file-change (in-page editors). |
 
-Notes:
-- **`_`-prefixed param names are the shell's**, and `_preview` is the one a page should read — only ever to do *less* work. See **"Reserved params and preview mode"**.
-- Params are **strings only, always**. Parse numbers yourself (`parseInt(fused.params.get("limit") || "50", 10)`), JSON-encode structure yourself if you need it.
-- Uncaught `runPython` rejections auto-show a red traceback overlay — a good debugging default; catch the rejection yourself when you want custom error UI.
-- **A `<script src>` that 404s (broken relative path, missing file) does not trigger the traceback overlay** — the page just stays inert. If a view silently does nothing, check the browser console for a plain 404 before assuming Python failed.
-- **Reach the filesystem only through these helpers**, never by fetching `/api/fs/*` yourself — the helpers are the stable contract and carry required headers (writes are rejected without them).
-- `readFile`/`rawUrl` split: text you'll process → `readFile`; anything the browser should load itself (images, media, PDFs, download links) → `rawUrl`.
-- **A multi-file app's own sibling assets need the same treatment as data files.** The page is served at `/render?path=<abs path>`, not at its own directory — a bare `<script src="./app.js">` or `<link href="./style.css">` resolves against `/render` and 404s silently (the script just never runs; no overlay, no console error). Point it at `fused.rawUrl("app.js")` instead — `rawUrl` resolves a relative path against the page's own `?path=` for you.
+- Uncaught `runPython` rejection → red traceback overlay (good default). Catch for custom UI.
+- Filesystem ONLY via these helpers — never fetch `/api/fs/*` yourself (writes rejected, unstable contract).
+- Page is served at `/render?path=...`, NOT its own dir: bare `<script src="./app.js">` 404s **silently** (no overlay, page inert). Use `fused.rawUrl("app.js")`. Blank view doing nothing → check console for 404 first.
+- Editing pattern (stat → readFile → writeFile with expectedMtime, handle conflict/readonly): see the built-in code editor template.
 
-The editing pattern (used by the built-in code editor template):
+## Canonical wiring
 
-```js
-const st = await fused.stat(file);       // 1. arm the lock
-let mtime = st.mtime;
-const text = await fused.readFile(file); // 2. load
-// … user edits `doc` …
-try {
-  const fresh = await fused.writeFile(file, doc, { expectedMtime: mtime });
-  mtime = fresh.mtime;                   // 3. re-arm for the next save
-} catch (err) {
-  if (err.type === "conflict") { /* offer reload vs overwrite (writeFile without expectedMtime) */ }
-  else if (err.type === "readonly") { /* file isn't writable — disable the save UI */ }
-  else throw err;
-}
-```
+Params ARE the state. Controls write params; `onChange` is the single re-render path; `draw()` reads params (never the control), so refresh/bookmark reproduces the view. Values passed to `runPython` stay strings — annotations coerce. Worked example: `fused_render/templates/fusedapp/template.html`.
 
-## AI calls (`fused.ai`)
+## Preview mode (`_preview=1`)
 
-`fused.ai` is a namespace of verbs (`.text`, `.image`, `.video`, `.transcribe`, `.embed`, `.models`, `.cancel`), not a function. `await fused.ai.text({prompt, ...opts})` — one options object, `prompt` a field like `.image({prompt})` — resolves with `text` plus **the result frame every verb shares**: `{provider, finishReason, warnings, usage, response: {id, modelId, timestamp}, providerMetadata}`. The server normalizes, so no guarding is needed. `response.modelId` is the full id that actually ran (no top-level `model`); `usage` is `null` or `{inputTokens, outputTokens, totalTokens}`; `provider` is the tier that answered. Two tiers, fixed order: `opts.provider: "local" | "claude"` pins one; omitted, the model id picks — an id containing a `/` or ending in `.gguf` runs on **this machine**, anything else goes to the **`claude` (Claude Code) CLI** on the user's own login. Common options are `provider`, `systemPrompt`, `model`, `effort` and `onChunk`.
+Shell renders pages nobody opened: /apps cards, listing peeks, hovers — stamped `_preview=1` (+`_nofocus=1`), many boot at once. Ungated boot = N cold starts on the home page.
 
-Three things decide whether a page using it behaves:
+- Read the flag AND climb parent frames (it's inherited; only an ancestor URL may carry it). Copy `isPreview()` from `fused_render/templates/fusedapp/template.html`.
+- Under preview: render cheap static placeholder. NO runPython, network, model loads, daemon starts, capture, writeFile, trackJob, timers, websockets, state mutation, dependency installs.
+- Forward `?_preview=1&_nofocus=1` to iframes you mount yourself.
+- A preview may SHOW a cached artifact, never compute one.
+- `_noopen=1` ≠ preview — it's a real interactive surface that just shouldn't count as an "open". Ignore it in `isPreview()`.
+- Runtime covers only `fused.daemon.*` rejection + URL writes; everything else is yours to gate.
 
-- **It is local-only, and the exporter enforces that textually.** Any page containing the string `fused.ai.text(` is rejected for export (SPEC RH-11) — an `if (fused.env === "local")` guard does not help. Keep AI out of a view that must export.
-- **Feed it aggregates, not the dataset.** Compute in Python, reduce to a compact summary, and hand the model that. A full table blows the token budget and drowns the signal.
-- **There is no stale-cancel channel.** Calls run fully concurrent, so a double-click fires two paid calls — disable the button while one is in flight.
+## Theming
 
-Rejections carry `.type`: `model_loading` (a local model is loading — `err.jobId` is the download it just started, not a failure), `ai_unavailable` (show a friendly state, not a raw overlay), `bad_request`, `ai_error`, `timeout`.
+Iframe is a blank canvas, but the shell follows OS/pref light-dark. Quick answer: `data-fused-theme="shell"` on `<html>`, author two `:root` token blocks against `data-theme`. Full rules → `fused-render-theming`.
 
-Everything else — the result frame, per-verb option lists, recipes for `.image()`, `.video()`, `.transcribe()`, `.embed()`, the `fused.ai.models.*` picker, calling AI from Python, and diagnosing a failing call → **`fused-render-ai`**.
+## Preview templates
 
-## The canonical wiring pattern
+Same html, opened FOR a target file: read-only `_file` param carries the path. Reader `.py` only when Python adds value; text → `readFile`, media → `rawUrl`. Built-ins: `fused_render/templates/<name>/` (see `xlsx/`). Extension → mode list: `fused_render/templates/registry.json`. User overrides → `fused-render-custom-templates`.
 
-Every interactive view is the same loop: **params are the state; controls write params; `onChange` re-renders.** Never store view state only in JS variables — put it in params, so refresh and bookmarks reproduce the view.
+## Testing
 
-```html
-<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"><title>Largest files</title></head>
-<body>
-  <label>limit <input id="limit" type="range" min="5" max="100"></label>
-  <div id="out">Loading…</div>
-  <script>
-    const limitEl = document.getElementById("limit");
-    const out = document.getElementById("out");
+Open in a real browser against the running server (`fused-render --port 1777 --no-browser`):
 
-    async function draw() {
-      const limit = fused.params.get("limit") || "20";   // URL wins; default only when absent
-      limitEl.value = limit;                              // reflect state INTO controls
-      out.textContent = "Loading…";
-      try {
-        // Dragging the slider supersedes stale in-flight runs by default (keyed
-        // by pyPath) — only the value the slider lands on is computed and drawn.
-        const data = await fused.runPython("./largest.py", { limit });
-        out.innerHTML = renderTable(data.entries);        // author's own rendering
-      } catch (err) {
-        out.textContent = `${err.type}: ${err.message}`;  // or rethrow for the overlay
-      }
-    }
+- `/explorer/embed/<abs path, leading slash dropped, segments URL-encoded>` — chrome-free. **Default for testing.**
+- `/explorer/view/<path>` — full shell chrome.
+- Templates: open the TARGET file's path; or template html directly with `?_file=<abs target>`.
 
-    limitEl.addEventListener("input", () => fused.params.set("limit", limitEl.value));
-    fused.params.onChange(draw);   // set() above triggers this
-    draw();                        // initial render reads URL state
-  </script>
-</body>
-</html>
-```
+Loop: render → interact → URL updates → hard refresh → identical view.
 
-Why this shape:
-- `draw()` reads **params, not the control**, so a bookmarked/refreshed URL renders identically before any interaction.
-- The control writes the param and nothing else; `onChange` is the single re-render path — no double-render logic, no drift between URL and UI.
-- Values passed to `runPython` can stay strings; annotations on `main` coerce them.
+## Verifying: the call log
 
-## Reserved params and preview mode
-
-### The `_` namespace is the shell's
-
-**Every query key starting with `_` belongs to the shell, not to your page.** The runtime enforces it: `set()` throws, `get()` returns `undefined`, `getAll()` filters them out — `_file` being the single readable exception. So:
-
-- **Name page params plainly** (`limit`, `sort`, `offset`, `theme`). The shell's set — `_file`, `_mode`, `_preview`, `_noopen`, `_nofocus`, `_layout`, `_side`, `_panel`, `_tab`, `_listing`, `_render`, `_rev` — grows without notice, and squatting on one means the shell overwrites your state or you overwrite the shell's.
-- **Read `_` params only through `fused.params`.** Reaching around it with `new URLSearchParams(location.search)` reads a value whose meaning is the shell's and can change under you. `_preview` is the one exception, below.
-- **Write the URL only through `fused.params.set`.** A `history.replaceState` built from your own params drops the shell's `_` keys and breaks the pane or tab the page is mounted in.
-
-### `_preview=1`: this render is a picture of the page, not a use of it
-
-The shell renders pages nobody asked to *open*: `/apps` cards, listing-pane peeks, hover previews. Those frames are stamped `_preview=1` (usually with `_nofocus=1`), they mount and unmount as the pointer moves, and **many boot at once on a home or listing page** for apps the user has not opened and may never open. A page that boots identically in a preview turns that listing into N simultaneous cold starts — the most common way an app folder makes the home page unusable.
-
-**Read the flag at boot and return early**, rendering something cheap and static — a title, a cached thumbnail, an inert placeholder. Under preview, start none of: `runPython` calls that import something heavy, scan a directory or hit the network; model loads and downloads; daemon starts; `fused.capture.*`, `writeFile`, `trackJob`; polling loops, `setInterval`, websockets, EventSource; anything that records an "open", mutates state, or unpacks on first use; the dependency install a run against a not-yet-installed environment would otherwise trigger — a previewed page fails to run instead.
-
-Read it by climbing, because the flag is **inherited** — your page may be framed by a template that was the one stamped, and only the ancestor's URL carries it (this mirrors the runtime's own `selfOrAncestorHasFlag`). This is safe only because the shell stamps `_preview` exclusively on non-interactive frames — a companion pane the user types into carries `_noopen=1` instead, precisely so a climbing `isPreview()` does not see it.
-
-```js
-function isPreview() {
-  const has = (s) => {
-    try { return new URLSearchParams(String(s).replace(/^\?/, "")).get("_preview") === "1"; }
-    catch (e) { return false; }
-  };
-  if (has(location.search)) return true;
-  try {
-    let w = window;
-    while (w.parent && w.parent !== w) {
-      w = w.parent;
-      if (has(w.location.search)) return true;
-    }
-  } catch (e) { /* cross-origin ancestor: the climb ends here */ }
-  return false;
-}
-
-const PREVIEW = isPreview();
-
-async function boot() {
-  if (PREVIEW) return renderPlaceholder();   // synchronous, no Python, no network
-  await loadEverything();                    // the real thing, only on a real open
-}
-boot();
-```
-
-- **`_noopen=1` is not `_preview=1`.** A surface can be a real, interactive use of the page that simply shouldn't count as an "open" for recording purposes (the explorer's chat/git/mcp companion pane is one) — it carries `_noopen=1`, never `_preview`. Only `_preview` means "treat this as a picture, skip real work"; `_noopen` says nothing about gating and `isPreview()` should ignore it.
-
-Two more rules:
-
-- **Forward the stamps to frames you mount yourself**: `frame.src = url + "?_preview=1&_nofocus=1"` when `PREVIEW`. Otherwise the inner page reads a clean URL and does the work you just skipped.
-- **A preview that *can* show real content shows a cached one, never computes one.** Ask for the already-extracted artifact and fall back to the placeholder when it is absent; never let a peek be the thing that populates the cache.
-
-The runtime covers two of these for you — `fused.daemon.*` rejects in a preview frame, and a preview never writes the shell's URL. **Everything else — your Python calls, AI calls, timers, fetches — runs exactly as it would in a real open unless you gate it.** `fused_render/templates/fusedapp/template.html` is the worked example.
-
-## Style and theming
-
-There is no imposed CSS — the iframe is a blank canvas, and nothing is written into your document by default. But the explorer around it follows the OS light/dark preference with a Light/Dark override in Preferences, so a hardcoded palette will sooner or later sit inside the opposite one. The quickest correct answer is `data-fused-theme="shell"` on your `<html>`: the runtime then writes `data-theme="light"`/`"dark"` on that element before your stylesheet is parsed and keeps it in step, so you author two `:root` token blocks and nothing else.
-
-The four strategies, when each is right, and the two rules that make a second palette work (every colour from a token; colours handed to canvas/charts/maplibre must be re-read on change) → **`fused-render-theming`**.
-
-## Preview templates (views for a file format)
-
-A template is the same kind of html file, but the explorer opens it *for* a target file and hands the path over as the read-only `_file` param:
-
-```js
-const file = fused.params.get("_file");
-if (!file) { /* show "no file selected" state */ }
-const page = await fused.runPython("./my_reader.py", { file, offset: fused.params.get("offset") || "0" });
-```
-
-A reader `.py` is only needed when Python adds value (parsing parquet/xlsx, paging, aggregation). Text formats can skip it entirely — `fused.stat` for a size guard, then `fused.readFile(file)` and render in JS (the markdown/JSON/code templates work this way); media formats just point a tag at `fused.rawUrl(file)`.
-
-Ship the reader `.py` next to the template html and call it with a relative path. Paging/sort/filter state goes in normal params (`offset`, `sort` …) exactly like any view. Built-in templates live one folder per template under `fused_render/templates/<name>/` — see `templates/xlsx/template.html` + `templates/xlsx/reader.py` — and each extension maps to an **ordered list of mode names** (first = default) in `fused_render/templates/registry.json`. **User-owned** templates that override, reorder or extend that list live under `~/.fused-render/`; the registry grammar and registration are covered by **`fused-render-custom-templates`** (this skill still owns how the html/py themselves are written).
-
-## Testing in the browser: URL paths & modes
-
-Verify a view by opening it in a real browser against the running server — do not rely on reading the files alone. Start the server (`fused-render --port 1777 --no-browser` keeps it from stealing focus) and open one of these on `http://127.0.0.1:<port>`:
-
-| Path | What it renders | Use it to |
-|---|---|---|
-| `/` | Redirects to `/apps` (the app hub); `/explorer` is the file-explorer homepage. | Browse to a file by clicking. |
-| `/explorer/embed/<abs-path-without-leading-slash>` | **Embed mode**: the page chrome-free (no sidebar/breadcrumb/header). | **The default way to open and test a view** — you see just the view itself. |
-| `/explorer/view/<abs-path-without-leading-slash>` | **Full-shell mode**: the same page inside the explorer shell, your page in an iframe. | Check how the view sits inside the chrome, or when browsing. |
-
-**Default to embed.** When you open a link to test a view or show it to the user, use `/explorer/embed/` — it renders the view alone, which is what you're iterating on. Reach for `/explorer/view/` only to inspect the surrounding chrome or when the user is browsing.
-
-Path encoding: the fs path rides in the URL after the prefix with its **leading slash dropped** and each segment URL-encoded. `/Users/me/proj/dash.html` → `http://127.0.0.1:1777/explorer/embed/Users/me/proj/dash.html`. A space becomes `%20`, etc.
-
-**View vs embed** is a fixed page-load mode (the prefix picks it; it cannot toggle without a full navigation). Both serve the same shell and route identically — embed just hides chrome. Params sync the same way in both; in nested embeds, param sync stops at each embed shell boundary so a tab's params stay tab-independent.
-
-**Preview templates** open at the *target file's* path (`/explorer/embed/<abs path to the data file>`) — the shell resolves the template by extension and hands it the file. To test a template's html directly, open it and pass the target yourself: `/explorer/embed/<abs path to template>.html?_file=<abs target path>`.
-
-Sanity loop: page renders → interact with a control → URL query updates → hard refresh → identical view. Python errors appear as the red overlay (with full traceback) and `print()` output in the browser console (prefixed `[python]`).
-
-## Verifying your work: the call log
-
-The overlay and the browser console only exist while someone is looking at the
-page. Every API call a page makes is also **recorded** — so after the page has
-been opened you can check what actually happened, from a terminal, without a
-browser:
+You cannot execute the page's JS from a terminal. After the user opens it:
 
 ```
-fused-render calls --page /abs/path/to/page.html --since 15m
-fused-render calls --failed --since 1h        # only what broke
-fused-render calls --json                     # digest as JSON
-fused-render calls --follow --page <page>      # block until the next calls land
+fused-render calls --page <abs html> --since 15m   # --failed, --json, --follow
 ```
 
-Read the digest, not the raw records — it is a per-target rollup (count, p50,
-p95, errors) plus any failures in full, with each failure's traceback and the
-exact params that produced it.
+Read the digest. Zero records + visible placeholder = preview-gated, fine. Zero records + blank page = JS died pre-boot (look for `page error` = window.onerror). `error` = Python raised (traceback + params in record). Way more calls than interactions = onChange/set render loop. High `stale` = normal for slider drags only. Raw store: `~/.fused-render/logs/<app>/*.calls.jsonl`.
 
-**You cannot render the page yourself** — nothing executes its JavaScript from
-a terminal. So the loop is: write the files → test the `.py` directly if you
-want (`fused.runPython`'s target is just a `main()`) → ask the user to open the
-page → read the log. `--follow` makes that one round trip instead of two.
+## Pitfalls
 
-What the record count tells you, before you read anything else:
-
-| What you see | What it means |
-|---|---|
-| calls, all `ok` | It works. Report the timings. |
-| zero records, but the page renders a visible placeholder | Correctly gated under `_preview` — expected, not a bug. |
-| zero records, and the page never rendered anything (blank/frozen) | JS failed before boot. Look for `page error` in the output: that is `window.onerror`, with the message and line number. |
-| one `error` | Python raised. The traceback and params are in the record. |
-| far more calls than interactions | A render loop — usually an `onChange` handler that calls `params.set` without a guard, so each write re-triggers itself. |
-| a high `stale` count | The page is issuing calls it throws away (superseded by the next one). Normal for a slider drag; suspicious otherwise. |
-
-The same data is in the **Calls** view mode on any page that has records
-(charts + the per-target table), and the raw store is JSONL under
-`~/.fused-render/logs/<app>/` (one directory per app; whole-store queries glob `logs/*/*.calls.jsonl`) if you want to `jq` it. Parameters are recorded by
-default, so treat the log as containing whatever your page passes around.
-
-## Native capture (`fused.capture`)
-
-`fused.capture.screen()`, `.audio()` and `.screenshot()` record or grab **natively**, so the result is a file this machine owns — the path is known before a recording ends (it feeds `fused.ai.transcribe({path})` directly) and the recording survives your page being navigated away from. Call `fused.capture.sources()` first and draw your UI off the answer: it never prompts, and what is available differs per platform.
-
-The per-platform matrix, the recording handle, and the rejection types → **`fused-render-capture`**.
-
-## Long-running work and the 60 s timeout
-
-Every `fused.runPython` call runs `main()` in a fresh subprocess the server **kills at 60 s** (`DEFAULT_TIMEOUT` in `fused_render/executor.py`), and there is no per-call override — an uncaught timeout becomes the red overlay. Design around it: precompute and cache to disk (**`.fused/cache/`** — see "Where an app keeps state"), chunk behind an `offset` param, move a genuinely long build out of band into a separate process, and cut per-call import cost.
-
-Work that outlives one call needs to be *visible* once the user browses away, because the shell replaces your page's frame: report it to the download manager with `fused.trackJob`, from the detached worker as well as from the page. The strategies, the job API, and the worker-side reporter → **`fused-render-jobs`**.
-
-Nothing here holds state indefinitely — `/api/run` never persists it. A folder that wants warm state opts into `[tool.fused-render.app]`: `main = "x.py"` gets a warm worker that's still reaped after `idle_timeout_s` (default 900s / 15 min), `daemon = "x.py"` gets its own resident daemon. See **`fused-render-background-apps`**.
-
-## Pitfalls checklist
-
-- `fused.params.set("n", 5)` → **throws** (number). Use `String(5)`.
-- Reading `input.value` inside `draw()` instead of `fused.params.get()` → refresh loses state.
-- Naming a page param with a leading underscore → `set()` throws, and routing around it collides with a shell param.
-- Building the URL query yourself (`history.replaceState`) → drops the shell's `_layout`/`_side`/`_file` and breaks the pane. Use `fused.params.set`.
-- Booting the full app under `_preview=1` → every card on a listing cold-starts at once for apps nobody opened. Gate boot on the flag.
-- Reading `_preview` off `location.search` alone → misses the inherited case where an outer frame carries the stamp. Climb the ancestors.
-- Mounting your own iframe in a preview without forwarding `?_preview=1&_nofocus=1` → the inner page does all the work you just skipped.
-- `main` returning a DataFrame / datetime / Decimal / numpy value → serialization error; convert to JSON-native first.
-- Missing annotation on a numeric param → `main` receives `"50"` and comparisons silently misbehave.
-- Expecting module state to persist between `runPython` calls → each call is a fresh process. On-disk memoisation under `.fused/cache/` is the replacement.
-- Writing app state next to `index.html`, into `~/.myapp`, or into the system temp dir → it belongs in `.fused/data/` (git history, portability, and a temp dir that vanishes are three separate bugs).
-- Putting something in `.fused/cache/` that cannot be rebuilt → a cache sweep destroys it. If losing it hurts, it is `data/`.
-- Writing a cache entry with a plain `open(...,"w")` → overlapping calls leave a half-written file the next call reads back. `os.replace` a temp file into place.
-- A cache key with no version segment → a changed result shape is served from stale entries forever.
-- Importing outside the bundled set without a folder `pyproject.toml` → `ModuleNotFoundError` in the packaged app.
-- Adding `<script src=".../runtime.js">` manually → double-injection; the explorer injects it.
-- Heavy import + slider wired without debounce → one full subprocess per tick; debounce ~150 ms when `main` is slow.
-- Fetching `/api/fs/raw` or POSTing `/api/fs/write` directly → writes get rejected (missing header) and you're coupled to internals.
-- `writeFile` without `expectedMtime` on an *existing* file → silently clobbers what is on disk now. For edits arm the lock and handle `.type === "conflict"`; for "create if absent" pass `{create: true}` and handle `.type === "exists"` rather than stat-ing first (a stat that fails for any reason other than absence otherwise reads as "go ahead and write").
-- Using `readFile` for an image/video and stuffing bytes into the DOM → point the element's `src` at `fused.rawUrl(path)`.
-- Walking the filesystem (`os.walk`, `glob`, `find`) to answer "how many / how big / where are all my X files" → the index already knows; use `fused.fileIndex.query()` (`fused-render-index`).
-- Calling `fused.ai` on a page meant for export → the exporter rejects it textually (SPEC RH-11); a `fused.env` guard does not help.
-- Reporting "I wrote the files, try it" as verification → `fused-render calls --page <page>` says whether it actually ran. Zero records with nothing rendered means the page's JS died before reaching Python — a different bug from a failing `main()`, and they look identical without the log. Zero records with a visible placeholder rendered is not a bug at all — check `_preview` gating before assuming one.
+- `params.set` with non-string → throws. `_`-prefixed page param → throws/collides.
+- Own `history.replaceState` → drops shell `_` keys, breaks the pane.
+- Ungated boot under `_preview` / not climbing ancestors / not forwarding to own iframes.
+- Non-JSON return, unannotated numeric param, expecting state across calls.
+- Plain `open(...,"w")` cache write; unversioned cache key; irreplaceable bytes in `cache/`.
+- Import outside bundled set with no `pyproject.toml`.
+- Slider + heavy import without ~150 ms debounce = subprocess per tick.
+- `writeFile` on existing file without `expectedMtime` = silent clobber; create-if-absent = `{create: true}`, not stat-then-write.
+- `readFile` for media → use `rawUrl`.
+- Walking the fs for counts/sizes → `fused.fileIndex.query` (`fused-render-index`).
+- `fused.ai` in an exportable page → exporter rejects textually; env guard doesn't help (`fused-render-ai`).
+- Claiming "done" without `fused-render calls` — blank-JS and failing-Python look identical without the log.

--- a/skills/fused-render-background-apps/SKILL.md
+++ b/skills/fused-render-background-apps/SKILL.md
@@ -28,7 +28,8 @@ Guest-process rules: may die anytime (persist under `--cache` with temp+`os.repl
 ## Environment (differs from /api/run)
 
 - Runs folder's OWN declared env, no ancestor walk, no bundled union — `[project]` list complete. No project deps → `sys.executable`; `import fused_render` never available.
-- `templates/shared` NOT on sys.path → `import fused_ai` / `import background_app` fail. Bootstrap: read `<FUSED_RENDER_HOME_DIR or ~/.fused-render>/server.json`, `sys.path.insert(0, info["shared"])`.- `background_app` module (from shared): `status()`, `stop()`, `restart()`, `set_autostart(bool)` — daemon's own control channel. Needs `FUSED_RENDER_APP_DIR` env (set for managed daemons); raises `NotUnderEngine`, `ServerNotRunning`, `BackgroundAppError` — catch them.
+- `templates/shared` NOT on sys.path → `import fused_ai` / `import background_app` fail. Bootstrap: read `<FUSED_RENDER_HOME_DIR or ~/.fused-render>/server.json`, `sys.path.insert(0, info["shared"])`.
+- `background_app` module (from shared): `status()`, `stop()`, `restart()`, `set_autostart(bool)` — daemon's own control channel. Needs `FUSED_RENDER_APP_DIR` env (set for managed daemons); raises `NotUnderEngine`, `ServerNotRunning`, `BackgroundAppError` — catch them.
 - Server-startup autostart skips folders whose venv isn't built (open page once first); `start()` falls back to `sys.executable`.
 
 ## Page side: `fused.daemon`

--- a/skills/fused-render-background-apps/SKILL.md
+++ b/skills/fused-render-background-apps/SKILL.md
@@ -1,61 +1,61 @@
 ---
 name: fused-render-background-apps
-description: Use when an app folder needs Python that keeps running after its page closes — a warm worker or resident daemon, [tool.fused-render.app], fused.daemon.*, autostart, or a worker "dying" after 15 min idle.
+description: Use when app folder needs Python alive after page closes — warm worker, resident daemon, [tool.fused-render.app], fused.daemon, autostart, worker "dying" after idle.
 ---
 
 # Background apps
 
-Three ways a folder's Python runs:
+Three ways folder's Python runs:
 
 | Path | Lifetime | State survives? | Idle-reaped? |
 |---|---|---|---|
 | `/api/run` (`fused.runPython`) | fresh subprocess, 60 s kill | no | n/a |
 | `main = "x.py"` | shipped warm worker, plain `main(**params)` | yes | after `idle_timeout_s` (default 900 s) |
-| `daemon = "x.py"` | your own HTTP daemon | yes | no (default) |
+| `daemon = "x.py"` | own HTTP daemon | yes | no by default; set `idle_timeout_s` > 0 to opt in |
 
-Pick `daemon =` only when idle-reap is the actual problem (websocket/poll server, held device/socket, tray UI). State between calls minutes apart = `main =`, no daemon script needed.
+Pick `daemon =` only when idle-reap is the actual problem (websocket/poll server, held device/socket, tray UI). State between calls minutes apart = `main =`, no daemon script.
 
 ## Manifest
 
-In the folder's `pyproject.toml`: `[tool.fused-render.app]` with EXACTLY ONE of `daemon =` / `main =` (path inside the folder, a file, not a dir). Optional `idle_timeout_s` (0 = resident). Bad manifests are **silently** rejected (read as "no manifest") — `background_apps.load_manifest` lists the rules; check `GET /api/apps/background/status?html=<page>` if unsure yours parsed.
+Folder's `pyproject.toml`: `[tool.fused-render.app]` with EXACTLY ONE of `daemon =` / `main =` (path inside folder, file not dir). Optional `idle_timeout_s` (0 = resident). Bad manifest **silently** rejected (read as "no manifest") — rules in `background_apps.load_manifest`; check `GET /api/apps/background/status?html=<page>` if unsure yours parsed.
 
 ## Daemon contract
 
-Plain script run as `[interpreter, daemon.py, --status <path>, --cache <dir>, --version <str>]`. Read `tests/fixtures/background_app/daemon.py` (minimal stdlib reference) before writing one. The sequence that has no race: parse args → bind `127.0.0.1:0` → atomically publish `{port, token, pid}` to the status file (temp + `os.replace`, BEFORE `serve_forever`) → serve. Require a random token on every request (parent proxies via `/api/engines/<id>/proxy/`, but any local process can hit your port). Answer `GET /ping` with `{"ok": true, "version": <the --version you were GIVEN — never hardcode, it defeats the staleness respawn>}` and `GET /quit` by `shutdown()` on a separate thread (same-thread deadlocks ThreadingHTTPServer).
+Plain script run as `[interpreter, daemon.py, --status <path>, --cache <dir>, --version <str>]`. Read `tests/fixtures/background_app/daemon.py` (minimal stdlib reference) before writing one. Race-free sequence: parse args → bind `127.0.0.1:0` → atomically publish `{port, token, pid}` to status file (temp + `os.replace`, BEFORE `serve_forever`) → serve. Require random token on every request (parent proxies via `/api/engines/<id>/proxy/`, but any local process can hit port). `GET /ping` → `{"ok": true, "version": <the --version you were GIVEN — never hardcode, defeats staleness respawn>}`. `GET /quit` → `shutdown()` on separate thread (same-thread deadlocks ThreadingHTTPServer).
 
-Guest-process rules: may be killed anytime (persist under `--cache` dir with temp+`os.replace`); respawns start empty — `reinit()` replay does NOT apply to background apps; tolerate mid-request death.
+Guest-process rules: may die anytime (persist under `--cache` with temp+`os.replace`); respawns start empty — `reinit()` replay does NOT apply here; tolerate mid-request death.
 
 ## Environment (differs from /api/run)
 
-- Runs on the folder's OWN declared env, no ancestor walk, no bundled union — the `[project]` list is complete. No project deps → `sys.executable`; `import fused_render` never available.
-- `templates/shared` is NOT on sys.path → `import fused_ai` / `import background_app` fail. Bootstrap: read `<FUSED_RENDER_HOME_DIR or ~/.fused-render>/server.json`, `sys.path.insert(0, info["shared"])`. Shipping example: `_bootstrap_background_app` in the OpenWhisper tray's `menubar.py`.
-- `background_app` module (from shared): `status()`, `stop()`, `restart()`, `set_autostart(bool)` — the daemon's own way to control itself via the server.
-- Server-startup autostart skips folders whose venv isn't built (open the page once first); `start()` falls back to `sys.executable` instead.
+- Runs folder's OWN declared env, no ancestor walk, no bundled union — `[project]` list complete. No project deps → `sys.executable`; `import fused_render` never available.
+- `templates/shared` NOT on sys.path → `import fused_ai` / `import background_app` fail. Bootstrap: read `<FUSED_RENDER_HOME_DIR or ~/.fused-render>/server.json`, `sys.path.insert(0, info["shared"])`. Shipping example: `_bootstrap_background_app` in OpenWhisper tray's `menubar.py`.
+- `background_app` module (from shared): `status()`, `stop()`, `restart()`, `set_autostart(bool)` — daemon's own control channel. Needs `FUSED_RENDER_APP_DIR` env (set for managed daemons); raises `NotUnderEngine`, `ServerNotRunning`, `BackgroundAppError` — catch them.
+- Server-startup autostart skips folders whose venv isn't built (open page once first); `start()` falls back to `sys.executable`.
 
 ## Page side: `fused.daemon`
 
-`start()`, `stop()`, `restart()`, `status()` → `{running, autostart, pid, version, engine_id, protocol}`, `watch(cb)` (fires on real changes — reflects tray quits etc.), `setAutostart(bool)`, `call(path, body)` (daemon protocol, POST proxied), `run(params)` (main protocol, `/call` envelope unwrapped). `call`/`run` auto-bring-up the daemon — `start()` not required first. Wrong-protocol calls reject with "use the other one".
+`start()`, `stop()`, `restart()`, `status()` → `{running, autostart, pid, version, engine_id, protocol}`, `watch(cb)` (fires on real changes — tray quits etc.), `setAutostart(bool)`, `call(path, body)` (daemon protocol, POST proxied), `run(params)` (main protocol, `/call` envelope unwrapped). `call`/`run` auto-bring-up daemon — no `start()` needed first. Wrong-protocol call rejects with "use the other one".
 
-**Two independent axes** — conflating them is THE bug here:
+**Two independent axes** — conflating them = THE bug here:
 
 - Run state: `start/stop/restart` only. Never touches autostart.
-- Autostart (come back at server launch): `setAutostart` only. Never starts/stops anything. Opt-in, default false — not an error state.
+- Autostart (come back at server launch): `setAutostart` only. Never starts/stops anything. Opt-in, default false — not error state.
 
-A stopped daemon comes back via exactly: (1) server start IF autostart on, (2) explicit `start()`/`restart()`, (3) **heal-on-proxy** — an EXTERNAL kill leaves the Child registered, so the next proxied `call()`/`run()` respawns it. `stop()` unregisters first, so it doesn't heal back. Therefore any outside-the-page quit (tray, CLI) must go through `stop()`/`background_app.stop()`, never a raw kill. Tray "Quit" = `stop()` only; autostart gets its own checkbox.
+Stopped daemon comes back via exactly: (1) server start IF autostart on, (2) explicit `start()`/`restart()`, (3) **heal-on-proxy** — EXTERNAL kill leaves Child registered, next proxied `call()`/`run()` respawns. `stop()` unregisters first, doesn't heal back. So any outside-the-page quit (tray, CLI) must go through `stop()`/`background_app.stop()`, never raw kill. Tray "Quit" = `stop()` only; autostart gets own checkbox.
 
-**Never `start()`/`setAutostart(true)`/`call()` on page load.** App cards render live iframes stamped `_preview=1`; the runtime refuses all mutating daemon methods in a preview frame with a named error (`status()` allowed; `watch()` does one read there). Mutations belong in click handlers. Render both facts (`running`, `autostart`) honestly — three states, none of them errors.
+**Never `start()`/`setAutostart(true)`/`call()` on page load.** App cards render live iframes stamped `_preview=1`; runtime refuses all mutating daemon methods in preview frame with named error (`status()` allowed; `watch()` one read there). Mutations belong in click handlers. Render both facts (`running`, `autostart`) honestly — three states, none errors.
 
 ## Native/tray work
 
-Don't write a fourth tray backend: `fused_render/supervisor/tray.py` is the seam (win32 pystray / linux D-Bus backends beside it); macOS menubar = `fused_render/menubar_pin.py`. On macOS all AppKit calls are main-thread only — hop from handler threads with `PyObjCTools.AppHelper.callAfter`.
+Don't write fourth tray backend: `fused_render/supervisor/tray.py` = the seam (win32 pystray / linux D-Bus backends beside it); macOS menubar = `fused_render/menubar_pin.py`. macOS AppKit = main-thread only — hop from handler threads with `PyObjCTools.AppHelper.callAfter`.
 
 ## Pitfalls
 
 - Status file published after `serve_forever` → bootstrap poll races. Publish after bind.
-- `server.shutdown()` from its own handler thread → deadlock.
+- `server.shutdown()` from own handler thread → deadlock.
 - Hardcoded `/ping` version → stale daemon kept forever.
-- Raw kill from a tray → heal-on-proxy revives it.
-- Expecting `import fused_ai` / bundled deps / reinit replay to work like `/api/run` — none do.
-- `daemon = "."`, paths outside the folder, both/neither protocol keys → silent manifest rejection.
+- Raw kill from tray → heal-on-proxy revives it.
+- Expecting `import fused_ai` / bundled deps / reinit replay like `/api/run` — none work.
+- `daemon = "."`, paths outside folder, both/neither protocol keys → silent manifest rejection.
 
-Related: page authoring + preview gating → `fused-render-authoring`; timeout strategies + job rows → `fused-render-jobs`; reading the index from a daemon → `fused-render-index`.
+Related: page authoring + preview gating → `fused-render-authoring`; timeout strategies + job rows → `fused-render-jobs`; reading index from daemon → `fused-render-index`.

--- a/skills/fused-render-background-apps/SKILL.md
+++ b/skills/fused-render-background-apps/SKILL.md
@@ -28,8 +28,7 @@ Guest-process rules: may die anytime (persist under `--cache` with temp+`os.repl
 ## Environment (differs from /api/run)
 
 - Runs folder's OWN declared env, no ancestor walk, no bundled union — `[project]` list complete. No project deps → `sys.executable`; `import fused_render` never available.
-- `templates/shared` NOT on sys.path → `import fused_ai` / `import background_app` fail. Bootstrap: read `<FUSED_RENDER_HOME_DIR or ~/.fused-render>/server.json`, `sys.path.insert(0, info["shared"])`. Shipping example: `_bootstrap_background_app` in OpenWhisper tray's `menubar.py`.
-- `background_app` module (from shared): `status()`, `stop()`, `restart()`, `set_autostart(bool)` — daemon's own control channel. Needs `FUSED_RENDER_APP_DIR` env (set for managed daemons); raises `NotUnderEngine`, `ServerNotRunning`, `BackgroundAppError` — catch them.
+- `templates/shared` NOT on sys.path → `import fused_ai` / `import background_app` fail. Bootstrap: read `<FUSED_RENDER_HOME_DIR or ~/.fused-render>/server.json`, `sys.path.insert(0, info["shared"])`.- `background_app` module (from shared): `status()`, `stop()`, `restart()`, `set_autostart(bool)` — daemon's own control channel. Needs `FUSED_RENDER_APP_DIR` env (set for managed daemons); raises `NotUnderEngine`, `ServerNotRunning`, `BackgroundAppError` — catch them.
 - Server-startup autostart skips folders whose venv isn't built (open page once first); `start()` falls back to `sys.executable`.
 
 ## Page side: `fused.daemon`

--- a/skills/fused-render-background-apps/SKILL.md
+++ b/skills/fused-render-background-apps/SKILL.md
@@ -1,304 +1,61 @@
 ---
 name: fused-render-background-apps
-description: Give a fused-render app folder its own long-running daemon the server supervises — a `daemon =` HTTP surface (resident) or a `main =` warm worker (idle-reaped), opt-in autostart. Use when a folder must keep running after its page closes, hold a connection or native tray UI, or when a `main =` daemon "keeps dying" after 15 minutes idle; covers [tool.fused-render.app] and fused.daemon.*.
+description: Use when an app folder needs Python that keeps running after its page closes — a warm worker or resident daemon, [tool.fused-render.app], fused.daemon.*, autostart, or a worker "dying" after 15 min idle.
 ---
 
-# Background apps: a folder's own long-running daemon
+# Background apps
 
-A background app is a **second** way a folder's Python runs alongside `/api/run` — and picking the wrong protocol within it is the main mistake here. Read the table before writing anything.
+Three ways a folder's Python runs:
 
-| Path | Lifetime | State survives between calls? | Idle-reaped? |
+| Path | Lifetime | State survives? | Idle-reaped? |
 |---|---|---|---|
-| `/api/run` (`fused.runPython`) | Fresh subprocess **per call**, killed at a 60 s timeout | No — nothing persists | N/A, it's already gone |
-| Background app, `main =` protocol | The shipped worker, spawned on first call, warm | Yes — imports, globals, loaded models | **Yes, after `idle_timeout_s` idle** (default 900s / 15 min) |
-| Background app, `daemon =` protocol | Your own resident daemon, spawned by `start()` and (only if opted in) at every server start | Yes — a whole separate process with its own lifecycle | **No** by default — that's the point of writing your own daemon |
+| `/api/run` (`fused.runPython`) | fresh subprocess, 60 s kill | no | n/a |
+| `main = "x.py"` | shipped warm worker, plain `main(**params)` | yes | after `idle_timeout_s` (default 900 s) |
+| `daemon = "x.py"` | your own HTTP daemon | yes | no (default) |
 
-Both protocols are declared in the same `[tool.fused-render.app]` manifest and share the whole rest of this skill — autostart, the preview guard, reinit, cross-platform tray work. Reach for `daemon =` only when `main =`'s idle-reap is the actual problem: a websocket/poll server, something holding a device handle or a long-lived socket, a tray/menu-bar presence, or state that must survive an idle gap longer than `idle_timeout_s`. State that only needs to survive between calls a few minutes apart already has `main =`, which needs no daemon script of your own — you write a plain `main(**params)`, the same shape `/api/run` calls.
+Pick `daemon =` only when idle-reap is the actual problem (websocket/poll server, held device/socket, tray UI). State between calls minutes apart = `main =`, no daemon script needed.
 
-## The manifest
+## Manifest
 
-A folder opts in with a table in its own `pyproject.toml`, declaring exactly one of two protocol keys:
+In the folder's `pyproject.toml`: `[tool.fused-render.app]` with EXACTLY ONE of `daemon =` / `main =` (path inside the folder, a file, not a dir). Optional `idle_timeout_s` (0 = resident). Bad manifests are **silently** rejected (read as "no manifest") — `background_apps.load_manifest` lists the rules; check `GET /api/apps/background/status?html=<page>` if unsure yours parsed.
 
-```toml
-[tool.fused-render.app]
-daemon = "daemon.py"    # your own HTTP surface; resident by default (idle_timeout_s=0)
-```
+## Daemon contract
 
-```toml
-[tool.fused-render.app]
-main = "compute.py"     # the shipped worker calls main(**params); reaped after
-                        # idle_timeout_s idle seconds (default 900)
-```
+Plain script run as `[interpreter, daemon.py, --status <path>, --cache <dir>, --version <str>]`. Read `tests/fixtures/background_app/daemon.py` (minimal stdlib reference) before writing one. The sequence that has no race: parse args → bind `127.0.0.1:0` → atomically publish `{port, token, pid}` to the status file (temp + `os.replace`, BEFORE `serve_forever`) → serve. Require a random token on every request (parent proxies via `/api/engines/<id>/proxy/`, but any local process can hit your port). Answer `GET /ping` with `{"ok": true, "version": <the --version you were GIVEN — never hardcode, it defeats the staleness respawn>}` and `GET /quit` by `shutdown()` on a separate thread (same-thread deadlocks ThreadingHTTPServer).
 
-An optional `idle_timeout_s = <float>` overrides that protocol's default — `0` means resident/never-reaped, so a `main =` folder can opt into staying warm forever, and a `daemon =` folder can opt into idle retirement.
+Guest-process rules: may be killed anytime (persist under `--cache` dir with temp+`os.replace`); respawns start empty — `reinit()` replay does NOT apply to background apps; tolerate mid-request death.
 
-`background_apps.load_manifest` reads this and **never raises** — a bad manifest reads as "no manifest" rather than reaching `engine_host` as an opaque `python <folder>` bring-up failure. It rejects, silently:
+## Environment (differs from /api/run)
 
-- Declaring **both** `daemon` and `main`, or **neither** — exactly one protocol key is required, never inferred.
-- The declared key's value missing, not a string, or empty.
-- The value resolving **outside** the folder — `daemon = "../elsewhere.py"` or a symlink that escapes, realpath-checked (the same containment guard `registered_apps.py` uses).
-- The value naming a **directory** (`daemon = "."` passes containment trivially — a folder is "inside" itself — so it needs its own `os.path.isfile` check).
+- Runs on the folder's OWN declared env, no ancestor walk, no bundled union — the `[project]` list is complete. No project deps → `sys.executable`; `import fused_render` never available.
+- `templates/shared` is NOT on sys.path → `import fused_ai` / `import background_app` fail. Bootstrap: read `<FUSED_RENDER_HOME_DIR or ~/.fused-render>/server.json`, `sys.path.insert(0, info["shared"])`. Shipping example: `_bootstrap_background_app` in the OpenWhisper tray's `menubar.py`.
+- `background_app` module (from shared): `status()`, `stop()`, `restart()`, `set_autostart(bool)` — the daemon's own way to control itself via the server.
+- Server-startup autostart skips folders whose venv isn't built (open the page once first); `start()` falls back to `sys.executable` instead.
 
-No error is surfaced for a rejected manifest short of the folder simply not offering a start option; check `GET /api/apps/background/status?html=<page>` if you're unsure yours parsed.
+## Page side: `fused.daemon`
 
-## The daemon contract
+`start()`, `stop()`, `restart()`, `status()` → `{running, autostart, pid, version, engine_id, protocol}`, `watch(cb)` (fires on real changes — reflects tray quits etc.), `setAutostart(bool)`, `call(path, body)` (daemon protocol, POST proxied), `run(params)` (main protocol, `/call` envelope unwrapped). `call`/`run` auto-bring-up the daemon — `start()` not required first. Wrong-protocol calls reject with "use the other one".
 
-Your `daemon.py` is a plain script, run directly as `[interpreter, daemon.py, --status <path>, --cache <dir>, --version <str>]` (`engine_host._spawn`) — not imported, not run through `_child.py`, no framework to subclass. `tests/fixtures/background_app/daemon.py` is the minimal stdlib-only reference; read it in full before writing your own. What it does, and why:
+**Two independent axes** — conflating them is THE bug here:
 
-1. **Parse `--status`, `--cache`, `--version`** (argparse, all three `required=True`).
-2. **Bind `("127.0.0.1", 0)`** — port 0 asks the OS for a free port; never hardcode one.
-3. **Publish `{port, token, pid}` to the status file, atomically, BEFORE serving** — temp file in the same directory, then `os.replace()`. Not a style choice: `_spawn` polls the status file, and bind → publish → serve is *the only sequence with no race*, because the file cannot exist until `bind()` has succeeded. Publish before `serve_forever()`.
-4. **Generate a random token** (`secrets.token_urlsafe(32)`) and require it on every request — `?t=<token>`, checked with `secrets.compare_digest`. The parent proxies all traffic through the stable server origin (`/api/engines/<id>/proxy/...`) so the browser never sees your port or token, but you still enforce it: you are listening on a loopback port any local process can reach.
-5. **Answer `GET /ping`** with `{"ok": true, "version": <the --version you were given>}`. The bootstrap wait polls this, and every later reuse check pings it — a `/ping` returning the wrong `version` is treated as a stale child and respawned.
-6. **Answer `GET /quit`** by starting `shutdown()` on a separate thread (calling `server.shutdown()` from the handler thread serving it deadlocks `ThreadingHTTPServer`). Nothing shipped calls `/quit` — `stop()` and respawns go through `engine_host`'s SIGTERM→SIGKILL tree-kill — but it is a cleaner exit path for your own tooling.
+- Run state: `start/stop/restart` only. Never touches autostart.
+- Autostart (come back at server launch): `setAutostart` only. Never starts/stops anything. Opt-in, default false — not an error state.
 
-Everything else — routes, state, threads — is yours. The fixture also serves `POST /count` as a worked example of the request shape `fused.daemon.call()` sends (JSON body, POST only; the runtime hardcodes the verb).
+A stopped daemon comes back via exactly: (1) server start IF autostart on, (2) explicit `start()`/`restart()`, (3) **heal-on-proxy** — an EXTERNAL kill leaves the Child registered, so the next proxied `call()`/`run()` respawns it. `stop()` unregisters first, so it doesn't heal back. Therefore any outside-the-page quit (tray, CLI) must go through `stop()`/`background_app.stop()`, never a raw kill. Tray "Quit" = `stop()` only; autostart gets its own checkbox.
 
-## Asking the server about yourself, from inside the daemon
+**Never `start()`/`setAutostart(true)`/`call()` on page load.** App cards render live iframes stamped `_preview=1`; the runtime refuses all mutating daemon methods in a preview frame with a named error (`status()` allowed; `watch()` does one read there). Mutations belong in click handlers. Render both facts (`running`, `autostart`) honestly — three states, none of them errors.
 
-Every `fused.daemon` method sends the caller's page path as `html`, which the server resolves to an app folder. Your daemon has no page — so it uses `templates/shared/background_app.py` instead, which reads the `FUSED_RENDER_APP_DIR` that `engine_host._spawn_env` exports into any child whose `Child.folder` is set — i.e. a background app's own daemon.
+## Native/tray work
 
-**A bare `import background_app` does not work here.** `/api/run` and the warm worker get `templates/shared` appended to `sys.path` for free (`_child.py`); a background daemon is spawned as a plain script with no such seeding, so the import raises `ModuleNotFoundError`. Bootstrap it off the discovery file `server/app.py` writes at bind time — `server.json`'s `shared` key names the exact `templates/shared` this server build ships, and `FUSED_RENDER_HOME_DIR` (branch-resolved for a dev worktree server, falling back to `~/.fused-render`) says where to find it:
+Don't write a fourth tray backend: `fused_render/supervisor/tray.py` is the seam (win32 pystray / linux D-Bus backends beside it); macOS menubar = `fused_render/menubar_pin.py`. On macOS all AppKit calls are main-thread only — hop from handler threads with `PyObjCTools.AppHelper.callAfter`.
 
-```python
-import json, os, sys
+## Pitfalls
 
-def _bootstrap_background_app():
-    home_dir = os.environ.get("FUSED_RENDER_HOME_DIR") or os.path.expanduser(
-        "~/.fused-render")
-    with open(os.path.join(home_dir, "server.json"), encoding="utf-8") as f:
-        info = json.load(f)
-    if info["shared"] not in sys.path:
-        sys.path.insert(0, info["shared"])
-    import background_app
-    return background_app
+- Status file published after `serve_forever` → bootstrap poll races. Publish after bind.
+- `server.shutdown()` from its own handler thread → deadlock.
+- Hardcoded `/ping` version → stale daemon kept forever.
+- Raw kill from a tray → heal-on-proxy revives it.
+- Expecting `import fused_ai` / bundled deps / reinit replay to work like `/api/run` — none do.
+- `daemon = "."`, paths outside the folder, both/neither protocol keys → silent manifest rejection.
 
-background_app = _bootstrap_background_app()
-
-background_app.status()             # {"running", "autostart", "pid", "version", "engine_id", "protocol"}
-background_app.stop()               # kills THIS process's daemon; autostart untouched
-background_app.set_autostart(True)  # persists the "come back at next launch" flag only
-background_app.restart()            # respawns
-```
-
-This is the production pattern, not a simplification — see `_bootstrap_fused_ai`/`_bootstrap_background_app` in the OpenWhisper tray's `menubar.py` for the shipping version, which wraps it in a try/except so an unreadable `server.json` degrades to `None` rather than crashing the daemon at import time.
-
-A tray "Quit" should call `stop()` here rather than a raw self-`terminate`/`exit` — see "When does it come back?" below. `set_autostart(bool)` is separate and orthogonal: it never starts or stops anything, so a "Start automatically" checkmark calls it directly. Raises `NotUnderEngine` if `FUSED_RENDER_APP_DIR` isn't set (you are not an engine-spawned daemon), and `ServerNotRunning`/`BackgroundAppError` for the same reasons `fused_ai`'s equivalents do.
-
-## Driving it from the page: `fused.daemon`
-
-```js
-await fused.daemon.start();                // spawn it now — does NOT touch autostart
-const st = await fused.daemon.status();     // {running, autostart, pid, version, engine_id, protocol}
-const res = await fused.daemon.call("/count", { hello: "world" }); // POST, proxied to the daemon
-const out = await fused.daemon.run({ hello: "world" }); // main = convenience: call("/call", params), envelope unwrapped
-await fused.daemon.stop();                  // kill it now — does NOT touch autostart
-await fused.daemon.restart();               // respawn — autostart-neutral too
-await fused.daemon.setAutostart(true);      // ONLY thing that persists "bring this back at launch"
-const unsubscribe = fused.daemon.watch((s) => {
-  // s is the same shape status() resolves to. Fires on the initial read and
-  // again whenever running/autostart/pid/version actually changes — NOT on
-  // every poll tick. This is how you reflect state that changed for a reason
-  // outside this page's own control, e.g. the tray's Quit.
-});
-```
-
-The JS namespace is `daemon` while the HTTP endpoints (`/api/apps/background/*`) and Python modules say "background": "app" already means three other things here (an `fused-app`-tagged folder, the warm-worker HTTP surface, the `/apps` hub), and `daemon` is the noun the manifest, the file and `engine_host` already use.
-
-Every method except `call`/`run` sends **this page's own path**, never a folder path — the server resolves which app folder the page belongs to, the same `resolve_py` pattern `/api/run` uses, so there is no path-typed API to defend. `call(path, body)` reaches the daemon through `/api/engines/<engine_id>/proxy/<path>`, resolving `engine_id` from a cached `status()` and bringing the daemon up transparently when it isn't known to be running — on a page's first call, or after the idle reaper has retired it — the same way `run()` always has; **`start()` is not required first**. `run(params)` is the `main =` convenience over the same proxy mechanics: POST `/call` with `params` as the body, the `{ok, result, error, stdout, resolved_py}` envelope unwrapped the way `runPython` unwraps `/api/run`'s.
-
-Each method also checks the folder actually declared the protocol it speaks, from `status()`'s `protocol` field: `run()` rejects with a "use `call()` instead" error against a `daemon =` folder (its own routes almost certainly don't serve `/call`), and `call()` rejects with a "use `run()` instead" error against a `main =` folder (it would otherwise "work" but hand back the raw envelope instead of the unwrapped result). A folder with no valid manifest at all reports `protocol: null` and gets neither check — its existing error paths already cover it.
-
-**Run state and autostart are two independent axes** (pinned by `test_api_start_calls_ensure_background_without_touching_autostart` and `test_api_autostart_sets_the_flag_without_starting_or_stopping_anything`):
-
-- `start()`/`stop()`/`restart()` change only whether the daemon is alive right now. None of them read or write the persisted autostart flag.
-- `setAutostart(true|false)` changes only the persisted "bring this back at every launch" flag. It never starts or stops the daemon.
-- **Autostart is opt-in and defaults to off.** A folder nobody has called `setAutostart(true)` on reports `autostart: false` forever, no matter how many times `start()` is called.
-
-Conflate the two and the daemon either fails to survive a restart the user expected it to survive, or comes back uninvited when they only meant to stop it once.
-
-### When does it come back? Two questions, not one
-
-**Is it running right now?** `status().running`. That changes only through `start()`, `stop()`, `restart()`, or heal-on-proxy (below) — never through `setAutostart()`.
-
-**Will it come back at the next server launch?** `status().autostart`. That changes ONLY through an explicit `setAutostart(bool)` (or server-side `background_apps.set_autostart`), and defaults to `false` for every folder.
-
-Given both facts, a stopped daemon comes back through exactly one of these — there is no other path:
-
-1. **Server start, but ONLY if autostart is on.** `_startup_resurrect_background_apps` walks `autostart_paths()` and brings each one up. A folder that was only ever `start()`ed is not in that list — the opt-in default in action, not an omission.
-2. **A page calling `start()` or `restart()`.** The deliberate path — unconditional, but never itself sets autostart.
-3. **Heal-on-proxy — the one that surprises people, and it is entirely about run state.** If the process was killed EXTERNALLY (a `kill`, a crash, a tray "Quit" that never talks to the server), the `Child` stays registered in `engine_host._children` — nothing popped it out. The next proxied call finds a `Child` that doesn't answer and heals by respawning it (`engine_forward.py`). **`stop()` does not have this problem**: it pops the child out of `_children` before killing it, so a later proxied call finds nothing registered, returns 409, and does not revive it. A raw external kill skips that pop, which makes it structurally the *weakest* way to end a background app — it leaves intact the one piece of bookkeeping that prevents an accidental revival.
-4. **Nothing else.** No heartbeat, no polling, no periodic sweep.
-
-So anything letting a user "quit and stay off" from OUTSIDE a page (a tray icon, a CLI, a native menu item) must call `stop()` through the server's own API, never a raw process kill — otherwise it has built path 3 by accident and the app returns the moment anything pokes it. Whether it also stays off at the next launch depends on autostart, which `stop()` never touches: "stopped now AND never comes back automatically" is two calls for two facts.
-
-## Starting it — and opting into autostart — are the user's decisions
-
-Opening a folder, or a page calling `fused.daemon.status()`, **never starts, stops, or persists anything**. `autostart_paths()` reads `<home_dir()>/background_apps.json` — the *only* thing "autostart" means — and the startup hook only resurrects folders already in that store.
-
-### Lead rule: never call `start()` (or `setAutostart(true)`) on page load
-
-An app going from off to running, or from "one-off" to "survives every server restart", is the user's decision, made by clicking something. And "the page's JS ran" is a much wider event than "the user opened my folder": Home's "Fused Apps" strip and the `/apps` hub render a **live picture** of each app, mounting its own `entry_html` in an iframe (`AppPreviewCard`) once the card nears the viewport, and a card that has a `preview.png` still swaps to the live iframe on hover. That iframe's sandbox is `allow-scripts allow-same-origin` — your script runs, on a card someone merely scrolled past.
-
-**The runtime enforces this, it is not only a convention.** `_preview=1` reaches a card's live iframe reliably — `thumbFrame`/`withPreviewFlag` stamp it onto the `/render?path=...` URL that becomes the iframe's `src`, and `GET /render` serves the app's HTML at exactly that URL with no redirect, so the flag lands in the page's own `location.search`. `start()`, `restart()`, `call()`, `stop()` and `setAutostart()` all check it (this frame's URL, or any same-origin ancestor's) and reject before any POST is sent. `status()` is deliberately ungated: it is read-only.
-
-`setAutostart()` is gated for the same reason as `start()`, only more so — an unwanted `start()` dies with the server, while a persisted "come back forever" flag set by a card scrolling past survives every restart.
-
-```js
-// Wrong: fires the instant this script runs, including inside a display-only
-// preview iframe that scrolled into view. The user never clicked anything.
-fused.daemon.start();
-fused.daemon.setAutostart(true);
-
-// Right: page load only reads and renders. Starting the daemon and opting into
-// autostart are each something a control does, in response to a click — two
-// SEPARATE controls, because they are two separate facts.
-async function refreshMenubar() {
-  const st = await fused.daemon.status();     // {running, autostart, pid, ...}
-  render(st);                                 // see "Render both facts" below
-}
-refreshMenubar();
-
-toggleBtn.addEventListener("click", async () => {
-  const turnOn = !toggleBtn.classList.contains("on");
-  turnOn ? await fused.daemon.start() : await fused.daemon.stop();
-  await refreshMenubar();
-});
-
-autostartCheckbox.addEventListener("change", async () => {
-  await fused.daemon.setAutostart(autostartCheckbox.checked);
-  await refreshMenubar();
-});
-```
-
-### What a page may do on load
-
-| On load | Allowed | Why |
-|---|---|---|
-| `fused.daemon.status()` | Yes | Read-only; spawns, persists and kills nothing. |
-| `fused.daemon.watch(cb)` | Yes — **one read and nothing more in a preview thumbnail** | `status()` underneath. In a live/hover preview it does a single read and returns a no-op unsubscribe rather than leaving a poll loop running in a sandbox that mounts and unmounts on every hover. |
-| Rendering the result | Yes | Pure display logic. |
-| `start()` / `restart()` | No — **refused in a preview thumbnail** | Spawns a daemon; a page render is not a reason to start one, or to bounce one the user may be mid-use of. |
-| `stop()` | No — **refused in a preview thumbnail** | Turning something the user has running *off* on a page render is exactly as surprising as turning it on. |
-| `setAutostart(bool)` | No — **refused in a preview thumbnail** | Persists a flag that survives a server restart. |
-| `call(path, body)` / `run(params)` | Only if it is a genuine read — **refused in a preview thumbnail** | `engine_forward.py`'s heal-on-proxy path respawns a dead-but-registered child on *any* proxied call, so a preview calling `call()`/`run()` against an app started elsewhere can resurrect its daemon exactly like `start()` would. Beyond the preview case, your own daemon may treat a route as "start work" — gate those routes behind an explicit control too. |
-
-### How the guard rejects
-
-A rejection is a plain `Error`, never a silent no-op, and it names the method and the rule so the author sees it in the console instead of wondering later why the daemon they turned off keeps coming back:
-
-```
-fused.daemon.start: refused — this page is rendering as a preview thumbnail
-(a card peek or hover, not a real open), and a page must never start a
-background daemon just by being displayed or hovered. Call
-fused.daemon.status() on load to read state, and call start()/restart()
-only from an explicit user action, e.g. a button's click handler.
-```
-
-The guard is **client-side** (`fused_render/static/runtime.js`), deliberately: the flag reaches the app's own frame reliably, so the check belongs where `start()` itself runs, before any request leaves the page. It protects against a careless app, not an evasive one — a page can always `fetch("/api/apps/background/start")` directly, a bypass that exists independent of preview rendering and is out of scope for this guard.
-
-### Render both facts honestly
-
-`status()` reports **`running`** and **`autostart`** as two independent booleans. Most UIs still want to show three states:
-
-- **Running** — up right now, whatever `autostart` says.
-- **Not running, `autostart: true`** — "will come back" at the next launch or on an explicit `start()`. Not broken, not an error; it is the ordinary state right after a `stop()`, or after an external kill heal-on-proxy hasn't repaired yet.
-- **Not running, `autostart: false`** — the default for every folder, and often the most common state a background app is in. Do not render it as an error, a missing dependency, or a disabled feature.
-
-`Sina/OpenWhisper/index.html`'s `mbRender`/`refreshMenubar` is a worked example — three labels, `.on`/`.pending` classes, and a separate "Start automatically" checkbox for the autostart fact. Read it for the pattern, not as a finished reference.
-
-### Reflect state that changed outside this page — `fused.daemon.watch()`
-
-`status()` alone tells you what is true at the moment you called it. A page that reads once on load and otherwise refreshes only after its own `start()`/`stop()` has a blind spot: **the daemon's state changes for reasons that have nothing to do with this page.** A tray "Quit" routes through the same `POST /api/apps/background/stop` the page's own button does, so the server knows — but a page reflecting only its own actions leaves its icon "on" until someone reloads.
-
-`watch(callback)` closes that gap: it calls back on the initial read and whenever `{running, autostart, pid, version}` changes, polling only while the tab is visible and refreshing immediately on `visibilitychange`→visible and window `focus` — the case that matters most, since reaching for a tray means this page was *not* focused when the state changed.
-
-```js
-const unsubscribe = fused.daemon.watch((s) => {
-  mbRunning = s.running;
-  mbAutostart = s.autostart;
-  refreshMenubar();  // re-render from the two facts, same as after your own start()/stop()
-});
-```
-
-The convention this establishes: **render from the server's actual state, not from an assumption that your own actions are the only source of change.** Updating local state directly in a click handler is fine for immediate feedback; anything a *different* surface (a tray, another tab, startup resurrection) can also change gets read back from the server.
-
-### Give the user a way to turn the app off from inside the app itself
-
-A background app running native desktop UI needs its own off switch there too — a user who never opens the page still needs a way to quit it. Two things follow from the run-state/autostart split:
-
-- A tray "Quit" only needs `stop()`. It should NOT also turn autostart off: "quit right now" and "never come back automatically" are different intents, and conflating them in the tray re-creates the bug the split exists to fix. Offer autostart as its own checkmark item reflecting `status().autostart` (see `menubar.py`'s `toggleAutostart_`).
-- Both controls go through the server's API — `fused.daemon.stop()`/`setAutostart()` from the page, or `background_app.stop()`/`set_autostart()` from inside the daemon — never a raw kill for the "stop it" half, which skips the `_children` bookkeeping and lets the next proxied call heal the daemon back to life.
-
-### The daemon is a guest process: assume nothing about its own continuity
-
-- **It may be killed at any time**, by the server's tree-kill or by anything external. Never assume a clean shutdown path runs — persist anything that must survive under `background_apps.cache_dir_for(engine_id)` (never beside the user's code) with interrupt-safe writes: write-to-temp-then-`os.replace()`, the same pattern as the status-file publish.
-- **It is not a singleton across restarts.** Nothing replays state into a fresh child (see "reinit" below) — a respawned daemon starts new, with only what it reads back or rebuilds. Design `main()` for "I might be the fifth process this folder has run today".
-- **It must tolerate its own work being interrupted mid-request.** A `call()` can be answered by a daemon killed moments later; don't leave on-disk state half-written or a resource half-acquired across that boundary.
-
-### What the version digest expects from you
-
-`version_for` hashes your `pyproject.toml`'s bytes, your `daemon.py`'s mtime+size, and the interpreter's path+mtime+size into the `--version` string you are spawned with; the reuse check retires and respawns a running child the moment that digest changes.
-
-- **You never bump a version yourself.** Editing `pyproject.toml` or `daemon.py` is enough — the next start or reuse check sees a new digest and spawns a fresh child.
-- **Never hardcode your `/ping` response's `version`.** Echo the `--version` you were given. Hardcoding defeats the staleness check silently: the reuse check always "matches", the stale child is kept forever, and respawn-on-edit stops working for your app specifically.
-
-### Conventions the engine does not enforce
-
-Nothing below is checked by any code path; no test or manifest rule will catch it.
-
-- Rendering both `status()` facts honestly, and not presenting `autostart: false` as an error.
-- Exposing an in-app off switch at all.
-- Routing that off switch through `stop()` instead of a raw kill — heal-on-proxy exists precisely because the engine tolerates a raw kill; it does not forbid one.
-- Persisting daemon state safely across an unannounced kill, and not assuming it is the only instance the folder has spawned.
-- Echoing the real `--version` from `/ping` — defeat the staleness check and nothing complains; the daemon just quietly stops picking up its own updates.
-
-## Where the daemon actually runs
-
-`start()` (and `restart()`'s ensure-background fallback) never block on an unbuilt venv: when the folder's own project venv isn't built yet, `_resolve()` falls back to `sys.executable` and starts the daemon there anyway — the same fallback `/api/run`'s builtin engine takes. There is no 409 to handle; a daemon started this way just doesn't have the folder's own `[project]` dependencies importable until that venv exists.
-
-Server-startup autostart resurrection is stricter: `resurrect_autostart()` will **not** fall back — a folder opted into autostart whose project venv isn't built yet is logged and skipped entirely ("project environment not built yet, skipping (open it once to install it)"), and stays stopped until something else starts it. Open the folder once (or call `fused.runPython`) to install its venv before relying on autostart.
-
-**The ordering trap specific to background apps:** the daemon runs on **the folder's own declared environment**, resolved from the folder itself — never from an ancestor project. `background_apps.interpreter_for` calls `projectenv.has_project_env(folder)` on the app's own folder only; it does **not** walk upward the way a plain `.py` script's resolution does. A folder declaring no `[project]` deps of its own runs its daemon on `sys.executable` (the app's bundled interpreter) whatever a parent directory declares, and `import fused_render` is **not** available there. Its `[project]` dependency list is also the **complete** list the daemon gets — nothing bundled is unioned in. Declare everything the daemon (or `main =` script) imports, stdlib aside.
-
-## Two things that do not work the way `/api/run` does
-
-**`templates/shared` is not on `sys.path`, so `import fused_ai` fails.** A `.py` under `/api/run` gets the seeding from `_child.py`; a background daemon is not spawned through `_child.py` at all — `engine_host._spawn` runs your script directly, and nothing appends `templates/shared`. Worse, a daemon on a project venv has `PYTHONPATH`/`PYTHONHOME`/`PYTHONEXECUTABLE`/`PYTHONSTARTUP` actively stripped by `_spawn_env` for venv hermeticity, so even an inherited `PYTHONPATH` would not survive. To use `fused_ai` or any other shared helper, bootstrap it off `server.json` (as "Asking the server about yourself" does) or copy the module in — the same "copy this reader" pattern `fused-render-index` uses.
-
-**`reinit()` replay does not apply, so your daemon must survive its own restart.** `engine_host.reinit()` records a request so a *template daemon*'s restart can replay it into the fresh child before any retried request lands — that is what makes a map-tile daemon's death invisible to the page. Nothing in `background_apps.py` or its router ever calls it; `restart()` still calls `_replay(child)` for every kind, but a `bg_*` engine never populated `_reinit`, so it is a no-op empty loop. A respawned daemon starts with whatever its own startup code rebuilds — persist under your cache dir or rebuild in `main()`, and treat dying and restarting as a normal event.
-
-## Cross-platform: native desktop work
-
-A daemon doing native desktop UI will not run unmodified on another platform, and there is no cross-platform API in scope to hand you one. Two facts to work from:
-
-- **fused-render already ships three tray/menu-bar backends.** `fused_render/supervisor/tray.py` is the platform-neutral seam (`TrayAction`, `_State`, `TrayHandle`, the retry-with-backoff `start()`), dispatching by `sys.platform` to `supervisor/_win32/tray.py` (pystray) or `supervisor/_linux/tray.py` (StatusNotifierItem over D-Bus); `fused_render/menubar_pin.py` is the separate macOS AppKit/NSPopover implementation. Guard your own platform branch on `sys.platform` and read the existing backend for your target before reinventing its retry/backoff or lifecycle handling.
-- **On macOS, `NSApplication.run()` cannot leave the main thread.** Every AppKit call in `menubar_pin.py` is main-thread only, and cross-thread work hops onto it with `PyObjCTools.AppHelper.callAfter(fn)` — the codebase's established hop. If your HTTP handler thread needs to touch AppKit state, post it through `callAfter` (or `NSOperationQueue.mainQueue()`) rather than calling AppKit from the handler thread.
-
-## Pitfalls checklist
-
-- Publishing the status file AFTER `serve_forever()` → the parent's bootstrap poll never sees it in time, or sees a port not yet accepting connections. Publish right after `bind()`.
-- Calling `server.shutdown()` from inside the handler answering `/quit` → deadlocks `ThreadingHTTPServer`; shut down from a separate thread.
-- `fused.daemon.start()` on page load → spawns a daemon nobody asked for, and a display-only preview iframe runs that same load path. The runtime now refuses it (and `restart`/`call`/`run`/`stop`/`setAutostart`) inside a preview and throws a named error.
-- Assuming `start()` or `stop()` also changes whether the app comes back at the next launch → only `setAutostart(bool)` touches that flag.
-- `setAutostart(true)` from page load, or as a side effect of a "start it" click → it persists across restarts; give it its own control.
-- Ending the app from a tray control with a raw kill instead of `stop()` → skips the bookkeeping that keeps it from silently reviving on the next proxied call.
-- Rendering `autostart: false` (or `autostart: true, running: false`) as an error → both are ordinary, and `autostart: false` is the default.
-- Assuming a tray "Quit" should also turn autostart off, or that autostart on means running → independent facts.
-- Assuming `import fused_ai` works in a daemon because it works in `/api/run` → it doesn't; bootstrap off `server.json` or copy the module in.
-- Expecting a daemon's descriptors to survive a restart the way a template's do → `reinit()`/`_replay` is never invoked for background apps.
-- Declaring a dependency somewhere other than the folder's own `[project]` table and expecting the daemon to get it → that table is the complete list.
-- Placing `daemon`/`main` outside the folder (`../daemon.py`) or naming a directory (`daemon = "."`) → silently rejected; the manifest reads as absent with no error surfaced.
-- Declaring both `daemon` and `main`, or neither → silently rejected; exactly one protocol key is required.
-- Relying on autostart before the folder's venv is built → `resurrect_autostart()` skips it and logs a warning; open the page once (or `fused.runPython`) first.
-- Reaching for `daemon =` when `main =`'s idle-reap was never the problem → the manifest, start step and HTTP contract are all overhead a plain `main =` folder doesn't need.
-- Writing a fourth tray/menu-bar implementation instead of reading `supervisor/tray.py` or `menubar_pin.py` first.
-- Touching AppKit state from the daemon's HTTP handler thread on macOS → hop with `PyObjCTools.AppHelper.callAfter`.
-
-## When to switch skills
-
-- The page's own `.html`/`.py` — `fused.runPython`, params, file IO, the venv-build precondition → **`fused-render-authoring`**.
-- The warm, zero-config worker, or any work longer than one call → **`fused-render-jobs`**.
-- Reading the machine-wide file index from your daemon or page → **`fused-render-index`** (its "copy the reader, don't import fused_render" pattern is the same one this skill points at for `templates/shared`).
-- Calling AI models from a page or from Python → **`fused-render-ai`**.
-- Registering a preview template for a file extension → **`fused-render-custom-templates`**.
-- Just opening or running the app → **`fused-render-usage`**.
+Related: page authoring + preview gating → `fused-render-authoring`; timeout strategies + job rows → `fused-render-jobs`; reading the index from a daemon → `fused-render-index`.

--- a/skills/fused-render-capture/SKILL.md
+++ b/skills/fused-render-capture/SKILL.md
@@ -24,9 +24,9 @@ So: don't hardcode extension in `path` — omit or read `rec.path`. Recordings t
 
 ## API
 
-`screen({audio: false|"mic"|"system"|"both", rect, path, maxSeconds})` and `audio({device, path, maxSeconds})` resolve **when recording starts**, handle = `{id, jobId, path, url, state, stop(), cancel()}`. `stop()` → `{path, url, mime, seconds, bytes}`. `cancel()` (and job row ✕) stops AND DELETES — treat as "user doesn't want it". Elapsed seconds: `fused.watchJob(rec.jobId).watch(...)` — no onTick. `maxSeconds` default 30 min; hitting it stops, keeps file.
+`screen({audio: false|"mic"|"system"|"both", display, rect, cursor, device, path, maxSeconds, title})` and `audio({source: "mic", device, path, maxSeconds, title})` resolve **when recording starts**, handle = `{id, jobId, path, url, state, stop(), cancel()}`. `stop()` → `{path, url, mime, seconds, bytes}`. `cancel()` (and job row ✕) stops AND DELETES — treat as "user doesn't want it". Elapsed seconds: `fused.watchJob(rec.jobId).watch(...)` — no onTick. `maxSeconds` default 30 min; hitting it stops, keeps file.
 
-`screenshot({rect, cursor, path})` — no handle, no job row, native every platform (no share prompt → can shoot cross-origin panes). Filename picks png/jpeg; no `format` option.
+`screenshot({display, rect, cursor, path})` — no handle, no job row, native every platform (no share prompt → can shoot cross-origin panes). Filename picks png/jpeg; no `format` option.
 
 `fused.capture.list()` finds live recordings (incl. pre-reload); `attach(id)` returns handle. Check on load before starting second recording. Microphone names empty until browser mic permission granted once.
 

--- a/skills/fused-render-capture/SKILL.md
+++ b/skills/fused-render-capture/SKILL.md
@@ -1,101 +1,38 @@
 ---
 name: fused-render-capture
-description: Record the screen, record the microphone, or grab a screenshot natively from a fused-render page — fused.capture.screen/audio/screenshot/sources. Use when a page records or captures anything, or a capture option is refused on this platform.
+description: Use when a page records the screen or microphone or grabs a screenshot — fused.capture.screen/audio/screenshot/sources — or a capture option is refused on a platform.
 ---
 
-# Native capture (`fused.capture`)
+# fused.capture
 
-Three verbs: `screen()`, `audio()`, `screenshot()`. All three write a file this
-machine owns, which is the whole reason to use them over `getDisplayMedia` /
-`MediaRecorder`: the path is known before the recording ends, so it feeds
-`fused.ai.transcribe({path})` directly, and the recording survives your page
-being navigated away from (it is a download-manager job row).
+Native capture → the result is a FILE on this machine: path known before recording ends (feeds `fused.ai.transcribe({path})` directly), survives navigation (it's a download-manager job row). Local only — no `fused.capture` on exported pages.
 
-Local only — a hosted/exported page has no `fused.capture`.
+**Draw UI off `await fused.capture.sources()`** (never prompts) — `{video: {available, reason}, displays, microphones}`. `displays` is empty on Linux/Wayland by design. Don't sniff the platform; read refusals and `reason`s.
 
-## Ask first, and it never prompts
-
-What is possible differs per machine and per browser, so draw your UI off the
-answer rather than off a try/catch:
-
-```js
-const src = await fused.capture.sources();
-if (!src.video.available) { hideRecordButton(src.video.reason); return; }
-// src.displays -> [{id, width, height, main}], src.microphones -> [{id, name, default}]
-// `displays` is empty on Linux and on Wayland by design — nothing to name there.
-```
-
-## Three platforms, one API, and deliberately no field telling you which you got
-
-Read the refusals and the `reason`s instead of sniffing the platform.
+Platform matrix:
 
 | | macOS | Windows | Linux |
 |---|---|---|---|
 | screen recording | native, no picker | browser share picker | browser share picker |
-| survives a page reload | yes | no (file is kept) | no (file is kept) |
-| `display` / `rect` / `cursor` on `screen()` | honoured | refused | refused |
-| `display` / `rect` / `cursor` on `screenshot()` | honoured | honoured | `rect` only |
-| `device` on `audio()` | refused | honoured | honoured |
-| container | `.mov` / `.m4a` | `.mp4` or `.webm` | `.mp4` or `.webm` |
+| survives page reload | yes | no (file kept) | no (file kept) |
+| `display`/`rect`/`cursor` on screen() | yes | refused | refused |
+| same on screenshot() | yes | yes | rect only |
+| `device` on audio() | refused (system input; use screen's `audio:"mic"`) | yes | yes |
+| container | .mov/.m4a | .mp4/.webm | .mp4/.webm |
 
-So: do not hardcode an extension when you pass `path` — let the default name the
-file, or read `rec.path`. And if the recording matters, keep the page that
-started it open on Windows and Linux; a reload ends it (the file is kept and the
-row says so, but it is shorter than the user expected).
+So: don't hardcode an extension in `path` — omit it or read `rec.path`. Recordings that matter: keep the page open on Windows/Linux.
 
-## Recording is a handle, not a promise that resolves at the end
+## API
 
-```js
-const rec = await fused.capture.screen({
-  audio: "both",              // false | "mic" | "system" | "both" — "system" is
-                              // the one a browser cannot do on macOS at all
-  rect: [0, 0, 1200, 800],    // macOS only — refused where the browser's own
-                              // share picker chooses the region
-  path: "walkthrough.mov",    // optional; relative = beside THIS page. Omit it
-                              // unless you know the container (see the table)
-  maxSeconds: 600,            // default 30 min; hitting it STOPS (keeps the file)
-});
-// elapsed seconds come off the recording's job row — there is no onTick:
-fused.watchJob(rec.jobId).watch((row) => (label.textContent = row.done + "s"));
-// rec.path / rec.url are already usable here — the file is being written to them
-const out = await rec.stop();          // {path, url, mime, seconds, bytes}
-const words = await fused.ai.transcribe({ path: out.path, words: true });
-```
+`screen({audio: false|"mic"|"system"|"both", rect, path, maxSeconds})` and `audio({device, path, maxSeconds})` resolve **when recording starts**, with a handle `{id, jobId, path, url, state, stop(), cancel()}`. `stop()` → `{path, url, mime, seconds, bytes}`. `cancel()` (and the job row's ✕) stops AND DELETES — treat as "user doesn't want it". Elapsed seconds: `fused.watchJob(rec.jobId).watch(...)` — no onTick. `maxSeconds` default 30 min; hitting it stops and keeps the file.
 
-`screen()` and `audio()` resolve **when the recording is running**, with a handle
-`{id, jobId, path, url, state, stop(), cancel()}`. `stop()` resolves with the
-finished file; `cancel()` deletes it.
+`screenshot({rect, cursor, path})` — no handle, no job row, native on every platform (no share prompt → can shoot cross-origin panes). Filename picks png/jpeg; no `format` option.
 
-- `rec.cancel()` stops **and deletes**. So does the ✕ on its download-manager
-  row — that is the one control left once your page is gone, so treat a cancel
-  as "the user does not want this recording", not as "stop".
-- `fused.capture.audio()` records the microphone alone. On macOS it uses the
-  system's current input and **refuses** a `device` (the error names the
-  alternative: a screen recording's `audio: "mic"` takes one); on Windows and
-  Linux a `device` from `sources().microphones` works. Those names are empty
-  until the browser's microphone permission has been granted once.
-- `fused.capture.list()` finds live recordings — including one your page started
-  before a reload — and `attach(id)` gives the handle back. Check it on load
-  instead of starting a second recording.
-- `screenshot({rect, cursor, path})` has no handle and no job row. The output
-  **filename** picks png or jpeg — there is no `format`, so a path and a format
-  cannot disagree about what was written. Native on **every** platform, so it
-  needs no readable document and raises no share prompt — which is what makes a
-  cross-origin pane shootable.
-- Rejections carry `.type`: `"unavailable"` (this machine cannot — show
-  `.message`, it names the reason), `"bad_request"` (your arguments).
+`fused.capture.list()` finds live recordings (incl. pre-reload ones); `attach(id)` returns the handle. Check on load before starting a second recording. Microphone names are empty until browser mic permission granted once.
 
-## Two rules that catch most capture bugs
+Rejections: `.type` `"unavailable"` (machine can't — show `.message`) or `"bad_request"` (your args).
 
-- **A preview must not record.** A page rendered as a card thumbnail or listing
-  peek is stamped `_preview=1`; starting a capture there records the machine of
-  someone who was merely browsing. Gate boot on the flag — see "Reserved params
-  and preview mode" in **`fused-render-authoring`**.
-- **The recording outlives the page, so the job row is the real UI.** Progress
-  and cancellation live on the download-manager row, not in your DOM. For how
-  those rows work, and for reporting your own long work into them, see
-  **`fused-render-jobs`**.
+## Two rules
 
-Related: **`fused-render-authoring`** (the rest of `window.fused`),
-**`fused-render-ai`** (`fused.ai.transcribe`, the usual next call after a
-recording).
+- **Previews must not record** — gate boot on `_preview` (`fused-render-authoring`).
+- The recording outlives the page: the job row IS the real UI → `fused-render-jobs`.

--- a/skills/fused-render-capture/SKILL.md
+++ b/skills/fused-render-capture/SKILL.md
@@ -7,7 +7,7 @@ description: Use when page records screen/mic or grabs screenshot — fused.capt
 
 Native capture → result = FILE on this machine: path known before recording ends, file written live — `rec.path`/`rec.url` usable mid-recording (tail it, feed `fused.ai.transcribe({path})` after). Survives navigation (it's a download-manager job row). Local only — no `fused.capture` on exported pages.
 
-**Draw UI off `await fused.capture.sources()`** (never prompts) — `{video: {available, reason}, displays, microphones}`. `displays` empty on Linux/Wayland by design. Don't sniff platform; read refusals + `reason`s.
+**Draw UI off `await fused.capture.sources()`** (never prompts — the permission dialog rides the first real capture) — `{video, audio, systemAudio, screenshot}`, EACH `{available, granted, reason}`, plus `displays` and `microphones`. Gate every control off its own key (mic button off `audio`, `audio: "system"`/`"both"` off `systemAudio`) — `available: false` always carries a `reason`, and a start rejects `unavailable` with that same sentence. `displays` empty on Linux/Wayland by design. Don't sniff platform; read refusals + `reason`s.
 
 Platform matrix:
 
@@ -30,7 +30,7 @@ So: don't hardcode extension in `path` — omit or read `rec.path`. Recordings t
 
 `fused.capture.list()` finds live recordings (incl. pre-reload); `attach(id)` returns handle. Check on load before starting second recording. Microphone names empty until browser mic permission granted once.
 
-Rejections: `.type` `"unavailable"` (machine can't — show `.message`) or `"bad_request"` (your args).
+Rejections: `.type` `"unavailable"` (machine can't — show `.message`), `"bad_request"` (your args), or — on `stop()`/`cancel()` only — `"capture_error"`: the call went through but the file failed to write, so there is no playable recording. Handle all three; a two-branch `switch` swallows a lost take.
 
 ## Two rules
 

--- a/skills/fused-render-capture/SKILL.md
+++ b/skills/fused-render-capture/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: fused-render-capture
-description: Use when a page records the screen or microphone or grabs a screenshot — fused.capture.screen/audio/screenshot/sources — or a capture option is refused on a platform.
+description: Use when page records screen/mic or grabs screenshot — fused.capture — or capture option refused on a platform.
 ---
 
 # fused.capture
 
-Native capture → the result is a FILE on this machine: path known before recording ends (feeds `fused.ai.transcribe({path})` directly), survives navigation (it's a download-manager job row). Local only — no `fused.capture` on exported pages.
+Native capture → result = FILE on this machine: path known before recording ends, file written live — `rec.path`/`rec.url` usable mid-recording (tail it, feed `fused.ai.transcribe({path})` after). Survives navigation (it's a download-manager job row). Local only — no `fused.capture` on exported pages.
 
-**Draw UI off `await fused.capture.sources()`** (never prompts) — `{video: {available, reason}, displays, microphones}`. `displays` is empty on Linux/Wayland by design. Don't sniff the platform; read refusals and `reason`s.
+**Draw UI off `await fused.capture.sources()`** (never prompts) — `{video: {available, reason}, displays, microphones}`. `displays` empty on Linux/Wayland by design. Don't sniff platform; read refusals + `reason`s.
 
 Platform matrix:
 
@@ -20,19 +20,19 @@ Platform matrix:
 | `device` on audio() | refused (system input; use screen's `audio:"mic"`) | yes | yes |
 | container | .mov/.m4a | .mp4/.webm | .mp4/.webm |
 
-So: don't hardcode an extension in `path` — omit it or read `rec.path`. Recordings that matter: keep the page open on Windows/Linux.
+So: don't hardcode extension in `path` — omit or read `rec.path`. Recordings that matter: keep page open on Windows/Linux.
 
 ## API
 
-`screen({audio: false|"mic"|"system"|"both", rect, path, maxSeconds})` and `audio({device, path, maxSeconds})` resolve **when recording starts**, with a handle `{id, jobId, path, url, state, stop(), cancel()}`. `stop()` → `{path, url, mime, seconds, bytes}`. `cancel()` (and the job row's ✕) stops AND DELETES — treat as "user doesn't want it". Elapsed seconds: `fused.watchJob(rec.jobId).watch(...)` — no onTick. `maxSeconds` default 30 min; hitting it stops and keeps the file.
+`screen({audio: false|"mic"|"system"|"both", rect, path, maxSeconds})` and `audio({device, path, maxSeconds})` resolve **when recording starts**, handle = `{id, jobId, path, url, state, stop(), cancel()}`. `stop()` → `{path, url, mime, seconds, bytes}`. `cancel()` (and job row ✕) stops AND DELETES — treat as "user doesn't want it". Elapsed seconds: `fused.watchJob(rec.jobId).watch(...)` — no onTick. `maxSeconds` default 30 min; hitting it stops, keeps file.
 
-`screenshot({rect, cursor, path})` — no handle, no job row, native on every platform (no share prompt → can shoot cross-origin panes). Filename picks png/jpeg; no `format` option.
+`screenshot({rect, cursor, path})` — no handle, no job row, native every platform (no share prompt → can shoot cross-origin panes). Filename picks png/jpeg; no `format` option.
 
-`fused.capture.list()` finds live recordings (incl. pre-reload ones); `attach(id)` returns the handle. Check on load before starting a second recording. Microphone names are empty until browser mic permission granted once.
+`fused.capture.list()` finds live recordings (incl. pre-reload); `attach(id)` returns handle. Check on load before starting second recording. Microphone names empty until browser mic permission granted once.
 
 Rejections: `.type` `"unavailable"` (machine can't — show `.message`) or `"bad_request"` (your args).
 
 ## Two rules
 
 - **Previews must not record** — gate boot on `_preview` (`fused-render-authoring`).
-- The recording outlives the page: the job row IS the real UI → `fused-render-jobs`.
+- Recording outlives page: job row IS the real UI → `fused-render-jobs`.

--- a/skills/fused-render-custom-templates/SKILL.md
+++ b/skills/fused-render-custom-templates/SKILL.md
@@ -1,122 +1,54 @@
 ---
 name: fused-render-custom-templates
-description: Register a custom preview template so files of an extension render with your own template — the ~/.fused-render layout, registry.json mode lists, and _mode. Use when the user wants their own viewer for a file type, or to override/reorder template modes.
+description: Use when registering a custom preview template for a file extension, or overriding/reordering built-in template modes — ~/.fused-render layout, registry.json, condition.py.
 ---
 
-# Custom templates for fused-render
+# Custom preview templates
 
-fused-render resolves an **ordered list of preview templates — modes** — for each file by extension; the first mode is the default, and when a file has more than one the shell shows an icon-only switcher to flip between them. Built-ins ship inside the package; a user can override, reorder, or extend the list with templates under `~/.fused-render/templates/`. A custom template is an **ordinary renderable-HTML page** — same injected `window.fused` runtime, same `_file` param, same sibling-`.py` pattern as every built-in, optionally with an `icon.svg` for the switcher. Nothing about authoring is special; only *registration* is.
+Each extension resolves to an ordered list of modes (first = default; >1 shows a switcher). This skill = registration only. Writing the `template.html`/reader `.py` → `fused-render-authoring` (its "Preview templates" section IS a custom template). A "template" that's really a long-running server → `fused-render-background-apps`.
 
-**Division of labor between skills (do not duplicate):**
-
-- **This skill:** where files go, how the registry binds extensions, how to test registration.
-- **`skills/fused-render-authoring/SKILL.md`:** how to write the `template.html` and reader `.py` themselves — the `fused` API, the `main()` contract, the params-are-state wiring pattern, the `_file` handling, the pitfalls. **Read it before writing any html/py.** In particular its "Preview templates" section is exactly what a custom template is.
-- **`skills/fused-render-background-apps/SKILL.md`:** a different concept entirely — a folder that needs a resident daemon process, not a file preview. Reach for it when the "template" you're building is really a long-running server the page talks to, not a render mode.
-
-## Guardrail: use fused's internal APIs, never raw OS/shell commands
-
-A custom template runs on every open of its extension, with the local server's privileges, inside the packaged app — which bundles **only** a fixed Python library set plus a few tools (`rclone`/`uv`/`duckdb`), not a general shell. Reach for fused's own APIs, not raw OS or network commands. This is a security and performance boundary, not a style preference.
-
-**In the reader `.py` / `condition.py`:**
-- ❌ Don't shell out — no `subprocess`, `os.system`, `os.popen`, or invoking system binaries (`gdalinfo`, `curl`, `ffmpeg`, …). They may not exist in the packaged app, run with the server's privileges, and pay a process-spawn cost on every preview.
-- ✅ Do the work in-process with the **bundled libraries** (numpy, pandas, pyarrow, duckdb, pillow, openpyxl, requests/httpx, … — the authoritative set is in `fused-render-authoring`; anything else, geopandas and rasterio included, needs a folder `pyproject.toml`). Reading local files with `open()` / `os.path` relative to your script is fine and idiomatic; spawning commands is not.
-- ✅ In `condition.py`, **keep reads bounded** — sniff a footer/header/prefix, never `read()` a whole file, and never shell out. The gate runs for every file of the extension, some on remote mounts.
-
-**In `template.html`:**
-- ❌ Don't `fetch()` the server's `/api/fs/*` endpoints directly, and don't `<script src>` a runtime or pull data from arbitrary external hosts.
-- ✅ Reach the filesystem only through the injected `window.fused` helpers — `fused.readFile` / `fused.rawUrl` / `fused.stat` / `fused.writeFile`, and `fused.runPython` for anything Python adds value to. They're the stable contract and carry the headers writes require.
-
-**Why:** the internal APIs keep the template working in the sandboxed packaged app (no system dependencies), avoid the security surface of running shell commands with server privileges, and stay fast — no per-open subprocess spawns, and remote-mounted files are streamed through the runtime instead of pulled whole.
-
-## Layout on disk
-
-One folder per template, self-contained:
+## Layout
 
 ```
 ~/.fused-render/templates/
-├── registry.json          ← bindings: extension → mode list (names)
-├── geo/                   ← a template — the folder name IS its name
-│   ├── template.html      ← required, this is what renders
-│   ├── reader.py          ← optional siblings: readers, css, assets
-│   ├── condition.py       ← optional gate: def main(path) -> bool
-│   └── icon.svg           ← optional, shown by the mode switcher
-└── wip-thing/             ← no registry entry → inert draft
+├── registry.json      extension → mode list
+└── <name>/            folder name IS the public name (registry ref, _mode value)
+    ├── template.html  required entry point
+    ├── reader.py      optional siblings, referenced relatively
+    ├── condition.py   optional per-file gate
+    └── icon.svg       optional switcher icon (monochrome, currentColor, square, legible 16px)
 ```
 
-- **The folder name is the template's public name** — it's what a registry list references, the `_mode=<name>` URL value, and the switcher's tooltip label. One name-resolution rule everywhere: a name resolves to `~/.fused-render/templates/<name>/template.html` if that exists, else the built-in `fused_render/templates/<name>/template.html`, else it's unusable. **Naming your folder after a built-in shadows it** — the built-in names include `code`, `xlsx`, `duckdb` (the tabular viewer), `sqlite`, `structure`, `tree`, `markdown`, `image`, `media`, `pdf`, `text`, `geotiff`, `netcdf`, `zarr_aoi`, `map`, `vector`, `pmtiles`, `h3`, `api`, plus many more (the authoritative set is every folder under `fused_render/templates/` that contains a `template.html`, also visible in the app's Templates → Library). Reuse one deliberately to replace that built-in everywhere it's referenced.
-- `template.html` is the fixed entry-point filename.
-- Sibling files are referenced relatively, e.g. `fused.runPython("./reader.py", {...})` — the template renders from its real path, so relative resolution just works.
-- `icon.svg` is optional: a monochrome single-fill SVG (`currentColor` or plain black — the shell tints it via a CSS mask, so only alpha matters), square viewBox (24×24 suggested), simple enough to read at 16px. No icon → the switcher shows a first-letter placeholder for that mode instead.
+Name resolution: user folder wins, else built-in `fused_render/templates/<name>/`. Naming after a built-in shadows it deliberately (built-in names = every folder there with a template.html; also Templates → Library). Folder names: single segment, no dots, no leading `_`. Folder without a registry entry = inert draft.
 
 ## registry.json
 
-Flat JSON object. Keys are **dotted extension patterns** (compound extensions, `*` wildcard segments, trailing `/` for directories — same grammar as the built-in `fused_render/templates/registry.json`), values are a **list of names**, a single **name** (string), or **`null`**:
+Flat object; same key grammar as built-in `fused_render/templates/registry.json`. Values: list of names (full ordered mode list — **replace semantics**, no merge; re-list built-in modes you want to keep), a string (single-mode shorthand), or `null`/`[]` (disable templating for the extension).
 
-```json
-{
-  ".parquet": ["geo", "duckdb"],
-  ".geojson": "geo",
-  ".tar.gz": "archive",
-  ".*.json": "config-view",
-  ".obt/": "bundle",
-  ".png": null
-}
-```
+- Keys: dot-anchored suffix patterns, case-insensitive, most-specific wins (`.tar.gz` > `.gz`; literal > `*` at equal length). `*` = exactly one whole segment. Trailing `/` binds a directory (`.zarr/`). Any extension allowed, `.html` included (rebind `["code", "_render"]` to make source the default).
+- `_`-prefixed names are shell sentinels; referenceable: `_render`, `_listing`. Any other `_name` is invalid → dropped, `template_error` set, rest of list works.
+- Any registry key beats the built-in table. Re-read on every file open — no restart.
 
-Rules:
+## condition.py
 
-- **List = the full ordered mode list for that extension — replace semantics.** Order matters: the first entry is the default mode, later entries only show up (as a switcher) when the file has more than one mode. Each entry is a name resolved by the rule above. A user list **replaces** the built-in list for that extension outright — there is no splice/merge with the built-ins, so if you want a built-in mode alongside yours, name it explicitly in your list (e.g. `["geo", "duckdb"]` to keep the tabular viewer as a second mode).
-- **String = shorthand for a single-mode list of that one name** — exactly `["geo"]`. This is the pre-modes registry shape; existing registries keep working unchanged.
-- **`null` (or an empty list `[]`) disables templating** for that extension entirely: no template renders; the explorer shows its plain metadata/raw-download fallback.
-- **Dotted keys, most-specific wins, case-insensitive.** A key is a dot-anchored suffix pattern of one or more segments. More segments beats fewer (`.tar.gz` beats `.gz` for `backup.tar.gz`); at equal length, comparing from the rightmost segment, a literal beats a wildcard (`.xyz.json` > `.*.json` > `.json` for `data.xyz.json`). Always include the leading dot. A match needs something before the suffix — a file literally named `.json` doesn't match the `.json` key (but `.hidden.json` does).
-- **`*` = exactly one whole segment.** `.*.json` matches `data.tiles.json` but not `data.json` (nothing for the `*`) and not partially (`.geo*.json` is invalid — a key like that never matches anything).
-- **Trailing `/` binds a directory.** `".obt/"` matches a *directory* named `data.obt` — the way built-in `.zarr` stores are bound (`".zarr/": ["zarr_aoi", "_listing"]`). Directory keys never match files and vice versa. A `null` on a directory key gives the plain listing view.
-- **Many-to-one is normal** — several extension keys may reference the same template name.
-- **Any extension is allowed**, including ones fused-render has no built-in for — and including `.html`/`.htm`: the rendered-page-first default (built-in `".html": ["_render", "code", "claude", "reader"]`) is just a built-in registry entry, and you can rebind or reorder it (e.g. `["code", "_render"]` to make the source editor the default). Remember a user list replaces the built-in one, so re-list any built-in modes you want to keep.
-- **Names starting with `_` are shell sentinels** — modes the shell itself implements, not template folders. The referenceable ones are **`_render`** ("render the HTML file itself") and **`_listing`** (the plain directory listing, used on directory keys); any *other* `_`-prefixed name in a registry list is invalid: dropped, `template_error` set, rest of the list still works. Sentinels can't be shadowed by a folder (`.` and leading `_` are banned in folder names). Same reservation as `_mode`/`_file` params.
-- Registry (any matching key) beats the built-in table — even a plain user `.json` key beats a more specific built-in `.xyz.json` one; no registry entry (or no `registry.json` at all) means built-in behavior.
-- A folder without a registry entry does nothing — that's the draft state. Registering = adding the line; unregistering = deleting it. No restart needed: the registry is re-read on every file open, so the next navigation/refresh picks changes up.
+`def main(path) -> bool` beside template.html — show this template for this specific file? No file = always shown. Runs after registry resolution, evaluated in the background (`GET /api/fs/conditions?path=…`), verdicts cached ~60 s. May read the file but keep reads bounded (headers/footers, remote mounts exist). Broken gate = template dropped, reason in `error` on the conditions response. Gated template is never the default while an ungated one exists. Shows a "conditional" badge in Templates → Library.
 
-## Conditional templates (`condition.py`)
+## Guardrail
 
-The registry decides *which* templates apply to an extension. A template folder can additionally decide *whether* it shows for a **specific file** by dropping a **`condition.py`** beside its `template.html`:
+Templates run on every open with server privileges inside the packaged app. In readers/conditions: no `subprocess`/`os.system`/system binaries — bundled libraries in-process only (list in `fused-render-authoring`; more needs a folder pyproject). In html: filesystem only via `window.fused` helpers, never raw `/api/fs/*` fetches or external script/data hosts.
 
-```python
-# ~/.fused-render/templates/reports-view/condition.py
-def main(path):
-    # path is the absolute path of the file being previewed.
-    # Return True to show this template for this file, False to hide it.
-    return "/reports/" in path and path.endswith("_final.csv")
-```
+## Workflow
 
-- **Signature:** `def main(path): bool`. `path` is the file being previewed; return truthy to keep the template in the list, falsy to drop it.
-- **No `condition.py` = always shown** — the common case. Only add one when a template should apply to *some* files of an extension, not all.
-- **Runs after registry resolution**, for both user and built-in folders (whichever `template.html` resolves). So `".csv": ["reports-view", "duckdb", "code"]` offers `reports-view` only for files where its `main` returns True; the others always show.
-- **Evaluated in the background, not at stat time.** Stat only marks the entry `"conditional": true`; the shell renders the first *unconditional* template immediately and resolves the gates via `GET /api/fs/conditions?path=<file>` while a pending spinner shows in the switcher. This means a gate MAY read the file's contents (e.g. sniff a parquet footer) without slowing every preview — but keep reads bounded (metadata/footers/prefixes, not whole files), especially for files on remote mounts.
-- **Never the default while a normal template exists:** a gated template can only be the default mode when every template in the list is gated.
-- **Re-evaluated when its verdict isn't cached** — the `condition.py` module is re-loaded fresh each time it runs (edit it, no restart needed), but the conditions endpoint keeps a short **~60 s TTL cache** per file, so a re-navigation within that window returns the cached verdict rather than re-running the gate. (The registry itself, by contrast, is re-read with no cache on every open.)
-- **Concurrent:** when an extension has several gated templates they're evaluated concurrently, so the cost is the slowest gate, not the sum — but every gate still runs on every file of that extension (a gate that returns False still had to run to decide that).
-- **A broken condition drops that template** (no callable `main`, an exception, etc.) and reports the reason as `error` on the conditions response — same fail-closed posture as a bad registry name. It's never silently shown.
-- **Sentinel modes** (`_render`, `_listing`) have no folder and can't be gated.
-- **Visible in the UI:** a template with a `condition.py` shows a **"conditional"** badge in the templates management page (Templates → Library), so you can tell at a glance which templates are gated.
-
-## Workflow: create and register a template
-
-1. **Make the folder:** `mkdir -p ~/.fused-render/templates/<name>` — the name is public: it's the registry reference, the `_mode` URL value, and the switcher tooltip. Pick a real name, or reuse a built-in name on purpose to shadow it. (Or let the app scaffold it for you — Templates → Library → New — which creates the folder from a starter kit and binds it; see the note after this list.)
-2. **Author `template.html` (+ readers) following `fused-render-authoring`.** The template reads its target from the read-only `_file` param and keeps UI state (paging, sort) in normal params. A reader `.py` is only needed where Python adds value — text formats can `fused.readFile(file)` directly, media can point at `fused.rawUrl(file)`.
-3. **Optionally add `icon.svg`** — monochrome, square, simple at 16px (see above). Skip it and the mode shows a first-letter placeholder in the switcher.
-4. **Develop before registering (optional):** the draft folder is invisible to dispatch, but the template is a plain fused page — open `http://127.0.0.1:1777/explorer/view/<abs path to template.html>?_file=<abs path to a sample file>` to iterate on it directly. Saving the html or a reader auto-reloads the open view.
-5. **Register:** add the extension line to `~/.fused-render/templates/registry.json` — a bare name string for a single-mode override, or a list to set the full ordered mode list (re-listing any built-in modes you want to keep, since a user list replaces the built-in one). Create the file with `{}` around the first entry if it doesn't exist.
-6. **Test dispatch:** open a file of that extension in the explorer. A single-mode list renders directly; with more than one mode, the preview header shows an icon-only switcher — click your mode's icon (or its first-letter placeholder), or navigate straight to `…?_mode=<name>`. Editing `template.html` afterwards live-reloads any open preview.
-
-You don't have to hand-edit JSON at all: the app ships a **Templates → Library** page (backed by `/api/templates/*`) to inspect the merged inventory, edit registry bindings per-extension, scaffold a new template, and export/import — the same operations this workflow does by hand.
+1. `mkdir -p ~/.fused-render/templates/<name>` (or scaffold via Templates → Library → New).
+2. Author per `fused-render-authoring` (`_file` param = target; UI state in normal params).
+3. Iterate before registering: open `…/explorer/view/<abs template.html>?_file=<abs sample>` — drafts are plain fused pages. Saves live-reload.
+4. Register: add the extension line to registry.json (create with `{}` if absent).
+5. Test: open a file of that extension; switcher appears only when >1 mode; `?_mode=<name>` opens a specific one.
 
 ## Troubleshooting
 
-- **One mode missing, rest of the list fine:** a single bad entry (typo, folder name mismatch, `template.html` missing in both locations) is dropped silently — everything else in the list still renders. Check `template_error` on the stat response (`fused.stat(path)` or `GET /api/fs/stat?path=…`) for the first bad name.
-- **Whole extension falls back to built-ins:** happens when the registry value is a shape-level error — invalid JSON, or a value that isn't a list/string/null. (An empty list `[]` and `null` are *not* errors — they deliberately disable previews.)
-- **Folder name rejected:** names must be a single path segment — no `/`, no `\`, no `.` at all (dots are banned to keep names unambiguous against dotted registry keys), no leading `_` (reserved for shell sentinels), not empty.
-- **Template renders but is blank / errors:** that's an authoring problem, not registration — debug with the `fused-render-authoring` skill (red traceback overlay, `print()` → browser console).
-- **Registry edits not applying to an already-open preview:** open previews watch their files, not the registry — refresh or re-navigate.
-- **Mode switcher doesn't show up:** it only renders when a file has more than one mode (`templates.length > 1`) — a single-mode extension, or a `null` override, never shows it.
-- **A mode is missing only for some files:** that's a `condition.py` doing its job (or misfiring). If it's unexpectedly hidden, check `error` on `GET /api/fs/conditions?path=…` for a condition exception, and confirm `main(path)` returns True for that file's path.
+- One mode missing, rest fine → bad name dropped silently; check `template_error` on `fused.stat(path)`.
+- Whole extension falls back to built-ins → shape-level registry error (invalid JSON / wrong value type). `null`/`[]` are not errors.
+- Mode missing for SOME files → condition.py verdict; check `error` on `/api/fs/conditions`.
+- Blank/erroring render → authoring problem, not registration → `fused-render-authoring`.
+- Registry edits not applying to an open preview → previews watch files, not the registry; re-navigate.

--- a/skills/fused-render-custom-templates/SKILL.md
+++ b/skills/fused-render-custom-templates/SKILL.md
@@ -1,54 +1,54 @@
 ---
 name: fused-render-custom-templates
-description: Use when registering a custom preview template for a file extension, or overriding/reordering built-in template modes — ~/.fused-render layout, registry.json, condition.py.
+description: Use when registering custom preview template for file extension, or overriding/reordering built-in template modes.
 ---
 
 # Custom preview templates
 
-Each extension resolves to an ordered list of modes (first = default; >1 shows a switcher). This skill = registration only. Writing the `template.html`/reader `.py` → `fused-render-authoring` (its "Preview templates" section IS a custom template). A "template" that's really a long-running server → `fused-render-background-apps`.
+Each extension resolves to ordered mode list (first = default; >1 shows switcher). This skill = registration only. Writing `template.html`/reader `.py` → `fused-render-authoring` (its "Preview templates" section IS a custom template). "Template" that's really long-running server → `fused-render-background-apps`.
 
 ## Layout
 
 ```
 ~/.fused-render/templates/
 ├── registry.json      extension → mode list
-└── <name>/            folder name IS the public name (registry ref, _mode value)
+└── <name>/            folder name IS public name (registry ref, _mode value)
     ├── template.html  required entry point
     ├── reader.py      optional siblings, referenced relatively
     ├── condition.py   optional per-file gate
     └── icon.svg       optional switcher icon (monochrome, currentColor, square, legible 16px)
 ```
 
-Name resolution: user folder wins, else built-in `fused_render/templates/<name>/`. Naming after a built-in shadows it deliberately (built-in names = every folder there with a template.html; also Templates → Library). Folder names: single segment, no dots, no leading `_`. Folder without a registry entry = inert draft.
+Name resolution: user folder wins, else built-in `fused_render/templates/<name>/`. Naming after built-in shadows it deliberately (built-in names = every folder there with template.html; also Templates → Library). Folder names: single segment, no dots, no leading `_`. Folder without registry entry = inert draft.
 
 ## registry.json
 
-Flat object; same key grammar as built-in `fused_render/templates/registry.json`. Values: list of names (full ordered mode list — **replace semantics**, no merge; re-list built-in modes you want to keep), a string (single-mode shorthand), or `null`/`[]` (disable templating for the extension).
+Flat object; same key grammar as built-in `fused_render/templates/registry.json`. Values: list of names (full ordered mode list — **replace semantics**, no merge; re-list built-in modes you keep), string (single-mode shorthand), or `null`/`[]` (disable templating for extension).
 
-- Keys: dot-anchored suffix patterns, case-insensitive, most-specific wins (`.tar.gz` > `.gz`; literal > `*` at equal length). `*` = exactly one whole segment. Trailing `/` binds a directory (`.zarr/`). Any extension allowed, `.html` included (rebind `["code", "_render"]` to make source the default).
-- `_`-prefixed names are shell sentinels; referenceable: `_render`, `_listing`. Any other `_name` is invalid → dropped, `template_error` set, rest of list works.
-- Any registry key beats the built-in table. Re-read on every file open — no restart.
+- Keys: dot-anchored suffix patterns, case-insensitive, most-specific wins (`.tar.gz` > `.gz`; literal > `*` at equal length). `*` = exactly one whole segment. Trailing `/` binds directory (`.zarr/`). Any extension allowed, `.html` included (rebind `["code", "_render"]` → source becomes default).
+- `_`-prefixed names = shell sentinels; referenceable: `_render`, `_listing`. Other `_name` invalid → dropped, `template_error` set, rest of list works.
+- Any registry key beats built-in table. Re-read every file open — no restart.
 
 ## condition.py
 
-`def main(path) -> bool` beside template.html — show this template for this specific file? No file = always shown. Runs after registry resolution, evaluated in the background (`GET /api/fs/conditions?path=…`), verdicts cached ~60 s. May read the file but keep reads bounded (headers/footers, remote mounts exist). Broken gate = template dropped, reason in `error` on the conditions response. Gated template is never the default while an ungated one exists. Shows a "conditional" badge in Templates → Library.
+`def main(path) -> bool` beside template.html — show this template for this file? No file = always shown. Runs after registry resolution, evaluated in background (`GET /api/fs/conditions?path=…`), verdicts cached ~60 s; multiple gates for one extension run concurrently (cost = slowest gate, all still run). May read file, keep reads bounded (headers/footers — remote mounts exist). Broken gate = template dropped, reason in `error` on conditions response. Gated template never default while ungated one exists. Shows "conditional" badge in Templates → Library.
 
 ## Guardrail
 
-Templates run on every open with server privileges inside the packaged app. In readers/conditions: no `subprocess`/`os.system`/system binaries — bundled libraries in-process only (list in `fused-render-authoring`; more needs a folder pyproject). In html: filesystem only via `window.fused` helpers, never raw `/api/fs/*` fetches or external script/data hosts.
+Templates run on every open, server privileges, inside packaged app. Readers/conditions: no `subprocess`/`os.system`/system binaries — bundled libraries in-process only (list in `fused-render-authoring`; more → folder pyproject). Html: filesystem only via `window.fused` helpers, never raw `/api/fs/*` or external script/data hosts.
 
 ## Workflow
 
-1. `mkdir -p ~/.fused-render/templates/<name>` (or scaffold via Templates → Library → New).
+1. `mkdir -p ~/.fused-render/templates/<name>` (or Templates → Library → New).
 2. Author per `fused-render-authoring` (`_file` param = target; UI state in normal params).
 3. Iterate before registering: open `…/explorer/view/<abs template.html>?_file=<abs sample>` — drafts are plain fused pages. Saves live-reload.
-4. Register: add the extension line to registry.json (create with `{}` if absent).
-5. Test: open a file of that extension; switcher appears only when >1 mode; `?_mode=<name>` opens a specific one.
+4. Register: add extension line to registry.json (create with `{}` if absent).
+5. Test: open file of that extension; switcher only when >1 mode; `?_mode=<name>` opens specific one.
 
 ## Troubleshooting
 
 - One mode missing, rest fine → bad name dropped silently; check `template_error` on `fused.stat(path)`.
-- Whole extension falls back to built-ins → shape-level registry error (invalid JSON / wrong value type). `null`/`[]` are not errors.
+- Whole extension falls to built-ins → shape-level registry error (invalid JSON / wrong value type). `null`/`[]` not errors.
 - Mode missing for SOME files → condition.py verdict; check `error` on `/api/fs/conditions`.
 - Blank/erroring render → authoring problem, not registration → `fused-render-authoring`.
-- Registry edits not applying to an open preview → previews watch files, not the registry; re-navigate.
+- Registry edits not applying to open preview → previews watch files, not registry; re-navigate.

--- a/skills/fused-render-custom-templates/SKILL.md
+++ b/skills/fused-render-custom-templates/SKILL.md
@@ -19,7 +19,7 @@ Each extension resolves to ordered mode list (first = default; >1 shows switcher
     └── icon.svg       optional switcher icon (monochrome, currentColor, square, legible 16px)
 ```
 
-Name resolution: user folder wins, else built-in `fused_render/templates/<name>/`. Naming after built-in shadows it deliberately (built-in names = every folder there with template.html; also Templates → Library). Folder names: single segment, no dots, no leading `_`. Folder without registry entry = inert draft.
+Name resolution: user folder wins, else built-in — resolved from staged copy `~/.fused-render/.core-templates/<name>/` (packaged `fused_render/templates/` tree copied there at server startup; repo tree is source only). Naming after built-in shadows it deliberately (built-in names = every staged folder with template.html; also Templates → Library). Folder names: single segment, no dots, no leading `_`. Folder without registry entry = inert draft.
 
 ## registry.json
 

--- a/skills/fused-render-index/SKILL.md
+++ b/skills/fused-render-index/SKILL.md
@@ -30,7 +30,7 @@ Facts:
 - Failures reject Error with `.message` (duckdb/server text), `.type`, `.status` — render `.message`.
 - Index calls **not superseded like `runPython`'s**: slower earlier keystroke's reply can land last. Guard own renders (below).
 - Page of rows ≠ match count — ask `count(*)` separately to page.
-- Not on bridge (raw fetch, POSTs need `X-Fused: 1`): `/api/index/scan`, `/api/index/cancel`, `/api/index/config`, `/api/index/status`, `/api/index/stats`, `/api/index/lookup`, `/api/index/runs`, `/api/index/delete`, `/api/index/ask` (spends AI credits — button, not debounce), `GET /api/git-repos`. Shapes: `fused_render/server/routers/` + `fused_render/static/runtime.js` comments. `/api/index/status`'s `error` field = data (last scan's failure), not throw.
+- Not on bridge (raw fetch, POSTs need `X-Fused: 1`): `/api/index/scan`, `/api/index/scan-folder`, `/api/index/cancel`, `/api/index/rank`, `/api/index/config`, `/api/index/status`, `/api/index/stats`, `/api/index/lookup`, `/api/index/runs`, `/api/index/delete`, `/api/index/ask` (spends AI credits — button, not debounce), `GET /api/git-repos`. Shapes: `fused_render/server/routers/` + `fused_render/static/runtime.js` comments. `/api/index/status`'s `error` field = data (last scan's failure), not throw.
 - Store location fixed: `home_dir()/index` — `/api/index/config` edits roots/ignore, cannot relocate store (only `FUSED_RENDER_HOME` at server start moves it).
 
 ### The canonical shape (per-keystroke)

--- a/skills/fused-render-index/SKILL.md
+++ b/skills/fused-render-index/SKILL.md
@@ -1,35 +1,37 @@
 ---
 name: fused-render-index
-description: Use when a page or .py needs file search, disk-usage/file-type breakdowns, or SQL over the filesystem — fused.fileIndex instead of walking the fs.
+description: Use when page or .py needs file search, disk-usage/file-type breakdowns, or SQL over filesystem — fused.fileIndex, not fs walks.
 ---
 
 # The file index
 
-fused-render keeps a parquet index of the filesystem (one row per file, one per dir). Read it instead of `os.walk`/`find`/per-row stats. Three ways in:
+fused-render keeps parquet index of filesystem (one row per file, one per dir). Read it, don't `os.walk`/`find`/per-row stat. Three ways in:
 
 | Need | Path |
 |---|---|
 | Interactive UI reads (search box, tiles, table) | `fused.fileIndex.*` (JS) |
-| Bulk/analytical Python (aggregate, join, pandas) | duckdb over the parquet directly |
-| Index management (scan, roots/ignore, repos) | raw `fetch` + `X-Fused: 1` header on POSTs |
+| Bulk/analytical Python (aggregate, join, pandas) | duckdb over parquet directly |
+| Index management (scan, roots/ignore, repos) | raw `fetch` + `X-Fused: 1` on POSTs |
 
 ## Readiness rule (the one that matters)
 
-Zero rows means BOTH "no matches" and "no index yet". Rendering the second as the first is the silent lie this design exists to prevent. Both JS calls resolve with `ready: {indexed, scanning, stale, reason}` (`reason`: `no-index` / `outdated` / `not-covered` / null); the Python reader returns `(None, None)` for an empty store. `indexed: false` → "building / not indexed", never "no results". `stale` never means "matches the fs" — an index is always slightly behind.
+Zero rows means BOTH "no matches" and "no index yet". Rendering second as first = silent lie this design exists to prevent. Both JS calls resolve with `ready: {indexed, scanning, stale, reason}` (`reason`: `no-index` / `outdated` / `not-covered` / null); Python reader returns `(None, None)` for empty store. `indexed: false` → "building / not indexed", never "no results". `stale` never means "matches fs" — index always slightly behind.
 
 ## JS: `fused.fileIndex`
 
-Two methods, that's the whole bridge:
+Two methods, whole bridge:
 
-- `search({root, q, limit})` — one folder's corpus, `/api/fs/walk` entry shape + `covered, fresh, age_s, truncated`. Per-keystroke cheap. `covered: false` is a 200 and a state, not an error.
-- `query({sql, limit})` — ONE read-only SQL statement over views `files` and `dirs` → `{columns, rows (positional arrays), truncated}`. limit default 200, cap 5000. Totals, breakdowns, path matches — all of it is `query`.
+- `search({root, q, limit})` — one folder's corpus, `/api/fs/walk` entry shape + `covered, fresh, age_s, truncated`. Per-keystroke cheap. `covered: false` = 200 + a state, not error.
+- `query({sql, limit})` — ONE read-only SQL statement over views `files`, `dirs` → `{columns, rows (positional arrays), truncated}`. limit default 200, cap 5000. Totals, breakdowns, path matches — all `query`.
 
 Facts:
 
-- **No bind parameters** — quote user strings by doubling `'` yourself. Guard (`fused_render/index/guarded_query.py`): one statement, read-only types only, two views only, 10 s wall clock, duckdb errors surface verbatim as 400 (show them).
-- Index calls are **not superseded like `runPython`'s**: the slower earlier keystroke's reply can land last. Guard your own renders (below).
-- A page of rows ≠ match count — ask `count(*)` separately to page.
-- Not on the bridge (raw fetch, POSTs need `X-Fused: 1`): `/api/index/scan`, `/api/index/cancel`, `/api/index/config`, `/api/index/status`, `/api/index/stats`, `/api/index/lookup`, `/api/index/runs`, `/api/index/delete`, `/api/index/ask` (spends AI credits — button, not debounce), `GET /api/git-repos`. Shapes: `fused_render/server/routers/` + `fused_render/static/runtime.js` comments. `/api/index/status`'s `error` field is data (last scan's failure), not a throw.
+- **No bind parameters** — quote user strings yourself, double `'`. Guard (`fused_render/index/guarded_query.py`): one statement, read-only types, two views only, 10 s wall clock, duckdb errors surface verbatim as 400 (show them).
+- Failures reject Error with `.message` (duckdb/server text), `.type`, `.status` — render `.message`.
+- Index calls **not superseded like `runPython`'s**: slower earlier keystroke's reply can land last. Guard own renders (below).
+- Page of rows ≠ match count — ask `count(*)` separately to page.
+- Not on bridge (raw fetch, POSTs need `X-Fused: 1`): `/api/index/scan`, `/api/index/cancel`, `/api/index/config`, `/api/index/status`, `/api/index/stats`, `/api/index/lookup`, `/api/index/runs`, `/api/index/delete`, `/api/index/ask` (spends AI credits — button, not debounce), `GET /api/git-repos`. Shapes: `fused_render/server/routers/` + `fused_render/static/runtime.js` comments. `/api/index/status`'s `error` field = data (last scan's failure), not throw.
+- Store location fixed: `home_dir()/index` — `/api/index/config` edits roots/ignore, cannot relocate store (only `FUSED_RENDER_HOME` at server start moves it).
 
 ### The canonical shape (per-keystroke)
 
@@ -38,7 +40,7 @@ let generation = 0;
 async function drawRows() {
   const mine = ++generation;
   const out = await fused.fileIndex.query({ sql });
-  if (mine !== generation) return;   // a newer keystroke owns the table
+  if (mine !== generation) return;   // newer keystroke owns table
   if (!out.ready.indexed) { showBuilding(out.ready); return; }
   render(out.rows);                  // positional arrays, per out.columns
 }
@@ -48,27 +50,27 @@ Schemas (`fused_render/index/store.py` `schemas()`): `files(path, dir, name, ext
 
 ## Python: read the parquet
 
-App venvs cannot `import fused_render` — copy `reader.py` (beside this SKILL.md, tested in CI) into the app and declare `duckdb` in its `pyproject.toml`. Store: `~/.fused-render/index/` — `partitions.json` (THE manifest), `files/part-*.parquet`, `dirs.parquet`. Everything else is writer-only; readers never take `store_lock`, never write.
+App venvs cannot `import fused_render` — copy `reader.py` (beside this SKILL.md, tested in CI) into app, declare `duckdb` in its `pyproject.toml`. Store: `~/.fused-render/index/` — `partitions.json` (THE manifest), `files/part-*.parquet`, `dirs.parquet`. Rest is writer-only; readers never take `store_lock`, never write.
 
-- **THE trap: never glob `files/*.parquet`.** Old generations stay on disk beside new ones — a glob double-counts (~2x) silently, and only on machines scanned twice. Open exactly the files `partitions.json` names.
-- Use the relation API (`con.read_parquet(list).create_view("files")`) — `CREATE VIEW ... read_parquet(?)` refuses prepared params.
-- No manifest / zero partitions / no dirs.parquet → return "not indexed" to the page, don't raise.
-- Dev worktrees are branch-scoped stores (`FUSED_RENDER_HOME` + `branches/<sanitized ref>/`, `fused_render/_branch.py`). Pass the `location` that `/api/index/stats` reports rather than resolving the path yourself.
+- **THE trap: never glob `files/*.parquet`.** Old generations stay on disk beside new — glob double-counts (~2x) silently, only on machines scanned twice. Open exactly what `partitions.json` names.
+- Relation API (`con.read_parquet(list).create_view("files")`) — `CREATE VIEW ... read_parquet(?)` refuses prepared params.
+- No manifest / zero partitions / no dirs.parquet → return "not indexed" to page, don't raise.
+- Dev worktrees = branch-scoped stores (`FUSED_RENDER_HOME` + `branches/<sanitized ref>/`, `fused_render/_branch.py`). Pass `location` that `/api/index/stats` reports; don't resolve path yourself.
 
-Deeper reference: `fused_render/index/query.py` (and the sanitize rule in `fused_render/_branch.py`).
+Deeper reference: `fused_render/index/query.py` (+ sanitize rule in `fused_render/_branch.py`).
 
 ## Deriving entity kinds
 
-Precedent: git repos = `dirs` rows named `.git` (leaf dirs are recorded, not descended) — zero stats vs ~71k per request. Before probing the fs per row, ask: did the scan already record the marker? BUT read `fused_render/server/routers/git_repos.py` before copying: `junk_path` + `MountGuard` parent-screening and the applied-ignore signature are Python-only — a page-side SELECT gets both kinds of zero wrong. For repos, just `GET /api/git-repos` (`{repos, indexed, scanning, stale, reason}`). A new kind needing those screens belongs in a server route, not a page.
+Precedent: git repos = `dirs` rows named `.git` (leaf dirs recorded, not descended) — zero stats vs ~71k per request. Before probing fs per row, ask: did scan already record the marker? BUT read `fused_render/server/routers/git_repos.py` before copying: `junk_path` + `MountGuard` parent-screening + applied-ignore signature are Python-only — page-side SELECT gets both kinds of zero wrong. For repos just `GET /api/git-repos` (`{repos, indexed, scanning, stale, reason}`). New kind needing those screens → server route, not page.
 
 ## Pitfalls
 
 - Globbing partitions; rendering `[]` without checking `ready.indexed`; treating `covered: false` as error.
 - No generation guard on per-keystroke queries.
 - Unescaped `'` in interpolated SQL.
-- `import fused_render` from an app `.py`; forgetting `duckdb` in the app's pyproject (dep list is complete — see `fused-render-authoring`).
+- `import fused_render` from app `.py`; forgetting `duckdb` in app pyproject (dep list complete — `fused-render-authoring`).
 - POST without `X-Fused: 1` → 403.
-- Looking for `fused.index.*` or stats/lookup/scan on the bridge — surface is `search` + `query`, period.
+- Looking for `fused.index.*` or stats/lookup/scan on bridge — surface = `search` + `query`, period.
 - `/api/index/ask` per keystroke.
 
-Related: authoring the page → `fused-render-authoring`; daemon reading the index → `fused-render-background-apps`.
+Related: page authoring → `fused-render-authoring`; daemon reading index → `fused-render-background-apps`.

--- a/skills/fused-render-index/SKILL.md
+++ b/skills/fused-render-index/SKILL.md
@@ -1,357 +1,74 @@
 ---
 name: fused-render-index
-description: Read fused-render's machine-wide file index instead of walking the filesystem — the fused.fileIndex.search/query bridge and a copy-paste duckdb reader for bulk Python. Use for a file search box, a disk-usage or file-type breakdown, or SQL over the filesystem.
+description: Use when a page or .py needs file search, disk-usage/file-type breakdowns, or SQL over the filesystem — fused.fileIndex instead of walking the fs.
 ---
 
-# Reading the fused-render file index
+# The file index
 
-fused-render keeps a **parquet index of the user's filesystem** — one row per file, one row per directory, built by a background scan and served by `/api/index/*`. It is what makes machine-wide search instant, and any app can read it. Nothing here is about building or configuring the index; it is about **answering questions from it** without walking the filesystem, spawning `find`, or stat-ing a million paths.
-
-Two ways in, and the choice is not stylistic:
+fused-render keeps a parquet index of the filesystem (one row per file, one per dir). Read it instead of `os.walk`/`find`/per-row stats. Three ways in:
 
 | Need | Path |
 |---|---|
-| Interactive UI reads — a search box, stat tiles, a result table, paging | **`fused.fileIndex.*`** (JS). No subprocess per keystroke; readiness is included. |
-| Bulk/analytical reads that stay in Python — aggregate the whole index, join it against another parquet, feed pandas/geopandas | **Read the parquet directly** with duckdb. A 200-row JSON response is the wrong shape *and* the wrong bottleneck. |
-| Writes and index management — start a scan, cancel one, edit roots/ignore, the repos list | **Raw `fetch` + `X-Fused: 1`** (section C). Not on the bridge: managing the index is a shell action, not a render path. Never write into the store directory yourself. |
+| Interactive UI reads (search box, tiles, table) | `fused.fileIndex.*` (JS) |
+| Bulk/analytical Python (aggregate, join, pandas) | duckdb over the parquet directly |
+| Index management (scan, roots/ignore, repos) | raw `fetch` + `X-Fused: 1` header on POSTs |
 
-## The readiness rule (read this before anything else)
+## Readiness rule (the one that matters)
 
-An index query answers **zero rows** both when nothing matches and when no index has ever been built. Rendering the second as the first is a silent lie — the failure mode `fused_render/server/routers/git_repos.py` calls "the original silent lie and the reason any of this exists". Whichever path you take, an empty result is **two different states** and your UI must be able to tell them apart:
+Zero rows means BOTH "no matches" and "no index yet". Rendering the second as the first is the silent lie this design exists to prevent. Both JS calls resolve with `ready: {indexed, scanning, stale, reason}` (`reason`: `no-index` / `outdated` / `not-covered` / null); the Python reader returns `(None, None)` for an empty store. `indexed: false` → "building / not indexed", never "no results". `stale` never means "matches the fs" — an index is always slightly behind.
 
-- **no index / not covered** → "still building" or "your folder isn't indexed yet", never "no results".
-- **a real empty answer** → "no matches".
+## JS: `fused.fileIndex`
 
-The JS bridge hands you that distinction on every call; the Python reader gets it by returning `(None, None)` for a store with nothing to read yet. Neither treats "no index" as an error — it is a state you render.
+Two methods, that's the whole bridge:
 
-## A. The JS bridge: `fused.fileIndex.*`
+- `search({root, q, limit})` — one folder's corpus, `/api/fs/walk` entry shape + `covered, fresh, age_s, truncated`. Per-keystroke cheap. `covered: false` is a 200 and a state, not an error.
+- `query({sql, limit})` — ONE read-only SQL statement over views `files` and `dirs` → `{columns, rows (positional arrays), truncated}`. limit default 200, cap 5000. Totals, breakdowns, path matches — all of it is `query`.
 
-Injected with the rest of `window.fused` — no script tag, no fetch, no `X-Fused` header to remember (the bridge sends it on the `query` POST for you).
+Facts:
 
-**Two methods, and that is the whole bridge:**
+- **No bind parameters** — quote user strings by doubling `'` yourself. Guard (`fused_render/index/guarded_query.py`): one statement, read-only types only, two views only, 10 s wall clock, duckdb errors surface verbatim as 400 (show them).
+- Index calls are **not superseded like `runPython`'s**: the slower earlier keystroke's reply can land last. Guard your own renders (below).
+- A page of rows ≠ match count — ask `count(*)` separately to page.
+- Not on the bridge (raw fetch, POSTs need `X-Fused: 1`): `/api/index/scan`, `/api/index/cancel`, `/api/index/config`, `/api/index/status`, `/api/index/stats`, `/api/index/lookup`, `/api/index/runs`, `/api/index/delete`, `/api/index/ask` (spends AI credits — button, not debounce), `GET /api/git-repos`. Shapes: `fused_render/server/routers/` + `fused_render/static/runtime.js` comments. `/api/index/status`'s `error` field is data (last scan's failure), not a throw.
 
-| Call | Answers |
-|---|---|
-| `await fused.fileIndex.search({root, q, limit})` | The in-folder corpus for `root`, in `/api/fs/walk`'s entry shape: `{entries: [{rel, is_dir, size, mtime}], covered, fresh, age_s, truncated}`. This is the explorer's own search source — reach for it when you want *one folder's* tree, not a machine-wide match. Cheap enough to call per keystroke. |
-| `await fused.fileIndex.query({sql, limit})` | One **read-only** SQL statement over the `files` and `dirs` views: `{columns, rows, truncated}` — `rows` are arrays, positional to `columns`. Everything machine-wide: totals, per-extension breakdowns, a path match, a report. `limit` defaults to 200 and caps at 5000. |
-
-Why only two. `query` *is* the totals and the path lookup — `/api/index/stats` and `/api/index/lookup` are SELECTs over the same two views, so wrapping them was a second spelling of one capability. Readiness rides on both responses, so a `status` method would have been surface without capability. And starting a scan, editing roots/ignore, or listing repos is **index management**: a shell action, reachable by raw `fetch` with `X-Fused: 1` (section C) for the rare page that genuinely means it, not something a render path should reach for by accident.
-
-**Both of them also resolve with `ready`:**
+### The canonical shape (per-keystroke)
 
 ```js
-ready = { indexed, scanning, stale, reason }
+let generation = 0;
+async function drawRows() {
+  const mine = ++generation;
+  const out = await fused.fileIndex.query({ sql });
+  if (mine !== generation) return;   // a newer keystroke owns the table
+  if (!out.ready.indexed) { showBuilding(out.ready); return; }
+  render(out.rows);                  // positional arrays, per out.columns
+}
 ```
 
-- `indexed` — a compacted index exists at all.
-- `scanning` — a scan is in flight. **Independent of `indexed`**: a rescan keeps serving the last completed generation, so this means "say indexing…", not "stop using the index".
-- `stale` — the answer may be behind the filesystem (a scan running, or a slice built under superseded ignore rules). It never means "identical to the filesystem" — an index is always slightly behind.
-- `reason` — `"no-index"`, `"outdated"` (the rule that would produce these rows never ran, so a rebuild is coming), `"not-covered"` (the index exists but has not visited this root), or `null`.
+Schemas (`fused_render/index/store.py` `schemas()`): `files(path, dir, name, ext, size, mtime, depth)`, `dirs(dir, sig, n_files, total_size, mtime_ns, n_subdirs, depth)`. Paths absolute POSIX; `ext` lowercase, no dot; `mtime` epoch seconds, `dirs.mtime_ns` nanoseconds.
 
-A field is `null` only where that response genuinely cannot say, never as a guess: `search()` reports `scanning: null` because it is the per-keystroke path and must not double its request count, and a failed readiness probe answers all-null rather than claiming the index is missing. Where the endpoint carries richer facts they stay on the result too — `covered`, `fresh`, `age_s`, `truncated`.
+## Python: read the parquet
 
-`query()` gets its envelope from one parallel `/api/index/status` GET. That probe is not billed as an app call (`calls.SKIP_PREFIXES`) and its `error` field is *data* — the last scan's failure sentence — so a crashed scan does not turn every subsequent call into a traceback.
+App venvs cannot `import fused_render` — copy `reader.py` (beside this SKILL.md, tested in CI) into the app and declare `duckdb` in its `pyproject.toml`. Store: `~/.fused-render/index/` — `partitions.json` (THE manifest), `files/part-*.parquet`, `dirs.parquet`. Everything else is writer-only; readers never take `store_lock`, never write.
 
-**Two routes are not reachable at all from the bridge and never were**, both still available by raw `fetch` for a caller that truly means it: `POST /api/index/delete` (wiping the user's whole index is not something a page does on load) and `POST /api/index/ask` (it spends AI credits per call, so it belongs behind an explicit user action, not a render path).
+- **THE trap: never glob `files/*.parquet`.** Old generations stay on disk beside new ones — a glob double-counts (~2x) silently, and only on machines scanned twice. Open exactly the files `partitions.json` names.
+- Use the relation API (`con.read_parquet(list).create_view("files")`) — `CREATE VIEW ... read_parquet(?)` refuses prepared params.
+- No manifest / zero partitions / no dirs.parquet → return "not indexed" to the page, don't raise.
+- Dev worktrees are branch-scoped stores (`FUSED_RENDER_HOME` + `branches/<sanitized ref>/`, `fused_render/_branch.py`). Pass the `location` that `/api/index/stats` reports rather than resolving the path yourself.
 
-### The canonical shape: stat tiles + a paginated table
+Deeper reference: `fused_render/index/query.py` (and the sanitize rule in `fused_render/_branch.py`).
 
-```html
-<div id="banner"></div>
-<div id="tiles"></div>
-<input id="q" placeholder="search files…">
-<table><tbody id="rows"></tbody></table>
-<script>
-  const PAGE = 50;
+## Deriving entity kinds
 
-  // ONE place decides what an empty result means. Every render path goes
-  // through it, so "no index yet" can never leak out as "no results".
-  function banner(ready) {
-    const el = document.getElementById("banner");
-    if (ready.indexed === false) {
-      el.textContent = ready.scanning
-        ? "Building the index…"
-        : "No index yet — run a scan to search your files.";
-      return false;
-    }
-    el.textContent = ready.stale ? "Indexing — results may be a little behind." : "";
-    return true;
-  }
+Precedent: git repos = `dirs` rows named `.git` (leaf dirs are recorded, not descended) — zero stats vs ~71k per request. Before probing the fs per row, ask: did the scan already record the marker? BUT read `fused_render/server/routers/git_repos.py` before copying: `junk_path` + `MountGuard` parent-screening and the applied-ignore signature are Python-only — a page-side SELECT gets both kinds of zero wrong. For repos, just `GET /api/git-repos` (`{repos, indexed, scanning, stale, reason}`). A new kind needing those screens belongs in a server route, not a page.
 
-  // /api/index/query takes ONE sql string and no bind parameters, so a value
-  // from the user has to be quoted here. Doubling `'` is the whole rule for a
-  // SQL literal, and the guard (`fused_render/index/guarded_query.py`) accepts a
-  // single read-only statement — so a stray `;` cannot become a second one.
-  const lit = (s) => "'" + String(s).replace(/'/g, "''") + "'";
+## Pitfalls
 
-  async function drawTiles() {
-    const out = await fused.fileIndex.query({
-      sql: "SELECT count(*), sum(size) FROM files",
-    });
-    if (!banner(out.ready)) return;
-    const [files, bytes] = out.rows[0];  // rows are arrays, positional to `columns`
-    document.getElementById("tiles").textContent =
-      `${files.toLocaleString()} files · ${(bytes / 1e9).toFixed(1)} GB`;
-  }
+- Globbing partitions; rendering `[]` without checking `ready.indexed`; treating `covered: false` as error.
+- No generation guard on per-keystroke queries.
+- Unescaped `'` in interpolated SQL.
+- `import fused_render` from an app `.py`; forgetting `duckdb` in the app's pyproject (dep list is complete — see `fused-render-authoring`).
+- POST without `X-Fused: 1` → 403.
+- Looking for `fused.index.*` or stats/lookup/scan on the bridge — surface is `search` + `query`, period.
+- `/api/index/ask` per keystroke.
 
-  // Index calls are NOT superseded the way runPython's are (D114): nothing
-  // aborts the in-flight "ab" query when "abc" starts, and the broader earlier
-  // query is usually the slower one — so its reply can land LAST and leave the
-  // table showing a query the box no longer contains. One generation counter per
-  // render path is the whole guard.
-  let generation = 0;
-
-  async function drawRows() {
-    const mine = ++generation;
-    const like = lit("%" + (fused.params.get("q") || "") + "%");
-    const offset = parseInt(fused.params.get("offset") || "0", 10);
-    const out = await fused.fileIndex.query({
-      sql: `SELECT name, size, dir FROM files WHERE path ILIKE ${like}
-            ORDER BY size DESC LIMIT ${PAGE} OFFSET ${offset}`,
-    });
-    if (mine !== generation) return;  // a newer keystroke already owns the table
-    if (!banner(out.ready)) return;
-    document.getElementById("rows").innerHTML = out.rows
-      .map(([name, size, dir]) => `<tr><td>${name}</td><td>${size}</td><td>${dir}</td></tr>`)
-      .join("");
-    // A page of rows is not a match count. Ask for one when you need to page:
-    // SELECT count(*) FROM files WHERE path ILIKE … — a second, cheap statement.
-  }
-
-  // Params are the state, exactly as in any other view (`fused-render-authoring`).
-  document.getElementById("q").addEventListener("input", (e) => {
-    fused.params.set("q", e.target.value);
-    fused.params.set("offset", "0");
-  });
-  fused.params.onChange(drawRows);
-  drawTiles();
-  drawRows();
-</script>
-```
-
-Rejections follow the rest of the bridge: an `Error` whose `.message` is the server's sentence verbatim (a duckdb `Binder Error: no such column: nope` is exactly what the user needs to read) plus `.type` (`"forbidden"` for a refused POST, `"bad_request"` otherwise, or the server's own type) and `.status`.
-
-## B. The Python side: read the parquet directly
-
-The index is real parquet on disk, so Python can read it with **nothing but `duckdb`** — no HTTP, no `import fused_render`. That last point is not a preference: an app folder with a `pyproject.toml` gets its own uv-built venv (`<project folder>/.venv`, or `<home_dir()>/venvs/<sha256(abspath)[:16]>` when the folder can't hold one — an in-package runner folder, an unwritable mount, or `FUSED_RENDER_VENV_IN_TREE=0`; see `fused_render/projectenv.py`) where `fused_render` is **not importable**. So you copy this reader into the app and declare `duckdb` in the app's own `pyproject.toml`; you do not import ours.
-
-### The store on disk
-
-```
-~/.fused-render/index/
-├── partitions.json        ← THE MANIFEST. Read this first, always.
-├── files/
-│   ├── part-000008-00000.parquet
-│   └── part-000008-00001.parquet
-├── dirs.parquet
-├── fsevents.json          ┐
-├── ignore_applied.json    │ writer-only state.
-├── config.json            │ A reader never opens these,
-├── scans.json             │ and never writes anything here at all.
-└── runs/                  ┘
-```
-
-`partitions.json` top-level keys: `generation`, `rows`, `updated`, `last_root`, `partitions`. Each partition entry: `file`, `rows`, `min`, `max`, `min_lower`, `max_lower` — the `_lower` pair is a **separate case-folded aggregate**, not `lower(min)`/`lower(max)`, because byte order and folded order disagree (see `prune` in `fused_render/index/query.py`).
-
-Schemas (`fused_render/index/store.py`, `schemas()`):
-
-- `files` — `path, dir, name, ext, size, mtime, depth`
-- `dirs` — `dir, sig, n_files, total_size, mtime_ns, n_subdirs, depth`
-
-Units and conventions: `path`/`dir` are absolute and POSIX-separated; `name` is the basename; `ext` is lowercase with no leading dot and `''` for no extension; `size` is bytes; `mtime` is epoch **seconds** (float) while `dirs.mtime_ns` is epoch **nanoseconds** and `0` there means unknown; `depth` is the absolute count of `/` in the path.
-
-### THE trap: never glob `files/*.parquet`
-
-Compaction writes the next generation **beside** the old one and deliberately leaves the previous generation on disk for readers still holding the previous manifest (`files_src` in `fused_render/index/query.py`). A glob picks up both and silently double-counts. Measured on a real store:
-
-```
-manifest names: ['part-000008-00000.parquet', 'part-000008-00001.parquet']
-on disk       : ['part-000007-00000.parquet', 'part-000007-00001.parquet',
-                 'part-000008-00000.parquet', 'part-000008-00001.parquet']
-correct rows (manifest): 578767
-naive glob rows        : 1157818   -> inflated by 579051 (2.00x)
-```
-
-Nothing errors. Every count, sum and average is simply wrong, by roughly 2x, and only on a store that has been scanned more than once — so it passes on a fresh machine and fails on the user's.
-
-The corollary is what makes the reader simple: **readers never take `store_lock`.** They follow the manifest, and generations make that safe (`store_lock`'s docstring in `fused_render/index/store.py`). No locking, no coordination, no retry loop.
-
-### The reader (copy this)
-
-```python
-"""Read-only access to the fused-render file index. Only dep: duckdb."""
-import json, os, re, duckdb
-
-def _branch_ref(ref):
-    # MUST match `sanitize` in fused_render/_branch.py — the server resolved the
-    # store path through it, so any drift here silently opens the WRONG store: a
-    # raw ref like "worktree-fused-index-api" names a branches/ dir that never
-    # existed (the real one is branches/worktree-fus), and the reader then reports
-    # "no index" against a store sitting right there.
-    if not ref or ref.lower() in ("main", "master", "head"):
-        return ""                     # a default branch IS the baseline: no nesting
-    collapsed = re.sub(r"[^a-z0-9]+", "-", ref.lower()).strip("-")
-    return collapsed[:12].rstrip("-")           # _MAX_LEN = 12
-
-def store_dir(location=None):
-    # Prefer the `location` that /api/index/stats and /api/index/config report;
-    # this env resolution is the fallback (fused.runPython inherits os.environ).
-    if location:
-        return location
-    home = os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render")
-    ref = _branch_ref(os.environ.get("FUSED_RENDER_BRANCH"))
-    if ref:
-        home = os.path.join(home, "branches", ref)
-    return os.path.join(home, "index")
-
-def connect(location=None):
-    """A duckdb connection with `files` and `dirs` views, plus the manifest.
-    Returns (None, None) for every "nothing to read yet" shape: no manifest, an
-    unreadable one, a manifest naming zero partitions, or no dirs.parquet."""
-    d = store_dir(location)
-    try:
-        with open(os.path.join(d, "partitions.json")) as f:
-            manifest = json.load(f)
-    except (OSError, ValueError):
-        return None, None                       # no index yet — an ANSWER, not an error
-    parts = [os.path.join(d, "files", p["file"])
-             for p in manifest.get("partitions") or []]
-    dirs = os.path.join(d, "dirs.parquet")
-    # Both of these are legitimate stores, not corruption: store.py defaults a
-    # manifest to {"rows": 0, "partitions": []}, and git_repos._repos checks for
-    # dirs.parquet separately from the manifest. read_parquet raises on either
-    # (InvalidInputException on [], IOException on a missing file), so they get
-    # the same "no index" answer rather than a traceback.
-    if not parts or not os.path.exists(dirs):
-        return None, None
-    con = duckdb.connect()
-    # NEVER a files/*.parquet glob: old generations stay on disk and would double-count.
-    con.read_parquet(parts).create_view("files")
-    con.read_parquet(dirs).create_view("dirs")
-    return con, manifest
-
-def main(min_size="0"):
-    con, manifest = connect()
-    if con is None:
-        # The Python half of the readiness rule: say so, don't return [].
-        return {"indexed": False, "rows": []}
-    rows = con.execute(
-        "SELECT ext, count(*) n, sum(size) bytes FROM files "
-        "WHERE size >= ? GROUP BY 1 ORDER BY bytes DESC LIMIT 20",
-        [int(min_size)]).fetchall()
-    return {"indexed": True, "updated": manifest["updated"],
-            "rows": [{"ext": e, "n": n, "bytes": b} for e, n, b in rows]}
-```
-
-Two gotchas, both hit while verifying this:
-
-- **`CREATE VIEW x AS SELECT * FROM read_parquet(?)` does not work.** It fails with `Binder Error: Unexpected prepared parameter. This type of statement can't be prepared!` The relation API (`con.read_parquet(list).create_view(...)`) avoids it *and* avoids having to SQL-quote the user's store path — which is exactly why `query.py` carries a `_q` helper for the paths it does interpolate. Parameters work fine in ordinary `SELECT`s (see `main` above); it is the `CREATE VIEW` that refuses them.
-- **Returning `(None, None)` rather than raising, for every empty shape.** "No index" is a state to render, not an error — the same discipline as the JS envelope. That covers a missing manifest (normal first boot), a manifest naming zero partitions, and a store with no `dirs.parquet`; each of the latter two makes `read_parquet` raise, and a legitimately empty store must not reach the page as a red traceback overlay.
-
-**Branch-scoping matters in a dev worktree.** `home_dir()` (`fused_render/shell/storage.py`) honours `FUSED_RENDER_HOME` and nests under `branches/<ref>/` when `FUSED_RENDER_BRANCH` is set, so a dev server's index is a *different store* from `~/.fused-render/index`. **Pass the `location` that `/api/index/stats` reports** — it is the store the server is actually using, and resolving the path twice is how a reader and a UI end up disagreeing about the row count. `<ref>` is not the env var: it is `sanitize()`d (`fused_render/_branch.py`) — lowercased, non-alphanumeric runs collapsed to `-`, cut to 12 chars, and `main`/`master`/`head` mapped to the baseline with no `branches/` segment at all. The snippet's `_branch_ref` ports that, and it only exists for the case where no `location` is at hand.
-
-## C. Raw HTTP reference
-
-**This is the only way to reach anything the bridge does not wrap** — starting or cancelling a scan, editing roots/ignore, the repos list, the live scan readout — so it is a reference, not an appendix. From a page, `fetch` it directly:
-
-```js
-// Start a scan over every configured root. X-Fused is NOT optional on a POST.
-const res = await fetch("/api/index/scan", {
-  method: "POST",
-  headers: { "Content-Type": "application/json", "X-Fused": "1" },
-  body: JSON.stringify({}),           // {root, full} to narrow it
-});
-const { run_id } = await res.json();
-// Then poll the readout. GETs need no header:
-const st = await (await fetch("/api/index/status?run_id=" + run_id)).json();
-// st.error is DATA — the last run's failure sentence, to render, not to throw on.
-```
-
-`GET`s are unguarded. **`POST`s require `X-Fused: 1`** (`_require_fused`, `fused_render/server/common.py`) — not authentication, a cross-origin-preflight tripwire — and the bridge sends it for you on `query`, which is the only POST it makes. Errors are `{"error": "<message>"}` with a 4xx/5xx; `/api/index/ask` can also answer the AI relay's nested `{"error": {"type", "message"}}`.
-
-| Route | Method | Params (defaults) | Answers |
-|---|---|---|---|
-| `/api/index/stats` | GET | `root=""` (→ manifest's `last_root`) | `ok, empty, location, rows, dirs, total_size, updated, last_root, partitions, types[]`. `types` is the top 50 extensions by size plus an `other` roll-up. Reads every partition — there is no cached rollup. |
-| `/api/index/lookup` | GET | `q=""`, `limit=100` (cap `MAX_LIMIT` = 5000), `offset=0`, `sort=mtime` (`path`/`size`/`mtime`/`name`; anything else falls back to `mtime`) | `ok, empty, location, rows[], total, partitions[], scanned_partitions, of_partitions` |
-| `/api/index/search` | GET | `root` **required**, `q=""`, `limit=200000` (`MAX_CORPUS`) | `ok, covered, fresh, updated, age_s, root, entries[], truncated, total, scanned_partitions, of_partitions`. `fresh` is informational (`FRESH_MAX_AGE_S` = 3600 s); `covered` is the gate. A miss is `{covered: false, entries: []}` with a **200**, never an error. |
-| `/api/index/status` | GET | `run_id=""` (→ the most recent *running* run, else the latest), `since=0` | `ok, has_index, indexed, scanning, files_indexed, last_completed_at, updated, run_id, root, phase, dirs, files, reused, current, summary, cancelled, error, running` (+ `events`, `cursor` when a `run_id` is given) |
-| `/api/index/runs` | GET | — | `ok, runs[]` — per run: `run_id, root, running, phase, files, dirs, …` |
-| `/api/index/config` | GET | — | `ok, roots, configured_roots, ignore, defaults, location` |
-| `/api/index/scan` | POST | `{root?, full?}` | `ok, run_id, root, runs[]`. No `root` = every configured root; one dead root does not fail the rest. |
-| `/api/index/cancel` | POST | `{run_id}` | `ok, cancelled` |
-| `/api/index/query` | POST | `{sql, limit?}` (`limit` default 200, cap 5000) | `ok, columns, rows, truncated` |
-| `/api/index/ask` | POST | `{prompt, limit?}` | `ok, sql, columns, rows, truncated` — a question in English compiled to SQL by the AI relay and then run through the *same* guard. The compiled `sql` comes back even when it is refused. **Costs AI credits per call.** |
-| `/api/index/config` | POST | `{roots?, ignore?}` | the GET's shape + `needs_rescan, rescan_run_id, rescan_run_ids` |
-| `/api/index/delete` | POST | — | `ok, deleted, cancelled, location`. Drops the whole store; cancels running scans first. |
-| `/api/git-repos` | GET | — | `indexed, reason, scanning, stale, repos[{path}]` — note **no `ok`** on this one |
-
-### What guarded SQL will and will not run
-
-`/api/index/query` (and `/ask`) execute the caller's statement in a confined DuckDB session (`fused_render/index/guarded_query.py`):
-
-- **One statement only.** A batch is refused — that is how a read-looking prefix smuggles a write past a reader skimming the box.
-- **Read-only statement types**: `SELECT` (which covers `WITH`, `DESCRIBE` and `PRAGMA` as DuckDB parses them), `CALL`, `EXPLAIN`. `INSERT`/`UPDATE`/`DELETE`/`CREATE`/`DROP`/`COPY`/`ATTACH`/`SET`/… are refused *before* anything runs, because an in-memory write would otherwise succeed even behind a locked configuration.
-- **Two views and nothing else**: `files` and `dirs`. The connection is confined to the index directory (`allowed_directories` → `enable_external_access=false` → `lock_configuration=true`, in that order), so any other path is a permission error.
-- **Caps**: `MAX_LIMIT` = 5000 rows (the cap goes *into* the SQL, so a whole-index statement is never materialised to be trimmed), and a **10 s** wall clock before `con.interrupt()` stops it.
-- A statement that parses but cannot run surfaces duckdb's own message as a 400, verbatim. Show it — "Binder Error: no such column: nope" tells the user what to fix.
-
-Written against an index with no partitions yet, a query still runs: the views become typed empty stand-ins, so it fails on its own logic or not at all.
-
-## D. Deriving a new *kind* of entity from the index
-
-The Repos tab is the worked precedent, and the pattern generalises: **a kind is an index fact, not a filesystem probe.**
-
-`.git` is in `ignore.LEAF_DIR_NAMES`, so the scan records exactly one `dirs` row for it and never descends. "Which directories are repositories" therefore *is* "which `dirs` rows are named `.git`", with the repo root as that row's parent:
-
-```sql
-SELECT dir FROM dirs WHERE regexp_extract(dir, '[^/]*$') = '.git'
-```
-
-Zero stats, zero subprocesses, no `git` binary. It replaced a first cut that read every indexed directory and asked `os.path.isdir(d + "/.git")` about each — **~71k stats per request** on a real home. Look for the same move whenever you are about to probe the filesystem per row: is the marker something the scan already recorded?
-
-Read `fused_render/server/routers/git_repos.py` in full before copying the pattern; it documents the parts that are not obvious, and two of them **an app cannot reproduce**:
-
-- **`junk_path` is applied to the PARENT, never the row.** `.git` is itself a dot-segment, so screening the raw row rejects every repository on the machine. Without the parent screen the tab is mostly other people's checkouts (`~/.local/share/nvim/lazy/*`, `~/.oh-my-zsh/custom/plugins/*`) outnumbering the user's own better than 2:1. `junk_path` is `fused_render/server/walk.py` — **Python-only, no endpoint**.
-- **`MountGuard`** screens the parent too, as the layer that holds when an older build wrote rows a newer guard would have pruned. Also **Python-only**.
-- **The per-root applied-ignore signature** — what separates "zero rows because the rule never ran" (`reason: "outdated"`, a rebuild is coming) from "zero rows because this machine genuinely has no repos" (`{indexed: true, repos: []}`, a real answer). It is exposed on **no endpoint**, and the test is on the RAW row count, before screening, because screening can legitimately take real rows to zero.
-
-That is precisely why the repo list is a ROUTE and not a `fileIndex.query()` you write: an app-side `SELECT` gets the list roughly right and gets both kinds of zero, and both screening layers, wrong. **`GET /api/git-repos`** (unguarded, section C) already answers `{repos, indexed, scanning, stale, reason}` — the whole readiness triple, `reason` included. Fetch that; do not re-derive it.
-
-When you need a *different* kind, the query is yours and `fileIndex.query()` is the tool — but the screening lesson is not optional, and a new kind that needs `junk_path`/`MountGuard` belongs in a server route beside `git_repos.py`, not in a page.
-
-## E. Replacing an app's own index engine
-
-An app shipping its own scanner is duplicating `fused_render/index/`, and the migration is a deletion, not a rewrite:
-
-- **Delete the scan engine wholesale** — the walk, the parquet sink, compaction, FSEvents replay, run bookkeeping, and the reader module beside it. All of it lives behind `/api/index/*` now.
-- **The app becomes pure HTML + JS** talking to `fused.fileIndex.*`. A `sql` action becomes `fused.fileIndex.query()` — which, unlike a hand-rolled one, is allowlisted and read-only. A scan button becomes a raw `POST /api/index/scan` with `X-Fused: 1` (section C).
-- **Anything genuinely bulk stays in Python**, using the direct reader in section B rather than a re-implemented store.
-
-One gap to know before you start: **the index directory cannot be relocated.** `IndexConfig.dir` is fixed to `home_dir()/index`, settable only via `FUSED_RENDER_HOME` at process start; `POST /api/index/config` takes `roots` and `ignore`, not `location`.
-
-## Pitfalls checklist
-
-- Globbing `files/*.parquet` instead of following `partitions.json` → every number silently ~2x too big, and only on a machine that has scanned twice.
-- Rendering `rows: []` as "no results" without checking `ready.indexed` → the original silent lie.
-- Treating `covered: false` from `search()` as an error → it is a 200 and a normal state; fall back to a live walk or say "not indexed yet".
-- Reading a page of `query()` rows as a match count → `LIMIT` cut them; ask `count(*)` in its own statement to page.
-- Interpolating a user's string into `sql` without doubling its `'` → a broken statement, or a rejected one. There are no bind parameters on `/api/index/query`; use the `lit()` helper above.
-- Taking `store_lock`, or writing anything into the index directory → readers follow the manifest; writers are the scan's business.
-- `import fused_render` from an app `.py` that has a `pyproject.toml` → `ModuleNotFoundError`; the project venv does not contain it. Copy the reader.
-- Forgetting `duckdb` in the app's own `pyproject.toml` → the declaration is the complete list; the bundled set is not unioned in (see `fused-render-authoring`).
-- `POST`ing `/api/index/*` by hand without `X-Fused: 1` → 403. The bridge sends it on `query`; on scan/cancel/config you send it yourself (section C).
-- Looking for `fused.index.*`, or for `stats`/`lookup`/`status`/`scan`/`config`/`repos` on the bridge → the surface is `fused.fileIndex.search` and `fused.fileIndex.query`, and nothing else. Totals and path matches are `query()`; index management is raw HTTP.
-- Rendering a per-keystroke `search()`/`query()` with no generation guard → **index calls are not superseded like `runPython`'s** (D114 gives that only to `runPython`). The slower earlier query wins the race and the table shows a stale answer with no error anywhere. Guard your own renders, as `drawRows` above does.
-- Treating `/api/index/status`'s `error` as a failure → it is the last run's failure sentence, arriving on a 200 for you to render.
-- Calling `/api/index/ask` per keystroke → it spends AI credits per call. It is a button, not a debounce target.
-- Re-implementing the repos query in a page → wrong on both kinds of zero and on both screening layers; `GET /api/git-repos`.
-- Assuming `stale: false` means the index matches the filesystem → it means "as fresh as the index gets". Nothing can know the difference without re-walking, which is the cost this whole thing avoids.
-- Comparing a Python reader's counts against the UI's on a dev worktree → different stores (`FUSED_RENDER_BRANCH`). Pass the `location` the API reports.
-
-## When to switch skills
-
-- Writing or debugging the `.html`/`.py` files themselves — the `fused` API, `main()`, params-as-state, the traceback overlay → **`fused-render-authoring`**.
-- Binding a preview template to a file extension → **`fused-render-custom-templates`**.
-- Opening a view or driving the running app → **`fused-render-usage`**.
-- Calling an AI model, local models, or image generation → **`fused-render-ai`**.
-- A folder needs a long-running daemon that outlives its page and survives the warm worker's 15-minute idle-retire → **`fused-render-background-apps`**.
+Related: authoring the page → `fused-render-authoring`; daemon reading the index → `fused-render-background-apps`.

--- a/skills/fused-render-index/SKILL.md
+++ b/skills/fused-render-index/SKILL.md
@@ -15,7 +15,7 @@ fused-render keeps parquet index of filesystem (one row per file, one per dir). 
 
 ## Readiness rule (the one that matters)
 
-Zero rows means BOTH "no matches" and "no index yet". Rendering second as first = silent lie this design exists to prevent. Both JS calls resolve with `ready: {indexed, scanning, stale, reason}` (`reason`: `no-index` / `outdated` / `not-covered` / null); Python reader returns `(None, None)` for empty store. `indexed: false` → "building / not indexed", never "no results". `stale` never means "matches fs" — index always slightly behind.
+Zero rows means BOTH "no matches" and "no index yet". Rendering second as first = silent lie this design exists to prevent. Both JS calls resolve with `ready: {indexed, scanning, stale, reason}` (`reason`: `no-index` / `not-covered` / null — `outdated` is a `/api/git-repos` value only, never on the bridge); Python reader returns `(None, None)` for empty store. `indexed: false` → "building / not indexed", never "no results". `stale` never means "matches fs" — index always slightly behind.
 
 ## JS: `fused.fileIndex`
 
@@ -30,7 +30,18 @@ Facts:
 - Failures reject Error with `.message` (duckdb/server text), `.type`, `.status` — render `.message`.
 - Index calls **not superseded like `runPython`'s**: slower earlier keystroke's reply can land last. Guard own renders (below).
 - Page of rows ≠ match count — ask `count(*)` separately to page.
-- Not on bridge (raw fetch, POSTs need `X-Fused: 1`): `/api/index/scan`, `/api/index/scan-folder`, `/api/index/cancel`, `/api/index/rank`, `/api/index/config`, `/api/index/status`, `/api/index/stats`, `/api/index/lookup`, `/api/index/runs`, `/api/index/delete`, `/api/index/ask` (spends AI credits — button, not debounce), `GET /api/git-repos`. Shapes: `fused_render/server/routers/` + `fused_render/static/runtime.js` comments. `/api/index/status`'s `error` field = data (last scan's failure), not throw.
+- Not on bridge (raw fetch, POSTs need `X-Fused: 1`): `/api/index/scan`, `/api/index/scan-folder`, `/api/index/cancel`, `/api/index/rank`, `/api/index/config`, `/api/index/status`, `/api/index/stats`, `/api/index/lookup`, `/api/index/runs`, `/api/index/delete`, `/api/index/ask` (spends AI credits — button, not debounce), `GET /api/git-repos`. `/api/index/status`'s `error` field = data (last scan's failure), not throw.
+
+  Params that bite (rest: `fused_render/server/routers/index.py`):
+
+  | Route | Params |
+  |---|---|
+  | `GET /api/index/lookup` | `q`, `limit` (100, capped 5000), `offset`, `sort` (`mtime`; **unknown value silently falls back to it**, no 400) |
+  | `GET /api/index/search` | `root` (**required**, else 400), `q`, `limit` (200000 — whole corpus), `fmt` (`""` = per-entry objects; `"columns"` = parallel arrays; anything else = `""`) |
+  | `GET /api/index/stats` | `root` (`""` → manifest's `last_root`, not every root) |
+  | `GET /api/index/status` | `run_id` (`""` → most recent run), `since`. Answers `has_index`+`indexed`, `scanning`, `files_indexed`, `last_completed_at`+`updated`, plus the run readout `run_id, root, phase, dirs, files, reused, current, summary, cancelled, error, running`. `scanning: true` means "say indexing…", NOT "stop using the index" |
+  | `GET /api/index/rank` | `root`, `q`, `limit` (200) |
+
 - Store location fixed: `home_dir()/index` — `/api/index/config` edits roots/ignore, cannot relocate store (only `FUSED_RENDER_HOME` at server start moves it).
 
 ### The canonical shape (per-keystroke)
@@ -55,9 +66,9 @@ App venvs cannot `import fused_render` — copy `reader.py` (beside this SKILL.m
 - **THE trap: never glob `files/*.parquet`.** Old generations stay on disk beside new — glob double-counts (~2x) silently, only on machines scanned twice. Open exactly what `partitions.json` names.
 - Relation API (`con.read_parquet(list).create_view("files")`) — `CREATE VIEW ... read_parquet(?)` refuses prepared params.
 - No manifest / zero partitions / no dirs.parquet → return "not indexed" to page, don't raise.
-- Dev worktrees = branch-scoped stores (`FUSED_RENDER_HOME` + `branches/<sanitized ref>/`, `fused_render/_branch.py`). Pass `location` that `/api/index/stats` reports; don't resolve path yourself.
+- **Never re-derive the store path.** Dev worktrees and packaged branch builds nest it (`branches/<sanitized ref>/`), and the ref may be BAKED IN — not in the environment at all. Best: pass the `location` that `/api/index/stats` reports. Else read `FUSED_RENDER_HOME_DIR`, which the server exports already branch-resolved, verbatim (SPEC PY-15 / D166, same rule as `fused_render/templates/shared/appenv.py:home_dir`). `FUSED_RENDER_BRANCH` + a hand-rolled sanitize opens the WRONG store and the page then says "not indexed" over a full one.
 
-Deeper reference: `fused_render/index/query.py` (+ sanitize rule in `fused_render/_branch.py`).
+Deeper reference: `fused_render/index/query.py`.
 
 ## Deriving entity kinds
 

--- a/skills/fused-render-index/reader.py
+++ b/skills/fused-render-index/reader.py
@@ -1,0 +1,66 @@
+"""Read-only access to the fused-render file index. Only dep: duckdb.
+
+Copy this file into the app (declare `duckdb` in its pyproject.toml) — app
+venvs cannot `import fused_render`.
+"""
+import json, os, re, duckdb
+
+
+def _branch_ref(ref):
+    # Must match sanitize() in fused_render/_branch.py — the server resolved the
+    # store path through it, so any drift here silently opens the WRONG store.
+    if not ref or ref.lower() in ("main", "master", "head"):
+        return ""  # a default branch IS the baseline: no branches/ nesting
+    collapsed = re.sub(r"[^a-z0-9]+", "-", ref.lower()).strip("-")
+    return collapsed[:12].rstrip("-")  # _MAX_LEN = 12
+
+
+def store_dir(location=None):
+    # Prefer the `location` that /api/index/stats reports; the env resolution
+    # below is the fallback (fused.runPython inherits os.environ).
+    if location:
+        return location
+    home = os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render")
+    ref = _branch_ref(os.environ.get("FUSED_RENDER_BRANCH"))
+    if ref:
+        home = os.path.join(home, "branches", ref)
+    return os.path.join(home, "index")
+
+
+def connect(location=None):
+    """A duckdb connection with `files` and `dirs` views, plus the manifest.
+
+    Returns (None, None) for every "nothing to read yet" shape: no manifest, an
+    unreadable one, a manifest naming zero partitions, or no dirs.parquet.
+    "No index" is an answer to render, not an error to raise.
+    """
+    d = store_dir(location)
+    try:
+        with open(os.path.join(d, "partitions.json")) as f:
+            manifest = json.load(f)
+    except (OSError, ValueError):
+        return None, None
+    parts = [os.path.join(d, "files", p["file"])
+             for p in manifest.get("partitions") or []]
+    dirs = os.path.join(d, "dirs.parquet")
+    # Legitimate empty stores, not corruption; read_parquet raises on both.
+    if not parts or not os.path.exists(dirs):
+        return None, None
+    con = duckdb.connect()
+    # NEVER a files/*.parquet glob: old generations stay on disk beside new
+    # ones and double-count. Relation API because CREATE VIEW refuses ? params.
+    con.read_parquet(parts).create_view("files")
+    con.read_parquet(dirs).create_view("dirs")
+    return con, manifest
+
+
+def main(min_size="0"):
+    con, manifest = connect()
+    if con is None:
+        return {"indexed": False, "rows": []}  # say so, don't return []
+    rows = con.execute(
+        "SELECT ext, count(*) n, sum(size) bytes FROM files "
+        "WHERE size >= ? GROUP BY 1 ORDER BY bytes DESC LIMIT 20",
+        [int(min_size)]).fetchall()
+    return {"indexed": True, "updated": manifest["updated"],
+            "rows": [{"ext": e, "n": n, "bytes": b} for e, n, b in rows]}

--- a/skills/fused-render-index/reader.py
+++ b/skills/fused-render-index/reader.py
@@ -3,16 +3,7 @@
 Copy this file into the app (declare `duckdb` in its pyproject.toml) — app
 venvs cannot `import fused_render`.
 """
-import json, os, re, duckdb
-
-
-def _branch_ref(ref):
-    # Must match sanitize() in fused_render/_branch.py — the server resolved the
-    # store path through it, so any drift here silently opens the WRONG store.
-    if not ref or ref.lower() in ("main", "master", "head"):
-        return ""  # a default branch IS the baseline: no branches/ nesting
-    collapsed = re.sub(r"[^a-z0-9]+", "-", ref.lower()).strip("-")
-    return collapsed[:12].rstrip("-")  # _MAX_LEN = 12
+import json, os, duckdb
 
 
 def store_dir(location=None):
@@ -20,10 +11,17 @@ def store_dir(location=None):
     # below is the fallback (fused.runPython inherits os.environ).
     if location:
         return location
-    home = os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render")
-    ref = _branch_ref(os.environ.get("FUSED_RENDER_BRANCH"))
-    if ref:
-        home = os.path.join(home, "branches", ref)
+    # FUSED_RENDER_HOME_DIR is exported by the server ALREADY BRANCH-RESOLVED
+    # (server/app.py:export_app_env), so re-derive nothing from it: no branches/
+    # nesting, no ref sanitizing. Duplicating those rules is how the copies
+    # drift, and a branch build's baked ref is not even in the environment —
+    # same reasoning as templates/shared/appenv.py:home_dir (SPEC PY-15, D166).
+    home = os.environ.get("FUSED_RENDER_HOME_DIR")
+    if not home:
+        # No server around: the un-branched baseline, the same override the app
+        # honors. A branch-scoped store is only findable via the server.
+        home = os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser(
+            "~/.fused-render")
     return os.path.join(home, "index")
 
 

--- a/skills/fused-render-jobs/SKILL.md
+++ b/skills/fused-render-jobs/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: fused-render-jobs
-description: Use on a runPython 60 s timeout, when work outlives one call, or when a download-manager progress row goes stalled — fused.trackJob from page and worker.
+description: Use on runPython 60 s timeout, work outliving one call, or stalled download-manager progress row — fused.trackJob.
 ---
 
 # Long work and the 60 s timeout
 
-`runPython` kills `main()` at 60 s (`DEFAULT_TIMEOUT`, `fused_render/executor.py`); no per-call override. Strategies: cache to `.fused/cache/` (see `fused-render-authoring`); chunk behind an `offset` param; move a long build into a detached process that writes an output file; import lazily + debounce sliders. Warm state between calls → `[tool.fused-render.app]` `main =` (reaped after 15 min idle) or `daemon =` → `fused-render-background-apps`.
+`runPython` kills `main()` at 60 s (`DEFAULT_TIMEOUT`, `fused_render/executor.py`); no per-call override. Strategies: cache to `.fused/cache/` (`fused-render-authoring`); chunk behind `offset` param; move long build into detached process writing output file; import lazy + debounce sliders (~150 ms). Warm state between calls → `[tool.fused-render.app]` `main =`, page calls it via `fused.daemon.run(params)` (reaped after 15 min idle) or `daemon =` → `fused-render-background-apps`.
 
 ## `fused.trackJob`
 
-The shell replaces your page's frame on navigation — in-page progress bars die. Report long work to the download manager instead:
+Shell replaces page frame on navigation — in-page progress bars die. Report long work to download manager:
 
 ```js
 const job = fused.trackJob({ title, kind: "download"|"task", unit: "bytes"?, cancellable: true?, id? });
@@ -20,21 +20,21 @@ if (job.cancelRequested) stopTheWork();
 
 Rules:
 
-- Fire-and-forget, never rejects, can't break the page. No-op on exported pages (doesn't block export).
-- **Cancel is a request YOU honor** — the ✕ sets a flag; your loop notices, stops, reports `cancelled()`. Can't stop it? omit `cancellable`.
-- Omit `total` while unknown (indeterminate bar); 0 is treated the same.
-- **Report a terminal call on every exit path** — otherwise the row goes "stalled" after 30 s.
-- A single await longer than 30 s trips the stall window even when fine — heartbeat with `setInterval(() => job.update({}), 10_000)`, clear in `finally`.
-- One row per user-meaningful operation, current filename in `detail`. Stable `id` lets a reloaded page re-attach instead of opening a second row.
+- Fire-and-forget, never rejects, can't break page. No-op on exported pages (doesn't block export).
+- **Cancel = request YOU honor** — ✕ sets flag; loop notices, stops, reports `cancelled()`. Can't stop? omit `cancellable`.
+- Omit `total` while unknown (indeterminate bar); 0 treated same.
+- **Terminal call on every exit path** — else row goes "stalled" after 30 s.
+- Single await >30 s trips stall window even when fine — heartbeat `setInterval(() => job.update({}), 10_000)`, clear in `finally`.
+- One row per user-meaningful operation, current filename in `detail`. Stable `id` → reloaded page re-attaches, no second row.
 
-`fused.watchJob(id).watch(cb)` = read side (follow a model download, a recording's elapsed seconds). A watched row's `state: "waiting"` = parked on a user question (e.g. build consent), not stuck.
+`fused.watchJob(id).watch(cb)` = read side (follow model download, recording's elapsed seconds). Watched row `state: "waiting"` = parked on user question (e.g. build consent), not stuck.
 
 ## Report from the WORKER too
 
-Page-only reporting freezes the row the moment the user navigates. The detached worker outlives the page: POST plain JSON to `{FUSED_RENDER_ORIGIN}/api/jobs` with headers `Content-Type: application/json` and `X-Fused: 1`, body `{id, title, kind, state, done, total, detail}`. The reply carries `cancel_requested` — the worker is the only thing that can honor ✕ once the page is gone. Best-effort: swallow all errors, rate-limit ~1/s. **Same job id on both sides** (derive from something both know) = one row, not two. Keep the page reporting too — it's the only reporter alive during a first-run env build.
+Page-only reporting freezes row when user navigates. Detached worker outlives page — and runs own venv, no `import fused_render`, so it speaks plain JSON over HTTP: POST `{FUSED_RENDER_ORIGIN}/api/jobs`, headers `Content-Type: application/json` + `X-Fused: 1`, body `{id, title, kind, state, done, total, detail}`. Reply carries `cancel_requested` — worker is only thing able to honor ✕ once page gone. Best-effort: swallow all errors, short timeout (~3 s), rate-limit ~1/s. **Same job id both sides** (derive from something both know) = one row, not two. Keep page reporting too — only reporter alive during first-run env build.
 
 ## Pitfalls
 
-- No terminal call → stalled row lying about a closed page.
+- No terminal call → stalled row lying about closed page.
 - Page-only reporting; two rows from mismatched ids; one row per file.
-- Job started under `_preview=1` → every listing card starts the work (gate boot — `fused-render-authoring`).
+- Job started under `_preview=1` → every listing card starts work (gate boot — `fused-render-authoring`).

--- a/skills/fused-render-jobs/SKILL.md
+++ b/skills/fused-render-jobs/SKILL.md
@@ -1,125 +1,40 @@
 ---
 name: fused-render-jobs
-description: Work that outlives one fused.runPython call — the 60 s executor timeout and the ways around it, plus fused.trackJob reporting into the shell's download manager from the page and from a detached worker. Use on a timeout, or when a progress row goes stalled.
+description: Use on a runPython 60 s timeout, when work outlives one call, or when a download-manager progress row goes stalled — fused.trackJob from page and worker.
 ---
 
-# Long-running work and the 60 s timeout
+# Long work and the 60 s timeout
 
-Every `fused.runPython` call runs `main()` in a fresh subprocess the server
-**kills at 60 s** (`DEFAULT_TIMEOUT` in `fused_render/executor.py`). On timeout
-the call rejects with a `TimeoutError` — uncaught, that becomes the red overlay.
-There is no per-call override, so design around it:
+`runPython` kills `main()` at 60 s (`DEFAULT_TIMEOUT`, `fused_render/executor.py`); no per-call override. Strategies: cache to `.fused/cache/` (see `fused-render-authoring`); chunk behind an `offset` param; move a long build into a detached process that writes an output file; import lazily + debounce sliders. Warm state between calls → `[tool.fused-render.app]` `main =` (reaped after 15 min idle) or `daemon =` → `fused-render-background-apps`.
 
-- **Precompute and cache to disk.** Do the expensive work once, write the result next to the script (`.json`/`.parquet`), and have `main()` return the cached bytes when they're fresh (compare mtimes) — recompute only when the input changed.
-- **Chunk / paginate.** Slice the work so each call stays well under 60 s, pass an `offset`/`page` param, and accumulate in JS across several calls. This also keeps the UI responsive.
-- **Move the heavy job out of band.** For a genuinely long build, run it as a separate process that writes an output file, and have the view read the finished result.
-- **Cut per-call cost.** Each call re-pays import cost (pandas ≈ 1 s); import lazily inside `main`, and debounce sliders (~150 ms) so a drag doesn't spawn a subprocess per tick.
+## `fused.trackJob`
 
-State does not survive any of this: a folder that opts into `[tool.fused-render.app]`
-with `main = "x.py"` gets a warm worker that keeps imports and globals alive
-between calls, but it's still reaped after `idle_timeout_s` idle seconds
-(default 900s / 15 min), reached from the page via `fused.daemon.run(params)`.
-A folder that genuinely needs to keep running past that — a poll loop, a held
-connection, a tray or menu-bar presence — wants its own resident daemon
-(`daemon = "x.py"`) instead: see **`fused-render-background-apps`**.
-
-## Show it in the download manager (`fused.trackJob`)
-
-The out-of-band pattern leaves a hole: a detached worker pulling an 8 GB model
-keeps running when the user browses to another file, and the shell replaces your
-page's frame the moment they do — so your in-page progress bar disappears and the
-download becomes invisible. Report it instead, and the shell shows it in the
-**download manager** for as long as it runs, whatever page the user is on:
+The shell replaces your page's frame on navigation — in-page progress bars die. Report long work to the download manager instead:
 
 ```js
-const job = fused.trackJob({
-  title: "FLUX.2-klein-4B",      // required — what is happening, in a few words
-  kind: "download",              // "download" | "task"
-  unit: "bytes",                 // "bytes" formats done/total as 1.2 / 8.1 GB
-  cancellable: true,             // shows a ✕; omit if you cannot honor it
-});
-
-// on each poll tick, from whatever your worker wrote:
-job.update({ done: s.bytes, total: s.size, detail: "transformer.gguf" });
-if (job.cancelRequested) await stopTheWorker();   // the manager's ✕ was clicked
-
-job.finish("Downloaded");        // or job.fail(err) / job.cancelled()
+const job = fused.trackJob({ title, kind: "download"|"task", unit: "bytes"?, cancellable: true?, id? });
+job.update({ done, total, detail });   // per tick
+job.finish("msg") / job.fail(err) / job.cancelled();
+if (job.cancelRequested) stopTheWork();
 ```
 
-- **It cannot break your page.** Every method is fire-and-forget and never rejects; a failed report is swallowed. `await job.update(...)` only if you want to read `cancelRequested` at that exact point — the property is also readable synchronously between ticks.
-- **Cancel is a request you honor**, not something the shell can do — it has no idea which process is doing the work. The ✕ sets a flag; your poll loop notices it, stops the worker, and reports `job.cancelled()`. If you cannot stop the work, leave `cancellable` off and no ✕ is offered.
-- **Omit `total` while you don't know it.** A job with no total draws a travelling "indeterminate" bar, which is the honest picture; a total of `0` is treated the same way rather than painted as complete.
-- **Report the finish.** Without a terminal call the row goes "stalled" after 30 s and says the page that started it was closed — accurate if that is what happened, misleading if the work just ended. Report `finish`/`fail`/`cancelled` on every exit path of your poll loop.
-- **A step longer than 30 s needs a tick of its own.** The stale window does not care that your work is fine, only that nothing has reported — so a row wrapped around a single long `await` (one `fused.ai.text()` call, one slow `runPython`) says "No longer reporting" partway through and then succeeds. Beat it: `const beat = setInterval(() => job.update({}), 10_000)` before the await, `clearInterval(beat)` in a `finally`. An empty `update({})` is exactly "still here" — it carries no fields, so it cannot move the bar or overwrite your detail.
-- **One job per user-meaningful operation**, not per file: aggregate a multi-file download into one row (sum the bytes) and put the current filename in `detail`.
-- Reuse a **stable `id`** (`fused.trackJob({id: "flux:" + jobId, ...})`) when a page can be reloaded mid-work — the reopened page re-attaches to the existing row instead of opening a second one.
-- **Exports fine.** `fused.trackJob` is a no-op on a hosted page, so unlike `fused.ai` it does not block export.
+Rules:
 
-`fused.watchJob(id).watch(cb)` is the read side: it streams a row's updates to
-your page — used to show elapsed seconds for a `fused.capture` recording, or to
-follow a model download the runtime started for you. A watched row's `job.state`
-can also read `"waiting"` — there's no way to set it yourself (`trackJob`'s
-methods only ever move a row to running or one of the terminal states); it
-shows up on a row you're only watching, such as an install parked on the
-build-consent prompt, and means the row is stalled on a question only the
-user can answer, not stuck and not an error.
+- Fire-and-forget, never rejects, can't break the page. No-op on exported pages (doesn't block export).
+- **Cancel is a request YOU honor** — the ✕ sets a flag; your loop notices, stops, reports `cancelled()`. Can't stop it? omit `cancellable`.
+- Omit `total` while unknown (indeterminate bar); 0 is treated the same.
+- **Report a terminal call on every exit path** — otherwise the row goes "stalled" after 30 s.
+- A single await longer than 30 s trips the stall window even when fine — heartbeat with `setInterval(() => job.update({}), 10_000)`, clear in `finally`.
+- One row per user-meaningful operation, current filename in `detail`. Stable `id` lets a reloaded page re-attach instead of opening a second row.
 
-## Report from the WORKER, not only the page — this is the one that bites
+`fused.watchJob(id).watch(cb)` = read side (follow a model download, a recording's elapsed seconds). A watched row's `state: "waiting"` = parked on a user question (e.g. build consent), not stuck.
 
-The shell replaces your page's frame on every navigation, so a page-only reporter
-freezes the row at its last number and the manager declares it stalled ~30 s later
-while the download carries on. Your detached worker outlives the page, so let it
-report too. It cannot `import fused_render` (it runs in its own venv), but the
-endpoint is plain JSON on the origin every spawned child inherits:
+## Report from the WORKER too
 
-```python
-import json, os, urllib.error, urllib.request
-
-class JobReport:
-    """Best-effort. Never raises: reporting must not break the work."""
-    def __init__(self, job_id, title):
-        self.url = (os.environ.get("FUSED_RENDER_ORIGIN") or "").rstrip("/") + "/api/jobs"
-        self.id, self.enabled, self.cancel_requested = job_id, self.url.startswith("http"), False
-        if self.enabled:
-            self.post(title=title, kind="download", state="running", cancellable=True)
-
-    def post(self, **fields):
-        if not self.enabled:
-            return None
-        fields["id"] = self.id
-        req = urllib.request.Request(self.url, data=json.dumps(fields).encode(),
-                                     headers={"Content-Type": "application/json", "X-Fused": "1"})
-        try:
-            with urllib.request.urlopen(req, timeout=3) as r:
-                record = json.loads(r.read().decode())
-        except (urllib.error.URLError, OSError, ValueError):
-            return None
-        if isinstance(record, dict) and record.get("cancel_requested"):
-            self.cancel_requested = True   # the manager's ✕ — act on it here
-        return record
-```
-
-Use the **same job id** on both sides — derive it from something both know (the
-job directory name, the model id) so the two reporters share ONE row instead of
-opening two. Keep the page reporting as well: it is the only thing alive during
-`uv run`'s first-run environment build, before your worker executes a line.
-Rate-limit the worker's posts to ~1/s — a download callback fires per chunk.
-
-**The worker is also the only thing that can honor a cancel once the page is
-gone.** `cancel_requested` comes back in the reply to the tick you were already
-sending; check it in your progress callback and stop. If your long step is an
-opaque subprocess (`uv sync`), run a small daemon thread that posts a heartbeat,
-reads the flag, and kills the child — otherwise the ✕ does nothing for the
-minutes that matter most.
+Page-only reporting freezes the row the moment the user navigates. The detached worker outlives the page: POST plain JSON to `{FUSED_RENDER_ORIGIN}/api/jobs` with headers `Content-Type: application/json` and `X-Fused: 1`, body `{id, title, kind, state, done, total, detail}`. The reply carries `cancel_requested` — the worker is the only thing that can honor ✕ once the page is gone. Best-effort: swallow all errors, rate-limit ~1/s. **Same job id on both sides** (derive from something both know) = one row, not two. Keep the page reporting too — it's the only reporter alive during a first-run env build.
 
 ## Pitfalls
 
-- Never calling `finish`/`fail`/`cancelled` → the row goes "stalled" after 30 s and tells the user the page was closed when the work simply ended.
-- Reporting progress ONLY from the page → the row freezes the moment the user opens another file.
-- A page-started job under `_preview=1` → every card on a listing starts the work at once. Gate boot on the preview flag (**`fused-render-authoring`**).
-- One row per file in a multi-file download → a manager full of rows for one user-meaningful operation.
-
-Related: **`fused-render-authoring`** (the `runPython` contract these limits
-apply to), **`fused-render-background-apps`** (work that must outlive every
-page), **`fused-render-capture`** (recordings, which are job rows too),
-**`fused-render-ai`** (model downloads, which report themselves).
+- No terminal call → stalled row lying about a closed page.
+- Page-only reporting; two rows from mismatched ids; one row per file.
+- Job started under `_preview=1` → every listing card starts the work (gate boot — `fused-render-authoring`).

--- a/skills/fused-render-theming/SKILL.md
+++ b/skills/fused-render-theming/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: fused-render-theming
-description: Use when a fused-render view must follow the app's light/dark appearance, or looks wrong in the opposite theme.
+description: Use when fused-render view must follow app light/dark, or looks wrong in opposite theme.
 ---
 
 # Theming a view
 
-The iframe is a blank canvas (nothing injected by default), but the shell follows OS light/dark with a Preferences override. Pick ONE strategy; the failure mode is half-following.
+Iframe = blank canvas (nothing injected by default), but shell follows OS light/dark with Preferences override. Pick ONE strategy; failure mode = half-following.
 
-1. **Fixed palette** — fine for a strong own look (dark map, photo grid). Don't pretend to follow.
-2. **Follow the app** (the usual right answer): `data-fused-theme="shell"` on `<html>`. The runtime writes `data-theme="light"|"dark"` there before your stylesheet parses and keeps it in step (pin, OS flip, other-window change). Author two `:root` token blocks against `[data-theme]` + `color-scheme`. What built-in templates use — see SPEC.md §30 (AP-8/AP-9) and any `fused_render/templates/*/template.html`.
-3. **Follow the desktop only**: `@media (prefers-color-scheme)` around the second token block, no attribute. Doesn't see an in-app pin.
-4. **Own switcher**: choice in a param (`fused.params.set("theme", …)`), drive `data-theme` yourself. INSTEAD of option 2, never alongside — the runtime re-applies and your button loses.
+1. **Fixed palette** — fine for strong own look (dark map, photo grid). Don't pretend to follow.
+2. **Follow the app** (usual right answer): `data-fused-theme="shell"` on `<html>`. Runtime writes `data-theme="light"|"dark"` there before stylesheet parses, keeps it in step (pin, OS flip, other-window change). Author two `:root` token blocks against `[data-theme]` + `color-scheme`. Built-in templates do this — SPEC.md §30 (AP-8/AP-9), any `fused_render/templates/*/template.html`.
+3. **Follow desktop only**: `@media (prefers-color-scheme)` around second token block, no attribute. Blind to in-app pin.
+4. **Own switcher**: choice in param (`fused.params.set("theme", …)`), drive `data-theme` yourself. INSTEAD of option 2, never alongside — runtime re-applies, your button loses.
 
-Two rules that make a second palette work:
+Two rules making second palette work:
 
-- **Every colour from a token.** Same token set in both blocks; zero colour literals elsewhere — a stray hex is a smear the other mode can't repaint.
-- **Colours handed to JS don't follow.** Canvas/chart/maplibre values: read via `getComputedStyle` at draw time, redraw on a `MutationObserver` over `data-theme`.
+- **Every colour from a token.** Same token set both blocks; zero colour literals elsewhere — stray hex = smear other mode can't repaint.
+- **Colours handed to JS don't follow.** Canvas/chart/maplibre values: read via `getComputedStyle` at draw time, redraw on `MutationObserver` over `data-theme`.
 
-Never read the app's own localStorage key — private, drifts. Options 2/3 give the answer without it.
+Never read app's own localStorage key — private, drifts. Options 2/3 give answer without it.
 
 Rest of page authoring → `fused-render-authoring`.

--- a/skills/fused-render-theming/SKILL.md
+++ b/skills/fused-render-theming/SKILL.md
@@ -1,70 +1,22 @@
 ---
 name: fused-render-theming
-description: Light/dark theming for a fused-render view — data-fused-theme="shell", the token rules, and colours handed to canvas/charts/maplibre. Use when a view must follow the app's appearance or looks wrong in the opposite one.
+description: Use when a fused-render view must follow the app's light/dark appearance, or looks wrong in the opposite theme.
 ---
 
-# Style and theming a view
+# Theming a view
 
-There is no imposed CSS — the iframe is a blank canvas, and by default nothing is
-written into your document: no class, no attribute, no stylesheet. But the
-explorer around it follows the OS light/dark preference, with a Light/Dark
-override in Preferences → Appearance, so a hardcoded palette will sooner or later
-sit inside the opposite one.
+The iframe is a blank canvas (nothing injected by default), but the shell follows OS light/dark with a Preferences override. Pick ONE strategy; the failure mode is half-following.
 
-Pick one of these and commit to it — the failure mode is picking none and
-half-following.
+1. **Fixed palette** — fine for a strong own look (dark map, photo grid). Don't pretend to follow.
+2. **Follow the app** (the usual right answer): `data-fused-theme="shell"` on `<html>`. The runtime writes `data-theme="light"|"dark"` there before your stylesheet parses and keeps it in step (pin, OS flip, other-window change). Author two `:root` token blocks against `[data-theme]` + `color-scheme`. What built-in templates use — see SPEC.md §30 (AP-8/AP-9) and any `fused_render/templates/*/template.html`.
+3. **Follow the desktop only**: `@media (prefers-color-scheme)` around the second token block, no attribute. Doesn't see an in-app pin.
+4. **Own switcher**: choice in a param (`fused.params.set("theme", …)`), drive `data-theme` yourself. INSTEAD of option 2, never alongside — the runtime re-applies and your button loses.
 
-**1. Fixed palette.** Fine for a view with its own strong look (a dark map, a
-photo grid). Just don't pretend to follow.
+Two rules that make a second palette work:
 
-**2. Follow the app** — one attribute, no JS. Put `data-fused-theme="shell"` on
-your `<html>` and the injected runtime resolves the app's setting, writes
-`data-theme="light"`/`"dark"` on that same element before your stylesheet is
-parsed, and keeps it in step afterwards — including an in-app pin, an OS flip
-mid-session, and a change made in another window. Author against the attribute:
+- **Every colour from a token.** Same token set in both blocks; zero colour literals elsewhere — a stray hex is a smear the other mode can't repaint.
+- **Colours handed to JS don't follow.** Canvas/chart/maplibre values: read via `getComputedStyle` at draw time, redraw on a `MutationObserver` over `data-theme`.
 
-```html
-<html data-fused-theme="shell">
-```
-```css
-:root       { color-scheme: dark;  --bg: #101318; --text: #dce2ea; --line: #2a303a; }
-:root[data-theme="light"]
-            { color-scheme: light; --bg: #f7f8fa; --text: #1a1f27; --line: #d8dce3; }
-body        { background: var(--bg); color: var(--text); }
-```
+Never read the app's own localStorage key — private, drifts. Options 2/3 give the answer without it.
 
-This is what the built-in templates use (`SPEC.md` §30, AP-8/AP-9), and it is the
-only option that agrees with the app when the user pins Light or Dark.
-
-**3. Follow the desktop** — `@media (prefers-color-scheme: light)` around the
-second `:root`, same tokens, no attribute. Tracks the OS, which is what the app's
-default System mode tracks too. It does *not* see an in-app pin.
-
-**4. Your own switcher.** Put the choice in a param
-(`fused.params.set("theme", …)`) so it is bookmarkable like the rest of your view
-state, and drive the same one `data-theme` attribute from it. Use it *instead of*
-option 2, never alongside: the runtime re-applies on every storage/OS event, so
-your button would silently lose to the app setting.
-
-## Two rules that make the second palette actually work
-
-- **Every colour comes from a token.** Two blocks defining *the same token set*,
-  and no colour literal anywhere else in the stylesheet. A stray `#1a1f27` in a
-  rule is one the other mode cannot repaint — and it shows up as an unreadable
-  smear, not an obvious bug.
-- **Colours you hand to JS don't follow.** Canvas fills, chart ramps, maplibre
-  paint expressions — `var()` does not resolve inside a JS string. Read them at
-  *draw* time and redraw when the attribute changes:
-
-  ```js
-  const token = (n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim();
-  new MutationObserver(() => redraw())
-    .observe(document.documentElement, { attributeFilter: ["data-theme"] });
-  ```
-
-Do not read the app's own `localStorage` key. It is private, it is not part of
-`window.fused`, and a view that reads it becomes a second copy of a resolution
-rule that will drift from the first — options 2 and 3 both get you the answer
-without one.
-
-Related: **`fused-render-authoring`** (everything else about writing the page).
+Rest of page authoring → `fused-render-authoring`.

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -9,17 +9,17 @@ Local file-explorer desktop app, single instance per user, serves on `127.0.0.1`
 
 ## Open path via app
 
-macOS `open -a FusedRender <path>` · Linux `gtk-launch fused-render <path>` (or AppImage binary) · Windows `FusedRender.exe <path>`. Dir → explorer; file → preview; `.html` → rendered view.
+macOS `open -a FusedRender <path>` · Linux `gtk-launch fused-render <path>` (or AppImage binary) · Windows `FusedRenderPy.exe <path>`. Dir → explorer; file → preview; `.html` → rendered view.
 
 ## Open by URL
 
 Reuse running instance's `http://127.0.0.1:<port>`. Path after prefix, leading slash dropped, segments URL-encoded:
 
-- `/` → `/apps` hub; `/explorer` = file-explorer homepage.
+- `/` → `/home`; `/explorer` = file-explorer homepage.
 - `/explorer/view/<path>` — full shell chrome (what app opens).
 - `/explorer/embed/<path>` — chrome-free; single view or screenshot.
 
-Mode fixed by prefix (no toggle without navigation); params sync same in both. Old `/view/`/`/embed/` links redirect; write `/explorer/` forms.
+Mode fixed by prefix (no toggle without navigation); params sync same in both. Old `/view/`/`/embed/` links rewritten client-side; write `/explorer/` forms.
 
 **Preview templates** (parquet/image/etc.): open TARGET file's path; shell resolves template by extension, passes `_file`. `?_mode=<name>` picks specific mode.
 

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -1,30 +1,30 @@
 ---
 name: fused-render-usage
-description: Use when opening, running or showing a fused-render project, file or view (not authoring one) — launching the desktop app, URL modes, browsing.
+description: Use when opening/running/showing fused-render project or view (not authoring) — launch app, URL modes, browsing.
 ---
 
 # Using fused-render
 
-Local file-explorer desktop app, single instance per user, serves on `127.0.0.1` — no accounts, no cloud. Browses directories, previews files, live-renders `.html` views that call local Python. Authoring → `fused-render-authoring`.
+Local file-explorer desktop app, single instance per user, serves on `127.0.0.1` — no accounts, no cloud. Browses dirs, previews files, live-renders `.html` views calling local Python (`.py` sibling convention → `fused-render-authoring`).
 
-## Open a path via the app
+## Open path via app
 
-macOS `open -a FusedRender <path>` · Linux `gtk-launch fused-render <path>` (or the AppImage binary) · Windows `FusedRender.exe <path>`. Directory → explorer there; file → preview; `.html` → rendered view.
+macOS `open -a FusedRender <path>` · Linux `gtk-launch fused-render <path>` (or AppImage binary) · Windows `FusedRender.exe <path>`. Dir → explorer; file → preview; `.html` → rendered view.
 
 ## Open by URL
 
-Reuse the running instance's `http://127.0.0.1:<port>`. Path rides after the prefix, leading slash dropped, segments URL-encoded:
+Reuse running instance's `http://127.0.0.1:<port>`. Path after prefix, leading slash dropped, segments URL-encoded:
 
 - `/` → `/apps` hub; `/explorer` = file-explorer homepage.
-- `/explorer/view/<path>` — full shell chrome (what the app opens).
-- `/explorer/embed/<path>` — chrome-free; best for a single view or a screenshot.
+- `/explorer/view/<path>` — full shell chrome (what app opens).
+- `/explorer/embed/<path>` — chrome-free; single view or screenshot.
 
-Mode is fixed by prefix (no toggle without navigation); params sync the same in both. Old `/view/`/`/embed/` links redirect; write the `/explorer/` forms.
+Mode fixed by prefix (no toggle without navigation); params sync same in both. Old `/view/`/`/embed/` links redirect; write `/explorer/` forms.
 
-**Preview templates** (parquet/image/etc.): open the TARGET file's path; the shell resolves the template by extension and passes `_file`. `?_mode=<name>` picks a specific mode.
+**Preview templates** (parquet/image/etc.): open TARGET file's path; shell resolves template by extension, passes `_file`. `?_mode=<name>` picks specific mode.
 
-**URL params are the shareable state** — copy the URL to reproduce the exact view.
+**URL params = shareable state** — copy URL, reproduce exact view.
 
 ## Switch skills
 
-Authoring/debugging views → `fused-render-authoring` · template registration → `fused-render-custom-templates` · AI → `fused-render-ai` · file index/search → `fused-render-index` · resident daemons → `fused-render-background-apps`.
+Authoring/debugging → `fused-render-authoring` · template registration → `fused-render-custom-templates` · AI → `fused-render-ai` · file index/search → `fused-render-index` · resident daemons → `fused-render-background-apps`.

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -1,57 +1,30 @@
 ---
 name: fused-render-usage
-description: Open and run a fused-render project — launching the FusedRender desktop app, opening files and views, browsing the filesystem. Use when the user wants to open, run or show a project or view rather than author one.
+description: Use when opening, running or showing a fused-render project, file or view (not authoring one) — launching the desktop app, URL modes, browsing.
 ---
 
-# Using a fused-render project
+# Using fused-render
 
-fused-render is a **local file-explorer desktop app** that runs entirely on `127.0.0.1` — no accounts, no cloud. It browses any directory in the browser, previews files, and live-renders `.html` views that call local Python. This skill covers **running and using** the app; it does not cover writing views (that's `fused-render-authoring`).
+Local file-explorer desktop app, single instance per user, serves on `127.0.0.1` — no accounts, no cloud. Browses directories, previews files, live-renders `.html` views that call local Python. Authoring → `fused-render-authoring`.
 
-This skill assumes **the FusedRender desktop app is already running** — there's a single instance per user, serving on `127.0.0.1`. Everything below is a way to open something into that running instance.
+## Open a path via the app
 
-## Opening a file, view, or directory
+macOS `open -a FusedRender <path>` · Linux `gtk-launch fused-render <path>` (or the AppImage binary) · Windows `FusedRender.exe <path>`. Directory → explorer there; file → preview; `.html` → rendered view.
 
-Hand the path to the app — it opens as a full-shell view (`/explorer/view/<path>`) in a browser tab, reusing the running instance:
+## Open by URL
 
-| Platform | Open a path |
-|---|---|
-| macOS | `open -a FusedRender <path>` |
-| Linux | `gtk-launch fused-render <path>`, right-click → *Open With → FusedRender*, or the AppImage binary `FusedRender-<ver>.AppImage <path>` |
-| Windows | `FusedRender.exe <path>`, or right-click → *Open with → FusedRender* |
+Reuse the running instance's `http://127.0.0.1:<port>`. Path rides after the prefix, leading slash dropped, segments URL-encoded:
 
-Opening a directory lands the explorer there; opening a file previews it; opening an `.html` view renders it.
+- `/` → `/apps` hub; `/explorer` = file-explorer homepage.
+- `/explorer/view/<path>` — full shell chrome (what the app opens).
+- `/explorer/embed/<path>` — chrome-free; best for a single view or a screenshot.
 
-## Opening by URL (view / embed / preview templates)
+Mode is fixed by prefix (no toggle without navigation); params sync the same in both. Old `/view/`/`/embed/` links redirect; write the `/explorer/` forms.
 
-Everything the app shows is a URL, so any view is bookmarkable and shareable. The running app already has a tab open — reuse its `http://127.0.0.1:<port>` from the address bar and swap the path.
+**Preview templates** (parquet/image/etc.): open the TARGET file's path; the shell resolves the template by extension and passes `_file`. `?_mode=<name>` picks a specific mode.
 
-The filesystem path rides in the URL after a **mode prefix**, with its **leading slash dropped** and each segment URL-encoded (space → `%20`). `/Users/me/proj/dash.html` → `…/explorer/view/Users/me/proj/dash.html`.
+**URL params are the shareable state** — copy the URL to reproduce the exact view.
 
-| Path | Renders |
-|---|---|
-| `/` | Redirects to `/apps` (the app hub). `/explorer` is the file-explorer homepage — click to browse. |
-| `/explorer/view/<path>` | **Full-shell mode** — the page wrapped in explorer chrome (sidebar, breadcrumb, preview header). What the app opens when you hand it a path. |
-| `/explorer/embed/<path>` | **Embed mode** — the page chrome-free (no sidebar/breadcrumb/header). Best for opening a specific view on its own or for a screenshot. |
+## Switch skills
 
-`/view/<path>` and `/embed/<path>` still redirect to the `/explorer/...` forms, so old links keep working — but write the new ones.
-
-View vs embed is a fixed page-load mode set by the prefix — it can't toggle without a full navigation. Both serve the same page and sync URL params the same way; embed just hides the chrome.
-
-**Preview templates** (parquet/image/text viewers, etc.) open at the *target file's* path — `…/explorer/view/<abs path to the data file>` — and the shell resolves the template by extension, handing it the file via a read-only `_file` param. Point at the data file, not the template html. When a file has more than one mode, add `?_mode=<name>` to open a specific one (or use the switcher in the preview header).
-
-## Params are the shareable state
-
-View state (paging, sort, selection) lives in **URL params**, so any view is refresh-proof and bookmarkable — copy the URL to reproduce or share the exact state.
-
-## Where things live in a project
-
-- A **view** is usually a sibling pair: an `.html` page (UI) + a `.py` file (data it fetches via `fused.runPython`).
-- Built-in preview templates live under `fused_render/templates/<name>/`; user-owned ones under `~/.fused-render/` (see `fused-render-custom-templates`).
-
-## When to switch skills
-
-- Creating, editing, or debugging an `.html` view or `.py` data file, or a blank/errored view → **`fused-render-authoring`**.
-- Registering a custom preview template for a file extension → **`fused-render-custom-templates`**.
-- Calling an AI model from a page, driving local models, or generating an image → **`fused-render-ai`**.
-- Searching, counting, or aggregating files across the machine — the file index, a scan, `fused.fileIndex.*` → **`fused-render-index`**.
-- Giving a folder its own long-running daemon that survives its page closing and the warm worker's idle-retire → **`fused-render-background-apps`**.
+Authoring/debugging views → `fused-render-authoring` · template registration → `fused-render-custom-templates` · AI → `fused-render-ai` · file index/search → `fused-render-index` · resident daemons → `fused-render-background-apps`.

--- a/tests/test_index_skill_reader.py
+++ b/tests/test_index_skill_reader.py
@@ -3,19 +3,15 @@
 The Python reader (``skills/fused-render-index/reader.py``) is copy-paste code:
 whatever it gets wrong propagates into every app that follows the skill, and
 prose review cannot catch a path that resolves to a directory which does not
-exist. So the file is run — its branch sanitization is checked against the real
-``fused_render._branch.sanitize`` it has to match, and ``connect()`` is pointed
-at the store shapes that made it raise. The JS example in SKILL.md gets the two
-checks that can be made statically: its cross-references, and the generation
-guard that keeps a per-keystroke render honest.
+exist. So the file is run — its store resolution is checked against the env the
+server actually exports, and ``connect()`` is pointed at the store shapes that
+made it raise. The JS example in SKILL.md gets the check that can be made
+statically: the generation guard that keeps a per-keystroke render honest.
 """
 import os
-import re
 from pathlib import Path
 
 import pytest
-
-from fused_render._branch import sanitize
 
 _SKILL_DIR = Path(__file__).resolve().parents[1] / "skills" / "fused-render-index"
 SKILL = (_SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
@@ -57,16 +53,6 @@ def test_the_skill_documents_only_the_two_bridge_methods():
 
 # --------------------------------------------------------------- the JS example
 
-def test_every_section_cross_reference_names_a_section_that_exists():
-    # Catches a pointer at a section that is not there. It cannot catch a
-    # pointer at the WRONG existing section (the repos row said "section E",
-    # the migration guide, instead of D) — that one is on review, and the
-    # sections are lettered here so a rename at least fails loudly.
-    letters = {m.group(1) for m in re.finditer(r"^## ([A-Z])\. ", SKILL, re.M)}
-    for cited in re.findall(r"[Ss]ection ([A-Z])\b", SKILL):
-        assert cited in letters, cited
-
-
 def test_the_per_keystroke_example_guards_its_own_renders():
     """`fused.fileIndex.*` has no supersede channel (runPython's D114 is not it),
     so the copy-pasted example must not let a slower earlier query win."""
@@ -80,28 +66,49 @@ def test_the_per_keystroke_example_guards_its_own_renders():
 
 # ------------------------------------------------------------- branch scoping
 
-# The refs that broke the unsanitized version: this very branch (truncated to
-# _MAX_LEN), a default branch (baseline — no branches/ nesting at all), mixed
-# case, and a ref whose 12-char cut lands on a separator.
+# The refs whose stores a hand-rolled resolution used to miss: this very branch
+# (truncated to _MAX_LEN), a default branch (baseline — no branches/ nesting at
+# all), mixed case, and a ref whose 12-char cut lands on a separator.
 _REFS = ["", "main", "MAIN", "master", "HEAD", "worktree-fused-index-api",
          "Worktree-Fused-Index-API", "feature/AB-123_fix", "a-very-long-branch-name",
          "abcdefghijk-more", "///", "Fix.The.Thing"]
 
 
 @pytest.mark.parametrize("ref", _REFS)
-def test_the_snippets_branch_ref_matches_the_real_sanitize(ref):
-    assert _reader()["_branch_ref"](ref) == sanitize(ref), ref
-
-
-@pytest.mark.parametrize("ref", _REFS)
 def test_store_dir_resolves_where_the_server_actually_wrote(ref, tmp_path,
                                                             monkeypatch):
+    """The server exports FUSED_RENDER_HOME_DIR already branch-resolved, so
+    taking it verbatim lands on the store for every ref — including a branch
+    build whose ref is baked in and never reaches the environment at all."""
     from fused_render._branch import branch_dir
 
+    home = branch_dir(str(tmp_path), ref)
+    monkeypatch.setenv("FUSED_RENDER_HOME_DIR", home)
+    monkeypatch.delenv("FUSED_RENDER_BRANCH", raising=False)
+    assert _reader()["store_dir"]() == os.path.join(home, "index"), ref
+
+
+def test_store_dir_never_re_derives_the_branch_nesting_itself(tmp_path,
+                                                              monkeypatch):
+    """FUSED_RENDER_HOME_DIR is the OUTPUT of the branch resolution, not its
+    input: appending `branches/<ref>` to it would answer
+    `branches/<ref>/branches/<ref>` on any worktree build (SPEC PY-15, D166)."""
+    monkeypatch.setenv("FUSED_RENDER_HOME_DIR",
+                       os.path.join(str(tmp_path), "branches", "some-branch"))
+    monkeypatch.setenv("FUSED_RENDER_BRANCH", "some-branch")
+    assert _reader()["store_dir"]() == os.path.join(
+        str(tmp_path), "branches", "some-branch", "index")
+
+
+def test_with_no_server_around_store_dir_is_the_unbranched_baseline(tmp_path,
+                                                                    monkeypatch):
+    """Nothing exported HOME_DIR, so there is no branch-resolved answer to
+    honor — and guessing one from FUSED_RENDER_BRANCH is the drift this
+    resolution exists to avoid. The baseline is the honest fallback."""
+    monkeypatch.delenv("FUSED_RENDER_HOME_DIR", raising=False)
     monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path))
-    monkeypatch.setenv("FUSED_RENDER_BRANCH", ref)
-    expected = os.path.join(branch_dir(str(tmp_path), ref), "index")
-    assert _reader()["store_dir"]() == expected, ref
+    monkeypatch.setenv("FUSED_RENDER_BRANCH", "some-branch")
+    assert _reader()["store_dir"]() == os.path.join(str(tmp_path), "index")
 
 
 def test_an_explicit_location_wins_over_the_env(tmp_path, monkeypatch):

--- a/tests/test_index_skill_reader.py
+++ b/tests/test_index_skill_reader.py
@@ -1,13 +1,13 @@
-"""The CODE in skills/fused-render-index/SKILL.md, checked rather than read.
+"""The CODE the fused-render-index skill hands out, checked rather than read.
 
-The Python reader is copy-paste code: whatever it gets wrong propagates into every
-app that follows the skill, and prose review cannot catch a path that resolves
-to a directory which does not exist. So the block is extracted from the
-markdown and run — its branch sanitization is checked against the real
+The Python reader (``skills/fused-render-index/reader.py``) is copy-paste code:
+whatever it gets wrong propagates into every app that follows the skill, and
+prose review cannot catch a path that resolves to a directory which does not
+exist. So the file is run — its branch sanitization is checked against the real
 ``fused_render._branch.sanitize`` it has to match, and ``connect()`` is pointed
-at the store shapes that made it raise. The JS example gets the two checks that
-can be made statically: its cross-references, and the generation guard that
-keeps a per-keystroke render honest.
+at the store shapes that made it raise. The JS example in SKILL.md gets the two
+checks that can be made statically: its cross-references, and the generation
+guard that keeps a per-keystroke render honest.
 """
 import os
 import re
@@ -17,16 +17,15 @@ import pytest
 
 from fused_render._branch import sanitize
 
-SKILL = (Path(__file__).resolve().parents[1] / "skills" / "fused-render-index"
-         / "SKILL.md").read_text(encoding="utf-8")
+_SKILL_DIR = Path(__file__).resolve().parents[1] / "skills" / "fused-render-index"
+SKILL = (_SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
 
 
 def _reader():
-    """Exec the ```python block under "The reader (copy this)"` and return it."""
-    after = SKILL.split("### The reader (copy this)", 1)[1]
-    code = after.split("```python", 1)[1].split("```", 1)[0]
+    """Exec the skill's reader.py and return its namespace."""
+    code = (_SKILL_DIR / "reader.py").read_text(encoding="utf-8")
     namespace = {}
-    exec(compile(code, "SKILL.md:reader", "exec"), namespace)  # noqa: S102
+    exec(compile(code, str(_SKILL_DIR / "reader.py"), "exec"), namespace)  # noqa: S102
     return namespace
 
 


### PR DESCRIPTION
## Summary

- Rewrites all 11 plugin skills (`skills/*/SKILL.md`) from scratch in a terse, reference-first style: 2124 lines → ~640. Descriptions are short "Use when …" triggers; bodies keep facts, contracts and pitfalls, and point at source files (`fused_render/executor.py`, `templates/fusedapp/template.html`, `index/guarded_query.py`, SPEC.md §30/§46, the daemon test fixture) instead of restating them. No historical context anywhere.
- All 11 stay **skills** (not demoted to plain reference .md): their names are load-bearing in shipped prompts and code (`app_starter/CLAUDE.md`, `starterPrompts.tsx`, `runtime.js`, `apps.py`, `fused_api_version.py` — `MIGRATION_SKILL` and the current API version both key off the migration skill's folder, whose `docs/v1.md` is untouched).
- Content that tests execute or pin stays tested: the index skill's copy-paste Python reader moves to `skills/fused-render-index/reader.py` (ships with the skill — the build `copytree`s each skill dir) and `test_index_skill_reader.py` now execs the file instead of extracting a markdown block. The generation-guard JS example, the `not superseded like `runPython`` phrase, the full `/api/index/*` route list, the AI skill's `## Images:`/`## Video:` field-drift sections, and the authoring skill's `### Available Python libraries` bullet list all keep the exact anchors their tests split on.
- `runtime.js`'s comment pointing at the removed lettered "section C" of the index skill now just names the skill.

## Visuals

How a tested copy-paste reader is sourced after this PR:

```mermaid
flowchart TD
    A[skills/fused-render-index/] --> B[SKILL.md — terse facts,\npoints at reader.py]
    A --> C[reader.py — copy-paste code]
    C --> D[test_index_skill_reader.py\nexecs the file, checks vs\nfused_render._branch.sanitize]
    A --> E[hatch_build copytree →\nfused_render/skills/ in the wheel]
```

The other pinned anchors (AI image/video sections, authoring library list, index routes/JS guard) are unchanged in *mechanism* — the rewritten skills keep the exact headings and strings their existing tests assert on.

## Usage

Not user-invocable in a new way — the same 11 skills load through the same names (authoring hub routes to the rest). Agents copying the index reader now copy `skills/fused-render-index/reader.py` rather than a fenced block.

## Test Plan

- [x] `tests/test_index_skill_reader.py` — 33 passed (reader execs from `reader.py`; JS guard, route list, description length, bridge-surface checks against the rewritten SKILL.md)
- [x] `tests/test_ai_runtime.py -k SKILL` — 4 passed (image/video sections name every field the endpoints resolve with)
- [x] `tests/test_bundle_contents.py -k "library or manifest or skill"` — 2 passed (library list promises only what ships; "Anything else" sentence names nothing bundled)
- [x] `tests/test_skill_plugin.py`, `tests/test_user_plugin.py` — 90 passed; scaffold tests (`test_new_app_has_no_dot_claude_and_publishes_the_plugin_root`, `test_new_template_scaffolds_and_binds`) pass
- [x] `-k "api_version or migration"` — 44 passed (migration skill's `docs/v1.md` registry intact)
- [ ] Full suite on CI (local /tmp quota can't run it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
