### PR TITLE
Workspace migration: never stat inside ~/Documents on a fresh install

### DIFF
--- a/fused_render/shell/storage.py
+++ b/fused_render/shell/storage.py
@@ -25,8 +25,15 @@ def home_dir() -> str:
     (no ref) is the unnested dir, byte-identical to today."""
     from fused_render._branch import branch_dir
 
-    base = os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render")
-    return branch_dir(base)
+    return branch_dir(base_home_dir())
+
+
+def base_home_dir() -> str:
+    """The unnested ``~/.fused-render`` (or FUSED_RENDER_HOME), whatever branch
+    ref is set. Its mere existence is the "this machine has run fused-render
+    before" witness ``workspace_migration`` gates on — a branch install's
+    nested dir may not exist yet while the baseline's does."""
+    return os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render")
 
 
 def read_json(path: str):

--- a/fused_render/workspace_migration.py
+++ b/fused_render/workspace_migration.py
@@ -29,14 +29,22 @@ b) **absolute paths written into the app's own state** — bookmark and
    an unattended run), and the menu-bar pin (the one of these that lives
    under Application Support, not ``home_dir()``).
 
-Re-entrant: (b) is attempted on every startup, gated on its own
-"old shape present, new shape absent" check, so a process that died between
-the folder move and the bookkeeping heals on the next start instead of leaving
-orphaned state behind forever.
+Re-entrant: (b) is attempted on every startup until a marker
+(``home_dir()/workspace_migrated.json``) says the question is settled, gated on
+its own "old shape present, new shape absent" check, so a process that died
+between the folder move and the bookkeeping heals on the next start instead of
+leaving orphaned state behind forever.
+
+Never on a fresh install: when ``home_dir()`` does not exist there is no
+pre-D337 user here, and the check returns before touching ``~/Documents`` at
+all. That stat is a macOS TCC folder access, and at this point in boot the app
+is not frontmost, so the prompt would be suppressed and a DENY cached
+(``shell/fda.py``) before the onboarding wizard ever reached its FDA step.
 """
 import logging
 import os
 import re
+import time
 from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 from fused_render._branch import branch_dir
@@ -49,6 +57,10 @@ logger = logging.getLogger(__name__)
 # The pre-D337 default. A literal, not a call to anything: this is history, and
 # it must keep naming the old location even as the default moves again.
 LEGACY_FUSED_DIR = "~/Documents/Fused"
+
+# Written under home_dir() once the migration question is settled, so no later
+# start stats inside ~/Documents again.
+_MARKER_NAME = "workspace_migrated.json"
 
 # Shell url prefixes whose remainder is the target's absolute path, mirroring
 # bookmarks._VIEW_PREFIXES / recents._VIEW_PREFIXES.
@@ -76,8 +88,27 @@ def _run() -> None:
     if os.environ.get("FUSED_RENDER_DIR"):
         # The user picked their own workspace. Nothing here applies to them.
         return
+    if not os.path.isdir(storage.base_home_dir()):
+        # A fresh install. Every pre-D337 user has shell state under
+        # ~/.fused-render (bookmarks/prefs/templates, D75/D76), and nothing on
+        # the boot path creates the dir before this runs (logs go to temp, the
+        # pidfile and token to Application Support, ensure_fused_dir is after).
+        # The UNNESTED base, not home_dir(): a branch install's nested dir may
+        # not exist yet on a machine that has plainly run the app before.
+        # No shell state means there is no legacy workspace to move, and the
+        # `isdir(src)` below is a stat INSIDE ~/Documents: on macOS that fires
+        # the TCC folder prompt at launch, before the wizard's FDA step, while
+        # the app is not yet frontmost, which is exactly the suppressed-prompt
+        # cached-DENY failure shell/fda.py documents. So we never look.
+        return
+    marker = os.path.join(storage.home_dir(), _MARKER_NAME)
+    if os.path.exists(marker):
+        # Settled on an earlier start. Without this, every launch paid a stat
+        # inside ~/Documents forever.
+        return
     src, dst = legacy_dir(), fused_dir()
     if src == dst:
+        _write_marker(marker, src, dst, "same-path")
         return
     if os.path.isdir(src):
         if os.path.exists(dst):
@@ -85,6 +116,7 @@ def _run() -> None:
                 "not migrating %s -> %s: the destination already exists. Both are "
                 "left exactly as they are; move the contents by hand if you want "
                 "them merged.", src, dst)
+            _write_marker(marker, src, dst, "destination-exists")
             return
         try:
             os.makedirs(os.path.dirname(dst), exist_ok=True)
@@ -100,8 +132,21 @@ def _run() -> None:
         # moved into would be worse than leaving it.
         return
     # Bookkeeping runs even when the folder move was a no-op: it is how a run
-    # interrupted between the two steps heals.
+    # interrupted between the two steps heals. The marker is written only
+    # AFTER it, so a process that dies between the rename and the rewrite
+    # still re-enters on the next start.
     _rewrite_state(src, dst)
+    _write_marker(marker, src, dst, "done")
+
+
+def _write_marker(marker: str, src: str, dst: str, outcome: str) -> None:
+    """Record that the migration question is settled for this home."""
+    try:
+        storage.write_json(marker, {"from": src, "to": dst, "outcome": outcome,
+                                    "at": time.time()})
+    except OSError:
+        logger.warning("could not write %s; the check will run again next start",
+                       marker, exc_info=True)
 
 
 # --------------------------------------------------------------- path remapping

--- a/fused_render/workspace_migration.py
+++ b/fused_render/workspace_migration.py
@@ -35,9 +35,10 @@ its own "old shape present, new shape absent" check, so a process that died
 between the folder move and the bookkeeping heals on the next start instead of
 leaving orphaned state behind forever.
 
-Never on a fresh install: when ``home_dir()`` does not exist there is no
-pre-D337 user here, and the check returns before touching ``~/Documents`` at
-all. That stat is a macOS TCC folder access, and at this point in boot the app
+Never on a fresh install: when ``~/.fused-render`` does not exist there is no
+pre-D337 user here, and the check writes the marker and returns before touching
+``~/Documents`` at all -- the marker matters, because the first session creates
+that dir and a second launch would otherwise stat ``~/Documents`` after all. That stat is a macOS TCC folder access, and at this point in boot the app
 is not frontmost, so the prompt would be suppressed and a DENY cached
 (``shell/fda.py``) before the onboarding wizard ever reached its FDA step.
 """
@@ -100,6 +101,14 @@ def _run() -> None:
         # the TCC folder prompt at launch, before the wizard's FDA step, while
         # the app is not yet frontmost, which is exactly the suppressed-prompt
         # cached-DENY failure shell/fda.py documents. So we never look.
+        #
+        # Settled right here, not left for next time: the first session
+        # creates ~/.fused-render (server.json, prefs), so a second launch
+        # would pass this gate and stat ~/Documents anyway, still before FDA
+        # was ever granted. Writing the marker creates the home dir, which
+        # is fine now that the gate has been read.
+        _write_marker(os.path.join(storage.home_dir(), _MARKER_NAME),
+                      legacy_dir(), fused_dir(), "fresh-install")
         return
     marker = os.path.join(storage.home_dir(), _MARKER_NAME)
     if os.path.exists(marker):
@@ -133,10 +142,14 @@ def _run() -> None:
         return
     # Bookkeeping runs even when the folder move was a no-op: it is how a run
     # interrupted between the two steps heals. The marker is written only
-    # AFTER it, so a process that dies between the rename and the rewrite
-    # still re-enters on the next start.
-    _rewrite_state(src, dst)
-    _write_marker(marker, src, dst, "done")
+    # AFTER it, and only when every store rewrote cleanly, so a process that
+    # dies between the rename and the rewrite -- or a store that failed to
+    # rewrite -- still re-enters on the next start instead of being recorded
+    # as settled with stale absolute paths left in place.
+    if _rewrite_state(src, dst):
+        _write_marker(marker, src, dst, "done")
+    else:
+        logger.warning("workspace path rewrite incomplete; will retry next start")
 
 
 def _write_marker(marker: str, src: str, dst: str, outcome: str) -> None:
@@ -267,12 +280,15 @@ def rewrite_absolute_paths(src: str, dst: str) -> None:
     _rewrite_state(src, dst)
 
 
-def _rewrite_state(src: str, dst: str) -> None:
+def _rewrite_state(src: str, dst: str) -> bool:
+    """True when every store rewrote (or had nothing to do); False when any
+    raised. A failure is logged and the others still run."""
     # community installs.json is deliberately absent here: the community
     # marketplace no longer produces installed copies (fused_render/
     # community.py), and installs.json from before that change is left on
     # disk untouched — nothing reads or writes it any more, so there is
     # nothing here for a workspace move to keep in step.
+    ok = True
     for label, fn in (("bookmarks", _rewrite_bookmarks),
                       ("recents", _rewrite_recents),
                       ("scheduled messages", _rewrite_schedule),
@@ -280,7 +296,9 @@ def _rewrite_state(src: str, dst: str) -> None:
         try:
             fn(src, dst)
         except Exception:
+            ok = False
             logger.exception("could not rewrite workspace paths in %s", label)
+    return ok
 
 
 def _rewrite_bookmarks(src: str, dst: str) -> None:

--- a/tests/test_workspace_migration.py
+++ b/tests/test_workspace_migration.py
@@ -135,7 +135,13 @@ def test_fresh_install_never_stats_inside_documents(machine, monkeypatch):
     assert touched == []
     assert legacy.is_dir()
     assert not new.exists()
-    assert not home.exists()
+    # Settled now, so the second launch (home dir created by the first
+    # session's stores) does not stat Documents either.
+    with open(_marker(home), encoding="utf-8") as f:
+        assert json.load(f)["outcome"] == "fresh-install"
+    wm.run()
+    assert touched == []
+    assert legacy.is_dir()
 
 
 def test_marker_is_written_and_stops_later_runs_from_looking(machine, monkeypatch):
@@ -180,6 +186,30 @@ def test_no_marker_when_the_move_itself_failed(machine, monkeypatch):
     wm.run()
 
     assert not os.path.exists(_marker(home))
+
+
+def test_no_marker_when_a_state_rewrite_failed(machine, monkeypatch):
+    """The folder moves, but a store that failed to rewrite is not settled:
+    the bookkeeping re-enters next start (and heals, since the move is a
+    no-op by then)."""
+    legacy, new, home = machine
+    legacy.mkdir(parents=True)
+
+    def boom(*a, **k):
+        raise RuntimeError("corrupt store")
+
+    # A nested MonkeyPatch, so lifting the fault does not also lift the
+    # fixture's fake HOME (a bare monkeypatch.undo() would).
+    with pytest.MonkeyPatch.context() as fault:
+        fault.setattr(wm, "_rewrite_recents", boom)
+        wm.run()
+
+    assert new.is_dir()
+    assert not os.path.exists(_marker(home))
+
+    wm.run()
+    with open(_marker(home), encoding="utf-8") as f:
+        assert json.load(f)["outcome"] == "done"
 
 
 def test_skipped_entirely_when_fused_render_dir_is_set(machine, tmp_path, monkeypatch):

--- a/tests/test_workspace_migration.py
+++ b/tests/test_workspace_migration.py
@@ -24,7 +24,16 @@ def machine(tmp_path, monkeypatch):
     monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / ".fused-render"))
     legacy = tmp_path / "Documents" / "Fused"
     new = tmp_path / "Fused"
-    return legacy, new, tmp_path / ".fused-render"
+    home = tmp_path / ".fused-render"
+    # An existing user: shell state has been written here before. A fresh
+    # install has no home dir and is the one case the migration must never
+    # even look (see test_fresh_install_never_stats_inside_documents).
+    home.mkdir()
+    return legacy, new, home
+
+
+def _marker(home) -> str:
+    return os.path.join(str(home), wm._MARKER_NAME)
 
 
 def _view_url(path) -> str:
@@ -93,6 +102,84 @@ def test_no_op_when_the_legacy_dir_is_missing(machine):
 
     assert not legacy.exists()
     assert not new.exists()
+
+
+def _spy_documents(monkeypatch):
+    """Record every os.path.isdir / exists call whose path is under Documents."""
+    touched = []
+    real_isdir, real_exists = os.path.isdir, os.path.exists
+
+    def spy(fn):
+        def inner(p, *a, **k):
+            if "Documents" in str(p):
+                touched.append(str(p))
+            return fn(p, *a, **k)
+        return inner
+
+    monkeypatch.setattr(os.path, "isdir", spy(real_isdir))
+    monkeypatch.setattr(os.path, "exists", spy(real_exists))
+    return touched
+
+
+def test_fresh_install_never_stats_inside_documents(machine, monkeypatch):
+    """No shell home dir means no pre-D337 user. The legacy path must not be
+    stat'ed at all: on macOS that is a TCC folder access fired before the
+    wizard's FDA step, while the app is not frontmost."""
+    legacy, new, home = machine
+    home.rmdir()
+    legacy.mkdir(parents=True)  # even if one exists, we do not look
+    touched = _spy_documents(monkeypatch)
+
+    wm.run()
+
+    assert touched == []
+    assert legacy.is_dir()
+    assert not new.exists()
+    assert not home.exists()
+
+
+def test_marker_is_written_and_stops_later_runs_from_looking(machine, monkeypatch):
+    legacy, new, home = machine
+    legacy.mkdir(parents=True)
+    (legacy / "a.html").write_text("a", encoding="utf-8")
+
+    wm.run()
+
+    with open(_marker(home), encoding="utf-8") as f:
+        assert json.load(f)["outcome"] == "done"
+    assert (new / "a.html").is_file()
+
+    # Second start: a legacy dir reappears, but the question is settled.
+    legacy.mkdir(parents=True)
+    touched = _spy_documents(monkeypatch)
+    wm.run()
+    assert touched == []
+    assert legacy.is_dir()
+
+
+def test_marker_records_a_refused_move(machine):
+    legacy, new, home = machine
+    legacy.mkdir(parents=True)
+    new.mkdir(parents=True)
+
+    wm.run()
+
+    with open(_marker(home), encoding="utf-8") as f:
+        assert json.load(f)["outcome"] == "destination-exists"
+
+
+def test_no_marker_when_the_move_itself_failed(machine, monkeypatch):
+    """A failed rename must re-enter next start, so nothing is settled."""
+    legacy, new, home = machine
+    legacy.mkdir(parents=True)
+
+    def boom(*a, **k):
+        raise OSError("nope")
+
+    monkeypatch.setattr(os, "rename", boom)
+    wm.run()
+
+    assert not os.path.exists(_marker(home))
 
 
 def test_skipped_entirely_when_fused_render_dir_is_set(machine, tmp_path, monkeypatch):


### PR DESCRIPTION
## Why

Fresh install, first onboarding page, macOS already asks for Documents access. One of two causes (the other, the startup file-index scan of `~`, is handled separately).

`workspace_migration._run()` did `os.path.isdir("~/Documents/Fused")` at process start in both entry points (`cli.py`, packaged `app.py`), before the browser tab opened. That stat is a TCC folder access while the app is not frontmost, so the prompt gets suppressed and a DENY cached before the wizard's FDA step ever runs, which is exactly what `shell/fda.py` and `FdaStep.tsx` document as the failure to avoid. Existing users also paid the stat on every launch.

## What

- **Fresh-install gate**: if the unnested `~/.fused-render` does not exist, return before touching Documents. Every pre-D337 user has shell state there (D75/D76); nothing on the boot path creates it before this runs (logs go to temp, pidfile/token to Application Support, `ensure_fused_dir` is after). New `storage.base_home_dir()` exposes the unnested base, because a branch install's nested `home_dir()` may not exist yet on a machine that has run the app.
- **Settled marker**: `home_dir()/workspace_migrated.json` written once the question is settled (`done`, `destination-exists`, `same-path`). Written only after the state rewrite, so the crash-between-rename-and-bookkeeping heal path is preserved; a failed rename writes none.

Trade accepted: a legacy user who somehow never wrote any shell state gets a fresh `~/Fused` and their old `~/Documents/Fused` stays put. No data loss, just a stale folder.

## Tests

`tests/test_workspace_migration.py`: fixture now models an existing user (home dir present); new tests spy `os.path.isdir/exists` for any Documents path on a fresh install and after the marker, marker outcomes, no marker on failed rename. 50 passed with `test_app_fused_dir.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes early startup migration and when absolute paths in shell state are rewritten; mistakes could skip a needed move or mark migration settled with stale paths, though gates and retry-without-marker limit blast radius.
> 
> **Overview**
> **Workspace migration no longer touches `~/Documents` on first launch**, avoiding a macOS TCC stat that can cache a denied Documents grant before onboarding’s FDA step.
> 
> Migration now treats an existing **unnested** `~/.fused-render` (`storage.base_home_dir()`, not branch-nested `home_dir()`) as “this machine has run the app before.” If that directory is missing, it writes `workspace_migrated.json` with outcome `fresh-install` and returns without checking the legacy `~/Documents/Fused` path—even on the second launch after the first session creates shell state.
> 
> For existing users, **`home_dir()/workspace_migrated.json`** records when migration is settled (`done`, `destination-exists`, `same-path`, etc.), so later starts skip legacy-path stats entirely. The marker is written **only after** bookmark/recents/schedule/pin rewrites all succeed; failed renames or partial rewrites leave no marker so startup retries bookkeeping on the next run.
> 
> Tests spy `Documents` path stats, cover fresh-install and marker outcomes, and assert no marker on failed move or failed rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526d4040a3f6b3186b84f901261f6e0e668b4650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->