### PR TITLE
Indexing waits for Full Disk Access on the packaged mac app

### DIFF
--- a/frontend/src/apps/explorer/FilesHome.render.test.tsx
+++ b/frontend/src/apps/explorer/FilesHome.render.test.tsx
@@ -805,6 +805,22 @@ describe("an uncovered index with no scan running offers the scan", () => {
     box.unmount();
   });
 
+  test("no Full Disk Access offers the grant, not a scan", async () => {
+    // The packaged mac app without FDA: no scan may start (shell/index_gate.py),
+    // so "Index my files" would be a button that cannot work. The callout asks
+    // for the grant instead, and the note says nothing on top of it.
+    const box = mount(scanStatus({ scanning: true }));
+    await type(box, "report");
+    await flush(() => rankCalls[0].resolve(answer({ ...uncovered, reason: "fda" })));
+    const cta = findByClass(box, "fh-index-cta-text") as { props: { children: unknown } }[];
+    expect(cta.length).toBe(1);
+    expect(String(cta[0].props.children)).toContain("Full Disk Access");
+    expect(findByClass(box, "fh-index-cta-btn").length).toBe(1);
+    expect(scanCalls).toEqual([]);
+    expect(noteText(box)).not.toContain("still building");
+    box.unmount();
+  });
+
   test("a permanently uncoverable root offers no scan either", async () => {
     // A button that cannot work is worse than none: no scan will ever cover a
     // mount-backed root.

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -836,10 +836,10 @@ export function FilesSearch({
     !suppressRank
       ? indexGap(displayAnswer.reason, liveScanning)
       : null;
-  // The `buildable` branch yields nothing — the `.fh-index-cta` callout is the
-  // message for that state — so the note paragraph is empty and the suffix's
-  // leading "·" would separate nothing.
-  const noteEmpty = gap === "buildable";
+  // The `buildable` and `fda` branches yield nothing — the `.fh-index-cta`
+  // callout is the message for those states — so the note paragraph is empty
+  // and the suffix's leading "·" would separate nothing.
+  const noteEmpty = gap === "buildable" || gap === "fda";
   // Whether AI search has anything to answer WITH. It executes its spec
   // against the same file index (`routers/search._search_index`), so with no
   // index built it fails the same way the instant search did — see

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -26,6 +26,7 @@ import {
 } from "@platform/lib/index-freshness";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
 import { RecentPreviewCard, FolderPreviewCard } from "@apps/explorer/BookmarkCards";
+import { IndexFdaCta } from "@apps/explorer/IndexFdaCta";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
 import {
   refreshIsPending,
@@ -1031,6 +1032,9 @@ export function FilesSearch({
               </button>
             </div>
           )}
+          {/* No Full Disk Access on the packaged mac app: no scan may start,
+              so the offer is the grant, not a scan (explorer/IndexFdaCta). */}
+          {gap === "fda" && <IndexFdaCta />}
           <p className="fh-result-note">
             {/* Branch on the ANSWER IN HAND, not on the request state: while a
                 new query is in flight the previous answer is what is on screen,
@@ -1085,6 +1089,10 @@ export function FilesSearch({
                 </button>
                 .
               </>
+            ) : gap === "fda" ? (
+              // Owned by the IndexFdaCta callout above, same reasoning as
+              // `buildable` below: one message, not two.
+              null
             ) : gap === "scanning" ? (
               // Never "no matches" for an index that has not been built: that
               // would blame the user's files for the app's state. The file

--- a/frontend/src/apps/explorer/IndexFdaCta.tsx
+++ b/frontend/src/apps/explorer/IndexFdaCta.tsx
@@ -1,0 +1,48 @@
+// The home search's callout for `IndexGap === "fda"`: the packaged mac app has
+// no Full Disk Access, so no index scan may start (shell/index_gate.py), so
+// there is nothing to search. The one thing the user can do about it is grant
+// the access, which is what this offers — in the `.fh-index-cta` slot the
+// "Index my files" button uses for the buildable case, because it is the same
+// kind of thing: the single action this screen asks for.
+//
+// Reads the shared FDA store (platform/lib/fda.ts) rather than rendering
+// FdaStrip: the strip shows itself only after a REFUSED read, and nothing here
+// was refused — nothing was even attempted. Same three faces as the wizard's
+// FdaStep: open Settings; the grant landed and a relaunch remains
+// (`pending_relaunch`); granted (which this process can only see after that
+// relaunch, so in practice the callout is gone by then — the startup scan has
+// begun and the gap reads `scanning`).
+import { useState } from "react";
+
+import { openFdaSettings } from "@platform/lib/api";
+import { FDA_COPY, RELAUNCH_HREF, pokeFda, useFda } from "@platform/lib/fda";
+
+export function IndexFdaCta() {
+  const fda = useFda();
+  const [opened, setOpened] = useState(false);
+  const pending = fda?.pending_relaunch === true;
+  const open = () => {
+    openFdaSettings()
+      .then(() => setOpened(true))
+      .catch(() => {})
+      .finally(pokeFda);
+  };
+  return (
+    <div className="fh-index-cta" data-testid="fh-index-fda">
+      <span className="fh-index-cta-text">
+        {pending
+          ? "Full Disk Access is granted — relaunch FusedRender to start indexing your files."
+          : "Search needs Full Disk Access to index your files — nothing is scanned until you grant it."}
+      </span>
+      {pending ? (
+        <a className="btn btn-secondary fh-index-cta-btn" href={RELAUNCH_HREF}>
+          {FDA_COPY.relaunch}
+        </a>
+      ) : (
+        <button type="button" className="btn btn-secondary fh-index-cta-btn" onClick={open}>
+          {opened ? FDA_COPY.reopen : FDA_COPY.open}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -639,6 +639,15 @@ describe("indexGap", () => {
     expect(indexGap("disabled", false)).toBe("disabled");
   });
 
+  it("never claims a scan without Full Disk Access either", () => {
+    // Every trigger is gated on the grant (shell/index_gate.py), and the
+    // grant applies to the next launch, so nothing this process reports as
+    // scanning can be a scan that finishes.
+    expect(indexGap("fda", true)).toBe("fda");
+    expect(indexGap("fda", false)).toBe("fda");
+    expect(indexGap("fda", null)).toBe("fda");
+  });
+
   it("calls the permanently uncoverable reasons what they are", () => {
     // Offering "index it now" for these would be a button that cannot work.
     for (const r of ["mount", "package", "ignored"] as const)

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -523,10 +523,13 @@ export function submitRow(
  *    Waiting fixes nothing; only a scan does.
  *  * `disabled` — the indexing pref is off, so no scan can start until it is
  *    back on.
+ *  * `fda` — the packaged mac app has no Full Disk Access, so no scan can
+ *    start until it is granted (and the app relaunched). The page offers the
+ *    grant, not a scan.
  *  * `unavailable` — mount-backed, inside a package, or pruned by the ignore
  *    rules: no scan will ever cover it (see `RankReason`).
  */
-export type IndexGap = "scanning" | "buildable" | "disabled" | "unavailable";
+export type IndexGap = "scanning" | "buildable" | "disabled" | "fda" | "unavailable";
 
 /**
  * Which of those an uncovered root is in.
@@ -562,6 +565,9 @@ export type IndexGap = "scanning" | "buildable" | "disabled" | "unavailable";
  */
 export function indexGap(reason: RankReason, scanning: boolean | null): IndexGap {
   if (reason === "disabled") return "disabled";
+  // Same argument as `disabled`: every trigger is gated on the grant, so a
+  // lagging `scanning` from the poll cannot be a scan that will finish.
+  if (reason === "fda") return "fda";
   if (scanning === true) return "scanning";
   if (reason === "scanning" && scanning === null) return "scanning";
   if (reason === "mount" || reason === "package" || reason === "ignored") {

--- a/frontend/src/apps/explorer/listing/index-source.test.ts
+++ b/frontend/src/apps/explorer/listing/index-source.test.ts
@@ -34,6 +34,7 @@ describe("what to do with a ranked answer", () => {
     // source available, same as mount/package/ignored.
     expect(at({ reason: "disabled" })).toBe("walk");
     expect(at({ reason: "disabled", asked: true, sinceAsk: 99 })).toBe("walk");
+    expect(at({ reason: "fda" })).toBe("walk");
   });
 
   test("an uncovered folder is scanned, once", () => {

--- a/frontend/src/apps/explorer/listing/index-source.ts
+++ b/frontend/src/apps/explorer/listing/index-source.ts
@@ -81,11 +81,13 @@ export function nextStep(input: SourceInput): SearchStep {
   // the other three are — the user can flip the preference back on — because
   // there is no server signal to poll for that, so a scan is exactly as
   // unaskable-for as it is for a mount, a package, or an ignored folder.
+  // `fda` likewise: the grant lands on the NEXT launch, not this one.
   if (
     reason === "mount" ||
     reason === "package" ||
     reason === "ignored" ||
-    reason === "disabled"
+    reason === "disabled" ||
+    reason === "fda"
   ) {
     return "walk";
   }

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -613,12 +613,17 @@ export interface IndexRankHit {
 // does not wait around for that: it walks, exactly as it does for `mount` /
 // `package` / `ignored`, because there is no server signal to poll for "the
 // user flipped a switch in Preferences".
+// `fda` is `disabled`'s sibling: the packaged mac app has no Full Disk Access,
+// so no scan may start (shell/index_gate.py — a home walk would prompt per
+// protected folder). Fixable by the user, but only through a grant plus a
+// relaunch, so the client offers THAT and never a scan.
 export type RankReason =
   | ""
   | "mount"
   | "package"
   | "ignored"
   | "disabled"
+  | "fda"
   | "uncovered"
   | "scanning";
 

--- a/frontend/src/shell/onboarding/FdaStep.tsx
+++ b/frontend/src/shell/onboarding/FdaStep.tsx
@@ -21,7 +21,7 @@
 // of a "waiting…" line that could never finish (macOS caches the running
 // process's verdict).
 import { useEffect, useState } from "react";
-import { Check, ExternalLink, FolderLock, Lock, RotateCw, ShieldCheck } from "lucide-react";
+import { Check, ExternalLink, FolderLock, Lock, RotateCw, Search, ShieldCheck } from "lucide-react";
 
 import { openFdaSettings, type Config } from "@platform/lib/api";
 import { FDA_COPY, RELAUNCH_HREF, pokeFda, seedFda, useFda } from "@platform/lib/fda";
@@ -60,10 +60,10 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: string }
       <StepHeader
         eyebrow={eyebrow}
         title="Let FusedRender read your files"
-        lead="macOS asks separately for Desktop, Documents, Downloads, external drives and network volumes — and if a prompt fires while the app is in the background, it is silently denied. Full Disk Access, granted once in System Settings, covers all of them and survives upgrades."
+        lead="macOS asks separately for Desktop, Documents, Downloads, external drives and network volumes — and if a prompt fires while the app is in the background, it is silently denied. Full Disk Access, granted once in System Settings, covers all of them, survives upgrades, and is what lets FusedRender index your files for search."
       />
 
-      <ul className="m-0 grid list-none gap-3 p-0 sm:grid-cols-3">
+      <ul className="m-0 grid list-none gap-3 p-0 sm:grid-cols-2 lg:grid-cols-4">
         {[
           {
             icon: <Lock className="size-4" />,
@@ -74,6 +74,11 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: string }
             icon: <FolderLock className="size-4" />,
             title: "One grant, every folder",
             body: "Replaces a prompt per protected folder — including the ones macOS never shows.",
+          },
+          {
+            icon: <Search className="size-4" />,
+            title: "Powers search",
+            body: "File search runs on an index of your home folder. Indexing waits for this grant — nothing is scanned before you say so.",
           },
           {
             icon: <ShieldCheck className="size-4" />,
@@ -155,7 +160,7 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: string }
       </div>
 
       <p className="text-xs text-muted-foreground">
-        You can do this later. If macOS ever refuses a file, the Home page shows a reminder with this same button.
+        You can do this later. If macOS ever refuses a file, the Home page shows a reminder with this same button, and file search offers it whenever it has no index to answer from.
       </p>
     </div>
   );

--- a/fused_render/index/runner.py
+++ b/fused_render/index/runner.py
@@ -141,10 +141,15 @@ def start(cfg: IndexConfig, root: str, full: bool = False) -> dict:
     # calls `start` directly without going through one of those — cheap
     # because prefs.json is a small local file, and `shell.prefs` imports
     # nothing from `index` at module scope, so this is not a cycle.
-    from fused_render.shell.prefs import indexing_enabled
+    from fused_render.shell import index_gate
 
-    if not indexing_enabled():
+    blocked = index_gate.indexing_blocked()
+    if blocked == "disabled":
         raise ValueError("indexing is disabled in Preferences")
+    if blocked == index_gate.FDA_REASON:
+        # A home walk without Full Disk Access reads under every TCC-protected
+        # folder and fires (or silently loses) a prompt per folder.
+        raise ValueError(index_gate.FDA_MESSAGE)
     # The guard runs BEFORE any kernel syscall on the caller's path: it is
     # pure string work against the mount records, while os.path.isdir on a
     # path under a wedged NFS mount blocks the request thread indefinitely

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -310,6 +310,7 @@ otherwise one of:
 | `package` | a `.app`/`.photoslibrary` — recorded as one opaque row, never listed | live streamed walk |
 | `ignored` | the scan's ignore list excludes this tree (`node_modules`, …) | live streamed walk |
 | `disabled` | the `indexing_enabled` preference is off (`shell/prefs.py`) — no scan will start | live streamed walk |
+| `fda` | the packaged mac app has no Full Disk Access (`shell/index_gate.py`) — no scan will start until it is granted and the app relaunched | live streamed walk; the home search offers the grant |
 | `uncovered` | not scanned yet, and scannable | ask for a scan (§7.2), then poll |
 | `scanning` | a run covering this root is live — in EITHER direction, an ancestor root or a descendant one | poll, rendering whatever came back |
 
@@ -337,6 +338,18 @@ the ordinary on-demand-scan path (§7.2) takes over from there. Precedence: `dis
 checked after `mount`/`package` and before `ignored`, so an ignored folder is still
 `ignored` regardless of the toggle — that fact is about the scan config, not about
 whether scanning can run at all.
+
+`fda` is `disabled`'s sibling and sits right after it in precedence (`shell/index_gate.py`
+answers both from one call). The default root is the user's home, and walking it reads
+under every TCC-protected folder — Desktop, Documents, Downloads and the rest — which on a
+fresh install fired a prompt per folder at boot, before onboarding had painted, or had
+those prompts silently denied because the app was not frontmost. So on the packaged mac
+app no trigger starts a scan (startup, on-demand, folder-open freshness, mutation rescan,
+`runner.start` as the backstop) while the in-process probe conclusively says not granted;
+an inconclusive probe (no target on the machine) does not block. The grant applies to the
+next launch, which runs the startup scan, so indexing begins on its own once the user
+grants and relaunches. `POST /api/index/scan` answers 409 with `reason: "fda"`;
+`scan-folder` answers `why: "fda"`.
 
 **Deciding this server-side is the point.** The mount policy is `MountGuard`'s — the
 same object `runner.start` refuses with — the ignore list is the scan config's, and the

--- a/fused_render/server/index_touch.py
+++ b/fused_render/server/index_touch.py
@@ -313,8 +313,8 @@ def note_index_mutation(*paths: str | None) -> None:
     the mutating page keeps touching files. Checked here rather than only at
     `_real_start` because THAT already having a scan to skip is the failure
     mode this avoids."""
-    from fused_render.shell.prefs import indexing_enabled
+    from fused_render.shell import index_gate
 
-    if not indexing_enabled():
+    if not index_gate.indexing_allowed():
         return
     _queue.note(*[p for p in paths if isinstance(p, str) and p])

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -52,6 +52,7 @@ from fused_render.index.store import (
 from fused_render.server import ai as _server_ai
 from fused_render.server import index_touch
 from fused_render.server.common import _error, _require_fused
+from fused_render.shell import index_gate
 from fused_render.shell.prefs import indexing_enabled
 
 logger = logging.getLogger(__name__)
@@ -110,11 +111,17 @@ def run_startup_scan(start_dir: str | None = None) -> None:
     Records each started run in `_startup_runs` for `run_startup_warm`, which
     warms only after the run covering its root has finished."""
     _startup_runs.clear()
-    if not indexing_enabled():
-        # No scan ever starts while the pref is off (shell/prefs.py). The
-        # warm still runs — it only searches the existing index, never
-        # scans — so search stays as snappy as the stale index allows.
-        logger.info("index: startup scan skipped (indexing is disabled)")
+    blocked = index_gate.indexing_blocked()
+    if blocked:
+        # No scan ever starts while the pref is off (shell/prefs.py) or, on
+        # the packaged mac app, without Full Disk Access (shell/index_gate.py:
+        # the home walk would prompt per protected folder before onboarding
+        # even painted). The warm still runs — it only searches the existing
+        # index, never scans — so search stays as snappy as the stale index
+        # allows.
+        logger.info("index: startup scan skipped (%s)",
+                    "indexing is disabled" if blocked == "disabled"
+                    else "no Full Disk Access yet")
         return
     try:
         cfg = load_config()
@@ -350,8 +357,12 @@ def _rank_reason(cfg: IndexConfig, root: str, out: dict) -> str:
         # scan will ever fix an uncovered folder, which is exactly the claim
         # `mount`/`package` make too — it just comes from a toggle rather
         # than from the filesystem's shape.
-        if not indexing_enabled():
-            return "disabled"
+        blocked = index_gate.indexing_blocked()
+        if blocked:
+            # "disabled" or "fda": either way no scan will start until the
+            # user acts (a toggle, or a grant plus relaunch), so the client
+            # must offer THAT rather than a scan.
+            return blocked
         if ignored_for_index(cfg.rules, norm(os.path.abspath(root)), tree=True):
             return "ignored"
     # Never claim a scan is in flight while the pref is off — nothing can be
@@ -611,7 +622,7 @@ def note_folder_opened(path: str) -> bool:
     is the ONE gate for every caller of this function (fs_read.py,
     git_repos.py, exported_apps.py), so a rescan-if-stale check never turns
     into a scan behind the pref's back."""
-    if not indexing_enabled():
+    if not index_gate.indexing_allowed():
         return False
     if not _freshness_slot.acquire(blocking=False):
         return False
@@ -632,8 +643,11 @@ def api_index_scan(body: dict = Body(default={}),
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
-    if not indexing_enabled():
-        return JSONResponse({"error": "indexing is disabled in Preferences"},
+    blocked = index_gate.indexing_blocked()
+    if blocked:
+        return JSONResponse({"error": "indexing is disabled in Preferences"
+                             if blocked == "disabled" else index_gate.FDA_MESSAGE,
+                             "reason": blocked},
                             status_code=409)
     cfg = load_config()
     full = bool(body.get("full"))
@@ -701,11 +715,12 @@ def api_index_scan_folder(body: dict = Body(default={}),
 
     cfg = load_config()
     root = runner.canonical_root(path)
-    if not indexing_enabled():
+    blocked = index_gate.indexing_blocked()
+    if blocked:
         # A durable "no", same as every other refusal here: the search box
-        # polls this on a retry loop, and "disabled" says as plainly as
-        # `refused` does that asking again will not change the answer.
-        return {"ok": True, "started": False, "why": "disabled",
+        # polls this on a retry loop, and "disabled" / "fda" say as plainly
+        # as `refused` does that asking again will not change the answer.
+        return {"ok": True, "started": False, "why": blocked,
                 "run_id": None, "root": root}
     # THE MOUNT GUARD FIRST, and the order is the point rather than a
     # preference: `blocks` is pure string work against the mount records,

--- a/fused_render/shell/index_gate.py
+++ b/fused_render/shell/index_gate.py
@@ -1,0 +1,55 @@
+"""The one answer to "may a file-index scan start right now?".
+
+Two things can say no, and every trigger of a scan — the startup scan, the
+on-demand routes, the freshness check a folder open queues, the rescan a
+mutating page queues, and `runner.start` itself as the backstop — asks this
+helper instead of `prefs.indexing_enabled()` alone, so the two refusals
+cannot drift apart between call sites:
+
+* ``"disabled"`` — the ``indexing_enabled`` preference is off (shell/prefs.py).
+* ``"fda"`` — the packaged macOS app does not have Full Disk Access
+  (shell/fda.py). The default scan root is the user's home, and a recursive
+  walk of it reads under Desktop, Documents, Downloads and the rest of the
+  TCC-protected folders. On a fresh install that walk used to start at boot,
+  before the onboarding wizard had even painted, and each protected folder
+  fired its own prompt — or, since the app was not frontmost yet, had the
+  prompt suppressed and a DENY cached. Full Disk Access silences all of them
+  at once, and the wizard already asks for it; so indexing simply waits for
+  the grant. A grant applies only to the next launch (macOS caches the
+  verdict per process, see fda.py), and the next launch runs the startup
+  scan, which is how "indexing starts once FDA is given" comes for free.
+
+Precedence: ``disabled`` first — a user who turned indexing off has said
+something stronger than "not yet".
+
+Only a CONCLUSIVE "not granted" blocks. `fda.granted()` answers None when no
+probe target exists on the machine; blocking on "cannot tell" would strand
+indexing forever with nothing the user could do about it, and an install with
+neither `~/Library/Safari` nor `~/Library/Mail` is rare enough that the
+per-folder prompts are the lesser wrong. Non-mac and dev-server processes are
+never blocked: there `fda.offered()` is False because TCC is not in play (or
+the identity is the terminal's).
+"""
+from fused_render.shell import fda, prefs
+
+#: The `reason` / `why` value every surface spells the FDA refusal as.
+FDA_REASON = "fda"
+
+#: Text for the 409 / ValueError shape, beside "indexing is disabled in
+#: Preferences".
+FDA_MESSAGE = "indexing needs Full Disk Access on macOS"
+
+
+def indexing_blocked() -> str:
+    """"" when a scan may start, else "disabled" or "fda"."""
+    # Module attribute lookups on purpose (not `from ... import`), so a test
+    # that patches `prefs.indexing_enabled` or `fda.granted` is seen here.
+    if not prefs.indexing_enabled():
+        return "disabled"
+    if fda.offered() and fda.granted() is False:
+        return FDA_REASON
+    return ""
+
+
+def indexing_allowed() -> bool:
+    return indexing_blocked() == ""

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -85,7 +85,7 @@ def test_scan_rejects_a_path_that_is_not_a_directory(home, tmp_path):
 
 
 def test_scan_409s_while_indexing_is_off(home, tmp_path, monkeypatch):
-    monkeypatch.setattr(index_router, "indexing_enabled", lambda: False)
+    monkeypatch.setattr(index_router.index_gate.prefs, "indexing_enabled", lambda: False)
     resp = _client(tmp_path).post("/api/index/scan", json={"root": str(tmp_path)},
                                   headers={"X-Fused": "1"})
     assert resp.status_code == 409
@@ -659,7 +659,7 @@ def test_startup_scan_skips_every_root_while_indexing_is_off(home, tmp_path,
     started = []
     monkeypatch.setattr(index_router.runner, "start",
                         lambda cfg, root, full=False: started.append(root))
-    monkeypatch.setattr(index_router, "indexing_enabled", lambda: False)
+    monkeypatch.setattr(index_router.index_gate.prefs, "indexing_enabled", lambda: False)
     cfg = load_config()
     cfg.roots = [str(src)]
     index_router.save_config(cfg)
@@ -1257,7 +1257,7 @@ def test_note_folder_opened_starts_nothing_while_indexing_is_off(
     threads = []
     monkeypatch.setattr(index_router.threading, "Thread",
                         lambda **kw: threads.append(kw) or _FakeThread())
-    monkeypatch.setattr(index_router, "indexing_enabled", lambda: False)
+    monkeypatch.setattr(index_router.index_gate.prefs, "indexing_enabled", lambda: False)
     assert _real_note_folder_opened(str(tmp_path)) is False
     assert threads == []
 

--- a/tests/test_index_fda_gate.py
+++ b/tests/test_index_fda_gate.py
@@ -1,0 +1,136 @@
+"""Indexing waits for Full Disk Access on the packaged mac app
+(fused_render/shell/index_gate.py).
+
+The default scan root is the user's home, and a recursive walk of it reads
+under every TCC-protected folder; on a fresh install that used to fire a
+prompt per folder at boot, before the onboarding wizard had painted. Every
+trigger of a scan now asks the one gate, and the gate says "fda" whenever the
+app offers the nudge and the in-process probe conclusively says not granted.
+"""
+import pytest
+
+from fused_render.index.config import load_config
+from fused_render.server import index_touch
+from fused_render.server.routers import index as index_router
+from fused_render.shell import fda as fda_mod
+from fused_render.shell import index_gate
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    return tmp_path
+
+
+def _no_fda(monkeypatch):
+    monkeypatch.setattr(fda_mod, "offered", lambda: True)
+    monkeypatch.setattr(fda_mod, "granted", lambda: False)
+
+
+# ------------------------------------------------------------------- the gate
+
+def test_not_blocked_where_the_nudge_is_not_offered(home, monkeypatch):
+    """Non-mac and dev servers: TCC is not in play (or the identity is the
+    terminal's), so a missing grant means nothing here."""
+    monkeypatch.setattr(fda_mod, "offered", lambda: False)
+    monkeypatch.setattr(fda_mod, "granted", lambda: False)
+    assert index_gate.indexing_blocked() == ""
+    assert index_gate.indexing_allowed()
+
+
+def test_blocked_when_offered_and_conclusively_not_granted(home, monkeypatch):
+    _no_fda(monkeypatch)
+    assert index_gate.indexing_blocked() == "fda"
+    assert not index_gate.indexing_allowed()
+
+
+def test_not_blocked_when_granted_or_inconclusive(home, monkeypatch):
+    """Only a conclusive "no" blocks: an install with no probe target would
+    otherwise never index, with nothing the user could do about it."""
+    monkeypatch.setattr(fda_mod, "offered", lambda: True)
+    monkeypatch.setattr(fda_mod, "granted", lambda: True)
+    assert index_gate.indexing_blocked() == ""
+    monkeypatch.setattr(fda_mod, "granted", lambda: None)
+    assert index_gate.indexing_blocked() == ""
+
+
+def test_the_preference_outranks_the_grant(home, monkeypatch):
+    _no_fda(monkeypatch)
+    monkeypatch.setattr(index_gate.prefs, "indexing_enabled", lambda: False)
+    assert index_gate.indexing_blocked() == "disabled"
+
+
+# ---------------------------------------------------------------- the triggers
+
+def test_startup_scan_starts_nothing_without_fda(home, tmp_path, monkeypatch):
+    """The boot-time trigger, the one that fired the prompts on a fresh
+    install. No config read either: the gate is checked first."""
+    _no_fda(monkeypatch)
+    started = []
+    monkeypatch.setattr(index_router.runner, "start",
+                        lambda cfg, root, full=False: started.append(root))
+    index_router.run_startup_scan(start_dir=str(tmp_path))
+    assert started == []
+
+
+def test_runner_start_refuses_without_fda(home, tmp_path, monkeypatch):
+    """The backstop for anything that reaches the runner directly."""
+    _no_fda(monkeypatch)
+    with pytest.raises(ValueError, match="Full Disk Access"):
+        index_router.runner.start(load_config(), str(tmp_path))
+
+
+def test_scan_route_409s_with_the_fda_reason(home, tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from fused_render.server import create_app
+
+    _no_fda(monkeypatch)
+    client = TestClient(create_app(str(tmp_path)))
+    resp = client.post("/api/index/scan", json={"root": str(tmp_path)},
+                       headers={"X-Fused": "1"})
+    assert resp.status_code == 409
+    assert resp.json()["reason"] == "fda"
+
+
+def test_scan_folder_reports_fda_and_starts_nothing(home, tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from fused_render.server import create_app
+
+    _no_fda(monkeypatch)
+    started = []
+    monkeypatch.setattr(index_router.runner, "start",
+                        lambda cfg, root, full=False: started.append(root))
+    client = TestClient(create_app(str(tmp_path)))
+    folder = tmp_path / "elsewhere"
+    folder.mkdir()
+    resp = client.post("/api/index/scan-folder", json={"path": str(folder)},
+                       headers={"X-Fused": "1"})
+    assert resp.status_code == 200
+    assert resp.json()["started"] is False
+    assert resp.json()["why"] == "fda"
+    assert started == []
+
+
+def test_folder_open_and_mutation_triggers_are_gated(home, tmp_path, monkeypatch):
+    _no_fda(monkeypatch)
+    threads = []
+    monkeypatch.setattr(index_router.threading, "Thread",
+                        lambda **kw: threads.append(kw))
+    assert index_router.note_folder_opened(str(tmp_path)) is False
+    assert threads == []
+    noted = []
+    monkeypatch.setattr(index_touch._queue, "note", lambda *p: noted.append(p))
+    index_touch.note_index_mutation(str(tmp_path / "a.txt"))
+    assert noted == []
+
+
+def test_rank_reason_is_fda_for_an_uncovered_root(home, tmp_path, monkeypatch):
+    """What the home search keys its "grant Full Disk Access" callout on."""
+    _no_fda(monkeypatch)
+    cfg = load_config()
+    reason = index_router._rank_reason(cfg, str(tmp_path), {"covered": False})
+    assert reason == "fda"

--- a/tests/test_index_scan_on_demand.py
+++ b/tests/test_index_scan_on_demand.py
@@ -157,7 +157,7 @@ def test_scan_folder_reports_disabled_and_starts_nothing(client, tmp_path,
     from fused_render.server.routers import index as index_routes
 
     calls = _started(monkeypatch)
-    monkeypatch.setattr(index_routes, "indexing_enabled", lambda: False)
+    monkeypatch.setattr(index_routes.index_gate.prefs, "indexing_enabled", lambda: False)
     folder = tmp_path / "elsewhere"
     folder.mkdir()
     body = _ask(client, folder)


### PR DESCRIPTION
Builds on #988 (merged to main).

## Why

Fresh install, first onboarding page, macOS asks for Desktop, Documents, Music. Cause: the startup file-index scan walks `~` at boot. `SKIP_DIRS` covers system dirs only, the only gate was the `indexing_enabled` pref (default on), and the debounce stamps at scan start so it never helps a first run. Before the app is frontmost those prompts are also silently denied and cached, which is the failure `shell/fda.py` exists to avoid. (The other boot-time Documents stat, the workspace migration, is #990.)

## What

**One gate.** `shell/index_gate.py` `indexing_blocked()` answers `""` / `"disabled"` / `"fda"`. `fda` when `fda.offered()` (packaged mac app) and `fda.granted()` is conclusively False. `disabled` outranks it. Inconclusive probe (no `~/Library/Safari` or `Mail`) does not block, so an odd install can still index.

**Every trigger asks it**: `run_startup_scan`, `POST /api/index/scan` (409, `reason: "fda"`), `scan-folder` (`why: "fda"`), `note_folder_opened`, `note_index_mutation`, and `runner.start` as the backstop (`ValueError("indexing needs Full Disk Access on macOS")`).

**Indexing starts when FDA is given**: a grant applies to the next launch (#988's relaunch), and the next launch runs the startup scan. Nothing new needed.

**Onboarding FDA step**: lead names search; fourth card "Powers search: indexing waits for this grant, nothing is scanned before you say so". Grid goes 2/4 columns.

**Search asks for FDA**: `RankReason` and `IndexGap` gain `"fda"`. `_rank_reason` reports it right after `disabled`. FilesHome renders `IndexFdaCta` in the `.fh-index-cta` slot: "Search needs Full Disk Access to index your files" + Open System Settings, flipping to the Relaunch link on `pending_relaunch`. Reads the #988 `useFda` store, not `FdaStrip` (which shows only after a refused read). Listing's `index-source` walks live for `fda`, same as `disabled`.

Spec: `index/specs/server-api.md` reason table + a paragraph.

## Tests

- New `tests/test_index_fda_gate.py`: gate truth table, every trigger starts nothing, 409/`why` shapes, `_rank_reason`.
- `test_index_api.py` / `test_index_scan_on_demand.py`: four patches of `indexing_enabled` moved to `shell.prefs` where the gate reads it.
- bun: `indexGap`, `nextStep`, FilesHome render test for the callout.
- 265 pytest pass across the index + fda files; 135 bun tests pass; `tsc --noEmit` clean apart from the preexisting `qrcode-generator` miss.

## Smoke (packaged build)

Fresh install → wizard step 1: no TCC prompts. Step 3 shows the search card. Skip it, go to Home, type in search: callout with Open System Settings, no "Index my files". Grant + relaunch → startup scan runs, search shows "still building".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core indexing startup and all scan triggers on macOS packaged builds; mis-gating could block indexing or reintroduce TCC prompts, but behavior is heavily tested and dev/non-packaged paths stay unblocked.
> 
> **Overview**
> **Indexing no longer starts on the packaged Mac app until Full Disk Access is granted**, avoiding boot-time home-folder walks that triggered per-folder TCC prompts (often silently denied).
> 
> A new **`shell/index_gate.py`** centralizes `indexing_blocked()` / `indexing_allowed()` (`disabled` beats `fda`; inconclusive FDA probes do not block). **Every scan entry point**—startup, `POST /api/index/scan` (409 + `reason: "fda"`), `scan-folder`, folder-open freshness, mutation rescans, and `runner.start`—uses that gate instead of the indexing pref alone. Rank responses can return **`reason: "fda"`**; the client maps it to a new **`IndexGap`** and shows **`IndexFdaCta`** on Files Home (open Settings / relaunch) instead of **Index my files**, with in-folder search **walking live** like `disabled`.
> 
> Onboarding’s FDA step copy and layout call out that search indexing waits on the grant. Spec and tests cover the gate, API shapes, `indexGap` / `nextStep`, and UI render behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5213143e059d0a0cb428c4a06703e94a38eaaffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

