### PR TITLE
CI: narrow the Windows skip in the follow-up respawn tests to the one failing case

### DIFF
--- a/tests/test_claude_followup_respawn_ownership.py
+++ b/tests/test_claude_followup_respawn_ownership.py
@@ -27,13 +27,6 @@ import json
 
 import pytest
 
-# WINDOWS: SKIPPED, NOT FIXED. The persistent session host (#979) never writes
-# `host.json` on the Windows runner - every test below waits for it and times
-# out - and `interrupted_offset` lands one byte off there (CRLF). That is a
-# platform gap in the host itself, not in these tests, and it needs a Windows
-# box to close; marking it here keeps main's Windows job honest about what it
-# does cover instead of red for everything (2026-09-04, red since #979).
-pytestmark = pytest.mark.skipif(os.name == "nt", reason="claude session host does not start on Windows yet (#979)")
 
 
 TEMPLATE = os.path.join(
@@ -116,6 +109,11 @@ def test_an_old_superseded_loop_does_not_add_a_stray_stopped_note(html):
     )
 
 
+# WINDOWS: this one test fails on the runner with a TypeError inside the node
+# harness (the JSON handed back is bytes, not str, on that platform); the other
+# tests in this file run `pollLoop` the same way and pass, so the skip is on the
+# one case and not the module (bugbot, #998; red since #979).
+@pytest.mark.skipif(os.name == "nt", reason="node harness returns bytes for this case on Windows (#979)")
 def test_the_only_loop_still_clears_the_param_and_notes_a_stop(html):
     """Sanity check: the guard must not silence the ordinary (non-respawn)
     case where this loop really is the current one."""


### PR DESCRIPTION
Bugbot on #998 (low): the module-level Windows skip was copied onto `test_claude_followup_respawn_ownership.py`, whose tests never start the session host - they run `pollLoop` under node. Only one of them fails on the Windows runner (a bytes-vs-str TypeError in the harness), so the skip now sits on that test alone and the other three run on Windows again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI scope change with no production code paths affected.
> 
> **Overview**
> **Removes the module-wide Windows skip** from `test_claude_followup_respawn_ownership.py` so three `pollLoop` harness tests run on the Windows CI job again.
> 
> Those tests never depended on the Claude session host; the old skip was copied from host-based suites. **Only** `test_the_only_loop_still_clears_the_param_and_notes_a_stop` stays skipped on Windows, with an updated comment explaining a platform-specific `TypeError` (JSON from the Node subprocess treated as bytes vs str in that scenario).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0921338d9b3fabe91a7c6a2c17ce0d3ecc97759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->