### PR TITLE
preview.webp counts as an app's authored thumbnail, PNG first

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -10538,9 +10538,13 @@ experience and nothing else: no editor, no Claude, no explorer chrome.
   search box still reach the rows). Opened exports join Home's recents row
   (`exported_apps.recent_exported_apps`, recents-only — no duckdb on the
   Home path).
-- **AF-11** (D396) The exported card's thumbnail is the payload's
-  `preview.png`, streamed by `GET /api/appfile/preview?path=` — a bounded
-  single-member zip read (never an extraction). Without one, a file the user
+- **AF-11** (D396) The exported card's thumbnail is the payload's authored
+  still — `preview.png`, else `preview.webp`, the same two names and the same
+  PNG-first precedence a FOLDER's thumbnail follows
+  (`app_listing.PREVIEW_IMAGE_NAMES`) — streamed by
+  `GET /api/appfile/preview?path=`, a bounded single-member zip read (never an
+  extraction) whose content type is sniffed from the bytes, since a zip member
+  name is whatever its author typed. Without one, a file the user
   has OPENED before live-renders instead: the card iframes its own fusedapp
   view under `_preview=1`, whose preview contract is `preview: true` on
   `POST /api/appfile/open` — reuse an existing extract only (`reuse_only`:
@@ -10552,9 +10556,9 @@ experience and nothing else: no editor, no Claude, no explorer chrome.
   behind `fused.capture.screenshot()` pointed at a browser-measured rect,
   PNG bytes back and no file in `<home>/recordings`; chosen over DOM
   serialization because canvas/WebGL apps rasterize blank) when and only
-  when the folder has no authored `preview.png`. The crop
+  when the folder has no authored still under either name. The crop
   source is the card's own thumbnail when it is on screen AND HAS PAINTED
-  the app — a card without a preview.png renders the live app there, so
+  the app — a card without an authored still renders the live app there, so
   nothing navigates or flashes, but only two card previews start at a time
   (`createPreviewStartQueue(2)`), so an unpainted thumb is the ordinary
   state of a card and cropping one would bake an empty box in as the
@@ -10574,7 +10578,8 @@ experience and nothing else: no editor, no Claude, no explorer chrome.
   granted the first shot raises the TCC dialog and that export ships plain.
   The
   X-Fused `POST /api/appfile/export` variant writes it as
-  `files/preview.png` (PNG magic + 8 MiB cap; the authored still always
+  `files/preview.png` (PNG or WebP magic + 8 MiB cap, the member named for
+  what the bytes ARE — a capture is always PNG; the authored still always
   wins; every capture failure — unsupported, permission denied, off-display,
   blank, over-cap — exports plain: the route drops a too-big screenshot rather than
   failing the download, where `export_app_file` itself still raises for a
@@ -11283,7 +11288,8 @@ and `retry_post` (whether a proxied POST to it is safely re-runnable).
   rendered (D507).**
   `AppPreviewCard`'s live thumbnail (Home's app strip, the `/apps` hub — the
   card mounts an app's own `entry_html` live and sandboxed
-  `allow-scripts allow-same-origin` whenever it has no `preview.png`, or on
+  `allow-scripts allow-same-origin` whenever it has no authored still
+  (`preview.png` / `preview.webp`), or on
   hover for ANY app) is not an
   "open"; `fused.daemon.enable()` unconditionally on page load used to fire
   on every such peek regardless (the OpenWhisper bug this whole feature

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -41,6 +41,7 @@ import {
   claudeTerminalCommand,
 } from "@apps/explorer/lib/fs-actions";
 import { crumbMenu, fileBarMenu } from "@apps/explorer/lib/bar-menus";
+import { PREVIEW_IMAGE_NAME, PREVIEW_IMAGE_NAMES } from "@apps/explorer/lib/folder-peek";
 import { enterPanel } from "@apps/explorer/lib/split-actions";
 import { publishTopbarMenu } from "@apps/explorer/topbar-menu";
 import { acquireOverlay, releaseOverlay } from "@platform/lib/ui-overlay";
@@ -318,6 +319,32 @@ function MigrateAppButton({ fsPath }: { fsPath: string }) {
   );
 }
 
+// The folder's authored still, if it has one: the FIRST of the thumbnail names
+// that exists, in the server's own precedence order (app_listing's
+// PREVIEW_IMAGE_NAMES — a folder holding both shows its PNG).
+//
+// Probed name by name rather than by listing the folder, which is what the two
+// callers below need: one wants the path to hand the exporter, the other wants
+// the stat so it can tell "already has a preview" from "that name is a folder".
+// `is_dir` counts as PRESENT here — a `preview.png` directory is not a
+// thumbnail, but it is very much in the way of writing one.
+//
+// An unreadable stat reads as absent, which is the safe answer for both: a
+// pointless capture at worst, never a silently skipped export.
+async function authoredPreview(
+  dir: string,
+): Promise<{ path: string; stat: StatResult } | null> {
+  for (const name of PREVIEW_IMAGE_NAMES) {
+    const path = join(dir, name);
+    const st = await statPath(path).then(
+      (s) => s,
+      () => null,
+    );
+    if (st) return { path, stat: st };
+  }
+  return null;
+}
+
 // Export the containing app as a .fused file (SPEC §43 AF-4), shown only when
 // the previewed page IS its folder's app entry — asked of the server (the one
 // shared entry rule, /api/apps/entry) rather than guessed from the filename.
@@ -355,23 +382,21 @@ function ExportAppButton({ fsPath }: { fsPath: string }) {
       // Same capture-on-export as the /apps card (appShot, D396): the shown
       // preview frame IS the app rendering, so it is the crop source — no
       // navigation, no flash. exportAppFile itself skips capture when the
-      // folder carries an authored preview.png; the probe below is only so a
-      // pointless native shot (and, on a Mac that has not granted Screen
-      // Recording, its permission dialog) isn't taken for a capture the
-      // server would discard anyway (stat failure reads as "no authored
-      // still" — worst case is that redundant shot, never a lost export).
+      // folder carries an authored still (under either thumbnail name); the
+      // probe below is only so a pointless native shot (and, on a Mac that has
+      // not granted Screen Recording, its permission dialog) isn't taken for a
+      // capture the server would discard anyway (stat failure reads as "no
+      // authored still" — worst case is that redundant shot, never a lost
+      // export).
       //
       // `.is-shown` satisfies appShot's crop-source contract (pixels that ARE
       // the app, not a box it may fill): the class rides `shown`, which the
       // frame swap only sets once that frame paints — the same guarantee
       // `data-fused-annotate-target` below relies on.
-      const authored = await statPath(dir + "/preview.png").then(
-        (s) => !s.is_dir,
-        () => false,
-      );
+      const authored = await authoredPreview(dir);
       await exportAppFile(
         { path: dir, name, entry_html: fsPath,
-          preview_image: authored ? dir + "/preview.png" : null },
+          preview_image: authored && !authored.stat.is_dir ? authored.path : null },
         document.querySelector(".preview-frame.is-shown"),
       );
     } catch (e) {
@@ -612,7 +637,7 @@ function usePreviewFileMenu(
   //
   // ORDER: the share prompt needs the click's own transient activation, which
   // Chrome expires a few seconds out. The one thing awaited before it is a stat
-  // of preview.png (milliseconds) — and when that says a still already exists,
+  // per thumbnail name (milliseconds) — and when that says a still exists,
   // the capture moves to the CONFIRM's click instead (Akshil: confirm before
   // overwriting), which is a fresh activation of its own. Nothing is written
   // until a frame is in hand: a dismissed prompt leaves the old file alone.
@@ -647,22 +672,35 @@ function usePreviewFileMenu(
     }
   };
   const doSetPreview = () => {
-    statPath(join(parent, "preview.png")).then(
-      (s) => {
-        if (s.is_dir) {
-          pushToast({ msg: "preview.png here is a folder — move it first", tone: "error" });
-          return;
-        }
-        setDialog({
-          kind: "confirm",
-          title: "Replace preview?",
-          message: `"${basename(parent)}" already has a preview.png. Replace it with what the app shows now?`,
-          confirmLabel: "Replace",
-          onConfirm: () => void shootPreview(true),
-        });
-      },
-      () => void shootPreview(false),
-    );
+    // Probes BOTH thumbnail names, not just the one this writes: a folder whose
+    // still is a `preview.webp` would otherwise get no confirm at all, and the
+    // capture would land on top of it — invisibly, since the PNG outranks it.
+    void authoredPreview(parent).then((found) => {
+      if (!found) {
+        void shootPreview(false);
+        return;
+      }
+      const name = basename(found.path);
+      if (found.stat.is_dir) {
+        pushToast({ msg: name + " here is a folder — move it first", tone: "error" });
+        return;
+      }
+      // Naming the file it found matters when the names differ: replacing a
+      // `preview.webp` writes a `preview.png`, which OUTRANKS it — the webp
+      // stays in the folder, unused — so the dialog says that rather than
+      // implying the file is overwritten.
+      setDialog({
+        kind: "confirm",
+        title: "Replace preview?",
+        message:
+          name === PREVIEW_IMAGE_NAME
+            ? `"${basename(parent)}" already has a ${name}. Replace it with what the app shows now?`
+            : `"${basename(parent)}" already has a ${name}. Save what the app shows now as ` +
+              `${PREVIEW_IMAGE_NAME}? It takes precedence; the ${name} stays in the folder.`,
+        confirmLabel: "Replace",
+        onConfirm: () => void shootPreview(true),
+      });
+    });
   };
 
   // The CRUMB BAR's menu for this file — deliberately not `buildMenu` above (see

--- a/frontend/src/apps/explorer/lib/folder-peek.ts
+++ b/frontend/src/apps/explorer/lib/folder-peek.ts
@@ -3,17 +3,24 @@
 // one per card is the whole embed budget — so this ranking decides the single
 // thing a folder shows about itself.
 //
-// The order, best first: `preview.png`, `index.html`, `readme.md`, then any
-// other file by extension tier. Ties break alphabetically, since entries arrive
-// sorted.
+// The order, best first: an authored still (`preview.png` / `preview.webp`),
+// `index.html`, `readme.md`, then any other file by extension tier. Ties break
+// alphabetically, since entries arrive sorted.
 //
 // Pure and DOM-free, in lib/ rather than beside the card component, so the rule
 // can be pinned by a test that imports a function instead of a React tree (the
 // same reason lib/app-button.ts exists).
 import type { FsEntry } from "@platform/lib/api";
 
-// The authored thumbnail, and the same file the /apps hub shows on an app card
-// (fused_render/app_listing.PREVIEW_IMAGE_NAME).
+// The authored thumbnail names, and the same files the /apps hub shows on an
+// app card (fused_render/app_listing.PREVIEW_IMAGE_NAMES — this list must stay
+// that list). PNG is what every capture in the product produces; webp is what
+// an author's own screenshot usually already is.
+//
+// Both share ONE rank rather than being ordered against each other: the server
+// prefers the PNG when a folder holds both, but a peek only ever shows the one
+// file it picked, and entries arrive sorted — so `preview.png` wins that tie
+// here anyway, by name.
 //
 // Compared EXACTLY, case included, which is the rule the server was made to
 // meet rather than the other way round: `os.path.isfile` inherits the
@@ -25,7 +32,12 @@ import type { FsEntry } from "@platform/lib/api";
 //
 // Matched by whole NAME, not by extension: any other .png in the folder is just
 // a file, and would be a poor guess at what the folder is about.
-export const PREVIEW_IMAGE_NAME = "preview.png";
+export const PREVIEW_IMAGE_NAMES = ["preview.png", "preview.webp"] as const;
+
+// The best-known one, for a caller that needs a single name to show or probe.
+export const PREVIEW_IMAGE_NAME = PREVIEW_IMAGE_NAMES[0];
+
+const PREVIEW_NAME_SET: ReadonlySet<string> = new Set(PREVIEW_IMAGE_NAMES);
 
 const PREVIEW_RANK = 0;
 
@@ -51,7 +63,7 @@ const PEEK_EXT_BASE = NAMED_BASE + NAMED_PEEK_ORDER.length;
 export const PAGE_RANK = PEEK_EXT_BASE + PEEK_EXT_ORDER.indexOf("html");
 
 export function peekRank(name: string): number {
-  if (name === PREVIEW_IMAGE_NAME) return PREVIEW_RANK;
+  if (PREVIEW_NAME_SET.has(name)) return PREVIEW_RANK;
   const lower = name.toLowerCase();
   const named = NAMED_PEEK_ORDER.indexOf(lower);
   if (named !== -1) return NAMED_BASE + named;
@@ -135,5 +147,5 @@ export function bestPeekFile(entries: FsEntry[]): FsEntry | null {
 // <img>, and its own chrome around it. Takes a PATH — the peek may come from a
 // probed subfolder, so only the basename is the name.
 export function isPreviewImage(fsPath: string): boolean {
-  return fsPath.slice(fsPath.lastIndexOf("/") + 1) === PREVIEW_IMAGE_NAME;
+  return PREVIEW_NAME_SET.has(fsPath.slice(fsPath.lastIndexOf("/") + 1));
 }

--- a/frontend/src/lan/App.tsx
+++ b/frontend/src/lan/App.tsx
@@ -30,7 +30,7 @@ interface LanAppRow {
   linked: boolean;
   recency: number; // epoch seconds; 0 = never opened and no mtime
   url: string;
-  preview: string | null; // preview.png, full-bleed
+  preview: string | null; // the authored still, full-bleed
   icon: string | null; // icon.svg
 }
 

--- a/frontend/src/platform/ui/AppPreviewCard.tsx
+++ b/frontend/src/platform/ui/AppPreviewCard.tsx
@@ -1,8 +1,9 @@
 // Big preview card for the /apps hub. Its thumbnail has three shapes, in
 // precedence order:
 //
-//   1. `preview.png` at the app folder's root — an AUTHORED still, served as
-//      bytes through /api/fs/raw. First because it is the only one the author
+//   1. `preview.png` (or `preview.webp`) at the app folder's root — an
+//      AUTHORED still, served as bytes through /api/fs/raw, which types it
+//      from the name. First because it is the only one the author
 //      chose: a live render shows the page in whatever state it comes up in
 //      (empty, mid-load, asking for a file), and a screenshot shows the app
 //      making its point. It is also by far the cheapest of the three.

--- a/fused_render/app_listing.py
+++ b/fused_render/app_listing.py
@@ -8,9 +8,9 @@ declare nothing (D301 removed the name rules; a one-time migration stamped the
 existing workspace apps, and the managed pipelines stamp what they write). The
 walk that finds them (`workspace_apps`, which is where the per-level rules are
 written down), and the facts reported about each one — a title read out of the
-entry, an authored `preview.png` thumbnail if there is one, and when the folder
-was last touched — live here rather than inside the route handler, so they can
-be tested and reused without a `TestClient`.
+entry, an authored `preview.png`/`preview.webp` thumbnail if there is one, and
+when the folder was last touched — live here rather than inside the route
+handler, so they can be tested and reused without a `TestClient`.
 
 Nothing in this module raises for a directory it cannot read: a listing degrades
 to what it could see. The one deliberate exception is `app_entry`, which lets
@@ -105,48 +105,96 @@ def app_entry(dir_path: str) -> str | None:
     return None
 
 
-# The one authored thumbnail name. A card's picture of an app is otherwise the
-# entry page rendered live in a scaled iframe, which is honest but is also a
-# whole page load per card and shows whatever the app looks like with no data in
-# it; dropping a `preview.png` in the folder is how an author overrides that.
+# The authored thumbnail names, BEST FIRST. A card's picture of an app is
+# otherwise the entry page rendered live in a scaled iframe, which is honest but
+# is also a whole page load per card and shows whatever the app looks like with
+# no data in it; dropping a `preview.png` — or a `preview.webp` — in the folder
+# is how an author overrides that.
 #
-# Exactly one name, not a search over `preview.*` or `screenshot.*`: a user
-# adding a thumbnail should never have to work out which of several candidates
-# wins. Matched EXACTLY, case included — see `app_preview_image` for why that
-# costs a listdir rather than a stat.
-PREVIEW_IMAGE_NAME = "preview.png"
+# Two names, still not a search over `preview.*` or `screenshot.*`: PNG because
+# every capture path in the product produces exactly that (`canvas.toBlob(…,
+# "image/png")`), WebP because an authored still is usually a screenshot the
+# author already has, and webp is a quarter of the bytes at the same look. The
+# ORDER is the precedence rule, so a folder holding both is not ambiguous and
+# every folder authored before webp existed still answers with its PNG.
+#
+# Matched EXACTLY, case included — see `app_preview_image` for why that costs a
+# listdir rather than a stat.
+PREVIEW_IMAGE_NAMES = ("preview.png", "preview.webp")
+
+# The name a CAPTURE is written under (routers/apps.api_app_set_preview, and the
+# still the .fused export injects): one name, because one encoder produces those
+# bytes. Reads go through PREVIEW_IMAGE_NAMES; writes go through this.
+PREVIEW_IMAGE_NAME = PREVIEW_IMAGE_NAMES[0]
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def preview_media_type(raw: bytes) -> str | None:
+    """The image type of authored-still bytes: `"image/png"`, `"image/webp"`, or
+    None for anything else.
+
+    Sniffed from the SIGNATURE, never from a name or an upload's claimed
+    content-type: both callers (the set-preview upload, a `.fused` member) hold
+    bytes some other process wrote, and each thumbnail name means exactly one
+    encoding — a `preview.webp` full of PNG bytes is a picture no browser
+    renders under the type its name implies, so it is not a thumbnail."""
+    if raw.startswith(_PNG_MAGIC):
+        return "image/png"
+    # A WebP file is a RIFF container whose form type is "WEBP" (bytes 8..12);
+    # bytes 4..8 in between are the chunk length, which says nothing about type.
+    if raw[:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def preview_name_for(media_type: str) -> str:
+    """The thumbnail file name that carries `media_type` bytes (the inverse of
+    :func:`preview_media_type`); PNG's name for anything unrecognised, since
+    that is the one every capture produces."""
+    return "preview.webp" if media_type == "image/webp" else PREVIEW_IMAGE_NAME
 
 
 def app_preview_image(dir_path: str) -> str | None:
-    """The app folder's authored thumbnail (`preview.png` at its root), or None.
+    """The app folder's authored thumbnail at its root — `preview.png`, else
+    `preview.webp` — or None when it has neither.
 
-    Resolved by LISTING the directory rather than probing the path, and the
+    Resolved by LISTING the directory rather than probing the paths, and the
     reason is case: `os.path.isfile` inherits the filesystem's own case-folding,
     so a `Preview.png` would be a thumbnail on macOS/Windows and not on ext4 —
     the same folder answering differently per machine, and disagreeing with the
     explorer's peek rule (apps/explorer/lib/folder-peek.ts), which compares the
     name exactly. An exact membership test is the only rule both sides can hold.
+    One listing covers both names, so the second one costs nothing.
 
     Zero-length is treated as absent. A truncated or interrupted write leaves a
     file `isfile` is perfectly happy with, and a non-null answer here is
     load-bearing in a way the entry rule's is not: the card's fallbacks (the
     live render, the monogram) are only reachable while this is None, so a
     wrongly-confident path is a permanently broken image rather than a
-    degraded one. It is not a validity check and does not pretend to be — a
-    corrupt non-empty PNG still gets through, which is why both card surfaces
-    also carry an onError fallback.
+    degraded one. A zero-length PNG therefore does not shadow a good webp — the
+    scan CONTINUES rather than returning None on the better name. It is not a
+    validity check and does not pretend to be — corrupt non-empty bytes still
+    get through, which is why both card surfaces also carry an onError fallback.
 
     Never raises: an unreadable or vanished directory is "no picture", which is
     exactly what the caller renders.
     """
     try:
-        if PREVIEW_IMAGE_NAME not in os.listdir(dir_path):
-            return None
-        p = os.path.join(dir_path, PREVIEW_IMAGE_NAME)
-        st = os.stat(p)
+        present = set(os.listdir(dir_path))
     except OSError:
         return None
-    return os.path.abspath(p) if stat.S_ISREG(st.st_mode) and st.st_size > 0 else None
+    for name in PREVIEW_IMAGE_NAMES:
+        if name not in present:
+            continue
+        p = os.path.join(dir_path, name)
+        try:
+            st = os.stat(p)
+        except OSError:
+            continue
+        if stat.S_ISREG(st.st_mode) and st.st_size > 0:
+            return os.path.abspath(p)
+    return None
 
 
 def app_category(dir_path: str) -> str | None:
@@ -200,8 +248,8 @@ def app_dict(path: str, name: str, tag: str, entry_html: str | None, *,
         "entry": entry_html,
         "entry_html": entry_html,
         # The card's thumbnail when the author supplied one: absolute path to
-        # `preview.png` at the folder's root, else None and the card falls back
-        # to rendering `entry_html` live.
+        # the folder's root `preview.png` (or `preview.webp`), else None and the
+        # card falls back to rendering `entry_html` live.
         "preview_image": app_preview_image(path),
         # The authored category from `metadata.json`, or None. Drives the apps
         # page's category filter; None means "All only".

--- a/fused_render/appfile.py
+++ b/fused_render/appfile.py
@@ -75,11 +75,13 @@ MAX_OPEN_TOTAL_BYTES = 1024 * 1024 * 1024
 # runs). A real manifest is a few hundred bytes; 256 KiB is generous.
 _MANIFEST_CAP_BYTES = 256 * 1024
 
-# Cap on the payload's preview.png, both directions (a capture injected at
+# Cap on the payload's authored still, both directions (a capture injected at
 # export time and the member `read_preview` streams to a card). A card
-# thumbnail is ~1280x800; 8 MiB is generous for any real screenshot.
+# thumbnail is ~1280x800; 8 MiB is generous for any real screenshot. The name
+# and the accepted encodings are `app_listing`'s (PNG or WebP,
+# `app_listing.preview_media_type`) — the payload's thumbnail is the same file
+# under the same rules as the folder's, only zipped.
 MAX_PREVIEW_BYTES = 8 * 1024 * 1024
-_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
 # Directory/file names never exported. Dotted names (`.git`, `.claude`,
 # `.venv`, `.DS_Store`, `.env` — which may hold secrets) are dropped by the
@@ -281,10 +283,12 @@ def export_app_file(app_dir: str, out_path: str,
     Non-destructive: refuses an existing ``out_path``.
 
     ``preview_bytes`` is an optional caller-captured card screenshot (D396):
-    it becomes the payload's ``preview.png`` ONLY when the folder has no
-    authored one — an author's chosen still always wins over a capture. It
-    must be a real PNG under the preview cap; anything else raises rather
-    than baking a broken thumbnail into the artifact forever. That strictness
+    it becomes the payload's authored still (``preview.png``, or
+    ``preview.webp`` when the bytes are one) ONLY when the folder has no
+    authored one under EITHER name — an author's chosen still always wins over
+    a capture. It must be a real PNG or WebP under the preview cap; anything
+    else raises rather than baking a broken thumbnail into the artifact
+    forever. That strictness
     is for a caller that MEANT to supply a still: the export ROUTE, whose
     bytes come off a best-effort screen grab, drops an over-cap capture before
     it gets here, because a failed grab must cost the thumbnail and not the
@@ -328,15 +332,22 @@ def export_app_file(app_dir: str, out_path: str,
             f"app folder is too large to export ({total} bytes > {MAX_EXPORT_TOTAL_BYTES})"
         )
 
+    preview_name = app_listing.PREVIEW_IMAGE_NAME
     if preview_bytes is not None:
         if len(preview_bytes) > MAX_PREVIEW_BYTES:
             raise AppFileError(
                 f"preview image is too large ({len(preview_bytes)} bytes > "
                 f"{MAX_PREVIEW_BYTES})")
-        if not preview_bytes.startswith(_PNG_MAGIC):
-            raise AppFileError("preview image is not a PNG")
-        if any(rel == app_listing.PREVIEW_IMAGE_NAME for _, rel in members):
-            preview_bytes = None  # the authored still wins
+        media_type = app_listing.preview_media_type(preview_bytes)
+        if media_type is None:
+            raise AppFileError("preview image is not a PNG or WebP")
+        # The member is named for what the bytes ARE, not for what the capture
+        # usually is: `read_preview` and the folder's own thumbnail rule both
+        # take the name as the encoding, so a webp under the .png name would
+        # serve as `image/png` and render nowhere.
+        preview_name = app_listing.preview_name_for(media_type)
+        if any(rel in app_listing.PREVIEW_IMAGE_NAMES for _, rel in members):
+            preview_bytes = None  # the authored still wins — either name of it
 
     manifest = {
         "fused_app_file": 1,
@@ -354,8 +365,7 @@ def export_app_file(app_dir: str, out_path: str,
         with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zf:
             zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, sort_keys=True) + "\n")
             if preview_bytes is not None:
-                zf.writestr(
-                    f"{PAYLOAD_DIR}/{app_listing.PREVIEW_IMAGE_NAME}", preview_bytes)
+                zf.writestr(f"{PAYLOAD_DIR}/{preview_name}", preview_bytes)
             for full, rel in members:
                 zf.write(full, arcname=f"{PAYLOAD_DIR}/{rel}")
         os.replace(tmp, out_path)
@@ -403,32 +413,44 @@ def read_manifest(fused_path: str) -> dict:
     return manifest
 
 
-def read_preview(fused_path: str) -> bytes | None:
-    """The payload's ``preview.png`` bytes, or None when the file ships
-    without one — read-only, single member, nothing extracted (the same
-    posture as :func:`read_manifest`; a card thumbnail must never trigger
-    extraction). Raises :class:`AppFileError` for an unreadable/invalid
-    ``.fused``; a member that is over the cap or not a PNG answers None —
-    for a THUMBNAIL, "broken still" and "no still" earn the same fallback."""
+def read_preview(fused_path: str) -> tuple[bytes, str] | None:
+    """The payload's authored still as ``(bytes, media_type)``, or None when the
+    file ships without one — read-only, one or two member opens, nothing
+    extracted (the same posture as :func:`read_manifest`; a card thumbnail must
+    never trigger extraction).
+
+    The names are tried in `app_listing.PREVIEW_IMAGE_NAMES` order, so a payload
+    carrying both answers with the PNG exactly as the folder it came from would.
+    The media type is returned rather than assumed because the caller serves
+    these bytes with no path to guess from (routers/appfile) — and it is
+    SNIFFED, not taken from the member name, since the name is whatever the
+    zip's author typed.
+
+    Raises :class:`AppFileError` for an unreadable/invalid ``.fused``; a member
+    that is over the cap or not a PNG/WebP is skipped like an absent one — for a
+    THUMBNAIL, "broken still" and "no still" earn the same fallback."""
     manifest = read_manifest(fused_path)
     root = manifest.get("root") or PAYLOAD_DIR
     if not isinstance(root, str) or "\\" in root or ".." in root.split("/"):
         raise AppFileError(f"invalid root path in manifest: {root!r}")
-    member = f"{root}/{app_listing.PREVIEW_IMAGE_NAME}"
     try:
         with zipfile.ZipFile(fused_path) as zf:
-            try:
-                with zf.open(member) as f:
-                    # Bounded read, like the manifest's: declared sizes in an
-                    # archive are attacker-controlled.
-                    raw = f.read(MAX_PREVIEW_BYTES + 1)
-            except KeyError:
-                return None
+            for name in app_listing.PREVIEW_IMAGE_NAMES:
+                try:
+                    with zf.open(f"{root}/{name}") as f:
+                        # Bounded read, like the manifest's: declared sizes in
+                        # an archive are attacker-controlled.
+                        raw = f.read(MAX_PREVIEW_BYTES + 1)
+                except KeyError:
+                    continue
+                if len(raw) > MAX_PREVIEW_BYTES:
+                    continue
+                media_type = app_listing.preview_media_type(raw)
+                if media_type is not None:
+                    return raw, media_type
     except (OSError, zipfile.BadZipFile) as exc:
         raise AppFileError(f"not a readable .fused file: {exc}")
-    if len(raw) > MAX_PREVIEW_BYTES or not raw.startswith(_PNG_MAGIC):
-        return None
-    return raw
+    return None
 
 
 def _slug(name: str, fallback: str = "app") -> str:

--- a/fused_render/server/routers/appfile.py
+++ b/fused_render/server/routers/appfile.py
@@ -84,8 +84,8 @@ async def api_appfile_export_with_preview(
     x_fused: str | None = Header(default=None),
 ):
     """The card's export path (D396): same download as the GET, plus an
-    optional caller-captured screenshot that becomes the payload's
-    ``preview.png`` when the folder has no authored one. A POST because it
+    optional caller-captured screenshot that becomes the payload's authored
+    still when the folder has no authored one. A POST because it
     carries a body; X-Fused-guarded because — unlike the GET — its caller is
     always our own fetch, never bare browser navigation.
 
@@ -96,8 +96,9 @@ async def api_appfile_export_with_preview(
     its strict answer for a caller that passes a preview deliberately; this
     route, which knows its bytes came off a best-effort screen grab, screens
     the size first. Read one byte past the cap so "exactly at the cap" ships.
-    A non-PNG still raises: `canvas.toBlob(…, "image/png")` cannot produce one,
-    so those bytes are a client bug worth reporting, not a failed grab.
+    Bytes that are neither PNG nor WebP still raise: `canvas.toBlob(…,
+    "image/png")` cannot produce them, so they are a client bug worth
+    reporting, not a failed grab.
     """
     guard = _require_fused(x_fused)
     if guard is not None:
@@ -129,20 +130,25 @@ async def api_appfile_export_with_preview(
 
 @router.get("/api/appfile/preview")
 def api_appfile_preview(path: str = ""):
-    """The ``preview.png`` inside the ``.fused`` at ``path``, as bytes — the
-    exported card's thumbnail (D396). Read-only single-member zip read, no
-    extraction (a grid of thumbnails must never populate the extract cache).
-    404 when the file ships without one, so the card's ordinary onError
-    fallback shows the empty thumb."""
+    """The authored still inside the ``.fused`` at ``path`` (``preview.png``,
+    else ``preview.webp``), as bytes — the exported card's thumbnail (D396).
+    Read-only single-member zip read, no extraction (a grid of thumbnails must
+    never populate the extract cache). 404 when the file ships without one, so
+    the card's ordinary onError fallback shows the empty thumb.
+
+    The content type comes from `read_preview`, which sniffed the bytes: this
+    route has no file name to guess from, and a webp served as ``image/png``
+    renders nowhere."""
     if not path or not os.path.isabs(path):
         return _error("path must be an absolute .fused file path")
     try:
-        raw = appfile.read_preview(path)
+        found = appfile.read_preview(path)
     except appfile.AppFileError as exc:
         return _error(str(exc))
-    if raw is None:
+    if found is None:
         return _error("this app file has no preview image", status=404)
-    return Response(raw, media_type="image/png",
+    raw, media_type = found
+    return Response(raw, media_type=media_type,
                     headers={"Cache-Control": "no-cache"})
 
 

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -23,8 +23,8 @@ what one listed app looks like. Each app reports its entry twice: ``entry`` is
 the file a card opens and previews, ``entry_html`` the narrower claim that the
 entry is a renderable page (the only one the HTML-only ``/render`` iframe may be
 pointed at). For an app of this shape they are the same file. ``preview_image``
-is a third, unrelated path: an authored ``preview.png`` at the folder's root,
-which a card shows INSTEAD of rendering the entry live.
+is a third, unrelated path: an authored ``preview.png`` (or ``preview.webp``)
+at the folder's root, which a card shows INSTEAD of rendering the entry live.
 
 POST /api/apps/new scaffolds ``<workspace>/local/<name>/`` from the packaged
 app starter kit (``fused_render/app_starter/`` — an ``index.html`` entry view
@@ -558,12 +558,12 @@ def api_migrate_app(body: dict = Body(...), x_fused: str | None = Header(default
     }
 
 
-# The authored thumbnail's cap and signature — the same two the .fused
-# export applies to a capture (appfile.py), because it is the same picture:
-# a card still, ~1280x800, and canvas.toBlob("image/png") is the only thing
-# that produces it.
+# The authored thumbnail's cap — the same one the .fused export applies to a
+# capture (appfile.py), because it is the same picture: a card still,
+# ~1280x800, and canvas.toBlob("image/png") is the only thing that produces it.
+# The signature check is `app_listing.preview_media_type`, shared with the
+# export and the folder's own thumbnail rule.
 _PREVIEW_MAX_BYTES = 8 * 1024 * 1024
-_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
 
 @router.post("/api/apps/preview")
@@ -578,8 +578,17 @@ async def api_app_set_preview(
     app's entry page (Akshil, 2026-08-27): the page captures the pixels the
     preview frame is showing (appShot.captureAppPreview — the same tab capture
     the .fused export bakes in) and posts them here. The file lands under the
-    ONE name `app_listing.app_preview_image` reads, so a card shows it on its
-    next listing with no new plumbing.
+    FIRST of the names `app_listing.app_preview_image` reads, so a card shows it
+    on its next listing with no new plumbing.
+
+    PNG only, and deliberately so even though a folder's authored still may also
+    be a `preview.webp`: the bytes here are always `canvas.toBlob(…,
+    "image/png")`, and a route that wrote the other name would let a capture
+    land UNDER an existing `preview.png` in the read order and be invisible. An
+    author's own `preview.webp` is left on disk, shadowed by the PNG this
+    writes — non-destructive, and `replaced` (resolved through
+    `app_preview_image`, so it sees either name) already told the caller its
+    thumbnail was about to change.
 
     Only an APP folder takes one — `app_listing.app_entry(path)` must resolve —
     because a preview.png in a folder that is not an app is a stray file
@@ -602,12 +611,12 @@ async def api_app_set_preview(
     if preview is None:
         return _error("preview.png is required")
     raw = await preview.read(_PREVIEW_MAX_BYTES + 1)
-    if not raw or not raw.startswith(_PNG_MAGIC):
+    if not raw or app_listing.preview_media_type(raw) != "image/png":
         return _error("preview must be a PNG")
     if len(raw) > _PREVIEW_MAX_BYTES:
         return _error("preview is larger than 8 MiB")
     target = os.path.join(path, app_listing.PREVIEW_IMAGE_NAME)
-    replaced = os.path.isfile(target)
+    replaced = app_listing.app_preview_image(path) is not None
     tmp = os.path.join(path, f".{app_listing.PREVIEW_IMAGE_NAME}.{os.getpid()}.tmp")
     try:
         with open(tmp, "wb") as fh:

--- a/ios/FusedRender/ManifestSync.swift
+++ b/ios/FusedRender/ManifestSync.swift
@@ -1,6 +1,6 @@
 // Keeps the shared manifest (Shared/AppManifest.swift) current: whenever the
 // grid loads, fetch the same /api/lan/apps the grid shows — with the webview's
-// cookie — cache each preview.png, write apps.json, and tell WidgetKit and the
+// cookie — cache each app's still, write apps.json, and tell WidgetKit and the
 // Home Screen quick actions. Best-effort throughout: a failed refresh leaves
 // the last manifest in place.
 import Foundation
@@ -58,7 +58,7 @@ enum ManifestSync {
         log.info("manifest: \(apps.count) apps from \(server.host, privacy: .public)")
     }
 
-    /// Download preview.png once per (app, mtime-less) — re-fetched on every
+    /// Download the authored still once per (app, mtime-less) — re-fetched on every
     /// refresh but only rewritten when the bytes changed; downscaled to widget
     /// size so the container stays small.
     private static func cachePreview(_ relative: String, for app: ManifestApp, cookieHeader: String,

--- a/ios/Shared/AppManifest.swift
+++ b/ios/Shared/AppManifest.swift
@@ -34,7 +34,7 @@ struct ManifestApp: Codable, Identifiable, Hashable {
     var url: String
     var tag: String?
     var recency: Double
-    /// Cached preview.png in `previews/`, when the app has one.
+    /// Cached authored still (preview.png / preview.webp) in `previews/`, when the app has one.
     var previewFile: String?
 
     /// A plain hex digest, not "host:port|/path": AppIntents persists a chosen

--- a/tests/test_exported_apps.py
+++ b/tests/test_exported_apps.py
@@ -245,13 +245,13 @@ def test_export_bakes_a_capture_only_when_no_authored_preview(tmp_path):
     a = _app_folder(tmp_path / "one", "a")
     out_a = tmp_path / "a.fused"
     appfile.export_app_file(str(a), str(out_a), preview_bytes=PNG)
-    assert appfile.read_preview(str(out_a)) == PNG
+    assert appfile.read_preview(str(out_a)) == (PNG, "image/png")
 
     b = _app_folder(tmp_path / "two", "b")
     (b / "preview.png").write_bytes(PNG + b"authored")
     out_b = tmp_path / "b.fused"
     appfile.export_app_file(str(b), str(out_b), preview_bytes=PNG)
-    assert appfile.read_preview(str(out_b)) == PNG + b"authored"
+    assert appfile.read_preview(str(out_b)) == (PNG + b"authored", "image/png")
 
 
 def test_export_refuses_a_non_png_capture(tmp_path):
@@ -287,7 +287,7 @@ def test_post_export_carries_the_capture_into_the_download(client, tmp_path):
     assert r.status_code == 200
     out = tmp_path / "posted.fused"
     out.write_bytes(r.content)
-    assert appfile.read_preview(str(out)) == PNG
+    assert appfile.read_preview(str(out)) == (PNG, "image/png")
     # The guard holds: no X-Fused, no export.
     assert client.post("/api/appfile/export",
                        data={"path": str(a)}).status_code == 403
@@ -316,7 +316,7 @@ def test_an_over_cap_capture_is_dropped_and_the_export_still_ships(
     assert r.status_code == 200
     out2 = tmp_path / "atcap.fused"
     out2.write_bytes(r.content)
-    assert appfile.read_preview(str(out2)) == PNG
+    assert appfile.read_preview(str(out2)) == (PNG, "image/png")
 
 
 def test_a_non_png_capture_is_still_an_error_not_a_silent_drop(client, tmp_path):


### PR DESCRIPTION
## What

An app folder's thumbnail was exactly one name, `preview.png`. `preview.webp` now counts too — it is what an author's own screenshot usually already is, and a quarter of the bytes at the same look.

## The rule

`app_listing.PREVIEW_IMAGE_NAMES = ("preview.png", "preview.webp")` — **order is the precedence**, so a folder holding both shows its PNG and every folder authored before this answers exactly as it did. Still exact-case membership over ONE `os.listdir`, so the server and the explorer's peek rule (`folder-peek.ts`) agree on every filesystem. A zero-length PNG no longer shadows a good WebP: the scan continues instead of returning None on the better name.

## Writes stay PNG-only, deliberately

"Set Current View as Preview" and the .fused export's baked-in capture are both `canvas.toBlob(…, "image/png")`. A route that wrote the other name would let a capture land *under* an existing `preview.png` in the read order and be invisible. What did change:

- the set-preview dialog probes **both** names — a folder whose still is a `preview.webp` used to get no confirm at all, so the capture overwrote nothing and then shadowed it silently — and says what replacing actually does when the names differ (the webp stays in the folder, unused);
- `replaced` is resolved through `app_preview_image`, so it sees either name.

## .fused files

- export's "the authored still wins" test covers both names;
- an explicitly-passed capture is named for what its bytes ARE (`preview_media_type` / `preview_name_for`), since the name IS the encoding downstream;
- `read_preview` returns `(bytes, media_type)` **sniffed from the signature** — `GET /api/appfile/preview` has no path to guess a type from, and a webp served as `image/png` renders nowhere. Its 5 assertions in `test_exported_apps.py` were updated for the tuple.

Folder stills need no route change: `/api/fs/raw` types from the name via `mimetypes` (`.webp` since 3.11; `requires-python >= 3.11`).

## Checks

`tsc --noEmit` clean (one pre-existing unrelated `qrcode-generator` miss). `test_app_listing.py` + `test_exported_apps.py`: 70 passed, the rest of that file's cases error on this worktree's missing `shell-dist`. Sanity-checked live: png-only, webp-only, both, empty-png+webp, and webp capture round-tripping through a `.fused`.

Not smoke-tested in the UI — drop a `preview.webp` in an app folder and check the /apps card, a folder card's peek, export and re-import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thumbnail discovery and preview streaming behavior change, but precedence preserves PNG-only folders and capture paths remain PNG; no auth or data-model changes.
> 
> **Overview**
> App folders and `.fused` payloads now recognize **`preview.webp`** alongside **`preview.png`**, with **PNG winning** when both exist. Server listing (`app_listing.PREVIEW_IMAGE_NAMES`), folder peek ranking, and cards/hubs all follow that same ordered rule; an empty `preview.png` no longer blocks a valid WebP.
> 
> **Writes stay PNG-only** for captures ("Set Current View as Preview" and export bake-ins). The explorer **probes both names** before export or overwrite: existing WebP triggers a confirm that explains saving as `preview.png` **shadows** the WebP instead of deleting it. `replaced` is based on whether any authored still exists, not only `preview.png`.
> 
> **`.fused` thumbnails** accept PNG or WebP on export, name zip members from **sniffed** bytes (`preview_media_type` / `preview_name_for`), and **`read_preview`** returns `(bytes, media_type)` so `GET /api/appfile/preview` serves the correct `Content-Type`. Tests for exported apps were updated for the new tuple return type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714aa8fb69d799cc3866d2b1fdb76d9042e8e505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->