### PR TITLE
Onboarding: a Models step that starts local downloads in the background

### DIFF
--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -61,20 +61,57 @@ export type ModelPicks = ModelPick[] | null;
 // that progress is visible HERE, since the wizard route renders without the
 // download manager — would not survive a single Back.
 //
-// Deriving `started` from the jobs list instead would be wrong: D663 keeps a
-// finished or failed row until it is dismissed, so last week's error on the
-// same repo would read as this visit's failure.
+// `started` is WHEN each model was asked for, not a flag — see `jobFor`: a
+// job row outlives its work (D663 keeps a finished or failed one until it is
+// dismissed), so "is this row mine" is a question about time, and a bare
+// boolean cannot answer it. It is never the row's state either; that is read
+// off the job, so a download that finishes or fails while the step is open
+// turns into a tick or a sentence on its own.
 let memory: {
   checked: Set<string> | null;
-  started: Set<string>;
+  /** model id -> `Date.now()` when its Download was sent. */
+  started: Map<string, number>;
   errors: Record<string, string>;
-} = { checked: null, started: new Set(), errors: {} };
+} = { checked: null, started: new Map(), errors: {} };
 
 /** Forget what the Models step started — called when the wizard completes,
  *  so a reopened wizard in the same page load offers a fresh selection
  *  rather than rows still claiming to be downloading. */
 export function forgetModelsStep(): void {
-  memory = { checked: null, started: new Set(), errors: {} };
+  memory = { checked: null, started: new Map(), errors: {} };
+}
+
+/** Clock skew allowance when comparing a job's server-side `finished_at`
+ *  against this page's `Date.now()`. Same machine, so the two clocks are the
+ *  same clock; this covers the second-granularity rounding either side. */
+const CLOCK_SLACK_MS = 2000;
+
+/** The job that is telling the truth about `id` right now, or none.
+ *
+ *  Two rules, and the second one is the whole reason this function exists.
+ *  A job still in flight is shown whoever started it: an app or another page
+ *  pulling the same repo IS this model downloading, and `supervisor.load`
+ *  joins rather than races, so reporting it is accurate and hiding it would
+ *  leave the row looking idle while bytes move.
+ *
+ *  A TERMINAL job is shown only when it belongs to this visit — the step
+ *  asked for the model, and the row finished after it asked. Without that,
+ *  every catalog row was matched against the whole server job list: a `done`
+ *  row from last week (kept until dismissed, D663) drew a tick on a model the
+ *  user had not chosen and took its checkbox away, and an old failure drew a
+ *  sentence about something that happened days ago. */
+function jobFor(
+  id: string,
+  jobs: Map<string, Job>,
+  started: Map<string, number>,
+): Job | undefined {
+  const job = jobs.get(id);
+  if (!job) return undefined;
+  if (!isTerminal(job)) return job;
+  const askedAt = started.get(id);
+  if (askedAt === undefined) return undefined;
+  if (job.finished_at == null) return undefined;
+  return job.finished_at * 1000 >= askedAt - CLOCK_SLACK_MS ? job : undefined;
 }
 
 /** The catalog, once, as picks. Lives at the WIZARD level (like
@@ -102,15 +139,16 @@ export function useModelPicks(): ModelPicks {
   return picks;
 }
 
-/** Jobs, polled only once something has been started here, and only while
- *  anything is still running. The wizard has no status bar and no download
- *  manager on screen (App.tsx renders this route alone), so progress has to
- *  be drawn in the step or it is invisible until the user leaves. */
-function useStartedJobs(started: boolean): Job[] {
+/** Jobs, polled for as long as this step is on screen, at `pollInterval`'s
+ *  own cadence (fast while anything runs, slow when nothing does). The wizard
+ *  has no status bar and no download manager on screen (App.tsx renders this
+ *  route alone), so progress has to be drawn in the step or it is invisible
+ *  until the user leaves — including progress that was already running when
+ *  the step opened, which is what a return to it after a Next looks like. */
+function useJobs(): Job[] {
   const [jobs, setJobs] = useState<Job[]>([]);
   const lastRunning = useRef(Date.now());
   useEffect(() => {
-    if (!started) return;
     let alive = true;
     let timer: number | undefined;
     const tick = () => {
@@ -131,7 +169,7 @@ function useStartedJobs(started: boolean): Job[] {
       alive = false;
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [started]);
+  }, []);
   return jobs;
 }
 
@@ -140,13 +178,13 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
   // mounts — the setters below write both, so a remount seeds from what the
   // last one left rather than from scratch.
   const [checked, setCheckedState] = useState<Set<string> | null>(memory.checked);
-  const [started, setStartedState] = useState<Set<string>>(memory.started);
+  const [started, setStartedState] = useState<Map<string, number>>(memory.started);
   const [errors, setErrorsState] = useState<Record<string, string>>(memory.errors);
   const setChecked = (next: Set<string>) => {
     memory.checked = next;
     setCheckedState(next);
   };
-  const setStarted = (next: Set<string>) => {
+  const setStarted = (next: Map<string, number>) => {
     memory.started = next;
     setStartedState(next);
   };
@@ -164,13 +202,14 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `setChecked` is a per-render closure
   }, [picks, checked]);
 
-  const jobs = useStartedJobs(started.size > 0);
+  const jobs = useJobs();
   // Deliberately NOT `activeJobByModel`: that map drops a terminal row (the
   // stale-busy fix for pages that gate on mere presence), and this step reads
   // the STATE — a `done` row is how a finished download turns into a tick, an
   // `error` row is the only place the failure's sentence exists. Same key
   // (`job.title` is the repo id, `supervisor.load`'s own `title=model`) and
-  // the same server-owned filter.
+  // the same server-owned filter. Which of those rows this step may believe
+  // is `jobFor`'s question, not this map's.
   const jobByModel = useMemo(
     () => new Map(jobs.filter((j) => j.owner === "server").map((j) => [j.title, j])),
     [jobs],
@@ -178,6 +217,26 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
 
   const selection = checked ?? new Set<string>();
   const total = useMemo(() => selectedTotal(picks ?? [], selection), [picks, selection]);
+
+  // Every row's state, read off its job rather than off what was clicked — so
+  // a download that finishes turns into a tick, one that fails gives its
+  // checkbox back with the reason beside it, and neither needs the step to
+  // still be mounted at the moment it happened. `pending` is what Start would
+  // act on: selected, not here already, and nothing in flight for it.
+  const rows = (picks ?? []).map((pick) => {
+    const job = jobFor(pick.model.id, jobByModel, started);
+    const busy = job !== undefined && !isTerminal(job);
+    const here = pick.model.downloaded || job?.state === "done";
+    return {
+      pick,
+      job,
+      busy,
+      here,
+      pending: selection.has(pick.model.id) && !busy && !here,
+    };
+  });
+  const pending = rows.filter((r) => r.pending);
+  const busyCount = rows.filter((r) => r.busy).length;
 
   // Driven by the checkbox's own reported value, not by flipping what this
   // render happened to see: the primitive owns the state transition.
@@ -189,10 +248,14 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
   };
 
   const start = () => {
-    if (!picks) return;
-    const wanted = picks.filter((p) => selection.has(p.model.id) && !started.has(p.model.id));
+    const wanted = pending.map((r) => r.pick);
     if (wanted.length === 0) return;
-    setStarted(new Set([...started, ...wanted.map((p) => p.model.id)]));
+    // The timestamp is what makes a job row believable afterwards (`jobFor`):
+    // a retry rewrites it, so the failed row it replaces stops counting.
+    const asked = new Map(started);
+    const now = Date.now();
+    for (const p of wanted) asked.set(p.model.id, now);
+    setStarted(asked);
     // A retry drops the previous sentence for the rows it retries: an old 409
     // printed beside a fresh progress bar reads as a failure that just
     // happened.
@@ -212,7 +275,9 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
         const message = e instanceof Error ? e.message : String(e);
         memory.errors = { ...memory.errors, [p.model.id]: message };
         setErrorsState(memory.errors);
-        const remaining = new Set(memory.started);
+        // The ask is withdrawn as well as reported: no job was opened, so the
+        // row goes back to being one the user can check and Start again.
+        const remaining = new Map(memory.started);
         remaining.delete(p.model.id);
         memory.started = remaining;
         setStartedState(remaining);
@@ -220,12 +285,9 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
     }
   };
 
-  const pending = picks
-    ? picks.filter((p) => selection.has(p.model.id) && !started.has(p.model.id))
-    : [];
   const pendingTotal = selectedTotal(
     picks ?? [],
-    pending.map((p) => p.model.id),
+    pending.map((r) => r.pick.model.id),
   );
   const models = `${pending.length} model${pending.length === 1 ? "" : "s"}`;
   // The figure only when there IS one: every selected model lacking a
@@ -251,15 +313,16 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
         </div>
       ) : (
         <ul className="m-0 flex list-none flex-col gap-3 p-0">
-          {picks.map((p) => (
+          {rows.map((r) => (
             <ModelRow
-              key={p.model.id}
-              pick={p}
-              checked={selection.has(p.model.id)}
-              started={started.has(p.model.id)}
-              job={jobByModel.get(p.model.id)}
-              error={errors[p.model.id]}
-              onToggle={(on) => setRow(p.model.id, on)}
+              key={r.pick.model.id}
+              pick={r.pick}
+              checked={selection.has(r.pick.model.id)}
+              busy={r.busy}
+              here={r.here}
+              job={r.job}
+              error={errors[r.pick.model.id]}
+              onToggle={(on) => setRow(r.pick.model.id, on)}
             />
           ))}
         </ul>
@@ -269,14 +332,14 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
         <Button onClick={start} disabled={pending.length === 0}>
           {pending.length > 0
             ? startLabel
-            : started.size > 0
+            : busyCount > 0
               ? "Downloading in the background"
-              : picks?.every((p) => p.model.downloaded)
+              : rows.length > 0 && rows.every((r) => r.here)
                 ? "Every model is already here"
                 : "Nothing selected"}
         </Button>
         <span className="text-xs text-muted-foreground">
-          {started.size > 0
+          {busyCount > 0
             ? "Carry on — the download keeps running while you finish setup, and appears in the download manager."
             : "Downloads run in the background. You can go to the next step straight away."}
         </span>
@@ -300,14 +363,19 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
 function ModelRow({
   pick,
   checked,
-  started,
+  busy,
+  here,
   job,
   error,
   onToggle,
 }: {
   pick: ModelPick;
   checked: boolean;
-  started: boolean;
+  /** A job of this model's is in flight — no checkbox, draw the bar. */
+  busy: boolean;
+  /** It is on this disk: the catalog said so, or this visit's download said
+      `done`. A tick either way. */
+  here: boolean;
   job: Job | undefined;
   error: string | undefined;
   onToggle: (on: boolean) => void;
@@ -332,16 +400,19 @@ function ModelRow({
   // than stuck. `jobAmount` is the byte count beside it, once there is one.
   const caption = job ? [jobStatusLine(job), jobAmount(job)].filter(Boolean).join(" · ") : "";
   const fraction = job ? jobFraction(job) : null;
-  const finished = model.downloaded || (job !== undefined && job.state === "done");
+  // A row shows its failure whether the REQUEST failed (no job was ever
+  // opened) or the JOB did — and only for a job this visit is entitled to
+  // read, which is `jobFor`'s filter upstream, not a state check here.
+  const failure = error || (job?.state === "error" ? job.message || "The download failed." : null);
 
   return (
     <li className="flex flex-col gap-2 rounded-xl border border-border bg-card p-4">
       <div className="flex items-start gap-3">
-        {finished ? (
+        {here ? (
           <span className="mt-0.5 grid size-4 place-items-center rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
             <Check className="size-3" strokeWidth={3} />
           </span>
-        ) : started ? (
+        ) : busy ? (
           <span className="mt-0.5 grid size-4 place-items-center text-muted-foreground">
             <HardDrive className="size-3.5" />
           </span>
@@ -355,7 +426,7 @@ function ModelRow({
         )}
         <div className="min-w-0 flex-1">
           <label
-            htmlFor={started || finished ? undefined : `model-${model.id}`}
+            htmlFor={busy || here ? undefined : `model-${model.id}`}
             className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm font-medium"
           >
             {name}
@@ -382,12 +453,12 @@ function ModelRow({
         <div className="shrink-0 text-right">
           <div className="text-sm font-semibold tabular-nums">{size}</div>
           <div className="text-xs text-muted-foreground">
-            {finished ? "already here" : "download"}
+            {here ? "already here" : "download"}
           </div>
         </div>
       </div>
 
-      {job && !finished && (
+      {busy && (
         <div className="flex flex-col gap-1.5">
           <div className="h-1 overflow-hidden rounded-full bg-muted">
             <div
@@ -401,10 +472,10 @@ function ModelRow({
         </div>
       )}
 
-      {(error || (job && isTerminal(job) && job.state === "error")) && (
+      {failure && (
         <p className="flex items-start gap-2 text-xs text-destructive">
           <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
-          {error || job?.message || "The download failed."}
+          {failure}
         </p>
       )}
     </li>

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -86,6 +86,12 @@ export function forgetModelsStep(): void {
  *  same clock; this covers the second-granularity rounding either side. */
 const CLOCK_SLACK_MS = 2000;
 
+/** How long a sent Download reads as busy before its job row has appeared —
+ *  the gap between the POST returning and the next poll seeing the row. A
+ *  bound, not a timeout: nothing is cancelled when it lapses, the row simply
+ *  becomes one the user can Start again. */
+const STARTING_GRACE_MS = 30_000;
+
 /** The job that is telling the truth about `id` right now, or none.
  *
  *  Two rules, and the second one is the whole reason this function exists.
@@ -144,25 +150,39 @@ export function useModelPicks(): ModelPicks {
  *  has no status bar and no download manager on screen (App.tsx renders this
  *  route alone), so progress has to be drawn in the step or it is invisible
  *  until the user leaves — including progress that was already running when
- *  the step opened, which is what a return to it after a Next looks like. */
-function useJobs(): Job[] {
+ *  the step opened, which is what a return to it after a Next looks like.
+ *
+ *  `refresh` is the out-of-band tick a click needs: the cadence is right for
+ *  watching, and wrong for the moment a Download has just been sent, when the
+ *  next scheduled poll may be `POLL_IDLE_MS` away. It drops the pending timer
+ *  and asks now, and a reply that lands after an unmount is discarded — the
+ *  epoch, not the `alive` flag of a closure a caller could be holding. */
+function useJobs(): { jobs: Job[]; refresh: () => void } {
   const [jobs, setJobs] = useState<Job[]>([]);
   const lastRunning = useRef(Date.now());
+  const refresh = useRef(() => {});
   useEffect(() => {
+    let epoch = 0;
     let alive = true;
     let timer: number | undefined;
     const tick = () => {
+      const mine = ++epoch;
       fetchJobs().then(
         ({ jobs: next }) => {
-          if (!alive) return;
+          if (!alive || mine !== epoch) return;
           setJobs(next);
           if (next.some(isRunning)) lastRunning.current = Date.now();
           timer = window.setTimeout(tick, pollInterval(next, Date.now() - lastRunning.current));
         },
         () => {
-          if (alive) timer = window.setTimeout(tick, 4000);
+          if (alive && mine === epoch) timer = window.setTimeout(tick, 4000);
         },
       );
+    };
+    refresh.current = () => {
+      if (!alive) return;
+      if (timer !== undefined) window.clearTimeout(timer);
+      tick();
     };
     tick();
     return () => {
@@ -170,7 +190,7 @@ function useJobs(): Job[] {
       if (timer !== undefined) window.clearTimeout(timer);
     };
   }, []);
-  return jobs;
+  return { jobs, refresh: () => refresh.current() };
 }
 
 export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: string }) {
@@ -202,7 +222,7 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `setChecked` is a per-render closure
   }, [picks, checked]);
 
-  const jobs = useJobs();
+  const { jobs, refresh } = useJobs();
   // Deliberately NOT `activeJobByModel`: that map drops a terminal row (the
   // stale-busy fix for pages that gate on mere presence), and this step reads
   // the STATE — a `done` row is how a finished download turns into a tick, an
@@ -225,8 +245,18 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
   // act on: selected, not here already, and nothing in flight for it.
   const rows = (picks ?? []).map((pick) => {
     const job = jobFor(pick.model.id, jobByModel, started);
-    const busy = job !== undefined && !isTerminal(job);
     const here = pick.model.downloaded || job?.state === "done";
+    // A Download that has been SENT is busy before its job row exists: the
+    // POST returns as soon as the worker thread is up, and the row only
+    // appears on the next poll. Without this the button stayed enabled and
+    // the checkbox stayed put for that gap — long enough to send the same
+    // downloads twice. Bounded, so a request that somehow never produces a
+    // row does not leave the model unfetchable: after the grace it reads as
+    // pending again and Start can be pressed.
+    const askedAt = started.get(pick.model.id);
+    const awaiting =
+      askedAt !== undefined && job === undefined && !here && Date.now() - askedAt < STARTING_GRACE_MS;
+    const busy = awaiting || (job !== undefined && !isTerminal(job));
     return {
       pick,
       job,
@@ -268,7 +298,10 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
     // thread server-side and returns immediately, and a model already being
     // fetched JOINS that fetch rather than racing it (supervisor.load).
     for (const p of wanted) {
-      downloadAiModel(p.model.id, p.capability).catch((e: unknown) => {
+      // `refresh` on the way OUT of each request, not once at the end: the
+      // reply is the first moment the row it opened can be read back, and the
+      // scheduled poll may be a whole idle interval away.
+      downloadAiModel(p.model.id, p.capability).then(refresh).catch((e: unknown) => {
         // Through `memory` rather than the wrappers above: this lands after an
         // await, so the closure's `errors`/`started` are a snapshot from
         // before the other requests in this same batch reported.

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -22,7 +22,7 @@
 // to different conclusions about the same machine. Comfortable ones start
 // checked; a tight or too-big one is shown, unchecked, with the reason — the
 // selection rule lives in `modelPicks.ts`.
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, Check, Cpu, HardDrive } from "lucide-react";
 
 import { fitNote } from "@apps/ai_models/shared/fitNote";
@@ -48,6 +48,33 @@ import { StepHeader } from "./StepHeader";
 /** `null` while the catalog is still answering — the wizard reads that as
  *  "unknown", not "none", and keeps the step in the list meanwhile. */
 export type ModelPicks = ModelPick[] | null;
+
+// What this step knows, kept at MODULE level for the reason `state.ts` keeps
+// the resume step there: the wizard mounts a step body per navigation, and
+// every step is a link in both directions — so Start, Next, Back would come
+// back to a step that had forgotten it had started anything. The selection
+// would be re-seeded from the fit verdicts (re-checking boxes the user
+// cleared), the jobs poll would not be running, and the button would offer
+// the whole ~9 GB again. A second Download is harmless server-side (a fetch
+// already in flight is JOINED, supervisor.load) but the step's one promise —
+// that progress is visible HERE, since the wizard route renders without the
+// download manager — would not survive a single Back.
+//
+// Deriving `started` from the jobs list instead would be wrong: D663 keeps a
+// finished or failed row until it is dismissed, so last week's error on the
+// same repo would read as this visit's failure.
+let memory: {
+  checked: Set<string> | null;
+  started: Set<string>;
+  errors: Record<string, string>;
+} = { checked: null, started: new Set(), errors: {} };
+
+/** Forget what the Models step started — called when the wizard completes,
+ *  so a reopened wizard in the same page load offers a fresh selection
+ *  rather than rows still claiming to be downloading. */
+export function forgetModelsStep(): void {
+  memory = { checked: null, started: new Set(), errors: {} };
+}
 
 /** The catalog, once, as picks. Lives at the WIZARD level (like
  *  `useClaudeSetup`) because the step list itself depends on the answer: a
@@ -108,14 +135,32 @@ function useStartedJobs(started: boolean): Job[] {
 }
 
 export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: string }) {
-  const [checked, setChecked] = useState<Set<string> | null>(null);
-  const [started, setStarted] = useState<Set<string>>(new Set());
-  const [errors, setErrors] = useState<Record<string, string>>({});
+  // Each of the three is React state for THIS mount and module memory across
+  // mounts — the setters below write both, so a remount seeds from what the
+  // last one left rather than from scratch.
+  const [checked, setCheckedState] = useState<Set<string> | null>(memory.checked);
+  const [started, setStartedState] = useState<Set<string>>(memory.started);
+  const [errors, setErrorsState] = useState<Record<string, string>>(memory.errors);
+  const setChecked = (next: Set<string>) => {
+    memory.checked = next;
+    setCheckedState(next);
+  };
+  const setStarted = (next: Set<string>) => {
+    memory.started = next;
+    setStartedState(next);
+  };
+  const setErrors = (next: Record<string, string>) => {
+    memory.errors = next;
+    setErrorsState(next);
+  };
 
-  // The preselection is seeded ONCE, from the first picks that arrive: a
-  // later render must not re-check a box the user has just cleared.
+  // The preselection is seeded ONCE, from the first picks that arrive: neither
+  // a later render nor a return to this step may re-check a box the user has
+  // cleared, which is why `null` (never seeded) and an empty set (seeded, then
+  // emptied) are different states here.
   useEffect(() => {
     if (picks && checked === null) setChecked(new Set(comfortableIds(picks)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `setChecked` is a per-render closure
   }, [picks, checked]);
 
   const jobs = useStartedJobs(started.size > 0);
@@ -135,35 +180,44 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: str
 
   // Driven by the checkbox's own reported value, not by flipping what this
   // render happened to see: the primitive owns the state transition.
-  const setRow = (id: string, on: boolean) =>
-    setChecked((prev) => {
-      const next = new Set(prev ?? []);
-      if (on) next.add(id);
-      else next.delete(id);
-      return next;
-    });
+  const setRow = (id: string, on: boolean) => {
+    const next = new Set(checked ?? []);
+    if (on) next.add(id);
+    else next.delete(id);
+    setChecked(next);
+  };
 
-  const start = useCallback(() => {
+  const start = () => {
     if (!picks) return;
     const wanted = picks.filter((p) => selection.has(p.model.id) && !started.has(p.model.id));
     if (wanted.length === 0) return;
-    setStarted((prev) => new Set([...prev, ...wanted.map((p) => p.model.id)]));
+    setStarted(new Set([...started, ...wanted.map((p) => p.model.id)]));
+    // A retry drops the previous sentence for the rows it retries: an old 409
+    // printed beside a fresh progress bar reads as a failure that just
+    // happened.
+    const cleared = { ...errors };
+    for (const p of wanted) delete cleared[p.model.id];
+    setErrors(cleared);
     // One request per model, each caught on its own: a 409 on one ("needs
     // Apple Silicon", a partly-fetched cache another page is already pulling)
-    // must not take the others down with it. The server does the queueing —
-    // each call starts its own worker thread and returns immediately.
+    // must not take the others down with it. Each call starts its own worker
+    // thread server-side and returns immediately, and a model already being
+    // fetched JOINS that fetch rather than racing it (supervisor.load).
     for (const p of wanted) {
       downloadAiModel(p.model.id, p.capability).catch((e: unknown) => {
+        // Through `memory` rather than the wrappers above: this lands after an
+        // await, so the closure's `errors`/`started` are a snapshot from
+        // before the other requests in this same batch reported.
         const message = e instanceof Error ? e.message : String(e);
-        setErrors((prev) => ({ ...prev, [p.model.id]: message }));
-        setStarted((prev) => {
-          const next = new Set(prev);
-          next.delete(p.model.id);
-          return next;
-        });
+        memory.errors = { ...memory.errors, [p.model.id]: message };
+        setErrorsState(memory.errors);
+        const remaining = new Set(memory.started);
+        remaining.delete(p.model.id);
+        memory.started = remaining;
+        setStartedState(remaining);
       });
     }
-  }, [picks, selection, started]);
+  };
 
   const pending = picks
     ? picks.filter((p) => selection.has(p.model.id) && !started.has(p.model.id))

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -1,0 +1,345 @@
+// Step 4 — local models, and a head start on downloading them.
+//
+// The step exists because of a timing problem, not a capability one: a model
+// this machine does not have is fetched on FIRST USE — the route answers
+// `model_loading` and starts the download rather than refusing (ai_runtime.py
+// `api_ai_download`/`_resolve_capability`) — so nothing here is required for
+// anything to work. What it buys is that the multi-GB wait happens while the
+// user is reading the next step and building their first app, instead of the
+// first time they ask an app for a sentence.
+//
+// So: NOTHING BLOCKS. Start is fire-and-forget (`supervisor.load(...,
+// weights_only=True)` returns the instant its thread is up), Next stays live
+// the whole time, and leaving the wizard leaves the fetch running — it is a
+// server-owned job, reported in the download manager like every other one.
+// Skipping costs the user nothing but the wait, later, and the copy says so
+// rather than implying a penalty.
+//
+// What it offers is ONE model per capability and WHETHER EACH ONE FITS: the
+// `fit` verdict already on every catalog row (fit.py — measured footprint,
+// curator's envelope, or the download's own bytes, in that order), drawn with
+// `fitNote`'s own words so this step and the Playground's badge cannot come
+// to different conclusions about the same machine. Comfortable ones start
+// checked; a tight or too-big one is shown, unchecked, with the reason — the
+// selection rule lives in `modelPicks.ts`.
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, Check, Cpu, HardDrive } from "lucide-react";
+
+import { fitNote } from "@apps/ai_models/shared/fitNote";
+import { downloadAiModel, getAiCatalog } from "@platform/lib/api";
+import { formatSize } from "@platform/lib/format";
+import {
+  fetchJobs,
+  isRunning,
+  isTerminal,
+  jobAmount,
+  jobFraction,
+  jobStatusLine,
+  pollInterval,
+  type Job,
+} from "@platform/lib/jobs";
+import { Button } from "@platform/shadcn/ui/button";
+import { Checkbox } from "@platform/shadcn/ui/checkbox";
+import { Skeleton } from "@platform/shadcn/ui/skeleton";
+
+import { comfortableIds, modelPicks, selectedTotal, type ModelPick } from "./modelPicks";
+import { StepHeader } from "./StepHeader";
+
+/** `null` while the catalog is still answering — the wizard reads that as
+ *  "unknown", not "none", and keeps the step in the list meanwhile. */
+export type ModelPicks = ModelPick[] | null;
+
+/** The catalog, once, as picks. Lives at the WIZARD level (like
+ *  `useClaudeSetup`) because the step list itself depends on the answer: a
+ *  machine no engine serves has no Models step at all, and a hook per step
+ *  would fetch twice to tell the same thing to two places. */
+export function useModelPicks(): ModelPicks {
+  const [picks, setPicks] = useState<ModelPicks>(null);
+  useEffect(() => {
+    let alive = true;
+    getAiCatalog().then(
+      ({ capabilities }) => {
+        if (alive) setPicks(modelPicks(capabilities));
+      },
+      // A catalog that cannot be read is an empty offer, not an error face:
+      // the step drops out and the user loses nothing they needed.
+      () => {
+        if (alive) setPicks([]);
+      },
+    );
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return picks;
+}
+
+/** Jobs, polled only once something has been started here, and only while
+ *  anything is still running. The wizard has no status bar and no download
+ *  manager on screen (App.tsx renders this route alone), so progress has to
+ *  be drawn in the step or it is invisible until the user leaves. */
+function useStartedJobs(started: boolean): Job[] {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const lastRunning = useRef(Date.now());
+  useEffect(() => {
+    if (!started) return;
+    let alive = true;
+    let timer: number | undefined;
+    const tick = () => {
+      fetchJobs().then(
+        ({ jobs: next }) => {
+          if (!alive) return;
+          setJobs(next);
+          if (next.some(isRunning)) lastRunning.current = Date.now();
+          timer = window.setTimeout(tick, pollInterval(next, Date.now() - lastRunning.current));
+        },
+        () => {
+          if (alive) timer = window.setTimeout(tick, 4000);
+        },
+      );
+    };
+    tick();
+    return () => {
+      alive = false;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [started]);
+  return jobs;
+}
+
+export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: string }) {
+  const [checked, setChecked] = useState<Set<string> | null>(null);
+  const [started, setStarted] = useState<Set<string>>(new Set());
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // The preselection is seeded ONCE, from the first picks that arrive: a
+  // later render must not re-check a box the user has just cleared.
+  useEffect(() => {
+    if (picks && checked === null) setChecked(new Set(comfortableIds(picks)));
+  }, [picks, checked]);
+
+  const jobs = useStartedJobs(started.size > 0);
+  // Deliberately NOT `activeJobByModel`: that map drops a terminal row (the
+  // stale-busy fix for pages that gate on mere presence), and this step reads
+  // the STATE — a `done` row is how a finished download turns into a tick, an
+  // `error` row is the only place the failure's sentence exists. Same key
+  // (`job.title` is the repo id, `supervisor.load`'s own `title=model`) and
+  // the same server-owned filter.
+  const jobByModel = useMemo(
+    () => new Map(jobs.filter((j) => j.owner === "server").map((j) => [j.title, j])),
+    [jobs],
+  );
+
+  const selection = checked ?? new Set<string>();
+  const total = useMemo(() => selectedTotal(picks ?? [], selection), [picks, selection]);
+
+  // Driven by the checkbox's own reported value, not by flipping what this
+  // render happened to see: the primitive owns the state transition.
+  const setRow = (id: string, on: boolean) =>
+    setChecked((prev) => {
+      const next = new Set(prev ?? []);
+      if (on) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+
+  const start = useCallback(() => {
+    if (!picks) return;
+    const wanted = picks.filter((p) => selection.has(p.model.id) && !started.has(p.model.id));
+    if (wanted.length === 0) return;
+    setStarted((prev) => new Set([...prev, ...wanted.map((p) => p.model.id)]));
+    // One request per model, each caught on its own: a 409 on one ("needs
+    // Apple Silicon", a partly-fetched cache another page is already pulling)
+    // must not take the others down with it. The server does the queueing —
+    // each call starts its own worker thread and returns immediately.
+    for (const p of wanted) {
+      downloadAiModel(p.model.id, p.capability).catch((e: unknown) => {
+        const message = e instanceof Error ? e.message : String(e);
+        setErrors((prev) => ({ ...prev, [p.model.id]: message }));
+        setStarted((prev) => {
+          const next = new Set(prev);
+          next.delete(p.model.id);
+          return next;
+        });
+      });
+    }
+  }, [picks, selection, started]);
+
+  const pending = picks
+    ? picks.filter((p) => selection.has(p.model.id) && !started.has(p.model.id))
+    : [];
+  const pendingTotal = selectedTotal(
+    picks ?? [],
+    pending.map((p) => p.model.id),
+  );
+  const models = `${pending.length} model${pending.length === 1 ? "" : "s"}`;
+  // The figure only when there IS one: every selected model lacking a
+  // published size would otherwise put "~0 B" on the button, which is a claim.
+  const startLabel =
+    pendingTotal.bytes > 0
+      ? `Download ${models} · ~${formatSize(pendingTotal.bytes)}`
+      : `Download ${models}`;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <StepHeader
+        eyebrow={eyebrow}
+        title="AI models run on this machine"
+        lead="No account, no API key, no cloud: an app that generates text or images loads a model into this machine's own memory. Download the ones that fit now and they are ready when you need them — skip, and an app fetches what it needs the first time it asks."
+      />
+
+      {picks === null ? (
+        <div className="flex flex-col gap-3">
+          {[0, 1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : (
+        <ul className="m-0 flex list-none flex-col gap-3 p-0">
+          {picks.map((p) => (
+            <ModelRow
+              key={p.model.id}
+              pick={p}
+              checked={selection.has(p.model.id)}
+              started={started.has(p.model.id)}
+              job={jobByModel.get(p.model.id)}
+              error={errors[p.model.id]}
+              onToggle={(on) => setRow(p.model.id, on)}
+            />
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button onClick={start} disabled={pending.length === 0}>
+          {pending.length > 0
+            ? startLabel
+            : started.size > 0
+              ? "Downloading in the background"
+              : picks?.every((p) => p.model.downloaded)
+                ? "Every model is already here"
+                : "Nothing selected"}
+        </Button>
+        <span className="text-xs text-muted-foreground">
+          {started.size > 0
+            ? "Carry on — the download keeps running while you finish setup, and appears in the download manager."
+            : "Downloads run in the background. You can go to the next step straight away."}
+        </span>
+      </div>
+
+      {total.unknown > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {total.unknown === 1 ? "One model does" : `${total.unknown} models do`} not publish a
+          file size, so {total.unknown === 1 ? "it is" : "they are"} not in the figure above.
+        </p>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        You can add, swap or delete models any time under AI Models — including a video model,
+        which is left out here because it is a far larger download than the rest put together.
+      </p>
+    </div>
+  );
+}
+
+function ModelRow({
+  pick,
+  checked,
+  started,
+  job,
+  error,
+  onToggle,
+}: {
+  pick: ModelPick;
+  checked: boolean;
+  started: boolean;
+  job: Job | undefined;
+  error: string | undefined;
+  onToggle: (on: boolean) => void;
+}) {
+  const { model } = pick;
+  const fit = fitNote(model.fit);
+  const size = model.size_gb == null ? null : formatSize(model.size_gb * 1e9);
+  const name = model.nickname || model.label;
+  // A fresh install builds the runner's environment before any bytes move
+  // (`supervisor._env_install_worker`, states `venv` -> `downloading`), so the
+  // job's own caption is what makes a row at 0 bytes read as working rather
+  // than stuck. `jobAmount` is the byte count beside it, once there is one.
+  const caption = job ? [jobStatusLine(job), jobAmount(job)].filter(Boolean).join(" · ") : "";
+  const fraction = job ? jobFraction(job) : null;
+  const finished = model.downloaded || (job !== undefined && job.state === "done");
+
+  return (
+    <li className="flex flex-col gap-2 rounded-xl border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        {finished ? (
+          <span className="mt-0.5 grid size-4 place-items-center rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
+            <Check className="size-3" strokeWidth={3} />
+          </span>
+        ) : started ? (
+          <span className="mt-0.5 grid size-4 place-items-center text-muted-foreground">
+            <HardDrive className="size-3.5" />
+          </span>
+        ) : (
+          <Checkbox
+            id={`model-${model.id}`}
+            className="mt-0.5"
+            checked={checked}
+            onCheckedChange={(next) => onToggle(!!next)}
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <label
+            htmlFor={started || finished ? undefined : `model-${model.id}`}
+            className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm font-medium"
+          >
+            {name}
+            {model.params && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
+                {model.params}
+              </span>
+            )}
+            <span className="text-xs font-normal text-muted-foreground">{pick.capabilityLabel}</span>
+          </label>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            <span className="inline-flex items-center gap-1">
+              <Cpu className="size-3" />
+              {pick.runnerShortLabel ?? "on this machine"}
+            </span>
+            <span>{finished && !job ? "Already on this machine" : (size ?? "size unknown")}</span>
+            {fit && (
+              <span className="inline-flex items-center gap-1.5" title={fit.title}>
+                <span className={`size-1.5 rounded-full ${fit.dot}`} />
+                {fit.text}
+              </span>
+            )}
+          </div>
+          {model.note && !job && (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{model.note}</p>
+          )}
+        </div>
+      </div>
+
+      {job && !finished && (
+        <div className="flex flex-col gap-1.5">
+          <div className="h-1 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary transition-[width] duration-500"
+              style={{ width: fraction === null ? "15%" : `${Math.round(fraction * 100)}%` }}
+            />
+          </div>
+          <span className="text-xs text-muted-foreground" role="status">
+            {caption || "Starting…"}
+          </span>
+        </div>
+      )}
+
+      {(error || (job && isTerminal(job) && job.state === "error")) && (
+        <p className="flex items-start gap-2 text-xs text-destructive">
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+          {error || job?.message || "The download failed."}
+        </p>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -81,10 +81,15 @@ export function forgetModelsStep(): void {
   memory = { checked: null, started: new Map(), errors: {} };
 }
 
-/** Clock skew allowance when comparing a job's server-side `finished_at`
- *  against this page's `Date.now()`. Same machine, so the two clocks are the
- *  same clock; this covers the second-granularity rounding either side. */
-const CLOCK_SLACK_MS = 2000;
+// There is deliberately NO slack in the `finished_at` vs `askedAt`
+// comparison in `jobFor`. `askedAt` is stamped BEFORE the POST goes out and
+// both clocks are this machine's clock (`time.time()` against `Date.now()`,
+// float seconds against ms — the same epoch, no rounding to a second), so a
+// job this visit caused always finishes strictly after the ask. A tolerance
+// only bought the opposite error: for its width, a row that had JUST failed
+// still counted as this visit's, so a retry kept the old sentence, kept its
+// checkbox and left Download enabled over exactly the gap `STARTING_GRACE_MS`
+// exists to cover.
 
 /** How long a sent Download reads as busy before its job row has appeared —
  *  the gap between the POST returning and the next poll seeing the row. A
@@ -105,7 +110,12 @@ const STARTING_GRACE_MS = 30_000;
  *  every catalog row was matched against the whole server job list: a `done`
  *  row from last week (kept until dismissed, D663) drew a tick on a model the
  *  user had not chosen and took its checkbox away, and an old failure drew a
- *  sentence about something that happened days ago. */
+ *  sentence about something that happened days ago.
+ *
+ *  "After it asked" is exact, with no tolerance — see the note above the
+ *  constants: a retry re-stamps the ask, so the row it is retrying stops
+ *  counting the instant Start is pressed, which is what lets `awaiting` take
+ *  over from a failure the user has just acted on. */
 function jobFor(
   id: string,
   jobs: Map<string, Job>,
@@ -117,7 +127,7 @@ function jobFor(
   const askedAt = started.get(id);
   if (askedAt === undefined) return undefined;
   if (job.finished_at == null) return undefined;
-  return job.finished_at * 1000 >= askedAt - CLOCK_SLACK_MS ? job : undefined;
+  return job.finished_at * 1000 >= askedAt ? job : undefined;
 }
 
 /** The catalog, once, as picks. Lives at the WIZARD level (like

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -23,9 +23,10 @@
 // checked; a tight or too-big one is shown, unchecked, with the reason — the
 // selection rule lives in `modelPicks.ts`.
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AlertTriangle, Check, Cpu, HardDrive } from "lucide-react";
+import { AlertTriangle, Check, HardDrive } from "lucide-react";
 
 import { fitNote } from "@apps/ai_models/shared/fitNote";
+import { modelSizeLabel } from "@apps/ai_models/shared/modelSize";
 import { downloadAiModel, getAiCatalog } from "@platform/lib/api";
 import { formatSize } from "@platform/lib/format";
 import {
@@ -313,7 +314,17 @@ function ModelRow({
 }) {
   const { model } = pick;
   const fit = fitNote(model.fit);
-  const size = model.size_gb == null ? null : formatSize(model.size_gb * 1e9);
+  // `modelSizeLabel`, not a local formatting of `size_gb`: it is the same
+  // never-understate reading /ai-models prints (a live download's own total
+  // may raise the catalog's constant, a `phase` total may not lower it), and
+  // the same em-dash for a model that publishes no size.
+  const size = modelSizeLabel(model.size_gb, job);
+  // The NICKNAME is the whole name here (`catalog.py`: "Qwen 3.5", not
+  // "Qwen3.5 4B (OptiQ 4-bit)"), and the parameter count that /ai-models
+  // prints beside it as a chip is left out on purpose — this reader is
+  // deciding whether to spend the download, and "4B" is not an input to that
+  // (owner, 2026-09-04). Same for the engine: "MLX LM" answers a question
+  // only somebody comparing backends is asking.
   const name = model.nickname || model.label;
   // A fresh install builds the runner's environment before any bytes move
   // (`supervisor._env_install_worker`, states `venv` -> `downloading`), so the
@@ -348,29 +359,31 @@ function ModelRow({
             className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm font-medium"
           >
             {name}
-            {model.params && (
-              <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
-                {model.params}
-              </span>
-            )}
             <span className="text-xs font-normal text-muted-foreground">{pick.capabilityLabel}</span>
           </label>
-          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-            <span className="inline-flex items-center gap-1">
-              <Cpu className="size-3" />
-              {pick.runnerShortLabel ?? "on this machine"}
-            </span>
-            <span>{finished && !job ? "Already on this machine" : (size ?? "size unknown")}</span>
-            {fit && (
-              <span className="inline-flex items-center gap-1.5" title={fit.title}>
-                <span className={`size-1.5 rounded-full ${fit.dot}`} />
-                {fit.text}
-              </span>
-            )}
-          </div>
+          {fit && (
+            <div
+              className="mt-1 inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+              title={fit.title}
+            >
+              <span className={`size-1.5 rounded-full ${fit.dot}`} />
+              {fit.text}
+            </div>
+          )}
           {model.note && !job && (
             <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{model.note}</p>
           )}
+        </div>
+
+        {/* The size is the number this step is ASKING FOR — disk space and a
+            wait — so it gets the right edge and its own weight rather than
+            third place in a row of captions. Tabular figures so a column of
+            them lines up. */}
+        <div className="shrink-0 text-right">
+          <div className="text-sm font-semibold tabular-nums">{size}</div>
+          <div className="text-xs text-muted-foreground">
+            {finished ? "already here" : "download"}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -6,11 +6,15 @@
 //   1 About        — what FusedRender is (download-page copy + video)
 //   2 Claude Code  — installed / new enough / signed in / on PATH, with buttons
 //   3 Disk Access  — macOS Full Disk Access, why, and the one button there is
-//   4 First app    — the Home composer, or a showcase local-AI app
+//   4 Models       — local models that fit this machine, downloaded in the background
+//   5 First app    — the Home composer, or a showcase local-AI app
 //
 // Steps 1–3 write nothing but the resume step (which step is open, so a
-// restart or a reopen lands back on it). Step 4's create (or a showcase open)
-// is the only other durable action and doubles as "complete". ✕ / Escape
+// restart or a reopen lands back on it). Step 4 starts model downloads, which
+// are server-owned jobs that outlive the wizard and block nothing in it — a
+// head start, since a model is fetched on first use anyway. Step 5's create
+// (or a showcase open) is the only other durable action and doubles as
+// "complete". ✕ / Escape
 // record a DISMISS — a different flag, so a later build can tell the two
 // apart. Both stop the auto-show; neither is undone by reopening from Help ›
 // Setup wizard, which resumes where the user left off.
@@ -34,13 +38,15 @@ import { AboutStep } from "./AboutStep";
 import { ClaudeStep } from "./ClaudeStep";
 import { FdaStep } from "./FdaStep";
 import { FirstAppStep } from "./FirstAppStep";
+import { ModelsStep, useModelPicks } from "./ModelsStep";
 
-type StepId = "about" | "claude" | "fda" | "app";
+type StepId = "about" | "claude" | "fda" | "models" | "app";
 
 const STEPS: { id: StepId; label: string }[] = [
   { id: "about", label: "About" },
   { id: "claude", label: "Claude Code" },
   { id: "fda", label: "Disk Access" },
+  { id: "models", label: "Models" },
   { id: "app", label: "First app" },
 ];
 
@@ -98,7 +104,21 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // hold their own snapshot. Focus re-checks only while the Claude step is up.
   const setup = useClaudeSetup(stepId === "claude");
   const { health } = setup;
-  const steps = STEPS.filter((s) => s.id !== "fda" || isMac(health?.platform));
+  // The catalog, once, for the whole wizard: the Models step's own contents AND
+  // whether it exists at all come from it (a machine no local engine serves has
+  // nothing to offer, so it gets no step).
+  const picks = useModelPicks();
+  const steps = STEPS.filter((s) => {
+    if (s.id === "fda") return isMac(health?.platform);
+    // Kept while the answer is UNKNOWN (`null`), unlike the FDA step's
+    // hidden-until-known: this is the only step a `?step=` resume is likely to
+    // name while its own fetch is still in flight, and dropping it for those
+    // few hundred milliseconds would render step 1 under a user who asked for
+    // step 4. A pill that disappears on the rare no-engine machine is the
+    // cheaper wrong.
+    if (s.id === "models") return picks === null || picks.length > 0;
+    return true;
+  });
   // A URL naming a step this machine does not have (`fda` off macOS) lands on
   // the first one rather than nowhere.
   const found = steps.findIndex((s) => s.id === stepId);
@@ -247,6 +267,7 @@ export function OnboardingWizard({ config }: { config: Config }) {
           {step.id === "about" && <AboutStep eyebrow={eyebrow} />}
           {step.id === "claude" && <ClaudeStep setup={setup} eyebrow={eyebrow} />}
           {step.id === "fda" && <FdaStep config={config} eyebrow={eyebrow} />}
+          {step.id === "models" && <ModelsStep picks={picks} eyebrow={eyebrow} />}
           {step.id === "app" && <FirstAppStep health={health} eyebrow={eyebrow} onComplete={markComplete} />}
         </div>
       </div>

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -38,7 +38,7 @@ import { AboutStep } from "./AboutStep";
 import { ClaudeStep } from "./ClaudeStep";
 import { FdaStep } from "./FdaStep";
 import { FirstAppStep } from "./FirstAppStep";
-import { ModelsStep, useModelPicks } from "./ModelsStep";
+import { forgetModelsStep, ModelsStep, useModelPicks } from "./ModelsStep";
 
 type StepId = "about" | "claude" | "fda" | "models" | "app";
 
@@ -137,8 +137,12 @@ export function OnboardingWizard({ config }: { config: Config }) {
     if (settled.current) return;
     settled.current = true;
     // The server clears its resume step on complete; mirror that in this
-    // page load's memory so a reopen starts at the top, not at step 4.
+    // page load's memory so a reopen starts at the top, not at the last step.
     rememberStep(null);
+    // Same reason, for the Models step's own across-mount memory: a wizard
+    // reopened in this page load should offer a fresh selection, not rows
+    // still reporting a download that has since finished.
+    forgetModelsStep();
     completeOnboarding().catch(() => undefined);
   }, []);
   const finish = useCallback(

--- a/frontend/src/shell/onboarding/modelPicks.ts
+++ b/frontend/src/shell/onboarding/modelPicks.ts
@@ -1,0 +1,107 @@
+// Which models the wizard's Models step offers, and which of them start
+// checked — the part with a RULE in it, kept out of the .tsx for the reason
+// `apps/ai_models/shared/fitNote.ts` gives about itself: there is no DOM
+// harness in this repo, so a decision a reader has to trust lives in a module
+// that can be read (and driven) on its own.
+//
+// The offer is ONE model per capability: the curated `recommended` row
+// (catalog.py's second curation axis, D425 — "the one this app stands behind"),
+// never the capability's `default`, which is the smallest entry and exists to
+// answer "just load something". A capability whose engine cannot run here
+// (`available: false`) offers nothing: a Download that would 409 is worse than
+// a row that is not there.
+//
+// **Video is excluded by id, not by curation.** `ltx-2.3-mlx-q4` is the
+// recommended video model and it is a 28.5 GB download — one entry that
+// dwarfs the other four put together (~9 GB). Onboarding is not where someone
+// decides to spend that, and a total reading "38 GB" makes the step look like
+// a demand rather than a head start. It stays one click away on /ai-models.
+import type { AiCatalogCapability, AiCatalogModel } from "@platform/lib/api";
+
+/** `registry.VIDEO_GENERATION`. Left out of the step — see the header. */
+const EXCLUDED_CAPABILITY = "text-to-video";
+
+export interface ModelPick {
+  capability: string;
+  /** What the model DOES, in words — the caption beside its name. */
+  capabilityLabel: string;
+  runnerShortLabel: string | null;
+  model: AiCatalogModel;
+}
+
+/** What the step offers, in the catalog's own order (the server decides which
+ *  capability comes first; a second ordering here could only disagree with
+ *  it). Empty when nothing on this machine can run anything — the signal the
+ *  wizard uses to drop the step entirely. */
+export function modelPicks(capabilities: AiCatalogCapability[]): ModelPick[] {
+  const picks: ModelPick[] = [];
+  for (const cap of capabilities) {
+    if (cap.capability === EXCLUDED_CAPABILITY) continue;
+    if (!cap.available) continue;
+    const model = cap.models.find((m) => m.recommended);
+    if (!model) continue;
+    picks.push({
+      capability: cap.capability,
+      capabilityLabel: capabilityLabel(cap.capability),
+      runnerShortLabel: cap.runnerShortLabel,
+      model,
+    });
+  }
+  return picks;
+}
+
+/** The capability in words. The server's own `runnerLabel` names the BACKEND
+ *  ("MLX LM (Apple Silicon)"), which is not what a first-run reader needs;
+ *  what they need is what the model is FOR. */
+function capabilityLabel(capability: string): string {
+  switch (capability) {
+    case "text-generation":
+      return "Chat and writing";
+    case "text-to-image":
+      return "Image generation";
+    case "automatic-speech-recognition":
+      return "Speech to text";
+    case "embeddings":
+      return "Search and similarity";
+    default:
+      return capability;
+  }
+}
+
+/** The ids that start checked: it fits comfortably (`fit.verdict === "easy"`,
+ *  fit.py's own word for "at or under the comfort utilization") and it is not
+ *  already here.
+ *
+ *  A `tight`/`no` verdict is OFFERED but not preselected, and a null fit —
+ *  nothing known about the footprint, so nothing to judge — is not
+ *  preselected either, the same no-guess rule `fitNote` follows by drawing no
+ *  badge at all. Nothing here DISABLES a row: /ai-models greys a Download
+ *  only when no engine can serve it (RecommendedCard.tsx), never on a fit
+ *  verdict, and two surfaces disagreeing about whether a big model may be
+ *  fetched is worse than a badge saying it will be tight. */
+export function comfortableIds(picks: ModelPick[]): string[] {
+  return picks
+    .filter((p) => !p.model.downloaded && p.model.fit?.verdict === "easy")
+    .map((p) => p.model.id);
+}
+
+/** The download total for `ids`, in bytes, and how many of them said. A model
+ *  with no `size_gb` contributes nothing and is counted in `unknown`, so the
+ *  button can say "~9 GB" honestly rather than folding a guess into the
+ *  figure (AI-11a's no-invented-size rule). */
+export function selectedTotal(
+  picks: ModelPick[],
+  ids: Iterable<string>,
+): { bytes: number; count: number; unknown: number } {
+  const wanted = new Set(ids);
+  let bytes = 0;
+  let count = 0;
+  let unknown = 0;
+  for (const p of picks) {
+    if (!wanted.has(p.model.id)) continue;
+    count += 1;
+    if (p.model.size_gb == null) unknown += 1;
+    else bytes += p.model.size_gb * 1e9;
+  }
+  return { bytes, count, unknown };
+}

--- a/frontend/src/shell/onboarding/modelPicks.ts
+++ b/frontend/src/shell/onboarding/modelPicks.ts
@@ -23,9 +23,12 @@ const EXCLUDED_CAPABILITY = "text-to-video";
 
 export interface ModelPick {
   capability: string;
-  /** What the model DOES, in words — the caption beside its name. */
+  /** What the model DOES, in words — the caption beside its name. The runner
+   *  ("MLX LM", "MLX FLUX") is deliberately NOT carried: a first-run reader
+   *  deciding whether to spend the download is not choosing a backend, and
+   *  naming one only invites a question they cannot act on. It is on the
+   *  /ai-models card, where somebody comparing engines will be. */
   capabilityLabel: string;
-  runnerShortLabel: string | null;
   model: AiCatalogModel;
 }
 
@@ -43,7 +46,6 @@ export function modelPicks(capabilities: AiCatalogCapability[]): ModelPick[] {
     picks.push({
       capability: cap.capability,
       capabilityLabel: capabilityLabel(cap.capability),
-      runnerShortLabel: cap.runnerShortLabel,
       model,
     });
   }

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -54,7 +54,7 @@ _KEY = "onboarding"
 #: The wizard's step ids (frontend shell/onboarding/OnboardingWizard STEPS).
 #: A closed set: prefs.json is shared state, and an unknown id is refused
 #: rather than stored.
-STEPS = ("about", "claude", "fda", "app")
+STEPS = ("about", "claude", "fda", "models", "app")
 
 #: `FUSED_RENDER_ONBOARDING=1` forces the auto-show (state reads as fresh) so a
 #: dev server can render the wizard without deleting prefs.json; `=0` forces


### PR DESCRIPTION
Adds step 4 of the first-run wizard, between Disk Access and First app: **AI models run on this machine**, and here are the ones worth having before you need them.

**Nothing about it blocks.** A model this machine does not have is already fetched on first use — the route answers `model_loading` and starts the download rather than refusing — so this step buys *timing*, not capability: the multi-GB wait happens while the user reads the next step and builds their first app, instead of the first time an app asks for a sentence. Start is fire-and-forget, Next stays live, and leaving the wizard leaves the fetch running as the server-owned job it already was. The copy says the skip costs nothing.

### What it offers

One model per capability — the curated `recommended` row, not the capability's smallest `default` — with the `fit` verdict already on every catalog row, drawn through `fitNote` so this step and the Playground's badge cannot disagree about the same machine:

| capability | recommended (MLX) | ~size |
|---|---|---|
| Chat and writing | `Qwen3.5-4B-OptiQ-4bit` | 4.0 GB |
| Image generation | `FLUX.2-Klein-4B-4bit` | 4.6 GB |
| Speech to text | `whisper-tiny.en-8bit` | 0.05 GB |
| Search and similarity | `nomicai-modernbert-embed-base-bf16` | 0.3 GB |

**Comfortable ones start checked** (`fit.verdict === "easy"`, and not already on disk). Tight and too-big ones are shown, unchecked, with the reason. Nothing is disabled on a fit verdict — `RecommendedCard` on /ai-models greys a Download only when no engine can serve it, and two surfaces disagreeing about whether a big model may be fetched is worse than a badge saying it will be tight. A model with no published size is not preselected and not folded into the total.

**Video is excluded by id.** The recommended video model is a 28.5 GB download, more than the other four put together; a total reading 38 GB makes the step look like a demand rather than a head start. It stays one click away on /ai-models, and the step's footer says so.

### Notes

- `modelPicks.ts` holds the rules (what is offered, what starts checked, the total) away from the `.tsx` — the split `fitNote.ts` documents for itself.
- Progress is drawn **in the step**: the wizard route renders alone (no status bar, no download manager), so a fetch would otherwise be invisible until the user left. `jobStatusLine` rather than a bare fraction, because a fresh install builds the runner venv before any bytes move and the row would read as stalled at 0.
- The map from model to job is built here rather than with `activeJobByModel`, which drops terminal rows: this step reads the state, and `done`/`error` are how a row becomes a tick or a sentence.
- The step hides itself when no local engine serves anything here, but **stays visible while the catalog is still answering** — a `?step=models` resume must not land on step 1 for the length of a fetch. (Deliberately unlike the FDA step's hidden-until-known.)
- Server: `"models"` joins the closed step-id set in `onboarding.py`, or the resume write 400s.
- No new endpoint — `GET /api/ai/catalog` and `POST /api/ai/runtime/download` already carry everything.

### Smoke test

`FUSED_RENDER_ONBOARDING=1` and open `/onboarding`: step through to Models, check the fit badges match /ai-models for the same models, hit Start, confirm Next still advances and the rows keep counting; then confirm the same downloads appear in the download manager once you leave the wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only UI using existing catalog and download APIs; no auth or persistence schema changes beyond extending the allowed step id list.
> 
> **Overview**
> Adds a new **Models** step to the first-run wizard (between Disk Access and First app) so users can kick off recommended local model downloads early while continuing setup. **Nothing blocks progression** — downloads are fire-and-forget server jobs via existing `getAiCatalog` / `downloadAiModel`; copy makes clear skipping only defers the wait until first use.
> 
> **`modelPicks.ts`** defines what appears: one **recommended** model per available capability (video excluded), **fit** badges via shared `fitNote`, and pre-check only models with `fit.verdict === "easy"` that are not already on disk. **`ModelsStep.tsx`** renders rows with size, fit, in-step progress (job polling because the wizard route has no download manager), module-level memory so Back/Next preserves selection and progress, and `jobFor` so stale terminal jobs from prior sessions do not show false ticks or errors.
> 
> **`OnboardingWizard`** fetches the catalog once with `useModelPicks`, omits the step when there is no local engine (but keeps it while catalog is loading for `?step=models` resume), and calls **`forgetModelsStep`** on wizard complete. Server **`onboarding.py`** adds `"models"` to the allowed resume step ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec89c1431d059d284269a934f068d0ad95993510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->