### PR TITLE
Green main again: a stop-marker off-by-one, a stale pref seam, and a Windows claude that never launched

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -3760,10 +3760,22 @@ def _cancelled_marker_state(run_dir: str, cursor: int) -> bool:
     own error `result` yet, so an immediate removal races a caller reading
     `cancelled` a moment later. So the marker outlives the turn it recorded,
     paired with `interrupted_offset` (the byte offset `_cancel` captured
-    right before queuing the interrupt): once `cursor` has advanced to or
+    right before queuing the interrupt): once `cursor` has advanced STRICTLY
     past that offset, a PROVEN new turn has started since, the interrupted
     turn is over and already attributed, and both files are retired here
     rather than tainting a later, unrelated turn as cancelled too.
+
+    Strictly past, not "to or past", and the offset file's own existence is
+    what makes that exact: it is written only once `_await_control_response`
+    has READ the CLI's `control_response` row out of `out.jsonl` starting at
+    that very offset, so whenever the file exists there are already bytes at
+    `>= interrupted_offset` that belong to the interrupted turn — a later
+    turn's own start is therefore always strictly greater. The one way
+    `cursor == interrupted_offset` is `0 == 0`: a stop pressed so early that
+    the turn had not written a byte yet, where cursor 0 is the interrupted
+    turn's own start and proves nothing. `>=` retired the marker on the very
+    next poll there, which is exactly the crash-instead-of-"Stopped" this
+    pairing exists to prevent.
 
     No `interrupted_offset` (an old marker predating it, or a write that
     failed) means staleness can't be proven — stays cancelled rather than
@@ -3777,7 +3789,7 @@ def _cancelled_marker_state(run_dir: str, cursor: int) -> bool:
             interrupted_offset = int(fh.read().strip())
     except (OSError, ValueError):
         return True
-    if cursor < interrupted_offset:
+    if cursor <= interrupted_offset:
         return True
     for stale in (cancelled_marker, offset_marker):
         try:
@@ -4268,7 +4280,7 @@ def _poll(run_id: str, file: str = "") -> dict:
     # — paired with `interrupted_offset`, the byte offset of `out.jsonl` at
     # the instant the interrupt was requested. `scan_cursor` (from
     # `_read_current_turn`) only ever advances past a PROVEN turn boundary,
-    # so `scan_cursor >= interrupted_offset` is the earliest point a later
+    # so `scan_cursor > interrupted_offset` is the earliest point a later
     # poll can tell "a genuinely new turn has started since" apart from
     # "still reporting the interrupted turn's own error" — the interrupted
     # turn is over and already attributed, so the marker (and the offset

--- a/fused_render/templates/claude/session_host.py
+++ b/fused_render/templates/claude/session_host.py
@@ -120,10 +120,12 @@ def _cli_popen_command(argv: list):
     unchanged everywhere except when `argv[0]` (`agent._claude_bin()`'s
     resolution) is a Windows `.bat`/`.cmd`.
 
-    CreateProcess's own documented handling of a `.bat`/`.cmd` target reroutes
-    the ENTIRE call through `%ComSpec% /c <original command line>` — cmd.exe,
-    not the batch file, is what actually receives argv, as one command-line
-    string. cmd.exe's `/c` parser then scans that WHOLE string for its own
+    A `.bat`/`.cmd` can only be started through cmd.exe — CreateProcess
+    talks to real executables and cannot launch one at all. Python's own hop
+    to cmd.exe is `shell=True`, which wraps the command line as
+    `%ComSpec% /c "<our string>"` — so cmd.exe, not the batch file, is what
+    actually receives argv, as one command-line string. cmd.exe's `/c`
+    parser then scans that WHOLE string for its own
     operators (`< > & | ^`) wherever they fall, quotes or no — double quotes
     protect a token from being split on whitespace, but do NOT stop cmd.exe
     from reading a `<`/`>` inside one as real redirection. `_claude_argv`'s
@@ -141,22 +143,35 @@ def _cli_popen_command(argv: list):
     fallback rule below its "no special characters between the quotes"
     case): when the argument to `/c` begins and ends with a double quote,
     cmd strips exactly that one outer pair and runs the interior literally,
-    without re-scanning it for redirection. Building the whole line with
-    `subprocess.list2cmdline` (correct Win32 argv quoting, the same
-    encoding `subprocess.Popen(list, ...)` would have produced) and wrapping
-    the result in one more pair of quotes lands exactly in that fallback —
-    the interior text reaches `claude.bat`/`claude.cmd`'s own CreateProcess
-    call untouched, `<live-app-state>` included. `subprocess.Popen` accepts
-    a plain string as `args` and uses it as the literal Win32 command line
-    (no further quoting), which is what makes the wrapped string usable
-    here at all.
+    without re-scanning it for redirection. That outer pair is exactly what
+    `shell=True` adds, so this returns the INTERIOR — every element quoted,
+    joined by spaces — and the caller spawns a `str` with `shell=True`. The
+    interior then reaches `claude.bat`/`claude.cmd`'s own CreateProcess call
+    untouched, `<live-app-state>` included.
+
+    EVERY element is quoted, not just the ones `subprocess.list2cmdline`
+    would quote for having whitespace in them: the outer pair stops cmd
+    re-parsing QUOTES, not metacharacters (`& | > < ^`), and a quoted run is
+    the only place those stay literal. An unquoted `<live-app-state>` inside
+    an otherwise correct line is still read as "redirect stdin from a file
+    named live-app-state". Nothing here can contain a `"` — Windows paths
+    cannot, and the rest is the product's own boilerplate — so a stray one
+    raises rather than silently producing a line that means something else.
+
+    This is the same shape `fused_render/server/ai.py` (`_popen_cmd` /
+    `_spawn_claude_stream`) already runs in production for the same `.cmd`
+    shim, arrived at the same way; the two are deliberately identical.
 
     Left as `argv` (the list form) whenever `argv[0]` is NOT a `.bat`/`.cmd`
     — including every POSIX launch, and a native `.exe` `claude` on Windows
     — since CreateProcess talks directly to a real executable there and
     never involves cmd.exe or its redirection scan."""
     if os.name == "nt" and os.path.splitext(argv[0])[1].lower() in (".bat", ".cmd"):
-        return '"' + subprocess.list2cmdline(argv) + '"'
+        for arg in argv:
+            if '"' in arg:
+                raise ValueError(
+                    "argument may not contain a double quote: %r" % (arg,))
+        return " ".join('"%s"' % arg for arg in argv)
     return argv
 
 
@@ -199,9 +214,19 @@ def main() -> None:
         # (Windows), independent of THIS host's own detachment from
         # `_start`'s caller. Nested detachment is fine — each process is its
         # own leader, and `_cancel`'s killpg only ever needs the CLI's.
+        command = _cli_popen_command(argv)
         cli = subprocess.Popen(
-            _cli_popen_command(argv), stdin=subprocess.PIPE, stdout=out_fh,
+            command, stdin=subprocess.PIPE, stdout=out_fh,
             stderr=err_fh, cwd=req["cwd"], env=agent._spawn_env(),
+            # A `str` is the Windows `.bat`/`.cmd` case and ONLY that (see
+            # `_cli_popen_command`): the cmd.exe hop is what can launch a
+            # batch file at all, and `shell=True` is what adds the single
+            # outer quote pair cmd parses deterministically. Not an
+            # injection surface — the payload is ours and fully quoted, and
+            # the user's message never appears in it (it rides the inbox).
+            # `_cancel` already kills with `taskkill /T`, which walks past
+            # the cmd.exe wrapper to the CLI underneath it.
+            shell=isinstance(command, str),
             **agent._DETACH)
     except Exception as exc:
         # No CLI process ever existed — write the failure where `_poll`'s

--- a/tests/_claude_stub_cli.py
+++ b/tests/_claude_stub_cli.py
@@ -20,6 +20,33 @@ import stat
 import sys
 
 
+def run_dir_report(run_dir):
+    """What a run dir holds, as an assertion message for a host that never
+    came up.
+
+    `session_host.main` writes the CLI-spawn failure into `err.log` and
+    returns without ever creating `host.json` (see its `except Exception`
+    block), so a bare `assert _wait_for(...host.json exists)` reports
+    `assert False` and throws the one line that says WHY away. That is a
+    round-trip to CI per guess on any platform the tests cannot be run on
+    locally, which is exactly the position Windows-only failures put you in.
+    """
+    lines = ["run_dir=%s" % run_dir]
+    try:
+        lines.append("entries=%s" % sorted(os.listdir(run_dir)))
+    except OSError as exc:
+        return "run_dir unreadable: %s" % exc
+    for name in ("err.log", "out.jsonl"):
+        path = os.path.join(run_dir, name)
+        try:
+            with open(path, "rb") as fh:
+                body = fh.read()[-2000:].decode("utf-8", "replace")
+        except OSError as exc:
+            body = "<%s>" % exc
+        lines.append("--- %s ---\n%s" % (name, body))
+    return "\n".join(lines)
+
+
 def write_stub_cli(bin_dir, script_body):
     """Write `script_body` (a `#!{python}`-shebang Python script, already
     `.format(python=...)`-filled) as a `claude` stub under `bin_dir` and

--- a/tests/test_claude_control_requests.py
+++ b/tests/test_claude_control_requests.py
@@ -22,7 +22,7 @@ import time
 
 import pytest
 
-from _claude_stub_cli import write_stub_cli
+from _claude_stub_cli import run_dir_report, write_stub_cli
 
 TEMPLATE_DIR = os.path.join("fused_render", "templates", "claude")
 
@@ -120,7 +120,8 @@ def _start(agent, monkeypatch, stub_cli, target, message="m1", **kwargs):
 def test_cancel_against_a_live_host_writes_an_interrupt_and_leaves_it_alive(
         agent, monkeypatch, stub_cli, target):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target)
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     result = agent._cancel(run_id)
     assert result["still_queued"] == []
@@ -166,7 +167,8 @@ def test_model_change_writes_a_set_model_control_request(agent, monkeypatch,
                                                            stub_cli, target):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target,
                              model="claude-opus-5")
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     result = agent._send(run_id, "follow-up", model="claude-haiku-4-5")
     assert result == {"sent": True}
@@ -197,7 +199,8 @@ def test_a_model_change_is_not_repeated_on_the_next_send(agent, monkeypatch,
     third, for every turn of the session."""
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target,
                              model="claude-opus-5")
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     agent._send(run_id, "first follow-up", model="claude-haiku-4-5")
     assert _wait_for(lambda: any(
@@ -225,7 +228,8 @@ def test_unchanged_model_writes_no_control_request(agent, monkeypatch,
                                                      stub_cli, target):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target,
                              model="claude-opus-5")
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     agent._send(run_id, "follow-up", model="claude-opus-5")
 
@@ -238,7 +242,8 @@ def test_unchanged_model_writes_no_control_request(agent, monkeypatch,
 def test_effort_change_returns_the_respawn_marker(agent, monkeypatch, stub_cli,
                                                     target):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target, effort="")
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     result = agent._send(run_id, "follow-up", effort="high")
     assert result == {"respawn": True}

--- a/tests/test_claude_followup_respawn_ownership.py
+++ b/tests/test_claude_followup_respawn_ownership.py
@@ -83,6 +83,13 @@ console.log(JSON.stringify(calls));
 """
     out = subprocess.run(["node", "-e", script], capture_output=True, text=True)
     assert out.returncode == 0, out.stderr
+    # Not `json.loads(out.stdout)` straight off: on Windows CI this arrives as
+    # None, and a bare `TypeError: the JSON object must be str, bytes or
+    # bytearray, not NoneType` says nothing about which of node, the harness
+    # or the extracted block produced nothing. Report what actually came back.
+    assert out.stdout, (
+        "node printed no stdout: returncode=%r stdout=%r stderr=%r"
+        % (out.returncode, out.stdout, out.stderr))
     return json.loads(out.stdout)
 
 

--- a/tests/test_claude_send_action.py
+++ b/tests/test_claude_send_action.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from _claude_stub_cli import write_stub_cli
+from _claude_stub_cli import run_dir_report, write_stub_cli
 
 TEMPLATE_DIR = os.path.join("fused_render", "templates", "claude")
 
@@ -105,7 +105,8 @@ def _start(agent, monkeypatch, stub_cli, target, message="m1", read_dirs=None,
 
 def test_live_host_matches_a_running_session(agent, monkeypatch, stub_cli, target):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target)
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
     assert agent._live_host(target) == {"run_id": run_id}
 
 
@@ -124,7 +125,8 @@ def test_live_host_ignores_a_dead_session(agent, tmp_path):
 def test_send_writes_an_inbox_entry_the_stub_echoes(agent, monkeypatch, stub_cli,
                                                       target):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target, message="first")
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     result = agent._send(run_id, "second", "")
     assert result == {"sent": True}
@@ -139,7 +141,8 @@ def test_send_writes_an_inbox_entry_the_stub_echoes(agent, monkeypatch, stub_cli
 def test_send_with_an_ungranted_dir_ends_the_session_and_asks_for_a_respawn(
         agent, monkeypatch, stub_cli, target, tmp_path):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target, message="first")
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     new_dir = tmp_path / "attachment"
     new_dir.mkdir()

--- a/tests/test_claude_session_host.py
+++ b/tests/test_claude_session_host.py
@@ -22,7 +22,7 @@ import time
 
 import pytest
 
-from _claude_stub_cli import write_stub_cli
+from _claude_stub_cli import run_dir_report, write_stub_cli
 
 TEMPLATE_DIR = os.path.join("fused_render", "templates", "claude")
 
@@ -129,7 +129,8 @@ def test_two_inbox_entries_reach_the_stub_in_order(agent, monkeypatch, stub_cli,
     # A follow-up written straight into the inbox, exactly the shape `_send`
     # (a later task) will write — the host does not care who wrote it.
     assert _wait_for(lambda: any(
-        r.get("type") == "echo" for r in _out_rows(run_dir)))
+        r.get("type") == "echo" for r in _out_rows(run_dir))), \
+        run_dir_report(run_dir)
     agent._write_inbox_entry(run_dir, "second")
 
     def both_echoed():
@@ -148,7 +149,7 @@ def test_host_survives_a_result_row(agent, monkeypatch, stub_cli, target):
     def turn_finished():
         return any(r.get("type") == "result" for r in _out_rows(run_dir))
 
-    assert _wait_for(turn_finished)
+    assert _wait_for(turn_finished), run_dir_report(run_dir)
     with open(os.path.join(run_dir, "pid"), encoding="utf-8") as f:
         pid = int(f.read().strip())
     assert agent._alive(run_dir), "the CLI's pid must still be alive right " \
@@ -180,7 +181,7 @@ def test_pending_tasks_hold_the_reap_off(agent, monkeypatch, stub_cli, target):
         turn_open, tasks_pending = agent._turn_state(run_dir)
         return tasks_pending
 
-    assert _wait_for(tasks_seen)
+    assert _wait_for(tasks_seen), run_dir_report(run_dir)
     # Well past the idle window — still up, because tasks_pending is True.
     time.sleep(0.6)
     assert agent._alive(run_dir), \

--- a/tests/test_claude_stop_marker_retirement.py
+++ b/tests/test_claude_stop_marker_retirement.py
@@ -27,7 +27,7 @@ import time
 
 import pytest
 
-from _claude_stub_cli import write_stub_cli
+from _claude_stub_cli import run_dir_report, write_stub_cli
 
 TEMPLATE_DIR = os.path.join("fused_render", "templates", "claude")
 
@@ -133,7 +133,8 @@ def _start(agent, monkeypatch, stub_cli, target, message="m1"):
 def test_a_stop_does_not_read_as_a_crash_to_a_second_viewer(
         agent, monkeypatch, stub_cli, target):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target)
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     result = agent._cancel(run_id)
     assert result["still_queued"] == []
@@ -173,7 +174,8 @@ def test_a_stop_does_not_read_as_a_crash_to_a_second_viewer(
 def test_a_later_completed_turn_clears_the_stale_stop_marker(
         agent, monkeypatch, stub_cli, target):
     run_id, run_dir = _start(agent, monkeypatch, stub_cli, target)
-    assert _wait_for(lambda: os.path.exists(os.path.join(run_dir, "host.json")))
+    assert _wait_for(lambda: os.path.exists(
+        os.path.join(run_dir, "host.json"))), run_dir_report(run_dir)
 
     agent._cancel(run_id)
     poll = agent._poll(run_id)

--- a/tests/test_claude_stop_marker_retirement.py
+++ b/tests/test_claude_stop_marker_retirement.py
@@ -65,6 +65,7 @@ def send(row):
     sys.stdout.flush()
 
 interrupted = False
+answered_one = False
 for line in sys.stdin:
     line = line.strip()
     if not line:
@@ -92,7 +93,12 @@ for line in sys.stdin:
     # pending-echo wait actually clears.
     send({{"type": "user", "message": {{"role": "user",
            "content": [{{"type": "text", "text": text}}]}}}})
-    send({{"type": "result", "session_id": "sess-stub", "result": "ok " + text}})
+    # The FIRST message's turn is held open — no `result` closes it, the way a
+    # long-running turn behaves — so the stop under test lands on a turn that
+    # is genuinely still in flight. Every later message answers normally.
+    if answered_one:
+        send({{"type": "result", "session_id": "sess-stub", "result": "ok " + text}})
+    answered_one = True
 '''
 
 

--- a/tests/test_claude_stop_run.py
+++ b/tests/test_claude_stop_run.py
@@ -161,7 +161,10 @@ def test_a_successful_interrupt_retires_the_marker_once_a_later_turn_proves_it_s
     # `_cancel` captures `out.jsonl`'s current size as `interrupted_offset`.
     streamed = json.dumps({"type": "assistant", "message": {
         "content": [{"type": "text", "text": "partial"}]}}) + "\n"
-    (run_dir / "out.jsonl").write_text(streamed)
+    # `write_bytes`, not `write_text`: text mode translates "\n" to "\r\n" on
+    # Windows, so the file would be one byte longer than the offset asserted
+    # below — and `_cancel` measures the real `os.path.getsize`, correctly.
+    (run_dir / "out.jsonl").write_bytes(streamed.encode("utf-8"))
 
     result = agent._cancel("run")
     assert result == {"cancelled": "run", "still_queued": []}

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -998,7 +998,11 @@ def test_an_uncovered_folder_reports_disabled_while_indexing_is_off(
     from fused_render.server.routers import index as index_routes
 
     client = TestClient(create_app(start_dir=str(tmp_path)))
-    monkeypatch.setattr(index_routes, "indexing_enabled", lambda: False)
+    # The pref is read through `index_gate` (shell/index_gate.py), which looks
+    # it up as a module attribute so the FDA refusal and this one cannot
+    # drift apart — patching the router's own bound import would not be seen.
+    monkeypatch.setattr(index_routes.index_gate.prefs, "indexing_enabled",
+                        lambda: False)
     body = client.get("/api/index/rank",
                       params={"root": str(tmp_path), "q": "x"}).json()
     assert body["covered"] is False and body["reason"] == "disabled"
@@ -1014,7 +1018,8 @@ def test_ignored_still_wins_over_disabled_ordering_is_not_swapped(
     root = str(tmp_path / "proj" / "node_modules")
     client = _ranked_client(tmp_path, str(tmp_path / "proj"),
                             [str(tmp_path / "proj") + "/a.txt"])
-    monkeypatch.setattr(index_routes, "indexing_enabled", lambda: False)
+    monkeypatch.setattr(index_routes.index_gate.prefs, "indexing_enabled",
+                        lambda: False)
     body = client.get("/api/index/rank", params={"root": root, "q": "a"}).json()
     assert body["reason"] == "disabled"
 


### PR DESCRIPTION
Main has been red since ~07:20 UTC today — **#979 and #991 both merged with failing checks**, so every PR opened since (e.g. #995) inherits the failures. Nothing is wrong with those PRs.

Four distinct bugs, two of them in the product.

## 1. `_cancelled_marker_state` retired the stop marker one poll too early

`agent.py` retired the `cancelled` marker once the poll cursor had reached `interrupted_offset`. But a stop pressed before the turn has written a byte captures offset `0`, and the cursor starts at `0` too — so the marker died on the very next poll and the interrupted turn's own error `result` read as a **crash** to every viewer that wasn't the tab that pressed Stop. That is precisely the bug the offset pairing exists to prevent.

The comparison is now strict. This is exact, not a fudge: `interrupted_offset` is written only once `_await_control_response` has read the CLI's `control_response` row out of `out.jsonl` *starting at that offset*, so whenever the file exists there are already bytes at `>= interrupted_offset` belonging to the interrupted turn, and a genuinely later turn's own start is always strictly greater. The single way `cursor == interrupted_offset` is the `0 == 0` case above.

The test's stub also contradicted its own docstring — it closed the first turn with a `result` instead of holding it open, so the stop landed on a *finished* turn rather than one in flight. It now holds turn 1 open, which is the scenario the retirement rule is about.

## 2. A Windows `.bat`/`.cmd` claude never launched at all

`session_host.py`'s `_cli_popen_command` built `'"' + list2cmdline(argv) + '"'` and handed it to `Popen` as a plain command line, on the assumption that CreateProcess reroutes a `.bat`/`.cmd` target through `%ComSpec% /c` by itself. It does not — CreateProcess talks to real executables and cannot launch a batch file at all, and with `lpApplicationName` NULL it reads the program name out of that leading quote, so it looked for a file named after the whole quoted line.

Windows CI confirmed it directly: `err.log` held `[WinError 2] The system cannot find the file specified`, the CLI process never existed, and `host.json` was never written — which is what 12 session-host tests were reporting as a bare `assert False`. **npm installs exactly one of `.cmd`/`.bat` on Windows, so this was every turn of every session there.**

The cmd.exe hop is `shell=True`, whose comspec wrapping supplies the single outer quote pair the fix's escape hatch depends on. So the function returns the *interior* and the spawn passes `shell=` on whether it got a `str`. Every element is quoted, not just the ones `list2cmdline` would quote, because the outer pair stops cmd re-parsing quotes but **not** metacharacters — an unquoted `<live-app-state>` still reads as a redirection. A stray `"` raises rather than silently changing what the line means. This is the shape `fused_render/server/ai.py` (`_popen_cmd` / `_spawn_claude_stream`) already runs in production against the same shim; the two are now deliberately identical.

## 3. `test_index_search` patched a seam the gate no longer reads

#991 moved the pref read behind `index_gate`, which looks `indexing_enabled` up as a module attribute so the FDA refusal and the disabled one cannot drift apart. Two tests still patched the router's own bound import, which the gate never consults, so they flipped nothing. The siblings in `test_index_api.py` and `test_index_scan_on_demand.py` were already updated; these now patch `index_gate.prefs` too.

The other two tests in that section deliberately keep the router-local patch — they exercise the `scanning` gate at `index.py:372`, which really is that bound import.

## 4. A Windows byte count in the stop test

`test_claude_stop_run` wrote its fixture with `Path.write_text`, whose text mode translates `\n` to `\r\n` on Windows: 86 bytes on disk against the 85 the test computed from `.encode("utf-8")`. `_cancel` reads the real `os.path.getsize`, so the product was right and the fixture was wrong. It writes bytes now.

## Diagnostics, kept on purpose

`session_host.main` writes a CLI-spawn failure into `err.log` and returns without creating `host.json`, so every one of those 12 tests reported `assert False` and discarded the one line that said why — one CI round trip per guess, on the one platform that can't be run locally. `run_dir_report` (`tests/_claude_stub_cli.py`) renders the run dir's entries plus the tails of `err.log` and `out.jsonl` as the assertion message, and is now wired into every `host.json` wait in the four affected files. It is what found bug 2.

## Still open, tracked not fixed here

- `test_claude_followup_respawn_ownership::test_the_only_loop_still_clears_the_param_and_notes_a_stop` fails on Windows with `TypeError: the JSON object must be str, bytes or bytearray, not NoneType` — its `node -e` runner gets `out.stdout is None` despite `capture_output=True`, on Windows only. A third independent bug with no mechanism established yet; the assertion now reports returncode/stdout/stderr so the next run identifies it instead of hiding it.
- `test_ai_runtime::test_a_model_loads_and_reports_its_memory` appeared in the second Windows run and not the first — the known model-load timing flake on a slow runner.

## Verification

- `tests/test_claude_stop_marker_retirement.py` + `tests/test_index_search.py`: 76 passed. Everything matching `-k "claude or index"`: 1823 passed.
- The 8 remaining local failures are environment-only (a real `claude` binary on this machine leaks into the "nothing installed" cases in `test_claude_health.py` / `test_ai_metrics.py`); they are green in CI and untouched here.
- Ran the stop-marker file 5× in a row — it drives real subprocesses, so this confirms the race is closed rather than shifted.
- All Linux jobs went green on the first push (`test-python` 3.11/3.12/3.13, `fused-engine`, `linux-desktop`, `bundle-contents`, `frontend`). The Windows work landed after that and is verified by CI, not locally — there is no Windows machine in this loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)