### PR TITLE
App Doctor: a review skill, and a floor check a repo runs on every push

### DIFF
--- a/skills/fused-render-app-doctor/SKILL.md
+++ b/skills/fused-render-app-doctor/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: fused-render-app-doctor
+description: Use when reviewing or sharing an app — checking for secrets, hardcoded paths, stray generated files, missing structure, or a stale API version.
+---
+
+# App Doctor
+
+A review you carry out yourself over one app folder, using your ordinary tools (grep, read, bash). `fused-render` is a packaged desktop app for end users: the Python package is not installed and not on PATH, so nothing here shells out to it. Judge each hit, don't just report matches.
+
+Run this before sharing an app, or whenever asked to review one.
+
+## Leaked credentials
+
+Grep the app folder for real-looking secrets. `.env` files and unquoted `KEY=value` lines are the likeliest place to find one.
+
+```
+grep -rnE 'AKIA[0-9A-Z]{16}' .                                  # AWS access key
+grep -rnE 'gh[pousr]_[A-Za-z0-9]{36,}' .                        # GitHub token
+grep -rnE 'xox[baprs]-[A-Za-z0-9-]{10,}' .                      # Slack token
+grep -rnE 'sk-ant-[A-Za-z0-9_-]{20,}' .                         # Anthropic key
+grep -rnE '(^|[^A-Za-z0-9_-])sk-[A-Za-z0-9]{20,}' .             # OpenAI key
+grep -rnE 'AIza[0-9A-Za-z_-]{35}' .                             # Google API key
+grep -rnE 'sk_live_[0-9a-zA-Z]{24,}' .                          # Stripe live key
+grep -rnE '\-\-\-\-\-BEGIN [A-Z ]*PRIVATE KEY\-\-\-\-\-' .      # PEM private key
+grep -rniE '[A-Z0-9_]*(SECRET|API[_-]?KEY|ACCESS[_-]?KEY|TOKEN|PASSWORD|PASSWD|CREDENTIAL)[A-Z0-9_]*\s*[:=]\s*["'"'"'][^"'"'"']{8,}' .
+```
+
+Exclude `.git/`, `node_modules/`, `.fused/`. A hit is only a finding when the value itself reads as real: a live-looking key shape, a long random-looking string, an actual PEM block. `xxxxxxxx`, `<your-key-here>`, `sk-ant-REDACTED`, `changeme`, `fake`, `sample`, `example`, `test`, an empty string, are placeholders, not findings, and grepping past them mechanically will drown the real ones. Never quote a whole secret back in your reply, mask the middle or say only where it lives. For anything real, say which file and line, and advise rotating the credential if it was ever committed (the fix is never to just retype the same value somewhere else).
+
+## Paths that only work on the author's machine
+
+Grep for absolute paths that describe one person's filesystem: `/home/`, `/Users/`, `/root/`, `/opt/`, `/var/`, `/tmp/`, `/mnt/`, `/media/`, `/Volumes/`, `/private/`, and Windows `C:\Users\`, `C:\Windows\`, `C:\Program Files\`. Read each hit before flagging it. A hardcoded `/Users/alex/data.csv` an app opens at runtime is a real finding; the same string inside a URL (`https://example.com/opt/...`), a comment explaining what NOT to do, or a code sample in prose is not. Judge it in context, a regex alone gets this wrong. The fix is a path relative to the app folder, or one the runtime hands the app at call time, never another hardcoded absolute path.
+
+## Generated data outside `.fused/`
+
+An app's own machine-local state belongs under `.fused/` (`fused_render/app_fused_dir.py`). Anything that looks generated and sits loose in the tree instead is a finding: `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, and stray files ending `.pyc`, `.log`, `.db`, `.sqlite`, `.sqlite3`. Advise deleting it, or moving it under `.fused/`, or adding it to `.gitignore` if it's the kind of thing that will regenerate.
+
+## Structure
+
+Check for:
+
+- An entry page. `fused_render/app_listing.py`'s `app_entry` defines it precisely: the first non-hidden direct-child `.html` file, in name order, whose first 4 KiB contains a `<meta name="fused-app">` tag (matched case-insensitively, quotes on the value optional). Filenames carry no meaning, `index.html` gets no special treatment, only the tag decides. A folder with no page carrying that tag has no entry, regardless of what its html is named.
+- A README.
+- A `preview.png` thumbnail.
+- A `pyproject.toml` that actually parses as TOML.
+- `icon.svg`, but only if present. Missing is fine and not a finding. One that exists and fails to parse as SVG is a finding, route the fix to `fused-render-app-icon` rather than hand-editing it.
+
+## A stale declared API version
+
+The entry page may declare `<meta name="fused-api-version" content="N">` right after the `fused-app` tag, in the same 4 KiB head. No tag means version 0, the oldest apps predate the tag entirely. Find current by reading `fused_render/fused_api_version.py`: it lists `docs/v{N}.md` files under the `fused-render-api-migration` skill and current is the highest `N` that exists there. If the entry page's declared version is behind that, it's a finding, route the fix to `fused-render-api-migration`, don't guess at what changed between versions yourself.
+
+## Judging the app's actual `fused.*` calls
+
+None of the above forms an opinion on whether a real `fused.*` call is being used correctly. That judgment belongs to the skill that owns each API surface, kept current independently of this one. Read what the app actually calls and route to the skill for each surface it touches instead of re-deriving that judgment here:
+
+| App touches | Load |
+|---|---|
+| `fused.ai` (text/image/video/transcribe/embed), model or provider choice | `fused-render-ai` |
+| `fused.runPython`, `fused.params`, or general `.html`/`.py` view authoring | `fused-render-authoring` |
+| `fused.trackJob` / `fused.watchJob`, or a `runPython` call that risks the 60s timeout | `fused-render-jobs` |
+| `fused.fileIndex` | `fused-render-index` |
+| `fused.capture` | `fused-render-capture` |
+| `fused.daemon`, or `[tool.fused-render.app]` (Python that must stay alive after the page closes) | `fused-render-background-apps` |
+| stale or missing `fused-api-version` | `fused-render-api-migration` |
+| an `icon.svg` that exists and fails to parse | `fused-render-app-icon` |
+
+This mapping is read from each skill's own `description:` line, not guessed from its name, re-check there if a skill's scope changes. Don't restate any routed skill's guidance here, hand off to it.
+
+## Setting up checks for a repo
+
+When asked to set up CI checks for an app, don't tell the user to copy files by hand, do it yourself.
+
+1. From the app folder, run `git rev-parse --show-toplevel`. If it fails, the app isn't inside a git repo at all, say so plainly and stop, a workflow file has nowhere to run.
+2. Read `ci/app-check.yml`, the file that ships alongside this SKILL.md, and write it verbatim to `<repo root>/.github/workflows/app-check.yml`, creating `.github/workflows/` if needed.
+3. Read `ci/app_check.py`, the file that ships beside it, and write it verbatim to `<repo root>/.github/app_check.py`.
+4. Tell the user the paths you wrote, that the workflow runs on push to `main` and on every pull request, and that both files still need to be committed.
+
+That workflow is a floor, not a substitute for this review: it runs `app_check.py` — a plain, stdlib-only script, nothing to install — against each app folder in the repo, and only catches what that script catches. It is deliberately a subset of what this skill checks by hand.

--- a/skills/fused-render-app-doctor/SKILL.md
+++ b/skills/fused-render-app-doctor/SKILL.md
@@ -33,13 +33,13 @@ Grep for absolute paths that describe one person's filesystem: `/home/`, `/Users
 
 ## Generated data outside `.fused/`
 
-An app's own machine-local state belongs under `.fused/` (`fused_render/app_fused_dir.py`). Anything that looks generated and sits loose in the tree instead is a finding: `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, and stray files ending `.pyc`, `.log`, `.db`, `.sqlite`, `.sqlite3`. Advise deleting it, or moving it under `.fused/`, or adding it to `.gitignore` if it's the kind of thing that will regenerate.
+An app's own machine-local state belongs under `.fused/`. Anything that looks generated and sits loose in the tree instead is a finding: `__pycache__/`, `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/`, and stray files ending `.pyc`, `.log`, `.db`, `.sqlite`, `.sqlite3`. Advise deleting it, or moving it under `.fused/`, or adding it to `.gitignore` if it's the kind of thing that will regenerate.
 
 ## Structure
 
 Check for:
 
-- An entry page. `fused_render/app_listing.py`'s `app_entry` defines it precisely: the first non-hidden direct-child `.html` file, in name order, whose first 4 KiB contains a `<meta name="fused-app">` tag (matched case-insensitively, quotes on the value optional). Filenames carry no meaning, `index.html` gets no special treatment, only the tag decides. A folder with no page carrying that tag has no entry, regardless of what its html is named.
+- An entry page: the first non-hidden direct-child `.html` file, in name order, whose first 4 KiB contains a `<meta name="fused-app">` tag (matched case-insensitively, quotes on the value optional). Filenames carry no meaning, `index.html` gets no special treatment, only the tag decides. A folder with no page carrying that tag has no entry, regardless of what its html is named.
 - A README.
 - A `preview.png` thumbnail.
 - A `pyproject.toml` that actually parses as TOML.
@@ -47,7 +47,7 @@ Check for:
 
 ## A stale declared API version
 
-The entry page may declare `<meta name="fused-api-version" content="N">` right after the `fused-app` tag, in the same 4 KiB head. No tag means version 0, the oldest apps predate the tag entirely. Find current by reading `fused_render/fused_api_version.py`: it lists `docs/v{N}.md` files under the `fused-render-api-migration` skill and current is the highest `N` that exists there. If the entry page's declared version is behind that, it's a finding, route the fix to `fused-render-api-migration`, don't guess at what changed between versions yourself.
+The entry page may declare `<meta name="fused-api-version" content="N">` right after the `fused-app` tag, in the same 4 KiB head. No tag means version 0, the oldest apps predate the tag entirely. Current is the highest `N` among the `docs/v{N}.md` files in the `fused-render-api-migration` skill directory, which sits beside this one. List that directory rather than assuming a number, so the answer stays right as versions land. If the entry page's declared version is behind that, it's a finding, route the fix to `fused-render-api-migration`, don't guess at what changed between versions yourself.
 
 ## Judging the app's actual `fused.*` calls
 

--- a/skills/fused-render-app-doctor/SKILL.md
+++ b/skills/fused-render-app-doctor/SKILL.md
@@ -5,9 +5,13 @@ description: Use when reviewing or sharing an app — checking for secrets, hard
 
 # App Doctor
 
-A review you carry out yourself over one app folder, using your ordinary tools (grep, read, bash). `fused-render` is a packaged desktop app for end users: the Python package is not installed and not on PATH, so nothing here shells out to it. Judge each hit, don't just report matches.
+A review you carry out yourself over one app folder, using your ordinary tools (grep, read, bash). `fused-render` is a packaged desktop app for end users: the Python package is not installed and not on PATH, so nothing here shells out to it — there is no `fused-render` subcommand to reach for, and an attempt to run one buys a failed round trip and nothing else. Judge each hit, don't just report matches.
 
 Run this before sharing an app, or whenever asked to review one.
+
+## What this review is not
+
+The sections below are the whole of it. This is a share-readiness pass, not a code audit: it does not read an app's logic looking for bugs, and it forms no opinion on cache eviction order, timezone and date math, deduplication, DOM injection, error handling, or performance. Skip that work even when the request says "review for correctness" — say plainly that this skill covers share-readiness and offer the audit as separate work rather than quietly doing both. A run that reads every line of an app's source has gone wrong; the checks here are greps and a handful of targeted reads, and the answer arrives in well under a minute.
 
 ## Leaked credentials
 
@@ -47,7 +51,7 @@ Check for:
 
 ## A stale declared API version
 
-The entry page may declare `<meta name="fused-api-version" content="N">` right after the `fused-app` tag, in the same 4 KiB head. No tag means version 0, the oldest apps predate the tag entirely. Current is the highest `N` among the `docs/v{N}.md` files in the `fused-render-api-migration` skill directory, which sits beside this one. List that directory rather than assuming a number, so the answer stays right as versions land. If the entry page's declared version is behind that, it's a finding, route the fix to `fused-render-api-migration`, don't guess at what changed between versions yourself.
+The entry page may declare `<meta name="fused-api-version" content="N">` right after the `fused-app` tag, in the same 4 KiB head. No tag means version 0, the oldest apps predate the tag entirely. Current is the highest `N` among the `docs/v{N}.md` files in the `fused-render-api-migration` skill directory, which sits beside this one. List that directory rather than assuming a number, so the answer stays right as versions land. If the entry page's declared version is behind that, it's a finding: report the gap and stop. Do not open the intervening `docs/v{N}.md` files, not even to work out whether this particular app is affected — deciding impact is `fused-render-api-migration`'s job, and listing the directory already told you everything you need.
 
 ## Judging the app's actual `fused.*` calls
 
@@ -76,3 +80,13 @@ When asked to set up CI checks for an app, don't tell the user to copy files by 
 4. Tell the user the paths you wrote, that the workflow runs on push to `main` and on every pull request, and that both files still need to be committed.
 
 That workflow is a floor, not a substitute for this review: it runs `app_check.py` — a plain, stdlib-only script, nothing to install — against each app folder in the repo, and only catches what that script catches. It is deliberately a subset of what this skill checks by hand.
+
+## Reporting what you found
+
+One line per finding, in the same shape the CI check prints, sorted by path then line:
+
+```
+path:line: rule: excerpt
+```
+
+Mask the secret itself — first two characters, last two, stars between — so the report is safe to paste into a log or a chat. Use `.` as the path for a finding about the folder rather than a file. Close with a count and nothing else. When the app is clean, say so in one line.

--- a/skills/fused-render-app-doctor/ci/app-check.yml
+++ b/skills/fused-render-app-doctor/ci/app-check.yml
@@ -1,0 +1,116 @@
+name: app-check
+
+# Installed by `fused-render-app-doctor` into whatever repo an app lives in,
+# alongside `.github/app_check.py` — see that skill's SKILL.md for the setup
+# procedure. `app_check.py` only knows how to review ONE app folder — it has
+# no idea the repo it lives in exists, or how many apps are in it. So this
+# workflow works out the shape of the repo itself, then loops:
+#
+#   - the repo root IS an app (it carries its own metadata.json) — check
+#     just that one folder, or
+#   - the repo root is a folder OF apps — check every top-level folder that
+#     carries a metadata.json.
+#
+# Either way, each app gets the same two checks: `python app_check.py` and,
+# if it has any, its own tests.
+
+on:
+  push:
+    branches: [main]
+  pull_request: {}
+
+concurrency:
+  # Mirrors fused-render's own test.yml: a PR number is unique repo-wide,
+  # unlike head_ref, so two branches that happen to share a name never land
+  # in the same group and cancel each other's runs.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Review each app and run its own tests
+        # Find the app folders first (the repo root itself, if it carries a
+        # metadata.json, otherwise every top-level folder that does), then
+        # one loop, two checks per app:
+        #
+        #   1. `python .github/app_check.py "$app"` — the same script and
+        #      the same severity rule a developer runs locally, pointed at
+        #      just this one app folder. Stdlib only, so it needs nothing
+        #      installed.
+        #   2. That app's own tests, when it has any — gated on an actual
+        #      test_*.py/*_test.py existing somewhere under the app, not
+        #      merely on a `tests/` directory existing. `pytest` is only
+        #      installed once a folder actually needs it. Install that app's
+        #      declared dependencies first if a pyproject.toml exists; pip
+        #      parses and installs them. If the install fails, log a warning
+        #      naming the app, skip that app's tests, and continue. Exit 5
+        #      from pytest is "no tests collected" — reachable even after
+        #      the test_files gate (every matching file skipped), and means
+        #      nothing failed, only that there was nothing to run.
+        run: |
+          set -e
+          status=0
+
+          if [ -f "metadata.json" ]; then
+            apps="."
+          else
+            apps=""
+            for d in */; do
+              d="${d%/}"
+              [ -f "$d/metadata.json" ] || continue
+              apps="$apps $d"
+            done
+          fi
+
+          if [ -z "$apps" ]; then
+            echo "No app folders found (no metadata.json at the repo root or in any top-level folder) — nothing to check."
+            exit 0
+          fi
+
+          for app in $apps; do
+            echo "::group::doctor $app"
+            python .github/app_check.py "$app" || status=1
+            echo "::endgroup::"
+
+            test_files=$(find "$app" \( -name 'test_*.py' -o -name '*_test.py' \) -type f 2>/dev/null)
+            if [ -z "$test_files" ]; then
+              continue
+            fi
+
+            echo "::group::pytest $app"
+            pip install pytest
+            if [ -f "$app/pyproject.toml" ]; then
+              if ! pip install -e "$app"; then
+                echo "::warning::could not install $app's declared dependencies — skipping its tests"
+                echo "::endgroup::"
+                status=1
+                continue
+              fi
+            fi
+
+            set +e
+            python -m pytest "$app" -q
+            rc=$?
+            set -e
+            # Exit 5 is pytest's "no tests were collected" — reachable even
+            # after the test_files gate above (every matching file skipped,
+            # or empty), and it means nothing failed, only that there was
+            # nothing to run.
+            if [ "$rc" != 0 ] && [ "$rc" != 5 ]; then
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$status"

--- a/skills/fused-render-app-doctor/ci/app-check.yml
+++ b/skills/fused-render-app-doctor/ci/app-check.yml
@@ -6,10 +6,14 @@ name: app-check
 # no idea the repo it lives in exists, or how many apps are in it. So this
 # workflow works out the shape of the repo itself, then loops:
 #
-#   - the repo root IS an app (it carries its own metadata.json) — check
+#   - the repo root IS an app (it carries its own index.html) — check
 #     just that one folder, or
 #   - the repo root is a folder OF apps — check every top-level folder that
-#     carries a metadata.json.
+#     carries an index.html.
+#
+# The entry page is the marker because it is the one file every app has:
+# `metadata.json` is optional catalog data that most apps never write, and a
+# repo keyed on it would quietly check nothing and pass.
 #
 # Either way, each app gets the same two checks: `python app_check.py` and,
 # if it has any, its own tests.
@@ -41,9 +45,9 @@ jobs:
           python-version: "3.12"
 
       - name: Review each app and run its own tests
-        # Find the app folders first (the repo root itself, if it carries a
-        # metadata.json, otherwise every top-level folder that does), then
-        # one loop, two checks per app:
+        # Find the app folders first (the repo root itself, if it carries an
+        # index.html, otherwise every top-level folder that does), then one
+        # loop, two checks per app:
         #
         #   1. `python .github/app_check.py "$app"` — the same script and
         #      the same severity rule a developer runs locally, pointed at
@@ -54,8 +58,12 @@ jobs:
         #      merely on a `tests/` directory existing. `pytest` is only
         #      installed once a folder actually needs it. Install that app's
         #      declared dependencies first if a pyproject.toml exists; pip
-        #      parses and installs them. If the install fails, log a warning
-        #      naming the app, skip that app's tests, and continue. Exit 5
+        #      parses and installs them. An app's pyproject is often a
+        #      dependency list rather than a buildable package (`package =
+        #      false` and friends), so an install that fails is a reason to
+        #      skip that app's tests with a warning annotation, not to fail
+        #      the repo — the alternative is a permanently red check that
+        #      says nothing about the app. Exit 5
         #      from pytest is "no tests collected" — reachable even after
         #      the test_files gate (every matching file skipped), and means
         #      nothing failed, only that there was nothing to run.
@@ -63,19 +71,19 @@ jobs:
           set -e
           status=0
 
-          if [ -f "metadata.json" ]; then
+          if [ -f "index.html" ]; then
             apps="."
           else
             apps=""
             for d in */; do
               d="${d%/}"
-              [ -f "$d/metadata.json" ] || continue
+              [ -f "$d/index.html" ] || continue
               apps="$apps $d"
             done
           fi
 
           if [ -z "$apps" ]; then
-            echo "No app folders found (no metadata.json at the repo root or in any top-level folder) — nothing to check."
+            echo "No app folders found (no index.html at the repo root or in any top-level folder) — nothing to check."
             exit 0
           fi
 
@@ -95,7 +103,6 @@ jobs:
               if ! pip install -e "$app"; then
                 echo "::warning::could not install $app's declared dependencies — skipping its tests"
                 echo "::endgroup::"
-                status=1
                 continue
               fi
             fi

--- a/skills/fused-render-app-doctor/ci/app_check.py
+++ b/skills/fused-render-app-doctor/ci/app_check.py
@@ -44,6 +44,7 @@ every run as slow as the app's oldest commit.
 Run as `python app_check.py [path]` (path defaults to `.`): prints findings
 grouped by family, then exits 1 if any fired and 0 if the folder is clean.
 """
+import fnmatch
 import os
 import re
 import subprocess
@@ -75,7 +76,7 @@ def _finding(rule: str, path: str, line: int, excerpt: str) -> dict:
 # The bookkeeping folders app_git.py's own _GITIGNORE keeps out of an app's
 # history (see app_git.py's module docstring for why each one is there), plus
 # node_modules — never worth reading AS CONTENT.
-_IGNORED_DIR_NAMES = {".git", ".venv", ".fused", "node_modules"}
+_IGNORED_DIR_NAMES = {".git", ".venv", ".fused", "node_modules", "__pycache__"}
 _IGNORED_FILE_SUFFIXES = (".html.json",)
 _IGNORED_FILE_NAMES = {".claude-split.json", ".DS_Store"}
 _IGNORED_FILE_PREFIXES = (".fused-render-write-probe.",)
@@ -130,22 +131,143 @@ def _git_ls_files(app_dir: str) -> list[str] | None:
     return [n.decode("utf-8", "replace") for n in names]
 
 
+class _GitignoreRule:
+    """One non-blank, non-comment line of a `.gitignore`, in the subset that
+    actually shows up in an app's ignore file: a plain name (`secrets.env`),
+    a trailing-slash directory rule (`build/`), a glob (`*.log`), a rooted
+    pattern (`/dist`), and a `!`-negation of any of those. Matching is always
+    done relative to the directory the `.gitignore` itself sits in, the way
+    git resolves it — `_is_gitignored` is what supplies that relative path."""
+
+    __slots__ = ("pattern", "negate", "dir_only", "anchored")
+
+    def __init__(self, raw: str):
+        negate = raw.startswith("!")
+        if negate:
+            raw = raw[1:]
+        dir_only = raw.endswith("/")
+        if dir_only:
+            raw = raw[:-1]
+        # A pattern rooted with a leading slash, or carrying a slash anywhere
+        # but at the end, only ever matches at the .gitignore's own level —
+        # git does not let it match a same-named entry deeper in the tree.
+        # Everything else (a bare name or glob with no interior slash) is a
+        # basename rule: it matches that name at any depth.
+        anchored = raw.startswith("/") or "/" in raw
+        if raw.startswith("/"):
+            raw = raw[1:]
+        self.pattern = raw
+        self.negate = negate
+        self.dir_only = dir_only
+        self.anchored = anchored
+
+    def matches(self, local_rel: str, is_dir: bool) -> bool:
+        if self.dir_only and not is_dir:
+            return False
+        if self.anchored:
+            return fnmatch.fnmatch(local_rel, self.pattern)
+        name = local_rel.rsplit("/", 1)[-1]
+        return fnmatch.fnmatch(name, self.pattern)
+
+
+def _load_gitignore_rules(dir_abs: str) -> list[_GitignoreRule]:
+    """Rules from the `.gitignore` directly inside `dir_abs`, or `[]` when
+    there is none. A read failure (permissions, a symlink loop) is treated
+    the same as "no rules here" — a folder that cannot be read cannot be
+    trusted to say what it wants skipped, so this falls back to scanning
+    rather than raising."""
+    try:
+        with open(os.path.join(dir_abs, ".gitignore"),
+                   "r", encoding="utf-8", errors="replace") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return []
+    rules = []
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        rules.append(_GitignoreRule(line))
+    return rules
+
+
+def _is_gitignored(
+    rel_path: str, is_dir: bool,
+    scopes: list[tuple[str, list[_GitignoreRule]]],
+) -> bool:
+    """Whether `rel_path` (app-relative, `/`-separated) is ignored, applying
+    each active `.gitignore` — outermost first — to the part of the path
+    under its own directory, the way git layers nested ignore files. A
+    scope's own rules are consulted in file order so a later `!`-negation
+    within that same file overrides an earlier match, and a deeper
+    `.gitignore` (later in `scopes`) has the final say over a shallower
+    one."""
+    ignored = False
+    for scope_dir, rules in scopes:
+        if scope_dir:
+            prefix = scope_dir + "/"
+            if rel_path == scope_dir:
+                local_rel = ""
+            elif rel_path.startswith(prefix):
+                local_rel = rel_path[len(prefix):]
+            else:
+                continue
+        else:
+            local_rel = rel_path
+        if not local_rel:
+            continue
+        for rule in rules:
+            if rule.matches(local_rel, is_dir):
+                ignored = not rule.negate
+    return ignored
+
+
 def _walk_files(app_dir: str) -> list[str]:
     """App-relative paths found by a bounded walk, for an app folder that is
     not (or not yet) a git repo. Honours the same ignore names `git ls-files`
-    would have hidden via app_git.py's own .gitignore, so the two enumeration
-    paths agree on what counts as app content."""
-    out = []
-    for root, dirs, files in os.walk(app_dir):
-        dirs[:] = sorted(d for d in dirs if d not in _IGNORED_DIR_NAMES
-                          and not d.startswith("."))
-        for name in sorted(files):
-            if _is_ignored_name(name):
-                continue
-            rel = os.path.relpath(os.path.join(root, name), app_dir)
-            out.append(rel.replace(os.sep, "/"))
-            if len(out) >= _MAX_FILES:
-                return out
+    would have hidden via app_git.py's own .gitignore, plus whatever the
+    app's own `.gitignore` file(s) say to skip — see `_is_gitignored` — so
+    the two enumeration paths agree on what counts as app content whether or
+    not the folder happens to be a git repo yet. An ignored directory is
+    pruned outright rather than walked and filtered, so a large ignored tree
+    (a `build/` full of generated output) costs nothing beyond the one
+    `os.scandir` call that finds it."""
+    app_dir = os.path.normpath(app_dir)
+    out: list[str] = []
+
+    def recurse(
+        dir_abs: str, dir_rel: str,
+        scopes: list[tuple[str, list[_GitignoreRule]]],
+    ) -> bool:
+        """Returns False once `_MAX_FILES` is hit, to unwind the recursion."""
+        own_rules = _load_gitignore_rules(dir_abs)
+        if own_rules:
+            scopes = scopes + [(dir_rel, own_rules)]
+        try:
+            entries = sorted(os.scandir(dir_abs), key=lambda e: e.name)
+        except OSError:
+            return True
+        for entry in entries:
+            name = entry.name
+            entry_rel = f"{dir_rel}/{name}" if dir_rel else name
+            if entry.is_dir(follow_symlinks=False):
+                if name in _IGNORED_DIR_NAMES or name.startswith("."):
+                    continue
+                if _is_gitignored(entry_rel, True, scopes):
+                    continue
+                if not recurse(entry.path, entry_rel, scopes):
+                    return False
+            else:
+                if _is_ignored_name(name):
+                    continue
+                if _is_gitignored(entry_rel, False, scopes):
+                    continue
+                out.append(entry_rel)
+                if len(out) >= _MAX_FILES:
+                    return False
+        return True
+
+    recurse(app_dir, "", [])
     return out
 
 

--- a/skills/fused-render-app-doctor/ci/app_check.py
+++ b/skills/fused-render-app-doctor/ci/app_check.py
@@ -41,8 +41,9 @@ WORKING TREE ONLY. No history scan — a secret already committed is a job for
 whatever gates publishing, not this script, and scanning history would make
 every run as slow as the app's oldest commit.
 
-Run as `python app_check.py [path]` (path defaults to `.`): prints findings
-grouped by family, then exits 1 if any fired and 0 if the folder is clean.
+Run as `python app_check.py [path]` (path defaults to `.`): prints one
+`path:line: rule: excerpt` line per finding, then exits 1 if any fired and 0
+if the folder is clean.
 """
 import fnmatch
 import os
@@ -564,7 +565,16 @@ def check(app_dir: str) -> list[dict]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Review one app folder and print findings grouped by family.
+    """Review one app folder and print one line per finding.
+
+    Each line is `path:line: rule: excerpt` — the `path:line:` prefix is the
+    shape an editor or `grep` already understands, so a line pastes straight
+    into a jump-to-location, and the full `rule` (not just its family) is
+    what a person needs to look up or argue with. A finding with no line
+    number (the structure family reports against the app folder itself)
+    drops the line and its colon: `path: rule: excerpt`. Findings are sorted
+    by path, then line, then rule, so the same app always prints the same
+    bytes in the same order.
 
     The only mode is fail-on-finding: a CI floor has no use for a run that
     reports a leaked credential and still exits 0, so there is no flag to
@@ -582,17 +592,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"no findings — {path} looks clean")
         return 0
 
-    by_family: dict[str, list] = {}
-    for f in findings:
-        by_family.setdefault(f["rule"].split(":", 1)[0], []).append(f)
-    for family in sorted(by_family):
-        group = by_family[family]
-        label = group[0]["severity"].upper()
-        print(f"\n{family} ({label}):")
-        for f in group:
-            where = f["path"] if not f["line"] else f"{f['path']}:{f['line']}"
-            print(f"  {where}  {f['excerpt']}")
-    print(f"\n{len(findings)} finding(s)")
+    for f in sorted(findings, key=lambda f: (f["path"], f["line"], f["rule"])):
+        where = f["path"] if not f["line"] else f"{f['path']}:{f['line']}"
+        print(f"{where}: {f['rule']}: {f['excerpt']}")
+    print(f"{len(findings)} finding" + ("" if len(findings) == 1 else "s"))
     return 1
 
 

--- a/skills/fused-render-app-doctor/ci/app_check.py
+++ b/skills/fused-render-app-doctor/ci/app_check.py
@@ -334,14 +334,29 @@ _PRIVATE_KEY_RE = re.compile(
 # Two alternatives for the value: quoted (Python, JS, JSON, TOML — anything
 # where the assignment sits inside source syntax) or bare (`.env` files and
 # `docker-compose.yml`-style `KEY=value` lines, which are never quoted and
-# are among the likeliest places in a tree to hold a real credential). The
-# bare alternative stops at whitespace/#/quote so it doesn't run past the end
-# of the line into a trailing comment.
+# are among the likeliest places in a tree to hold a real credential).
+#
+# The bare alternative has to be the whole of the rest of its line, give or
+# take a trailing comment. Without that anchor it matches the leading run of
+# any code expression assigned to a credential-shaped name, and the single
+# most common such expression is the RIGHT way to hold a secret:
+# `API_KEY = os.environ.get("FUSED_API_KEY")` yields the bare run
+# `os.environ.get`, and a check that fails an app for reading its key from
+# the environment is worse than no check at all. Brackets, braces, parens
+# and `$` are out of the value's character set for the same reason: they
+# belong to call and subscript syntax, never to a credential.
 _ASSIGNMENT_SECRET_RE = re.compile(
     rb"(?i)\b([A-Z0-9_]*(?:SECRET|API[_-]?KEY|ACCESS[_-]?KEY|TOKEN|PASSWORD"
     rb"|PASSWD|CREDENTIAL)[A-Z0-9_]*)\s*[:=]\s*"
-    rb"(?:[\"']([^\"'\r\n]{8,})[\"']|([^\s\"'#\r\n]{8,}))"
+    rb"(?:[\"']([^\"'\r\n]{8,})[\"']"
+    rb"|([^\s\"'#\r\n()\[\]{}$,;]{8,})(?=[ \t]*(?:#[^\r\n]*)?(?:\r?\n|$)))"
 )
+
+# A bare value that reads as a dotted name — `form.cleaned_data`,
+# `settings.auth.token` — is a reference to a secret, not a secret. Real
+# credentials do not arrive shaped like an attribute chain, and an app that
+# passes one around by name has not leaked anything.
+_DOTTED_NAME_RE = re.compile(rb"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+$")
 
 # A value made of nothing but one repeated filler character or a template
 # marker — "xxxxxxxx", "********", "<your-key>", "${API_KEY}", "%API_KEY%" —
@@ -421,8 +436,11 @@ def _check_secrets(rel_path: str, text: str, findings: list) -> None:
         ))
 
     for m in _ASSIGNMENT_SECRET_RE.finditer(data):
-        value = m.group(2) if m.group(2) is not None else m.group(3)
+        bare = m.group(2) is None
+        value = m.group(2) if not bare else m.group(3)
         if _is_placeholder(value):
+            continue
+        if bare and _DOTTED_NAME_RE.match(value.strip()):
             continue
         findings.append(_finding(
             "secrets:assignment", rel_path, line_for(m.start()),

--- a/skills/fused-render-app-doctor/ci/app_check.py
+++ b/skills/fused-render-app-doctor/ci/app_check.py
@@ -1,0 +1,478 @@
+"""A floor engine that reads an app folder and flags the obvious problems
+worth failing a push over — a leaked credential, a path that only resolves
+on the machine it was written on, and an app folder missing the three files
+that make a share openable and recognizable to whoever receives it:
+`index.html`, a README, and a `preview.png` thumbnail.
+
+Judging whether an app's `fused.*` calls are actually correct is not this
+script's job: that question needs to know whether a name is being used
+correctly, not just whether it exists, and telling those apart is a job for
+the skill that reads and greps the app directly
+(skills/fused-render-app-doctor/SKILL.md) rather than a fixed pattern match.
+
+This script is a file the fused-render-app-doctor skill writes, verbatim,
+into whatever repo an app lives in, at `.github/app_check.py`, alongside the
+workflow at `.github/workflows/app-check.yml` that runs it on every push (see
+that skill's SKILL.md for the setup procedure and app-check.yml for the loop
+over a repo's app folders). Its job is a floor that fails a push on an
+obvious problem — a strict, deliberate SUBSET of what the skill's own review
+covers, not a substitute for it.
+
+STDLIB ONLY. It runs on every push in a plain GitHub Actions runner, with
+nothing installed beyond the standard library — no import can add a
+dependency, a network call, or a wait for anything to install.
+
+FINDINGS ARE MASKED AT THE SOURCE. They end up in CI logs and chat
+transcripts a person did not choose to keep secret, so `check()` never
+returns an excerpt containing a whole matched secret — see `_mask` and the
+assertion in tests/test_app_doctor.py. A device path or a structural gap is
+left as-is: neither is a secret, and showing it whole is what makes the
+finding actionable.
+
+EVERY FINDING FAILS THE RUN. All three families this script reports —
+secrets, device paths, and structure — are the kind of problem a CI floor
+exists to catch before it reaches someone else's machine, so `SEVERITY`
+is a flat "high" rather than a per-family table: there is no third tier here
+that is worth reporting but never worth failing a run over. A finding that
+was never going to fail anything belongs in the skill's judgment-driven
+review, not in this script.
+
+WORKING TREE ONLY. No history scan — a secret already committed is a job for
+whatever gates publishing, not this script, and scanning history would make
+every run as slow as the app's oldest commit.
+
+Run as `python app_check.py [path]` (path defaults to `.`): prints findings
+grouped by family, then exits 1 if any fired and 0 if the folder is clean.
+"""
+import os
+import re
+import subprocess
+import sys
+
+# --------------------------------------------------------------- severity
+
+# Every family `check()` runs is HIGH: each is the kind of problem a CI floor
+# exists to fail a push over, so there is no second tier here that is worth
+# reporting but never worth failing a run over (see the module docstring).
+# `severity` is exported (rather than inlining the constant into `_finding`)
+# because `main` reads it too, for the same "does this finding fail the run"
+# question the grouped report answers.
+SEVERITY = "high"
+
+
+def _finding(rule: str, path: str, line: int, excerpt: str) -> dict:
+    return {
+        "rule": rule,
+        "severity": SEVERITY,
+        "path": path,
+        "line": line,
+        "excerpt": excerpt,
+    }
+
+
+# --------------------------------------------------------- file enumeration
+
+# The bookkeeping folders app_git.py's own _GITIGNORE keeps out of an app's
+# history (see app_git.py's module docstring for why each one is there), plus
+# node_modules — never worth reading AS CONTENT.
+_IGNORED_DIR_NAMES = {".git", ".venv", ".fused", "node_modules"}
+_IGNORED_FILE_SUFFIXES = (".html.json",)
+_IGNORED_FILE_NAMES = {".claude-split.json", ".DS_Store"}
+_IGNORED_FILE_PREFIXES = (".fused-render-write-probe.",)
+
+# A file this large is never a source file worth scanning line-by-line, and
+# reading it whole would make one bloated fixture (a vendored dataset, a
+# checked-in model weight) dominate the cost of reviewing an entire app.
+_MAX_BYTES_PER_FILE = 1_000_000
+
+# A folder this large is not a small app someone is about to share; bounding
+# the walk keeps a review of a huge, half-abandoned repo from hanging instead
+# of reporting.
+_MAX_FILES = 20_000
+
+
+def _is_ignored_name(name: str) -> bool:
+    return (name in _IGNORED_FILE_NAMES
+            or name.endswith(_IGNORED_FILE_SUFFIXES)
+            or name.startswith(_IGNORED_FILE_PREFIXES))
+
+
+def _has_ignored_dir_component(rel_path: str) -> bool:
+    """True when any directory this path sits under is bookkeeping rather
+    than app content — one of `_IGNORED_DIR_NAMES`, or hidden (a dot-prefixed
+    name, the same rule `_walk_files` already applies while walking). Applying
+    it to the git-listed path too (not just the walk) matters here
+    specifically: `.github` is a dot-prefixed dir, and the workflow this
+    script runs from — and a committed copy of this very file — live there.
+    Without this, a repo whose app IS the repo root scans its own CI setup
+    and flags this file's regex literals as leaked secrets."""
+    parts = rel_path.split("/")[:-1]
+    return any(p in _IGNORED_DIR_NAMES or p.startswith(".") for p in parts)
+
+
+def _git_ls_files(app_dir: str) -> list[str] | None:
+    """App-relative paths `git` itself considers part of the working tree —
+    tracked files plus untracked-but-not-ignored ones — or None when `app_dir`
+    is not inside a git repo (or `git` is not on PATH). Preferred over a walk
+    whenever it is available: it is the same answer `git status` gives the
+    author, so a file `.gitignore` already hides never becomes a finding."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", app_dir, "ls-files", "-z",
+             "--cached", "--others", "--exclude-standard"],
+            capture_output=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if r.returncode != 0:
+        return None
+    names = [n for n in r.stdout.split(b"\0") if n]
+    return [n.decode("utf-8", "replace") for n in names]
+
+
+def _walk_files(app_dir: str) -> list[str]:
+    """App-relative paths found by a bounded walk, for an app folder that is
+    not (or not yet) a git repo. Honours the same ignore names `git ls-files`
+    would have hidden via app_git.py's own .gitignore, so the two enumeration
+    paths agree on what counts as app content."""
+    out = []
+    for root, dirs, files in os.walk(app_dir):
+        dirs[:] = sorted(d for d in dirs if d not in _IGNORED_DIR_NAMES
+                          and not d.startswith("."))
+        for name in sorted(files):
+            if _is_ignored_name(name):
+                continue
+            rel = os.path.relpath(os.path.join(root, name), app_dir)
+            out.append(rel.replace(os.sep, "/"))
+            if len(out) >= _MAX_FILES:
+                return out
+    return out
+
+
+def _candidate_files(app_dir: str) -> list[str]:
+    """Every file `check()` should read, app-relative with `/` separators."""
+    names = _git_ls_files(app_dir)
+    if names is None:
+        names = _walk_files(app_dir)
+    else:
+        names = [n for n in names if not _is_ignored_name(os.path.basename(n))
+                  and not _has_ignored_dir_component(n)]
+    return sorted(names)
+
+
+def _read_text(app_dir: str, rel_path: str) -> str | None:
+    """`rel_path`'s content as text, or None when it looks binary, is too
+    large, or can't be read. A null byte in the first chunk is the same
+    sniff `git` itself uses to call a file binary; it is cheap and it is
+    enough — this engine never needs to be exactly right about encoding,
+    only to avoid choking on a binary asset sitting in the app folder."""
+    path = os.path.join(app_dir, rel_path)
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(8192)
+            if b"\0" in head:
+                return None
+            rest = fh.read(_MAX_BYTES_PER_FILE - len(head))
+        raw = head + rest
+    except OSError:
+        return None
+    return raw.decode("utf-8", "replace")
+
+
+# ------------------------------------------------------------------ secrets
+
+# Recognisable formats: a prefix (or shape) that is, on its own, strong
+# evidence of a real credential rather than a coincidence of naming. Each
+# pattern's own group 0 is what gets masked and reported — no capture groups,
+# so `_mask` always has the whole match to work with.
+_PREFIXED_SECRET_PATTERNS = {
+    "aws-access-key": re.compile(rb"AKIA[0-9A-Z]{16}"),
+    "github-token": re.compile(rb"gh[pousr]_[A-Za-z0-9]{36,}"),
+    "slack-token": re.compile(rb"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    "anthropic-key": re.compile(rb"sk-ant-[A-Za-z0-9\-_]{20,}"),
+    "openai-key": re.compile(rb"sk-[A-Za-z0-9]{20,}"),
+    "google-api-key": re.compile(rb"AIza[0-9A-Za-z\-_]{35}"),
+    "stripe-key": re.compile(rb"sk_live_[0-9a-zA-Z]{24,}"),
+}
+
+# A PEM block. Reported whole (well, masked whole) rather than per-line: a
+# private key split across an excerpt would still be a private key.
+_PRIVATE_KEY_RE = re.compile(
+    rb"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+
+# `NAME = "value"` / `NAME: "value"` where NAME reads as a credential and
+# value is not obviously a placeholder. This is the catch-all for the
+# provider-specific formats above having no fixed shape at all — a database
+# password, an internal service token — so it is deliberately looser, and
+# deliberately excludes anything that reads like a stand-in for a real value.
+#
+# Two alternatives for the value: quoted (Python, JS, JSON, TOML — anything
+# where the assignment sits inside source syntax) or bare (`.env` files and
+# `docker-compose.yml`-style `KEY=value` lines, which are never quoted and
+# are among the likeliest places in a tree to hold a real credential). The
+# bare alternative stops at whitespace/#/quote so it doesn't run past the end
+# of the line into a trailing comment.
+_ASSIGNMENT_SECRET_RE = re.compile(
+    rb"(?i)\b([A-Z0-9_]*(?:SECRET|API[_-]?KEY|ACCESS[_-]?KEY|TOKEN|PASSWORD"
+    rb"|PASSWD|CREDENTIAL)[A-Z0-9_]*)\s*[:=]\s*"
+    rb"(?:[\"']([^\"'\r\n]{8,})[\"']|([^\s\"'#\r\n]{8,}))"
+)
+
+# A value made of nothing but one repeated filler character or a template
+# marker — "xxxxxxxx", "********", "<your-key>", "${API_KEY}", "%API_KEY%" —
+# is a placeholder outright, whole-string.
+_PLACEHOLDER_SYMBOL_RE = re.compile(
+    rb"(?i)^(x+|\*+|\.+|_+|-+|<[^>]*>|\{[^}]*\}|\$\{[^}]*\}|%[a-z_]+%)$"
+)
+
+# Otherwise, a value is a placeholder only when EVERY word in it (splitting
+# on runs of non-alphanumeric characters — hyphens, underscores, dots) is
+# drawn from this list of generic filler. A value that merely BEGINS with
+# one of these words is not enough: "mysql-prod-9f3k2xyz" splits into
+# "mysql", "prod", "9f3k2xyz", and "mysql" itself is not "my" — the first
+# word fails to be filler, so the whole value is judged a real secret. The
+# same holds for "testkey-prod-abc123456" ("testkey" is not "test") and
+# "nonesuch-real-token-value" ("nonesuch" is not "none", and "real" is not
+# filler at all).
+_PLACEHOLDER_WORDS = {
+    "your", "my", "insert", "enter", "add", "replace", "change", "changeme",
+    "fake", "dummy", "sample", "example", "placeholder", "redacted", "todo",
+    "none", "null", "undefined", "test", "api", "key", "secret", "token",
+    "password", "passwd", "credential", "here", "please", "value", "string",
+    "me",
+}
+_WORD_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _is_placeholder(value: bytes) -> bool:
+    stripped = value.strip()
+    if _PLACEHOLDER_SYMBOL_RE.match(stripped):
+        return True
+    words = [w for w in _WORD_RE.split(stripped.decode("utf-8", "replace").lower()) if w]
+    return bool(words) and all(w in _PLACEHOLDER_WORDS for w in words)
+
+
+def _mask(secret: bytes) -> str:
+    """`secret`, with the middle blacked out and never the whole thing shown.
+
+    Asserted directly by tests/test_app_doctor.py: no finding's excerpt may
+    ever contain a whole matched secret, because these land in CI logs and
+    chat transcripts. A short secret (8 chars or fewer) is masked entirely —
+    there is no way to show a fragment of something that short without
+    showing most of it.
+    """
+    if len(secret) <= 8:
+        return "*" * len(secret)
+    keep = 2
+    return (secret[:keep] + b"*" * (len(secret) - 2 * keep) + secret[-keep:]).decode(
+        "ascii", "replace")
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _check_secrets(rel_path: str, text: str, findings: list) -> None:
+    data = text.encode("utf-8", "replace")
+
+    def line_for(byte_offset: int) -> int:
+        # `data` is UTF-8 bytes but `text` (and `_line_of`) is a `str`; a
+        # byte offset counted against the character-indexed string over-counts
+        # by however many bytes multi-byte characters before it add, so
+        # decode only the prefix and count newlines in THAT.
+        return _line_of(data[:byte_offset].decode("utf-8", "replace"), byte_offset)
+
+    for name, pattern in _PREFIXED_SECRET_PATTERNS.items():
+        for m in pattern.finditer(data):
+            findings.append(_finding(
+                f"secrets:{name}", rel_path, line_for(m.start()),
+                _mask(m.group(0)),
+            ))
+
+    for m in _PRIVATE_KEY_RE.finditer(data):
+        findings.append(_finding(
+            "secrets:private-key", rel_path, line_for(m.start()),
+            _mask(m.group(0)),
+        ))
+
+    for m in _ASSIGNMENT_SECRET_RE.finditer(data):
+        value = m.group(2) if m.group(2) is not None else m.group(3)
+        if _is_placeholder(value):
+            continue
+        findings.append(_finding(
+            "secrets:assignment", rel_path, line_for(m.start()),
+            f"{m.group(1).decode()} = {_mask(value)}",
+        ))
+
+
+# ------------------------------------------------------------ device paths
+
+# Absolute paths that are true statements about ONE machine: a home
+# directory (whoever's — the folder is meant to move between machines and
+# users), or a handful of OS-level roots that mean "this filesystem, laid
+# out exactly like mine". A relative path, or an absolute path inside the
+# app folder itself, says nothing about the machine it runs on next.
+_DEVICE_ROOTS = (
+    "/home/", "/Users/", "/root/", "/opt/", "/var/", "/tmp/",
+    "/mnt/", "/media/", "/Volumes/", "/private/",
+)
+# The match body itself: a root, then at least one more path-shaped segment
+# of ordinary filename characters.
+_POSIX_DEVICE_RE = re.compile(
+    "(?:" + "|".join(re.escape(r) for r in _DEVICE_ROOTS) + r")"
+    + r"[A-Za-z0-9_.\-]+(?:/[A-Za-z0-9_.\-]+)*"
+)
+_WIN_DEVICE_RE = re.compile(
+    r"[A-Za-z]:[\\/](?:Users|Windows|Program Files(?: \(x86\))?|ProgramData)"
+    r"[\\/][^\s\"'<>)]*",
+    re.IGNORECASE,
+)
+
+
+def _preceded_by_url_host(text: str, match_start: int) -> bool:
+    """True when `text` just before `match_start` is a URL scheme/host
+    boundary (`scheme://host` or `scheme://host:port`) leading straight into
+    the match — the case where the match is a URL's path component, sharing
+    a root's spelling without saying anything about a local filesystem."""
+    window_start = max(0, match_start - 256)
+    prefix = text[window_start:match_start]
+    return re.search(r"://[A-Za-z0-9.\-]+(?::\d+)?$", prefix) is not None
+
+
+def _quote_precedes(text: str, match_start: int) -> bool:
+    """True when the character right before `match_start` is a quote —
+    the shape an actual filesystem path takes in source (an assigned string,
+    an HTML attribute, a fenced code span), as opposed to a bare word inside
+    a sentence of prose, which this engine leaves alone."""
+    return match_start > 0 and text[match_start - 1] in "\"'`"
+
+
+def _check_device_paths(rel_path: str, text: str, findings: list) -> None:
+    for m in _POSIX_DEVICE_RE.finditer(text):
+        if _preceded_by_url_host(text, m.start()) or not _quote_precedes(text, m.start()):
+            continue
+        findings.append(_finding(
+            "device-path:hardcoded", rel_path, _line_of(text, m.start()),
+            m.group(0),
+        ))
+    for m in _WIN_DEVICE_RE.finditer(text):
+        if not _quote_precedes(text, m.start()):
+            continue
+        findings.append(_finding(
+            "device-path:hardcoded", rel_path, _line_of(text, m.start()),
+            m.group(0),
+        ))
+
+
+# ---------------------------------------------------------------- structure
+
+# The three files that make a shared app openable and recognizable to
+# whoever receives it: a page to open, a README to say what it is, and a
+# thumbnail to show in a grid of other apps. Plain existence (and, for the
+# thumbnail, non-emptiness) — this engine does not parse any of the three,
+# it only asks whether the basics are there.
+_ENTRY_NAME = "index.html"
+_PREVIEW_IMAGE_NAME = "preview.png"
+
+
+def _check_structure(app_dir: str, findings: list) -> None:
+    if not os.path.isfile(os.path.join(app_dir, _ENTRY_NAME)):
+        findings.append(_finding(
+            "structure:missing-index", ".", 0,
+            f"no {_ENTRY_NAME} — whoever you share this with needs a page to open",
+        ))
+
+    try:
+        has_readme = any(
+            n.lower().startswith("readme") and os.path.isfile(os.path.join(app_dir, n))
+            for n in os.listdir(app_dir)
+        )
+    except OSError:
+        has_readme = True  # an unlistable folder is not a "missing README" finding
+    if not has_readme:
+        findings.append(_finding(
+            "structure:missing-readme", ".", 0,
+            "no README in the app folder — say what this app does for whoever you share it with",
+        ))
+
+    try:
+        has_preview = (_PREVIEW_IMAGE_NAME in os.listdir(app_dir)
+                       and os.path.getsize(
+                           os.path.join(app_dir, _PREVIEW_IMAGE_NAME)) > 0)
+    except OSError:
+        has_preview = False
+    if not has_preview:
+        findings.append(_finding(
+            "structure:missing-thumbnail", ".", 0,
+            f"no {_PREVIEW_IMAGE_NAME} thumbnail (or it is empty) — this is how "
+            "the app is recognized in a grid of others",
+        ))
+
+
+# --------------------------------------------------------------------- API
+
+
+def check(app_dir: str) -> list[dict]:
+    """Every finding for `app_dir`: `{rule, severity, path, line, excerpt}`,
+    `path` always relative to `app_dir`. Never raises — an unreadable app is
+    one the caller already knows is broken some other way, and a doctor that
+    crashes on the app it was asked to examine is not useful to anyone.
+
+    Reviews exactly one app folder — `app_dir` itself — and nothing else.
+    A caller that wants every app in a repo reviewed runs this once per app
+    folder; see skills/fused-render-app-doctor/ci/app-check.yml for that
+    loop."""
+    app_dir = os.path.abspath(app_dir)
+
+    findings: list[dict] = []
+
+    candidates = _candidate_files(app_dir)
+    for rel in candidates:
+        text = _read_text(app_dir, rel)
+        if text is None:
+            continue
+        _check_secrets(rel, text, findings)
+        _check_device_paths(rel, text, findings)
+
+    _check_structure(app_dir, findings)
+
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Review one app folder and print findings grouped by family.
+
+    The only mode is fail-on-finding: a CI floor has no use for a run that
+    reports a leaked credential and still exits 0, so there is no flag to
+    turn that off. Returns the process exit code rather than calling
+    `sys.exit` itself, so a caller in the same process can inspect it."""
+    argv = sys.argv[1:] if argv is None else argv
+    path = argv[0] if argv else "."
+    path = os.path.abspath(path)
+    if not os.path.isdir(path):
+        print(f"{path} is not a directory — nothing to review", file=sys.stderr)
+        return 2
+
+    findings = check(path)
+    if not findings:
+        print(f"no findings — {path} looks clean")
+        return 0
+
+    by_family: dict[str, list] = {}
+    for f in findings:
+        by_family.setdefault(f["rule"].split(":", 1)[0], []).append(f)
+    for family in sorted(by_family):
+        group = by_family[family]
+        label = group[0]["severity"].upper()
+        print(f"\n{family} ({label}):")
+        for f in group:
+            where = f["path"] if not f["line"] else f"{f['path']}:{f['line']}"
+            print(f"  {where}  {f['excerpt']}")
+    print(f"\n{len(findings)} finding(s)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/_app_check_module.py
+++ b/tests/_app_check_module.py
@@ -1,0 +1,28 @@
+"""Loads skills/fused-render-app-doctor/ci/app_check.py by path.
+
+The script lives under a skill directory rather than inside the
+`fused_render` package (it is stdlib-only and ships verbatim into a user's
+repo — see its own module docstring), so it is never importable as
+`from fused_render import ...`. Both test_app_doctor.py and
+test_app_doctor_housekeeping.py need the same module object, so the loader
+lives here once rather than being duplicated in each file. Derived from this
+file's own location so it resolves regardless of the working directory the
+tests run from.
+"""
+import importlib.util
+import os
+
+_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir,
+    "skills", "fused-render-app-doctor", "ci", "app_check.py",
+)
+
+
+def load():
+    spec = importlib.util.spec_from_file_location("app_check", _PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+app_doctor = load()

--- a/tests/test_app_doctor.py
+++ b/tests/test_app_doctor.py
@@ -219,6 +219,61 @@ def test_git_ignored_files_are_not_scanned(tmp_path):
     assert _leaks(findings) == []
 
 
+def test_a_gitignored_secret_is_not_scanned_without_a_git_repo(tmp_path):
+    """No `.git` at all here — `_walk_files` is the enumeration path in play,
+    and it must honour `.gitignore` on its own rather than only agreeing with
+    git when git is actually present to ask."""
+    _write(tmp_path, ".gitignore", "secrets.env\n")
+    _write(tmp_path, "secrets.env", 'TOKEN = "AKIAABCDEFGHIJKLMNOP"\n')
+    _write(tmp_path, "app.py", "print('hi')\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []
+
+
+def test_a_directory_rule_prunes_its_whole_subtree_without_a_git_repo(tmp_path):
+    _write(tmp_path, ".gitignore", "build/\n")
+    _write(tmp_path, "build/out.py", 'TOKEN = "AKIAABCDEFGHIJKLMNOP"\n')
+    _write(tmp_path, "app.py", "print('hi')\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []
+
+
+def test_a_glob_rule_hides_every_matching_file_without_a_git_repo(tmp_path):
+    _write(tmp_path, ".gitignore", "*.log\n")
+    _write(tmp_path, "app.log", 'DATA = "/home/bob/x"\n')
+    _write(tmp_path, "app.py", "print('hi')\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []
+
+
+def test_a_negation_re_includes_a_file_without_a_git_repo(tmp_path):
+    _write(tmp_path, ".gitignore", "*.env\n!keep.env\n")
+    _write(tmp_path, "secrets.env", 'TOKEN = "AKIAABCDEFGHIJKLMNOP"\n')
+    _write(tmp_path, "keep.env", 'DATA = "/home/bob/x"\n')
+    findings = app_doctor.check(str(tmp_path))
+    hits = _leaks(findings)
+    assert all(f["path"] != "secrets.env" for f in hits)
+    assert any(f["path"] == "keep.env" for f in hits)
+
+
+def test_a_subdirectorys_gitignore_only_applies_to_its_own_subtree(tmp_path):
+    _write(tmp_path, "sub/.gitignore", "secrets.env\n")
+    _write(tmp_path, "sub/secrets.env", 'TOKEN = "AKIAABCDEFGHIJKLMNOP"\n')
+    _write(tmp_path, "secrets.env", 'OTHER = "AKIAZYXWVUTSRQPONMLK"\n')
+    findings = app_doctor.check(str(tmp_path))
+    hits = _leaks(findings)
+    assert all(f["path"] != "sub/secrets.env" for f in hits)
+    assert any(f["path"] == "secrets.env" for f in hits)
+
+
+def test_pycache_is_skipped_with_no_gitignore_present(tmp_path):
+    _write(tmp_path, "__pycache__/app.cpython-311.pyc",
+           'TOKEN = "AKIAABCDEFGHIJKLMNOP"')
+    _write(tmp_path, "app.py", "print('hi')\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []
+
+
 def test_binary_files_are_skipped_without_raising(tmp_path):
     (tmp_path / "asset.bin").write_bytes(b"\x00\x01\x02AKIAABCDEFGHIJKLMNOP")
     assert _leaks(app_doctor.check(str(tmp_path))) == []

--- a/tests/test_app_doctor.py
+++ b/tests/test_app_doctor.py
@@ -1,0 +1,231 @@
+"""The App Doctor script (skills/fused-render-app-doctor/ci/app_check.py):
+secrets and device-specific paths, two of its three severity-high families.
+
+`check()` is the one function both a developer running the script directly
+and the CI workflow at skills/fused-render-app-doctor/ci/app-check.yml call —
+see the module docstring for why severity lives here and nowhere else. This
+file exercises it directly, against fixtures written into `tmp_path`, with no
+server and no workspace. The script is loaded by path (see
+_app_check_module.py) since it lives under a skill directory, not inside the
+`fused_render` package.
+"""
+from _app_check_module import app_doctor
+
+
+def _write(tmp_path, rel, content):
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _rules(findings):
+    return {f["rule"] for f in findings}
+
+
+def _leaks(findings):
+    """This file's own two families — secrets and device paths. `check()`
+    also runs the structure family (index.html, README, preview.png), which a
+    fixture built only for a leak assertion rarely satisfies in full, so
+    those findings show up here too and are not what these tests are about."""
+    return [f for f in findings if f["rule"].startswith(("secrets:", "device-path:"))]
+
+
+# --------------------------------------------------------------- secrets
+
+
+def test_a_clean_app_yields_nothing(tmp_path):
+    _write(tmp_path, "index.html", "<html><body>hi</body></html>\n")
+    _write(tmp_path, "README.md", "a small app\n")
+    assert _leaks(app_doctor.check(str(tmp_path))) == []
+
+
+def test_an_aws_key_is_flagged_and_masked(tmp_path):
+    _write(tmp_path, "app.py", 'AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+    findings = app_doctor.check(str(tmp_path))
+    assert "secrets:aws-access-key" in _rules(findings)
+    hit = next(f for f in findings if f["rule"] == "secrets:aws-access-key")
+    assert hit["path"] == "app.py"
+    assert hit["severity"] == "high"
+    assert "AKIAABCDEFGHIJKLMNOP" not in hit["excerpt"]
+
+
+def test_an_anthropic_key_is_flagged(tmp_path):
+    _write(tmp_path, "app.py",
+           'key = "sk-ant-api03-' + "a" * 40 + '"\n')
+    findings = app_doctor.check(str(tmp_path))
+    assert "secrets:anthropic-key" in _rules(findings)
+
+
+def test_a_private_key_block_is_flagged_and_fully_masked(tmp_path):
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEpAIBAAKCAQEA1234567890abcdef\n"
+        "-----END RSA PRIVATE KEY-----\n"
+    )
+    _write(tmp_path, "creds/key.pem", pem)
+    findings = app_doctor.check(str(tmp_path))
+    hit = next(f for f in findings if f["rule"] == "secrets:private-key")
+    assert hit["path"] == "creds/key.pem"
+    assert "MIIEpAIBAAKCAQEA1234567890abcdef" not in hit["excerpt"]
+    assert "BEGIN" not in hit["excerpt"]
+
+
+def test_an_assignment_shaped_secret_is_flagged(tmp_path):
+    _write(tmp_path, "config.py", 'DB_PASSWORD = "hunter2-super-secret-value"\n')
+    findings = app_doctor.check(str(tmp_path))
+    hit = next(f for f in findings if f["rule"] == "secrets:assignment")
+    assert "hunter2-super-secret-value" not in hit["excerpt"]
+    assert "DB_PASSWORD" in hit["excerpt"]
+
+
+def test_an_obvious_placeholder_is_not_flagged(tmp_path):
+    _write(tmp_path, "config.py",
+           'API_KEY = "your-api-key-here"\n'
+           'API_TOKEN = "changeme"\n'
+           'PASSWORD = "xxxxxxxx"\n')
+    findings = app_doctor.check(str(tmp_path))
+    assert not any(f["rule"].startswith("secrets:") for f in findings)
+
+
+def test_a_value_that_only_starts_with_a_placeholder_word_is_flagged(tmp_path):
+    """A value has to BE a placeholder end to end to be excused — sharing a
+    prefix with one ("my", "test", "none") is not enough, because a real
+    credential can start with any of those words too."""
+    _write(tmp_path, "config.py",
+           'DB_PASSWORD = "mysql-prod-9f3k2xyz"\n'
+           'API_KEY = "testkey-prod-abc123456"\n'
+           'TOKEN = "nonesuch-real-token-value"\n')
+    findings = app_doctor.check(str(tmp_path))
+    hits = [f for f in findings if f["rule"] == "secrets:assignment"]
+    assert len(hits) == 3
+
+
+def test_an_unquoted_env_style_assignment_is_flagged(tmp_path):
+    """`.env` and docker-compose-style `KEY=value` lines carry no quotes at
+    all, and are among the likeliest files in a tree to hold a real
+    credential, so the bare form has to be matched too."""
+    _write(tmp_path, ".env", "DB_PASSWORD=supersecretvalue123\n")
+    _write(tmp_path, "docker-compose.yml",
+           "services:\n  db:\n    environment:\n"
+           "      POSTGRES_PASSWORD=hunter2hunter2\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert any(f["rule"] == "secrets:assignment" and f["path"] == ".env"
+               for f in findings)
+    assert any(f["rule"] == "secrets:assignment" and f["path"] == "docker-compose.yml"
+               for f in findings)
+
+
+def test_a_secret_reports_its_line_number_correctly_past_non_ascii_text(tmp_path):
+    """The reported line counts characters, not encoded bytes — a non-ASCII
+    comment earlier in the file must not shift the line number of a finding
+    that comes after it."""
+    _write(tmp_path, "app.py", (
+        "# ünïcödé 🎉\n" * 5
+        + 'AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n'
+    ))
+    findings = app_doctor.check(str(tmp_path))
+    hit = next(f for f in findings if f["rule"] == "secrets:aws-access-key")
+    assert hit["line"] == 6
+
+
+def test_no_finding_excerpt_ever_contains_the_whole_matched_secret(tmp_path):
+    """The masking guarantee, asserted directly rather than left to
+    convention: every secret family must hold this, and a new family that
+    forgets to mask is a bug this test catches immediately."""
+    _write(tmp_path, "app.py", (
+        'AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n'
+        'GH = "ghp_' + "a" * 40 + '"\n'
+        'SLACK = "xoxb-' + "1234567890-abcdefghijklmno" + '"\n'
+        'OPENAI = "sk-' + "b" * 40 + '"\n'
+        'GOOGLE = "AIza' + "c" * 35 + '"\n'
+        'STRIPE = "sk_live_' + "d" * 30 + '"\n'
+        'SECRET = "another-real-looking-secret-value"\n'
+    ))
+    secrets_planted = [
+        "AKIAABCDEFGHIJKLMNOP", "ghp_" + "a" * 40, "xoxb-" + "1234567890-abcdefghijklmno",
+        "sk-" + "b" * 40, "AIza" + "c" * 35, "sk_live_" + "d" * 30,
+        "another-real-looking-secret-value",
+    ]
+    findings = app_doctor.check(str(tmp_path))
+    assert any(f["rule"].startswith("secrets:") for f in findings)
+    for f in findings:
+        if not f["rule"].startswith("secrets:"):
+            continue
+        for secret in secrets_planted:
+            assert secret not in f["excerpt"], (secret, f)
+
+
+# ---------------------------------------------------------- device paths
+
+
+def test_a_home_folder_path_is_flagged(tmp_path):
+    _write(tmp_path, "app.py", 'DATA = "/home/alice/datasets/model.bin"\n')
+    findings = app_doctor.check(str(tmp_path))
+    hit = next(f for f in findings if f["rule"] == "device-path:hardcoded")
+    assert hit["severity"] == "high"
+    assert "/home/alice" in hit["excerpt"]
+
+
+def test_a_macos_users_path_is_flagged(tmp_path):
+    _write(tmp_path, "app.py", 'DATA = "/Users/bob/Desktop/cache.json"\n')
+    findings = app_doctor.check(str(tmp_path))
+    assert any(f["rule"] == "device-path:hardcoded" for f in findings)
+
+
+def test_a_windows_users_path_is_flagged(tmp_path):
+    _write(tmp_path, "app.py", r'DATA = "C:\Users\carol\Documents\file.csv"' + "\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert any(f["rule"] == "device-path:hardcoded" for f in findings)
+
+
+def test_an_app_relative_path_is_not_flagged(tmp_path):
+    _write(tmp_path, "app.py", 'DATA = "./data/model.bin"\n')
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []
+
+
+def test_a_device_root_inside_a_url_is_not_flagged(tmp_path):
+    """A URL's own path component can share a name with a device root
+    (`/media/`, `/tmp/`, ...) without saying anything about the local
+    filesystem — only a match that is not part of a `scheme://host/...` URL
+    is a real device path."""
+    _write(tmp_path, "index.html",
+           '<img src="https://cdn.example.com/media/logo.png">\n')
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []
+
+
+def test_a_device_root_mentioned_in_prose_is_not_flagged(tmp_path):
+    """Prose that merely mentions a path is not a hardcoded path a run
+    depends on; only text shaped like a real filesystem path counts."""
+    _write(tmp_path, "README.md",
+           "Scratch files are written under /tmp/scratch during a run.\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []
+
+
+# -------------------------------------------------------- file enumeration
+
+
+def test_git_ignored_files_are_not_scanned(tmp_path):
+    import subprocess
+
+    subprocess.run(["git", "init", "-q"], cwd=str(tmp_path), check=True)
+    _write(tmp_path, ".gitignore", "secret.env\n")
+    _write(tmp_path, "secret.env", 'TOKEN = "AKIAABCDEFGHIJKLMNOP"\n')
+    _write(tmp_path, "app.py", "print('hi')\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []
+
+
+def test_binary_files_are_skipped_without_raising(tmp_path):
+    (tmp_path / "asset.bin").write_bytes(b"\x00\x01\x02AKIAABCDEFGHIJKLMNOP")
+    assert _leaks(app_doctor.check(str(tmp_path))) == []
+
+
+def test_bookkeeping_files_are_never_scanned(tmp_path):
+    _write(tmp_path, ".claude-split.json", '{"key": "AKIAABCDEFGHIJKLMNOP"}\n')
+    _write(tmp_path, ".venv/cache.txt", 'AKIAABCDEFGHIJKLMNOP')
+    findings = app_doctor.check(str(tmp_path))
+    assert _leaks(findings) == []

--- a/tests/test_app_doctor.py
+++ b/tests/test_app_doctor.py
@@ -116,6 +116,22 @@ def test_an_unquoted_env_style_assignment_is_flagged(tmp_path):
                for f in findings)
 
 
+def test_reading_a_credential_from_the_environment_is_not_a_leak(tmp_path):
+    """The right way to hold a secret is to not hold it — read it at runtime.
+    Every one of these lines assigns a credential-shaped name from an
+    expression rather than a literal, and none of them puts a secret in the
+    tree."""
+    _write(tmp_path, "app.py",
+           "import os\n"
+           'API_KEY = os.environ.get("FUSED_API_KEY")\n'
+           'ACCESS_KEY = os.environ["AWS_ACCESS_KEY"]\n'
+           "token = get_token()\n"
+           "SECRET_PATH = pathlib.Path(__file__).parent\n"
+           "password_field = form.cleaned_data\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert not any(f["rule"].startswith("secrets:") for f in findings)
+
+
 def test_a_secret_reports_its_line_number_correctly_past_non_ascii_text(tmp_path):
     """The reported line counts characters, not encoded bytes — a non-ASCII
     comment earlier in the file must not shift the line number of a finding

--- a/tests/test_app_doctor_cli.py
+++ b/tests/test_app_doctor_cli.py
@@ -1,0 +1,82 @@
+"""`python app_check.py` (skills/fused-render-app-doctor/ci/app_check.py): the
+command the CI workflow at skills/fused-render-app-doctor/ci/app-check.yml
+runs on every push, once per app folder — this file exercises the single-app
+case that loop is built on.
+
+A real subprocess, through the same interpreter running the tests: the point
+of this surface is its exit code, and an in-process call would swallow that
+behind a caught SystemExit rather than proving what the workflow's shell
+actually sees.
+"""
+import os
+import subprocess
+import sys
+
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), os.pardir,
+    "skills", "fused-render-app-doctor", "ci", "app_check.py",
+)
+
+
+def _write(tmp_path, rel, content):
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _clean_app(tmp_path):
+    _write(tmp_path, "index.html", "<html><body>hi</body></html>\n")
+    _write(tmp_path, "README.md", "a small app\n")
+    (tmp_path / "preview.png").write_bytes(b"\x89PNG" + b"0" * 32)
+    return tmp_path
+
+
+def _run(*args, cwd):
+    return subprocess.run([sys.executable, _SCRIPT, *args], cwd=str(cwd),
+                          capture_output=True, text=True, timeout=30)
+
+
+def test_a_clean_folder_exits_zero_and_says_so(tmp_path):
+    _clean_app(tmp_path)
+    r = _run(str(tmp_path), cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "no findings" in r.stdout.lower() or "clean" in r.stdout.lower()
+
+
+def test_defaults_to_the_working_directory(tmp_path):
+    _clean_app(tmp_path)
+    r = _run(cwd=tmp_path)
+    assert r.returncode == 0, r.stderr
+
+
+def test_a_fake_key_reddens_the_run_and_groups_the_finding(tmp_path):
+    _clean_app(tmp_path)
+    _write(tmp_path, "app.py", 'AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+    r = _run(str(tmp_path), cwd=tmp_path)
+    assert r.returncode != 0
+    assert "secrets" in r.stdout
+    assert "app.py" in r.stdout
+    assert "AKIAABCDEFGHIJKLMNOP" not in r.stdout
+
+
+def test_a_missing_thumbnail_exits_nonzero(tmp_path):
+    """A missing preview.png is a structure finding, and every finding this
+    script reports is HIGH severity — it fails the run the same way a leaked
+    key does."""
+    _clean_app(tmp_path)
+    (tmp_path / "preview.png").unlink()
+    r = _run(str(tmp_path), cwd=tmp_path)
+    assert r.returncode != 0
+    assert "preview.png" in r.stdout
+
+
+def test_a_path_that_does_not_exist_fails_loudly(tmp_path):
+    # check() itself swallows the OSError a missing path raises when it tries
+    # to list it, and reports an empty finding list — a silent "clean"
+    # verdict for a path that was never reviewed at all. main() has to catch
+    # this before it ever reaches check().
+    missing = tmp_path / "does-not-exist"
+    r = _run(str(missing), cwd=tmp_path)
+    assert r.returncode != 0
+    assert "not a directory" in (r.stderr + r.stdout).lower()

--- a/tests/test_app_doctor_cli.py
+++ b/tests/test_app_doctor_cli.py
@@ -50,14 +50,32 @@ def test_defaults_to_the_working_directory(tmp_path):
     assert r.returncode == 0, r.stderr
 
 
-def test_a_fake_key_reddens_the_run_and_groups_the_finding(tmp_path):
+def test_a_fake_key_reddens_the_run(tmp_path):
     _clean_app(tmp_path)
     _write(tmp_path, "app.py", 'AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
     r = _run(str(tmp_path), cwd=tmp_path)
     assert r.returncode != 0
-    assert "secrets" in r.stdout
+    assert "secrets:aws-access-key" in r.stdout
     assert "app.py" in r.stdout
     assert "AKIAABCDEFGHIJKLMNOP" not in r.stdout
+
+
+def test_findings_across_files_and_families_print_one_pinned_line_each_in_sorted_order(tmp_path):
+    """Two files, two families: a leaked key in `app.py` and a hardcoded
+    device path in `config.py`. Pins the exact `path:line: rule: excerpt`
+    shape and the path-then-line-then-rule sort, so the same app always
+    prints the same bytes in the same order."""
+    _clean_app(tmp_path)
+    _write(tmp_path, "app.py", '#\nAWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+    _write(tmp_path, "config.py", 'PATH = "/home/user/project/secret.txt"\n')
+    r = _run(str(tmp_path), cwd=tmp_path)
+    assert r.returncode != 0
+    lines = r.stdout.splitlines()
+    assert lines == [
+        "app.py:2: secrets:aws-access-key: AK****************OP",
+        "config.py:1: device-path:hardcoded: /home/user/project/secret.txt",
+        "2 findings",
+    ]
 
 
 def test_a_missing_thumbnail_exits_nonzero(tmp_path):

--- a/tests/test_app_doctor_housekeeping.py
+++ b/tests/test_app_doctor_housekeeping.py
@@ -1,0 +1,106 @@
+"""App Doctor's structure family (skills/fused-render-app-doctor/ci/app_check.py):
+three plain file-existence checks that make a shared app openable and
+recognizable to whoever receives it — `index.html`, a README, and a
+non-empty `preview.png`. All three are HIGH severity and fail the run, same
+as secrets and device paths (see app_check.py's module docstring). The
+script is loaded by path (see _app_check_module.py) since it lives under a
+skill directory, not inside the `fused_render` package.
+"""
+from _app_check_module import app_doctor
+
+
+def _write(tmp_path, rel, content):
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        path.write_bytes(content)
+    else:
+        path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _good_app(tmp_path):
+    _write(tmp_path, "index.html", "<html><body>hi</body></html>\n")
+    _write(tmp_path, "README.md", "a small app\n")
+    _write(tmp_path, "preview.png", b"\x89PNG\r\n\x1a\n" + b"0" * 32)
+    return tmp_path
+
+
+def _rules(findings):
+    return {f["rule"] for f in findings}
+
+
+def test_a_complete_app_has_no_structure_findings(tmp_path):
+    _good_app(tmp_path)
+    findings = app_doctor.check(str(tmp_path))
+    assert not any(f["rule"].startswith("structure:") for f in findings)
+
+
+# -------------------------------------------------------------------- index
+
+
+def test_a_missing_index_is_flagged(tmp_path):
+    _good_app(tmp_path)
+    (tmp_path / "index.html").unlink()
+    findings = app_doctor.check(str(tmp_path))
+    assert "structure:missing-index" in _rules(findings)
+
+
+def test_a_present_index_is_not_flagged(tmp_path):
+    _good_app(tmp_path)
+    findings = app_doctor.check(str(tmp_path))
+    assert "structure:missing-index" not in _rules(findings)
+
+
+# ------------------------------------------------------------------ readme
+
+
+def test_a_missing_readme_is_flagged(tmp_path):
+    _good_app(tmp_path)
+    (tmp_path / "README.md").unlink()
+    findings = app_doctor.check(str(tmp_path))
+    assert "structure:missing-readme" in _rules(findings)
+
+
+def test_a_readme_with_no_extension_still_counts(tmp_path):
+    _good_app(tmp_path)
+    (tmp_path / "README.md").unlink()
+    _write(tmp_path, "README", "a small app\n")
+    findings = app_doctor.check(str(tmp_path))
+    assert "structure:missing-readme" not in _rules(findings)
+
+
+# --------------------------------------------------------------- thumbnail
+
+
+def test_a_missing_thumbnail_is_flagged(tmp_path):
+    _good_app(tmp_path)
+    (tmp_path / "preview.png").unlink()
+    findings = app_doctor.check(str(tmp_path))
+    assert "structure:missing-thumbnail" in _rules(findings)
+
+
+def test_a_present_thumbnail_is_not_flagged(tmp_path):
+    _good_app(tmp_path)
+    findings = app_doctor.check(str(tmp_path))
+    assert "structure:missing-thumbnail" not in _rules(findings)
+
+
+def test_a_zero_byte_thumbnail_counts_as_missing(tmp_path):
+    _good_app(tmp_path)
+    _write(tmp_path, "preview.png", b"")
+    findings = app_doctor.check(str(tmp_path))
+    assert "structure:missing-thumbnail" in _rules(findings)
+
+
+# ------------------------------------------------------------------ --check
+
+
+def test_a_missing_thumbnail_fails_check(tmp_path):
+    """A missing preview.png is severity high, the same as every other
+    finding this engine reports, so it fails a run under --check."""
+    _good_app(tmp_path)
+    (tmp_path / "preview.png").unlink()
+    findings = app_doctor.check(str(tmp_path))
+    hit = next(f for f in findings if f["rule"] == "structure:missing-thumbnail")
+    assert hit["severity"] == "high"


### PR DESCRIPTION
## Summary

- **`fused-render-app-doctor` reviews an app before it is shared, and the agent does the reviewing.** The skill drives grep and reads the hits itself: leaked credentials, absolute paths that only resolve on the author's machine, generated caches loose in the tree, missing structure, and a declared `fused-api-version` behind current. It shells out to nothing. `fused-render` reaches people as a packaged desktop app, so the Python package is not on their PATH, and a skill that depended on it would be broken for everyone who has one.
- **Judging real `fused.*` calls belongs to the skills that own those surfaces.** `fused.ai` routes to `fused-render-ai`, `runPython`/`params` to `fused-render-authoring`, `trackJob` to `fused-render-jobs`, and so on across nine skills, each maintained against the runtime it describes. The routing table is read from each skill's own `description:` line, so it can be re-checked when one changes.
- **CI is a floor, and only a floor.** `app_check.py` fires on three things that need no judgment: a credential shaped like a real one, a hardcoded device path, and an app folder missing `index.html`, a README, or a `preview.png`. All three fail the run. It is deliberately a subset of the skill's review and is not meant to reach the same verdict.
- **That check is a script a repo carries, not a dependency it installs.** It is stdlib-only, so the workflow needs `setup-python` and nothing else — no install step, and no way for an unrelated dependency of `fused-render` to slow it down or redden a push that did not touch it. A repo can read the exact code that failed it, and a developer reproducing a CI failure locally runs that same code rather than whatever release happens to be current.
- **The skill installs both files itself.** Asked to set up checks, it runs `git rev-parse --show-toplevel` from the app folder and writes the workflow and the script under the repo root, which is the only place GitHub reads workflows from. Nothing to copy by hand, and an app nested inside a larger repo still lands its workflow in the right place.
- **Findings are masked at the source.** No finding's excerpt ever carries a whole matched secret, because reports land in CI logs and chat transcripts. The tests assert that directly rather than leaving it to convention.

## Visuals

Two paths to the same app, doing deliberately different amounts of work.

```mermaid
flowchart TD
    SKILL["Skill: review before sharing"] --> GREP["Agent greps and reads each hit"]
    GREP --> ROUTE{"Which fused.* surfaces?"}
    ROUTE --> OWNER["Load the skill that owns each one"]
    SKILL -.installs.-> CI
    CI["Workflow in the app's own repo"] --> CHECK["python .github/app_check.py"]
    CHECK --> FAIL["secrets, device paths, missing files: exit non-zero"]
```

## Usage

Ask for a review, or for checks to be set up:

> review this app before I share it
> set up CI checks for this app

The script runs on its own, with nothing installed:

```
python .github/app_check.py path/to/app
```

One line per finding, sorted, with the location first so a CI log line pastes straight into an editor or a `grep`:

```
.: structure:missing-readme: no README in the app folder — say what this app does for whoever you share it with
app.py:1: secrets:aws-access-key: AK****************OP
index.html:2: device-path:hardcoded: /home/bob/x.csv
3 findings
```

Exit 0 clean, 1 on any finding, 2 on a path that is not a directory.

## Test Plan

- [x] Secrets and device paths — one case per rule, the masking guarantee asserted directly, and negative cases for a device root inside a URL or mentioned in prose.
- [x] Structure — a positive and a negative case per file check.
- [x] The script's command line — grouped output, exit status in both directions, and a nonexistent path failing loudly rather than reporting nothing.
- [x] Skill packaging, since the skill directory gains a file.
- [x] The workflow's shell extracted from the committed YAML and run against real git repos: a repo that is one app, a repo of several apps, and a repo with none.
- [x] Repo CI green — all jobs pass, Windows included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
