### PR TITLE
Showcase clone goes shallow: --depth 1, one branch, no tags

### DIFF
--- a/fused_render/community.py
+++ b/fused_render/community.py
@@ -18,8 +18,10 @@ Actions:
               there yet, then return the same payload as `catalog`; once the
               clone exists this never fetches or syncs it again
 
-The repo is a FULL clone living inside the user's workspace
-(~/Fused/showcase). It is the user's tree: apps are edited in place, and
+The repo is a full WORKING TREE (every app's files on disk, no sparse
+checkout, no materialize step) living inside the user's workspace
+(~/Fused/showcase), cloned SHALLOW — `--depth 1 --single-branch --no-tags`,
+one commit of history. It is the user's tree: apps are edited in place, and
 nothing here ever resets, deletes, fetches, or syncs it once cloned — that
 is the whole point of "edit in the showcase" (there is no separate installed
 copy to keep in sync). Opening an app there IS opening your copy.
@@ -74,12 +76,14 @@ LOCK_PATH = os.path.join(STATE_DIR, ".lock")
 # The one definition of the workspace, imported rather than mirrored — this
 # used to be a hand-copied expanduser() that had to be kept in step by hand.
 WORKSPACE = fused_dir()
-# The full clone of the community repo, inside the user's workspace so the
+# The clone of the community repo, inside the user's workspace so the
 # explorer lists it like any other folder and apps are editable in place.
 SHOWCASE_DIR = os.path.join(WORKSPACE, "showcase")
 
 GIT_TIMEOUT = 45  # bounded so a bad network surfaces as an error
-CLONE_TIMEOUT = 180  # the full clone (every app + preview.png) is the long call
+# The clone (every app + its preview.png) is the long call: 25 apps, ~19 MiB
+# even shallow, and it runs on a first-visit request path.
+CLONE_TIMEOUT = 180
 LOCK_TIMEOUT = CLONE_TIMEOUT + 20
 
 
@@ -274,7 +278,26 @@ def _refresh():
     # rename — no half-clone ever flashes up in the explorer listing.
     staging = tempfile.mkdtemp(dir=WORKSPACE, prefix=".showcase-clone-")
     try:
-        r = _git(WORKSPACE, "clone", "--", REPO_URL,
+        # Shallow, one branch, no tags. Nobody here reads history: this
+        # module clones once and never fetches again (D550), and the two
+        # reads it does perform work fine at depth 1 (`rev-parse HEAD` for
+        # the catalog's commit, `remote get-url origin` for _cache_ready).
+        # Measured against fused-render-community-apps: 22.03 -> 18.59 MiB
+        # transferred, 931 -> 317 objects. The rest of the weight is the
+        # working tree itself (preview.png files alone are ~9 MiB), which
+        # only the community repo can shrink.
+        #
+        # It stays an ordinary git work tree, which is what SPEC §33/GT-20
+        # needs: `fetch` + `rev-list --left-right --count HEAD...origin/x` +
+        # `pull --ff-only` all behave on a shallow clone, so the opt-in
+        # Update row still reports and applies upstream commits. A user who
+        # wants the full log runs `git fetch --unshallow` themselves.
+        #
+        # Not partial (`--filter=blob:none`): every blob is checked out
+        # anyway, so it measured ~0.3 MiB better while leaving a promisor
+        # remote — a network dependency — inside the user's editable tree.
+        r = _git(WORKSPACE, "clone", "--depth", "1", "--single-branch",
+                 "--no-tags", "--", REPO_URL,
                  os.path.join(staging, "showcase"), timeout=CLONE_TIMEOUT)
         if r.returncode != 0:
             detail = (r.stderr or "").strip().splitlines()

--- a/fused_render/community.py
+++ b/fused_render/community.py
@@ -81,7 +81,7 @@ WORKSPACE = fused_dir()
 SHOWCASE_DIR = os.path.join(WORKSPACE, "showcase")
 
 GIT_TIMEOUT = 45  # bounded so a bad network surfaces as an error
-# The clone (every app + its preview.png) is the long call: 25 apps, ~19 MiB
+# The clone (every app + its preview.png) is the long call: 25 apps, ~10 MiB
 # even shallow, and it runs on a first-visit request path.
 CLONE_TIMEOUT = 180
 LOCK_TIMEOUT = CLONE_TIMEOUT + 20
@@ -282,9 +282,14 @@ def _refresh():
         # module clones once and never fetches again (D550), and the two
         # reads it does perform work fine at depth 1 (`rev-parse HEAD` for
         # the catalog's commit, `remote get-url origin` for _cache_ready).
-        # Measured against fused-render-community-apps: 22.03 -> 18.59 MiB
-        # transferred, 931 -> 317 objects. The rest of the weight is the
-        # working tree itself (preview.png files alone are ~9 MiB), which
+        # Measured against fused-render-community-apps: 29.35 -> 9.72 MiB
+        # transferred, 1022 -> 317 objects, 44 -> 25 MB on disk. Depth is
+        # worth MORE than it looks, and increasingly so: the upstream
+        # recompression of its previews and assets added slim blobs without
+        # removing the fat originals from history, so a full clone pays for
+        # both copies (it grew from 22.03 MiB before that cleanup, while
+        # shallow fell from 18.59). The rest of the weight is the working
+        # tree itself (14.20 MB raw at HEAD, previews ~3.5 MB of it), which
         # only the community repo can shrink.
         #
         # It stays an ordinary git work tree, which is what SPEC §33/GT-20

--- a/fused_render/community.py
+++ b/fused_render/community.py
@@ -81,8 +81,8 @@ WORKSPACE = fused_dir()
 SHOWCASE_DIR = os.path.join(WORKSPACE, "showcase")
 
 GIT_TIMEOUT = 45  # bounded so a bad network surfaces as an error
-# The clone (every app + its preview.png) is the long call: 25 apps, ~10 MiB
-# even shallow, and it runs on a first-visit request path.
+# The clone (every app, with its preview still and assets) is the long call —
+# tens of megabytes even shallow, on a first-visit request path.
 CLONE_TIMEOUT = 180
 LOCK_TIMEOUT = CLONE_TIMEOUT + 20
 
@@ -282,15 +282,12 @@ def _refresh():
         # module clones once and never fetches again (D550), and the two
         # reads it does perform work fine at depth 1 (`rev-parse HEAD` for
         # the catalog's commit, `remote get-url origin` for _cache_ready).
-        # Measured against fused-render-community-apps: 29.35 -> 9.72 MiB
-        # transferred, 1022 -> 317 objects, 44 -> 25 MB on disk. Depth is
-        # worth MORE than it looks, and increasingly so: the upstream
-        # recompression of its previews and assets added slim blobs without
-        # removing the fat originals from history, so a full clone pays for
-        # both copies (it grew from 22.03 MiB before that cleanup, while
-        # shallow fell from 18.59). The rest of the weight is the working
-        # tree itself (14.20 MB raw at HEAD, previews ~3.5 MB of it), which
-        # only the community repo can shrink.
+        # Depth is worth more than it looks, and grows more so over time: the
+        # repo's heaviest content is preview stills and app assets, and every
+        # recompression pass upstream adds a slim blob without removing the
+        # fat original from history — a full clone pays for both copies, a
+        # shallow one only for HEAD. What is left after depth is the working
+        # tree itself, which only the community repo can shrink.
         #
         # It stays an ordinary git work tree, which is what SPEC §33/GT-20
         # needs: `fetch` + `rev-list --left-right --count HEAD...origin/x` +
@@ -298,9 +295,10 @@ def _refresh():
         # Update row still reports and applies upstream commits. A user who
         # wants the full log runs `git fetch --unshallow` themselves.
         #
-        # Not partial (`--filter=blob:none`): every blob is checked out
-        # anyway, so it measured ~0.3 MiB better while leaving a promisor
-        # remote — a network dependency — inside the user's editable tree.
+        # Not partial (`--filter=blob:none`): the tree is fully checked out,
+        # so every blob gets fetched anyway — it measured barely better than
+        # plain shallow, and the price is a promisor remote (a standing
+        # network dependency) inside the user's editable tree.
         r = _git(WORKSPACE, "clone", "--depth", "1", "--single-branch",
                  "--no-tags", "--", REPO_URL,
                  os.path.join(staging, "showcase"), timeout=CLONE_TIMEOUT)

--- a/tests/test_community_marketplace_fixes.py
+++ b/tests/test_community_marketplace_fixes.py
@@ -1,9 +1,10 @@
 """Regression tests for the community marketplace backend
 (fused_render/community.py):
 
-- `refresh` performs a FULL clone of the community repo into the workspace's
-  showcase folder and serves the catalog from it, and never fetches or
-  merges again once that clone exists.
+- `refresh` clones the community repo into the workspace's showcase folder
+  and serves the catalog from it, and never fetches or merges again once that
+  clone exists. The clone is shallow but fully checked out — every app's
+  files on disk, no materialize step.
 - a pre-existing showcase folder that is not our clone is never deleted —
   refresh refuses with a friendly error instead.
 - `_cache_lock` is a real cross-process lock: a call that can't acquire it
@@ -71,7 +72,8 @@ def test_refresh_full_clones_into_workspace_showcase(tmp_path, community_mod, mo
     assert res["status"] == "ok"
     assert res["cache_root"] == mod.SHOWCASE_DIR
     assert [a["slug"] for a in res["apps"]] == ["widget"]
-    # Full clone: the app's files are on disk immediately, no materialize step.
+    # Fully checked out (shallow history, full tree): the app's files are on
+    # disk immediately, no materialize step.
     assert os.path.isfile(os.path.join(mod.SHOWCASE_DIR, "widget", "index.html"))
     # No staging droppings left in the workspace.
     assert not [n for n in os.listdir(mod.WORKSPACE) if n.startswith(".showcase-clone-")]


### PR DESCRIPTION
## What

`community._refresh` cloned the showcase repo with full history into `~/Fused/showcase`. Nothing reads that history: the module clones once and never fetches again (D550), and its only two git reads — `rev-parse HEAD` for the catalog's `commit`, `remote get-url origin` for `_cache_ready` — both work at depth 1.

Clone is now `--depth 1 --single-branch --no-tags`. Still a FULL checkout: every app's files land on disk, no sparse checkout, no materialize step.

## Measured

Against `fusedio/fused-render-community-apps` at today's HEAD:

| | transferred | objects | on disk |
|---|---|---|---|
| full clone (before) | 29.35 MiB | 1022 | 44 MB (`.git` 30 MB) |
| `--depth 1 --single-branch --no-tags` | **9.72 MiB** | 317 | 25 MB (`.git` 10 MB) |

**−67% bytes, −69% objects.** Wall-clock is not quoted: runs saw anywhere from 1.7 to 12.3 MiB/s, so the seconds are network noise.

**Depth is worth more than it first measured, and the gap keeps widening.** When this PR opened the same comparison was 22.03 → 18.59 MiB, a −16% win. Upstream then recompressed its previews and assets — which added slim blobs without removing the fat originals from history. So a full clone now pays for *both* copies and got **bigger** (22.03 → 29.35 MiB), while the shallow clone only pays for HEAD and got smaller (18.59 → 9.72 MiB). Every future optimization pass upstream repeats that split, which means the upstream slimming only reaches users if this merges.

What is left is the working tree itself — 14.20 MB raw at HEAD across 25 apps: previews 3.48 MB, `.github/images/` 0.68 MB, app assets 10.04 MB. The heaviest single files still are `pano-viewer/samples/*.jpg` (2.09 MB together) and a vendored `temperature-explorer/vendor/maplibre-gl.js` (1.06 MB). Only the community repo can shrink those.

## GT-20 still works

SPEC §33 requires the showcase clone to be an ordinary git work tree so GT-20's opt-in Update row means something. Verified on a shallow clone against a moving upstream:

- `git fetch origin <ref>` — fetches the new commit
- `git rev-list --left-right --count HEAD...origin/main` — prints `0	1`, i.e. correct ahead/behind
- `git pull --ff-only origin main` — fast-forwards, new file on disk

`git fetch --unshallow` is the escape hatch for a user who wants the full log.

## Rejected

A partial clone (`--depth 1 --filter=blob:none --sparse`, sparse patterns covering everything but `.github/`). The tree is fully checked out, so every blob gets fetched anyway — it measured ~0.3 MiB better than plain shallow, and the price is a promisor remote, a standing network dependency, inside the user's editable tree.

Sparse-checkout of just `metadata.json` + `preview.png` per app does get much smaller (8.7 MiB when measured), but it breaks apps-run-in-place: `app_listing` needs the entry file to list an app at all, and Run needs the folder. That is a materialize-on-open feature, not a flag.

## Notes

No new DECISIONS row — the depth is an implementation detail of D550's clone, and no existing row or SPEC line claims full history. Three stale "FULL clone" comments (which meant "full working tree", not "full history") are reworded, in `community.py`'s docstring and in the test file's docstring/comment.

Byte counts are deliberately **not** in the source comments: they went stale twice during this branch's own lifetime. The code carries the reasoning, this PR carries the measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)