### PR TITLE
Showcase clone says git is required when it is missing

### DIFF
--- a/frontend/src/apps/builder/Apps.tsx
+++ b/frontend/src/apps/builder/Apps.tsx
@@ -85,7 +85,15 @@ type ShowcaseCatalog = { status?: string };
 // the first visit doesn't keep a stale listing until reload. An
 // already-cloned catalog never touches the network here (it's cloned once,
 // then left alone), so this never blocks on git after the first visit.
-function useShowcaseSync(onSynced: () => void): void {
+//
+// Returns the clone's failure message when it refused (no usable git on the
+// machine, no network, a foreign folder already at <workspace>/showcase).
+// This used to be swallowed, which left the hub silently short of every
+// showcase app with nothing on screen to say why; the local grid still loads
+// either way, so it renders as a muted line rather than the page's error
+// banner. The backend composes the whole user-facing sentence.
+function useShowcaseSync(onSynced: () => void): string | null {
+  const [syncError, setSyncError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
     (async () => {
@@ -95,12 +103,15 @@ function useShowcaseSync(onSynced: () => void): void {
       await runCommunity<ShowcaseCatalog>({ action: "refresh" });
       if (!alive) return;
       onSynced();
-    })().catch(() => undefined);
+    })().catch((e: Error) => {
+      if (alive) setSyncError(e.message);
+    });
     return () => {
       alive = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- once per mount
   }, []);
+  return syncError;
 }
 
 // Folder paths (keys of GET /api/apps/background/running) whose background
@@ -264,7 +275,7 @@ export default function Apps({ config }: { config: Config }) {
     () => orderCategories(all.map((a) => a.category).filter((c): c is string => !!c)),
     [all],
   );
-  useShowcaseSync(() => setNonce((n) => n + 1));
+  const showcaseError = useShowcaseSync(() => setNonce((n) => n + 1));
   const runningPaths = useRunningBackgroundApps();
   const q = query.trim().toLowerCase();
   const shown = useMemo(
@@ -364,6 +375,9 @@ export default function Apps({ config }: { config: Config }) {
         </div>
 
         {error && <ErrorBanner>{error}</ErrorBanner>}
+        {/* Above the grid, not inside its empty state: the local apps below
+            are fine, it is only the showcase half that is missing. */}
+        {showcaseError && <div className="apps-showcase-note">{showcaseError}</div>}
         {/* Skeleton only while there is nothing drawable at all: once the fast
             row has landed the cards themselves are the loading indicator, and
             the count line below says the rest is still coming. */}

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -394,8 +394,15 @@ export default function Home({ config }: { config: Config }) {
           if (!alive) return;
           setApps(retry.apps.slice(0, MAX_ROW));
           return;
-        } catch {
-          // Community backend unreachable — fall through to the empty state.
+        } catch (e) {
+          // The clone refused (no usable git, network, a foreign folder at
+          // <workspace>/showcase). On a brand-new install this row is empty
+          // BECAUSE of that, so the reason belongs in the empty state — the
+          // bare "No apps yet" reads as a normal fresh workspace and leaves
+          // the user waiting on a download that will never arrive. The
+          // backend composes the whole sentence; it renders verbatim below.
+          if (!alive) return;
+          setAppsError((e as Error).message);
         }
         setApps([]);
       },

--- a/frontend/src/shell/onboarding/FirstAppStep.tsx
+++ b/frontend/src/shell/onboarding/FirstAppStep.tsx
@@ -28,8 +28,14 @@ function isLocalAi(app: AppInfo): boolean {
   return app.tag === "showcase" && app.name.startsWith("local-");
 }
 
-function useLocalAiShowcase(): AppInfo[] | null {
+function useLocalAiShowcase(): { apps: AppInfo[] | null; error: string | null } {
   const [apps, setApps] = useState<AppInfo[] | null>(null);
+  // Why the clone produced nothing, when it produced nothing. An empty row
+  // used to read "still downloading" unconditionally — on a machine with no
+  // git that sentence is a lie that never resolves, and this step is the
+  // first place a new user meets the showcase. The backend composes the
+  // whole sentence (community.py `_require_git`), so it lands verbatim.
+  const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     let alive = true;
     const fetchGrid = () =>
@@ -47,12 +53,14 @@ function useLocalAiShowcase(): AppInfo[] | null {
       if (!alive || local.status !== "no-cache") return;
       await runCommunity<ShowcaseCatalog>({ action: "refresh" });
       if (alive) fetchGrid();
-    })().catch(() => undefined);
+    })().catch((e: Error) => {
+      if (alive) setError(e.message);
+    });
     return () => {
       alive = false;
     };
   }, []);
-  return apps;
+  return { apps, error };
 }
 
 export function FirstAppStep({
@@ -66,7 +74,7 @@ export function FirstAppStep({
       need no hook: the navigation they perform is what the wizard reads. */
   onComplete: () => void;
 }) {
-  const showcase = useLocalAiShowcase();
+  const { apps: showcase, error: showcaseError } = useLocalAiShowcase();
   const claudeReady = health ? health.found && !health.broken && health.signed_in !== false : true;
 
   return (
@@ -98,7 +106,15 @@ export function FirstAppStep({
             Runs AI on this machine — the first open downloads the model.
           </span>
         </div>
-        {showcase === null ? (
+        {/* The failure outranks both the skeleton and the wait copy: once the
+            clone has refused there is nothing left to wait for, and the
+            message says what to do about it. */}
+        {showcaseError && (!showcase || showcase.length === 0) ? (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            <span>{showcaseError}</span>
+          </div>
+        ) : showcase === null ? (
           <div className="grid gap-4 sm:grid-cols-2">
             {[0, 1, 2, 3].map((i) => (
               <Skeleton key={i} className="aspect-[16/10] w-full rounded-xl" />

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -123,6 +123,20 @@
   color: var(--fg-muted);
 }
 
+/* The showcase clone refused (no usable git, no network). A notice, not the
+   page's error banner: the local apps in the grid below loaded fine, so this
+   states what is missing without claiming the page failed. */
+.apps-showcase-note {
+  margin-bottom: 12px;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  background: color-mix(in srgb, var(--fg) 4%, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
 /* Filter facet selector (Category | Folders): a small segmented control that
    decides which chip set shows. Neutral fill on the active segment (accent
    stays reserved for focus/selection).

--- a/fused_render/community.py
+++ b/fused_render/community.py
@@ -29,7 +29,9 @@ copy to keep in sync). Opening an app there IS opening your copy.
 The lock file (`.lock`, `_cache_lock`) stays under ~/.fused-render/community/.
 Every git call runs with GIT_TERMINAL_PROMPT=0 and a bounded timeout — a
 first clone that can't finish in time surfaces as a friendly retry error
-rather than a hang.
+rather than a hang. A machine with no usable git is refused BEFORE the clone
+(`_require_git`), naming git as the requirement, since every surface that
+would otherwise sit on "still downloading" forever renders that message.
 """
 import contextlib
 import json
@@ -258,6 +260,48 @@ def _clear_stale_staging():
         shutil.rmtree(leftover, ignore_errors=True)
 
 
+def _git_install_hint():
+    """The one-line "get git" instruction for this platform. macOS is called
+    out on its own because /usr/bin/git is a shim that EXISTS on every Mac
+    without the developer tools behind it — `which` finds it, so the missing
+    piece is the toolchain, not a download."""
+    if sys.platform == "darwin":
+        return "run `xcode-select --install` to get it, then revisit this page"
+    if sys.platform == "win32":
+        return "install it from https://git-scm.com/download/win, then revisit this page"
+    return ("install it with your package manager (for example `apt install "
+            "git`), then revisit this page")
+
+
+def _require_git():
+    """Refuse the clone up front when git can't run, with a message that says
+    so — the showcase is a git clone and there is no fallback.
+
+    `git --version` is the probe, not `shutil.which`: on macOS /usr/bin/git is
+    an xcode-select shim present on every machine whether or not the developer
+    tools are installed, so `which` succeeds and only actually RUNNING git
+    reveals `xcrun: error: invalid active developer path`. That failure used to
+    reach the page (when it reached it at all) as a raw xcrun line under
+    "could not fetch the community catalog"; a git that cannot report its own
+    version is unambiguously unusable, so it is named as such here instead of
+    pattern-matching stderr.
+
+    Cheap enough to run on every clone attempt (milliseconds, once — the clone
+    behind it is tens of seconds), and it never runs again after the first
+    successful clone, since _refresh returns early then."""
+    try:
+        r = _git(WORKSPACE, "--version", timeout=15)
+        ok = r.returncode == 0
+    except ActionError:
+        # _git already maps FileNotFoundError/timeout to a message, but both
+        # mean the same thing here and this one names the consequence.
+        ok = False
+    if not ok:
+        raise ActionError(
+            "could not download the showcase apps: git is required to clone "
+            f"them and it isn't available on this machine — {_git_install_hint()}")
+
+
 def _refresh():
     """Clone the showcase repo if it isn't there yet; once it exists this is
     a no-op that just serves the catalog. The clone is the user's tree —
@@ -274,6 +318,10 @@ def _refresh():
             f"{SHOWCASE_DIR} exists but is not the showcase clone — "
             "move it aside to let the catalog sync")
     os.makedirs(WORKSPACE, exist_ok=True)
+    # Ahead of mkdtemp, so a machine without git leaves no staging dir behind
+    # — and AFTER makedirs, since `_git` runs with `-C WORKSPACE` and a missing
+    # cwd fails even `--version`.
+    _require_git()
     # Clone into a hidden staging dir, then claim the final name with one
     # rename — no half-clone ever flashes up in the explorer listing.
     staging = tempfile.mkdtemp(dir=WORKSPACE, prefix=".showcase-clone-")

--- a/fused_render/community.py
+++ b/fused_render/community.py
@@ -264,13 +264,16 @@ def _git_install_hint():
     """The one-line "get git" instruction for this platform. macOS is called
     out on its own because /usr/bin/git is a shim that EXISTS on every Mac
     without the developer tools behind it — `which` finds it, so the missing
-    piece is the toolchain, not a download."""
+    piece is the toolchain, not a download.
+
+    No backticks or other markup: every surface drops this into a plain text
+    node, so markup would render as literal characters."""
     if sys.platform == "darwin":
-        return "run `xcode-select --install` to get it, then revisit this page"
+        return "run xcode-select --install to get it, then revisit this page"
     if sys.platform == "win32":
         return "install it from https://git-scm.com/download/win, then revisit this page"
-    return ("install it with your package manager (for example `apt install "
-            "git`), then revisit this page")
+    return ("install it with your package manager (apt install git, brew "
+            "install git), then revisit this page")
 
 
 def _require_git():


### PR DESCRIPTION
On a machine with no usable git the first showcase clone can never succeed, but nothing said so — the failure was swallowed at all three call sites, so the UI claimed the clone was still in flight indefinitely.

## What the user saw

- **Onboarding wizard** — "The showcase is still downloading — it appears under Apps once it lands", forever. This is the "it keeps showing that it is cloning".
- **Home** — an empty Fused Apps row reading "No apps yet. Build one and it'll show up here.", indistinguishable from an ordinary fresh workspace.
- **/apps hub** — silently short of every showcase app, no notice at all.

All three called `runCommunity({action:"refresh"})` and ended in `.catch(() => undefined)`. The backend was already reporting `{status:"error", message}` and `runCommunity` was already throwing it; nobody rendered it.

## The macOS case the old message missed

`_git` mapped `FileNotFoundError` to "git is not installed (or not on PATH)", but on macOS `/usr/bin/git` exists on **every** machine as an xcode-select shim whether or not the developer tools are behind it. `shutil.which("git")` finds it, the spawn succeeds, and `clone` exits nonzero with `xcrun: error: invalid active developer path` — so the not-installed branch was effectively dead code for the common case, and the message that would have surfaced was a raw xcrun line.

`_refresh` now probes `git --version` before staging anything (`_require_git`). A git that cannot report its own version is unambiguously unusable, so there is no stderr pattern-matching. Placement matters both ways: **after** `os.makedirs(WORKSPACE)` (`_git` runs with `-C WORKSPACE`, and a missing cwd fails even `--version`) and **before** `mkdtemp`, so a known-missing git leaves no `.showcase-clone-*` staging dir behind. It only ever runs on the clone path — once the clone exists `_refresh` returns early — and costs milliseconds ahead of a call that takes tens of seconds.

The refusal names git as the requirement and how to get it, branched by platform (`xcode-select --install` / git-scm.com / package manager).

## Surfacing it

The backend composes the whole user-facing sentence, per this module's existing `{status:"error", message}`-rendered-verbatim contract, so no new wire fields:

- **FirstAppStep** — `useLocalAiShowcase` returns `{apps, error}`; the error outranks both the skeleton and the wait copy, rendered in the same amber notice the step already uses for a disconnected Claude Code.
- **Home** — the existing `catch` now calls `setAppsError(e.message)`, and the empty state already renders `appsError ?? "No apps yet…"`.
- **Apps** — `useShowcaseSync` returns `string | null`, rendered as a new muted `.apps-showcase-note` above the grid rather than the page's red `ErrorBanner`: the local apps loaded fine, only the showcase half is missing.

## Verification

Backend messages checked directly against both shapes — binary absent, and a stub that runs and exits nonzero the way the xcode-select shim does. Both refuse with the git-required sentence and leave no staging dir. `tsc --noEmit` clean (the one `qrcode-generator` error is pre-existing on main). UI smoke is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted error surfacing and a pre-clone git probe on the showcase refresh path; no changes to auth, data handling, or successful clone behavior after the first successful sync.
> 
> **Overview**
> When the showcase clone cannot run (especially **no usable git**), the UI no longer pretends it is still downloading. The backend now **refuses before staging** via `_require_git()` (`git --version`, with platform-specific install hints including the macOS xcode-select shim case), and three surfaces **stop swallowing** `runCommunity` refresh errors.
> 
> **Onboarding** shows the backend message in an amber notice instead of endless “still downloading.” **Home** puts the same text in the Fused Apps empty state via `appsError`. **Apps hub** shows a muted `.apps-showcase-note` above the grid so local apps still look fine while showcase apps are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f742b75bbd20aa41956037d1f0424a3cd0268b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->