### PR TITLE
CI: exclusive-section tests start from an empty store (fixes red frontend job on main)

### DIFF
--- a/frontend/src/platform/lib/exclusiveSection.test.tsx
+++ b/frontend/src/platform/lib/exclusiveSection.test.tsx
@@ -8,9 +8,22 @@
 // own `useAutoExpandOnNew` call never feeds anything into `ids`), so the only
 // tie this arbiter can ever see is still Activity vs Notifications, which is
 // the one case these tests pin.
-import { expect, test } from "bun:test";
+import { beforeEach, expect, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
-import { useExclusiveSection, type SectionKey } from "./exclusiveSection";
+import {
+  resetExclusiveSectionsForTests,
+  useExclusiveSection,
+  type SectionKey,
+} from "./exclusiveSection";
+
+// The arbiter's store is module-level and bun shares one module registry
+// across test files, so a section some OTHER file mounted and never unmounted
+// would still be sitting in it, wanting to be open, and would win or lose
+// ties here that it was never part of. That is exactly what happened on the
+// Linux runner (file order differs from a Mac's): "two sections ... resolve to
+// Activity" and "a LATER request beats ..." went red on every push while the
+// same suite was green locally. Each case starts from an empty store.
+beforeEach(() => resetExclusiveSectionsForTests());
 
 /** A stand-in for one bar section: declares whether it wants to be open and
  *  records every time the arbiter closes it. */

--- a/frontend/src/platform/lib/exclusiveSection.ts
+++ b/frontend/src/platform/lib/exclusiveSection.ts
@@ -85,6 +85,22 @@ function currentTick(): number {
   return tick;
 }
 
+/** Test-only: forget every section and rewind the tick.
+ *
+ *  The store is module-level ON PURPOSE (see the top of the file), and bun
+ *  runs every test file in one module registry — so a section a sibling
+ *  file's test mounted and never unmounted is still in `entries`, wanting to
+ *  be open, when this file's tie-break tests run. Which file runs first is
+ *  readdir order, and readdir order is what differed between a Mac (green)
+ *  and the Linux runner (two tests red on every push). The tests call this
+ *  before each case so they arbitrate over their own sections only. */
+export function resetExclusiveSectionsForTests(): void {
+  entries.clear();
+  closers.clear();
+  tick = 0;
+  tickScheduled = false;
+}
+
 function arbitrate(): void {
   const wanting = [...entries.entries()].filter(([, e]) => e.want);
   if (wanting.length <= 1) return;


### PR DESCRIPTION
## Why
The `frontend` job has been red on main since the status-bar merge (#966): `exclusiveSection.test.tsx` fails two tests on every Linux run — "two sections wanting open in the SAME commit resolve to Activity" and "a LATER request beats whatever was already open" — while the same suite is green on macOS. Every PR inherits the red.

## Root cause
`exclusiveSection.ts` keeps its arbitration store at module level on purpose. bun runs all test files in one module registry, and a sibling file's test mounts a status-bar section it never unmounts, so that section is still in `entries`, wanting to be open, when these tie-break tests run. Which file runs first is readdir order — the part that differs between a Mac and the Linux runner.

## Fix
- `resetExclusiveSectionsForTests()` — test-only export that clears both maps and rewinds the tick.
- `beforeEach` in the test file calls it, so each case arbitrates over its own sections only.

No production behaviour changes.

## Verification
- `bun test` → 2967 pass, 0 fail; `tsc --noEmit` clean.
- CI on this PR is the real check (Linux order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only reset helper and hook in one test file; production arbitration logic is unchanged.
> 
> **Overview**
> Fixes **Linux CI failures** in `exclusiveSection.test.tsx` where two tie-break tests passed on macOS but failed on the runner because Bun shares one module registry across test files and the exclusive-section arbiter keeps state at module scope.
> 
> Adds a **test-only** `resetExclusiveSectionsForTests()` that clears `entries`, `closers`, and the arbitration tick, and wires **`beforeEach`** in the test file so each case starts from an empty store instead of inheriting sections left mounted by other tests (order-dependent via readdir). **No production behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97fa4b57da75d1df8af766349dcbc0e59c626878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->