### PR TITLE
Git view: "Deselect all" uses the plain grey outline

### DIFF
--- a/fused_render/templates/git/template.html
+++ b/fused_render/templates/git/template.html
@@ -478,7 +478,9 @@
   /* The constructive twin of `.danger`: "Select all" rides the Changes header
      beside "Discard all", and the two are the section's opposite verbs — one
      keeps every change, one throws every change away — so they wear opposite
-     colours in the same outline shape. */
+     colours in the same outline shape. Green is for the ADDING direction only:
+     once everything is in, the same button reads "Deselect all" and drops to
+     the plain grey outline, because undoing a selection is neutral, not good. */
   .btn.good { color: var(--good-fg); border-color: var(--good-line); }
   .btn.good:hover:not([disabled]) { color: var(--good-fg); background: var(--good-bg); border-color: var(--good-fg); }
   .btn.good[disabled] { color: var(--ink-3); border-color: var(--line); }
@@ -3999,7 +4001,7 @@ function render(data, stashes, diff) {
   const anyConflict = changes.some((c) => c.conflicted && !c.resolved);
   const selectAll = changes.length ? action(selectOp,
       [icon(CHECK_GLYPH, 14), btnLabel(allIn ? "Deselect all" : "Select all")], {
-    className: "good",
+    className: allIn ? "" : "good",
     disabled: anyConflict,
     label: anyConflict ? "Resolve the conflicted files before selecting all"
          : allIn ? "Remove every change from the next commit"


### PR DESCRIPTION
## Summary
- The Changes header button is green only while it reads "Select all". Once every change is ticked and it flips to "Deselect all", it drops `.good` and takes the default grey outline — undoing a selection is neutral, not constructive.

Follow-up to #1002.

## Test plan
- [x] `pytest tests/test_theme.py tests/test_git_view*.py tests/test_app_git.py tests/test_git_conflicts.py` — 190 pass
- [x] Verified in dev server: all-staged repo renders "Deselect all" with `btn` class, ink-2 text, plain border

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only conditional class on one header button plus a comment; no git ops or data handling changes.
> 
> **Overview**
> The Changes header **Select all** / **Deselect all** control no longer always wears the green `.good` style. **Select all** still uses `.good` (constructive “include everything”); when every change is already staged and the label flips to **Deselect all**, the button drops `.good` and uses the default grey outline so clearing the selection reads as neutral, not “good.”
> 
> The `.btn.good` comment in the stylesheet is updated to document that green is reserved for the adding direction only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b46dd9a7ea65ec2e00350b95a8b3043f260d480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->