### PR TITLE
Full Disk Access: two-stage probe, one shared store, and a relaunch that applies the grant

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -3,6 +3,16 @@ import { noteFsMutation, noteIndexLifecycle } from "@platform/lib/index-freshnes
 import { outcomeFrom } from "@platform/lib/index-query";
 import type { IndexQueryOutcome } from "@platform/lib/index-query";
 
+export interface FdaState {
+  // What THIS server process can read. Final for the process's lifetime.
+  granted: boolean;
+  // The two-stage verdict (shell/fda.py): this process cannot read, but a
+  // fresh child of the app can — the grant landed, only a relaunch remains.
+  pending_relaunch: boolean;
+  // An fs route was refused and nobody has dismissed it yet.
+  denied: boolean;
+}
+
 export interface Config {
   start_dir: string;
   home: string;
@@ -30,11 +40,14 @@ export interface Config {
   // the Windows/Linux packages (those update through their supervisor).
   update?: UpdateStatus;
   // Full Disk Access state (fused_render/shell/fda.py) — present only on the
-  // packaged mac app when the probe is conclusive. FdaStrip renders off this;
-  // absent means render nothing and stop watching. `denied` flips when this
-  // session hits a PermissionError on an fs route — the moment the warning
-  // is worth showing; dismissing clears it server-side until the next one.
-  fda?: { granted: boolean; denied: boolean };
+  // packaged mac app when the probe is conclusive. Read through the one store
+  // in platform/lib/fda.ts (FdaStrip + the onboarding FdaStep); absent means
+  // render nothing and stop watching. `pending_relaunch`: a fresh child of
+  // the app can read but this process cannot — the grant landed, relaunch to
+  // apply. `denied` flips when this session hits a PermissionError on an fs
+  // route — the moment the warning is worth showing; dismissing clears it
+  // server-side until the next one.
+  fda?: FdaState;
   // First-run wizard flag (fused_render/shell/onboarding.py). The shell
   // auto-shows the wizard while BOTH timestamps are null; `complete` and
   // `dismiss` are distinct writes (reached the end vs "skip for now").

--- a/frontend/src/platform/lib/fda.ts
+++ b/frontend/src/platform/lib/fda.ts
@@ -1,0 +1,158 @@
+// Full Disk Access state — ONE store for every surface that talks about it.
+//
+// FdaStrip (Home, /apps, the explorer's AccessDenied card) and the onboarding
+// FdaStep used to each poll /api/config on their own timer with their own
+// idea of the state, so a grant could be "seen" by one and not another, and
+// the copy drifted. This module owns the poll, the shape, and the words; the
+// components render.
+//
+// The server (fused_render/shell/fda.py) is the only source of truth: the
+// `fda` field of /api/config, or its absence. Absent = not offered (non-mac,
+// dev server) or inconclusive = render nothing, and this store stops polling.
+//
+// The poll runs only while someone is subscribed and the answer can still
+// change: `granted` is final for this process (a revoke needs a relaunch too),
+// so polling stops there as well. A subscriber joining kicks an immediate
+// fetch — AccessDenied's contract is that the server flipped `denied` inside
+// the very request that failed, so the card's mount-time read must already
+// see it, not wait for the next tick.
+import { useSyncExternalStore } from "react";
+
+import { getConfig, type FdaState } from "@platform/lib/api";
+
+export type { FdaState };
+
+// undefined = not fetched yet; null = the server has no `fda` field.
+export type FdaSnapshot = FdaState | null | undefined;
+
+//: While anyone is watching and the answer can still change. Localhost, and
+//: the server memoizes the one expensive part (the child probe), so one
+//: cadence for every stage is fine.
+export const POLL_MS = 3000;
+
+// The one deep link that respawns the SAME version so a fresh grant takes
+// effect (fused_render/deeplink.py). Rendered as a plain <a>, like the
+// update-restart banner: the OS hands it to the running app, which quits
+// through the normal teardown and respawns; this tab's poll picks the new
+// server up on its own.
+export const RELAUNCH_HREF = "fused-render://relaunch?reason=fda";
+
+// Shared copy, so the wizard step and the strip say the same thing.
+export const FDA_COPY = {
+  steps: [
+    "Open System Settings on the Full Disk Access pane.",
+    "Turn on FusedRender in the list.",
+    "Relaunch FusedRender — the grant applies to the next launch.",
+  ],
+  waiting: "Waiting for the grant… turn FusedRender on in the pane that just opened.",
+  pending: "Full Disk Access is granted. Relaunch FusedRender to apply it.",
+  grantedToast: "Full Disk Access is on — no more prompts",
+  deniedToast: "macOS denied FusedRender access to a file — grant Full Disk Access to fix this",
+  open: "Open System Settings",
+  reopen: "Open System Settings again",
+  relaunch: "Relaunch FusedRender",
+} as const;
+
+let snapshot: FdaSnapshot = undefined;
+const listeners = new Set<() => void>();
+let timer: number | null = null;
+let inflight = false;
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+function set(next: FdaSnapshot) {
+  const prev = snapshot;
+  const same =
+    prev === next ||
+    (prev != null &&
+      next != null &&
+      prev.granted === next.granted &&
+      prev.pending_relaunch === next.pending_relaunch &&
+      prev.denied === next.denied);
+  if (same) return;
+  snapshot = next;
+  emit();
+}
+
+function shouldPoll(): boolean {
+  if (listeners.size === 0) return false;
+  if (snapshot === null) return false; // not offered: nothing will change
+  if (snapshot?.granted) return false; // final for this process
+  return true;
+}
+
+function schedule() {
+  if (timer !== null) return;
+  if (!shouldPoll()) return;
+  timer = window.setTimeout(() => {
+    timer = null;
+    void refresh().finally(schedule);
+  }, POLL_MS);
+}
+
+function stop() {
+  if (timer !== null) {
+    window.clearTimeout(timer);
+    timer = null;
+  }
+}
+
+// Re-read the server now. Returns the fresh snapshot. A failed fetch (server
+// down mid-relaunch, say) keeps the last snapshot rather than blanking it —
+// the strip must not vanish and reappear while the app respawns.
+export async function refresh(): Promise<FdaSnapshot> {
+  if (inflight) return snapshot;
+  inflight = true;
+  try {
+    const config = await getConfig();
+    set(config.fda ?? null);
+  } catch {
+    // keep what we have
+  } finally {
+    inflight = false;
+  }
+  return snapshot;
+}
+
+// Seed from a config the caller already holds (the wizard is handed one), so
+// the first paint does not wait on a round trip.
+export function seedFda(fda: FdaState | undefined) {
+  if (snapshot === undefined) set(fda ?? null);
+}
+
+export function getFda(): FdaSnapshot {
+  return snapshot;
+}
+
+export function subscribeFda(cb: () => void): () => void {
+  listeners.add(cb);
+  if (listeners.size === 1) {
+    void refresh().finally(schedule);
+  } else {
+    schedule();
+  }
+  return () => {
+    listeners.delete(cb);
+    if (listeners.size === 0) stop();
+  };
+}
+
+// Restart the poll after a change that makes it worth watching again — e.g.
+// a dismissal took `denied` down, or the Settings pane was just opened.
+export function pokeFda() {
+  void refresh().finally(schedule);
+}
+
+export function useFda(): FdaSnapshot {
+  return useSyncExternalStore(subscribeFda, getFda, getFda);
+}
+
+// Test seam.
+export function _resetFdaStore() {
+  stop();
+  snapshot = undefined;
+  inflight = false;
+  listeners.clear();
+}

--- a/frontend/src/platform/ui/FdaStrip.tsx
+++ b/frontend/src/platform/ui/FdaStrip.tsx
@@ -15,163 +15,83 @@
 // moment an fs route actually hits a PermissionError — the server flips
 // `fda.denied` on that first denial (fused_render/shell/fda.py), which also
 // catches the silent-deny case above, since the cached deny still surfaces
-// as EPERM on the next read. Until then this renders nothing and quietly
-// watches /api/config.
+// as EPERM on the next read. Until then this renders nothing.
 //
-// macOS has no API to request FDA; explain + open the exact Settings pane is
-// the entire affordance. The `fda` field of /api/config gates everything
-// (fused_render/shell/fda.py): absent (non-mac, dev server, inconclusive
-// probe) means render nothing. "✕" acknowledges the CURRENT denial on the
-// server — every tab converges to hidden — and the next PermissionError
-// raises strip and toast again: dismiss is "not now", not "never".
+// STATE lives in platform/lib/fda.ts — one store, one poll, one set of words,
+// shared with the onboarding FdaStep — so every copy of this strip (Home,
+// /apps, the explorer's AccessDenied card) and the wizard agree. This file
+// only decides what to render for a given snapshot: absent → nothing;
+// granted → nothing (plus one toast if we were showing); pending_relaunch →
+// the Relaunch button; denied → the steps. "✕" acknowledges the CURRENT
+// denial on the server — every tab converges to hidden — and the next
+// PermissionError raises strip and toast again: dismiss is "not now", not
+// "never".
 import { useEffect, useRef, useState } from "react";
 
-import { dismissFdaNudge, getConfig, openFdaSettings } from "@platform/lib/api";
+import { dismissFdaNudge, openFdaSettings } from "@platform/lib/api";
+import { FDA_COPY, RELAUNCH_HREF, pokeFda, useFda } from "@platform/lib/fda";
 import { pushToast } from "@platform/lib/toast";
-
-//: While showing, watch for the grant landing. Most grants only apply to a
-//: relaunched process, but when macOS relaunches the app for us the fresh
-//: server answers granted and a still-open tab converges — and another tab's
-//: dismissal converges the same way.
-const GRANT_POLL_MS = 3000;
-
-//: While hidden but eligible (fda present, not granted), watch for the next
-//: denial so the strip appears when trouble starts — or starts again.
-const WATCH_MS = 5000;
-
-// hidden → (watching) → showing. "watching" renders nothing: the machine
-// qualifies but no fs route has been refused yet.
-type Stage = "hidden" | "watching" | "showing";
 
 //: One toast per DENIAL EPISODE, not per tab lifetime: the strip re-detects
 //: `denied` on every remount, so the flag suppresses repeats — but a
-//: dismissal ends the episode (noteNotDenied resets this), and the next
-//: denial gets its own toast. The toast just breaks the news through the
-//: app's normal queue; the strip itself is the explanation and the fix.
+//: dismissal ends the episode (the flag resets), and the next denial gets its
+//: own toast. The toast just breaks the news through the app's normal queue;
+//: the strip itself is the explanation and the fix.
 let toastShown = false;
 
-function noteDenialToast() {
-  if (toastShown) return;
-  toastShown = true;
-  pushToast({
-    msg: "macOS denied FusedRender access to a file — grant Full Disk Access to fix this",
-    tone: "error",
-  });
-}
-
-function noteNotDenied() {
-  toastShown = false;
-}
-
-// The last stage seen, so walking between Home and /apps — which both render
-// this — starts from what we already know instead of flashing a visible strip
-// away and back while the fresh getConfig is in flight (same seed-not-
-// short-circuit pattern as ClaudeHealthStrip's `cached`). The fetch still
-// runs on every mount and overwrites this.
-let cachedStage: Stage = "hidden";
-
 export function FdaStrip() {
-  const [stage, setStageState] = useState<Stage>(cachedStage);
-  const setStage = (next: Stage) => {
-    cachedStage = next;
-    setStageState(next);
-  };
+  const fda = useFda();
   // "Open System Settings" was pressed: the steps collapse into a one-line
   // "turn it on over there" so the strip reads as in-progress, not nagging.
   const [waiting, setWaiting] = useState(false);
-  const stageRef = useRef(stage);
-  stageRef.current = stage;
-  const showing = stage === "showing";
+  // Whether THIS mount has shown the strip, so the grant toast fires only for
+  // a user who was looking at the warning when the grant landed.
+  const wasShowing = useRef(false);
+
+  const showing = !!fda && !fda.granted && fda.denied;
 
   useEffect(() => {
-    let disposed = false;
-    getConfig()
-      .then((config) => {
-        if (disposed) return;
-        const fda = config.fda;
-        // Explicit "hidden" rather than an early return: the seeded stage can
-        // say "showing" from a previous mount while a grant or another tab's
-        // dismissal has since landed.
-        if (!fda || fda.granted) setStage("hidden");
-        else if (fda.denied) {
-          noteDenialToast();
-          setStage("showing");
-        } else {
-          noteNotDenied();
-          setStage("watching");
-        }
-      })
-      .catch(() => {}); // no config, no warning — the server card owns outages
-    return () => {
-      disposed = true;
-    };
-  }, []);
-
-  // While "watching", wait for the next denial.
-  useEffect(() => {
-    if (stage !== "watching") return;
-    const timer = window.setInterval(() => {
-      getConfig()
-        .then((config) => {
-          if (stageRef.current !== "watching") return;
-          const fda = config.fda;
-          if (!fda || fda.granted) setStage("hidden");
-          else if (fda.denied) {
-            noteDenialToast();
-            setStage("showing");
-          }
-        })
-        .catch(() => {});
-    }, WATCH_MS);
-    return () => window.clearInterval(timer);
-  }, [stage]);
-
-  useEffect(() => {
-    if (!showing) return;
-    const timer = window.setInterval(() => {
-      getConfig()
-        .then((config) => {
-          if (stageRef.current !== "showing") return;
-          const fda = config.fda;
-          if (fda?.granted) {
-            setStage("hidden");
-            // "info" is this app's confirmation tone — there is no green toast
-            // (Toast.tsx), and every other success ("Path copied") is info too.
-            pushToast({ msg: "Full Disk Access is on — no more prompts", tone: "info" });
-          } else if (!fda) {
-            setStage("hidden");
-          } else if (!fda.denied) {
-            // Another tab dismissed (the server cleared its flag). Back to
-            // watching, not hidden: the next denial must resurface the strip —
-            // and start it on the steps, not a stale "In System Settings…".
-            noteNotDenied();
-            setWaiting(false);
-            setStage("watching");
-          }
-        })
-        .catch(() => {});
-    }, GRANT_POLL_MS);
-    return () => window.clearInterval(timer);
-  }, [showing]);
+    if (showing) {
+      wasShowing.current = true;
+      if (!toastShown) {
+        toastShown = true;
+        pushToast({ msg: FDA_COPY.deniedToast, tone: "error" });
+      }
+      return;
+    }
+    if (fda && !fda.denied) {
+      // Dismissed here or in another tab: the episode is over, the next
+      // denial gets its own toast and starts on the steps again.
+      toastShown = false;
+      setWaiting(false);
+    }
+    if (fda?.granted && wasShowing.current) {
+      wasShowing.current = false;
+      // "info" is this app's confirmation tone — there is no green toast
+      // (Toast.tsx), and every other success ("Path copied") is info too.
+      pushToast({ msg: FDA_COPY.grantedToast, tone: "info" });
+    }
+  }, [showing, fda]);
 
   if (!showing) return null;
 
   // "Not now": acknowledge on the server (clears `denied`, every tab hides)
-  // and go back to watching so the next denial brings strip + toast back.
+  // and keep watching so the next denial brings strip + toast back.
   const close = () => {
-    noteNotDenied();
-    // Next episode starts on the steps, not a stale "In System Settings…".
     setWaiting(false);
-    setStage("watching");
-    dismissFdaNudge().catch(() => {});
+    dismissFdaNudge().catch(() => {}).finally(pokeFda);
   };
+
+  const pending = fda.pending_relaunch;
 
   return (
     <section className="claude-health" role="status" aria-label="Full Disk Access setup">
       <div className="claude-health-head">
         {/* Says what is still needed, not that something is broken — same
             posture as ClaudeHealthStrip (SPEC §42: "Nothing red"). */}
-        <h2 className="claude-health-title">Give FusedRender Full Disk Access</h2>
+        <h2 className="claude-health-title">
+          {pending ? "Relaunch to finish Full Disk Access" : "Give FusedRender Full Disk Access"}
+        </h2>
         <div className="claude-health-head-actions">
           <button
             type="button"
@@ -186,38 +106,48 @@ export function FdaStrip() {
       </div>
       <ul className="claude-health-issues">
         <li className="claude-health-issue">
-          <p className="claude-health-issue-detail">
-            macOS just refused FusedRender access to a file or folder —
-            sometimes it does this with no permission prompt at all, just
-            "permission denied". Granting Full Disk Access once fixes Desktop,
-            Documents, Downloads and external volumes permanently. FusedRender
-            is completely local: your files are read on this Mac and no data
-            ever leaves your computer.
-          </p>
-          {waiting ? (
-            <p className="claude-health-issue-detail">
-              In System Settings: turn on FusedRender under Full Disk Access,
-              then relaunch when asked.
-            </p>
+          {pending ? (
+            <>
+              <p className="claude-health-issue-detail">{FDA_COPY.pending}</p>
+              <div className="claude-health-actions">
+                <a className="claude-health-action" href={RELAUNCH_HREF}>
+                  {FDA_COPY.relaunch}
+                </a>
+              </div>
+            </>
           ) : (
-            <ol className="claude-health-issue-detail fda-steps">
-              <li>Open System Settings</li>
-              <li>Privacy &amp; Security → Full Disk Access</li>
-              <li>Turn on FusedRender, relaunch when asked</li>
-            </ol>
+            <>
+              <p className="claude-health-issue-detail">
+                macOS just refused FusedRender access to a file or folder —
+                sometimes it does this with no permission prompt at all, just
+                "permission denied". Granting Full Disk Access once fixes Desktop,
+                Documents, Downloads and external volumes permanently. FusedRender
+                is completely local: your files are read on this Mac and no data
+                ever leaves your computer.
+              </p>
+              {waiting ? (
+                <p className="claude-health-issue-detail">{FDA_COPY.waiting}</p>
+              ) : (
+                <ol className="claude-health-issue-detail fda-steps">
+                  {FDA_COPY.steps.map((s) => (
+                    <li key={s}>{s}</li>
+                  ))}
+                </ol>
+              )}
+              <div className="claude-health-actions">
+                <button
+                  type="button"
+                  className="claude-health-action"
+                  onClick={() => {
+                    setWaiting(true);
+                    openFdaSettings().catch(() => {}).finally(pokeFda);
+                  }}
+                >
+                  {waiting ? FDA_COPY.reopen : FDA_COPY.open}
+                </button>
+              </div>
+            </>
           )}
-          <div className="claude-health-actions">
-            <button
-              type="button"
-              className="claude-health-action"
-              onClick={() => {
-                setWaiting(true);
-                openFdaSettings().catch(() => {});
-              }}
-            >
-              {waiting ? "Reopen System Settings" : "Open System Settings"}
-            </button>
-          </div>
         </li>
       </ul>
     </section>

--- a/frontend/src/shell/onboarding/FdaStep.tsx
+++ b/frontend/src/shell/onboarding/FdaStep.tsx
@@ -33,7 +33,11 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: string }
   // The wizard already holds a config: seed so the first paint is right,
   // then the shared store takes over.
   useEffect(() => seedFda(config.fda), [config.fda]);
-  const fda = useFda();
+  const live = useFda();
+  // Before the store's first answer, render off the config prop synchronously:
+  // an effect-time seed alone would flash the disabled "dev server" button
+  // for a frame on a packaged app.
+  const fda = live === undefined ? (config.fda ?? null) : live;
   const [opened, setOpened] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const offered = fda != null;

--- a/frontend/src/shell/onboarding/FdaStep.tsx
+++ b/frontend/src/shell/onboarding/FdaStep.tsx
@@ -12,47 +12,41 @@
 // the whole affordance. The button is live only when the server offers it
 // (`config.fda` present: packaged mac app, conclusive probe); on a dev server
 // the copy still renders and the button says why it is disabled.
+//
+// State and copy come from platform/lib/fda.ts, the same store the strip
+// reads, so this step and the strip never disagree about whether the grant
+// landed. The one state this step adds a face to is `pending_relaunch`: the
+// user turned FusedRender on, a fresh child of the app can read, and only a
+// relaunch stands between them and the grant — so offer the relaunch instead
+// of a "waiting…" line that could never finish (macOS caches the running
+// process's verdict).
 import { useEffect, useState } from "react";
-import { Check, ExternalLink, FolderLock, Lock, ShieldCheck } from "lucide-react";
+import { Check, ExternalLink, FolderLock, Lock, RotateCw, ShieldCheck } from "lucide-react";
 
-import { getConfig, openFdaSettings, type Config } from "@platform/lib/api";
+import { openFdaSettings, type Config } from "@platform/lib/api";
+import { FDA_COPY, RELAUNCH_HREF, pokeFda, seedFda, useFda } from "@platform/lib/fda";
 import { Button } from "@platform/shadcn/ui/button";
 
 import { StepHeader } from "./StepHeader";
 
-//: Poll for the grant while the pane is open. Most grants apply to a relaunched
-//: process only, but when macOS relaunches the app for us the fresh server
-//: answers granted and this still-open tab converges.
-const GRANT_POLL_MS = 3000;
-
 export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: string }) {
-  const [fda, setFda] = useState(config.fda);
+  // The wizard already holds a config: seed so the first paint is right,
+  // then the shared store takes over.
+  useEffect(() => seedFda(config.fda), [config.fda]);
+  const fda = useFda();
   const [opened, setOpened] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const offered = fda !== undefined;
+  const offered = fda != null;
   const granted = fda?.granted === true;
-
-  useEffect(() => {
-    if (!opened || granted) return;
-    let alive = true;
-    const t = window.setInterval(() => {
-      getConfig().then(
-        (c) => {
-          if (alive) setFda(c.fda);
-        },
-        () => undefined,
-      );
-    }, GRANT_POLL_MS);
-    return () => {
-      alive = false;
-      window.clearInterval(t);
-    };
-  }, [opened, granted]);
+  const pending = fda?.pending_relaunch === true;
 
   const open = () => {
     setError(null);
     openFdaSettings().then(
-      () => setOpened(true),
+      () => {
+        setOpened(true);
+        pokeFda();
+      },
       (e) => setError(String(e?.message || e)),
     );
   };
@@ -106,26 +100,39 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: string }
               <div className="text-xs text-muted-foreground">Already granted — nothing to do here.</div>
             </div>
           </div>
+        ) : pending ? (
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <span className="grid size-6 place-items-center rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
+                <Check className="size-3.5" strokeWidth={3} />
+              </span>
+              <div>
+                <div className="text-sm font-medium">Granted — one relaunch to go</div>
+                <div className="text-xs text-muted-foreground">{FDA_COPY.pending}</div>
+              </div>
+            </div>
+            {/* A plain link, like the update-restart banner: the OS hands the
+                deep link to the running app, which quits and respawns. This
+                tab keeps polling and flips to "Already granted" on its own. */}
+            <Button render={<a href={RELAUNCH_HREF} />}>
+              <RotateCw data-icon="inline-start" />
+              {FDA_COPY.relaunch}
+            </Button>
+          </div>
         ) : (
           <>
             <ol className="m-0 flex list-none flex-col gap-1.5 p-0 text-sm">
-              <li className="flex gap-2">
-                <span className="w-4 shrink-0 text-muted-foreground">1.</span>
-                <span>Open System Settings on the Full Disk Access pane.</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="w-4 shrink-0 text-muted-foreground">2.</span>
-                <span>Turn on <strong className="font-medium">FusedRender</strong> in the list.</span>
-              </li>
-              <li className="flex gap-2">
-                <span className="w-4 shrink-0 text-muted-foreground">3.</span>
-                <span>Relaunch the app when macOS asks — the grant applies to the next launch.</span>
-              </li>
+              {FDA_COPY.steps.map((s, i) => (
+                <li key={s} className="flex gap-2">
+                  <span className="w-4 shrink-0 text-muted-foreground">{i + 1}.</span>
+                  <span>{s}</span>
+                </li>
+              ))}
             </ol>
             <div className="flex flex-wrap items-center gap-3">
               <Button onClick={open} disabled={!offered} title={offered ? undefined : "Available in the installed FusedRender app"}>
                 <ExternalLink data-icon="inline-start" />
-                {opened ? "Open System Settings again" : "Open System Settings"}
+                {opened ? FDA_COPY.reopen : FDA_COPY.open}
               </Button>
               {!offered && (
                 <span className="text-xs text-muted-foreground">
@@ -134,7 +141,7 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: string }
               )}
               {opened && offered && (
                 <span className="text-xs text-muted-foreground" role="status">
-                  Waiting for the grant… turn FusedRender on in the pane that just opened.
+                  {FDA_COPY.waiting}
                 </span>
               )}
             </div>

--- a/frontend/src/styles/dialogs.css
+++ b/frontend/src/styles/dialogs.css
@@ -323,6 +323,9 @@
    actually does something — an update that would no-op renders no button at
    all, only the command that would work. */
 .claude-health-action {
+  /* Also an <a> (FdaStrip's Relaunch deep link): same fill, no underline. */
+  text-decoration: none;
+  display: inline-block;
   font: inherit;
   font-weight: 600;
   padding: 5px 12px;

--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -736,7 +736,8 @@ def spawn_relauncher(bundle: str, pid: int, *, popen=subprocess.Popen):
 
 
 def begin_relaunch(*, quit_action, bundle=None, spawn=None,
-                   running=None, installed=None, same_version=False) -> bool:
+                   running=None, installed=None, same_version=False,
+                   fda_granted=None) -> bool:
     """fused-render://relaunch: quit through the normal teardown and park a
     relauncher on our pid. True if the relaunch was started.
 
@@ -762,16 +763,31 @@ def begin_relaunch(*, quit_action, bundle=None, spawn=None,
     "The teardown drains for seconds" used to make this safe by accident; the
     hook makes it safe by construction.
 
-    `same_version=True` (fused-render://relaunch?reason=fda) skips ONLY the
-    staleness check: a Full Disk Access grant applies to the next process, so
-    respawning the very same version is the whole point. The bundle check and
-    the quit-in-flight check still apply."""
+    `same_version=True` (fused-render://relaunch?reason=fda) swaps the
+    staleness check for a different "am I the one who needs replacing" test:
+    a Full Disk Access grant applies to the next process, so respawning the
+    very same version is the whole point — but ONLY while THIS process still
+    lacks the grant. The same fresh-instance hazard applies here: the OS may
+    launch a new instance just to deliver the link (a second click after the
+    old pid died, or a cold start), and that instance already has the grant
+    and reads fine — quitting it would re-run the pidfile race the version
+    guard exists to avoid. `fda_granted` is the in-process probe
+    (shell/fda.py granted()), injectable for tests. The bundle check and the
+    quit-in-flight check still apply."""
     if bundle is None:
         bundle = bundle_path()
     if bundle is None:
         logger.info("relaunch deep link ignored: not running from a bundle")
         return False
     if same_version:
+        if fda_granted is None:
+            from fused_render.shell import fda as shell_fda
+
+            fda_granted = shell_fda.granted
+        if fda_granted() is not False:
+            logger.info("fda relaunch deep link ignored: this process already "
+                        "reads fine — nothing a relaunch would change")
+            return False
         if spawn is None:
             spawn = spawn_relauncher
         if not quit_action(on_claim=lambda: spawn(bundle, os.getpid())):

--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -736,7 +736,7 @@ def spawn_relauncher(bundle: str, pid: int, *, popen=subprocess.Popen):
 
 
 def begin_relaunch(*, quit_action, bundle=None, spawn=None,
-                   running=None, installed=None) -> bool:
+                   running=None, installed=None, same_version=False) -> bool:
     """fused-render://relaunch: quit through the normal teardown and park a
     relauncher on our pid. True if the relaunch was started.
 
@@ -760,12 +760,24 @@ def begin_relaunch(*, quit_action, bundle=None, spawn=None,
     can be dead before a statement after `quit_action()` finishes — and a
     relauncher that was never spawned means the app quits with no successor.
     "The teardown drains for seconds" used to make this safe by accident; the
-    hook makes it safe by construction."""
+    hook makes it safe by construction.
+
+    `same_version=True` (fused-render://relaunch?reason=fda) skips ONLY the
+    staleness check: a Full Disk Access grant applies to the next process, so
+    respawning the very same version is the whole point. The bundle check and
+    the quit-in-flight check still apply."""
     if bundle is None:
         bundle = bundle_path()
     if bundle is None:
         logger.info("relaunch deep link ignored: not running from a bundle")
         return False
+    if same_version:
+        if spawn is None:
+            spawn = spawn_relauncher
+        if not quit_action(on_claim=lambda: spawn(bundle, os.getpid())):
+            logger.info("relaunch deep link ignored: quit already in progress")
+            return False
+        return True
     if running is None:
         from fused_render import __version__ as running
     if installed is None:
@@ -1023,12 +1035,23 @@ def main() -> None:
     # openurls_target_path tells the two apart (mirrors the scheme check in
     # winopen.py's _open()).
     def application_openURLs_(self, _app, urls):
-        from fused_render.deeplink import is_launch_url, is_relaunch_url
+        from fused_render.deeplink import (
+            is_fda_relaunch_url,
+            is_launch_url,
+            is_relaunch_url,
+        )
 
         raws = [str(u.absoluteString()) for u in urls]
         logger.info("deep-link open-URLs event: %s", raws)
         state["docs"] = True  # a deep-link launch shouldn't also open the home tab
         for raw in raws:
+            if is_fda_relaunch_url(raw):
+                # fused-render://relaunch?reason=fda (FdaStrip / FdaStep's
+                # "Relaunch" button): a Full Disk Access grant only reaches a
+                # fresh process, so respawn this same version.
+                logger.info("fda relaunch deep link: quitting to respawn for the grant")
+                begin_relaunch(quit_action=_do_quit, same_version=True)
+                continue
             if is_relaunch_url(raw):
                 # fused-render://relaunch (the update-restart banner's button):
                 # park a relauncher on our pid and quit through the normal

--- a/fused_render/deeplink.py
+++ b/fused_render/deeplink.py
@@ -82,6 +82,20 @@ _RELAUNCH_FORMS = frozenset(
     {"fused-render://relaunch", "fused-render://relaunch/", "fused-render:relaunch"}
 )
 
+# The relaunch action's one payload (D110: payloads are query params on the
+# same action): `reason=fda`. A Full Disk Access grant applies to the NEXT
+# process — macOS caches the running one's verdict — so the shell's "Relaunch
+# to apply" button (FdaStrip / FdaStep) needs a relaunch that respawns the SAME
+# version, which the bare relaunch refuses to do (it only acts when the disk
+# version differs). Exact forms, not a parser: the payload has one legal value.
+_RELAUNCH_FDA_FORMS = frozenset(
+    {
+        "fused-render://relaunch?reason=fda",
+        "fused-render://relaunch/?reason=fda",
+        "fused-render:relaunch?reason=fda",
+    }
+)
+
 _CLONE_PAGE = os.path.join(os.path.dirname(__file__), "static", "clone.html")
 
 # Conservative GitHub owner/repo shapes; blocks anything that could smuggle
@@ -121,6 +135,12 @@ def is_relaunch_url(src: str) -> bool:
     """True for a `fused-render://relaunch` deep link: quit-and-respawn so the
     version installed on disk takes over. Same strictness as is_launch_url."""
     return (src or "").strip().lower() in _RELAUNCH_FORMS
+
+
+def is_fda_relaunch_url(src: str) -> bool:
+    """True for `fused-render://relaunch?reason=fda`: quit-and-respawn the SAME
+    bundle so a freshly granted Full Disk Access takes effect."""
+    return (src or "").strip().lower() in _RELAUNCH_FDA_FORMS
 
 
 def github_url_from(src: str) -> str:

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -592,6 +592,13 @@ def create_app(start_dir: str) -> FastAPI:
             logger.info("reclaimed %d orphaned project venv(s)", removed)
 
     app.exception_handler(Exception)(unhandled_exception)
+    # A PermissionError no route caught: 403 + the Full Disk Access warning
+    # hears about it (shell/fda.py), instead of a 500 that explains nothing.
+    # Routes that handle their own denial return shell_fda.refused() and
+    # never reach this.
+    from fused_render.shell import fda as _shell_fda
+
+    app.exception_handler(PermissionError)(_shell_fda.permission_error_handler)
 
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
     # Vendored JS libraries (marked, CodeMirror) that templates load by absolute

--- a/fused_render/server/mount.py
+++ b/fused_render/server/mount.py
@@ -343,8 +343,7 @@ def _fs_stat(path: str):
         # historical "no such file" — a path the OS refused is not gone.
         if isinstance(e, PermissionError):
             from fused_render.shell import fda as shell_fda
-            shell_fda.note_denied(e)
-            return _error(f"cannot read {path}: {e}", status=403)
+            return shell_fda.refused(path, e)
         return _error(f"no such file or directory: {path}", status=404)
     return _stat_payload(path, stat_mod.S_ISDIR(st.st_mode), st)
 _STAT_TIMEOUT_S = 4.0  # a stat outliving this reports "unchanged" for this tick

--- a/fused_render/server/routers/fs_read.py
+++ b/fused_render/server/routers/fs_read.py
@@ -266,18 +266,16 @@ def api_fs_list(path: str, cursor: str | None = None):
         with os.scandir(path) as it:
             dents = list(itertools.islice(it, _server_walk.LIST_MAX_ENTRIES + 1))
     except OSError as e:
-        # A PermissionError here is the moment the Full Disk Access warning
-        # becomes worth showing (shell/fda.py) — on macOS a TCC deny lands as
-        # exactly this EPERM, sometimes with no prompt ever shown.
-        shell_fda.note_denied(e)
         broken = shell_mounts.broken_mount_error(path)
         if broken:
             return _error(broken, status=503)
-        # 403, matching stat (mount.py) and read below, so the explorer can
-        # tell "refused" from "not a directory" by status and show the
-        # Full Disk Access card instead of the raw errno text.
+        # A PermissionError here is the moment the Full Disk Access warning
+        # becomes worth showing (shell/fda.py) — on macOS a TCC deny lands as
+        # exactly this EPERM, sometimes with no prompt ever shown. refused()
+        # is the one place that records it AND shapes the 403 the explorer
+        # keys its card on, same as stat (mount.py) and read below.
         if isinstance(e, PermissionError):
-            return _error(f"cannot read {path}: {e}", status=403)
+            return shell_fda.refused(path, e)
         return _error(f"cannot read directory {path}: {e}", status=400)
     truncated = len(dents) > _server_walk.LIST_MAX_ENTRIES
     if truncated:
@@ -618,8 +616,7 @@ async def _api_fs_raw_read(path: str, request: Request, base: str | None,
     try:
         st = await asyncio.to_thread(os.stat, path)
     except PermissionError as e:
-        shell_fda.note_denied(e)
-        return _error(f"cannot read {path}: {e}", status=403)
+        return shell_fda.refused(path, e)
     except OSError:
         # Any other OSError keeps the historical _stat_or_none contract:
         # ENOENT, ENOTDIR, ELOOP and friends all report as missing.
@@ -634,8 +631,7 @@ async def _api_fs_raw_read(path: str, request: Request, base: str | None,
     try:
         await asyncio.to_thread(lambda: open(path, "rb").close())
     except PermissionError as e:
-        shell_fda.note_denied(e)
-        return _error(f"cannot read {path}: {e}", status=403)
+        return shell_fda.refused(path, e)
     except OSError:
         # A non-permission open failure (EIO, a file racing away) keeps its
         # previous behavior: FileResponse surfaces it as the send-time error.

--- a/fused_render/shell/fda.py
+++ b/fused_render/shell/fda.py
@@ -21,10 +21,30 @@ install up front.
 Detection probes paths that only FDA unlocks. FDA-class paths never raise a
 TCC prompt (unlike the per-folder categories) — a failed probe is silent,
 so probing on every /api/config read costs nothing but a stat.
+
+Detection is TWO-STAGE (amends D486's single in-process probe). macOS caches
+a process's TCC verdict for its lifetime — that is what the "Quit & Reopen"
+dialog in the Settings pane is about — so once this process has probed
+not-granted, the grant the user just made is invisible to it until relaunch.
+The in-process probe therefore only answers "can THIS process read". When it
+says no, `snapshot()` asks a FRESH CHILD (`/bin/ls` on the same target): a
+child of the app bundle is attributed to the bundle's TCC identity but has
+no cached verdict, so it sees the grant live. Child yes + self no is the
+`pending_relaunch` state the shell turns into a Relaunch button
+(fused-render://relaunch?reason=fda), instead of a "waiting…" spinner that
+can never finish. The child probe is memoized for a few seconds because
+/api/config is polled by several surfaces across tabs.
+
+Every consumer — the onboarding step, the Home/Apps/explorer strip — reads
+the ONE `fda` field of /api/config, and every route that hits a
+PermissionError reports it through the ONE `refused()` helper (or the
+server's PermissionError backstop handler, for routes that never caught it),
+so "denied" means the same thing everywhere.
 """
 import os
 import subprocess
 import sys
+import time
 
 from fastapi import APIRouter, Header
 from fastapi.responses import JSONResponse
@@ -98,6 +118,66 @@ def granted() -> bool | None:
     return None
 
 
+#: How long one child-probe answer stands in for the next. /api/config is
+#: polled every few seconds by the status banner, the strip and the wizard
+#: step, in every open tab; a fork per poll would be silly, and a grant
+#: landing a couple of seconds late is invisible next to the relaunch it needs.
+CHILD_PROBE_TTL_S = 3.0
+
+#: Errno texts /bin/ls prints for a refused read: TCC denies as EPERM
+#: ("Operation not permitted"), classic mode bits as EACCES.
+_REFUSED_TEXTS = ("operation not permitted", "permission denied")
+
+_child_memo: tuple[float, bool | None] = (0.0, None)
+
+
+def _child_probe_target() -> str | None:
+    """The first listdir probe target that exists. Directory targets only:
+    `ls` on the TCC.db path is a stat, which succeeds without FDA."""
+    for raw, how in _PROBES:
+        if how != "listdir":
+            continue
+        path = os.path.expanduser(raw)
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def child_granted() -> bool | None:
+    """Whether Full Disk Access is granted to a FRESHLY SPAWNED child of this
+    process — i.e. to the app's TCC identity as of right now, uncached.
+
+    True when `ls <FDA-gated dir>` succeeds, False when it is refused, None
+    when there is no target to ask about or `ls` failed for another reason.
+    Memoized for CHILD_PROBE_TTL_S. Never called on its own by the shell: it
+    only matters once the in-process probe has said no (see snapshot()).
+    """
+    global _child_memo
+    if os.environ.get(FORCE_ENV) == "demo":
+        return False
+    now = time.monotonic()
+    stamp, cached = _child_memo
+    if now - stamp < CHILD_PROBE_TTL_S:
+        return cached
+    result: bool | None = None
+    target = _child_probe_target()
+    if target is not None:
+        try:
+            proc = subprocess.run(
+                ["/bin/ls", "-d", target + "/"],
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            proc = None
+        if proc is not None:
+            if proc.returncode == 0:
+                result = True
+            elif any(t in proc.stderr.lower() for t in _REFUSED_TEXTS):
+                result = False
+    _child_memo = (now, result)
+    return result
+
+
 #: Whether THIS session has hit a PermissionError on an fs route — the moment
 #: macOS actually refused a read, prompted or silent. The strip renders only
 #: after that: a user whose files all open fine never needs a word about Full
@@ -126,6 +206,11 @@ def snapshot() -> dict | None:
     probe is inconclusive — an absent field is the shell's "render nothing
     AND stop watching", so uncertainty never nags and never polls.
 
+    `granted` is what THIS process can do. `pending_relaunch` is the
+    two-stage verdict (module docstring): this process cannot, but a fresh
+    child can, so the grant has landed and only a relaunch stands between
+    the user and it. Never both true.
+
     `denied` is the trigger: the strip renders only while the current denial
     stands unacknowledged. Dismissing clears it ON THE SERVER (every tab
     converges), and the NEXT PermissionError raises it again — an ✕ is "not
@@ -139,7 +224,26 @@ def snapshot() -> dict | None:
     if state is None:
         return None
     denied = _denied or os.environ.get(FORCE_ENV) == "demo"
-    return {"granted": state, "denied": denied}
+    pending = (not state) and child_granted() is True
+    return {"granted": state, "pending_relaunch": pending, "denied": denied}
+
+
+def refused(path: str, exc: BaseException) -> JSONResponse:
+    """THE answer to a refused read: record the denial for the warning and
+    build the 403 the explorer keys its Full Disk Access card on. Every fs
+    route that catches a PermissionError returns this, so the wire shape and
+    the side effect cannot drift apart between routes."""
+    note_denied(exc)
+    return JSONResponse({"error": f"cannot read {path}: {exc}"}, status_code=403)
+
+
+async def permission_error_handler(request, exc: PermissionError) -> JSONResponse:
+    """Backstop for a PermissionError no route caught: it would otherwise
+    surface as a generic 500 and the warning would never hear about the one
+    failure it exists to explain. Registered by the server for the whole app;
+    a route that handles its own denial (through refused()) never gets here."""
+    path = request.query_params.get("path") or request.url.path
+    return refused(path, exc)
 
 
 def _require_fused(x_fused: str | None) -> JSONResponse | None:

--- a/fused_render/shell/fda.py
+++ b/fused_render/shell/fda.py
@@ -41,6 +41,7 @@ PermissionError reports it through the ONE `refused()` helper (or the
 server's PermissionError backstop handler, for routes that never caught it),
 so "denied" means the same thing everywhere.
 """
+import logging
 import os
 import subprocess
 import sys
@@ -50,6 +51,7 @@ from fastapi import APIRouter, Header
 from fastapi.responses import JSONResponse
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 #: Deep-link straight to System Settings -> Privacy & Security -> Full Disk
 #: Access. The legacy `com.apple.preference.security` anchor still routes on
@@ -133,7 +135,9 @@ _child_memo: tuple[float, bool | None] = (0.0, None)
 
 def _child_probe_target() -> str | None:
     """The first listdir probe target that exists. Directory targets only:
-    `ls` on the TCC.db path is a stat, which succeeds without FDA."""
+    `ls` on the TCC.db path is a stat, which succeeds without FDA — the
+    child has to READ the directory (readdir), same as the in-process probe's
+    os.listdir, or a bare stat would fake a grant on every install."""
     for raw, how in _PROBES:
         if how != "listdir":
             continue
@@ -163,8 +167,10 @@ def child_granted() -> bool | None:
     target = _child_probe_target()
     if target is not None:
         try:
+            # No -d and no trailing slash: those make ls stat the entry, which
+            # succeeds without FDA. Plain `ls <dir>` opens and reads it.
             proc = subprocess.run(
-                ["/bin/ls", "-d", target + "/"],
+                ["/bin/ls", target],
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=5,
             )
         except (OSError, subprocess.SubprocessError):
@@ -241,8 +247,13 @@ async def permission_error_handler(request, exc: PermissionError) -> JSONRespons
     """Backstop for a PermissionError no route caught: it would otherwise
     surface as a generic 500 and the warning would never hear about the one
     failure it exists to explain. Registered by the server for the whole app;
-    a route that handles its own denial (through refused()) never gets here."""
+    a route that handles its own denial (through refused()) never gets here.
+    Logged with the request line — the 500 handler this preempts wrote a
+    traceback, and a surprise denial must stay traceable."""
     path = request.query_params.get("path") or request.url.path
+    logger.warning(
+        "permission denied (uncaught) %s %s: %s", request.method, request.url.path, exc
+    )
     return refused(path, exc)
 
 

--- a/tests/test_app_relaunch.py
+++ b/tests/test_app_relaunch.py
@@ -196,10 +196,28 @@ def test_same_version_relaunch_skips_only_the_staleness_check():
         bundle="/Applications/FusedRender.app",
         spawn=lambda bundle, pid: calls.append(("spawn", bundle, pid)),
         running="0.5.0", installed="0.5.0",
-        same_version=True,
+        same_version=True, fda_granted=lambda: False,
     )
     assert started is True
     assert calls == [("spawn", "/Applications/FusedRender.app", os.getpid()), "quit"]
+
+
+def test_same_version_relaunch_is_a_noop_once_this_process_has_the_grant():
+    # The OS may launch a FRESH instance just to deliver the link (a second
+    # click after the old pid died, or a cold start). That instance already
+    # has the grant — quitting it would re-run the pidfile race the version
+    # guard exists to avoid. Inconclusive (None) is also a no-op: nothing a
+    # relaunch would provably change.
+    for verdict in (True, None):
+        calls = []
+        started = app_mod.begin_relaunch(
+            quit_action=lambda on_claim=None: calls.append("quit") or True,
+            bundle="/Applications/FusedRender.app",
+            spawn=lambda *a: calls.append(a),
+            same_version=True, fda_granted=lambda: verdict,
+        )
+        assert started is False
+        assert calls == []
 
 
 def test_same_version_relaunch_still_needs_a_bundle(monkeypatch):
@@ -208,7 +226,7 @@ def test_same_version_relaunch_still_needs_a_bundle(monkeypatch):
     started = app_mod.begin_relaunch(
         quit_action=lambda on_claim=None: calls.append("quit") or True,
         spawn=lambda *a: calls.append(a),
-        same_version=True,
+        same_version=True, fda_granted=lambda: False,
     )
     assert started is False
     assert calls == []
@@ -220,7 +238,7 @@ def test_same_version_relaunch_joins_a_quit_already_in_flight():
         quit_action=lambda on_claim=None: False,
         bundle="/Applications/FusedRender.app",
         spawn=lambda *a: calls.append(a),
-        same_version=True,
+        same_version=True, fda_granted=lambda: False,
     )
     assert started is False
     assert calls == []

--- a/tests/test_app_relaunch.py
+++ b/tests/test_app_relaunch.py
@@ -187,6 +187,45 @@ def test_begin_relaunch_is_a_noop_when_the_disk_version_is_unknown():
     assert calls == []
 
 
+def test_same_version_relaunch_skips_only_the_staleness_check():
+    # fused-render://relaunch?reason=fda: a Full Disk Access grant applies to
+    # the NEXT process, so respawning the very same version is the point.
+    calls = []
+    started = app_mod.begin_relaunch(
+        quit_action=lambda on_claim=None: (on_claim(), calls.append("quit"))[1] or True,
+        bundle="/Applications/FusedRender.app",
+        spawn=lambda bundle, pid: calls.append(("spawn", bundle, pid)),
+        running="0.5.0", installed="0.5.0",
+        same_version=True,
+    )
+    assert started is True
+    assert calls == [("spawn", "/Applications/FusedRender.app", os.getpid()), "quit"]
+
+
+def test_same_version_relaunch_still_needs_a_bundle(monkeypatch):
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    calls = []
+    started = app_mod.begin_relaunch(
+        quit_action=lambda on_claim=None: calls.append("quit") or True,
+        spawn=lambda *a: calls.append(a),
+        same_version=True,
+    )
+    assert started is False
+    assert calls == []
+
+
+def test_same_version_relaunch_joins_a_quit_already_in_flight():
+    calls = []
+    started = app_mod.begin_relaunch(
+        quit_action=lambda on_claim=None: False,
+        bundle="/Applications/FusedRender.app",
+        spawn=lambda *a: calls.append(a),
+        same_version=True,
+    )
+    assert started is False
+    assert calls == []
+
+
 def test_quit_action_reports_whether_it_claimed_the_teardown():
     # begin_relaunch's no-respawn guard rides this bool: the first quit from
     # any surface claims the teardown, every later one joins it.

--- a/tests/test_deeplink.py
+++ b/tests/test_deeplink.py
@@ -17,6 +17,7 @@ from fused_render.deeplink import (
     DeeplinkError,
     clone_or_pull,
     github_url_from,
+    is_fda_relaunch_url,
     is_launch_url,
     is_relaunch_url,
     parse_github_url,
@@ -150,6 +151,39 @@ def test_is_relaunch_url_accepts(src):
 )
 def test_is_relaunch_url_rejects(src):
     assert is_relaunch_url(src) is False
+
+
+# The one relaunch payload (D110: a query param on the same action): reason=fda
+# respawns the SAME version so a fresh Full Disk Access grant takes effect.
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "fused-render://relaunch?reason=fda",
+        "fused-render://relaunch/?reason=fda",
+        "fused-render:relaunch?reason=fda",
+        "FUSED-RENDER://RELAUNCH?REASON=FDA",
+    ],
+)
+def test_is_fda_relaunch_url_accepts(src):
+    assert is_fda_relaunch_url(src) is True
+    assert is_relaunch_url(src) is False  # the two actions never both match
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "",
+        None,
+        "fused-render://relaunch",  # bare relaunch is the update swap, not this
+        "fused-render://relaunch?reason=update",
+        "fused-render://relaunch?reason=fda&x=1",
+        "fused-render://launch?reason=fda",
+    ],
+)
+def test_is_fda_relaunch_url_rejects(src):
+    assert is_fda_relaunch_url(src) is False
 
 
 def test_github_url_from_passthrough():

--- a/tests/test_fda.py
+++ b/tests/test_fda.py
@@ -138,9 +138,9 @@ def test_child_granted_reads_ls_exit_and_errno_text(tmp_path, monkeypatch):
 
     monkeypatch.setattr(fda_mod.subprocess, "run", _run)
     assert fda_mod.child_granted() is True
-    # -d + trailing slash: list the directory ENTRY's existence via readdir,
-    # never its (possibly huge) contents.
-    assert calls == [["/bin/ls", "-d", str(target) + "/"]]
+    # Plain `ls <dir>`: it must READ the directory. `ls -d` or a trailing
+    # slash would stat the entry, which succeeds without FDA.
+    assert calls == [["/bin/ls", str(target)]]
 
     monkeypatch.setattr(fda_mod, "_child_memo", (0.0, None))
     monkeypatch.setattr(

--- a/tests/test_fda.py
+++ b/tests/test_fda.py
@@ -46,11 +46,14 @@ def test_demo_forces_offered_ungranted_and_denied(monkeypatch):
     # A terminal-launched dev server inherits the terminal's TCC identity,
     # which usually has FDA — "demo" is how the strip gets exercised anyway,
     # so it also forces `denied` without manufacturing a real PermissionError.
+    # Both probes answer not-granted: a child of a dev terminal WITH FDA would
+    # otherwise turn demo into a phantom "pending relaunch".
     monkeypatch.setenv(fda_mod.FORCE_ENV, "demo")
     monkeypatch.setattr(fda_mod, "_denied", False)
     assert fda_mod.offered() is True
     assert fda_mod.granted() is False
-    assert fda_mod.snapshot()["denied"] is True
+    assert fda_mod.child_granted() is False
+    assert fda_mod.snapshot() == {"granted": False, "pending_relaunch": False, "denied": True}
 
 
 def test_snapshot_is_none_when_not_offered(monkeypatch):
@@ -70,10 +73,117 @@ def test_snapshot_carries_granted_and_denied(tmp_path, monkeypatch):
     monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
     monkeypatch.setenv(fda_mod.FORCE_ENV, "1")
     monkeypatch.setattr(fda_mod, "granted", lambda: False)
+    monkeypatch.setattr(fda_mod, "child_granted", lambda: False)
     monkeypatch.setattr(fda_mod, "_denied", False)
-    assert fda_mod.snapshot() == {"granted": False, "denied": False}
+    assert fda_mod.snapshot() == {"granted": False, "pending_relaunch": False, "denied": False}
     monkeypatch.setattr(fda_mod, "_denied", True)
-    assert fda_mod.snapshot() == {"granted": False, "denied": True}
+    assert fda_mod.snapshot() == {"granted": False, "pending_relaunch": False, "denied": True}
+
+
+# ---- the two-stage probe: pending_relaunch ------------------------------------
+
+
+def test_pending_relaunch_when_only_a_fresh_child_can_read(monkeypatch):
+    # macOS caches this process's TCC verdict, so after the user grants FDA the
+    # in-process probe keeps saying no. A fresh child sees the grant: that is
+    # the "granted, relaunch to apply" state.
+    monkeypatch.setenv(fda_mod.FORCE_ENV, "1")
+    monkeypatch.setattr(fda_mod, "granted", lambda: False)
+    monkeypatch.setattr(fda_mod, "child_granted", lambda: True)
+    monkeypatch.setattr(fda_mod, "_denied", False)
+    assert fda_mod.snapshot() == {"granted": False, "pending_relaunch": True, "denied": False}
+
+
+def test_child_probe_is_not_asked_once_this_process_can_read(monkeypatch):
+    monkeypatch.setenv(fda_mod.FORCE_ENV, "1")
+    monkeypatch.setattr(fda_mod, "granted", lambda: True)
+
+    def _boom():
+        raise AssertionError("child probe must not run when granted")
+
+    monkeypatch.setattr(fda_mod, "child_granted", _boom)
+    assert fda_mod.snapshot() == {"granted": True, "pending_relaunch": False, "denied": False}
+
+
+def test_inconclusive_child_probe_is_not_pending(monkeypatch):
+    monkeypatch.setenv(fda_mod.FORCE_ENV, "1")
+    monkeypatch.setattr(fda_mod, "granted", lambda: False)
+    monkeypatch.setattr(fda_mod, "child_granted", lambda: None)
+    monkeypatch.setattr(fda_mod, "_denied", False)
+    assert fda_mod.snapshot()["pending_relaunch"] is False
+
+
+class _Proc:
+    def __init__(self, rc, stderr=""):
+        self.returncode = rc
+        self.stderr = stderr
+
+
+def _fresh_child(monkeypatch, tmp_path):
+    target = tmp_path / "gated"
+    target.mkdir()
+    monkeypatch.setattr(fda_mod, "_PROBES", [(str(target), "listdir")])
+    monkeypatch.setattr(fda_mod, "_child_memo", (0.0, None))
+    monkeypatch.delenv(fda_mod.FORCE_ENV, raising=False)
+    return target
+
+
+def test_child_granted_reads_ls_exit_and_errno_text(tmp_path, monkeypatch):
+    target = _fresh_child(monkeypatch, tmp_path)
+    calls = []
+
+    def _run(cmd, **kw):
+        calls.append(cmd)
+        return _Proc(0)
+
+    monkeypatch.setattr(fda_mod.subprocess, "run", _run)
+    assert fda_mod.child_granted() is True
+    # -d + trailing slash: list the directory ENTRY's existence via readdir,
+    # never its (possibly huge) contents.
+    assert calls == [["/bin/ls", "-d", str(target) + "/"]]
+
+    monkeypatch.setattr(fda_mod, "_child_memo", (0.0, None))
+    monkeypatch.setattr(
+        fda_mod.subprocess, "run",
+        lambda cmd, **kw: _Proc(1, "ls: gated: Operation not permitted\n"),
+    )
+    assert fda_mod.child_granted() is False
+
+    # Any other failure is "don't know", not "denied".
+    monkeypatch.setattr(fda_mod, "_child_memo", (0.0, None))
+    monkeypatch.setattr(fda_mod.subprocess, "run", lambda cmd, **kw: _Proc(1, "ls: something else\n"))
+    assert fda_mod.child_granted() is None
+
+
+def test_child_granted_is_memoized(tmp_path, monkeypatch):
+    # /api/config is polled by several surfaces across tabs: one fork per
+    # CHILD_PROBE_TTL_S, not one per poll.
+    _fresh_child(monkeypatch, tmp_path)
+    calls = []
+
+    def _run(cmd, **kw):
+        calls.append(cmd)
+        return _Proc(0)
+
+    monkeypatch.setattr(fda_mod.subprocess, "run", _run)
+    assert fda_mod.child_granted() is True
+    assert fda_mod.child_granted() is True
+    assert len(calls) == 1
+
+
+def test_child_granted_none_without_a_directory_target(tmp_path, monkeypatch):
+    # A file target (`read` probe) is skipped: `ls` on a file is a stat,
+    # which succeeds without FDA and would fake a grant.
+    db = tmp_path / "TCC.db"
+    db.write_bytes(b"x")
+    monkeypatch.setattr(fda_mod, "_PROBES", [(str(tmp_path / "missing"), "listdir"), (str(db), "read")])
+    monkeypatch.setattr(fda_mod, "_child_memo", (0.0, None))
+    monkeypatch.delenv(fda_mod.FORCE_ENV, raising=False)
+    monkeypatch.setattr(
+        fda_mod.subprocess, "run",
+        lambda cmd, **kw: (_ for _ in ()).throw(AssertionError("must not spawn")),
+    )
+    assert fda_mod.child_granted() is None
 
 
 # ---- note_denied(): what makes the warning worth showing ----------------------
@@ -93,6 +203,44 @@ def test_denied_is_inert_when_not_offered(monkeypatch):
     monkeypatch.setattr(fda_mod, "_denied", False)
     fda_mod.note_denied(PermissionError("EPERM"))
     assert fda_mod._denied is False
+
+
+# ---- refused(): the one answer to a denied read -------------------------------
+
+
+def test_refused_records_the_denial_and_answers_403(monkeypatch):
+    monkeypatch.setenv(fda_mod.FORCE_ENV, "1")
+    monkeypatch.setattr(fda_mod, "_denied", False)
+    resp = fda_mod.refused("/x/y", PermissionError("EPERM"))
+    assert resp.status_code == 403
+    assert b"cannot read /x/y" in resp.body
+    assert fda_mod._denied is True
+
+
+def test_an_uncaught_permission_error_is_a_403_not_a_500(tmp_path, monkeypatch):
+    # The backstop handler: a route that never caught its PermissionError used
+    # to 500 and the warning never heard about it.
+    from fastapi import FastAPI
+
+    monkeypatch.setenv(fda_mod.FORCE_ENV, "1")
+    monkeypatch.setattr(fda_mod, "_denied", False)
+    app = FastAPI()
+    app.exception_handler(PermissionError)(fda_mod.permission_error_handler)
+
+    @app.get("/boom")
+    def boom(path: str):
+        raise PermissionError(1, "Operation not permitted", path)
+
+    resp = TestClient(app, raise_server_exceptions=False).get("/boom", params={"path": "/p"})
+    assert resp.status_code == 403
+    assert "cannot read /p" in resp.json()["error"]
+    assert fda_mod._denied is True
+
+
+def test_server_registers_the_permission_error_backstop(tmp_path, monkeypatch):
+    client, _ = _client(tmp_path, monkeypatch)
+    handlers = client.app.exception_handlers
+    assert handlers.get(PermissionError) is fda_mod.permission_error_handler
 
 
 # ---- granted() probe semantics ----------------------------------------------
@@ -147,6 +295,7 @@ def test_dismiss_clears_denied_until_the_next_denial(tmp_path, monkeypatch):
     # the next PermissionError raises it again.
     client, _ = _client(tmp_path, monkeypatch)
     monkeypatch.setattr(fda_mod, "granted", lambda: False)
+    monkeypatch.setattr(fda_mod, "child_granted", lambda: False)
     monkeypatch.setattr(fda_mod, "_denied", True)
 
     resp = client.post("/api/fda/dismiss", headers=FUSED)
@@ -180,9 +329,10 @@ def test_settings_opens_the_fda_pane(tmp_path, monkeypatch):
 def test_config_carries_fda_only_when_offered(tmp_path, monkeypatch):
     client, _ = _client(tmp_path, monkeypatch)
     monkeypatch.setattr(fda_mod, "granted", lambda: False)
+    monkeypatch.setattr(fda_mod, "child_granted", lambda: False)
     monkeypatch.setattr(fda_mod, "_denied", False)
     body = client.get("/api/config").json()
-    assert body["fda"] == {"granted": False, "denied": False}
+    assert body["fda"] == {"granted": False, "pending_relaunch": False, "denied": False}
 
     monkeypatch.setenv(fda_mod.FORCE_ENV, "0")
     assert "fda" not in client.get("/api/config").json()
@@ -191,6 +341,7 @@ def test_config_carries_fda_only_when_offered(tmp_path, monkeypatch):
 def test_a_refused_listing_flips_denied(tmp_path, monkeypatch):
     client, _ = _client(tmp_path, monkeypatch)
     monkeypatch.setattr(fda_mod, "granted", lambda: False)
+    monkeypatch.setattr(fda_mod, "child_granted", lambda: False)
     monkeypatch.setattr(fda_mod, "_denied", False)
     gated = tmp_path / "gated"
     gated.mkdir()
@@ -208,5 +359,8 @@ def test_a_refused_listing_flips_denied(tmp_path, monkeypatch):
 
     import fused_render.server.routers.fs_read as fs_read_mod
     monkeypatch.setattr(fs_read_mod.os, "scandir", _deny)
-    client.get("/api/fs/list", params={"path": str(gated)})
+    resp = client.get("/api/fs/list", params={"path": str(gated)})
+    # 403 with the refused() shape — the explorer keys its card on exactly this.
+    assert resp.status_code == 403
+    assert resp.json()["error"].startswith(f"cannot read {gated}")
     assert client.get("/api/config").json()["fda"]["denied"] is True


### PR DESCRIPTION
## Why

macOS caches a process's TCC verdict for its lifetime (that is what the "Quit & Reopen" dialog in the Full Disk Access pane is about). Once the packaged app had probed "not granted", the grant the user just made was invisible to it until relaunch — so the onboarding step's "Waiting for the grant…" never finished, and the strip on Home/Apps/explorer never flipped either. On top of that, the step and the strip each polled `/api/config` on their own timer with their own state machine and their own copy, and denial was recorded at four hand-placed `note_denied()` sites.

## What

**Backend — `fused_render/shell/fda.py`**
- Detection is two-stage. When the in-process probe says no, a fresh child (`/bin/ls -d <FDA-gated dir>/`) is asked: a child of the bundle carries the app's TCC identity but no cached verdict, so it sees the grant live. Child yes + self no is the new `pending_relaunch` field on `config.fda`. Memoized 3s (several surfaces poll config across tabs); `FUSED_RENDER_FDA_BANNER=demo` forces both probes to no.
- `refused(path, exc)` is the one answer to a denied read: records the denial and shapes the 403 the explorer keys its card on. The four sites in `fs_read.py` / `mount.py` return it.
- A `PermissionError` no route caught now hits a registered backstop handler → 403 + recorded, instead of a bare 500.

**Relaunch** — `fused-render://relaunch?reason=fda` (a D110-style query payload on the existing action). `begin_relaunch(same_version=True)` skips only the staleness check, so the same version respawns; bundle and quit-in-flight checks still apply.

**Frontend** — `platform/lib/fda.ts` owns the poll, the shape and the copy (`useSyncExternalStore`). `FdaStrip` and `FdaStep` render off it; the strip's module-level stage cache and both timers are gone. `pending_relaunch` renders a **Relaunch FusedRender** link in both surfaces. A fetch fires on first subscribe so `AccessDenied`'s mount-time read still sees the denial the failing request just recorded. Polling stops when the field is absent or `granted`.

## Tests

`tests/test_fda.py`, `tests/test_deeplink.py`, `tests/test_app_relaunch.py` updated and extended (two-stage verdict, child probe parsing + memo, `refused()`, backstop handler registered, new deep-link forms, `same_version` relaunch). 127 pass. `tsc --noEmit` clean apart from a preexisting missing `qrcode-generator` module in `Preferences.tsx` (untouched here).

## Unverified — needs a packaged build

Child-process TCC attribution to the bundle is standard macOS behaviour but I could not exercise it from a dev server (its identity is the terminal). Failure modes are benign: a wrong True costs one useless relaunch; a wrong False is exactly today's behaviour. Smoke: install DMG → onboarding step 3 → turn FusedRender on in the pane → within ~3s the step should say "Granted — one relaunch to go" with the Relaunch button → click → app respawns → tab flips to "Already granted".

No DECISIONS row: D486's single-process probe is amended in the module docstring; owner can ask for a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global PermissionError handling and macOS FDA detection/relaunch behavior; child-process TCC attribution is assumed but not fully exercisable from a dev server, though tests cover the logic paths.
> 
> **Overview**
> macOS caches TCC for the lifetime of a process, so after the user grants **Full Disk Access** the old in-process probe could stay “not granted” forever and the UI’s “waiting…” state never resolved. This PR adds a **two-stage backend probe** (`granted` for this process, plus a memoized child `ls` check) and exposes **`pending_relaunch`** on `/api/config`’s `fda` field when a fresh child can read but the running process still cannot.
> 
> **Frontend:** new **`platform/lib/fda.ts`** centralizes polling (`useSyncExternalStore`), shared copy, and **`fused-render://relaunch?reason=fda`**. **`FdaStrip`** and onboarding **`FdaStep`** drop their separate timers/state machines and show a **Relaunch FusedRender** affordance when pending.
> 
> **Backend:** denied reads go through one **`refused()`** helper (403 + flip `denied`); uncaught **`PermissionError`**s map to that instead of 500. **`begin_relaunch(same_version=True)`** and **`is_fda_relaunch_url`** wire the relaunch button to respawn the same bundle version so the grant applies to a new process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06576d6d33fcd1287b331eb8424e4f8e29744373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->