### PR TITLE
Home search reports the index's actual state, and offers to build it

### DIFF
--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -27,7 +27,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { createElement } from "react";
-import type { IndexRankResult, StatResult } from "@platform/lib/api";
+import type { IndexRankResult, IndexStatus, StatResult } from "@platform/lib/api";
 import { Clock } from "@apps/explorer/listing/hook-harness";
 import { STALE_CLEAR_MS } from "@platform/lib/instant-search";
 import { resetFsMutations } from "@platform/lib/index-freshness";
@@ -48,6 +48,9 @@ interface StatCall {
 }
 const rankCalls: RankCall[] = [];
 const statCalls: StatCall[] = [];
+/** Every POST /api/index/scan, by URL — the observable trace of the note's
+ * "index them now" button actually asking for a scan. */
+const scanCalls: string[] = [];
 /** Every `history.pushState(..., url)` the router's `navigate()` makes — the
  * observable trace of a navigation, since `navigate` itself is a frozen ES
  * module export this file cannot spy on (see the file-header comment on why
@@ -84,6 +87,18 @@ function fakeFetch(url: string | URL): Promise<Response> {
       });
     });
   }
+  // The "index them now" button's POST. Answered immediately rather than
+  // deferred like the two above: the test's interest is that the scan was
+  // ASKED FOR, and the note's state after it comes from the status poll
+  // (`indexScan`, a prop here), not from this reply.
+  if (u.startsWith("/api/index/scan")) {
+    scanCalls.push(u);
+    return Promise.resolve(
+      new Response(JSON.stringify({ ok: true, run_id: "r1", root: HOME, runs: [] }), {
+        status: 200,
+      }),
+    );
+  }
   throw new Error("FilesHome.render.test.tsx: unexpected fetch " + u);
 }
 
@@ -116,6 +131,7 @@ const mounted: ReactTestRenderer[] = [];
 beforeEach(() => {
   rankCalls.length = 0;
   statCalls.length = 0;
+  scanCalls.length = 0;
   navPushes.length = 0;
   globalThis.fetch = fakeFetch as typeof fetch;
   // `indexRescanPending` (platform/lib/index-freshness) reads a module-level
@@ -170,14 +186,36 @@ async function flush(fn: () => void = () => {}): Promise<void> {
   });
 }
 
-function mount(): { renderer: ReactTestRenderer; input: () => any; unmount: () => void } {
+/** The shared status poll's reading, as the page's own `useIndexStatus` would
+ * hand it down. Null (the default) is "no poll answer yet", which is what
+ * every test that does not care about scan state wants. */
+function scanStatus(over: Partial<IndexStatus> = {}): IndexStatus {
+  return {
+    scanning: false,
+    has_index: false,
+    files_indexed: 0,
+    last_completed_at: null,
+    running: false,
+    run_id: null,
+    root: HOME,
+    phase: "",
+    dirs: 0,
+    files: 0,
+    error: null,
+    ...over,
+  };
+}
+
+function mount(
+  indexScan: IndexStatus | null = null,
+): { renderer: ReactTestRenderer; input: () => any; unmount: () => void } {
   let renderer!: ReactTestRenderer;
   act(() => {
     renderer = create(
       createElement(FilesSearch, {
         home: HOME,
         initialQuery: "",
-        indexScan: null,
+        indexScan,
         onActiveChange: () => {},
       }),
     );
@@ -634,6 +672,87 @@ describe("the AI row's sticky positioning is on the LIST ITEM, not the button in
     );
     expect(carriers.length).toBeGreaterThan(0);
     for (const n of carriers) expect(n.type).toBe("li");
+    box.unmount();
+  });
+});
+
+// An uncovered root with nothing scanning used to render the same "still
+// building" note as a live scan. Nothing on this page ever asks for a scan
+// (that is the in-folder box's `requestFolderScan`) and the startup scheduler
+// runs once per boot, so that note promised a build that had already failed,
+// been refused, or been debounce-skipped — for as long as the user was
+// willing to wait, which in the report that prompted this was twenty minutes.
+describe("an uncovered index with no scan running offers the scan", () => {
+  const uncovered = { covered: false, reason: "uncovered" as const, hits: [], total: 0 };
+
+  test("says the files are not indexed rather than that something is coming", async () => {
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    const note = noteText(box);
+    expect(note).toContain("aren’t indexed yet");
+    expect(note).not.toContain("still building");
+    box.unmount();
+  });
+
+  test("the button asks for a whole-index scan, not a folder one", async () => {
+    // POST /api/index/scan (every configured root, no debounce) — NOT
+    // /api/index/scan-folder, whose 15-minute floor would refuse exactly the
+    // case this button exists for.
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    expect(noteText(box)).toContain("Index them now");
+    const button = findByClass(box, "fh-link-button") as { props: { onClick: () => void } }[];
+    expect(button).toHaveLength(1);
+    await flush(() => button[0].props.onClick());
+    expect(scanCalls).toEqual(["/api/index/scan"]);
+    box.unmount();
+  });
+
+  test("a live scan still says building, with its progress", async () => {
+    // The other half of the same distinction: when a scan really is running,
+    // waiting IS the advice — and the count is what tells the user that
+    // "building" is a live claim rather than the wedged one above.
+    const box = mount(scanStatus({ scanning: true, files: 12345 }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    const note = noteText(box);
+    expect(note).toContain("still building");
+    expect(note).toContain("12,345 files so far");
+    box.unmount();
+  });
+
+  test("a scan started since the answer was ranked flips the note off the poll", async () => {
+    // `reason` was fixed when the answer was ranked, so the status poll is
+    // the only thing that can report the scan the button just started. Same
+    // uncovered answer, `scanning: true` from the poll.
+    const box = mount(scanStatus({ scanning: true }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    expect(noteText(box)).toContain("still building");
+    box.unmount();
+  });
+
+  test("indexing turned off keeps its own message and offers no scan", async () => {
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer({ ...uncovered, reason: "disabled" })));
+    const note = noteText(box);
+    expect(note).toContain("File indexing is off");
+    expect(note).not.toContain("Index them now");
+    box.unmount();
+  });
+
+  test("a permanently uncoverable root offers no scan either", async () => {
+    // A button that cannot work is worse than none: no scan will ever cover a
+    // mount-backed root.
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer({ ...uncovered, reason: "mount" })));
+    const note = noteText(box);
+    expect(note).toContain("can’t be indexed");
+    expect(note).not.toContain("Index them now");
     box.unmount();
   });
 });

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -51,6 +51,10 @@ const statCalls: StatCall[] = [];
 /** Every POST /api/index/scan, by URL — the observable trace of the note's
  * "index them now" button actually asking for a scan. */
 const scanCalls: string[] = [];
+/** How many times the box told its parent to re-poll the index status — the
+ * one thing that turns the parent's idle ten-second beat into a look NOW, so
+ * that a scan this box started is not invisible until then. */
+let scanRequested = 0;
 /** Every `history.pushState(..., url)` the router's `navigate()` makes — the
  * observable trace of a navigation, since `navigate` itself is a frozen ES
  * module export this file cannot spy on (see the file-header comment on why
@@ -132,6 +136,7 @@ beforeEach(() => {
   rankCalls.length = 0;
   statCalls.length = 0;
   scanCalls.length = 0;
+  scanRequested = 0;
   navPushes.length = 0;
   globalThis.fetch = fakeFetch as typeof fetch;
   // `indexRescanPending` (platform/lib/index-freshness) reads a module-level
@@ -208,17 +213,26 @@ function scanStatus(over: Partial<IndexStatus> = {}): IndexStatus {
 
 function mount(
   indexScan: IndexStatus | null = null,
-): { renderer: ReactTestRenderer; input: () => any; unmount: () => void } {
+): {
+  renderer: ReactTestRenderer;
+  input: () => any;
+  /** Hand down a fresh poll reading, the way the parent's re-render would. */
+  poll: (next: IndexStatus | null) => void;
+  unmount: () => void;
+} {
   let renderer!: ReactTestRenderer;
+  const element = (scan: IndexStatus | null) =>
+    createElement(FilesSearch, {
+      home: HOME,
+      initialQuery: "",
+      indexScan: scan,
+      onActiveChange: () => {},
+      onScanRequested: () => {
+        scanRequested += 1;
+      },
+    });
   act(() => {
-    renderer = create(
-      createElement(FilesSearch, {
-        home: HOME,
-        initialQuery: "",
-        indexScan,
-        onActiveChange: () => {},
-      }),
-    );
+    renderer = create(element(indexScan));
   });
   // Tracked for the unconditional afterEach sweep (above) — removed here on a
   // NORMAL unmount so that sweep does not try to unmount an already-unmounted
@@ -227,6 +241,7 @@ function mount(
   return {
     renderer,
     input: () => renderer.root.findByProps({ className: "files-search-input" }),
+    poll: (next: IndexStatus | null) => act(() => renderer.update(element(next))),
     // Unmount INSIDE act(): effect cleanups (the pending timers, the
     // document listener) must run in the same batched world the rest of the
     // test drives, or React can warn about — or in practice mis-schedule —
@@ -707,6 +722,45 @@ describe("an uncovered index with no scan running offers the scan", () => {
     expect(button).toHaveLength(1);
     await flush(() => button[0].props.onClick());
     expect(scanCalls).toEqual(["/api/index/scan"]);
+    // And the parent is told to look at the status again NOW: its poll is on a
+    // ten-second idle beat, so without this the run the user just started
+    // would not exist as far as this note is concerned.
+    expect(scanRequested).toBe(1);
+    box.unmount();
+  });
+
+  test("does not re-offer the button while the poll has yet to see the scan", async () => {
+    // The POST returns in milliseconds; the poll answers when it answers. In
+    // between, the note used to go straight back to "Index them now" — a
+    // click that reads as a no-op on the one screen whose whole point is that
+    // waiting is futile, and whose obvious response is to click again.
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    type Button = { props: { onClick: () => void; disabled?: boolean } };
+    const button = findByClass(box, "fh-link-button") as Button[];
+    await flush(() => button[0].props.onClick());
+    expect(noteText(box)).toContain("Starting the scan…");
+    expect((findByClass(box, "fh-link-button") as Button[])[0].props.disabled).toBe(true);
+    // Poll catches up: now "building" is the true claim, and it comes with a
+    // count.
+    box.poll(scanStatus({ scanning: true, files: 21 }));
+    expect(noteText(box)).toContain("still building");
+    box.unmount();
+  });
+
+  test("a stale `scanning` gives way to the poll saying nothing runs", async () => {
+    // The other route into the twenty-minute wedge: this answer was ranked
+    // while the startup scan was alive, then that worker died. Status reports
+    // idle (after ABANDONED_RUN_S), `last_completed_at` never moves so no
+    // lifecycle event re-ranks anything, and trusting `reason` would leave
+    // "still building" — with a frozen file count — on screen forever.
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer({ ...uncovered, reason: "scanning" })));
+    const note = noteText(box);
+    expect(note).not.toContain("still building");
+    expect(note).toContain("Index them now");
     box.unmount();
   });
 

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -29,7 +29,11 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { createElement } from "react";
 import type { IndexRankResult, IndexStatus, StatResult } from "@platform/lib/api";
 import { Clock } from "@apps/explorer/listing/hook-harness";
-import { STALE_CLEAR_MS } from "@platform/lib/instant-search";
+import {
+  INSTANT_DEBOUNCE_MS,
+  PENDING_INDICATOR_MS,
+  STALE_CLEAR_MS,
+} from "@platform/lib/instant-search";
 import { resetFsMutations } from "@platform/lib/index-freshness";
 
 // --- the module boundary: a fetch stub, not a module mock -------------------
@@ -810,6 +814,104 @@ describe("an uncovered index with no scan running offers the scan", () => {
     const note = noteText(box);
     expect(note).toContain("can’t be indexed");
     expect(note).not.toContain("Index them now");
+    box.unmount();
+  });
+});
+
+describe("the scan CTA follows the note's own precedence guards", () => {
+  const uncovered = { covered: false, reason: "uncovered" as const, hits: [], total: 0 };
+
+  // Regression for `gap` reading `displayAnswer` alone: a held uncovered
+  // answer kept the CTA on screen after the note itself had moved on to
+  // "Keep typing…", offering "Index my files" next to a note that no longer
+  // has an uncovered answer to report on at all.
+  test("dropping below MIN_QUERY_CHARS removes the CTA along with the note's claim", async () => {
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    expect(findByClass(box, "fh-index-cta")).toHaveLength(1);
+
+    await flush(() => box.input().props.onChange({ target: { value: "r" } }));
+    expect(noteText(box)).toContain("Keep typing");
+    expect(findByClass(box, "fh-index-cta")).toHaveLength(0);
+    box.unmount();
+  });
+
+  // Same bug, the other guard: once an address resolves the Open row is the
+  // whole story, and the CTA has nothing left to add to it.
+  test("a resolved address removes the CTA even with a held uncovered answer", async () => {
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    expect(findByClass(box, "fh-index-cta")).toHaveLength(1);
+
+    await flush(() => box.input().props.onChange({ target: { value: "/tmp/report.csv" } }));
+    await flush(() => statCalls[statCalls.length - 1].resolve({
+      path: "/tmp/report.csv", name: "report.csv", is_dir: false, size: 1, mtime: 1, templates: [],
+    }));
+    expect(box.renderer.root.findAllByProps({ id: "fh-row-0" }).length).toBeGreaterThan(0);
+    expect(findByClass(box, "fh-index-cta")).toHaveLength(0);
+    box.unmount();
+  });
+});
+
+describe("the scan latch is one-shot: the poll owns the state once it sees the run", () => {
+  const uncovered = { covered: false, reason: "uncovered" as const, hits: [], total: 0 };
+
+  // Regression for `pendingBuild` never being cleared: a scan that dies
+  // between two polls without moving `last_completed_at` left
+  // `scanStarting`'s last clause (`completedAt === pending.completedAt`) true
+  // again, re-arming "Starting the scan…" (disabled) for the rest of the
+  // 20s grace window on the one screen whose whole point is that waiting is
+  // futile — and blocking the retry the button exists to offer.
+  test("a scan that dies after the poll saw it running re-offers an enabled button", async () => {
+    const box = mount(scanStatus({ scanning: false, last_completed_at: 1000 }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    type Button = { props: { onClick: () => void; disabled?: boolean } };
+    const button = () => (findByClass(box, "fh-index-cta-btn") as Button[])[0];
+    await flush(() => button().props.onClick());
+    expect(button().props.disabled).toBe(true);
+
+    // The poll sees the run: the latch's one job is done.
+    await flush(() => box.poll(scanStatus({ scanning: true, last_completed_at: 1000 })));
+    expect(findByClass(box, "fh-index-cta")).toHaveLength(0);
+
+    // The worker dies without moving `last_completed_at`. If the latch were
+    // still armed, `scanStarting` would read this as the SAME pending scan
+    // and re-disable the button reading "Starting the scan…".
+    await flush(() => box.poll(scanStatus({ scanning: false, last_completed_at: 1000 })));
+    const retry = button() as Button & { props: { children: unknown } };
+    expect(retry.props.disabled).toBe(false);
+    // Enabled AND saying the true thing: no scan is starting, so the button
+    // has to read as the offer again, not as a claim about a dead run.
+    expect(retry.props.children).toBe("Index my files");
+    box.unmount();
+  });
+});
+
+describe("the empty (buildable) note paints no leading separator", () => {
+  const uncovered = { covered: false, reason: "uncovered" as const, hits: [], total: 0 };
+
+  // Regression for the slow-search suffix rendering unconditionally: the
+  // `buildable` branch of the note cascade returns null (the `.fh-index-cta`
+  // callout carries the message instead), so the suffix used to be the ONLY
+  // content of the paragraph — a leading "· Searching…" separating nothing.
+  test("the slow-search suffix drops its leading dot while the note is empty", async () => {
+    const box = mount(scanStatus({ scanning: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    expect(noteText(box)).toBe("");
+
+    // Extend the query so a new request is pending (and left hanging). The
+    // debounce timer and the `slow` timer are each scheduled by an effect
+    // that only runs once React re-renders on the PREVIOUS timer firing, so
+    // each has to fire in its own flush — advancing past both in one call
+    // races ahead of the effect that schedules the second timer.
+    await flush(() => box.input().props.onChange({ target: { value: "reports" } }));
+    await flush(() => clock.advance(INSTANT_DEBOUNCE_MS)); // past the leading debounce
+    await flush(() => clock.advance(PENDING_INDICATOR_MS + 50)); // past the slow threshold
+    expect(noteText(box)).toBe("Searching…");
     box.unmount();
   });
 });

--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -701,12 +701,14 @@ describe("an uncovered index with no scan running offers the scan", () => {
   const uncovered = { covered: false, reason: "uncovered" as const, hits: [], total: 0 };
 
   test("says the files are not indexed rather than that something is coming", async () => {
+    // The message lives in the .fh-index-cta callout, and there only: the
+    // note renders nothing for `buildable`, so it cannot say it twice.
     const box = mount(scanStatus({ scanning: false }));
     await type(box, "report");
     await flush(() => rankCalls[0].resolve(answer(uncovered)));
-    const note = noteText(box);
-    expect(note).toContain("aren’t indexed yet");
-    expect(note).not.toContain("still building");
+    expect(findByClass(box, "fh-index-cta-text")).toHaveLength(1);
+    expect(noteText(box)).not.toContain("aren’t indexed yet");
+    expect(noteText(box)).not.toContain("still building");
     box.unmount();
   });
 
@@ -717,8 +719,8 @@ describe("an uncovered index with no scan running offers the scan", () => {
     const box = mount(scanStatus({ scanning: false }));
     await type(box, "report");
     await flush(() => rankCalls[0].resolve(answer(uncovered)));
-    expect(noteText(box)).toContain("Index them now");
-    const button = findByClass(box, "fh-link-button") as { props: { onClick: () => void } }[];
+    expect(findByClass(box, "fh-index-cta")).toHaveLength(1);
+    const button = findByClass(box, "fh-index-cta-btn") as { props: { onClick: () => void } }[];
     expect(button).toHaveLength(1);
     await flush(() => button[0].props.onClick());
     expect(scanCalls).toEqual(["/api/index/scan"]);
@@ -731,21 +733,22 @@ describe("an uncovered index with no scan running offers the scan", () => {
 
   test("does not re-offer the button while the poll has yet to see the scan", async () => {
     // The POST returns in milliseconds; the poll answers when it answers. In
-    // between, the note used to go straight back to "Index them now" — a
+    // between, the CTA used to go straight back to "Index my files" — a
     // click that reads as a no-op on the one screen whose whole point is that
     // waiting is futile, and whose obvious response is to click again.
     const box = mount(scanStatus({ scanning: false }));
     await type(box, "report");
     await flush(() => rankCalls[0].resolve(answer(uncovered)));
     type Button = { props: { onClick: () => void; disabled?: boolean } };
-    const button = findByClass(box, "fh-link-button") as Button[];
+    const button = findByClass(box, "fh-index-cta-btn") as Button[];
     await flush(() => button[0].props.onClick());
-    expect(noteText(box)).toContain("Starting the scan…");
-    expect((findByClass(box, "fh-link-button") as Button[])[0].props.disabled).toBe(true);
+    expect((findByClass(box, "fh-index-cta-btn") as Button[])[0].props.disabled).toBe(true);
     // Poll catches up: now "building" is the true claim, and it comes with a
-    // count.
+    // count, back in the note (the CTA disappears once `gap` is no longer
+    // `buildable`).
     box.poll(scanStatus({ scanning: true, files: 21 }));
     expect(noteText(box)).toContain("still building");
+    expect(findByClass(box, "fh-index-cta")).toHaveLength(0);
     box.unmount();
   });
 
@@ -760,7 +763,7 @@ describe("an uncovered index with no scan running offers the scan", () => {
     await flush(() => rankCalls[0].resolve(answer({ ...uncovered, reason: "scanning" })));
     const note = noteText(box);
     expect(note).not.toContain("still building");
-    expect(note).toContain("Index them now");
+    expect(findByClass(box, "fh-index-cta-btn")).toHaveLength(1);
     box.unmount();
   });
 
@@ -807,6 +810,45 @@ describe("an uncovered index with no scan running offers the scan", () => {
     const note = noteText(box);
     expect(note).toContain("can’t be indexed");
     expect(note).not.toContain("Index them now");
+    box.unmount();
+  });
+});
+
+// AI search executes its spec against the same file index
+// (routers/search._search_index), so offering it — or promising it "can
+// answer in the meantime" — when there is no index built is a dead end: the
+// click produces the exact "file index has not been built yet" error the
+// note was standing next to. `aiSearchUsable`/`has_index` gate that offer.
+describe("the AI offer is gated on has_index", () => {
+  const uncovered = { covered: false, reason: "mount" as const, hits: [], total: 0 };
+
+  test("has_index: false hides the Search with AI row entirely", async () => {
+    const box = mount(scanStatus({ scanning: false, has_index: false }));
+    await type(box, "zzzqqqnomatch");
+    await flush(() => rankCalls[0].resolve(answer({ hits: [], total: 0 })));
+    expect(findByClass(box, "fh-ai-row")).toHaveLength(0);
+    expect(noteText(box)).not.toContain("AI search");
+    box.unmount();
+  });
+
+  test("has_index: false drops the AI clause from an uncoverable-root note", async () => {
+    const box = mount(scanStatus({ scanning: false, has_index: false }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    const note = noteText(box);
+    expect(note).toContain("can’t be indexed");
+    expect(note).not.toContain("AI search");
+    box.unmount();
+  });
+
+  test("has_index: true keeps the Search with AI row and the note's AI clause", async () => {
+    const box = mount(scanStatus({ scanning: false, has_index: true }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer(uncovered)));
+    const note = noteText(box);
+    expect(note).toContain("can’t be indexed");
+    expect(note).toContain("AI search");
+    expect(findByClass(box, "fh-ai-row")).toHaveLength(1);
     box.unmount();
   });
 });

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -995,7 +995,7 @@ export function FilesSearch({
               </span>
               <button
                 type="button"
-                className="btn btn-primary fh-index-cta-btn"
+                className="btn btn-secondary fh-index-cta-btn"
                 disabled={starting}
                 onClick={startBuild}
               >

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -45,6 +45,7 @@ import {
   MIN_QUERY_CHARS,
   RANK_FETCH_LIMIT,
   activeRow,
+  aiSearchUsable,
   answerFrom,
   formatElapsed,
   homeCountNote,
@@ -820,6 +821,11 @@ export function FilesSearch({
     displayAnswer !== null && !displayAnswer.covered
       ? indexGap(displayAnswer.reason, liveScanning)
       : null;
+  // Whether AI search has anything to answer WITH. It executes its spec
+  // against the same file index (`routers/search._search_index`), so with no
+  // index built it fails the same way the instant search did — see
+  // `aiSearchUsable`'s doc comment.
+  const aiUsable = aiSearchUsable(indexScan);
   const [pendingBuild, setPendingBuild] = useState<PendingScan | null>(null);
   // Scoped to the query it was raised on. The note is per-query real estate,
   // and this message REPLACES the "your files aren't indexed yet" diagnosis:
@@ -867,11 +873,13 @@ export function FilesSearch({
   // row, then files, then at most one AI row. `showOpenRow` forces the other
   // two off — the request that would have produced file hits was never sent
   // (7c), and a paid model call is never the intent for something shaped like
-  // a path (7e, independent of whether it actually resolved).
+  // a path (7e, independent of whether it actually resolved). `aiUsable`
+  // gates it too: offering a paid model call that will fail on the same
+  // missing index is a dead end, not an offer.
   const rowModel: RowModel = {
     openRow: showOpenRow,
     fileCount: showOpenRow ? 0 : hits.length,
-    aiRow: searchable && !showOpenRow && address === null,
+    aiRow: searchable && !showOpenRow && address === null && aiUsable,
   };
   const current = activeRow(highlight, rowModel, settled);
 
@@ -973,6 +981,28 @@ export function FilesSearch({
         <AiResults home={home} query={ai.query} result={ai.result} />
       ) : (
         <div className="fh-panel">
+          {/* The one action this screen asks of the user, promoted out of the
+              muted footnote and into a real CTA — a link-button buried mid-
+              sentence at 12px was invisible in testing. The note chain below
+              still has a `gap === "buildable"` case, but it renders nothing:
+              this block is the whole message for that state. */}
+          {gap === "buildable" && (
+            <div className="fh-index-cta">
+              <span className="fh-index-cta-text">
+                {buildFailure !== ""
+                  ? `The scan could not be started: ${buildFailure}`
+                  : "Your files aren’t indexed yet — one scan is all it takes."}
+              </span>
+              <button
+                type="button"
+                className="btn btn-primary fh-index-cta-btn"
+                disabled={starting}
+                onClick={startBuild}
+              >
+                {starting ? "Starting the scan…" : "Index my files"}
+              </button>
+            </div>
+          )}
           <p className="fh-result-note">
             {/* Branch on the ANSWER IN HAND, not on the request state: while a
                 new query is in flight the previous answer is what is on screen,
@@ -1037,34 +1067,22 @@ export function FilesSearch({
                 indexScan && indexScan.files > 0
                   ? ` (${indexScan.files.toLocaleString()} files so far)`
                   : ""
-              } — AI search can answer in the meantime.`
+              }${aiUsable ? " — AI search can answer in the meantime." : ""}`
             ) : gap === "buildable" ? (
-              // Nothing is scanning and nothing will start on its own: the
-              // startup scheduler ran once at boot (and may have been
-              // refused, debounce-skipped, or lost its worker), and this page
-              // — unlike the in-folder box — never asks for a scan. Telling
-              // the user to wait here is a promise the app cannot keep, so
-              // say what is true and offer the scan instead.
-              <>
-                {buildFailure !== ""
-                  ? `The index scan could not be started: ${buildFailure} `
-                  : "Your files aren’t indexed yet. "}
-                <button
-                  type="button"
-                  className="fh-link-button"
-                  disabled={starting}
-                  onClick={startBuild}
-                >
-                  {starting ? "Starting the scan…" : "Index them now"}
-                </button>
-                {" — AI search can answer in the meantime."}
-              </>
+              // Owned by the `.fh-index-cta` block above, not this note — a
+              // paragraph AND a callout saying the same thing would say it
+              // twice. Kept as its own branch so the chain still accounts
+              // for every `IndexGap` value.
+              null
             ) : gap === "unavailable" ? (
               // mount / package / ignored: no scan will ever cover this root,
               // so offering one would be a button that cannot work. There is
               // no live walk on this page to fall back to either (that is the
-              // listing's), which leaves AI search as the honest offer.
-              "This location can’t be indexed — AI search can still answer."
+              // listing's), which leaves AI search as the honest offer —
+              // when the index backing it actually exists.
+              aiUsable
+                ? "This location can’t be indexed — AI search can still answer."
+                : "This location can’t be indexed."
             ) : hits.length === 0 && settled && rowModel.aiRow ? (
               // `hits`, not `answer.hits`: `settled` already rules out
               // `behind` (see `hits`'s own comment — `rankingSettled` is

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -9,7 +9,13 @@ import { basename, formatMtime, formatMtimeFull, formatSize } from "@platform/li
 import { iconForEntry } from "@platform/ui/FileIcons";
 import type { Config, ClaudeSessionFolder, GitRepos, IndexStatus } from "@platform/lib/api";
 import { searchCaveat } from "@apps/explorer/listing/index-caveat";
-import { getClaudeSessionFolders, getGitRepos, indexRank, statPath } from "@platform/lib/api";
+import {
+  getClaudeSessionFolders,
+  getGitRepos,
+  indexRank,
+  startIndexScan,
+  statPath,
+} from "@platform/lib/api";
 import { useUrlVersion } from "@platform/lib/hooks";
 import {
   fsMutationCount,
@@ -42,6 +48,7 @@ import {
   answerFrom,
   formatElapsed,
   homeCountNote,
+  indexGap,
   isAiRow,
   isOpenRow,
   nameStart,
@@ -789,6 +796,41 @@ export function FilesSearch({
       ? searchCaveat(indexScan, { behind, pending, rescanPending: indexRescanPending() })
       : null;
 
+  // Why an uncovered answer is uncovered, and — for the one value of that the
+  // user can act on — the action itself (lib/home-search's `indexGap`).
+  //
+  // `indexScan?.scanning` is fed in alongside the answer's own `reason` so a
+  // scan started since the last keystroke counts: the button below flips the
+  // note to "building" off the poll, a second later, rather than sitting on
+  // "not indexed" until something else re-ranks.
+  const gap =
+    displayAnswer !== null && !displayAnswer.covered
+      ? indexGap(displayAnswer.reason, indexScan?.scanning === true)
+      : null;
+  const [building, setBuilding] = useState(false);
+  const [buildError, setBuildError] = useState("");
+  // POST /api/index/scan with no root — every configured root, and NOT
+  // `requestFolderScan`, whose 15-minute debounce is right for a keystroke and
+  // wrong for a button: the whole reason the user is looking at this button is
+  // that a scan started minutes ago and left nothing behind, which is exactly
+  // what that debounce would refuse.
+  //
+  // `building` only covers the request. Once it returns, the status poll owns
+  // the state — it is what `gap` reads, and it is what survives this component
+  // remounting mid-scan.
+  const startBuild = () => {
+    if (building) return;
+    setBuilding(true);
+    setBuildError("");
+    startIndexScan().then(
+      () => setBuilding(false),
+      (err: Error) => {
+        setBuilding(false);
+        setBuildError(err.message);
+      },
+    );
+  };
+
   // The row-model descriptor (lib/home-search): at most one leading "Open"
   // row, then files, then at most one AI row. `showOpenRow` forces the other
   // two off — the request that would have produced file hits was never sent
@@ -937,7 +979,7 @@ export function FilesSearch({
               // Never settled once for this typing run yet — nothing held to
               // fall back on, so there is nothing else honest to say.
               "Searching…"
-            ) : !displayAnswer.covered && displayAnswer.reason === "disabled" ? (
+            ) : gap === "disabled" ? (
               // Distinct from "still building": nothing is coming, because
               // nothing is scanning, because the user turned it off. Saying
               // "still building" here would be a lie the user has no way to
@@ -953,10 +995,44 @@ export function FilesSearch({
                 </button>
                 .
               </>
-            ) : !displayAnswer.covered ? (
+            ) : gap === "scanning" ? (
               // Never "no matches" for an index that has not been built: that
-              // would blame the user's files for the app's state.
-              "The file index is still building — AI search can answer in the meantime."
+              // would blame the user's files for the app's state. The file
+              // count is the listing's chip in words — a claim that something
+              // is coming should be able to show its progress, or it is
+              // indistinguishable from the wedged case below.
+              `The file index is still building${
+                indexScan && indexScan.files > 0
+                  ? ` (${indexScan.files.toLocaleString()} files so far)`
+                  : ""
+              } — AI search can answer in the meantime.`
+            ) : gap === "buildable" ? (
+              // Nothing is scanning and nothing will start on its own: the
+              // startup scheduler ran once at boot (and may have been
+              // refused, debounce-skipped, or lost its worker), and this page
+              // — unlike the in-folder box — never asks for a scan. Telling
+              // the user to wait here is a promise the app cannot keep, so
+              // say what is true and offer the scan instead.
+              <>
+                {buildError !== ""
+                  ? `The index scan could not be started: ${buildError} `
+                  : "Your files aren’t indexed yet. "}
+                <button
+                  type="button"
+                  className="fh-link-button"
+                  disabled={building}
+                  onClick={startBuild}
+                >
+                  {building ? "Starting…" : "Index them now"}
+                </button>
+                {" — AI search can answer in the meantime."}
+              </>
+            ) : gap === "unavailable" ? (
+              // mount / package / ignored: no scan will ever cover this root,
+              // so offering one would be a button that cannot work. There is
+              // no live walk on this page to fall back to either (that is the
+              // listing's), which leaves AI search as the honest offer.
+              "This location can’t be indexed — AI search can still answer."
             ) : hits.length === 0 && settled && rowModel.aiRow ? (
               // `hits`, not `answer.hits`: `settled` already rules out
               // `behind` (see `hits`'s own comment — `rankingSettled` is

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -58,10 +58,12 @@ import {
   positionsWithin,
   rankingSettled,
   redirectsToSearch,
+  scanStarting,
   stepHighlight,
   submitRow,
   type HomeAnswer,
   type HomeHit,
+  type PendingScan,
   type RowModel,
 } from "@apps/explorer/lib/home-search";
 import { renderHighlight } from "@apps/explorer/listing/bits";
@@ -339,12 +341,21 @@ export function FilesSearch({
   initialQuery,
   indexScan,
   onActiveChange,
+  onScanRequested,
 }: {
   home: string;
   initialQuery: string;
   /** The shared index poll (see FilesHome) — this box adds no poller of its own. */
   indexScan: IndexStatus | null;
   onActiveChange: (active: boolean) => void;
+  /**
+   * A scan was just started from in here, so the shared poll should look
+   * again NOW. Owning the poll is the parent's job (one poller, several
+   * consumers), which also means only the parent can shorten its beat: while
+   * idle it is on a ten-second timer, and a run that this box asked for should
+   * not have to wait that out to be admitted to exist.
+   */
+  onScanRequested: () => void;
 }) {
   const [query, setQuery] = useState(initialQuery);
   const [ai, setAi] = useState<AiPhase>(AI_OFF);
@@ -799,34 +810,49 @@ export function FilesSearch({
   // Why an uncovered answer is uncovered, and — for the one value of that the
   // user can act on — the action itself (lib/home-search's `indexGap`).
   //
-  // `indexScan?.scanning` is fed in alongside the answer's own `reason` so a
-  // scan started since the last keystroke counts: the button below flips the
-  // note to "building" off the poll, a second later, rather than sitting on
-  // "not indexed" until something else re-ranks.
+  // The poll's scan state is fed in alongside the answer's own `reason`, as a
+  // TRI-STATE: `null` while the poll has not answered, so that a definite
+  // "nothing is running" can contradict a `reason` frozen at rank time in
+  // either direction (see `indexGap`). `indexScan?.scanning === true` would
+  // collapse "no answer yet" into "idle" and lose half of that.
+  const liveScanning = indexScan === null ? null : indexScan.scanning;
   const gap =
     displayAnswer !== null && !displayAnswer.covered
-      ? indexGap(displayAnswer.reason, indexScan?.scanning === true)
+      ? indexGap(displayAnswer.reason, liveScanning)
       : null;
-  const [building, setBuilding] = useState(false);
-  const [buildError, setBuildError] = useState("");
+  const [pendingBuild, setPendingBuild] = useState<PendingScan | null>(null);
+  // Scoped to the query it was raised on. The note is per-query real estate,
+  // and this message REPLACES the "your files aren't indexed yet" diagnosis:
+  // held across keystrokes, one failed click (a 409 from the pref being
+  // flipped in another window, say) would prefix every later uncovered query
+  // with a stale complaint and hide the actual state. Typing is the retry
+  // gesture here, the same as `retryNonce`.
+  const [buildError, setBuildError] = useState<{ query: string; message: string } | null>(
+    null,
+  );
+  const buildFailure = buildError !== null && buildError.query === q ? buildError.message : "";
+  const starting = scanStarting(pendingBuild, liveScanning, indexScan?.last_completed_at ?? null, Date.now());
   // POST /api/index/scan with no root — every configured root, and NOT
   // `requestFolderScan`, whose 15-minute debounce is right for a keystroke and
   // wrong for a button: the whole reason the user is looking at this button is
   // that a scan started minutes ago and left nothing behind, which is exactly
   // what that debounce would refuse.
   //
-  // `building` only covers the request. Once it returns, the status poll owns
-  // the state — it is what `gap` reads, and it is what survives this component
-  // remounting mid-scan.
+  // `pendingBuild` covers the request AND the wait for the poll to see the run
+  // it started (`scanStarting`); after that the poll owns the state, because
+  // the poll is what `gap` reads and what survives this component remounting
+  // mid-scan. `onScanRequested` re-fires that poll immediately rather than
+  // leaving the run unseen until the next idle beat — the latch is the honest
+  // bridge across the round trip, not a substitute for asking.
   const startBuild = () => {
-    if (building) return;
-    setBuilding(true);
-    setBuildError("");
+    if (starting) return;
+    setPendingBuild({ at: Date.now(), completedAt: indexScan?.last_completed_at ?? null });
+    setBuildError(null);
     startIndexScan().then(
-      () => setBuilding(false),
+      () => onScanRequested(),
       (err: Error) => {
-        setBuilding(false);
-        setBuildError(err.message);
+        setPendingBuild(null);
+        setBuildError({ query: q, message: err.message });
       },
     );
   };
@@ -1014,16 +1040,16 @@ export function FilesSearch({
               // the user to wait here is a promise the app cannot keep, so
               // say what is true and offer the scan instead.
               <>
-                {buildError !== ""
-                  ? `The index scan could not be started: ${buildError} `
+                {buildFailure !== ""
+                  ? `The index scan could not be started: ${buildFailure} `
                   : "Your files aren’t indexed yet. "}
                 <button
                   type="button"
                   className="fh-link-button"
-                  disabled={building}
+                  disabled={starting}
                   onClick={startBuild}
                 >
-                  {building ? "Starting…" : "Index them now"}
+                  {starting ? "Starting the scan…" : "Index them now"}
                 </button>
                 {" — AI search can answer in the meantime."}
               </>
@@ -1249,7 +1275,10 @@ export default function FilesHome({ config }: { config: Config }) {
   // starting mid-session would otherwise go unnoticed by the box. One poller,
   // two consumers, the listing's rule (poll only while a search is open) still
   // honoured for the search half.
-  const indexScan = useIndexStatus(reposNeedsIndexPoll(repos) || searching);
+  // Bumped when the search box starts a scan: `useIndexStatus` restarts on a
+  // new nonce, which turns the idle ten-second beat into an immediate look.
+  const [indexNonce, setIndexNonce] = useState(0);
+  const indexScan = useIndexStatus(reposNeedsIndexPoll(repos) || searching, indexNonce);
   // Refetch whenever the index's OBSERVABLE STATE changes — not when a scan
   // "completes". Completion was the previous trigger and it was subtly wrong:
   // `last_completed_at` is read off the manifest, and a cancelled, failed or
@@ -1337,6 +1366,7 @@ export default function FilesHome({ config }: { config: Config }) {
             initialQuery={initialQuery}
             indexScan={indexScan}
             onActiveChange={setSearching}
+            onScanRequested={() => setIndexNonce((n) => n + 1)}
           />
         </header>
 

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -830,8 +830,14 @@ export function FilesSearch({
   const [buildError, setBuildError] = useState<{ query: string; message: string } | null>(
     null,
   );
-  const buildFailure = buildError !== null && buildError.query === q ? buildError.message : "";
-  const starting = scanStarting(pendingBuild, liveScanning, indexScan?.last_completed_at ?? null, Date.now());
+  const buildFailure =
+    buildError !== null && buildError.query === q ? buildError.message : "";
+  const starting = scanStarting(
+    pendingBuild,
+    liveScanning,
+    indexScan?.last_completed_at ?? null,
+    Date.now(),
+  );
   // POST /api/index/scan with no root — every configured root, and NOT
   // `requestFolderScan`, whose 15-minute debounce is right for a keystroke and
   // wrong for a button: the whole reason the user is looking at this button is

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -817,10 +817,28 @@ export function FilesSearch({
   // either direction (see `indexGap`). `indexScan?.scanning === true` would
   // collapse "no answer yet" into "idle" and lose half of that.
   const liveScanning = indexScan === null ? null : indexScan.scanning;
+  // Two renderers read `gap` — the note's ternary cascade below and the
+  // `.fh-index-cta` callout — so the guards deciding whether this screen is
+  // reporting on an uncovered answer AT ALL belong in the value, not repeated
+  // at each reader where they would drift apart. They are the cascade's own
+  // earlier branches: `showOpenRow`, `!searchable` and `suppressRank` each
+  // short-circuit it before any `gap === …` case, because a held answer must
+  // not describe a search that was never sent (see `hits` and `suppressRank`).
+  // Without them here, a stale uncovered `displayAnswer` puts "Index my files"
+  // on screen underneath "Keep typing…" or an "Open this path" row — two
+  // claims about what the screen means, only one of them true.
   const gap =
-    displayAnswer !== null && !displayAnswer.covered
+    displayAnswer !== null &&
+    !displayAnswer.covered &&
+    !showOpenRow &&
+    searchable &&
+    !suppressRank
       ? indexGap(displayAnswer.reason, liveScanning)
       : null;
+  // The `buildable` branch yields nothing — the `.fh-index-cta` callout is the
+  // message for that state — so the note paragraph is empty and the suffix's
+  // leading "·" would separate nothing.
+  const noteEmpty = gap === "buildable";
   // Whether AI search has anything to answer WITH. It executes its spec
   // against the same file index (`routers/search._search_index`), so with no
   // index built it fails the same way the instant search did — see
@@ -868,6 +886,16 @@ export function FilesSearch({
       },
     );
   };
+
+  // The latch bridges ONE round trip: the POST returning before the poll can
+  // see the run it started. Once the poll reports a run, that job is done and
+  // the poll owns the state — holding the latch any longer means a run that
+  // starts and then dies inside the grace window re-arms it, putting
+  // "Starting the scan…" back on screen for a scan that is already gone and
+  // disabling the retry.
+  useEffect(() => {
+    if (liveScanning === true) setPendingBuild(null);
+  }, [liveScanning]);
 
   // The row-model descriptor (lib/home-search): at most one leading "Open"
   // row, then files, then at most one AI row. `showOpenRow` forces the other
@@ -1129,7 +1157,9 @@ export function FilesSearch({
                 (see `displayAnswer`, above), and this suffix is what tells the
                 user a fresh answer for `q` is still on the way. */}
             {searchable && !showOpenRow && slow && displayAnswer !== null && (
-              <span className="fh-searching-note"> · Searching…</span>
+              <span className="fh-searching-note">
+                {noteEmpty ? "Searching…" : " · Searching…"}
+              </span>
             )}
             {caveat && (
               <span className="fh-index-chip" title={caveat.title}>

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -5,6 +5,7 @@ import {
   answerFrom,
   formatElapsed,
   homeCountNote,
+  indexGap,
   isAiRow,
   isOpenRow,
   nameStart,
@@ -571,5 +572,44 @@ describe("redirectsToSearch", () => {
     // Not merely redundant: focusing on every keystroke would reset the caret
     // to the end, so editing the middle of a query would be impossible.
     expect(redirectsToSearch(key({ tagName: "INPUT", isSearchInput: true }))).toBe(false);
+  });
+});
+
+describe("indexGap", () => {
+  it("separates a scan that is running from one that is not", () => {
+    // The distinction the page did not make, and the whole of the
+    // sit-on-"indexing"-for-20-minutes report: `uncovered` with nothing
+    // running is not a build in progress, it is a build that has to be asked
+    // for.
+    expect(indexGap("scanning", false)).toBe("scanning");
+    expect(indexGap("uncovered", false)).toBe("buildable");
+  });
+
+  it("takes the live poll's word for a scan the answer predates", () => {
+    // `reason` was fixed when the answer was ranked, so the scan the user
+    // just started is only visible in the status poll until the next query.
+    expect(indexGap("uncovered", true)).toBe("scanning");
+  });
+
+  it("never claims a scan while indexing is off", () => {
+    // Nothing can be in flight with the pref off — every trigger is gated and
+    // a running scan is cancelled at toggle-off — so a lagging `scanning`
+    // from the poll must not out-vote it, or the note promises a build that
+    // cannot start.
+    expect(indexGap("disabled", true)).toBe("disabled");
+    expect(indexGap("disabled", false)).toBe("disabled");
+  });
+
+  it("calls the permanently uncoverable reasons what they are", () => {
+    // Offering "index it now" for these would be a button that cannot work.
+    for (const r of ["mount", "package", "ignored"] as const)
+      expect(indexGap(r, false)).toBe("unavailable");
+  });
+
+  it("treats an unnamed miss as buildable", () => {
+    // `""` only reaches here if a not-covered answer arrived without a
+    // reason; a scan is the one thing that could fix it, so offer that
+    // rather than a dead end.
+    expect(indexGap("", false)).toBe("buildable");
   });
 });

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -3,6 +3,7 @@ import {
   HOME_RESULT_CAP,
   SCAN_START_GRACE_MS,
   activeRow,
+  aiSearchUsable,
   answerFrom,
   formatElapsed,
   homeCountNote,
@@ -574,6 +575,25 @@ describe("redirectsToSearch", () => {
     // Not merely redundant: focusing on every keystroke would reset the caret
     // to the end, so editing the middle of a query would be impossible.
     expect(redirectsToSearch(key({ tagName: "INPUT", isSearchInput: true }))).toBe(false);
+  });
+});
+
+describe("aiSearchUsable", () => {
+  it("offers AI search before the poll has answered", () => {
+    // `null` is "no status yet"; hiding the row for the first second of every
+    // page load would be its own wrong answer.
+    expect(aiSearchUsable(null)).toBe(true);
+  });
+
+  it("withholds the offer with no index built", () => {
+    // AI search executes its spec against the same file index
+    // (routers/search._search_index) — with nothing built it raises
+    // IndexUnavailable, so offering the row is a click into a wall.
+    expect(aiSearchUsable({ has_index: false })).toBe(false);
+  });
+
+  it("offers it once the index exists", () => {
+    expect(aiSearchUsable({ has_index: true })).toBe(true);
   });
 });
 

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   HOME_RESULT_CAP,
+  SCAN_START_GRACE_MS,
   activeRow,
   answerFrom,
   formatElapsed,
@@ -15,6 +16,7 @@ import {
   positionsWithin,
   rankingSettled,
   redirectsToSearch,
+  scanStarting,
   stepHighlight,
   submitRow,
   type HomeAnswer,
@@ -581,7 +583,7 @@ describe("indexGap", () => {
     // sit-on-"indexing"-for-20-minutes report: `uncovered` with nothing
     // running is not a build in progress, it is a build that has to be asked
     // for.
-    expect(indexGap("scanning", false)).toBe("scanning");
+    expect(indexGap("scanning", true)).toBe("scanning");
     expect(indexGap("uncovered", false)).toBe("buildable");
   });
 
@@ -589,6 +591,23 @@ describe("indexGap", () => {
     // `reason` was fixed when the answer was ranked, so the scan the user
     // just started is only visible in the status poll until the next query.
     expect(indexGap("uncovered", true)).toBe("scanning");
+  });
+
+  it("demotes a stale `scanning` once the poll says nothing is running", () => {
+    // The other way into the same wedge: the rank landed while the startup
+    // scan was alive, then that worker was killed. Status goes idle,
+    // `last_completed_at` never moves so nothing re-ranks, and a `reason`
+    // frozen at "scanning" would keep promising a build (with a frozen file
+    // count for evidence) until the user gave up.
+    expect(indexGap("scanning", false)).toBe("buildable");
+  });
+
+  it("trusts `reason` while the poll has not answered", () => {
+    // `null` is "no status yet", not "idle" — demoting on it would flash
+    // "your files aren't indexed" over a scan that is genuinely running, on
+    // every first paint.
+    expect(indexGap("scanning", null)).toBe("scanning");
+    expect(indexGap("uncovered", null)).toBe("buildable");
   });
 
   it("never claims a scan while indexing is off", () => {
@@ -611,5 +630,46 @@ describe("indexGap", () => {
     // reason; a scan is the one thing that could fix it, so offer that
     // rather than a dead end.
     expect(indexGap("", false)).toBe("buildable");
+  });
+});
+
+describe("scanStarting", () => {
+  const at = 1_000_000;
+  const pending = { at, completedAt: 500 };
+
+  it("is false with nothing requested", () => {
+    expect(scanStarting(null, false, 500, at)).toBe(false);
+  });
+
+  it("holds the claim across the gap between the POST and the poll", () => {
+    // The window the button was previously re-offered in: the request has
+    // returned, the idle poll is up to ten seconds from its next look, and
+    // status still says idle with the same completion stamp.
+    expect(scanStarting(pending, false, 500, at + 900)).toBe(true);
+    // No status at all yet counts the same way.
+    expect(scanStarting(pending, null, null, at + 900)).toBe(true);
+  });
+
+  it("hands off as soon as the poll sees the run", () => {
+    // From here `indexGap` says "scanning" and the note has a live file count
+    // to show, which is a better claim than this one.
+    expect(scanStarting(pending, true, 500, at + 900)).toBe(false);
+  });
+
+  it("hands off to a scan that finished before the poll looked", () => {
+    // A small root can be scanned and done inside one poll interval, so
+    // "starting" must also end on a MOVED completion stamp — otherwise a
+    // finished scan keeps the button disabled.
+    expect(scanStarting(pending, false, 900, at + 900)).toBe(false);
+  });
+
+  it("gives up rather than claim a start forever", () => {
+    // A scan that died between two polls without writing a completion stamp
+    // leaves status idle and the stamp frozen — indistinguishable, from here,
+    // from a request the poll simply has not caught up with. After the grace
+    // window the button comes back, because clicking again is the one thing
+    // that can help and staring at "Starting the scan…" is the bug this file
+    // exists to fix.
+    expect(scanStarting(pending, false, 500, at + SCAN_START_GRACE_MS)).toBe(false);
   });
 });

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -510,3 +510,49 @@ export function submitRow(
 ): number | null {
   return activeRow(highlight, m, settled);
 }
+
+// -- why there is no index answer --------------------------------------------
+
+/**
+ * The four states a not-covered answer can be in. They differ in what the
+ * user can do about it, which is the only reason to tell them apart.
+ *
+ *  * `scanning` — a scan is running, so waiting really is the advice.
+ *  * `buildable` — the root is not in the index and NOTHING is running.
+ *    Waiting fixes nothing; only a scan does.
+ *  * `disabled` — the indexing pref is off, so no scan can start until it is
+ *    back on.
+ *  * `unavailable` — mount-backed, inside a package, or pruned by the ignore
+ *    rules: no scan will ever cover it (see `RankReason`).
+ */
+export type IndexGap = "scanning" | "buildable" | "disabled" | "unavailable";
+
+/**
+ * Which of those an uncovered root is in.
+ *
+ * The page used to render one message — "the file index is still building" —
+ * for every `reason`, and that message is a promise that something is coming.
+ * For `uncovered` nothing is: this page never asks for a scan (that is the
+ * in-folder box's `requestFolderScan`) and the startup scheduler runs once per
+ * boot, so a first scan that was refused, debounce-skipped, or died with its
+ * worker leaves the page promising a build that no longer exists — for as long
+ * as the user is willing to stare at it. `buildable` is that case as its own
+ * state, so the page can offer the scan instead of describing one.
+ *
+ * `scanning` is read from the LIVE status poll as well as from `reason`:
+ * `reason` was fixed when the answer was ranked, so a scan started since the
+ * last keystroke (by the user's own button, or by anything else) shows up in
+ * the poll a second later and in `reason` only on the next query.
+ *
+ * `disabled` outranks the poll because nothing can be in flight while the pref
+ * is off — every trigger is gated on it, and a scan running at the moment of
+ * toggle-off is cancelled outright (routers/index.cancel_all_scans).
+ */
+export function indexGap(reason: RankReason, scanning: boolean): IndexGap {
+  if (reason === "disabled") return "disabled";
+  if (scanning || reason === "scanning") return "scanning";
+  if (reason === "mount" || reason === "package" || reason === "ignored") {
+    return "unavailable";
+  }
+  return "buildable";
+}

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -23,7 +23,8 @@
 //
 //  * a cold index. The home page has no live-walk fallback (that is the
 //    listing's job, one folder at a time), so an uncovered root is reported as
-//    "still building", never as "no matches" — blaming the user's files for
+//    the state of the INDEX (`indexGap`, below — building, not built, off, or
+//    never coverable), never as "no matches" — blaming the user's files for
 //    the app's state is exactly the failure the server's search refuses to
 //    make.
 //  * the WAIT. Ranking used to be local, so results repainted within a frame
@@ -110,10 +111,10 @@ export interface HomeAnswer {
   covered: boolean;
   /**
    * WHY, when `covered` is false — carried through verbatim from the
-   * server's `reason` (platform/lib/api.ts's `RankReason`). FilesHome reads
-   * this only to say "indexing is off" instead of the generic "still
-   * building" when `reason === "disabled"`; every other value renders the
-   * same not-covered message it always has.
+   * server's `reason` (platform/lib/api.ts's `RankReason`). FilesHome pairs
+   * it with the live scan poll to pick which of the four not-covered states
+   * the root is in, and only one of them tells the user to wait: see
+   * `indexGap`.
    */
   reason: RankReason;
   /**
@@ -539,20 +540,78 @@ export type IndexGap = "scanning" | "buildable" | "disabled" | "unavailable";
  * as the user is willing to stare at it. `buildable` is that case as its own
  * state, so the page can offer the scan instead of describing one.
  *
- * `scanning` is read from the LIVE status poll as well as from `reason`:
- * `reason` was fixed when the answer was ranked, so a scan started since the
- * last keystroke (by the user's own button, or by anything else) shows up in
- * the poll a second later and in `reason` only on the next query.
+ * `scanning` is read from the LIVE status poll as well as from `reason`, and
+ * the poll wins in BOTH directions — which is why it is tri-state (`null` is
+ * "the poll has not answered yet", not "idle"):
+ *
+ *  * `reason` was fixed when the answer was ranked, so a scan started since
+ *    the last keystroke (by the user's own button, or by anything else) shows
+ *    up in the poll a second later and in `reason` only on the next query.
+ *  * a definite `false` DEMOTES `reason === "scanning"` to `buildable`. A rank
+ *    that landed while the startup scan was alive says "scanning" forever
+ *    after: if that worker is then killed, `/api/index/status` reports idle
+ *    (runner._with_liveness, after ABANDONED_RUN_S) but `last_completed_at`
+ *    never moves, so no lifecycle event fires and nothing re-ranks. Trusting
+ *    the frozen `reason` there is the twenty-minute wedge again, wearing the
+ *    other reason's clothes — and with a frozen file count to make it
+ *    convincing.
  *
  * `disabled` outranks the poll because nothing can be in flight while the pref
  * is off — every trigger is gated on it, and a scan running at the moment of
  * toggle-off is cancelled outright (routers/index.cancel_all_scans).
  */
-export function indexGap(reason: RankReason, scanning: boolean): IndexGap {
+export function indexGap(reason: RankReason, scanning: boolean | null): IndexGap {
   if (reason === "disabled") return "disabled";
-  if (scanning || reason === "scanning") return "scanning";
+  if (scanning === true) return "scanning";
+  if (reason === "scanning" && scanning === null) return "scanning";
   if (reason === "mount" || reason === "package" || reason === "ignored") {
     return "unavailable";
   }
   return "buildable";
+}
+
+/**
+ * A scan this page asked for that the status poll has not accounted for yet.
+ *
+ * `at` is `Date.now()` when the request went out, `completedAt` the
+ * `last_completed_at` it went out under.
+ */
+export interface PendingScan {
+  at: number;
+  completedAt: number | null;
+}
+
+/**
+ * How long a requested scan may stay unaccounted for before the note stops
+ * claiming it is starting. Two idle poll intervals
+ * (`INDEX_IDLE_POLL_MS`) — long enough that the poll has certainly had a turn,
+ * short enough that a scan which died between two polls without moving
+ * `last_completed_at` cannot leave "Starting…" on screen indefinitely. That
+ * failure mode is the one this whole file is about; it does not get to come
+ * back as the spinner for its own fix.
+ */
+export const SCAN_START_GRACE_MS = 20_000;
+
+/**
+ * Whether to say a requested scan is starting rather than re-offer the button.
+ *
+ * The POST returning is not the scan appearing. While idle the shared poll is
+ * on a ten-second beat, so between "started" and "scanning" the answer's
+ * `reason` is still `uncovered` and the note would go back to offering "Index
+ * them now" — a click that reads as a no-op on the one screen whose whole
+ * point is that waiting is futile, and whose obvious response is to click
+ * again. The claim is held until the poll either shows the scan running or
+ * shows it already over (`last_completed_at` moved).
+ */
+export function scanStarting(
+  pending: PendingScan | null,
+  scanning: boolean | null,
+  completedAt: number | null,
+  now: number,
+): boolean {
+  if (pending === null) return false;
+  if (now - pending.at >= SCAN_START_GRACE_MS) return false;
+  if (scanning === null) return true;
+  if (scanning) return false;
+  return completedAt === pending.completedAt;
 }

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -571,6 +571,29 @@ export function indexGap(reason: RankReason, scanning: boolean | null): IndexGap
 }
 
 /**
+ * Whether AI search is worth offering.
+ *
+ * AI search is not a second engine. The spec the model produces is executed
+ * against the SAME file index — `routers/search._search_index`, whose
+ * docstring says "the only engine" — so with nothing built it raises
+ * `IndexUnavailable` and reports "the file index has not been built yet". That
+ * is the message the note is standing next to, which makes "AI search can
+ * answer in the meantime" false in exactly the state that printed it, and the
+ * "Search with AI" row a click into the same wall.
+ *
+ * A root the index deliberately does not cover (mount / package / ignored) is
+ * a different case: the index is built, so AI search does answer — just not
+ * about that root's files. `has_index` is the right question either way.
+ *
+ * `null` — no poll answer yet — offers it. `has_index` is false on a cold
+ * poll, and hiding the row for the first second of every page load would be
+ * its own wrong answer.
+ */
+export function aiSearchUsable(status: { has_index: boolean } | null): boolean {
+  return status === null || status.has_index;
+}
+
+/**
  * A scan this page asked for that the status poll has not accounted for yet.
  *
  * `at` is `Date.now()` when the request went out, `completedAt` the

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -551,8 +551,10 @@ export interface IndexRankHit {
 // Why a ranked answer is what it is. `""` is a real answer; the rest are the
 // five ways the index cannot give one, and they are NOT interchangeable —
 // `uncovered` is fixed by scanning the folder, `scanning` by waiting, and the
-// other three never (see listing/index-source, which is the only place that
-// switches on this). `disabled` is the one of those three that can become
+// other three never. Two places switch on this: listing/index-source picks the
+// in-folder box's SOURCE from it, and explorer/lib/home-search's `indexGap`
+// turns it into what the home box tells the user. `disabled` is the one of
+// those three that can become
 // fixable again — turning the indexing preference back on — but the client
 // does not wait around for that: it walks, exactly as it does for `mount` /
 // `package` / `ignored`, because there is no server signal to poll for "the

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -432,7 +432,10 @@ export default function Home({ config }: { config: Config }) {
   // as the explorer home. The index poll only runs while the box needs its
   // "indexing…" caveat.
   const [searching, setSearching] = useState(false);
-  const indexScan = useIndexStatus(searching);
+  // Bumped when the box starts a scan, so the poll looks again immediately
+  // instead of on its next idle beat (see FilesSearch's `onScanRequested`).
+  const [indexNonce, setIndexNonce] = useState(0);
+  const indexScan = useIndexStatus(searching, indexNonce);
   const initialQuery = useRef(new URLSearchParams(location.search).get("q") || "").current;
 
   return (
@@ -444,6 +447,7 @@ export default function Home({ config }: { config: Config }) {
             initialQuery={initialQuery}
             indexScan={indexScan}
             onActiveChange={setSearching}
+            onScanRequested={() => setIndexNonce((n) => n + 1)}
           />
         </header>
 

--- a/frontend/src/shell/Indexing.tsx
+++ b/frontend/src/shell/Indexing.tsx
@@ -184,6 +184,17 @@ export function IndexingPanel({
               : ""}
           </p>
         )}
+        {/* How the last scan ENDED, when it ended badly. Nothing used to show
+            this anywhere in the app: a worker that dies without a `run_end`
+            (killed, OOM, a spawn that never reached Python) reads as
+            `scanning` for ABANDONED_RUN_S and then simply stops, leaving "No
+            index yet" with nothing running and no reason given — which is how
+            a first-run failure can be waited out for twenty minutes. Only
+            while idle: mid-scan this is the PREVIOUS run's verdict, and the
+            counts above are the live story. */}
+        {status && status.error && !scanning && (
+          <ErrorBanner>The last scan did not finish: {status.error}</ErrorBanner>
+        )}
         <div className="prefs-actions">
           <button
             type="button"

--- a/frontend/src/shell/Indexing.tsx
+++ b/frontend/src/shell/Indexing.tsx
@@ -24,6 +24,7 @@ import { SkeletonLines } from "@platform/ui/Skeleton";
 import {
   missingDefaults,
   patternsToText,
+  scanErrorLine,
   textToPatterns,
   unionWithDefaults,
 } from "./indexing-lib";
@@ -193,7 +194,9 @@ export function IndexingPanel({
             while idle: mid-scan this is the PREVIOUS run's verdict, and the
             counts above are the live story. */}
         {status && status.error && !scanning && (
-          <ErrorBanner>The last scan did not finish: {status.error}</ErrorBanner>
+          <ErrorBanner>
+            The last scan did not finish: {scanErrorLine(status.error)}
+          </ErrorBanner>
         )}
         <div className="prefs-actions">
           <button

--- a/frontend/src/shell/indexing-lib.test.ts
+++ b/frontend/src/shell/indexing-lib.test.ts
@@ -1,9 +1,11 @@
 // The pure half of Indexing.tsx: text<->pattern conversion, stale-default
-// detection, and the "Restore defaults" union merge.
+// detection, the "Restore defaults" union merge, and the one line of a failed
+// scan's traceback the panel shows.
 import { describe, expect, it } from "bun:test";
 import {
   missingDefaults,
   patternsToText,
+  scanErrorLine,
   textToPatterns,
   unionWithDefaults,
 } from "./indexing-lib";
@@ -80,5 +82,31 @@ describe("unionWithDefaults", () => {
   it("keeps an interior blank line the user typed", () => {
     const text = "a\n\nb";
     expect(unionWithDefaults(text, ["node_modules"])).toBe("a\n\nb\nnode_modules");
+  });
+});
+
+describe("scanErrorLine", () => {
+  it("pulls the exception out of a Python traceback", () => {
+    // What a failed scan actually reports (traceback.format_exc()). The
+    // actionable half is the last line; the rest is this app's own files.
+    const tb = [
+      "Traceback (most recent call last):",
+      '  File "/opt/fused/index/scan.py", line 214, in _walk',
+      "    store.flush(rows)",
+      "OSError: [Errno 28] No space left on device",
+    ].join("\n");
+    expect(scanErrorLine(tb)).toBe("OSError: [Errno 28] No space left on device");
+  });
+
+  it("passes a one-line error through unchanged", () => {
+    // An abandoned worker's own message is already the whole story.
+    expect(scanErrorLine("worker exited without finishing")).toBe(
+      "worker exited without finishing",
+    );
+  });
+
+  it("survives trailing newlines and an all-blank value", () => {
+    expect(scanErrorLine("ValueError: bad root\n\n")).toBe("ValueError: bad root");
+    expect(scanErrorLine("\n  \n")).toBe("");
   });
 });

--- a/frontend/src/shell/indexing-lib.ts
+++ b/frontend/src/shell/indexing-lib.ts
@@ -52,3 +52,16 @@ export function unionWithDefaults(text: string, defaults: string[]): string {
     lines.length > 0 && lines[lines.length - 1] === "" ? lines.slice(0, -1) : lines;
   return [...base, ...missing].join("\n");
 }
+
+// The one line of a failed scan's `error` worth putting in a settings panel.
+//
+// A scan that raised reports `traceback.format_exc()` (index/scan.py's
+// `run_end msg="failed"`), so the raw value is a multi-line Python traceback:
+// a screen of this app's own file paths, with the only part the user could act
+// on — "No space left on device", "Permission denied" — at the bottom. The
+// last non-empty line IS the exception, and a short one-line error (an
+// abandoned worker's own message) passes through unchanged.
+export function scanErrorLine(error: string): string {
+  const lines = error.split("\n").filter((l) => l.trim() !== "");
+  return lines.length === 0 ? "" : lines[lines.length - 1].trim();
+}

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -298,10 +298,11 @@
   color: var(--fg);
 }
 
+/* Position only — the size, weight and hover come from `.btn.btn-primary`
+   untouched, so this reads as the same button as every other primary action
+   in the app rather than a one-off small variant of it. */
 .fh-index-cta-btn {
   margin-left: auto;
-  padding: 4px 12px;
-  font-size: 12px;
 }
 
 .fh-result-note kbd {

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -298,9 +298,11 @@
   color: var(--fg);
 }
 
-/* Position only — the size, weight and hover come from `.btn.btn-primary`
-   untouched, so this reads as the same button as every other primary action
-   in the app rather than a one-off small variant of it. */
+/* Position only — chassis and hover come from `.btn.btn-secondary` untouched.
+   Secondary, not primary: `.fh-panel` has no surface of its own, so a filled
+   `var(--fg)` primary is a near-white block sitting on the bare page, louder
+   than anything else on it. The bordered button inside the callout is already
+   unmissable next to the 12px muted note it replaced. */
 .fh-index-cta-btn {
   margin-left: auto;
 }

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -276,6 +276,34 @@
   color: var(--fg);
 }
 
+/* The one action the buildable-index screen asks of the user, promoted out
+   of the muted .fh-result-note footnote into a real callout — a link-button
+   buried mid-sentence at 12px tested as invisible. A compact single-row bar,
+   not a full panel: this sits above a results list that is otherwise empty,
+   so it should read as "the thing to do here" without taking over the box. */
+.fh-index-cta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: var(--bg-alt);
+  margin-bottom: 8px;
+}
+
+.fh-index-cta-text {
+  font-size: 13px;
+  color: var(--fg);
+}
+
+.fh-index-cta-btn {
+  margin-left: auto;
+  padding: 4px 12px;
+  font-size: 12px;
+}
+
 .fh-result-note kbd {
   font: inherit;
   padding: 0 4px;


### PR DESCRIPTION
## Summary

- **The explorer home search told a new user the file index was "still building" for twenty minutes while nothing was building.** It rendered one sentence for every uncovered answer, so `reason === "uncovered"` — nothing scanning, nothing scheduled — read exactly like a live scan. This page also never asks for a scan (that's the in-folder box's `requestFolderScan`), and `run_startup_scan` fires once per boot and only logs its refusals, so there was no way out of that sentence.
- **The note now distinguishes the four states an uncovered root can actually be in**, and only one of them tells the user to wait. `buildable` — the wedged case — offers `Index them now`, which posts `/api/index/scan` (every configured root, no debounce; `scan-folder`'s 15-minute floor would refuse exactly this case).
- **The live status poll now outranks the answer's frozen `reason` in both directions.** A rank that landed mid-startup-scan says `"scanning"` forever; kill that worker and `/api/index/status` goes idle while `last_completed_at` never moves, so no lifecycle event re-ranks anything — the same twenty-minute wedge, with a frozen file count as evidence.
- **Preferences → Indexing shows why the last scan died.** A worker that never writes a `run_end` set `status.error` and nothing in the app displayed it.

## Visuals

How an uncovered answer becomes a message. Everything below the first branch is new; the old page had one leaf.

```mermaid
flowchart TD
    A["Uncovered rank answer"] --> B{"indexing pref on?"}
    B -->|"off"| C["Enable it in Preferences"]
    B -->|"on"| D{"status poll"}
    D -->|"scanning"| E["Still building + live count"]
    D -->|"idle"| F{"root coverable?"}
    F -->|"never"| G["Can't be indexed"]
    F -->|"yes"| H["Index them now → POST /api/index/scan"]
```

`status poll` is tri-state: `null` (no answer yet) trusts the answer's own `reason`, a definite `false` demotes a stale `"scanning"` down the `idle` branch.

## Usage

Type a filename into the search box on `/explorer` or `/home` with no index built. Instead of "The file index is still building", a callout sits above the results with a filled button:

> Your files aren't indexed yet — one scan is all it takes.  **[ Index my files ]**

Clicking it starts a whole-index scan, holds the claim ("Starting the scan…") until the poll confirms the run, then the callout gives way to the live "still building (12,345 files so far)" in the note. Results appear on their own when the scan lands — `noteIndexLifecycle` already re-runs the query.

Two states deliberately offer no button: indexing turned off (points at Preferences instead) and a root no scan can ever cover — mount-backed, inside a package, or pruned by the ignore rules.

**AI search is not a fallback, so it is no longer offered as one.** The spec the model writes runs against the same SQL index (`_search_index` — "the only engine"), which raises `IndexUnavailable` with "the file index has not been built yet" when nothing is built. Both the "AI search can answer in the meantime" clause and the "Search with AI" row are now gated on `has_index`. An uncoverable root keeps the AI offer: there the index exists and simply does not cover that path.

Nothing new server-side; both endpoints already existed.

| Where | What's new |
|---|---|
| `/explorer`, `/home` search note | four messages instead of two; live file count; the AI offer gated on `has_index` |
| `/explorer`, `/home` results panel | a callout with a filled **Index my files** button when the index is buildable |
| Preferences → Indexing | "The last scan did not finish: …" while idle |

## Test Plan

- [x] `bun test` — 2968 pass, 0 fail. New unit tests: `indexGap` (both routes into the wedge, plus the `null` poll case), `scanStarting` (the POST↔poll gap, both hand-offs, the grace expiry), `aiSearchUsable`, `scanErrorLine`.
- [x] New render tests in `FilesHome.render.test.tsx`: uncovered-and-idle renders the CTA and posts exactly `/api/index/scan`; the button stays disabled until the poll agrees and the CTA then disappears; the note never repeats the CTA's message; a stale `"scanning"` gives way to an idle poll; `disabled` and `mount` offer no scan button; with `has_index: false` no `.fh-ai-row` renders and no note mentions AI search, and with `has_index: true` both come back.
- [x] `tsc --noEmit` clean; `check:boundaries` OK (424 files).
- [ ] Manual, the original report: delete the index (`~/.fused/index`), restart, type a filename on `/explorer`. Expect the button, not a wait. Click it; the note should not flicker back to offering the button.
- [ ] Manual, the wedge: start a scan, `kill -9` the worker, wait out `ABANDONED_RUN_S` (5 min). The note should drop from "still building" to offering the scan, and Preferences → Indexing should say the last scan did not finish.
- [ ] Manual, no regression when it works: with a healthy index, typing still ranks and paints with no note about building.

## Knowingly left alone

- `IndexStatus.scanning` is global (`any(running)` across roots), so a scan of an unrelated root still reads as "building" for a home root nothing will cover. Per-root scan state is a server change; the existing search caveat chip shares the seam.
- The home page still requires the click rather than auto-requesting one scan the way the in-folder box does. That removes a step, but it's a retry loop on a per-keystroke surface and wants its own guard.
- `Indexing.tsx` has no component test, so the new banner's `!scanning` gate is covered only through `scanErrorLine`'s unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
