### PR TITLE
Explorer permission errors show the Full Disk Access card

### DIFF
--- a/frontend/src/apps/explorer/AccessDenied.tsx
+++ b/frontend/src/apps/explorer/AccessDenied.tsx
@@ -1,0 +1,43 @@
+// The OS refused a read. Shown in place of the raw "Failed to list <path>:
+// [Errno 1] Operation not permitted" plate, which named the symptom and
+// offered nothing to do about it.
+//
+// One plain sentence, then the Full Disk Access strip (platform/ui/FdaStrip)
+// right where the user is looking — the same strip Home and /apps show, so
+// the fix is one click away from the folder that just failed rather than a
+// trip back to the front door. The strip gates itself off /api/config's `fda`
+// field: absent (non-mac, dev server, inconclusive probe) it renders nothing,
+// so the sentence has to stand on its own. The server flips `fda.denied`
+// inside the very request that failed, before it answers, so the strip's
+// mount-time config fetch already sees the denial — no race to wait out.
+//
+// Deliberately NOT inside `.status-message.error`: that is the red monospace
+// failure plate, and the strip's warning-toned "nothing red" posture would
+// inherit its colour and font. A refused read is a setup gap, not an outage.
+import { FdaStrip } from "@platform/ui/FdaStrip";
+
+// Whether a failed fs read was REFUSED rather than missing/broken. The read
+// routes (list, stat, read) all answer 403 for a PermissionError and nothing
+// else on a read path answers 403 (the readonly guard is write-only). The text
+// fallback covers an error state that lost its status on the way here: macOS
+// TCC denies land as EPERM "Operation not permitted", classic mode bits as
+// EACCES "Permission denied".
+export function isAccessDenied(err: { status?: number; message?: string }): boolean {
+  if (err.status === 403) return true;
+  const msg = (err.message ?? "").toLowerCase();
+  return msg.includes("permission denied") || msg.includes("operation not permitted");
+}
+
+// No file/folder wording: a refused stat can't tell which it was.
+export function AccessDenied({ path }: { path: string }) {
+  return (
+    <div className="access-denied">
+      <p className="access-denied-text">
+        The system won’t let FusedRender read <code>{path}</code>.
+      </p>
+      <FdaStrip />
+    </div>
+  );
+}
+
+export default AccessDenied;

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -50,6 +50,7 @@ import ContextMenu from "@platform/ui/ContextMenu";
 import { EllipsisIcon } from "@apps/explorer/BarMenu";
 import { PromptDialog, ConfirmDialog } from "@apps/explorer/FsDialogs";
 import ListingPreviewPane from "@apps/explorer/ListingPreviewPane";
+import { AccessDenied, isAccessDenied } from "@apps/explorer/AccessDenied";
 import { resultCountLabel } from "@apps/explorer/listing/result-cap";
 import { claimFolderChrome } from "@apps/explorer/listing/folder-chrome";
 import { searchSlot, subscribeSearchSlot } from "@apps/explorer/search-slot";
@@ -1534,8 +1535,18 @@ export default function Listing({
     // error and show the neutral loading skeleton — stat is still resolving and
     // will replace this scaffold with the correct file view. Post-stat
     // (committed render), a genuine list failure surfaces normally.
+    //
+    // A REFUSED read (403 — macOS TCC, mode bits) is not a failure of ours to
+    // report in red: it gets the plain access card with the Full Disk Access
+    // strip, so the fix sits where the error is (AccessDenied.tsx).
     body = provisional ? (
       skeletonRows(8)
+    ) : isAccessDenied({ status: state.httpStatus, message: state.message }) ? (
+      <tr>
+        <td colSpan={cols} className="status-message">
+          <AccessDenied path={fsPath} />
+        </td>
+      </tr>
     ) : (
       <tr>
         <td colSpan={cols} className="status-message error">

--- a/frontend/src/apps/explorer/listing/types.ts
+++ b/frontend/src/apps/explorer/listing/types.ts
@@ -124,7 +124,9 @@ export type ListingState =
   // "no more can be fetched" — the banner then just states the listing is
   // partial without a Load more button.
   | { status: "ok"; entries: FsEntry[]; truncated: boolean; cursor: string | null }
-  | { status: "error"; message: string };
+  // `httpStatus`: the response code when the failure was an HTTP error, so
+  // the view can tell a refused read (403 → AccessDenied) from the rest.
+  | { status: "error"; message: string; httpStatus?: number };
 
 // Streamed walk state. `entries` is one append-only array shared across the
 // streaming updates (each batch pushes into it); every update still creates a

--- a/frontend/src/apps/explorer/listing/useDirListing.ts
+++ b/frontend/src/apps/explorer/listing/useDirListing.ts
@@ -2,7 +2,7 @@
 // Load-more pagination for truncated listings, the WebSocket dir watch that
 // drives refreshes, and the "new row" tint cue.
 import { useEffect, useRef, useState } from "react";
-import { clearListPrefetch, listDir, prefetchListDir } from "@platform/lib/api";
+import { clearListPrefetch, listDir, prefetchListDir, type HttpError } from "@platform/lib/api";
 import { appearedKeys } from "@platform/lib/flip";
 import { pushToast } from "@platform/lib/toast";
 import { ROW_NEW_MS, type ListingState } from "@apps/explorer/listing/types";
@@ -42,7 +42,8 @@ export function useDirListing(fsPath: string) {
           truncated: !!data.truncated,
           cursor: data.cursor ?? null,
         }),
-      (err: Error) => alive && setState({ status: "error", message: err.message })
+      (err: HttpError) =>
+        alive && setState({ status: "error", message: err.message, httpStatus: err.status })
     );
     return () => {
       alive = false;

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -31,9 +31,11 @@ import {
   getMounts,
   reconnectMount,
   type Config,
+  type HttpError,
   type Mount,
   type StatResult,
 } from "@platform/lib/api";
+import { AccessDenied, isAccessDenied } from "@apps/explorer/AccessDenied";
 import {
   useNavEpoch,
   useDocumentTitle,
@@ -106,7 +108,9 @@ const CanvasWorkspace = lazy(() =>
 type StatState =
   | { status: "loading" }
   | { status: "ok"; stat: StatResult }
-  | { status: "error"; message: string };
+  // `httpStatus`: the response code, so StatErrorView can tell a refused
+  // read (403 → the Full Disk Access card) from missing/broken.
+  | { status: "error"; message: string; httpStatus?: number };
 
 // `reloadKey` re-runs the stat without a navigation — used to recover after a
 // disconnected mount is reconnected in place (StatErrorView), where fsPath and
@@ -126,8 +130,9 @@ function useStat(
     setState({ status: "loading" });
     statPath(fsPath).then(
       (stat) => alive && setState({ status: "ok", stat }),
-      (err: Error) =>
-        alive && setState({ status: "error", message: err.message }),
+      (err: HttpError) =>
+        alive &&
+        setState({ status: "error", message: err.message, httpStatus: err.status }),
     );
     return () => {
       alive = false;
@@ -145,10 +150,12 @@ function useStat(
 function StatErrorView({
   fsPath,
   message,
+  httpStatus,
   onReload,
 }: {
   fsPath: string;
   message: string;
+  httpStatus?: number;
   onReload: () => void;
 }) {
   // undefined = still checking; null = not under any mount.
@@ -210,6 +217,18 @@ function StatErrorView({
           {busy ? "Reconnecting…" : wedged ? "Reconnect" : "Mount"}
         </button>
         {mountErr && <div className="deploy-error">{mountErr}</div>}
+      </div>
+    );
+  }
+  // A refused stat (403 — a file or folder macOS/TCC or mode bits won't let us
+  // read) gets the access card with the Full Disk Access strip in place of
+  // the raw errno plate (explorer/AccessDenied.tsx). Checked after the mount
+  // branch: a dead mount can surface as EPERM too, and reconnecting is the
+  // right offer there.
+  if (isAccessDenied({ status: httpStatus, message })) {
+    return (
+      <div className="status-message">
+        <AccessDenied path={fsPath} />
       </div>
     );
   }
@@ -378,6 +397,7 @@ function StatView({
       <StatErrorView
         fsPath={fsPath}
         message={stat.message}
+        httpStatus={stat.httpStatus}
         onReload={() => setReloadKey((k) => k + 1)}
       />
     );

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -918,6 +918,9 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
    own bottom margin is for sitting above a grid; here it is the last thing. */
 .access-denied {
   max-width: 640px;
+  /* The listing's td is `white-space: nowrap` (one entry per line); this cell
+     holds prose and a card, both of which must wrap inside the 640px. */
+  white-space: normal;
 }
 .access-denied-text {
   margin: 0 0 12px;

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -918,9 +918,9 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
    own bottom margin is for sitting above a grid; here it is the last thing. */
 .access-denied {
   /* Full width of the listing like the strip is on Home (a band, not a
-     floating plate), with the same ~28px gutters Home's column has: the cell's
-     own 24px of padding plus a little margin here. */
-  margin: 4px 4px 12px;
+     floating plate). Side gutters: the cell's own 24px of padding plus 40px
+     here — wider than Home's 28px on purpose, the listing is a wider column. */
+  margin: 8px 40px 16px;
   /* The listing's td is `white-space: nowrap` (one entry per line); this cell
      holds prose and a card, both of which must wrap inside the 640px. */
   white-space: normal;

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -911,3 +911,25 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   color: var(--fg);
 }
 
+
+/* Refused read (explorer/AccessDenied.tsx): one plain sentence over the Full
+   Disk Access strip. Lives in the muted .status-message cell, never the red
+   .error plate — a permission gap is a setup step, not an outage. The strip's
+   own bottom margin is for sitting above a grid; here it is the last thing. */
+.access-denied {
+  max-width: 640px;
+}
+.access-denied-text {
+  margin: 0 0 12px;
+  color: var(--fg);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+.access-denied-text code {
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+.access-denied .claude-health {
+  margin-bottom: 0;
+}

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -917,7 +917,10 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
    .error plate — a permission gap is a setup step, not an outage. The strip's
    own bottom margin is for sitting above a grid; here it is the last thing. */
 .access-denied {
-  max-width: 640px;
+  /* Full width of the listing like the strip is on Home (a band, not a
+     floating plate), with the same ~28px gutters Home's column has: the cell's
+     own 24px of padding plus a little margin here. */
+  margin: 4px 4px 12px;
   /* The listing's td is `white-space: nowrap` (one entry per line); this cell
      holds prose and a card, both of which must wrap inside the 640px. */
   white-space: normal;

--- a/fused_render/server/routers/fs_read.py
+++ b/fused_render/server/routers/fs_read.py
@@ -273,6 +273,11 @@ def api_fs_list(path: str, cursor: str | None = None):
         broken = shell_mounts.broken_mount_error(path)
         if broken:
             return _error(broken, status=503)
+        # 403, matching stat (mount.py) and read below, so the explorer can
+        # tell "refused" from "not a directory" by status and show the
+        # Full Disk Access card instead of the raw errno text.
+        if isinstance(e, PermissionError):
+            return _error(f"cannot read {path}: {e}", status=403)
         return _error(f"cannot read directory {path}: {e}", status=400)
     truncated = len(dents) > _server_walk.LIST_MAX_ENTRIES
     if truncated:


### PR DESCRIPTION
## What

When the explorer cannot read a folder or file because the OS refused it, the view showed a red monospace plate with the raw errno and no way forward. This PR renders the existing Full Disk Access strip in place, under one plain sentence, so the fix sits where the error is.

## How

- `fs_read.py` list route: `PermissionError` now answers 403 (stat and read already did), so the client branches on status instead of errno text.
- `ListingState` / `StatState` error arms carry `httpStatus`.
- New `explorer/AccessDenied.tsx`: sentence + `<FdaStrip />`, plus `isAccessDenied()` (403, with a text fallback for EPERM/EACCES wording).
- `Listing.tsx` and `App.tsx`'s `StatErrorView` route denied reads to it inside the muted `.status-message` cell, not the red `.error` plate. Mount-reconnect branch still takes precedence.

## Smoke

- Dev server: `FUSED_RENDER_FDA_BANNER=demo` renders the strip; `chmod 000` a folder and open it to see the card.
- Real TCC denial needs the packaged mac app. Non-mac / dev without the flag shows only the sentence, since FdaStrip self-gates on `/api/config`'s `fda` field.
- Note: FdaStrip still fires its one-per-episode toast on first show, so the first denial announces twice (toast + inline card). Left as-is; say if the toast should go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI routing and a list-endpoint status change (400→403 for permission errors); mount-reconnect handling is preserved before the access-denied branch.
> 
> **Overview**
> When macOS or filesystem permissions block a **list** or **stat**, the explorer no longer shows the red monospace “Failed to …” plate. It shows a short explanation for the path and embeds the existing **`FdaStrip`** in the muted status area so users can fix Full Disk Access where the failure happened.
> 
> The **list** API now returns **403** for `PermissionError` (aligned with stat/read), and listing/stat error state carries **`httpStatus`** so the UI can branch on **403** via **`isAccessDenied`** (with message fallbacks for EPERM/EACCES). **Mount reconnect** in `StatErrorView` still wins when the path is under a bad mount. New **`.access-denied`** styles keep the card out of the red error treatment and allow wrapping in listing cells.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd84f5a625d5365f84c3db7b2893672f675f4ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->