### PR TITLE
Explorer: "Open in project" replaces "Open app", adds the app to the sidebar desk

### DIFF
--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -1921,7 +1921,7 @@ export default function Listing({
               {!paneOpen && appEntryPath && (
                 <button
                   type="button"
-                  className="bar-ctl bar-ctl-strong"
+                  className="bar-ctl bar-ctl-bordered"
                   title={"Open " + basename(base) + " as a project"}
                   onClick={openAppEntry}
                 >

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -36,12 +36,20 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { IS_PANEL_PANE, IS_SNAPSHOT, navigate, replaceSearch } from "@platform/lib/router";
+import {
+  IS_PANEL_PANE,
+  IS_SNAPSHOT,
+  encodeFsPathSegments,
+  navigate,
+  navigateUrl,
+  replaceSearch,
+} from "@platform/lib/router";
 import { dirname, normDir } from "@apps/explorer/lib/fs-actions";
-import { getAppEntry } from "@platform/lib/api";
+import { addCurrentApp, getAppEntry } from "@platform/lib/api";
+import { announceCurrentAppsChanged } from "@platform/lib/tasksChanged";
 import { acquireOverlay, releaseOverlay } from "@platform/lib/ui-overlay";
 import { isMod } from "@platform/lib/platform";
-import { formatSize, formatMtime, formatMtimeFull } from "@platform/lib/format";
+import { basename, formatSize, formatMtime, formatMtimeFull } from "@platform/lib/format";
 import { iconForEntry } from "@platform/ui/FileIcons";
 import { getViewState, setViewState } from "@platform/lib/viewstate";
 import { useFlip, FLIP_KEY_ATTR } from "@platform/lib/flip";
@@ -122,8 +130,8 @@ const FLIP_BUDGET = 2;
 
 // (The folder-entry rule is the SERVER's — `app_listing.app_entry`, D301: the
 // first top-level page carrying `<meta name="fused-app">`. A filename tells
-// the client nothing under the marker rule, so the "Open app" button asks
-// GET /api/apps/entry instead of re-deriving anything from row names.)
+// the client nothing under the marker rule, so the "Open in project" button
+// asks GET /api/apps/entry instead of re-deriving anything from row names.)
 
 // The window global the injected runtime calls to hand this pane a prompt the
 // git companion's "Fix with AI" button built for a failed operation
@@ -901,14 +909,26 @@ export default function Listing({
     };
   }, [base]);
 
-  // The ONE "Open app" click, shared by the pane strip's button and its
-  // shut-pane fallback in the bar so they can't drift. The click just
-  // navigates: recording the open — recents for a workspace app, /apps hub
-  // registration for an external folder — is the SERVER's, done by GET /render
-  // when it serves the marker-carrying page this navigation renders (D301).
-  const openAppEntry = () => {
+  // The ONE "Open in project" click, shared by the pane strip's button and its
+  // shut-pane fallback in the bar so they can't drift. Gated on the folder
+  // having an entry page (it IS an app), it puts the folder on the sidebar's
+  // desk (POST /api/current-apps/add — a no-op when the row is already there,
+  // which then simply reads as the active row) and hops to the folder's app
+  // page, `/apps/<folder>` — spelled here rather than imported from
+  // shell/current-apps-lib's appPageUrl because an app may not import the
+  // shell (Preview.tsx's Migrate button does the same). The add is awaited
+  // and announced before the hop so the row is on top the moment the page
+  // paints; a failed add still opens the page — the desk is a convenience,
+  // the page is the point.
+  const openAppEntry = async () => {
     if (!appEntryPath) return;
-    navigate(appEntryPath, { isDir: false });
+    try {
+      await addCurrentApp(base);
+      announceCurrentAppsChanged();
+    } catch {
+      /* the page still opens; the row shows up on the next task under it */
+    }
+    navigateUrl("/apps/" + encodeFsPathSegments(base));
   };
 
   const paneSides = paneSideList(sideEntries);
@@ -1882,28 +1902,30 @@ export default function Listing({
                   Here rather than in the crumb bar because over a folder THIS ROW
                   is the bar (it portals into it — search-slot.ts), and this is the
                   folder's own chrome, beside the folder's own search box. */}
-              {/* OPEN APP, the SHUT-PANE FALLBACK. Its home is the pane's own strip,
-                  beside the chevron and the pill (ListingPreviewPane) — the button is
-                  about the pane's SUBJECT, so it belongs to the pane. With the pane
-                  shut there is no strip to live in, and this row is the folder's own
-                  chrome, so it lands here instead of vanishing with the column.
+              {/* OPEN IN PROJECT, the SHUT-PANE FALLBACK. Its home is the pane's own
+                  strip, beside the chevron and the pill (ListingPreviewPane) — the
+                  button is about the pane's SUBJECT, so it belongs to the pane. With
+                  the pane shut there is no strip to live in, and this row is the
+                  folder's own chrome, so it lands here instead of vanishing with the
+                  column.
 
                   `!paneOpen` and not `!pane.on`: a pane the user has closed
                   (`_side=off`) is the case this exists for. When the pane is open the
                   strip has it and a second copy here would be two buttons for one
                   action a few pixels apart, which reads as a rendering fault.
 
-                  Same `navigate(path, { isDir: false })` as the row's own
-                  open-on-click (onRowPointerUp), reused rather than reinvented: no
-                  new view and no `_mode`, just the file. */}
+                  It hops to the folder's app page (`/apps/<folder>`) and puts the
+                  folder on the sidebar's desk on the way — `openAppEntry`, above.
+                  It used to open the entry page itself ("Open app"); the app page's
+                  Overview tab frames that page, so nothing is lost. */}
               {!paneOpen && appEntryPath && (
                 <button
                   type="button"
                   className="bar-ctl bar-ctl-strong"
-                  title={"Open " + appEntryPath.slice(appEntryPath.lastIndexOf("/") + 1)}
+                  title={"Open " + basename(base) + " as a project"}
                   onClick={openAppEntry}
                 >
-                  Open app
+                  Open in project
                 </button>
               )}
               {pane.on && !sideState.open && (

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -130,7 +130,7 @@ export default function ListingPreviewPane({
         {appEntry && (
           <button
             type="button"
-            className="bar-ctl bar-ctl-strong"
+            className="bar-ctl bar-ctl-bordered"
             title={"Open " + folder.slice(folder.lastIndexOf("/") + 1) + " as a project"}
             onClick={onOpenApp}
           >

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -73,11 +73,12 @@ export default function ListingPreviewPane({
   sideEntries: PaneSideEntries;
   onSelectSide: (side: PaneSideChoice) => void;
   // The FOLDER's entry page (`index.html`), or null when it has none — the
-  // "Open app" button in the strip.
+  // "Open in project" button in the strip (gates it: an app, not any folder).
   appEntry: string | null;
-  // Opens it. The caller's own `navigate`, for the reason the whole button lives in
-  // Listing: an EMBEDDED pane may not move the host view, and the way that stays
-  // true is that this component never navigates.
+  // Opens the folder as a project (its /apps page). The caller's own
+  // navigation, for the reason the whole button lives in Listing: an EMBEDDED
+  // pane may not move the host view, and the way that stays true is that this
+  // component never navigates.
   onOpenApp: () => void;
   // Shuts the pane (`_side=off`). The listing's search row grows the reopening
   // half of the affordance while the pane is down — SideChrome writes the split
@@ -119,7 +120,7 @@ export default function ListingPreviewPane({
   // It opens with the way OUT of the column and it ends with the mode pill,
   // which is the file sidebar's header exactly (SideChrome, PreviewSidebar) —
   // the two columns are the same column over a folder and over a file, so they
-  // wear the same bar. "Open app" rides in here too, ahead of the pill, in
+  // wear the same bar. "Open in project" rides in here too, ahead of the pill, in
   // every state including the skeleton — the subject (the open folder) is
   // known long before the pane has resolved what to show about it.
   const strip = () => (
@@ -130,10 +131,10 @@ export default function ListingPreviewPane({
           <button
             type="button"
             className="bar-ctl bar-ctl-strong"
-            title={"Open " + appEntry.slice(appEntry.lastIndexOf("/") + 1)}
+            title={"Open " + folder.slice(folder.lastIndexOf("/") + 1) + " as a project"}
             onClick={onOpenApp}
           >
-            Open app
+            Open in project
           </button>
         )}
         {sideMenu}

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -358,7 +358,7 @@ function OpenInProjectButton({ fsPath }: { fsPath: string }) {
   return (
     <button
       type="button"
-      className="bar-ctl bar-ctl-strong"
+      className="bar-ctl bar-ctl-bordered"
       title={"Open " + basename(dir) + " as a project"}
       onClick={open}
     >
@@ -1786,8 +1786,8 @@ function TemplatePreview({
       {!stat.is_dir && <MigrateAppButton fsPath={fsPath} />}
       {!stat.is_dir && <ExportAppButton fsPath={fsPath} />}
       {/* The folder view's "Open in project", offered on the app's entry page
-          too (same server-side entry gate). Last, as the strongest control in
-          the bar — the explorer strip puts it at the tail as well. */}
+          too (same server-side entry gate), wearing the same bordered look as
+          Export App beside it. */}
       {!stat.is_dir && <OpenInProjectButton fsPath={fsPath} />}
       {/* One mode control per view, and for an explorer FOLDER it is the
           preview pane's, not this one. The pane header carries a ModeMenu of

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -1787,8 +1787,12 @@ function TemplatePreview({
       {!stat.is_dir && <ExportAppButton fsPath={fsPath} />}
       {/* The folder view's "Open in project", offered on the app's entry page
           too (same server-side entry gate), wearing the same bordered look as
-          Export App beside it. */}
-      {!stat.is_dir && <OpenInProjectButton fsPath={fsPath} />}
+          Export App. Its HOME is the sidebar's header, right before the mode
+          pill — exactly where the folder pane's strip puts it — so the two
+          views agree on where the hop lives. This copy is the SHUT-SIDEBAR
+          fallback (`!activeSide`, Listing's `!paneOpen` rule): with the column
+          down there is no strip, and the button must not vanish with it. */}
+      {!stat.is_dir && !activeSide && <OpenInProjectButton fsPath={fsPath} />}
       {/* One mode control per view, and for an explorer FOLDER it is the
           preview pane's, not this one. The pane header carries a ModeMenu of
           its own beside the previewed row (ListingPreviewPane), so a folder
@@ -2061,6 +2065,7 @@ function TemplatePreview({
             src={sideEntry && isSidePending(sideEntry) ? null : sideSrcFor(activeSide)}
             onSelect={setSide}
             onClose={() => setSide(null)}
+            lead={<OpenInProjectButton fsPath={fsPath} />}
           />,
           sideSlot
         )}

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
+  addCurrentApp,
   getAppEntry,
   migrateApp,
   setAppPreview,
@@ -25,7 +26,7 @@ import {
 import type { StatResult, TemplateEntry, RegistryEntryForPath } from "@platform/lib/api";
 import { captureAppPreview, cropRect, exportAppFile } from "@platform/lib/appShot";
 import { appLandingUrl } from "@platform/lib/appLanding";
-import { announceTasksChanged } from "@platform/lib/tasksChanged";
+import { announceCurrentAppsChanged, announceTasksChanged } from "@platform/lib/tasksChanged";
 import { navigate, navigateUrl, urlForFsPath, viewUrlForFsPath, replaceSearch, encodeFsPathSegments, IS_EMBED, IS_FOREIGN_EMBED, IS_PREVIEW } from "@platform/lib/router";
 import { formatSize, formatMtimeFull, basename } from "@platform/lib/format";
 import {
@@ -314,6 +315,54 @@ function MigrateAppButton({ fsPath }: { fsPath: string }) {
     >
       {busy && <span className="mode-icon-spinner" />}
       {busy ? "Creating task…" : "Migrate to new version"}
+    </button>
+  );
+}
+
+// The explorer folder view's "Open in project" (Listing.tsx openAppEntry),
+// here on the ENTRY PAGE's own header: viewing an app's index.html is the
+// other place one is standing in an app, so the same hop is offered — put the
+// folder on the sidebar's desk (POST /api/current-apps/add, a no-op when the
+// row is there already, which then reads as the active row) and open the
+// folder's app page, `/apps/<folder>`, spelled as the Migrate button spells it
+// since an app may not import shell/current-apps-lib. Same gate as
+// ExportAppButton beside it: the server's entry rule, never the filename.
+function OpenInProjectButton({ fsPath }: { fsPath: string }) {
+  const [isEntry, setIsEntry] = useState(false);
+  const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
+  const dir = fsPath.slice(0, fsPath.lastIndexOf("/")) || "/";
+  useEffect(() => {
+    let alive = true;
+    setIsEntry(false);
+    getAppEntry(dir)
+      .then((r) => {
+        if (alive) setIsEntry(r.entry != null && canon(r.entry) === fsPath);
+      })
+      .catch(() => {
+        /* indeterminate reads as "not an entry" — no button for nothing */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [fsPath, dir]);
+  if (!isEntry) return null;
+  const open = async () => {
+    try {
+      await addCurrentApp(dir);
+      announceCurrentAppsChanged();
+    } catch {
+      /* the page still opens; the row shows up on the next task under it */
+    }
+    navigateUrl("/apps/" + encodeFsPathSegments(dir));
+  };
+  return (
+    <button
+      type="button"
+      className="bar-ctl bar-ctl-strong"
+      title={"Open " + basename(dir) + " as a project"}
+      onClick={open}
+    >
+      Open in project
     </button>
   );
 }
@@ -1736,6 +1785,10 @@ function TemplatePreview({
           .fused app never shows it. */}
       {!stat.is_dir && <MigrateAppButton fsPath={fsPath} />}
       {!stat.is_dir && <ExportAppButton fsPath={fsPath} />}
+      {/* The folder view's "Open in project", offered on the app's entry page
+          too (same server-side entry gate). Last, as the strongest control in
+          the bar — the explorer strip puts it at the tail as well. */}
+      {!stat.is_dir && <OpenInProjectButton fsPath={fsPath} />}
       {/* One mode control per view, and for an explorer FOLDER it is the
           preview pane's, not this one. The pane header carries a ModeMenu of
           its own beside the previewed row (ListingPreviewPane), so a folder

--- a/frontend/src/apps/explorer/PreviewSidebar.tsx
+++ b/frontend/src/apps/explorer/PreviewSidebar.tsx
@@ -103,6 +103,7 @@ export default function PreviewSidebar({
   src,
   onSelect,
   onClose,
+  lead,
 }: {
   // The switcher's whole list: every companion, in SIDEBAR_MODES order, the ones
   // this file cannot show disabled and carrying their reason.
@@ -124,6 +125,11 @@ export default function PreviewSidebar({
   // Clears `_side`. The title bar's opener is hidden while this column is up
   // (SideChrome writes the split down), so this is the only way out of it.
   onClose: () => void;
+  // What rides in the header's tail AHEAD of the mode pill — the entry page's
+  // "Open in project" button (Preview.tsx), in the slot the folder pane's
+  // strip gives the same button (ListingPreviewPane). Rendered as given: the
+  // caller gates it, this header only places it.
+  lead?: ReactNode;
 }) {
   // A width the user DRAGGED earlier in this document leads (lib/side-store) — that
   // is what makes the divider hold still while you walk from file to file, since
@@ -313,6 +319,7 @@ export default function PreviewSidebar({
               always a menu to draw and always more in it than the mode you are
               looking at. */}
           <div className="side-header-tail">
+            {lead}
             <ModeMenu entries={entries} active={active} onSelect={onSelect} />
           </div>
         </div>

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2415,6 +2415,18 @@ export async function removeAppIcon(
   return r.json();
 }
 
+/** Put an app folder on the desk by hand — the explorer's "Open in project"
+ *  button, ahead of the hop to `/apps/<folder>`. `added` is false when the
+ *  row was already there; the sidebar then focuses it rather than inserting. */
+export function addCurrentApp(
+  path: string,
+): Promise<{ ok: boolean; added: boolean; path: string }> {
+  return postJson<{ ok: boolean; added: boolean; path: string }>(
+    "/api/current-apps/add",
+    { path },
+  );
+}
+
 /** Take an app off the desk. SIDE EFFECT, by design: every task whose project
  *  is the folder or inside it is archived (the same gesture as
  *  `archiveTask`, per task — cancelled work, filed session, nothing destroyed). */

--- a/frontend/src/platform/lib/tasksChanged.ts
+++ b/frontend/src/platform/lib/tasksChanged.ts
@@ -15,3 +15,14 @@ export const TASKS_CHANGED_EVENT = "fused-render:tasks-changed";
 export function announceTasksChanged(): void {
   window.dispatchEvent(new Event(TASKS_CHANGED_EVENT));
 }
+
+// "The desk just changed" — the same wall-throw for the sidebar's Projects
+// table (shell/CurrentAppsSection). The explorer's "Open in project" button
+// puts a folder on the desk (POST /api/current-apps/add) and then hops to
+// its app page; the section refetches on this so the new row is there — on
+// top, focused — the moment the page paints, not on the next task pulse.
+export const CURRENT_APPS_CHANGED_EVENT = "fused-render:current-apps-changed";
+
+export function announceCurrentAppsChanged(): void {
+  window.dispatchEvent(new Event(CURRENT_APPS_CHANGED_EVENT));
+}

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -43,6 +43,7 @@ import { Modal } from "@platform/ui/modal/Modal";
 import { HeroComposer } from "@apps/builder/HomeHero";
 import { inFlight, isDoneUnread, opensElsewhere, statusColumn } from "@shell/tasks-lib";
 import { pokeTasks, useTasksPulseRows } from "@shell/tasksPulse";
+import { CURRENT_APPS_CHANGED_EVENT } from "@platform/lib/tasksChanged";
 import {
   appPageTabFromSearch,
   appPageUrl,
@@ -464,6 +465,15 @@ export default function CurrentAppsSection() {
   });
 
   const refetch = useCallback(() => setRefreshEpoch((n) => n + 1), []);
+
+  // The explorer's "Open in project" button adds a row (POST
+  // /api/current-apps/add) and announces it over the window — apps cannot
+  // import this section — so the new row lands on top as its page opens,
+  // rather than on the next task pulse (platform/lib/tasksChanged).
+  useEffect(() => {
+    window.addEventListener(CURRENT_APPS_CHANGED_EVENT, refetch);
+    return () => window.removeEventListener(CURRENT_APPS_CHANGED_EVENT, refetch);
+  }, [refetch]);
 
   // ---- the icon picker -------------------------------------------------------
   // The glyph toggles the Bookmarks' emoji picker (IconPicker), anchored to

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -481,7 +481,7 @@
   display: block;
 }
 
-/* THE STRONGEST CONTROL IN A BAR — the "Open app" button in the pane's strip.
+/* THE STRONGEST CONTROL IN A BAR — the "Open in project" button in the pane's strip.
    Filled with --fg on --bg, which is the same idiom `.btn-primary`
    (buttons-modal.css) and the home composer's send button use, so it inherits
    maximal contrast in BOTH themes by construction rather than by a chosen colour:

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -481,50 +481,6 @@
   display: block;
 }
 
-/* THE STRONGEST CONTROL IN A BAR — the "Open in project" button in the pane's strip.
-   Filled with --fg on --bg, which is the same idiom `.btn-primary`
-   (buttons-modal.css) and the home composer's send button use, so it inherits
-   maximal contrast in BOTH themes by construction rather than by a chosen colour:
-   the pair IS the theme's text-on-surface, whichever way round the theme puts them.
-   --on-fg on hover is the token that file defines for exactly this ("one step
-   further from --bg than --fg").
-
-   DELIBERATELY NOT ACCENT, and this is a reservation rather than a preference.
-   `.btn-menu-item.active` in this same strip uses `color-mix(--accent 16%)` to say
-   WHICH MODE THE PANE IS ON, and the crumb bar next to it uses --accent for drop
-   targets and the spring-armed highlight. Accent here would put a second accent
-   element inches from the one that means "this is the mode you are looking at", and
-   `.btn-primary` states the house rule twice over: "reads strongest through
-   contrast, not accent — accent stays for focus/selection". A filled --fg button is
-   already the loudest thing in a strip of ghost controls. */
-.bar-ctl.bar-ctl-strong {
-  background: var(--fg);
-  color: var(--bg);
-  font-weight: 600;
-}
-
-.bar-ctl.bar-ctl-strong:hover:not(:disabled) {
-  /* NOT var(--on-fg) — that moved --fg one step FURTHER toward the same
-     extreme (near-black to pure black in light, near-white to pure white in
-     dark), which is a luminance delta of ~0.01–0.02 and reads as no hover at
-     all. This instead steps --fg back TOWARD --bg — the same "mix off --fg"
-     idiom `.apps-tag-chip.is-active` / `.apps-filter-mode-btn.is-active` use
-     (apps.css) to get a background that shifts visibly in BOTH themes while
-     keeping a --bg label legible on it, because the mix moves each theme's
-     fill away from that theme's own extreme rather than further into it.
-     82% keeps it reading as the same filled/strong button (still mostly
-     --fg, not washed toward a ghost tint) while giving a clearly visible
-     step: ~0.28 luminance delta in dark, ~0.05 in light — both an order of
-     magnitude bigger than --on-fg's. */
-  background: color-mix(in srgb, var(--fg) 82%, var(--bg));
-  /* The generic .bar-ctl:hover rule right below sets color: var(--fg), which
-     was already illegible against the old --on-fg hover and would be no
-     better against this one. Restate --bg explicitly so the label stays
-     high-contrast through the hover (>9:1 in both themes against the mix
-     above). */
-  color: var(--bg);
-}
-
 .bar-ctl:hover:not(:disabled) {
   background: rgba(var(--tint), 0.08);
   color: var(--fg);

--- a/fused_render/current_apps.py
+++ b/fused_render/current_apps.py
@@ -15,7 +15,9 @@ questions: "what is on my desk" and "what is filed". The owner's redesign
   (`observe`, run inside the tasks listing so it sees every task on the
   machine, however it was started — chat, schedule, CLI).
 * Nothing removes an app automatically. Archive every task under it and the
-  row stays; the table only grows through tasks.
+  row stays; the table grows through tasks — and through the explorer's
+  "Open in project" button (`add`, POST /api/current-apps/add), which puts
+  the folder on the desk before opening its app page.
 * Removing an app (the row's cross, DELETE /api/current-apps) ARCHIVES every
   task under it as a side effect — the one place the coupling still runs, and
   it runs desk → tasks, not the other way.
@@ -166,6 +168,24 @@ def observe(rows: list[dict]) -> None:
     if changed or pruned != set(state["seen"]):
         state["seen"] = sorted(pruned)
         write_state(state)
+
+
+def add(path: str) -> bool:
+    """Put `path` on the desk by hand — the explorer's "Open in project"
+    button. True when it was added, False when it was already there (the
+    row keeps its place and its sequence: the sidebar focuses it rather than
+    re-inserting). The one way onto the desk besides a task; `observe`'s
+    dedupe on `known` means a later task under the folder adds nothing."""
+    folder = canonical_fs_path(os.path.abspath(path)).rstrip("/")
+    state = read_state()
+    if any(a["path"] == folder for a in state["apps"]):
+        return False
+    state["apps"].append({
+        "path": folder,
+        "addedAt": datetime.now(timezone.utc).isoformat(),
+    })
+    write_state(state)
+    return True
 
 
 def remove(path: str) -> bool:

--- a/fused_render/server/routers/current_apps.py
+++ b/fused_render/server/routers/current_apps.py
@@ -19,9 +19,13 @@ The row's right-click menu adds three more verbs, all folder-scoped:
 * ``POST /api/current-apps/archive`` — the DELETE's task half without its desk
   half: archive every task under the folder, keep the row.
 
-There is no POST that adds a row: the table is fed by the tasks listing
-(`current_apps.observe`, run inside `tasks._task_rows`) and by nothing else. An
-app arrives on the desk by having work started in it.
+Two ways onto the desk: the tasks listing (`current_apps.observe`, run inside
+`tasks._task_rows`) adds the app of every new task, and
+
+* ``POST /api/current-apps/add`` — the explorer's "Open in project" button
+  puts the folder on the desk by hand before hopping to its app page. Already
+  there is not an error (``added: false``): the sidebar focuses the row it
+  has rather than inserting a second.
 """
 import os
 import time
@@ -92,6 +96,17 @@ def api_current_apps_remove(path: str = Query(...)):
 
 class FolderPatch(BaseModel):
     path: str
+
+
+@router.post("/api/current-apps/add")
+def api_current_apps_add(patch: FolderPatch):
+    """Put a folder on the desk. The client gates the button on the folder
+    having an entry page; here the folder only has to exist — a linked or
+    workspace app alike, the same breadth `list_apps` shows."""
+    folder = _require_folder(patch.path)
+    if not os.path.isdir(folder):
+        raise HTTPException(status_code=404, detail="no such folder")
+    return {"ok": True, "added": current_apps.add(folder), "path": folder}
 
 
 @router.post("/api/current-apps/archive")


### PR DESCRIPTION
## Summary
- The explorer folder view's **Open app** button (pane strip + shut-pane fallback) becomes **Open in project**: it opens the folder's app page (`/apps/<folder>`) instead of the entry page. The app page's Overview tab frames the entry page, so nothing is lost.
- On the way it puts the folder on the sidebar's Projects desk via a new `POST /api/current-apps/add`. Idempotent: already there → the row stays and reads as the active row for the route; new → inserted, lands on top (fresh sequence).
- The sidebar section listens for a `fused-render:current-apps-changed` window event the button fires, so the row appears as the page paints rather than on the next task pulse.
- The same button is offered on an app's `index.html` preview header next to Export App, under the same server-side entry gate.

## Smoke (owner)
- Explorer over an app folder → **Open in project** → lands on `/apps/<folder>`, sidebar row appears on top and is highlighted.
- Click again from the same folder → no duplicate row, same row highlighted.
- Preview `index.html` of an app → button present in header, same behavior. Plain html file → no button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes explorer navigation and mutates persisted "current apps" desk state via a new API; behavior is mostly UX with graceful degradation if add fails.
> 
> **Overview**
> Renames explorer **Open app** to **Open in project** and changes what it does: instead of opening the entry HTML in the file viewer, it navigates to **`/apps/<folder>`** (Overview still frames the entry page).
> 
> On click, the client **`POST`s `/api/current-apps/add`** (new `addCurrentApp` + `current_apps.add`) so the folder appears on the sidebar Projects desk before navigation. The add is **idempotent** (already on desk → focus, no duplicate). Failures on add are swallowed and navigation still proceeds. **`announceCurrentAppsChanged`** lets **`CurrentAppsSection`** refetch immediately so the row is visible when the app page paints.
> 
> The same control is wired in **folder listing** (pane strip + shut-pane fallback), **entry-page preview** (`OpenInProjectButton` in the topbar when the sidebar is closed, and in **`PreviewSidebar`** via a new **`lead`** slot). Styling drops **`bar-ctl-strong`** in favor of **`bar-ctl-bordered`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c804d9d118e033eab5da1a7bd8949ad5da1367c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->