### PR TITLE
Claude chat: Escape never stops a run, and growth follows the tail

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -2690,7 +2690,8 @@
   .send:hover { filter: brightness(1.1); transform: translateY(-1px); }
   .send:active { transform: none; }
   /* While a run is live the send buttons become stop buttons: the arrow hides and
-     a stop square shows. Clicking then kills the run (same as Escape). */
+     a stop square shows. Clicking then kills the run — the ONLY keyless way to
+     do it, and with Escape out of the business the only one on this page. */
   .send .ic-stop { display: none; }
   body.running .send .ic-send { display: none; }
   body.running .send .ic-stop { display: block; }
@@ -6706,10 +6707,9 @@ async function annCommit() {
   if (isNew && !sending) annAutoSubmit();
 }
 annTa.addEventListener("keydown", (e) => {
-  // stopPropagation, because the document-level Escape binding also kills a live
-  // run: without it, closing the composer would end the turn as well (this
-  // handler runs first and would leave the popover already hidden, so the
-  // precedence check up there could not see it).
+  // stopPropagation, because the document-level Escape binding would otherwise
+  // see an ALREADY-CLOSED composer (this handler runs first) and fall through to
+  // the next claimant, leaving annotate mode as well. One press, one undo.
   if (e.key === "Escape") { e.stopPropagation(); annCloseComposer(); }
   if (e.key === "Enter" && !e.shiftKey) {
     e.preventDefault();
@@ -8031,9 +8031,9 @@ function applyNarrowView() {
   // arming annotate mode with both columns on screen and then dragging the
   // divider under 800px used to hide the control and keep the state: NARROW_MQ's
   // change handler called through to here and the guard failed. The cost was
-  // `escapeAction` returning "exit-annotate" ahead of "stop-run", so the user's
-  // first Escape during a live turn disarmed an invisible switch instead of
-  // stopping the run.
+  // `escapeAction` returning "exit-annotate" for a switch that was not on
+  // screen, so the user's first Escape disarmed an invisible mode instead of
+  // doing the visible thing they meant.
   //
   // The widened test costs nothing on the calls it newly reaches (a narrow,
   // chat-view params.onChange for `split`): the reset is idempotent, and
@@ -11223,8 +11223,9 @@ document.addEventListener("pointerdown", (ev) => {
   }
 });
 // Capture phase, and the event is CONSUMED — same discipline as .selpop's
-// Escape: the document-level binding kills a live run, and dismissing a confirm
-// must not also do that.
+// Escape: the document-level binding has its own claimants (the screenshot
+// viewer, the annotation composer, annotate mode), and dismissing a confirm must
+// not also close one of those.
 document.addEventListener("keydown", (ev) => {
   if (ev.key !== "Escape" || !schedPopFor) return;
   ev.stopPropagation();
@@ -11679,9 +11680,10 @@ document.addEventListener("pointerdown", (ev) => {
   if (selPopFor && !selPop.contains(ev.target) && ev.target !== selPopFor) closeSelPop();
 });
 // Capture phase, and the event is CONSUMED when it closes a menu: the
-// document-level Escape binding kills a live run (and annotate has its own
-// exit), and dismissing a dropdown must not also do either. Same discipline
-// as the annotate composer's stopPropagation on its Escape.
+// document-level Escape binding would otherwise take the same press for one of
+// its own claimants (annotate mode has its exit there), and dismissing a
+// dropdown must not also do that. Same discipline as the annotate composer's
+// stopPropagation on its Escape.
 document.addEventListener("keydown", (ev) => {
   if (ev.key !== "Escape" || !selPopFor) return;
   ev.stopPropagation();
@@ -11870,6 +11872,44 @@ logwrap.addEventListener("scroll", () => {
   else if (nearBottom()) followTail = true;
   lastTop = top; lastHeight = h;
 }, { passive: true });
+
+// ── growth follows, wherever it comes from ─────────────────────────────────
+// The flag above says WHETHER to follow; every write site so far also had to
+// remember to ASK. That is the half that kept leaking: a mid-turn write only
+// stays pinned if the code that made it calls followBottom() afterwards AND the
+// element it appended has its final height by then. Neither holds for most of
+// what lands in a live turn — a tool card that expands when its output arrives,
+// the working line re-rendering a longer verb, a code block growing as the
+// highlighter runs, an artifact iframe or a picture that only takes up room once
+// it loads, a permission card, the whole bubble re-rendering as markdown at
+// message end. Every one of those grows the transcript AFTER the append that
+// scrolled, so the reader sat one card's height short of the bottom and the rest
+// of the turn arrived off-screen — the reported "some elements come in and mess
+// that behaviour".
+//
+// So growth is observed instead of announced. A ResizeObserver on the two
+// children of the scrollport fires on any height change whatever caused it, and
+// the answer is the same one flag: if the reader is following, follow. This
+// makes followBottom() at a write site a belt-and-braces nicety rather than the
+// mechanism, which is why none of them had to be hunted down.
+//
+// Writing scrollTop cannot resize anything, so this observer cannot re-enter
+// itself — no "ResizeObserver loop" noise of the kind fitComposerChrome had to
+// be restructured around (see the column observer above).
+// Both children by id rather than `queueEl`, which is declared with the queue's
+// own code several thousand lines below and is still in its temporal dead zone
+// here.
+const followGrowth = new ResizeObserver(followBottom);
+for (const el of [log, document.getElementById("queue")]) followGrowth.observe(el);
+// Belt and braces for the one growth a ResizeObserver can miss: a replaced
+// element that reserves its box up front (an <img> with width/height, an iframe
+// with a fixed height) paints into a box that never changes size, and any
+// LAYOUT its load shifts around it may land in the same frame the observer
+// already answered. `load` does not bubble, hence the capture phase, and one
+// listener on the scrollport covers every picture and frame the transcript will
+// ever hold — including the ones a restored history fetches through /api/fs/raw
+// long after their turn was rendered.
+logwrap.addEventListener("load", followBottom, true);
 
 // ── scroll to one message (?msg=<transcript record uuid>) ──────────────────
 //
@@ -13609,8 +13649,8 @@ function parkResolvedCard(card) {
   const port = logwrap.getBoundingClientRect();
   const wasVisible = box.bottom > port.top && box.top < port.bottom;
   seg.appendChild(el);
-  if (followTail) scrollBottom();
-  else if (wasVisible) el.scrollIntoView({ block: "nearest" });
+  followBottom();
+  if (!followTail && wasVisible) el.scrollIntoView({ block: "nearest" });
 }
 
 // Reconcile the poll's request list with what is on screen. Idempotent — poll
@@ -14705,8 +14745,9 @@ async function answerAppState(list, run_id, working) {
 // Mirrors the claude template (this chat is a fork of it): agent.py could always
 // kill a run, and until the stop button nothing called it — a turn that went off
 // the rails could only be waited out or escaped by navigating away, which leaves
-// the detached subprocess working on. pollLoop publishes the live run so the
-// button and Escape have something to aim at, which covers a re-attached run too.
+// the detached subprocess working on. pollLoop publishes the live run so the stop
+// button has something to aim at, which covers a re-attached run too. The button
+// is the whole of it: Escape stops nothing here (see escapeAction).
 let activeRun = null;
 let activeWorking = null;
 // The live turn's segment container, or null between turns. Published by pollLoop
@@ -14775,24 +14816,32 @@ async function stopRun() {
   }
 }
 
-// Escape has four claimants in this pane: the screenshot viewer, the annotation
-// composer, annotate mode, and a live run. Ordered least-destructive first —
-// closing a picture undoes nothing at all, dismissing a popover is small and
-// repeatable, leaving annotate mode costs one click to undo, killing a turn costs
-// the turn. So a user reaching for Escape with a text box in front of them means
-// the text box, and one reaching for it while annotating means annotate mode, not
-// the run they may also have going. Split out as a pure decision so the
+// Escape has three claimants in this pane: the screenshot viewer, the annotation
+// composer, and annotate mode. Ordered least-destructive first — closing a
+// picture undoes nothing at all, dismissing a popover is small and repeatable,
+// leaving annotate mode costs one click to undo. So a user reaching for Escape
+// with a text box in front of them means the text box, and one reaching for it
+// while annotating means annotate mode. Split out as a pure decision so the
 // precedence is a tested rule and not an ordering accident.
 //
 // The viewer goes FIRST for a stronger reason than cheapness: it is MODAL. It
-// covers the composer and the pane, so every other claimant is behind it, and an
-// Escape that stopped a run the user could not even see would be the worst
-// outcome this key can produce.
-function escapeAction(viewerOpen, composerOpen, annotating, runId) {
+// covers the composer and the pane, so every other claimant is behind it.
+//
+// A LIVE RUN IS NOT A CLAIMANT, and used to be the last one. Escape killed the
+// turn whenever nothing else wanted the key, so a reader who reached for it out
+// of habit — dismissing a popover this page had already closed, backing out of
+// the shell's own UI, or simply clearing a stray focus — lost the whole turn to
+// a keystroke never aimed at the run (Akshil, 2026-09-03). Work in progress is
+// not something a bare keypress may throw away, and no other claimant here costs
+// anything to undo, so the key has no destructive branch left at all. Stopping
+// is a deliberate press on a control that says what it does: the stop square the
+// send button becomes, and the ✕ on the tasks queue card. stopRun() is unchanged
+// and still reachable from both.
+function escapeAction(viewerOpen, composerOpen, annotating) {
   if (viewerOpen) return "close-viewer";
   if (composerOpen) return "close-composer";
   if (annotating) return "exit-annotate";
-  return runId ? "stop-run" : "";
+  return "";
 }
 
 // Gated on there being something to do, so the binding is inert the rest of the
@@ -14803,13 +14852,12 @@ function onEscape(e) {
   // The textarea's own Escape handler stops propagation, so what reaches here
   // with the popover open is an Escape pressed with focus somewhere else.
   const act = escapeAction(!shotView.hidden, annPop.style.display === "block",
-                           annOn, activeRun);
+                           annOn);
   if (!act) return;
   e.preventDefault();
   if (act === "close-viewer") shotViewClose();
   else if (act === "close-composer") annCloseComposer();
-  else if (act === "exit-annotate") annSetMode(false);
-  else stopRun();
+  else annSetMode(false);
 }
 
 // Bound on BOTH documents. Annotate mode is driven with the pointer over the
@@ -15075,7 +15123,7 @@ let logGen = 0;
 async function pollLoop(run_id, gen = logGen) {
   const seat = ++loopSeq;
   const w = addWorking();
-  // This run is now the one the stop button and Escape aim at. Set here, the one
+  // This run is now the one the stop button aims at. Set here, the one
   // place a run is ever in flight, which covers a re-attached run for free.
   activeRun = run_id;
   activeWorking = w;
@@ -15205,13 +15253,13 @@ async function pollLoop(run_id, gen = logGen) {
     // running forever, holding the whole closure — one leaked timer per turn.
     w.stop();
     if (w.el.isConnected) w.el.remove();
-    // Nothing is interruptible any more. Cleared even when the loop threw: an
-    // Escape landing after this must not cancel a finished run and then mislabel
-    // the NEXT turn's ending as a stop. OWNERSHIP-GUARDED (Bugbot, PR #653),
+    // Nothing is interruptible any more. Cleared even when the loop threw: a
+    // stop click landing after this must not cancel a finished run and then
+    // mislabel the NEXT turn's ending as a stop. OWNERSHIP-GUARDED (PR #653),
     // and ownership means being the NEWEST loop, not matching the run id: a
     // chat left mid-turn and reopened re-attaches to the SAME run_id, and the
     // abandoned loop's late finally matched it and stripped the new loop's
-    // Stop square and Escape target.
+    // Stop square.
     if (loopSeq === seat) {
       activeRun = null;
       activeWorking = null;
@@ -15257,16 +15305,16 @@ function noteChatActivity() {
 
 // The composer's send buttons double as stop buttons while a run is live: the
 // arrow swaps for a stop square (CSS on body.running) and a click aims at the
-// run, same as Escape. Labels follow so a screen reader hears the real action.
+// run. It is the only thing that does — Escape deliberately stops nothing (see
+// escapeAction). Labels follow so a screen reader hears the real action.
 function setRunningUi(on) {
   document.body.classList.toggle("running", on);
   document.querySelectorAll(".send").forEach((b) => {
     b.setAttribute("aria-label", on ? "Stop" : "Send");
-    // No "(Esc)" hint: Escape's first claim is the annotation composer, then
-    // annotate mode (default ON) — during a normal run it disarms annotating,
-    // not the turn. Advertising it here would teach a keystroke that usually
-    // does something else; the working line's own stop control stays the
-    // keyboard-adjacent path.
+    // No "(Esc)" hint, and there is nothing to hint at any more: Escape has no
+    // claim on a run at all. Its claimants are the screenshot viewer, the
+    // annotation composer and annotate mode; the button (and the working line's
+    // own stop control) is the only way to end a turn.
     b.title = on ? "Stop this turn" : "";
   });
 }
@@ -15982,10 +16030,13 @@ function applyComposerBlockState() {
   // reader who was at the bottom is put back at the bottom. Measured before the
   // render, applied only on the hidden → shown edge: on the way out the log grows
   // downward and there is nothing to correct.
+  // "Was the reader at the bottom" is the follow flag, not a geometry read: this
+  // banner SHRINKS the scrollport as it appears, which is precisely the case a
+  // distance threshold gets wrong (the gap crosses 60px because the viewport
+  // moved, not because the reader did). See the follow-the-tail block.
   const wasHidden = schedBlockEl.hidden;
-  const pinned = wasHidden && nearBottom();
   renderSchedBlock();
-  if (pinned && !schedBlockEl.hidden) scrollBottom();
+  if (wasHidden && !schedBlockEl.hidden) followBottom();
   const blocked = schedBlocked();
   box.disabled = blocked;
   // Short, because this box is 300px wide in the side pane and a longer line is
@@ -16135,8 +16186,8 @@ document.addEventListener("pointerdown", (ev) => {
   if (schedStopArmed && !schedBlockEl.contains(ev.target)) schedDisarmStop();
 });
 // Capture phase and the event is CONSUMED — the same discipline the schedule
-// confirm takes: the document-level Escape binding kills a live run, and backing
-// out of a half-pressed confirm must not also do that.
+// confirm takes: the document-level Escape binding has claimants of its own, and
+// backing out of a half-pressed confirm must not also trip one of them.
 document.addEventListener("keydown", (ev) => {
   if (ev.key !== "Escape" || !schedStopArmed) return;
   ev.stopPropagation();
@@ -16679,8 +16730,9 @@ document.getElementById("inputbox").onsubmit = (e) => {
 };
 box.addEventListener("keydown", (e) => {
   // Enter never stops a run — a user drafting the next message mid-run must not
-  // kill the turn with a keystroke meant to queue text. Only the button (now a
-  // stop square) and Escape do.
+  // kill the turn with a keystroke meant to queue text. NO key does: Escape lost
+  // that job for the same reason (see escapeAction). Only the button, now a stop
+  // square, ends a turn.
   if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submitChat(); }
 });
 
@@ -16737,9 +16789,9 @@ function renderLogSkeleton() {
 //   * NO SKELETON. The turns already on screen are the right thing to look at
 //     until the new ones are ready; blanking to placeholders for the length of a
 //     round trip is a flicker that announces nothing.
-//   * SCROLL IS KEPT, not sent to the bottom — except for a reader who was
-//     already at the bottom, who is following along and gets carried with the
-//     new turn (the same `nearBottom` rule streaming output obeys).
+//   * SCROLL IS KEPT, not sent to the bottom — except for a reader who is
+//     following along, who gets carried with the new turn (the same `followTail`
+//     flag streaming output obeys).
 //   * The per-transcript records are NOT cleared. `scheduleResetForNewTranscript`
 //     re-baselines which scheduled runs may attach, so doing it here would write
 //     a run that fired seconds ago off as "already on screen", every five
@@ -16755,7 +16807,7 @@ async function loadHistory(session_id, opts) {
   if (sending) return;
   sending = true;
   const seat = ++sendSeq;
-  const keepTop = refresh && !nearBottom() ? logwrap.scrollTop : null;
+  const keepTop = refresh && !followTail ? logwrap.scrollTop : null;
   permCards.clear();
   notedSkills.clear();
   if (!refresh) {

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -13698,8 +13698,8 @@ function retryVerb(retry) {
 // `opts.stoppable: false` drops the stop button, and `opts.verb` fixes the word
 // instead of drawing one from the phase. Both exist for the same caller — the
 // line that reports a turn running OUTSIDE this app (D415's transcript-follow),
-// which has no process to kill and no phase to read, and where a "stop · esc"
-// that quietly does nothing would be the worst control on the page.
+// which has no process to kill and no phase to read, and where a "stop"
+// button that quietly does nothing would be the worst control on the page.
 // The verb for a run this page owns, from the poll's phase and `activity`. ONE
 // PLAIN SENTENCE a person who has never heard of tokens can read: what Claude
 // is doing right now, in everyday words. The specifics (which command, which
@@ -13778,7 +13778,7 @@ function addWorking(opts) {
     // claude template — a separate hint line grows and shrinks the chrome every
     // time a turn starts and ends, and the pane here is narrower still.
     + (stoppable
-       ? '<button id="stopbtn" class="stop" type="button" title="Stop this turn">stop · esc</button>'
+       ? '<button id="stopbtn" class="stop" type="button" title="Stop this turn">stop</button>'
        : "");
   const verbEl = d.querySelector(".verb");
   const meta = d.querySelector(".meta");

--- a/tests/test_claude_app_state.py
+++ b/tests/test_claude_app_state.py
@@ -1460,36 +1460,72 @@ def test_a_null_snapshot_on_the_wire_is_the_hard_error_the_page_now_avoids(
 # ------------------------------------------------- Escape has three claimants
 
 def test_escape_prefers_the_smallest_undo_it_can_do(html):
-    """Four features bind Escape in this pane, and the order is least-destructive
-    first. Closing the screenshot viewer undoes nothing at all, dismissing a
-    popover is small and repeatable, leaving annotate mode is reversible with one
-    click, killing a live turn is none of those — so an Escape pressed with a text
-    box open means the text box, and one pressed while annotating means annotate
-    mode, not the run.
+    """Three features bind Escape in this pane, and the order is
+    least-destructive first. Closing the screenshot viewer undoes nothing at all,
+    dismissing a popover is small and repeatable, leaving annotate mode is
+    reversible with one click — so an Escape pressed with a text box open means
+    the text box, and one pressed while annotating means annotate mode.
 
     The viewer leads for a stronger reason than cheapness: it is MODAL, so every
-    other claimant is literally behind it, and an Escape that stopped a run the
-    user could not see would be the worst thing this key can do."""
-    def act(viewer, open_, annotating, run):
+    other claimant is literally behind it."""
+    def act(viewer, open_, annotating):
         return _node(["function escapeAction("],
-                     "console.log(JSON.stringify(escapeAction(%s, %s, %s, %s)));"
+                     "console.log(JSON.stringify(escapeAction(%s, %s, %s)));"
                      % (json.dumps(viewer), json.dumps(open_),
-                        json.dumps(annotating), json.dumps(run)),
+                        json.dumps(annotating)),
                      html)
 
-    # the viewer outranks every other claimant, including a live run
-    assert act(True, True, True, "run-7") == "close-viewer"
-    assert act(True, False, False, None) == "close-viewer"
-    assert act(False, True, False, "run-7") == "close-composer"
-    assert act(False, True, True, None) == "close-composer"
-    # The banner says "Esc or click to stop", so Escape must leave annotate mode —
-    # and must do it in preference to ending the turn.
-    assert act(False, False, True, None) == "exit-annotate"
-    assert act(False, False, True, "run-7") == "exit-annotate"
-    assert act(False, False, False, "run-7") == "stop-run"
+    assert act(True, True, True) == "close-viewer"
+    assert act(True, False, False) == "close-viewer"
+    assert act(False, True, False) == "close-composer"
+    assert act(False, True, True) == "close-composer"
+    # The banner says "Esc or click to stop", so Escape must leave annotate mode.
+    assert act(False, False, True) == "exit-annotate"
     # Inert otherwise: this page is in an iframe and must not swallow the shell's
     # Escape for nothing.
-    assert act(False, False, False, None) == ""
+    assert act(False, False, False) == ""
+
+
+def test_escape_never_stops_a_live_run(html):
+    """It used to, as the last claimant — so a reader who reached for the key out
+    of habit (a popover this page had already closed, backing out of the shell's
+    own UI) lost the whole turn to a keystroke never aimed at the run (Akshil,
+    2026-09-03). Work in progress is not something a bare keypress may throw
+    away. Stopping is now a deliberate press on a control that says so: the stop
+    square the send button becomes, and the tasks queue card's ✕.
+
+    Pinned three ways, because any one of them alone can be reintroduced without
+    the others noticing: the decision has no stop branch, it does not even take
+    the run to branch on, and no keydown handler in the page calls stopRun()."""
+    decision = html[html.index("function escapeAction("):]
+    decision = decision[:decision.index("\n}\n")]
+    assert "stop-run" not in decision
+    assert "runId" not in decision, "the decision still takes a run to kill"
+
+    handler = html[html.index("function onEscape(e) {"):]
+    handler = handler[:handler.index("\n}\n")]
+    assert "stopRun" not in handler
+
+    # ...and nothing else reaches it from a key either. Every keydown binding in
+    # the page is swept; the stop button's own `onsubmit` paths are untouched by
+    # this and are what still call stopRun().
+    at = html.find('addEventListener("keydown"')
+    seen = 0
+    while at >= 0:
+        # The handler only, not the code that happens to follow it: every one of
+        # these bindings closes on a `});` at the start of a line (or is a
+        # one-liner naming a function), and reading past that swept in the send
+        # button's `onsubmit`, which legitimately stops runs.
+        eol = html.find("\n", at)
+        if html[at:eol].rstrip().endswith(");"):
+            end = eol                       # a one-liner naming its handler
+        else:
+            end = min(x for x in (html.find("\n});", at),
+                                  html.find("\n}, true);", at)) if x > 0)
+        seen += 1
+        assert "stopRun" not in html[at:end], html[at:end]
+        at = html.find('addEventListener("keydown"', at + 1)
+    assert seen > 3, "the keydown sweep found almost nothing to sweep"
 
 
 def test_escape_is_bound_inside_the_framed_app_too(html):
@@ -1504,10 +1540,11 @@ def test_escape_is_bound_inside_the_framed_app_too(html):
     assert "document.addEventListener(\"keydown\", onEscape" in html
 
 
-def test_the_composers_escape_does_not_also_reach_the_run_killer(html):
+def test_the_composers_escape_does_not_also_reach_the_next_claimant(html):
     """The textarea's handler runs first and hides the popover, so without a
     stopPropagation the document binding would look at an already-closed
-    composer and end the turn as well."""
+    composer, fall through, and leave annotate mode as well. One press, one
+    undo."""
     start = html.index("annTa.addEventListener(\"keydown\"")
     head = html[start:start + 400]
     assert "stopPropagation" in head, head

--- a/tests/test_claude_composer_block.py
+++ b/tests/test_claude_composer_block.py
@@ -139,7 +139,7 @@ _STATE_FNS = ["let schedBlockers", "const BOX_PLACEHOLDER",
 # there is one. Everything else here is a surface the state function writes to.
 _STATE_STUBS = """
 const fused = { params: { get: (k) => (k === "session_id" ? "S1" : "") } };
-function nearBottom() { return false; }
+function followBottom() {}
 function scrollBottom() {}
 function schedLoadTaskRow() {}
 let confirmClosed = 0;
@@ -450,13 +450,14 @@ def test_the_arriving_banner_does_not_move_the_composer(code, source):
     """The one thing a card directly above the input must never do. It does not,
     by LAYOUT rather than by reserved space: #logwrap is #chat's only `flex: 1`
     child, so the height comes out of the transcript and the composer stays put.
-    The transcript's last line is what moves, so a reader who was at the bottom is
-    put back there — measured before the render, applied on the shown edge only."""
+    The transcript's last line is what moves, so a reader who was following the
+    tail is put back at the bottom — through the follow FLAG, not a geometry
+    read: this banner shrinks the scrollport as it appears, which is exactly the
+    case a distance threshold gets wrong (see tests/test_claude_scroll_follow.py)."""
     state = _fn(code, "function applyComposerBlockState(")
     assert "const wasHidden = schedBlockEl.hidden;" in state
-    assert "const pinned = wasHidden && nearBottom();" in state
-    assert state.index("nearBottom()") < state.index("renderSchedBlock()")
-    assert "if (pinned && !schedBlockEl.hidden) scrollBottom();" in state
+    assert "nearBottom()" not in state, "a threshold read came back into the banner"
+    assert "if (wasHidden && !schedBlockEl.hidden) followBottom();" in state
     # no reserved strip and no entry animation: #schedblock is `display: none`
     # when hidden, so an unblocked composer pays nothing for it
     assert "#schedblock[hidden] { display: none; }" in source

--- a/tests/test_claude_live_run.py
+++ b/tests/test_claude_live_run.py
@@ -918,14 +918,16 @@ console.log(JSON.stringify(calls.filter((c) => c[0] !== "stat")));
 def test_a_refresh_does_not_move_the_reader(html_pane):
     """A refresh is not a navigation. This lap can fire every five seconds under
     a reader who is scrolled back reading an earlier turn, so it restores the
-    scroll it found — except for a reader already at the bottom, who is
-    following along and gets carried to the turn that just landed (the same
-    `nearBottom` rule the streaming output obeys). `?msg=` is a link followed
-    once, so the anchor is not re-honoured on every lap either."""
+    scroll it found — except for a reader who is following the tail, who gets
+    carried to the turn that just landed (the same `followTail` flag the
+    streaming output obeys, rather than a fresh geometry read: a composer that
+    grew under the reader must not be mistaken for the reader moving).
+    `?msg=` is a link followed once, so the anchor is not re-honoured on every
+    lap either."""
     body = _block_between(html_pane,
                           "async function loadHistory(session_id, opts) {",
                           "\n}\n")
-    assert "const keepTop = refresh && !nearBottom() ? logwrap.scrollTop : null;" in body
+    assert "const keepTop = refresh && !followTail ? logwrap.scrollTop : null;" in body
     assert "if (keepTop !== null) logwrap.scrollTop = keepTop;" in body
     # ...and a failed refresh keeps the turns it has: blanking a conversation
     # because one stat round trip lost is strictly worse than showing it stale.

--- a/tests/test_claude_scroll_follow.py
+++ b/tests/test_claude_scroll_follow.py
@@ -61,6 +61,19 @@ const logwrap = {
   set scrollTop(v) { this._top = v; writes.push(v); },
   addEventListener(name, fn) { handlers[name] = fn; },
 };
+// The transcript's two children, and the observer that watches them grow. Both
+// are recorded rather than faked away: which elements the page decided to watch
+// is part of what these tests check.
+const log = { id: "log" };
+const document = { getElementById: (id) => ({ id }) };
+const observed = [];
+let growthCb = null;
+class ResizeObserver {
+  constructor(cb) { growthCb = cb; }
+  observe(el) { observed.push(el.id); }
+}
+// Fire what the browser fires when something in the log changes height.
+const grow = (h) => { logwrap.scrollHeight = h; growthCb(); };
 // Drive a reader gesture: move the port, then fire the scroll event the browser
 // would have fired. Bypasses the setter so it is not recorded as our own write.
 const userScrollTo = (top) => { logwrap._top = top; handlers.scroll(); };
@@ -249,3 +262,55 @@ def test_only_a_blocked_run_may_scroll_the_reader_unasked(html):
     note = html[html.index("function addNote(text, working, glyph)"):]
     note = note[:note.index("\n}\n")]
     assert "followBottom();" in note
+
+
+# ------------------------------------------------- growth follows on its own
+#
+# The flag says WHETHER to follow; these say the page no longer relies on each
+# write site remembering to ASK. Most of what lands in a live turn reaches its
+# final height AFTER the append that scrolled — a tool card expanding when its
+# output arrives, a code block growing under the highlighter, a picture or an
+# artifact iframe that takes up room only once it loads, the bubble re-rendering
+# as markdown at message end. Each of those left the reader one element's height
+# short of the bottom with the rest of the turn arriving off-screen.
+
+
+def test_content_growing_after_the_append_keeps_the_reader_at_the_bottom(html):
+    """The reported bug, in one line: nothing called followBottom() for this
+    growth, because the code that caused it does not know it caused it."""
+    out = _run(html, """
+logwrap._top = 500; handlers.scroll();
+grow(1400);                               // a tool card expanded under the reader
+console.log(JSON.stringify({ writes, followTail }));
+""")
+    assert out["writes"] == [1400], "growth after the append was not followed"
+    assert out["followTail"] is True
+
+
+def test_growth_does_not_yank_a_reader_who_scrolled_away(html):
+    """The observer answers with the SAME flag, so it inherits the whole
+    contract — including the part where a reader who scrolled up is left alone."""
+    out = _run(html, """
+logwrap._top = 500; handlers.scroll();
+wheelUp(); userScrollTo(200);
+grow(1400);
+console.log(JSON.stringify({ writes: writes.length, top: logwrap._top }));
+""")
+    assert out["writes"] == 0
+    assert out["top"] == 200
+
+
+def test_both_children_of_the_scrollport_are_watched(html):
+    """#log and #queue: queued messages render as a sibling AFTER the log, so a
+    queue that grows moves the bottom just as a turn does."""
+    out = _run(html, """
+console.log(JSON.stringify({ observed }));
+""")
+    assert out["observed"] == ["log", "queue"]
+
+
+def test_a_picture_finishing_its_load_is_followed_too(html):
+    """`load` does not bubble, so the listener has to be in the capture phase —
+    one on the scrollport for every image and iframe the transcript will hold."""
+    body = _follow_block(html)
+    assert 'logwrap.addEventListener("load", followBottom, true);' in body

--- a/tests/test_claude_stop_run.py
+++ b/tests/test_claude_stop_run.py
@@ -84,17 +84,14 @@ def test_the_page_sends_the_cancel_action_the_backend_dispatches(agent, template
     assert "unknown action" in str(agent.main(action="stop"))
 
 
-def test_stopping_is_offered_both_as_a_button_and_as_escape(template):
-    """Two affordances, one path: the click target is discoverable, the key is
-    what a terminal user reaches for. Both must call the same stopRun()."""
+def test_stopping_is_offered_as_a_button(template):
+    """The click target is discoverable and calls stopRun(). Escape no longer
+    stops a live run (see escapeAction), so the button must not teach a key
+    that does not do anything."""
     html = _html(template)
     assert "function stopRun(" in html
-    # the working line's button, whose label is also where the key is taught
-    # (the hint row below is space-between around the selectors, and a left item
-    # long enough to say it wrapped that row onto a second line mid-turn)
     assert 'id="stopbtn"' in html, "no stop control on the page"
-    assert "stop · esc" in html, "the button does not teach the key"
-    assert '"Escape"' in html, "Escape is not bound"
+    assert "stop · esc" not in html, "the button still teaches a key that does not stop the run"
 
 
 # ------------------------------------------- the backend contract runEnding sits on

--- a/tests/test_claude_stream.py
+++ b/tests/test_claude_stream.py
@@ -555,3 +555,42 @@ def test_a_delta_less_turn_shows_its_text_before_the_process_exits(agent, run_di
     data = _poll(agent, run_dir, [{"type": "result", "session_id": "s",
                                    "result": "hello"}])
     assert data["text"] == "hello"
+
+
+# ---------------------------------------- two rules about what the page may do
+#                                          to a run the user is watching stream
+#
+# Both pinned as strings, right here beside the stream the page renders, because
+# both are one edit away from coming back and neither has a symptom a stream test
+# would notice: the first cost the user the whole turn, the second cost them
+# sight of it.
+
+
+def test_no_key_binding_stops_a_run(html):
+    """Escape used to kill a live turn whenever nothing else claimed the key —
+    so a reader who reached for it out of habit lost the run to a keystroke never
+    aimed at it (Akshil, 2026-09-03). Work in progress is not something a bare
+    keypress may throw away. The behavioural half is in
+    tests/test_claude_app_state.py; this is the pin that survives that file being
+    refactored."""
+    assert "stop-run" not in html
+    handler = html[html.index("function onEscape(e) {"):]
+    assert "stopRun" not in handler[:handler.index("\n}\n")]
+    # the stop button itself is untouched — there IS still a way to stop a turn
+    assert "async function stopRun() {" in html
+    assert "if (activeRun) { stopRun(); return; }" in html
+
+
+def test_the_transcript_follows_growth_it_was_not_told_about(html):
+    """A live turn reaches its final height long after the append that scrolled:
+    tool cards expand when their output lands, code blocks grow under the
+    highlighter, pictures and artifact iframes take up room only once they load,
+    the bubble re-renders as markdown at message end. So growth is OBSERVED
+    rather than announced — one ResizeObserver on the scrollport's two children,
+    answering with the same follow flag every write site uses. Behaviour in
+    tests/test_claude_scroll_follow.py."""
+    assert "const followGrowth = new ResizeObserver(followBottom);" in html
+    assert ('for (const el of [log, document.getElementById("queue")]) '
+            "followGrowth.observe(el);") in html
+    # `load` does not bubble, so the picture/iframe backstop must be in capture
+    assert 'logwrap.addEventListener("load", followBottom, true);' in html


### PR DESCRIPTION
## What

Two ways a reader loses control of a turn in the Claude chat pane.

**Escape stopped the run.** It was the last claimant on the key, so it killed the live turn whenever nothing else wanted the press. A reader reaching for Escape out of habit — dismissing a popover the page had already closed, backing out of the shell's own UI, clearing a stray focus — lost the whole turn to a keystroke never aimed at the run. Work in progress is not something a bare keypress may throw away, and no other claimant on this key costs anything to undo, so the key now has no destructive branch at all.

**Auto-scroll came unstuck mid-stream.** "some elements come in and mess that behaviour" — the reported symptom, and an accurate description of the mechanism.

## The sticky-scroll model

`followTail` already existed and already said *whether* to follow: true by default, dropped only by a real reader gesture (wheel up, touch drag down, a scroll that moves up while the content did not shrink), re-armed only by arriving back at the bottom or by sending a message. That half was right and is unchanged.

The half that leaked is that every write site also had to remember to **ask** — and a mid-turn write only stays pinned if the code that made it calls `followBottom()` afterwards **and** the element it appended already has its final height. Neither holds for most of what lands in a live turn:

- a tool card that expands when its output arrives
- the working line re-rendering a longer verb
- a code block growing as the highlighter runs
- an artifact iframe or a picture that takes up room only once it loads
- a permission card
- the whole bubble re-rendering as markdown at message end

Each grows the transcript *after* the append that scrolled, leaving the reader one element's height short of the bottom with the rest of the turn arriving off-screen.

So growth is **observed** rather than announced:

- one `ResizeObserver` on the scrollport's two children (`#log`, `#queue`), answering with the same `followTail` flag — if the reader is following, follow; otherwise leave them exactly where they are
- a capture-phase `load` listener on the scrollport, for replaced elements that reserve their box up front and shift layout around themselves on load (`load` does not bubble)

Writing `scrollTop` cannot resize anything, so the observer cannot re-enter itself — no "ResizeObserver loop" noise.

With the flag now the single answer, the two remaining ad-hoc geometry reads go with it:

| Site | Was | Now |
|---|---|---|
| `applyComposerBlockState` (schedule banner) | `wasHidden && nearBottom()` | `wasHidden && …` → `followBottom()` — the banner SHRINKS the scrollport as it appears, which is exactly the case a distance threshold gets wrong |
| `loadHistory` refresh anchor | `refresh && !nearBottom()` | `refresh && !followTail` |
| `parkResolvedCard` | `if (followTail) scrollBottom()` | `followBottom()` |

`nearBottom()` survives in one place only: the scroll handler, where it decides re-arming. No "jump to latest" affordance was added — none existed, and it is out of scope.

## Escape audit

Every `key === "Escape"` handler in the template, and what happened to it:

| Handler | Verdict |
|---|---|
| `escapeAction` — screenshot viewer (modal, goes first) | **kept** |
| `escapeAction` — annotation composer | **kept** |
| `escapeAction` — annotate mode | **kept** |
| `escapeAction` — **live run → `stop-run`** | **REMOVED** (branch gone; the function no longer takes a run) |
| `onEscape` — `else stopRun()` | **REMOVED** |
| `annTa` keydown (annotation textarea, `stopPropagation`) | **kept** |
| left-pane popover `closeLeftPop` | **kept** |
| screenshot-sent popover (`sentPop`) | **kept** |
| schedule confirm popover (capture, consumed) | **kept** |
| schedule stop-arm (capture, consumed) | **kept** |
| `.selpop` dropdown (capture, consumed) | **kept** |
| kebab menu | **kept** |
| inline edit field (`otherField`) | **kept** |
| `#box` / `#homebox` keydown (Enter only) | **kept** — never had an Escape branch |

Every `stopPropagation` on those popover handlers is kept: it still matters, just for a different reason (it stops the press falling through to the *next* claimant, e.g. leaving annotate mode as well). Their comments, and every other comment in the file asserting "the document-level Escape binding kills a live run", are corrected — that sentence appears in ~12 places and was about to become a lie the next reader would act on.

Stopping is now a deliberate press on a control that says what it does: the stop square the send button becomes, and the tasks queue card's ✕. `stopRun()` itself is untouched.

## Tests

`tests/test_claude_stream.py` — two new string pins beside the stream the page renders:
- `test_no_key_binding_stops_a_run` — no `stop-run` anywhere in the template, no `stopRun` in `onEscape`, and the stop button's own path still there
- `test_the_transcript_follows_growth_it_was_not_told_about` — the observer, both observed children, the capture-phase `load` backstop

`tests/test_claude_scroll_follow.py` — four new behavioural tests against the page's real glue under node (the file's existing harness, extended with a `ResizeObserver` stub):
- growth after the append keeps a following reader at the bottom
- growth does **not** yank a reader who scrolled away
- both children of the scrollport are watched
- the `load` backstop is in capture phase

`tests/test_claude_app_state.py` — `escapeAction` precedence rewritten for three claimants; new `test_escape_never_stops_a_live_run` pins it three ways (no stop branch, no run parameter, and a sweep of *every* keydown binding in the page for `stopRun`).

`tests/test_claude_composer_block.py`, `tests/test_claude_live_run.py` — pins updated to the flag.

```
pytest tests/test_claude_stream.py tests/test_claude_working_line.py -q   → 91 passed
pytest tests/ -k claude -n auto                                          → 1756 passed
```
(8 pre-existing failures in `test_claude_health.py` / `test_ai_metrics.py` — machine-local CLI detection, identical on a clean tree.)

## How verified

Dev server from this worktree (`FUSED_RENDER_BRANCH=chat-scroll-esc`, port 2773), real Claude chat on `showcase/sine-starter`, driven through the cmux browser CLI inside the `chat_only` iframe. Prompt: *"Say hello in 5 short lines, then run the bash command `ls -la`, then write 8 more lines about what you saw."* — text → tool card → text, twice.

- **Pinned while streaming**: `scrollHeight - scrollTop - clientHeight` sampled through the run — 0 at every settled sample, including across the tool card landing (824 → 1224 with `scrollTop` following 549 → 1049).
- **Escape does not stop the run**: pressed three times mid-turn (real key press + synthetic keydown on the box and on `document`). `body.running` stayed true, no "Stopped." note, the turn kept streaming and finished on its own.
- **Scrolling up mid-stream stays put**: wheel-up + scroll to `top: 0`, then a 400px unannounced growth — reader stayed at 0.
- **Returning to the bottom re-arms**: scrolled back, then a 500px unannounced growth — `scrollTop` 549 → 1049, gap 0. Nothing called `followBottom()` for that append; the ResizeObserver did it. This is the fix, isolated.
- **Small window**: same with the scrollport clamped to 260px — 564 → 864, gap 0.
- **Console**: zero errors, warnings or unhandled rejections across the whole session (`error`, `unhandledrejection`, `console.warn`, `console.error` all hooked).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes high-touch chat UX (Escape semantics and scroll behavior during streaming) in a large monolithic template; mistakes could strand users off-screen or make stopping less discoverable, though stop buttons remain and tests heavily pin the new rules.
> 
> **Overview**
> **Escape no longer stops an in-flight turn.** `escapeAction` only handles the screenshot viewer, annotation composer, and annotate mode; the live-run branch and `stopRun()` from `onEscape` are gone. Stopping is explicit via the send/stop control and the working-line stop button (labels drop the misleading “· esc” hint). Comments across popover handlers are updated so they no longer claim Escape cancels runs.
> 
> **Transcript “follow tail” stays pinned when content grows after append.** A `ResizeObserver` on `#log` and `#queue` plus a capture-phase `load` listener on the scrollport call `followBottom()` whenever height changes, so late-expanding tool cards, images, iframes, and markdown re-renders don’t leave the reader one card short. Schedule-banner pinning and history refresh now key off the existing `followTail` flag instead of ad-hoc `nearBottom()` geometry reads; `parkResolvedCard` always calls `followBottom()` when following.
> 
> Tests are extended/updated to lock in the three-claimant Escape model, forbid keyboard paths to `stopRun()`, and exercise growth-based follow behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bff2b178a2fb11d44152e21aee4993ce77db3928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->