### PR TITLE
Annotation bar over the app: mode, one-line hint, Element/Point and Done/■ move onto the pane

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -302,12 +302,15 @@
      away instead of sending them (Akshil, 2026-09-04: the strip keeps the
      two exits, keep and discard, in both modes; what a click pins moved onto
      the bar over the app). Derived from the same state class as every other
-     face.
+     face. `:not(.busy)`: through Stopping…/Transcribing… the mode is still
+     armed but the recording's marks are waiting for their words, and a
+     discard there would delete them (Bugbot, PR #1008) — the old
+     #annrec.on gate hid the seat then, and so does this.
      `#anncta #anndiscard`, two ids, because a bare `#anndiscard` LOSES to
      the base `#anncta button` display rule on specificity and the trash sat
      on the strip in every state (Akshil, 2026-08-19). */
   #anncta #anndiscard { display: none; }
-  #anncta:has(#annbtn.on) #anndiscard { display: inline-flex; padding: 0 8px; }
+  #anncta:not(.busy):has(#annbtn.on) #anndiscard { display: inline-flex; padding: 0 8px; }
   /* Two ids + the same pseudo-class count as the base hover above, or the
      resting brighten wins and the destructive hint never paints. */
   #anncta #anndiscard:hover:not(:disabled):not(.on) { color: var(--error); border-color: var(--error); }
@@ -6571,7 +6574,10 @@ function annBarPush(doc) {
   if (doc) doc.documentElement.style.setProperty("margin-top", "43px", "important");
 }
 function annBarPaint() {
-  if (!annBar) return;
+  // No bar (the hosted target went away, or is showing nothing marked) still
+  // hands a pushed document its margin back (Bugbot, PR #1008): the frame the
+  // shell keeps mounted must not keep a 43px gap with no bar on it.
+  if (!annBar) { annBarPush(null); return; }
   const show = annOn && !annCta.classList.contains("busy");
   const hostedDoc = annBar.getRootNode() !== document && !annXO ? annBar.ownerDocument : null;
   annBarPush(show ? hostedDoc : null);
@@ -7109,8 +7115,13 @@ document.addEventListener("mousedown", (e) => {
   // could reach annDone, silently dropping the words the user was about to
   // send (Bugbot, PR #664). The Element/Point picker rides along — choosing
   // the next click's tool is not walking away from this note.
+  // ...and the bar over the app (its ✓ Done, ■ and the picker it carries):
+  // the split layout's bar is in THIS document, and a mousedown on its Done
+  // closed the composer before annDone could commit the draft (Bugbot, PR
+  // #1008). Hosted, the bar is inside the layer host, which the target
+  // document's own handler already exempts.
   if (annPop.contains(t) || (t.closest && (t.closest(".annpin") || t.closest(".annchip")
-      || t.closest("#anncta") || t.closest("#anntool")))) return;
+      || t.closest("#anncta") || t.closest("#anntool") || t.closest(".annbar")))) return;
   annCloseComposer();
 });
 annDelBtn.addEventListener("click", () => {
@@ -8044,7 +8055,10 @@ async function annRecDiscard() {
 // notes are not this round's to throw (annRoundStart), and sent ones are
 // already Claude's.
 function annNotesDiscard() {
-  if (annRecOn || !annOn) return;
+  // Not while a walkthrough settles either (Bugbot, PR #1008): annRecOn is
+  // already down through Stopping…/Transcribing…, and the marks are the
+  // recording's, waiting for words — not a typed round to throw away.
+  if (annRecOn || !annOn || annCta.classList.contains("busy")) return;
   annCloseComposer();
   const keep = annotations.filter((a) => a.sent || (a.createdAt || 0) < annRoundStart);
   if (keep.length !== annotations.length) {

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -297,14 +297,17 @@
   #anncta:has(#annbtn.on):not(:has(#annrec.on)) #annbtn .cmt-word { display: none; }
   #anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on)) #annbtn .cmt-done { display: block; }
   #anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on)) #annbtn .done-word { display: var(--annlbl, inline); }
-  /* The discard seat exists ONLY while a walkthrough records — an outline
-     trash beside the stop, for throwing the recording away instead of
-     sending it. Derived from the same state class as every other face.
+  /* The discard seat exists while a MODE is on — an outline trash beside the
+     ■/clock or the ✓ Done, for throwing the walkthrough or the round's notes
+     away instead of sending them (Akshil, 2026-09-04: the strip keeps the
+     two exits, keep and discard, in both modes; what a click pins moved onto
+     the bar over the app). Derived from the same state class as every other
+     face.
      `#anncta #anndiscard`, two ids, because a bare `#anndiscard` LOSES to
      the base `#anncta button` display rule on specificity and the trash sat
      on the strip in every state (Akshil, 2026-08-19). */
   #anncta #anndiscard { display: none; }
-  #anncta:has(#annrec.on) #anndiscard { display: inline-flex; padding: 0 8px; }
+  #anncta:has(#annbtn.on) #anndiscard { display: inline-flex; padding: 0 8px; }
   /* Two ids + the same pseudo-class count as the base hover above, or the
      resting brighten wins and the destructive hint never paints. */
   #anncta #anndiscard:hover:not(:disabled):not(.on) { color: var(--error); border-color: var(--error); }
@@ -649,6 +652,131 @@
     border-radius: 4px;
     background: color-mix(in srgb, var(--accent) 12%, transparent);
   }
+  /* The annotation bar (Akshil, 2026-09-04, from a mock): the mode's
+     controls sit ON THE APP, across its top edge, while a mode is armed —
+     a lead segment in the accent fill saying what a click does now, then the
+     Element/Point picker (the strip's #anntool, PORTALED here: one node, one
+     state) and ✓ Done, on the bar's own dark ground. The strip across the
+     divider keeps only the way OUT of the mode (■ clock / ✓ Done, and the
+     trash). An overlay, not a row: the app under it is arbitrary and cannot
+     be reflowed, so the bar is 36px of the app's own top, gone on disarm.
+     `pointer-events: auto`, unlike the pins: it carries buttons. z 3 sits
+     above the pins (2) and under the composer (5). annBarPaint is the one
+     writer. This copy is the split layout's; ANN_LAYER_CSS carries the same
+     rules for the layers in other documents. */
+  .annbar {
+    position: absolute;
+    z-index: 3;
+    top: 0;
+    left: 0;
+    right: 0;
+    /* The STRIP's box, restated (#anntools: 26px seats, 8px 16px padding,
+       12px gap, one hairline) so the two rows line up across the divider
+       and the bar's buttons are the strip's buttons, not cousins of them. */
+    box-sizing: border-box;
+    height: 43px;
+    display: none;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 16px;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    color: var(--fg);
+    font-size: 12px;
+    line-height: 1.3;
+    pointer-events: auto;
+    overflow: hidden;
+  }
+  .annbar.show { display: flex; animation: annbarin .18s ease; }
+  @keyframes annbarin { from { opacity: 0; transform: translateY(-6px); } }
+  @media (prefers-reduced-motion: reduce) { .annbar.show { animation: none; } }
+  /* The lead: a MODE TAG in the armed seat's own idiom (accent outline on a
+     faint accent wash — the filled seat shouted, Akshil 2026-08-19) and the
+     one sentence in the muted ink beside it. Recording wears --error like
+     the ■/clock across the divider: one mode, one colour, both panes. */
+  .annbar .lead { flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 10px; overflow: hidden; }
+  .annbar .tag {
+    flex-shrink: 0;
+    height: 26px;
+    color: var(--accent);
+    font-weight: 400;
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .annbar .tag b { font-weight: inherit; }
+  .annbar .tag svg { width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; flex-shrink: 0; }
+  .annbar .tag .ic-mic { display: none; }
+  .annbar.rec .tag .ic-mic { display: block; }
+  .annbar.rec .tag .ic-cmt { display: none; }
+  .annbar.rec .tag { color: var(--error); }
+  /* The sentence is the point of the bar: full ink at the composer's 13px,
+     not the muted 12px the strip's words wear (Akshil, 2026-09-05: "not
+     prominent enough" — and the mode's colour stays on the tag alone, so
+     nothing here shouts). */
+  .annbar .txt { min-width: 0; color: var(--fg); font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .annbar .slot { display: flex; align-items: center; flex-shrink: 0; }
+  .annbar .slot:empty { display: none; }
+  .annbar .done {
+    border: 1px solid var(--accent);
+    border-radius: 8px;
+    background: transparent;
+    color: var(--accent);
+    font: inherit;
+    font-size: 12px;
+    white-space: nowrap;
+    height: 26px;
+    padding: 0 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background .12s;
+  }
+  .annbar .done:hover { background: color-mix(in srgb, var(--accent) 14%, transparent); }
+  .annbar .done svg { width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; }
+  /* Recording: ✓ Done gives way to ■ plus the live clock — the same stop the
+     strip's seat carries, in the recording's --error, so the walkthrough can
+     be ended from the bar the user is looking at (Akshil, 2026-09-05). The
+     clock is state, not a label: it never folds. */
+  .annbar.rec .done { display: none; }
+  .annbar .stop { display: none; }
+  .annbar.rec .stop {
+    display: inline-flex;
+    border: 1px solid var(--error);
+    border-radius: 8px;
+    background: transparent;
+    color: var(--error);
+    font: inherit;
+    font-size: 12px;
+    white-space: nowrap;
+    height: 26px;
+    padding: 0 10px;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background .12s;
+  }
+  .annbar .stop:hover { background: color-mix(in srgb, var(--error) 14%, transparent); }
+  .annbar .stop svg { width: 14px; height: 14px; fill: currentColor; stroke: none; flex-shrink: 0; }
+  .annbar .stop .clk:empty { display: none; }
+  /* Narrow, by MEASURE (annBarFit — collision, never a breakpoint): first
+     the sentence yields (.t1), then the buttons' words (.t2), the tag's word
+     last of all. Controls never clip. */
+  .annbar.t1 .txt { display: none; }
+  /* Two ids' worth on the picker's words: `#anntool .lbl` up top reads the
+     strip's --annlbl token and would outrank a bare class here. */
+  .annbar.t2 #anntool .lbl, .annbar.t2 .done .lbl { display: none; }
+  .annbar.t2 #anntool button, .annbar.t2 .done { padding: 0 8px; }
+  .annbar.t3 .tag b { display: none; }
+  /* The split layout's bar is a real ROW above the frame — #left is a flex
+     column and the bar goes in before #leftview, so the app is pushed down,
+     not covered (Akshil, 2026-09-05: "it covers the top of the page"). The
+     hosted layers push their document with a margin instead (annBarPush). */
+  #left > .annbar { position: relative; flex-shrink: 0; }
   #annpop {
     position: absolute;
     z-index: 5;
@@ -3637,6 +3765,8 @@
       <iframe id="leftframe" title="Preview"></iframe>
       <div id="annhl"></div>
       <div id="annpins"></div>
+      <!-- The annotation bar lands here at boot (annBarNode(document)): the
+           same node the layers in other documents get, so it is built once. -->
       <div id="annpop">
         <!-- Just the words (Akshil, 2026-08-19): the anchor chip and the
              per-note mic left this card. What a click pins is chosen up front
@@ -3712,9 +3842,8 @@
              empty marks deleted) where the stop seat keeps it. -->
         <button id="anndiscard" type="button" aria-label="Discard the recording"
                 title="Discard the recording — nothing is transcribed or sent"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 4h11"/><path d="M5.5 4V2.75a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1V4"/><path d="M3.75 4l.6 9a1 1 0 0 0 1 .95h5.3a1 1 0 0 0 1-.95l.6-9"/><line x1="6.5" y1="7" x2="6.5" y2="10.5"/><line x1="9.5" y1="7" x2="9.5" y2="10.5"/></svg></button>
-        <button id="annbtn" type="button" aria-pressed="false" aria-label="Comment on the preview"
-                title="Comment on the preview, then send the notes to Claude"><svg class="cmt-bubble" viewBox="0 0 16 16" aria-hidden="true"><path d="M13.5 2.5h-11a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2.5v2.9l3.4-2.9h5.1a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z"/></svg><svg class="cmt-stop" viewBox="0 0 16 16" aria-hidden="true"><rect class="fill" x="4" y="4" width="8" height="8" rx="1.5"/></svg><svg class="cmt-done" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 8.5l3.5 3.5 7-8"/></svg><span class="lbl cmt-word">Comment</span><span class="lbl done-word">Done</span><span id="annreclbl"></span></button>
-        <!-- Screenshot, between Comment and Record (Akshil, 2026-08-27). It
+        <!-- Screenshot, FIRST of the three (Akshil, 2026-09-04; it sat between
+             Comment and Record from 2026-08-27). It
              was a camera pill beside Send in BOTH composers; it moved up
              here because it acts on the PREVIEW, like its two neighbours,
              not on the draft — the picture it takes still lands as a chip
@@ -3727,6 +3856,8 @@
         <button id="viewshot" class="viewshot" type="button"
                 aria-label="Screenshot the preview and attach it to this message"
                 title="Screenshot the preview and attach it to this message"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.6 5.4h2.1l1-1.6h4.6l1 1.6h2.1a1 1 0 0 1 1 1v5.6a1 1 0 0 1-1 1H2.6a1 1 0 0 1-1-1V6.4a1 1 0 0 1 1-1Z" stroke-linejoin="round"/><circle cx="8" cy="9" r="2.4"/></svg><span class="lbl">Screenshot</span></button>
+        <button id="annbtn" type="button" aria-pressed="false" aria-label="Comment on the preview"
+                title="Comment on the preview, then send the notes to Claude"><svg class="cmt-bubble" viewBox="0 0 16 16" aria-hidden="true"><path d="M13.5 2.5h-11a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2.5v2.9l3.4-2.9h5.1a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z"/></svg><svg class="cmt-stop" viewBox="0 0 16 16" aria-hidden="true"><rect class="fill" x="4" y="4" width="8" height="8" rx="1.5"/></svg><svg class="cmt-done" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 8.5l3.5 3.5 7-8"/></svg><span class="lbl cmt-word">Comment</span><span class="lbl done-word">Done</span><span id="annreclbl"></span></button>
         <button id="annrec" type="button" aria-pressed="false"
                 aria-label="Annotate with a spoken walkthrough"
                 title="Annotate with a spoken walkthrough — talk while you click, and each click becomes a note"><svg class="rec-mic" viewBox="0 0 16 16" aria-hidden="true"><rect x="6" y="1.5" width="4" height="7.5" rx="2"/><path d="M3.5 7.5a4.5 4.5 0 0 0 9 0"/><line x1="8" y1="12" x2="8" y2="14.5"/></svg><span class="lbl rec-word">Annotate</span></button>
@@ -5695,6 +5826,17 @@ const annOwnFrame = document.getElementById("leftframe");
 let annFrame = CHAT_ONLY ? annMarkedFrame() : annOwnFrame;
 let annPins = document.getElementById("annpins");
 let annHl = document.getElementById("annhl");
+// The split layout's bar, appended after the pins so it paints above them
+// and under the composer (#annpop is z 5). annSyncTarget rebinds this to
+// the layer's own bar in the other two layouts.
+let annBar = annStageOrNull(document.getElementById("leftview"));
+function annStageOrNull(view) {
+  // A ROW above the frame, not an overlay on it: #left is a flex column and
+  // the bar takes its place before #leftview, so arming pushes the app down
+  // by the bar's height instead of hiding its first 43px (Akshil, 2026-09-05).
+  // The pins keep their coordinate space — #leftview is still the frame's box.
+  return view ? view.parentNode.insertBefore(annBarNode(document), view) : null;
+}
 let annStageEl = document.getElementById("leftview");
 let annLayerRoot = null;
 // The re-render observer on the target's document, declared UP HERE with the
@@ -5842,6 +5984,57 @@ function annXORemove() {
 // Returns the same {root, pins, hl, stage} shape annInjectLayer does, so the
 // pins, the composer portal and annPlacePop need no second code path — the
 // stage is the overlay host itself, whose box IS the frame's box.
+// The annotation bar's node, built for whichever document the layer stands
+// in — the split layout's #leftview, the hosted shadow layer, the cross-origin
+// overlay — so annBarPaint can write to any of them by class. Empty of words:
+// the paint fills them from the mode. The picker is NOT built here: it is the
+// strip's own #anntool, portaled into `.slot` by the paint (one node, one
+// state, one set of handlers). Done's handler is this window's annDone, which
+// works on a node in any same-origin document.
+function annBarNode(doc) {
+  const bar = doc.createElement("div");
+  bar.className = "annbar";
+  bar.setAttribute("role", "toolbar");
+  bar.setAttribute("aria-label", "Annotation");
+  const lead = doc.createElement("div");
+  lead.className = "lead";
+  const tag = doc.createElement("span");
+  tag.className = "tag";
+  // The strip's own glyphs — the Comment seat's bubble, the mic — so the tag
+  // names the mode with the very icon the user pressed to enter it.
+  tag.innerHTML = '<svg class="ic-cmt" viewBox="0 0 16 16" aria-hidden="true"><path d="M13.5 2.5h-11a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2.5v2.9l3.4-2.9h5.1a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z"/></svg>'
+    + '<svg class="ic-mic" viewBox="0 0 16 16" aria-hidden="true"><rect x="6" y="1.5" width="4" height="7.5" rx="2"/><path d="M3.5 7.5a4.5 4.5 0 0 0 9 0"/><line x1="8" y1="12" x2="8" y2="14.5"/></svg>'
+    + '<b></b>';
+  const txt = doc.createElement("span");
+  txt.className = "txt";
+  lead.append(tag, txt);
+  const slot = doc.createElement("div");
+  slot.className = "slot";
+  const done = doc.createElement("button");
+  done.className = "done";
+  done.type = "button";
+  done.title = "Send the notes to Claude and finish · Esc cancels";
+  done.setAttribute("aria-label", "Done — send the notes and finish");
+  done.innerHTML = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 8.5l3.5 3.5 7-8"/></svg><span class="lbl">Done</span>';
+  done.addEventListener("click", () => annDone());
+  // ■ plus the live clock while a walkthrough records — annRecPaint mirrors
+  // the strip's clock into `.clk`, one writer for both faces of the same
+  // fact. Click ends the recording exactly as the strip's seat does.
+  const stop = doc.createElement("button");
+  stop.className = "stop";
+  stop.type = "button";
+  stop.title = "Stop the recording · Esc also stops it";
+  stop.setAttribute("aria-label", "Stop the recording");
+  stop.innerHTML = '<svg viewBox="0 0 16 16" aria-hidden="true"><rect x="4" y="4" width="8" height="8" rx="1.5"/></svg><span class="clk"></span>';
+  stop.addEventListener("click", () => annRecEnd());
+  bar.append(lead, slot, done, stop);
+  // The bar's box changes with the pane (the divider drags, the window
+  // resizes) — refit the words on every change. The observer is the bar's
+  // OWN window's: the node may live in another document.
+  const RO = doc.defaultView && doc.defaultView.ResizeObserver;
+  if (RO) new RO(() => { if (bar === annBar) annBarFit(); }).observe(bar);
+  return bar;
+}
 function annXOLayer() {
   let pdoc = null;
   try { pdoc = window.parent.document; } catch (err) { return null; }
@@ -5869,7 +6062,7 @@ function annXOLayer() {
     hl.className = "hl";
     const pins = pdoc.createElement("div");
     pins.className = "pins";
-    root.append(style, catcher, hl, pins);
+    root.append(style, catcher, hl, pins, annBarNode(pdoc));
     catcher.addEventListener("click", (e) => {
       if (!annOn) return;
       e.preventDefault();
@@ -5897,6 +6090,7 @@ function annXOLayer() {
   return { root: host.shadowRoot,
            pins: host.shadowRoot.querySelector(".pins"),
            hl: host.shadowRoot.querySelector(".hl"),
+           bar: host.shadowRoot.querySelector(".annbar"),
            stage: host };
 }
 
@@ -5955,6 +6149,71 @@ const ANN_LAYER_CSS = [
   ".hl { position: absolute; display: none; pointer-events: none;"
   + " border: 1.5px solid #d97757; border-radius: 4px;"
   + " background: rgba(217, 119, 87, .14); }",
+  // The annotation bar — see .annbar in the page sheet for the why; same
+  // numbers, literal colours for the same reason the pin's are. The picker's
+  // rules are the strip's #anntool rules restated: the node is portaled in
+  // here and the strip's stylesheet cannot follow it.
+  // The bar and the picker in it read the SHELL's tokens, not literals: unlike
+  // a pin or the composer card — which float over the app and bring one fixed
+  // look — the bar is chrome, a row of the same strip the chat pane shows, and
+  // a dark strip over a light shell is the wrong theme (Akshil, 2026-09-05).
+  // annBarPaint copies this document's tokens onto the bar node (ANN_BAR_TOKENS)
+  // and re-copies when the theme flips; the literals are only the dark
+  // fallbacks for a token that has not arrived.
+  ".annbar { position: absolute; top: 0; left: 0; right: 0; box-sizing: border-box;"
+  + " height: 43px; display: none; align-items: center; gap: 12px; padding: 8px 16px;"
+  + " background: var(--bg, #191a1e); border-bottom: 1px solid var(--border, #34363e);"
+  + " color: var(--fg, #ececf1); pointer-events: auto; overflow: hidden;"
+  + " font: 400 12px/1.3 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }",
+  ".annbar.show { display: flex; animation: annbarin .18s ease; }",
+  "@keyframes annbarin { from { opacity: 0; transform: translateY(-6px); } }",
+  "@media (prefers-reduced-motion: reduce) { .annbar.show { animation: none; } }",
+  ".annbar .lead { flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 10px;"
+  + " overflow: hidden; }",
+  ".annbar .tag { flex-shrink: 0; height: 26px; color: var(--accent, #d97757); font-weight: 400;"
+  + " white-space: nowrap; display: inline-flex; align-items: center; gap: 6px; }",
+  ".annbar .tag b { font-weight: inherit; }",
+  ".annbar .tag svg { width: 14px; height: 14px; fill: none; stroke: currentColor;"
+  + " stroke-width: 1.5; stroke-linecap: round; flex-shrink: 0; }",
+  ".annbar .tag .ic-mic { display: none; }",
+  ".annbar.rec .tag .ic-mic { display: block; }",
+  ".annbar.rec .tag .ic-cmt { display: none; }",
+  ".annbar.rec .tag { color: var(--error, #f26d6d); }",
+  ".annbar .txt { min-width: 0; color: var(--fg, #ececf1); font-size: 13px; white-space: nowrap;"
+  + " overflow: hidden; text-overflow: ellipsis; }",
+  ".annbar .slot { display: flex; align-items: center; flex-shrink: 0; }",
+  ".annbar .slot:empty { display: none; }",
+  ".annbar .done, .annbar.rec .stop { border: 1px solid var(--accent, #d97757); border-radius: 8px;"
+  + " background: transparent; color: var(--accent, #d97757);"
+  + " font: 400 12px/1 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  + " white-space: nowrap; height: 26px; padding: 0 10px; margin: 0; display: inline-flex;"
+  + " align-items: center; gap: 6px; cursor: pointer; flex-shrink: 0; }",
+  ".annbar .done:hover { background: color-mix(in srgb, var(--accent, #d97757) 14%, transparent); }",
+  ".annbar .done svg { width: 14px; height: 14px; fill: none; stroke: currentColor;"
+  + " stroke-width: 1.5; stroke-linecap: round; }",
+  ".annbar.rec .done { display: none; }",
+  ".annbar .stop { display: none; }",
+  ".annbar.rec .stop { border-color: var(--error, #f26d6d); color: var(--error, #f26d6d); }",
+  ".annbar .stop:hover { background: color-mix(in srgb, var(--error, #f26d6d) 14%, transparent); }",
+  ".annbar .stop svg { width: 14px; height: 14px; fill: currentColor; stroke: none; flex-shrink: 0; }",
+  ".annbar .stop .clk:empty { display: none; }",
+  ".annbar.t1 .txt { display: none; }",
+  ".annbar.t2 #anntool .lbl, .annbar.t2 .done .lbl { display: none; }",
+  ".annbar.t2 #anntool button, .annbar.t2 .done { padding: 0 8px; }",
+  ".annbar.t3 .tag b { display: none; }",
+  "#anntool { display: flex; flex-shrink: 0; border: 1px solid var(--border, #34363e);"
+  + " border-radius: 8px; overflow: hidden; height: 26px; }",
+  "#anntool[hidden] { display: none; }",
+  "#anntool button { border: 0; background: transparent; color: var(--dim, #9a9fa9); margin: 0;"
+  + " font: 400 12px/1 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  + " padding: 0 10px; height: 100%; display: inline-flex; align-items: center; gap: 5px;"
+  + " cursor: pointer; }",
+  "#anntool button + button { border-left: 1px solid var(--border, #34363e); }",
+  "#anntool button:hover { color: var(--fg, #ececf1); background: var(--surface, #26282f); }",
+  '#anntool button[aria-checked="true"] { color: var(--on-accent, #1a1a1a); background: var(--accent, #d97757); }',
+  "#anntool svg { width: 14px; height: 14px; fill: none; stroke: currentColor;"
+  + " stroke-width: 1.5; stroke-linecap: round; flex-shrink: 0; }",
+  "#anntool svg .fill { fill: currentColor; stroke: none; }",
   // The note composer's looks, restated for the document it gets PORTALED into
   // (annPortalPop). The node is the very one the markup declares — its handlers
   // and its draft ride along — but a stylesheet does not: `#annpop` and friends
@@ -6023,12 +6282,14 @@ function annInjectLayer(doc) {
     // Ring first, pins second: painted in tree order, so a pin is never hidden
     // behind the ring of the element it marks (#annpins/#annhl do this with
     // z-index in the split layout, where they are not siblings of nothing else).
-    root.append(style, hl, pins);
+    // The bar last of the three, above the pins and — the portaled composer
+    // is appended after it — under the card.
+    root.append(style, hl, pins, annBarNode(doc));
     doc.body.appendChild(host);
   }
   const root = host.shadowRoot;
   return { root, pins: root.querySelector(".pins"), hl: root.querySelector(".hl"),
-           stage: doc.documentElement };
+           bar: root.querySelector(".annbar"), stage: doc.documentElement };
 }
 
 // Point the four bindings at whatever the host is showing NOW. Cheap enough to
@@ -6068,6 +6329,7 @@ function annSyncTarget() {
   const layer = doc ? annInjectLayer(doc) : (annXO ? annXOLayer() : null);
   annPins = layer && layer.pins;
   annHl = layer && layer.hl;
+  annBar = layer && layer.bar;
   annStageEl = layer && layer.stage;
   annLayerRoot = (layer && layer.root) || null;
   // The composer, while portaled, is a node we LENT to that document — and this
@@ -6222,6 +6484,116 @@ function annLabelFor(i) {
   return s;
 }
 
+// The annotation bar's ONE writer. Shown while a mode is armed — the
+// controls it carries are the mode's — and gone on disarm; not while the seat
+// is busy transcribing (the mode is still armed then, but the clicks are over).
+// Derived, never toggled: every path that changes the answer (arm, disarm, the
+// mic starting or stopping) repaints through renderAnn or calls this directly.
+//
+// The picker RIDES the bar: the strip's #anntool is adopted into the current
+// layer's slot on show, so whichever document the layer is in this round, the
+// one picker and its one state (annSetTool) are what the user clicks. A
+// cross-origin target has no elements to pick (annXO — annToolShow refuses
+// it too), so its bar is the sentence and Done alone. Between rounds the
+// node is left where it last stood, hidden; a layer rebuilt by a live reload
+// simply adopts it again.
+const ANN_BAR = {
+  comment: ["Comment", "Click an element or a point, then type the change."],
+  rec: ["Voice annotation", "Click an element or a point, then say the change."],
+};
+// The bar's words fit or fold, by MEASURE (the strip's annFitStrip idiom —
+// collision detection, never a breakpoint): everything on, then the sentence
+// yields first (.t1), the buttons' words second (.t2). Summed by hand like
+// the strip's verdict, with the sentence at its NATURAL width (scrollWidth:
+// the ellipsis has already clipped offsetWidth), so a folded bar can still
+// tell when there is room to unfold.
+function annBarFit() {
+  if (!annBar || !annBar.classList.contains("show")) return;
+  annBar.classList.remove("t1", "t2", "t3");
+  const cs = annBar.ownerDocument.defaultView.getComputedStyle(annBar);
+  const gap = parseFloat(cs.columnGap) || 0;
+  const box = annBar.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+  const tag = annBar.querySelector(".tag"), txt = annBar.querySelector(".txt");
+  const slot = annBar.querySelector(".slot"), done = annBar.querySelector(".done");
+  const stop = annBar.querySelector(".stop");
+  // tag + picker + Done/■, with the row's gaps between whichever are present.
+  const need = () => {
+    const parts = [slot.offsetWidth, done.offsetWidth, stop.offsetWidth].filter(Boolean);
+    return tag.offsetWidth + parts.reduce((a, b) => a + b, 0) + gap * parts.length;
+  };
+  const words = need();
+  if (words + 10 + txt.scrollWidth > box) annBar.classList.add("t1");
+  if (words > box) {
+    annBar.classList.add("t2");
+    // Re-measured with the buttons' words gone: the tag's word is the last
+    // to yield, and only if the icon-only buttons still do not fit.
+    if (need() > box) annBar.classList.add("t3");
+  }
+}
+// The hosted bar is an overlay in someone else's document, and "it covers the
+// top of the page" (Akshil, 2026-09-05) is answered by PUSHING that document
+// down by the bar's height while the bar shows — a margin on its root,
+// set with the important priority so an app's own reset cannot undo it,
+// removed on hide. One
+// document at a time: a target that changes under an armed mode (live reload,
+// the shell's mode switch) hands the margin back before the new one takes it.
+// Not the cross-origin overlay (that bar stands in the HOST's document, which
+// is not the app) and not the split layout (its bar is a real row — see
+// annStageOrNull).
+// The shell's palette, handed to a bar standing in another document: the
+// tokens the layer's .annbar rules read (with dark literals as fallbacks),
+// copied as inline custom properties on the node. Read off THIS document's
+// root, so `data-theme` here is what the bar over there wears.
+const ANN_BAR_TOKENS = ["--bg", "--surface", "--border", "--fg", "--dim", "--accent",
+                        "--on-accent", "--error"];
+function annBarTheme() {
+  if (!annBar || annBar.ownerDocument === document) return;   // the page sheet has them
+  const cs = getComputedStyle(document.documentElement);
+  for (const t of ANN_BAR_TOKENS) {
+    const v = cs.getPropertyValue(t).trim();
+    if (v) annBar.style.setProperty(t, v);
+  }
+}
+// A theme flip repaints the bar (the tokens are copied, not live).
+new MutationObserver(() => annBarPaint())
+  .observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+// The strip's clock, mirrored onto the bar's stop seat — same text, same tick.
+function annBarClock() {
+  const clk = annBar && annBar.querySelector(".stop .clk");
+  if (clk) clk.textContent = annRecOn ? annRecLbl.textContent : "";
+}
+let annPushedDoc = null;
+function annBarPush(doc) {
+  if (annPushedDoc && annPushedDoc !== doc) {
+    try { annPushedDoc.documentElement.style.removeProperty("margin-top"); } catch (err) { /* torn down */ }
+  }
+  annPushedDoc = doc;
+  if (doc) doc.documentElement.style.setProperty("margin-top", "43px", "important");
+}
+function annBarPaint() {
+  if (!annBar) return;
+  const show = annOn && !annCta.classList.contains("busy");
+  const hostedDoc = annBar.getRootNode() !== document && !annXO ? annBar.ownerDocument : null;
+  annBarPush(show ? hostedDoc : null);
+  const words = ANN_BAR[annRecOn ? "rec" : "comment"];
+  annBar.classList.toggle("rec", annRecOn);
+  annBarTheme();
+  annBarClock();
+  annBar.querySelector(".tag b").textContent = words[0];
+  annBar.querySelector(".txt").textContent = words[1];
+  annBar.classList.toggle("show", show);
+  if (!show) annBar.classList.remove("t1", "t2", "t3");   // a fresh fit on the next show
+  if (show && !annXO) {
+    const slot = annBar.querySelector(".slot");
+    if (annToolEl.parentNode !== slot) {
+      try {
+        slot.ownerDocument.adoptNode(annToolEl);
+        slot.appendChild(annToolEl);
+      } catch (err) { /* document torn down mid-gesture: next paint retries */ }
+    }
+  }
+  annBarFit();
+}
 function renderAnn() {
   // No pane, no pins and no chips: both hosts (#annpins over the frame, the two
   // #annchips rows in the composers) describe notes anchored to a document this
@@ -6243,6 +6615,9 @@ function renderAnn() {
   // `annCapable()` is false, and there is genuinely nothing to photograph.)
   if (noPane && !CHAT_ONLY) { renderShotChips(); return; }
   annSyncTarget();
+  // After the sync, which is what binds annBar to the layer the pins are
+  // about to land in.
+  annBarPaint();
   // pins over the frame
   if (annPins) {
     annPins.innerHTML = "";
@@ -6871,24 +7246,10 @@ function annToolHide() {
 // #anntools itself: annFitStrip writes #anntools's own class list, and
 // observing the node it writes would make every verdict schedule the next.
 const annToolsEl = document.getElementById("anntools");
-// The picker's width while it is OFF screen — RESERVED in the verdict below,
-// so arming Comment (which slides the picker in) can never flip the words to
-// icons under the click (Akshil, 2026-08-19: "it should remain consistent").
-// The row collapses a little early instead: words stay only where they would
-// still fit WITH the picker. Probed by giving the hidden node one out-of-flow
-// layout pass via inline style — not [hidden], which the observers watch, so
-// a probe never schedules a re-probe — inside a pre-paint callback, so
-// nothing flashes. No reservation for a picker that can never arrive: a
-// removed node (enterNoPane), a cross-origin target (annXO — annToolShow
-// refuses it), or no target at all (the buttons themselves are hidden).
-function annToolReserve() {
-  if (!annToolEl.hidden) return 0;   // already in the row, already measured
-  if (annXO || !annToolEl.isConnected || annBtn.hidden) return 0;
-  annToolEl.style.cssText = "display: flex; visibility: hidden; position: absolute;";
-  const w = annToolEl.offsetWidth;
-  annToolEl.style.cssText = "";
-  return w;
-}
+// No reserve for the picker any more: it slides onto the BAR over the app
+// (annBarPaint), never into this row, so the words here have nothing to make
+// room for. (2026-08-19 to 2026-09-04 it was reserved off screen so arming
+// could not flip the words under the click.)
 // NOT scrollWidth: a flex row's scrollWidth is floored at clientWidth, so
 // slack is invisible to it and adding the reserve would read as overflow on
 // a half-empty strip. The need is summed by hand — visible children, the
@@ -6904,8 +7265,6 @@ function annFitStrip() {
     need += c.offsetWidth;
     kids += 1;
   }
-  const reserve = annToolReserve();
-  if (reserve) { need += reserve; kids += 1; }
   if (kids > 1) need += (parseFloat(cs.columnGap) || 0) * (kids - 1);
   if (need > annToolsEl.clientWidth) annToolsEl.classList.add("tight");
 }
@@ -7004,6 +7363,8 @@ function annSetMode(on) {
     annBtn.setAttribute("aria-label", annOn
       ? "Done — send the notes and finish commenting"
       : "Comment on the " + paneNoun);
+    annDiscardBtn.setAttribute("aria-label", "Discard the notes");
+    annDiscardBtn.title = "Discard the notes — nothing is sent";
   }
   // Arming over a cross-origin target is the natural moment to raise the ONE
   // share prompt the tab-capture screenshots need (annXOStreamGet keeps the
@@ -7102,6 +7463,7 @@ function annRecPaint() {
   const secs = (performance.now() - annRecStartedAt) / 1000;
   annRecLbl.textContent = annRecClock(secs)
     + (annRecIds.length ? " · " + annRecIds.length : "");
+  annBarClock();
 }
 // Warm the transcriber the moment a recording STARTS, so the words are not
 // waiting on a cold model when it stops — the load runs while the reader is
@@ -7205,6 +7567,10 @@ async function annRecBegin() {
   annToolShow();
   annRecBtn.classList.add("on");
   annRecBtn.setAttribute("aria-pressed", "true");
+  // The bar swaps to the recording's sentence (and loses its Done — the stop
+  // is in the strip): annSetMode(true) above painted it before annRecOn was
+  // set, and nothing else repaints until the first mark.
+  annBarPaint();
   // Both buttons are exits now: the Comment seat has become the ■/clock stop
   // control (the stylesheet swaps its face off `.on`), and the pulsing mic
   // stops too — either click ends the walkthrough. The aria-label too, not
@@ -7215,6 +7581,8 @@ async function annRecBegin() {
   annRecBtn.title = "Recording — click to stop · Esc also stops it";
   annBtn.setAttribute("aria-label", "Stop the recording");
   annBtn.title = "Stop the recording · Esc also stops it";
+  annDiscardBtn.setAttribute("aria-label", "Discard the recording");
+  annDiscardBtn.title = "Discard the recording — nothing is transcribed or sent";
   annRecPaint();
   annRecTimerId = setInterval(annRecPaint, 250);
 }
@@ -7459,6 +7827,7 @@ async function annRecEnd() {
   annBtn.title = "Stopping the recording…";
   annCta.classList.add("busy");
   annRecLbl.textContent = "Stopping…";
+  annBarPaint();   // the clicks are over: the bar goes with them
   // The ending that KEEPS the file (CP-4) — `cancel()` is the discard. Its
   // reply is the finished file, so nothing here uploads anything. Swallowed
   // like the transcription below: a failed stop leaves the clicks stamped and
@@ -7637,6 +8006,7 @@ async function annRecDiscard() {
   annBtn.title = "Discarding the recording…";
   annCta.classList.add("busy");
   annRecLbl.textContent = "Discarding…";
+  annBarPaint();   // the clicks are over: the bar goes with them
   // `cancel()` STOPS AND DELETES (CP-4) — the ✕'s own meaning — where a stop
   // would leave the file behind. It cannot lose to the stop seat either: the
   // handle memoizes ONE ending, so a stop click landing inside this await gets
@@ -7669,7 +8039,21 @@ async function annRecDiscard() {
   // the settle is not this discard's to close.
   if (annOn && annArmEpoch === armed) annSetMode(false);
 }
-annDiscardBtn.addEventListener("click", () => annRecDiscard());
+// Comment mode's discard (Akshil, 2026-09-04): the round's unsent notes are
+// deleted — an open draft with them — and the mode goes away. Earlier rounds'
+// notes are not this round's to throw (annRoundStart), and sent ones are
+// already Claude's.
+function annNotesDiscard() {
+  if (annRecOn || !annOn) return;
+  annCloseComposer();
+  const keep = annotations.filter((a) => a.sent || (a.createdAt || 0) < annRoundStart);
+  if (keep.length !== annotations.length) {
+    annotations = keep;
+    annSave();
+  }
+  annSetMode(false);
+}
+annDiscardBtn.addEventListener("click", () => (annRecOn ? annRecDiscard() : annNotesDiscard()));
 
 // ── hosted only: keeping up with a target this document cannot hear ────────
 // The split layout is told about its pane by the pane itself — one iframe, one

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -360,7 +360,7 @@ def test_discard_throws_the_walkthrough_away(html):
     auto-send — and the clicks' empty marks are deleted with it. annRecEnd
     no-ops after it, so a stop click racing the discard cannot resurrect the
     walkthrough."""
-    assert "#anncta:has(#annrec.on) #anndiscard { display: inline-flex;" in html
+    assert "#anncta:has(#annbtn.on) #anndiscard { display: inline-flex;" in html
     # two ids on the hide: a bare #anndiscard loses to the base
     # `#anncta button` display rule on specificity, and the trash sat on the
     # strip in every state
@@ -395,7 +395,7 @@ def test_discard_throws_the_walkthrough_away(html):
     assert "fused.ai.transcribe" not in body and "annAutoSubmit" not in body
     assert "if (annOn && annArmEpoch === armed) annSetMode(false);" in body, \
         "a new arming that slipped into the settle is not this discard's to close"
-    assert 'annDiscardBtn.addEventListener("click", () => annRecDiscard());' in html
+    assert 'annDiscardBtn.addEventListener("click", () => (annRecOn ? annRecDiscard() : annNotesDiscard()));' in html
 
 
 def test_the_busy_seat_is_a_status_not_a_button(html):
@@ -471,13 +471,6 @@ def test_the_words_yield_only_when_they_truly_collide(html):
     # NOT scrollWidth: a flex row's scrollWidth floors at clientWidth, so the
     # picker reserve added to it would read as overflow on a half-empty strip
     assert "scrollWidth" not in body
-    # the OFF-screen picker's width is reserved, so arming (which slides it
-    # in) can never flip the words under the click — the row folds early
-    assert "const reserve = annToolReserve();" in body
-    probe = _block(html, "function annToolReserve()", "\n}\n")
-    assert "if (!annToolEl.hidden) return 0;" in probe
-    assert "annXO || !annToolEl.isConnected || annBtn.hidden" in probe
-    assert "annToolEl.offsetWidth" in probe
     assert "@container" not in html, "collision detection, not a breakpoint"
     assert "container-type" not in html
     assert "new ResizeObserver(annFitStrip).observe(annToolsEl);" in html
@@ -829,3 +822,143 @@ def test_the_capture_stream_state_is_declared_before_its_boot_time_teardown(html
     assert html.index("let annXOStream = null;") \
         < html.index("function annXORemove()") \
         < html.index('annSetMode(fused.params.get("annmode") === "1");')
+
+
+# ------------------------------------------------------- the annotation bar
+
+def test_the_bar_stands_in_every_layer(html):
+    """One bar per layer the pins can land in — the split layout's #leftview,
+    the hosted shadow layer, the cross-origin overlay — all built by the one
+    builder, so annBarPaint writes to any of them by class."""
+    assert html.count("annBarNode(") == 5          # builder, boot, two layers, one comment
+    inject = _block(html, "function annInjectLayer(", "\n}\n")
+    xo = _block(html, "function annXOLayer(", "\n}\n")
+    for body in (inject, xo):
+        assert "annBarNode(" in body
+        assert "bar: " in body                        # handed back with pins/hl
+    assert "annBar = layer && layer.bar;" in html
+    assert 'view.parentNode.insertBefore(annBarNode(document), view)' in html   # a row, not an overlay
+    # both stylesheets carry it: tokens in the page, literals in the layer
+    assert ".annbar.show { display: flex;" in html
+    assert '".annbar.show { display: flex;' in html
+    # ...and the layer restates the picker's looks, which follow it in there
+    assert '#anntool button[aria-checked="true"] { color: var(--on-accent, #1a1a1a); background: var(--accent, #d97757); }' in html
+
+
+def test_the_bar_carries_the_picker_and_done(html):
+    """The mock (Akshil, 2026-09-04): Element/Point and ✓ Done sit on the bar
+    over the app; the strip keeps the exits. The picker is the strip's OWN
+    node, portaled — one state, one set of handlers — and a cross-origin
+    target, which has no elements to pick, gets the sentence and Done alone.
+    Recording has no Done on the bar: the stop is the strip's ■/clock."""
+    body = _block(html, "function annBarPaint(", "\n}\n")
+    assert 'annOn && !annCta.classList.contains("busy")' in body
+    assert 'annBar.classList.toggle("rec", annRecOn)' in body
+    assert "if (show && !annXO) {" in body
+    assert "slot.ownerDocument.adoptNode(annToolEl);" in body
+    node = _block(html, "function annBarNode(", "\n}\n")
+    assert 'done.addEventListener("click", () => annDone());' in node
+    assert ".annbar.rec .done { display: none; }" in html
+    # renderAnn paints it right after the sync that binds the node
+    render = _block(html, "function renderAnn() {", "// pins over the frame")
+    assert render.index("annSyncTarget();") < render.index("annBarPaint();")
+    # the mic's start repaints too — annSetMode painted before annRecOn was set
+    rec = _block(html, "async function annRecBegin(", "\n}\n")
+    assert rec.index("annRecOn = true;") < rec.index("annBarPaint();")
+    # the strip no longer makes room for a picker that never comes
+    assert "annToolReserve" not in html
+
+
+def test_the_bar_speaks_one_plain_line(html):
+    """The lead is the mode; the sentence is one plain line per mode (Akshil,
+    2026-09-05: "one liner but easy to understand")."""
+    assert '"Voice annotation", "Click an element or a point, then say the change."' in html
+    assert '"Comment", "Click an element or a point, then type the change."' in html
+    # the tag is a LABEL (no border, no wash — it read as a button), red while
+    # recording; the sentence carries full ink at the composer's 13px
+    assert ".annbar.rec .tag { color: var(--error); }" in html
+    assert '".annbar.rec .tag { color: var(--error, #f26d6d); }"' in html
+    assert "border: 1px solid #d97757; background: rgba(217, 119, 87, .14); color: #d97757;" not in html
+    assert '".annbar .txt { min-width: 0; color: var(--fg, #ececf1); font-size: 13px;' in html
+
+
+def test_the_bar_wears_the_shell_s_theme(html):
+    """Chrome, not a pin: the bar in another document reads the SHELL's tokens
+    (copied onto the node, re-copied on a data-theme flip), with the dark
+    literals only as fallbacks — a dark strip over a light shell was the wrong
+    theme (Akshil, 2026-09-05)."""
+    assert '"--bg", "--surface", "--border", "--fg", "--dim", "--accent",' in html
+    theme = _block(html, "function annBarTheme(", "\n}\n")
+    assert "annBar.ownerDocument === document) return;" in theme
+    assert "getComputedStyle(document.documentElement)" in theme
+    assert "annBar.style.setProperty(t, v);" in theme
+    assert 'attributeFilter: ["data-theme"] });' in html
+    assert '".annbar { position: absolute; top: 0; left: 0; right: 0; box-sizing: border-box;"' in html
+    assert "background: var(--bg, #191a1e); border-bottom: 1px solid var(--border, #34363e);" in html
+    assert '#anntool button[aria-checked="true"] { color: var(--on-accent, #1a1a1a); background: var(--accent, #d97757); }' in html
+    paint = _block(html, "function annBarPaint(", "\n}\n")
+    assert "annBarTheme();" in paint
+
+
+def test_the_bar_can_stop_the_recording(html):
+    """■ plus the live clock on the bar while a walkthrough records (Akshil,
+    2026-09-05), in the recording's --error, replacing ✓ Done; the strip's
+    clock is mirrored by its one writer, and the clock never folds."""
+    node = _block(html, "function annBarNode(", "\n}\n")
+    assert 'stop.addEventListener("click", () => annRecEnd());' in node
+    assert '<span class="clk"></span>' in node
+    assert ".annbar .stop { display: none; }" in html
+    assert ".annbar.rec .stop {" in html
+    assert ".annbar.rec .done { display: none; }" in html
+    rec = _block(html, "function annRecPaint(", "\n}\n")
+    assert "annBarClock();" in rec
+    fit = _block(html, "function annBarFit(", "\n}\n")
+    assert "stop.offsetWidth" in fit
+    assert ".annbar.t2 #anntool .lbl, .annbar.t2 .done .lbl { display: none; }" in html   # not .clk
+
+
+def test_the_bar_pushes_the_app_down_instead_of_covering_it(html):
+    """Split: a real row before #leftview in the #left column. Hosted: a
+    43px !important margin on the target document's root while the bar
+    shows, handed back on hide and when the target changes; never the
+    cross-origin overlay's host document."""
+    assert "#left > .annbar { position: relative; flex-shrink: 0; }" in html
+    push = _block(html, "function annBarPush(", "\n}\n")
+    assert 'setProperty("margin-top", "43px", "important")' in push
+    assert 'removeProperty("margin-top")' in push
+    paint = _block(html, "function annBarPaint(", "\n}\n")
+    assert "annBar.getRootNode() !== document && !annXO" in paint
+    assert "annBarPush(show ? hostedDoc : null);" in paint
+
+
+def test_the_bar_folds_by_measure_not_breakpoint(html):
+    """Sentence first, buttons' words second — decided by summing the parts
+    against the box (the strip's annFitStrip idiom), refit on every resize
+    through the bar's OWN window's observer (the node may be in another
+    document). Controls never clip."""
+    body = _block(html, "function annBarFit(", "\n}\n")
+    assert 'annBar.classList.remove("t1", "t2", "t3");' in body
+    assert "txt.scrollWidth" in body                # natural width, not the clipped one
+    assert 'classList.add("t1")' in body and 'classList.add("t2")' in body
+    node = _block(html, "function annBarNode(", "\n}\n")
+    assert "doc.defaultView.ResizeObserver" in node
+    assert "if (bar === annBar) annBarFit();" in node
+    paint = _block(html, "function annBarPaint(", "\n}\n")
+    assert "annBarFit();" in paint
+    assert ".annbar.t1 .txt { display: none; }" in html
+    # two ids' worth: the strip's `#anntool .lbl` rule would outrank a class
+    assert ".annbar.t2 #anntool .lbl, .annbar.t2 .done .lbl { display: none; }" in html
+    assert ".annbar.t3 .tag b { display: none; }" in html
+    assert "@container" not in html
+
+
+def test_discard_covers_the_typed_round_too(html):
+    """The strip keeps BOTH exits in both modes (Akshil, 2026-09-04): the
+    trash beside ✓ Done throws this round's unsent notes away — an open draft
+    with them — and leaves the mode; earlier rounds' and sent notes stay."""
+    assert "#anncta:has(#annbtn.on) #anndiscard { display: inline-flex;" in html
+    body = _block(html, "function annNotesDiscard(", "\n}\n")
+    assert "annCloseComposer();" in body
+    assert "a.sent || (a.createdAt || 0) < annRoundStart" in body
+    assert "annSetMode(false);" in body
+    assert "(annRecOn ? annRecDiscard() : annNotesDiscard())" in html

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -360,7 +360,7 @@ def test_discard_throws_the_walkthrough_away(html):
     auto-send — and the clicks' empty marks are deleted with it. annRecEnd
     no-ops after it, so a stop click racing the discard cannot resurrect the
     walkthrough."""
-    assert "#anncta:has(#annbtn.on) #anndiscard { display: inline-flex;" in html
+    assert "#anncta:not(.busy):has(#annbtn.on) #anndiscard { display: inline-flex;" in html
     # two ids on the hide: a bare #anndiscard loses to the base
     # `#anncta button` display rule on specificity, and the trash sat on the
     # strip in every state
@@ -929,6 +929,11 @@ def test_the_bar_pushes_the_app_down_instead_of_covering_it(html):
     paint = _block(html, "function annBarPaint(", "\n}\n")
     assert "annBar.getRootNode() !== document && !annXO" in paint
     assert "annBarPush(show ? hostedDoc : null);" in paint
+    # losing the bar (target gone) still hands the pushed margin back
+    assert "if (!annBar) { annBarPush(null); return; }" in paint
+    # the bar's Done is exempt from the outside-click dismiss, like the strip's
+    dismiss = _block(html, 'document.addEventListener("mousedown", (e) => {\n  if (annPop.style.display', "\n});")
+    assert 't.closest(".annbar")' in dismiss
 
 
 def test_the_bar_folds_by_measure_not_breakpoint(html):
@@ -956,8 +961,11 @@ def test_discard_covers_the_typed_round_too(html):
     """The strip keeps BOTH exits in both modes (Akshil, 2026-09-04): the
     trash beside ✓ Done throws this round's unsent notes away — an open draft
     with them — and leaves the mode; earlier rounds' and sent notes stay."""
-    assert "#anncta:has(#annbtn.on) #anndiscard { display: inline-flex;" in html
+    assert "#anncta:not(.busy):has(#annbtn.on) #anndiscard { display: inline-flex;" in html
     body = _block(html, "function annNotesDiscard(", "\n}\n")
+    # not through Stopping…/Transcribing… either: annRecOn is already down and
+    # the marks are the recording's, waiting for words (Bugbot, PR #1008)
+    assert 'annRecOn || !annOn || annCta.classList.contains("busy")' in body
     assert "annCloseComposer();" in body
     assert "a.sent || (a.createdAt || 0) < annRoundStart" in body
     assert "annSetMode(false);" in body

--- a/tests/test_claude_kind.py
+++ b/tests/test_claude_kind.py
@@ -477,11 +477,17 @@ def test_the_hosted_pin_overlay_is_injected_into_the_target_document():
     # Found again rather than stacked: a second call on the same document reuses
     # the layer it already put there.
     assert 'doc.querySelector("[" + ANN_LAYER_MARK + "]")' in inject
-    # The injected stylesheet travels with the injection and names no token — it
-    # lives in a document that never heard of this page's palette.
+    # The injected stylesheet travels with the injection and the PIN, RING and
+    # COMPOSER rules name no token — they float over the app in a document that
+    # never heard of this page's palette. The bar's rules (and the picker's,
+    # which rides it) are the exception since 2026-09-05: the bar is shell
+    # chrome and reads the shell's tokens, copied onto the node by annBarTheme,
+    # with the dark literals only as fallbacks.
     css = code[code.index("const ANN_LAYER_CSS = ["):]
     css = css[:css.index('].join("\\n");')]
-    assert "var(--" not in css
+    floating = css[:css.index(".annbar {")] + css[css.index('"#annpop { position: absolute;'):]
+    assert "var(--" not in floating
+    assert "var(--bg, #191a1e)" in css   # fallback beside every token
     assert "box-sizing: border-box" in css, \
         "no reset comes with a shadow tree, and the ring's border would grow it"
     # And the app's own outline never reports our layer as part of the app.
@@ -659,8 +665,11 @@ def test_the_re_render_observer_follows_the_target_document():
     # (2026-08-19) watches the #anntools clusters for the strip's word-fit, and
     # fitComposerChrome's (2026-08-20) watches the composer rows and the landing
     # title for the control row's compact/stack verdict. Both stay in the PARENT
-    # document and never look at the target's.
-    assert code.count("new MutationObserver") == 3
+    # document and never look at the target's. The fourth (2026-09-05) watches
+    # THIS document's `data-theme` to re-copy the shell's tokens onto the bar —
+    # also a fact about this document's own chrome, never the pane's.
+    assert code.count("new MutationObserver") == 4
+    assert 'attributeFilter: ["data-theme"] });' in code
     fit = code[code.index("const mo = new MutationObserver(annFitStrip);"):]
     fit = fit[:fit.index("\n}")]
     assert "[annToolEl, annCta]" in fit, \

--- a/tests/test_claude_shots.py
+++ b/tests/test_claude_shots.py
@@ -2633,7 +2633,7 @@ def test_the_button_is_absent_wherever_there_is_nothing_to_photograph(html):
 def test_the_strip_carries_the_one_button_between_comment_and_record(html):
     """ONE button, in the #anncta strip (Akshil, 2026-08-27): it used to be a
     camera pill beside Send in both composers; it acts on the PREVIEW like Comment
-    and Record, so it sits with them — in that order: Comment, Screenshot, Record.
+    and Record, so it sits with them — first of the three: Screenshot, Comment, Record.
     The strip is the one row the home card and the chat both keep, so one copy
     serves both composers, and the chip still lands above whichever is showing.
     Hidden while a mode is armed, like the mic."""
@@ -2641,7 +2641,8 @@ def test_the_strip_carries_the_one_button_between_comment_and_record(html):
     assert 'class="pill viewshot"' not in html
     strip = _between(html, '<div id="anncta">', "\n      </div>")
     assert 'id="viewshot"' in strip
-    assert strip.index('id="annbtn"') < strip.index('id="viewshot"') < strip.index('id="annrec"')
+    # Screenshot · Comment · Annotate (Akshil, 2026-09-04)
+    assert strip.index('id="viewshot"') < strip.index('id="annbtn"') < strip.index('id="annrec"')
     assert "#anncta:has(#annbtn.on) #viewshot { display: none; }" in html
     btns = _between(html, "function shotBtns()", "\n}\n")
     assert '"viewshot"' in btns and "hviewshot" not in btns


### PR DESCRIPTION
## What

Arming **Comment** or starting a **recording** now shows a bar across the top of the app pane:

`💬 Comment  Click an element or a point, then type the change.        [◱ Element | ✛ Point]  [✓ Done]`
`🎙 Voice annotation  Click an element or a point, then say the change.  [◱ Element | ✛ Point]  [■ 0:12 · 3]`

- Same row as the chat pane's strip (43px, 26px seats, 8px radius, hairline) so the two read as one family across the divider; mode label in accent (red while recording), sentence in full ink.
- Element/Point picker is the strip's own `#anntool`, **portaled** onto the bar — one node, one state, one set of handlers.
- ✓ Done (comment) / ■ + live clock (recording) on the bar; the strip keeps 🗑 + ✓ Done / 🗑 + ■ clock. The trash now discards a typed round's unsent notes too.
- **Pushes the app down** instead of covering it: a real row before `#leftview` (split), a 43px margin on the target document's root while armed (hosted), removed on Done/Esc/discard.
- **Theme-aware**: the bar reads the shell's tokens (copied onto the node, re-copied on `data-theme` change) — light shell gets a light bar. Pins and composer keep their fixed look over the app.
- **Folds by measure**, never a breakpoint: sentence → button words → label word; controls never clip.
- Idle strip order: Screenshot · Comment · Annotate. The picker's strip width-reserve is gone with the picker.

## Verified
- cmux browser runs: arm/disarm both modes, pin math after the push (pixel-exact), Point/Element toggle on the bar, Done/discard/Esc/stop, tiers at 1015/700/480/340/240/200px, no console errors.
- `pytest tests/` green (env-only known failures aside), `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large client-side change (DOM portaling, cross-document styling, margin on hosted apps) touches the core annotation UX; mitigated by busy-state guards, teardown cleanup, and extensive regression tests.
> 
> **Overview**
> Arming **Comment** or a **voice walkthrough** now shows an **annotation bar** on the preview pane: mode label, a one-line instruction, the **Element/Point** picker, and **Done** (or **■ + live clock** while recording). The chat strip keeps the **exit** controls (Done/stop, trash) and idle tools are reordered to **Screenshot · Comment · Annotate**.
> 
> **Element/Point** is no longer reserved in the strip width calculation—the strip’s `#anntool` is **adopted into the bar** while the mode is on (one node, one state). Cross-origin targets skip the picker on the bar.
> 
> The bar **does not cover** the app: in the split layout it is a **flex row above** `#leftview`; in hosted targets it applies a **43px `margin-top`** on the target document (cleared on hide/target loss). Shell **theme tokens** are copied onto bars in other documents and refreshed on `data-theme` changes. **Narrow widths** fold copy via measured tiers (`annBarFit`), not breakpoints.
> 
> **Discard** is visible for any armed mode (not only recording), hidden while `.busy` (stopping/transcribing). Clicks route to **`annRecDiscard`** or new **`annNotesDiscard`** (drops unsent notes from the current round). Composer outside-click handling treats **`.annbar`** like the strip so bar **Done** does not drop drafts.
> 
> Tests cover bar placement in all annotation layers, paint/fit/push/theme behavior, and typed-round discard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca29d9017882c73368bb665b1d38aa6d4ee9b280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->