### PR TITLE
Git view: Select all header button, ink-filled Commit/Send, clearer AI failure

### DIFF
--- a/fused_render/templates/git/log.py
+++ b/fused_render/templates/git/log.py
@@ -120,6 +120,44 @@ MAX_CONFLICT_BYTES = 60_000
 # which refuses to APPLY content that still contains them.
 CONFLICT_MARKERS = ("<<<<<<< ", "=======", ">>>>>>> ")
 
+# How much of an unmerged file `_marker_free` will read to decide whether its
+# markers are gone. A conflicted source file is not a 4 MB artefact; one that is
+# gets the cautious answer (not resolved), and the command line.
+MAX_RESOLVED_SCAN_BYTES = 4_000_000
+
+
+def _marker_free(root, rel):
+    """True when the working-tree copy of an UNMERGED path holds no conflict
+    markers any more — i.e. someone (Apply, or an editor) has resolved it and
+    the only step left is `git add`.
+
+    This is what lets the view offer that step: the row tick and "Select all"
+    are disabled on a conflicted file precisely because `git add` on marked-up
+    text commits the markers, so they need a fact — not the index, which still
+    says unmerged until the add — to know when the file is safe again. Only the
+    two bracketing markers are looked for: a bare `=======` line is legal
+    Markdown (a setext underline) and would keep a resolved README unstageable.
+
+    A path that no longer exists on disk (a both-deleted `DD`, or a side that
+    chose deletion) is marker-free by definition — `git add` records the
+    removal. Unreadable or oversized files answer False: not knowing is the same
+    as not yet.
+    """
+    full = os.path.join(root, *rel.split("/"))
+    if not os.path.exists(full):
+        return True
+    try:
+        with open(full, "rb") as handle:
+            raw = handle.read(MAX_RESOLVED_SCAN_BYTES + 1)
+    except OSError:
+        return False
+    if len(raw) > MAX_RESOLVED_SCAN_BYTES:
+        return False
+    for line in raw.splitlines():
+        if line.startswith(b"<<<<<<< ") or line.startswith(b">>>>>>> "):
+            return False
+    return True
+
 # `git status` is unbounded in principle (a build tree can hold 100k untracked
 # files). Bounded on the way in — bytes off the pipe — and again on the way out.
 MAX_STATUS_BYTES = 4_000_000
@@ -630,6 +668,11 @@ def _status(root, rel, is_dir):
             # and getting it wrong means offering to resolve a file that is not
             # conflicted, or hiding the button on one that is.
             "conflicted": "U" in (x, y) or code in ("AA", "DD"),
+            # For a conflicted entry only: the working tree copy has no markers
+            # left, so staging it is the resolve rather than a mistake. Read
+            # per unmerged file — there are rarely more than a handful.
+            "resolved": ("U" in (x, y) or code in ("AA", "DD"))
+                        and _marker_free(root, path),
             "staged": not untracked and x not in (" ", "?"),
             "unstaged": not untracked and y not in (" ", "?"),
             "untracked": untracked,

--- a/fused_render/templates/git/log.py
+++ b/fused_render/templates/git/log.py
@@ -154,7 +154,10 @@ def _marker_free(root, rel):
     if len(raw) > MAX_RESOLVED_SCAN_BYTES:
         return False
     for line in raw.splitlines():
-        if line.startswith(b"<<<<<<< ") or line.startswith(b">>>>>>> "):
+        if (
+            line.startswith(b"<<<<<<< ") or line == b"<<<<<<<"
+            or line.startswith(b">>>>>>> ") or line == b">>>>>>>"
+        ):
             return False
     return True
 

--- a/fused_render/templates/git/template.html
+++ b/fused_render/templates/git/template.html
@@ -3985,13 +3985,22 @@ function render(data, stashes, diff) {
   const allIn = changes.length > 0
     && changes.every((c) => c.staged && !c.unstaged && !c.untracked);
   const selectOp = allIn ? "unstage_all" : "stage_all";
+  /* Disabled while any file is conflicted, for the same reason that file's own
+     tick is: `stage_all` is `git add` over the lot, and staging a file that
+     still has markers in it clears the conflict without resolving it, letting
+     Commit record the markers. The row tick already refuses; the header must
+     not offer a way around it. */
+  const anyConflict = changes.some((c) => c.conflicted);
   const selectAll = changes.length ? action(selectOp,
       [icon(CHECK_GLYPH, 14), btnLabel(allIn ? "Deselect all" : "Select all")], {
     className: "good",
-    label: allIn ? "Remove every change from the next commit"
-                 : "Include every change in the next commit",
-    title: allIn ? "Leave every change out of the next commit"
-                 : "Include every change in the next commit",
+    disabled: anyConflict,
+    label: anyConflict ? "Resolve the conflicted files before selecting all"
+         : allIn ? "Remove every change from the next commit"
+         : "Include every change in the next commit",
+    title: anyConflict ? "Resolve the conflicted files first."
+         : allIn ? "Leave every change out of the next commit"
+         : "Include every change in the next commit",
     onClick: () => run(selectOp, { op: selectOp }),
   }) : null;
 

--- a/fused_render/templates/git/template.html
+++ b/fused_render/templates/git/template.html
@@ -461,15 +461,27 @@
      fired 48px too late — the band where labels showed AND the bar clipped is
      gone with the buttons. */
   .btn[aria-expanded="true"] .caret { color: inherit; transform: rotate(180deg); }
+  /* Filled in INK, not accent: Commit and Send are the next step, and a solid
+     block says so, but an accent slab beside an accent-ringed sparkle was two
+     yellow controls shouting at once. Ink-on-bg is the loudest quiet colour the
+     palette has, and it inverts cleanly in light mode. */
   .btn.primary {
-    border-color: var(--accent-dim);
-    background: var(--accent);
-    color: var(--on-accent);
+    border-color: var(--ink);
+    background: var(--ink);
+    color: var(--bg);
     font-weight: 700;
   }
-  .btn.primary:hover:not([disabled]) { background: var(--accent-dim); color: var(--on-accent); }
+  .btn.primary:hover:not([disabled]) { background: var(--ink-2); border-color: var(--ink-2); color: var(--bg); }
+  .btn.primary .count { background: var(--bg); color: var(--ink); }
   .btn.danger { color: var(--danger); border-color: var(--danger-line); }
   .btn.danger:hover:not([disabled]) { color: var(--danger); background: var(--danger-bg); border-color: var(--danger); }
+  /* The constructive twin of `.danger`: "Select all" rides the Changes header
+     beside "Discard all", and the two are the section's opposite verbs — one
+     keeps every change, one throws every change away — so they wear opposite
+     colours in the same outline shape. */
+  .btn.good { color: var(--good-fg); border-color: var(--good-line); }
+  .btn.good:hover:not([disabled]) { color: var(--good-fg); background: var(--good-bg); border-color: var(--good-fg); }
+  .btn.good[disabled] { color: var(--ink-3); border-color: var(--line); }
   .btn .count {
     padding: 0 5px;
     border-radius: 999px;
@@ -528,6 +540,10 @@
      does not reflow while text is streaming into the textarea above it. */
   .btn.ai { color: var(--ink-3); }
   .btn.ai:hover:not([disabled]) { color: var(--accent); }
+  /* Once something is ticked the offer is LIVE — the same moment Commit fills
+     in — so the sparkle steps up with it: accent ink and an accent ring, still
+     an outline so Commit stays the one filled control on the row. */
+  .btn.ai.ready:not([disabled]) { color: var(--accent); border-color: var(--accent-dim); }
   .btn.ai.working { opacity: 1; color: var(--accent); animation: ai-pulse 1.2s ease-in-out infinite; }
   /* 0.65, not 0.45: a 55% opacity swing reads as BLINKING, and the streaming
      text in the textarea above is already the real progress signal — this only
@@ -865,7 +881,9 @@
     flex: none;
     align-self: center;
     margin: 0 0 0 14px;
-    accent-color: var(--accent-dim);
+    /* Ink, matching the filled Commit button the ticks feed — an accent tick
+       beside an ink Commit was the one yellow thing left in the column. */
+    accent-color: var(--ink);
     width: 14px;
     height: 14px;
     cursor: pointer;
@@ -874,11 +892,6 @@
   .tick:disabled { cursor: not-allowed; }
   /* A row that follows a checkbox loses its left padding — the tick owns it. */
   .tick + .row { padding-left: 8px; }
-  /* The select-all row: first line of the list, quiet, the master tick and its
-     words one click surface. It lives IN the list because it acts on the list —
-     parked in the header's action cluster it read as an unrelated control (and
-     wore the browser's blue, styled by nothing). */
-  .line.select-all .row { color: var(--ink-3); font-size: 12px; }
   .line[aria-current="true"] .subject, .line[aria-current="true"] .path { font-weight: 700; }
   .row .sha {
     flex: none;
@@ -1595,6 +1608,7 @@ const STASH_GLYPH = ["M4 5h16v4H4z", "M6 9v9a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V9",
 const RESTORE_GLYPH = ["M4 5h16v4H4z", "M6 9v9a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V9",
                        "M12 17v-4.5", "M9.5 15L12 12.5 14.5 15"];
 const CROSS_GLYPH = ["M6 6l12 12", "M18 6L6 18"];
+const CHECK_GLYPH = ["M5 12l5 5L20 7"];
 
 /* Which sections are folded shut. MEMORY, deliberately not a param: which
    accordion is open is a reading posture, not a place — a refresh starting
@@ -1755,6 +1769,10 @@ function toolbar(data) {
      face of the button speaks the user's language. */
   const behind = repo.behind || 0;
   const ahead = repo.upstream ? (repo.ahead || 0) : 0;
+  /* The states with commits to MOVE wear `.primary` — filled, like Commit —
+     because they are the one thing left to do; "Check for updates" and
+     "Publish to GitHub" stay outlined, as offers rather than the next step. An
+     outlined Send after a commit read as one more grey button and was missed. */
   const canPush = remote && !repo.detached;
   if (!remote) {
     /* No remote used to be a dead end — a greyed-out button with nothing
@@ -1772,6 +1790,7 @@ function toolbar(data) {
     }));
   } else if (behind) {
     group.append(action("pull", [icon(PULL_GLYPH, 14), btnLabel("Get latest")], {
+      className: "primary",
       label: "Get the latest — " + plural(behind, "commit") + " to pull",
       count: behind,
       title: (ahead
@@ -1782,6 +1801,7 @@ function toolbar(data) {
     }));
   } else if (ahead && canPush) {
     group.append(action("push", [icon(PUSH_GLYPH, 14), btnLabel("Send")], {
+      className: "primary",
       label: "Send " + plural(ahead, "commit"),
       count: ahead,
       title: "git push to " + repo.upstream,
@@ -1792,6 +1812,7 @@ function toolbar(data) {
        PUBLISHES it. The old toolbar hid this distinction in a tooltip on a
        button that just said Push. */
     group.append(action("push", [icon(PUSH_GLYPH, 14), btnLabel("Publish branch")], {
+      className: "primary",
       label: "Publish " + repo.branch + " to " + remote,
       title: "git push — create " + repo.branch + " on " + remote + " and track it",
       onClick: () => run("push", { op: "push" }),
@@ -2687,7 +2708,7 @@ function commitBox(data) {
         : "Nothing is ticked yet — tick the changes to include them.",
       onClick: () => commit(box.value),
     }),
-    generateButton(),
+    generateButton(total > 0 && !conflicted),
     el("span", { className: "hint", textContent: hint }));
 
   const wrap = el("div", { className: "commit" }, box, actions);
@@ -2748,12 +2769,15 @@ const AI_SYSTEM = [
    disabled instead of handing the user a second click into the same stream. */
 let aiBusy = false;
 
-function generateButton() {
+const AI_STALE_MESSAGE = "The AI helper did not load in this view. Reload the "
+  + "app and try again, or write the message yourself in the box above.";
+
+function generateButton(ready) {
   /* While it writes, the sparkle IS a spinner — the pulse alone read as
      nothing happening, and the button got clicked three times by a user who
      never learned a generation was already running. */
   return action("ai", aiBusy ? el("span", { className: "spin" }) : icon(SPARK_GLYPH, 14), {
-    className: "icon ai" + (aiBusy ? " working" : ""),
+    className: "icon ai" + (aiBusy ? " working" : "") + (ready ? " ready" : ""),
     disabled: aiBusy,
     label: "Generate a commit message with AI",
     title: aiBusy ? "Writing a commit message…"
@@ -2805,9 +2829,12 @@ function aiPrompt(payload) {
 /* A failure is a `flash`, exactly like a failed mutation: an AI that is not
    configured on this server, or a model that errored, is an ordinary answer
    this view reports in its own words — never the red traceback overlay. */
-function aiFailed(message) {
+function aiFailed(message, noAsk) {
   aiBusy = false;
-  flash = { ok: false, message };
+  /* `noAsk`: the failure is this page's (the AI helper never loaded, nothing
+     to describe), not the repository's — a "Fix with AI" that opens Claude on
+     it would send the user to fix something that is not theirs. */
+  flash = { ok: false, message, noAsk: !!noAsk };
   announce(message);
   draw(true);
 }
@@ -2829,7 +2856,15 @@ async function generateMessage() {
     return;
   }
   if (payload.empty) {
-    aiFailed("There is nothing to describe — no changes were found.");
+    aiFailed("Nothing to describe yet — make a change first, then the sparkle "
+             + "can write its message.", true);
+    return;
+  }
+  /* The runtime is injected by the shell; a stale bundle cached from before
+     `fused.ai` became a namespace has no `.text`, and the raw TypeError
+     ("fused.ai.text is not a function") is a bug report, not a message. */
+  if (!window.fused || !fused.ai || typeof fused.ai.text !== "function") {
+    aiFailed(AI_STALE_MESSAGE, true);
     return;
   }
 
@@ -2861,10 +2896,16 @@ async function generateMessage() {
     if (written) written.focus();
   } catch (err) {
     if (!received) setMessage(before);
-    aiFailed(err && err.type === "ai_unavailable"
-      ? "AI is not available on this server."
-      : "Could not write a commit message: "
+    if (err && err.type === "ai_unavailable") {
+      aiFailed("AI is not available on this server.");
+    } else if (err instanceof TypeError) {
+      /* A TypeError out of the bridge is the page's fault, never git's or the
+         model's — say what to do about it instead of quoting the stack. */
+      aiFailed(AI_STALE_MESSAGE, true);
+    } else {
+      aiFailed("Could not write a commit message: "
         + ((err && err.message) || "the request failed."));
+    }
   }
 }
 
@@ -3929,66 +3970,58 @@ function render(data, stashes, diff) {
 
   /* ONE Changes section. Staged / unstaged / untracked was git's index model
      rendered at people who do not have it; the checkbox on each row (see
-     `changeLine`) is the model everyone has. The master checkbox stages or
-     unstages the lot; discard-all and the stash dialog ride the header as
-     icon+word buttons whose words give way in a narrow pane. */
+     `changeLine`) is the model everyone has. Select all, discard-all and the
+     stash dialog ride the header as icon+word buttons whose words give way in
+     a narrow pane. */
   const changes = data.changes;
-  const stagedCount = changes.filter((c) => c.staged).length;
   const changesAsk = askIn("changes");
   const showChanges = changes.length || changesAsk || truncNote;
 
-  /* The master tick heads the LIST, not the header's action cluster: it acts
-     on the rows below it, it belongs in their column (and in the cluster it
-     sat unstyled in the browser's blue, matching nothing). One quiet
-     "Select all" row, the tick aligned over the rows' own ticks. */
-  const master = el("input", { type: "checkbox", className: "tick" });
+  /* "Select all" is a header BUTTON beside "Discard all", not a master tick
+     heading the list: the two are the section's opposite verbs over the same
+     rows, and reading them side by side — green keep, red throw away — is what
+     a row-level tick could never say. It flips to "Deselect all" once every
+     change is in, so the label always names what a click will do. */
   const allIn = changes.length > 0
     && changes.every((c) => c.staged && !c.unstaged && !c.untracked);
-  master.checked = allIn;
-  master.indeterminate = stagedCount > 0 && !allIn;
-  master.disabled = busy !== null || !changes.length;
-  master.setAttribute("aria-label", allIn
-    ? "Remove every change from the next commit"
-    : "Include every change in the next commit");
-  master.title = allIn ? "Untick to leave everything out of the next commit"
-                       : "Tick to include every change in the next commit";
-  master.addEventListener("change", () => {
-    if (busy !== null) return;
-    if (master.checked) run("stage_all", { op: "stage_all" });
-    else run("unstage_all", { op: "unstage_all" });
-  });
-  const selectAllRow = el("button", {
-    className: "row", type: "button",
-    disabled: busy !== null,
-    title: master.title,
-    textContent: "Select all",
-  });
-  selectAllRow.addEventListener("click", () => { if (!master.disabled) master.click(); });
-  const selectAllLine = el("div", { className: "line select-all" }, master, selectAllRow);
+  const selectOp = allIn ? "unstage_all" : "stage_all";
+  const selectAll = changes.length ? action(selectOp,
+      [icon(CHECK_GLYPH, 14), btnLabel(allIn ? "Deselect all" : "Select all")], {
+    className: "good",
+    label: allIn ? "Remove every change from the next commit"
+                 : "Include every change in the next commit",
+    title: allIn ? "Leave every change out of the next commit"
+                 : "Include every change in the next commit",
+    onClick: () => run(selectOp, { op: selectOp }),
+  }) : null;
 
   const stashOpen = param("panel") === "stash";
   const changeRows = spliceDiff(
     changes.map((c) => changeLine(data.repo, c, c.path === wt)),
     wt ? changes.findIndex((c) => c.path === wt) : -1);
-  if (changes.length > 1) changeRows.unshift(selectAllLine);
   if (showChanges) sections.push(listSection(
     "Changes", String(changes.length),
-    [changes.length ? confirmable("discard_all",
-        [icon(REVERT_GLYPH, 14), btnLabel("Discard all")],
-        "Discard every change under this path?",
-        { label: "Discard every change under this path" }) : null,
-     changes.length ? action("panel-stash",
+    /* Stash, Discard all, Select all: neutral, then destructive, then the
+       constructive one nearest the rows it acts on. */
+    [changes.length ? action("panel-stash",
         [icon(STASH_GLYPH, 14), btnLabel("Stash")], {
           label: "Stash — set these changes aside for later",
           title: "Set these changes aside for later (git stash). They come "
                  + "back with Restore.",
           expanded: stashOpen,
           onClick: () => setParams({ panel: stashOpen ? null : "stash" }),
-        }) : null],
+        }) : null,
+     changes.length ? confirmable("discard_all",
+        [icon(REVERT_GLYPH, 14), btnLabel("Discard all")],
+        "Discard every change under this path?",
+        { label: "Discard every change under this path" }) : null,
+     selectAll],
     changeRows,
     data.repo.dirty ? "No changes under this path." : "Working tree is clean.",
     footer(changesAsk, truncNote),
-    headState(data.repo) + (data.repo.has_commits ? "" : " · no commits yet"),
+    /* No branch name here — the chip in the toolbar already says it, and a
+       second copy beside the count read as a filter on the list. */
+    data.repo.has_commits ? null : "no commits yet",
     "changes"));
 
   const stashAsk = askIn("stashes");
@@ -4056,7 +4089,7 @@ function render(data, stashes, diff) {
   if (flash) {
     const note = el("div", { className: "flash" + (flash.ok ? "" : " bad") },
                     el("span", { textContent: flash.message }));
-    if (!flash.ok && resolving === null && proposal === null && !aiBusy) {
+    if (!flash.ok && !flash.noAsk && resolving === null && proposal === null && !aiBusy) {
       if (askUnavailable) {
         /* Confirmed (not merely guessed, see `askClaudeOnError`) that nothing
            up the ancestor chain can open this into a chat. A dead button that

--- a/fused_render/templates/git/template.html
+++ b/fused_render/templates/git/template.html
@@ -3315,15 +3315,21 @@ function changeLine(repo, change, selected) {
   const tick = el("input", { type: "checkbox", className: "tick" });
   tick.checked = !!change.staged && !change.unstaged && !change.untracked;
   tick.indeterminate = !!(change.staged && (change.unstaged || change.untracked));
-  /* A conflicted file's tick is disabled: `git add` on a file that still has
-     markers in it is the classic way half a conflict gets committed. The
-     sparkle (or hand-editing) is the way through, and a checkbox saying "not
-     yet" is part of that message. */
-  tick.disabled = busy !== null || !!change.conflicted || !canAct;
+  /* A conflicted file's tick is disabled while the markers are still in it:
+     `git add` on that text is the classic way half a conflict gets committed.
+     The sparkle (or hand-editing) is the way through — and once the reader
+     says the markers are gone (`resolved`), the tick comes back, because
+     `git add` is now the act that marks the conflict resolved, and the row is
+     the only place left in the view that can offer it (Apply deliberately
+     writes the file and stops). */
+  const blocked = !!change.conflicted && !change.resolved;
+  tick.disabled = busy !== null || blocked || !canAct;
   tick.setAttribute("aria-label",
     (tick.checked ? "Remove " + path + " from" : "Include " + path + " in")
     + " the next commit");
-  tick.title = change.conflicted ? "Resolve the conflict first."
+  tick.title = blocked ? "Resolve the conflict first."
+    : change.conflicted ? "Markers are gone — tick to mark " + path
+      + " resolved and include it in the next commit"
     : tick.checked ? "Ticked: goes into the next commit. Untick to leave it out."
     : "Tick to include " + path + " in the next commit";
   tick.addEventListener("change", () => {
@@ -3338,7 +3344,7 @@ function changeLine(repo, change, selected) {
      was spending the plain one on the tooltip while printing git's shorthand
      at the exact audience that has never read `git status --short`. */
   const word = change.untracked ? "New"
-    : change.conflicted ? "Conflict"
+    : change.conflicted ? (change.resolved ? "Resolved" : "Conflict")
     : (change.label || change.status);
   const row = el("button", {
     className: "row",
@@ -3985,12 +3991,12 @@ function render(data, stashes, diff) {
   const allIn = changes.length > 0
     && changes.every((c) => c.staged && !c.unstaged && !c.untracked);
   const selectOp = allIn ? "unstage_all" : "stage_all";
-  /* Disabled while any file is conflicted, for the same reason that file's own
-     tick is: `stage_all` is `git add` over the lot, and staging a file that
-     still has markers in it clears the conflict without resolving it, letting
-     Commit record the markers. The row tick already refuses; the header must
-     not offer a way around it. */
-  const anyConflict = changes.some((c) => c.conflicted);
+  /* Disabled while any file still has conflict markers in it, for the same
+     reason that file's own tick is: `stage_all` is `git add` over the lot, and
+     staging marked-up text clears the conflict without resolving it, letting
+     Commit record the markers. A conflicted file the reader calls `resolved`
+     (markers gone) does not block — staging it IS the resolve. */
+  const anyConflict = changes.some((c) => c.conflicted && !c.resolved);
   const selectAll = changes.length ? action(selectOp,
       [icon(CHECK_GLYPH, 14), btnLabel(allIn ? "Deselect all" : "Select all")], {
     className: "good",

--- a/tests/test_git_conflicts.py
+++ b/tests/test_git_conflicts.py
@@ -526,3 +526,37 @@ def test_resolve_never_stages_or_commits(ops):
     for forbidden in ('"add"', '"commit"', '"checkout"', '"merge"', '"restore"'):
         assert forbidden not in body, forbidden
     assert body.count("_git_ok(") == 1
+
+
+# ------------------------------------------------- "resolved": markers are gone
+
+
+def test_status_says_when_a_conflicted_file_has_no_markers_left(reader, tmp_path):
+    """The row tick and "Select all" are disabled on a conflicted file because
+    `git add` on marked-up text commits the markers. `resolved` is the fact that
+    lets them come back: once the working-tree copy is marker-free (Apply, or an
+    editor, wrote it) the add IS the resolve, and the index — still unmerged
+    until then — cannot say so."""
+    root = conflicted_repo(str(tmp_path / "resolved"))
+
+    def entry():
+        payload = reader.main(file=root)
+        (change,) = [c for c in payload["changes"] if c["path"] == "pkg/mod.py"]
+        return change
+
+    before = entry()
+    assert before["conflicted"] is True
+    assert before["resolved"] is False
+
+    _put(root, "pkg/mod.py", "one\nBOTH\nthree\n")
+    after = entry()
+    assert after["conflicted"] is True          # the index has not been told yet
+    assert after["resolved"] is True
+
+    # A lone `=======` is legal Markdown, not a marker: it must not block staging.
+    _put(root, "pkg/mod.py", "Title\n=======\nbody\n")
+    assert entry()["resolved"] is True
+
+    # The two bracketing markers do.
+    _put(root, "pkg/mod.py", "one\n>>>>>>> other\nthree\n")
+    assert entry()["resolved"] is False

--- a/tests/test_git_conflicts.py
+++ b/tests/test_git_conflicts.py
@@ -398,7 +398,7 @@ def test_failed_operation_toast_offers_fix_with_ai_not_explain():
     assert "async function adviseOnError" not in src
     assert "ADVISE_SYSTEM" not in src
     # The button's click handler is the new function, not the deleted one.
-    toast = src[src.index("if (!flash.ok && resolving === null"):]
+    toast = src[src.index("if (!flash.ok && !flash.noAsk && resolving === null"):]
     toast = toast[:toast.index("\n    }")]
     assert "onClick: () => askClaudeOnError(flash.message)" in toast
 
@@ -410,10 +410,12 @@ def test_the_fix_with_ai_button_stays_gated_on_this_panes_own_ai_state():
     entire git iframe, and an unmount throws away a conflict resolution
     streaming in `resolving`/`streamed` and any `proposal` sitting unreviewed
     with no warning at all — the exact work `resolveButton`'s own gate exists
-    to protect. Restored to the same three-part gate `resolveButton` uses."""
+    to protect. Restored to the same three-part gate `resolveButton` uses,
+    now alongside `!flash.noAsk` (a page-side failure, not the repository's,
+    offers no "Fix with AI" at all — see `aiFailed`'s `noAsk` param)."""
     src = _view_source()
-    assert ("if (!flash.ok && resolving === null && proposal === null "
-            "&& !aiBusy) {") in src
+    assert ("if (!flash.ok && !flash.noAsk && resolving === null "
+            "&& proposal === null && !aiBusy) {") in src
 
 
 def test_ask_claude_on_error_builds_the_same_context_advise_used_to():
@@ -498,7 +500,7 @@ def test_a_confirmed_unavailable_claude_replaces_the_button_not_the_error():
     explanation — `flash.message` (the original op's error) is never
     overwritten by anything in this branch."""
     src = _view_source()
-    toast = src[src.index("if (!flash.ok && resolving === null"):]
+    toast = src[src.index("if (!flash.ok && !flash.noAsk && resolving === null"):]
     toast = toast[:toast.index("\n    }\n    page.append(")]
     assert "if (askUnavailable) {" in toast
     branch = toast[toast.index("if (askUnavailable) {"):]


### PR DESCRIPTION
## Summary
- "Select all" moves from a list row to a green-outline header button (Stash → Discard all → Select all); becomes "Deselect all" when everything is ticked.
- Send / Get latest / Publish branch are now `.primary`; `.primary` (Commit included) fills in ink instead of accent. Row checkboxes use ink too.
- AI sparkle gets an accent ring (`.ready`) when Commit is enabled.
- `fused.ai.text` missing (stale cached runtime) → plain-words toast, no "Fix with AI" button for page-side faults.
- Changes heading drops the duplicated branch name.

## Test plan
- [x] `pytest tests/test_theme.py tests/test_git_view*.py tests/test_app_git.py` — 160 pass
- [x] Verified in dev server: header order/colours, Send filled, sparkle ring, toast copy, tick colour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem reads per conflicted path and marker heuristics affect when users can stage during merges; UI-only paths are lower risk but conflict staging mistakes could still commit bad state if detection is wrong.
> 
> **Overview**
> **Conflict workflow:** Status payloads add a **`resolved`** flag (via `_marker_free` in `log.py`) when an unmerged file’s working copy no longer has `<<<<<<<` / `>>>>>>>` markers—bare `=======` lines are ignored so Markdown isn’t blocked. Row checkboxes and **Select all** stay disabled only while markers remain; resolved rows show **Resolved** and can be staged with `git add`.
> 
> **Changes UI:** **Select all** moves from a list-row master checkbox to a green-outline header button (**Deselect all** when everything is ticked), ordered Stash → Discard all → Select all. **Commit**, **Send** / **Get latest** / **Publish branch**, and row ticks use **ink** fills/rings instead of accent; the AI sparkle gets a **`.ready`** accent ring when commit is enabled.
> 
> **AI errors:** Missing `fused.ai.text` (stale bundle) and similar page-side failures use clearer toasts and **`flash.noAsk`** so **Fix with AI** isn’t offered for faults that aren’t repo/git errors. The Changes heading no longer repeats the branch name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit facaba3815491fcfa5435da285c36a23a4a253e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->