### PR TITLE
Onboarding wizard resumes at the last open step

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -185,6 +185,9 @@ export function dismissFdaNudge(): Promise<{ ok: boolean }> {
 export interface OnboardingState {
   completed_at: number | null;
   dismissed_at: number | null;
+  // The step id the user last had open — the resume point after a server
+  // restart or a dismiss. Optional: an older server does not send it.
+  step?: string | null;
   version: number;
 }
 
@@ -198,6 +201,10 @@ export function completeOnboarding(): Promise<OnboardingState> {
 
 export function dismissOnboarding(): Promise<OnboardingState> {
   return postJson<OnboardingState>("/api/onboarding/dismiss", {});
+}
+
+export function setOnboardingStep(step: string): Promise<OnboardingState> {
+  return postJson<OnboardingState>("/api/onboarding/step", { step });
 }
 
 // -- Is Claude Code usable (fused_render/claude_health.py) -------------------

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -52,7 +52,7 @@ import GlobalSidebar from "@shell/GlobalSidebar";
 import { appPathFromPath } from "@shell/current-apps-lib";
 import NotificationHost from "@platform/ui/NotificationHost";
 import OnboardingWizard from "@shell/onboarding/OnboardingWizard";
-import { ONBOARDING_PATH, shouldAutoShow } from "@shell/onboarding/state";
+import { ONBOARDING_PATH, onboardingUrl, shouldAutoShow } from "@shell/onboarding/state";
 import StatusBar from "@platform/ui/StatusBar";
 import ModelsDock from "@shell/ModelsDock";
 import ActivityDock from "@shell/ActivityDock";
@@ -642,14 +642,15 @@ export default function App({ config }: { config: Config }) {
   // door: a deep link (a bookmark, an app URL from the CLI) is honoured, and
   // leaving the wizard must not bounce back in. Same render-time rewrite as
   // "/" above; the flag the rule reads is the server's, so a completed or
-  // dismissed wizard stays gone across ports and browsers.
+  // dismissed wizard stays gone across ports and browsers. The URL names the
+  // server's stored step, so a restart mid-wizard resumes where it was.
   if (
     !IS_EMBED &&
     !autoShowDecided &&
     location.pathname === "/home" &&
     shouldAutoShow(config)
   ) {
-    history.replaceState(null, "", ONBOARDING_PATH);
+    history.replaceState(null, "", onboardingUrl(config));
   }
   autoShowDecided = true;
   // Legacy: the CLAUDE.md explorer ("MD Files") was deleted from the Config

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -75,13 +75,19 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // relaunches on /home) the wizard RESUMES: this page load's memory, then the
   // server's stored step (shell/onboarding/state), then the first step. Every
   // step change is written back, fire-and-forget — the write is a courtesy to
-  // the next open, and a failed one must not hold this page.
+  // the next open, and a failed one must not hold this page. Not once the
+  // wizard has settled (complete / dismiss): a completed wizard's resume point
+  // is cleared, and a step change made while it is still mounted afterwards
+  // (Back after a composer `task_error`, a step pill) must not restore one.
   const [stepId, setStepId] = useState<StepId>(
     () => stepFromUrl() ?? asStepId(recallStep(config)) ?? "about",
   );
+  const settled = useRef(false);
   useEffect(() => {
-    rememberStep(stepId);
-    setOnboardingStep(stepId).catch(() => undefined);
+    if (!settled.current) {
+      rememberStep(stepId);
+      setOnboardingStep(stepId).catch(() => undefined);
+    }
     const url = new URL(location.href);
     if (url.searchParams.get(STEP_PARAM) === stepId) return;
     url.searchParams.set(STEP_PARAM, stepId);
@@ -105,8 +111,8 @@ export function OnboardingWizard({ config }: { config: Config }) {
 
   // Fire-and-forget, and at most one flag per visit: the flag is a courtesy
   // to the NEXT launch, and a failed write must not hold the page over the
-  // app the user is trying to reach.
-  const settled = useRef(false);
+  // app the user is trying to reach. (`settled` is declared above, by the
+  // step effect that reads it.)
   const markComplete = useCallback(() => {
     if (settled.current) return;
     settled.current = true;

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -15,13 +15,19 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowLeft, ArrowRight, Check, X } from "lucide-react";
 
-import { completeOnboarding, dismissOnboarding, type Config } from "@platform/lib/api";
+import {
+  completeOnboarding,
+  dismissOnboarding,
+  setOnboardingStep,
+  type Config,
+} from "@platform/lib/api";
 import { useClaudeSetup } from "@platform/lib/claude-setup";
 import { navigateUrl, replaceSearch } from "@platform/lib/router";
 import { Button } from "@platform/shadcn/ui/button";
 import { cn } from "@platform/lib/utils";
 import { FusedMark } from "@platform/ui/FusedMark";
 
+import { recallStep, rememberStep } from "./state";
 import { AboutStep } from "./AboutStep";
 import { ClaudeStep } from "./ClaudeStep";
 import { FdaStep } from "./FdaStep";
@@ -38,9 +44,11 @@ const STEPS: { id: StepId; label: string }[] = [
 
 // The step id rides in the query so a refresh and a link both land on it.
 const STEP_PARAM = "step";
-function stepFromUrl(): StepId | null {
-  const v = new URLSearchParams(location.search).get(STEP_PARAM);
+function asStepId(v: string | null | undefined): StepId | null {
   return STEPS.some((s) => s.id === v) ? (v as StepId) : null;
+}
+function stepFromUrl(): StepId | null {
+  return asStepId(new URLSearchParams(location.search).get(STEP_PARAM));
 }
 
 // Where the wizard lets go: the front door.
@@ -60,8 +68,18 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // is held, so the FDA step appearing once health answers "darwin" does not
   // shift the page under the user. Mirrored with replaceState: steps are not
   // history entries, Back leaves the wizard.
-  const [stepId, setStepId] = useState<StepId>(() => stepFromUrl() ?? "about");
+  //
+  // Without a step in the URL (Help › Setup wizard is a plain link, a restart
+  // relaunches on /home) the wizard RESUMES: this page load's memory, then the
+  // server's stored step (shell/onboarding/state), then the first step. Every
+  // step change is written back, fire-and-forget — the write is a courtesy to
+  // the next open, and a failed one must not hold this page.
+  const [stepId, setStepId] = useState<StepId>(
+    () => stepFromUrl() ?? asStepId(recallStep(config)) ?? "about",
+  );
   useEffect(() => {
+    rememberStep(stepId);
+    setOnboardingStep(stepId).catch(() => undefined);
     const url = new URL(location.href);
     if (url.searchParams.get(STEP_PARAM) === stepId) return;
     url.searchParams.set(STEP_PARAM, stepId);
@@ -90,6 +108,9 @@ export function OnboardingWizard({ config }: { config: Config }) {
   const markComplete = useCallback(() => {
     if (settled.current) return;
     settled.current = true;
+    // The server clears its resume step on complete; mirror that in this
+    // page load's memory so a reopen starts at the top, not at step 4.
+    rememberStep(null);
     completeOnboarding().catch(() => undefined);
   }, []);
   const finish = useCallback(

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -8,10 +8,12 @@
 //   3 Disk Access  — macOS Full Disk Access, why, and the one button there is
 //   4 First app    — the Home composer, or a showcase local-AI app
 //
-// Steps 1–3 write nothing. Step 4's create (or a showcase open) is the only
-// durable action and doubles as "complete". ✕ / Escape record a DISMISS — a
-// different flag, so a later build can tell the two apart. Both stop the
-// auto-show; neither is undone by reopening from Help › Setup wizard.
+// Steps 1–3 write nothing but the resume step (which step is open, so a
+// restart or a reopen lands back on it). Step 4's create (or a showcase open)
+// is the only other durable action and doubles as "complete". ✕ / Escape
+// record a DISMISS — a different flag, so a later build can tell the two
+// apart. Both stop the auto-show; neither is undone by reopening from Help ›
+// Setup wizard, which resumes where the user left off.
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ArrowLeft, ArrowRight, Check, X } from "lucide-react";
 

--- a/frontend/src/shell/onboarding/state.ts
+++ b/frontend/src/shell/onboarding/state.ts
@@ -2,7 +2,7 @@
 // renders it alone (no sidebar, no status bar) on that path, the server
 // answers a refresh on it (server/routers/shell.py), and Help › Setup wizard
 // is an ordinary link. Opening and closing are navigations — nothing here
-// needs a store. What is left is the one boot-time rule.
+// needs a store. What is left is the boot-time rule, and the resume point.
 import type { Config } from "@platform/lib/api";
 
 export const ONBOARDING_PATH = "/onboarding";
@@ -13,4 +13,34 @@ export function shouldAutoShow(config: Config): boolean {
   const s = config.onboarding;
   if (!s) return false;
   return s.completed_at == null && s.dismissed_at == null;
+}
+
+// The resume point. The server keeps the last open step (shell/onboarding.py
+// `step`) so a restart lands on it; but `config` is fetched ONCE at boot
+// (main.tsx), so within a page load the wizard's own writes would be invisible
+// to a reopen — dismiss on step 3, Help › Setup wizard, and the prop still
+// says whatever boot said. This module-level memory is the same-page-load
+// half; the server is the across-restart half. Not localStorage: every port
+// is a new origin (see the server module's docstring).
+//
+// `undefined` = this page load has not touched the wizard (defer to boot);
+// `null` = it completed the wizard (start over, as the server also says now).
+let rememberedStep: string | null | undefined = undefined;
+
+export function rememberStep(step: string | null): void {
+  rememberedStep = step;
+}
+
+/** Where a reopen should land, most recent source first: this page load's
+    memory, then the boot snapshot. Null when neither knows. */
+export function recallStep(config: Config): string | null {
+  if (rememberedStep !== undefined) return rememberedStep;
+  return config.onboarding?.step ?? null;
+}
+
+/** The wizard's URL for the boot auto-show: names the resume step when the
+    server has one, so a restart mid-wizard reopens the same page. */
+export function onboardingUrl(config: Config): string {
+  const step = recallStep(config);
+  return step ? `${ONBOARDING_PATH}?step=${encodeURIComponent(step)}` : ONBOARDING_PATH;
 }

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -15,6 +15,13 @@ what lets a later "Setup" entry in the sidebar's Help menu reopen the wizard
 without either write being touched, and what a future version bump could key
 a re-show on (a dismissed user is a different audience from a completed one).
 
+`step` is the third field: the id of the wizard step the user last had open,
+written by the shell on every step change. It is what lets the wizard RESUME —
+after a server restart (the auto-show lands on that step, not the first) and
+after a dismiss (Help › Setup wizard reopens where the user left). `complete`
+clears it, so a finished user who reopens the wizard starts from the top;
+`dismiss` keeps it. Server-side for the same reason as the flags.
+
 `seed_for_existing_users` is the upgrade edge: "first time they open the app"
 means a NEW user, and an existing install upgrading into this build has no
 flag either. A workspace that already holds apps under <fused_dir>/local is
@@ -44,6 +51,11 @@ VERSION = 1
 
 _KEY = "onboarding"
 
+#: The wizard's step ids (frontend shell/onboarding/OnboardingWizard STEPS).
+#: A closed set: prefs.json is shared state, and an unknown id is refused
+#: rather than stored.
+STEPS = ("about", "claude", "fda", "app")
+
 #: `FUSED_RENDER_ONBOARDING=1` forces the auto-show (state reads as fresh) so a
 #: dev server can render the wizard without deleting prefs.json; `=0` forces
 #: it off. Read per request: flipping it needs no restart.
@@ -68,12 +80,15 @@ def _write(patch: dict) -> dict:
 
 def snapshot() -> dict:
     """The `onboarding` field of /api/config: `{completed_at, dismissed_at,
-    version}` — each timestamp epoch seconds or None. The shell auto-shows
-    when BOTH are None."""
+    step, version}` — each timestamp epoch seconds or None, `step` the last
+    open step id or None. The shell auto-shows when BOTH timestamps are None."""
     force = os.environ.get(FORCE_ENV)
-    if force == "1":
-        return {"completed_at": None, "dismissed_at": None, "version": VERSION}
     state = _read()
+    step = state.get("step") if state.get("step") in STEPS else None
+    if force == "1":
+        # The override fakes the FLAGS, not the step: a dev server forced into
+        # the wizard still resumes where it was, which is how this is smoked.
+        return {"completed_at": None, "dismissed_at": None, "step": step, "version": VERSION}
     if force == "0" and state.get("dismissed_at") is None:
         # Reads as dismissed without writing anything: the override is for
         # this process, not a decision the user made.
@@ -81,6 +96,7 @@ def snapshot() -> dict:
     return {
         "completed_at": state.get("completed_at"),
         "dismissed_at": state.get("dismissed_at"),
+        "step": step,
         "version": VERSION,
     }
 
@@ -124,7 +140,9 @@ def api_onboarding_complete(x_fused: str | None = Header(default=None)):
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
-    _write({"completed_at": time.time()})
+    # Completion resets the resume point: reopening a FINISHED wizard from
+    # Help starts at the top, a dismissed one resumes (see module docstring).
+    _write({"completed_at": time.time(), "step": None})
     return snapshot()
 
 
@@ -134,4 +152,18 @@ def api_onboarding_dismiss(x_fused: str | None = Header(default=None)):
     if guard is not None:
         return guard
     _write({"dismissed_at": time.time()})
+    return snapshot()
+
+
+@router.post("/api/onboarding/step")
+def api_onboarding_step(body: dict, x_fused: str | None = Header(default=None)):
+    """Remember the step the user has open, so a restart or a reopen resumes
+    there. Fire-and-forget from the shell; refuses ids it does not know."""
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    step = body.get("step") if isinstance(body, dict) else None
+    if step not in STEPS:
+        return JSONResponse({"error": f"unknown step {step!r}"}, status_code=400)
+    _write({"step": step})
     return snapshot()


### PR DESCRIPTION
## Summary
- The wizard remembers the step the user last had open, server-side in prefs.json next to the complete/dismiss flags (`onboarding.step`), and resumes there:
  - **server restart** → the boot auto-show redirect carries `?step=<stored>`, so a relaunch on `/home` reopens the same step;
  - **dismissed, then Help › Setup wizard** → the wizard opens on the last step instead of "About".
- New `POST /api/onboarding/step` (X-Fused guarded, closed set of four ids, 400 otherwise). Written fire-and-forget on every step change.
- `complete` clears the stored step, so a finished user who reopens from Help starts from the top; `dismiss` keeps it.
- `/api/config` is fetched once at boot, so `shell/onboarding/state.ts` also keeps a module-level memory of the step for same-page-load reopens.

## Verification
- `tsc --noEmit`: only the pre-existing `qrcode-generator` module error.
- In-process TestClient smoke of the router: step stored, unknown id → 400, missing header → 403, dismiss keeps step, complete clears it.
- UI smoke pending: `FUSED_RENDER_ONBOARDING=1`, walk to step 2 or 3, restart server → reopens there; ✕ then Help › Setup wizard → reopens there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to first-run onboarding prefs and shell routing; the new endpoint is guarded and validates step ids, with no impact on auth or core app data.
> 
> **Overview**
> The first-run onboarding wizard now **remembers which step was open** and opens there again after a server restart, after dismiss + reopen from Help, or when boot auto-redirects from `/home`.
> 
> **Backend:** `onboarding.step` is stored in prefs with complete/dismiss flags. **`POST /api/onboarding/step`** (X-Fused, known step ids only) updates it on each navigation; **complete clears** the step so a finished user starts at About, while **dismiss keeps** it. `/api/config` and `snapshot()` expose optional `step`; dev override `FUSED_RENDER_ONBOARDING=1` still auto-shows but preserves resume.
> 
> **Frontend:** `setOnboardingStep` and optional `OnboardingState.step` in the API client. Initial step is URL `?step=` → in-memory **`rememberStep` / `recallStep`** (same page load, since config is boot-only) → server step → About. Step changes sync URL, module memory, and the server (skipped after complete/dismiss via `settled`). Boot redirect uses **`onboardingUrl(config)`** instead of plain `/onboarding`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a5ef84d6c891cfe070549d5888bafbb3920693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->