### PR TITLE
Cards: a task popup from the head, nine a page, every lane but Archive

### DIFF
--- a/frontend/src/platform/ui/modal/Modal.tsx
+++ b/frontend/src/platform/ui/modal/Modal.tsx
@@ -35,8 +35,12 @@ import {
   isDisarmingInteraction,
 } from "./dirty-guard";
 
+// `iframe` is in the list because a framed document IS a focusable stop — the
+// Tasks page's card popup is a chat in a frame, and a trap that skipped it would
+// cycle the head's two buttons forever while the thing the dialog exists for
+// sat one Tab away and unreachable (Bugbot, #1009).
 const FOCUSABLE =
-  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
+  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),iframe,[tabindex]:not([tabindex="-1"])';
 
 export interface ModalProps {
   title: ReactNode;

--- a/frontend/src/platform/ui/modal/Modal.tsx
+++ b/frontend/src/platform/ui/modal/Modal.tsx
@@ -58,6 +58,12 @@ export interface ModalProps {
   dialogClassName?: string;
   // Tooltip for the ✕ button (e.g. "the action keeps running" for a busy={false} modal).
   closeTitle?: string;
+  // Controls that sit in the head BESIDE the ✕ — the same row, the same weight
+  // (`.deploy-close`), to its left. For a dialog whose actions are about the
+  // thing it shows rather than about the form in it (the Tasks page's card
+  // popup: open in List, open in Explorer, archive), where a footer row of
+  // buttons under a live chat read as a form's Save/Cancel.
+  headActions?: ReactNode;
   // Drop the `deploy-body` form vocabulary from the body — its descendant
   // `button`/`p` rules (fields.css) out-specify a component's own classes and
   // would re-skin a surface that arrives already designed. For hosting a
@@ -78,6 +84,7 @@ export function Modal({
   dialogClassName,
   closeTitle,
   plainBody = false,
+  headActions,
 }: ModalProps) {
   const titleId = useId();
   // Exit animation. Callers render this as `{open && <Modal …/>}`, so the modal
@@ -298,6 +305,7 @@ export function Modal({
               frees rclone's callback port, which is what closing out from under
               it would strand). So the corner is empty for those seconds rather
               than occupied by something inert. */}
+          {headActions && <div className="modal-head-actions">{headActions}</div>}
           {!busy && (
             <button
               type="button"

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -44,6 +44,7 @@ import {
 } from "@platform/lib/api";
 import type { Task, TaskMessage } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
+import { useMarginWheel } from "./useMarginWheel";
 import { BOARD_COLUMNS, BOARD_LANES, columnLabel, laneOf } from "./schedule-lib";
 import type { BoardColumn, BoardLane } from "./schedule-lib";
 import {
@@ -1382,48 +1383,10 @@ export function TaskList({
     remember({ ...memory.current, expanded: [...expanded] });
   }, [expanded]);
 
-  // ---- the wheel works in the margins too -------------------------------------
-  // `.schedule-main` is capped at 1050px and centred, so a wide window leaves a
-  // band of empty page either side of the card — and the card is the scroller,
-  // so a wheel out in that band lands on `.schedule-page`, which is
-  // `overflow: hidden` and scrolls nothing: the reader had to aim at the card
-  // (Akshil, 2026-08-20). Making the scroller full-width instead was tried first
-  // and traded this for two worse bugs — the card's frame scrolled away with its
-  // content, and the reserved scrollbar gutters pushed the card off the
-  // toolbar's axis (bugbot, #678) — so the geometry stays exactly as it was and
-  // the wheel is forwarded: a wheel anywhere on this page that no scroller of
-  // its own claims is handed to the list. Board and Calendar mount their own
-  // components, so nothing here can touch their scrolling.
-  useEffect(() => {
-    // The page div, NOT via the ref: on the mount this effect runs after, the
-    // rows are usually still in flight and the ref is still null — the page
-    // ancestor is the one element of this pair that is always there. The ref is
-    // read again inside the handler, per wheel, for the same reason.
-    const page = document.querySelector<HTMLElement>(".schedule-page");
-    if (!page) return;
-    const onWheel = (e: WheelEvent) => {
-      const el = listRef.current;
-      if (!el || !(e.target instanceof Element) || e.deltaY === 0) return;
-      // Pinch-zoom arrives as ctrl+wheel; that is a zoom, not a scroll.
-      if (e.ctrlKey) return;
-      // Anything between the pointer and the page that scrolls for itself —
-      // the list, a menu, a popover — keeps its native wheel untouched.
-      for (let n: Element | null = e.target; n && n !== page; n = n.parentElement) {
-        const s = getComputedStyle(n);
-        if (
-          (s.overflowY === "auto" || s.overflowY === "scroll") &&
-          n.scrollHeight > n.clientHeight
-        ) {
-          return;
-        }
-      }
-      // deltaMode 1 is lines (Firefox with a wheel mouse); everything else
-      // that reaches a web page is already pixels.
-      el.scrollTop += e.deltaMode === 1 ? e.deltaY * 16 : e.deltaY;
-    };
-    page.addEventListener("wheel", onWheel, { passive: true });
-    return () => page.removeEventListener("wheel", onWheel);
-  }, []);
+  // A wheel out in the empty band either side of the 1050px column reaches the
+  // list (useMarginWheel — shared with the Cards wall, and the history of why
+  // the geometry is left alone is written there).
+  useMarginWheel(listRef);
 
   const onScroll = () => {
     const el = listRef.current;

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -83,7 +83,7 @@ import {
 } from "./ScheduleTaskViews";
 import type { TaskFilters } from "./ScheduleTaskViews";
 import { publishTasks, TASKS_POKE_EVENT, useTasksFeeder } from "./tasksPulse";
-import { CARD_LANES, TASK_VIEWS, mergeTaskChanges, viewFromSearch, viewUrl } from "./tasks-lib";
+import { TASK_VIEWS, mergeTaskChanges, viewFromSearch, viewUrl } from "./tasks-lib";
 import type { TaskView } from "./tasks-lib";
 import { TaskCards } from "./TaskCards";
 import { isUnderDir } from "./current-apps-lib";
@@ -615,20 +615,12 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           ) : view === "cards" ? (
             <TaskCards
               // The FILTERED set, like every other view: Cards narrows it again
-              // to what is running (tasks-lib.cardsForTasks), and a Project or
-              // a Search the reader set on another view is a lens they meant to
+              // (tasks-lib.cardsForTasks drops Archive), and a Project or a
+              // Search the reader set on another view is a lens they meant to
               // keep — the same argument that put the toolbar on the calendar.
               tasks={shown}
               home={home}
-              // Past the cap, the trailing card hands the overflow to the List
-              // with the Status facet set to what this view was showing. Both
-              // halves in one gesture — a switch to a List still showing
-              // everything would be an answer to a different question than the
-              // one the card was asked.
-              onShowRunning={() => {
-                setFilters((f) => ({ ...f, statuses: CARD_LANES }));
-                pickView("list");
-              }}
+              onReload={reload}
             />
           ) : (
             <TaskList

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -1,6 +1,7 @@
-// The Tasks page's fourth view: CARDS — every running conversation, side by
-// side, streaming (Akshil, 2026-09-03: "like a eagle eye view of all chats
-// streaming in at the same time").
+// The Tasks page's fourth view: CARDS — every task's conversation, side by
+// side, the running ones streaming (Akshil, 2026-09-03: "like a eagle eye view
+// of all chats streaming in at the same time"; 2026-09-05: "all tasks here
+// except archived").
 //
 // It is the one view on this page that does not draw ROWS ABOUT tasks. The List,
 // the Board and the Calendar all answer "what is there and where does it sit";
@@ -21,20 +22,24 @@
 //   * IDENTITY ACROSS POLLS. The page re-renders every 20 seconds with a fresh
 //     array. A card keyed by anything but the task would remount its iframe on
 //     each poll, which is a reload of a live conversation every 20 seconds.
-//   * A BUDGET. Live documents are not free (tasks-lib.CARD_CAP).
+//   * A BUDGET. Live documents are not free, so the wall is drawn a page of
+//     nine at a time (tasks-lib.CARD_PAGE) and grows only when asked.
 //
 // Everything about WHICH tasks and in WHAT ORDER is tasks-lib.cardsForTasks —
 // pure, tested, and out of here, because a wall of iframes is the last place
 // anybody can test a sort.
 import { useEffect, useMemo, useRef, useState } from "react";
-import { statPath } from "@platform/lib/api";
+import { archiveTask, statPath, unarchiveTask } from "@platform/lib/api";
 import type { Task } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
-import { cardFrameSrc, folderHref } from "./schedule-lib";
+import { Modal } from "@platform/ui/modal/Modal";
+import { cardFrameSrc, folderHref, peekFrameSrc } from "./schedule-lib";
 import { StatusIcon } from "./ScheduleTaskViews";
 import {
+  CARD_PAGE,
   cardKey,
   cardsForTasks,
+  filingIntent,
   firstLine,
   opensElsewhere,
   taskColumn,
@@ -42,11 +47,12 @@ import {
   taskWhen,
   tildePath,
 } from "./tasks-lib";
+import { useMarginWheel } from "./useMarginWheel";
 
-/** What the page says when nothing is running. The same words whatever the
- *  reason — nothing started, or a filter narrowed it away — because the view's
- *  claim is about the set it was handed, and it cannot tell those apart. */
-export const CARDS_EMPTY = "Nothing running right now.";
+/** What the page says when there is nothing to draw — the Board's own words,
+ *  whatever the reason (no tasks, or a filter narrowed them away), because the
+ *  view's claim is about the set it was handed and it cannot tell those apart. */
+export const CARDS_EMPTY = "Nothing to show here.";
 
 /** The claude template's path for one folder, cached for this mounting.
  *
@@ -96,20 +102,35 @@ function useChatTemplates(dirs: string[]): Record<string, string> {
 export function TaskCards({
   tasks,
   home = "",
-  onShowRunning,
+  onReload,
 }: {
-  /** Already filtered, in the SERVER's order — `cardsForTasks` picks the running
-   * ones and orders them, which is the one thing this view does to the set it is
-   * handed and the one place it is decided. */
+  /** Already filtered, in the SERVER's order — `cardsForTasks` drops the
+   * archived ones and orders the rest, which is the one thing this view does to
+   * the set it is handed and the one place it is decided. */
   tasks: Task[];
   home?: string;
-  /** "+N more running": take the reader to the List, narrowed to what this view
-   * was showing. A callback and not an href because the filter lives in page
-   * state rather than in the URL — and a link that PROMISED a filtered list and
-   * delivered an unfiltered one would be the worse half of that trade. */
-  onShowRunning?: () => void;
+  /** After the popup archives or unarchives: the card's lane changed, so the
+   * page re-reads — the same call the Board's drops and the List's row make. */
+  onReload?: () => void;
 }) {
-  const { cards, hidden } = useMemo(() => cardsForTasks(tasks), [tasks]);
+  // THE POPUP (Akshil, 2026-09-05): one task at a time, opened from a card's
+  // head. Held as the Task itself and not a key — a task that leaves the set
+  // (archived from inside the popup, or filtered away) keeps its popup until
+  // the reader closes it, because the frame in it is a real session and
+  // closing it under them would lose whatever they were typing.
+  const [peek, setPeek] = useState<Task | null>(null);
+  // HOW MANY PAGES THE READER HAS ASKED FOR. Nine cards to begin with, and each
+  // press of the trailing card adds nine (Akshil, 2026-09-05). Never wound back
+  // by a poll: the list refreshes every 20 seconds, and a wall that collapsed to
+  // its first page each time would undo the reader's own gesture under them.
+  const [pages, setPages] = useState(1);
+  const { cards, hidden } = useMemo(() => cardsForTasks(tasks, pages * CARD_PAGE), [tasks, pages]);
+  // The wheel works in the gutters either side of the column (Akshil,
+  // 2026-09-05: "when I try to scroll, it does not scroll") — forwarded to the
+  // wall, the List's own rule, rather than by widening the scroller, which is
+  // what put the two views' scrollbars in different places.
+  const wallRef = useRef<HTMLDivElement | null>(null);
+  useMarginWheel(wallRef);
   // Distinct folders, in a stable order, so the template lookup below is keyed
   // on the SET and not on which card happened to sort first this poll.
   const dirs = useMemo(() => {
@@ -148,7 +169,13 @@ export function TaskCards({
   }
 
   return (
-    <div className="task-cards">
+    // The SCROLLER is this outer pane — the List's own shape (tasks.css
+    // `.tasks-list`), so the bar sits where the List's does — and the grid is
+    // one child of it, the "Show more" control another, full width beneath. Put
+    // inside the grid the control was one cell of a row sized for a chat, with a
+    // chat's worth of empty track under it (Akshil, 2026-09-05).
+    <div className="task-cards-scroll" ref={wallRef}>
+      <div className="task-cards">
       {cards.map((task) => (
         <TaskCard
           // KEYED BY THE TASK'S IDENTITY and nothing else. Not the index (a
@@ -168,13 +195,27 @@ export function TaskCards({
           // a card that has a session to frame.
           key={cardKey(task)}
           task={task}
-          home={home}
           template={templates[task.target || task.project] ?? null}
+          onPeek={setPeek}
         />
       ))}
+      </div>
+      {peek && (
+        <TaskPeek
+          task={peek}
+          home={home}
+          template={templates[peek.target || peek.project] ?? null}
+          onClose={() => setPeek(null)}
+          onReload={onReload}
+        />
+      )}
       {hidden > 0 && (
-        <button type="button" className="task-card task-card--more" onClick={onShowRunning}>
-          {`+${hidden} more running`}
+        <button
+          type="button"
+          className="task-cards-more"
+          onClick={() => setPages((n) => n + 1)}
+        >
+          Show more
         </button>
       )}
     </div>
@@ -183,18 +224,13 @@ export function TaskCards({
 
 function TaskCard({
   task,
-  home,
   template,
+  onPeek,
 }: {
   task: Task;
-  home: string;
   template: string | null;
+  onPeek: (task: Task) => void;
 }) {
-  // Same fallback the List row's popover makes: a run that is in flight but has
-  // not reported its session yet is still reachable through its FOLDER, and
-  // hiding the only way in during exactly the minutes somebody needs it is the
-  // wrong trade (schedule-lib, above `folderHref`).
-  const href = taskHref(task) ?? folderHref(task);
   const when = taskWhen(task);
   const title = firstLine(task.title) || "(untitled)";
   // Both halves have to be there before anything can be framed: no session means
@@ -206,11 +242,30 @@ function TaskCard({
 
   return (
     <section className="task-card" aria-label={`${task.task_id} ${title}`}>
-      <header className="task-card-head">
+      {/* THE HEAD IS THE DOOR (Akshil, 2026-09-05: "when I click on the heading
+          of the card ... it should open the preview"). The whole strip — ring,
+          id, time, title — is one button that opens the task's popup; the body
+          under it is the live chat and keeps its own clicks. A real button role
+          with the keyboard's two keys, because a header that only a pointer
+          can press is a door with no handle for everyone else. */}
+      <header
+        className="task-card-head"
+        role="button"
+        tabIndex={0}
+        aria-label={`Preview ${task.task_id}`}
+        onClick={() => onPeek(task)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onPeek(task);
+          }
+        }}
+      >
         {/* TWO ROWS (Akshil, 2026-09-04): ring then id at the top-left — the
-            List row's own order — with the time and Open at the right, and the
-            title alone on the second row so it gets the card's whole width at a
-            size that can be read across a wall. */}
+            List row's own order — with the time at the right, and the title
+            alone on the second row so it gets the card's whole width at a size
+            that can be read across a wall. No Open button (Akshil, 2026-09-05):
+            the head itself opens the popup, and the popup carries the doors. */}
         <div className="task-card-head-row">
           {/* The ring is unconditional here, unlike the Board's. A card on this
               view sits under no lane header, so nothing else on it says what
@@ -224,28 +279,6 @@ function TaskCard({
           <span className="task-card-when" title={when.title}>
             {when.text}
           </span>
-          {href && (
-            <a
-              // The app's own small secondary button, not a bare accent link: a
-              // word in the corner of a card read as a label, not as a thing to
-              // press (Akshil, 2026-09-03). Still an <a> with a real href, so
-              // ⌘-click and middle-click keep working.
-              className="btn btn-secondary task-card-open"
-              href={href}
-              aria-label={`Open ${task.task_id}`}
-              onClick={(e) => {
-                // A modified press is left entirely alone — ⌘-click means "open
-                // that in a tab", and this page has no business intercepting it.
-                // The same rule every row on this page follows.
-                if (opensElsewhere(e)) return;
-                e.preventDefault();
-                navigateUrl(href);
-              }}
-              title={tildePath(task.target || task.project, home)}
-            >
-              Open
-            </a>
-          )}
         </div>
         {/* `data-hint`, not `title`: the List row shows its full title in the
             app's own hint the moment the pointer rests (hints.ts), and a native
@@ -269,13 +302,225 @@ function TaskCard({
             // the one frame in the app whose contract differs from the rest.
           />
         ) : (
-          // The window between "claimed and sent" and "we know which chat that
-          // is" (schedule-lib, above `folderHref`) — a real state, a few seconds
-          // to a few minutes long, and the card says so rather than framing the
-          // wrong thing or showing an empty box.
-          <p className="task-card-starting">Starting…</p>
+          // No session to frame. For a scheduled task that is simply not due yet;
+          // for anything else it is the window between "claimed and sent" and
+          // "we know which chat that is" (schedule-lib, above `folderHref`) — a
+          // real state, a few seconds to a few minutes long. Either way the card
+          // says which rather than framing the wrong thing or an empty box.
+          <p className="task-card-starting">
+            {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}
+          </p>
         )}
       </div>
     </section>
   );
 }
+
+/** The popup a card's head opens: the same task's chat at FULL size — a tall
+ *  column, most of the window — with its composer, so a reader can answer a
+ *  question or send the next message without leaving the wall (Akshil,
+ *  2026-09-05), and the two doors the List row already has: the folder with the
+ *  Claude pane, and Archive. Not a third one back to the List — "we are already
+ *  in tasks" (Akshil, 2026-09-05).
+ *
+ *  Built on the app's one modal chassis (platform/ui/modal/Modal) so Esc, the
+ *  backdrop, the ✕, the focus trap and the exit animation are the ones every
+ *  other dialog has. `plainBody`, because the body is a frame and not a form. */
+function TaskPeek({
+  task,
+  home,
+  template,
+  onClose,
+  onReload,
+}: {
+  task: Task;
+  home: string;
+  template: string | null;
+  onClose: () => void;
+  onReload?: () => void;
+}) {
+  const title = firstLine(task.title) || "(untitled)";
+  const src = task.session_id && template
+    ? peekFrameSrc(template, task.target || task.project, task.session_id)
+    : null;
+  // The List row's own fallback: a run with no session yet is still reachable
+  // through its folder (schedule-lib, above `folderHref`).
+  const explorer = taskHref(task) ?? folderHref(task);
+  const filing = filingIntent(task);
+  const [acting, setActing] = useState(false);
+  const [note, setNote] = useState("");
+
+  // ESCAPE FROM INSIDE THE FRAME. The chassis closes on Esc with a listener on
+  // THIS document, and the frame is the dialog's first focusable, so the focus
+  // trap puts the caret in the chat — where the reader wants it — and every key
+  // from then on fires in the frame's document, which the chassis cannot hear.
+  // Measured: Esc did nothing while the composer had focus. Same origin, so the
+  // frame's document takes a listener of its own; a key the template already
+  // stops (its own popovers close on Esc and stopPropagation) never reaches
+  // it, which is the right precedence — Esc closes the innermost thing open.
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  useEffect(() => {
+    const frame = frameRef.current;
+    if (!frame) return;
+    let doc: Document | null = null;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    const attach = () => {
+      try {
+        doc = frame.contentDocument;
+        doc?.addEventListener("keydown", onKey);
+      } catch {
+        // A frame that is not ours (it never is — /render is same-origin — but
+        // a listener is not worth a thrown error).
+      }
+    };
+    frame.addEventListener("load", attach);
+    attach();
+    return () => {
+      frame.removeEventListener("load", attach);
+      doc?.removeEventListener("keydown", onKey);
+    };
+  }, [src, onClose]);
+
+  const refile = async () => {
+    if (!filing) return;
+    setActing(true);
+    setNote("");
+    try {
+      if (filing.kind === "archive") await archiveTask(task.key);
+      else await unarchiveTask(task.key);
+      // The card's lane changed (or it left the wall), so the page re-reads —
+      // and the popup goes with it: a filed task is a closed matter.
+      onReload?.();
+      onClose();
+    } catch (e) {
+      // The server's own sentence, in the List row's quiet voice: nothing was
+      // destroyed either way, which is the whole point of archiving.
+      setNote((e as Error).message);
+      setActing(false);
+    }
+  };
+
+  return (
+    <Modal
+      title={
+        <span className="task-peek-title">
+          <StatusIcon status={taskColumn(task)} failed={task.failed} />
+          <span className="tasks-id tasks-id--task">{task.task_id}</span>
+          {/* Shrink-to-fit, so the hint rides the WORDS and not the empty run
+              of head to their right (Akshil, 2026-09-05). */}
+          <span className="task-peek-name" data-hint={task.title}>
+            {title}
+          </span>
+        </span>
+      }
+      onClose={onClose}
+      width="54vw"
+      dialogClassName="task-peek"
+      plainBody
+      // THE DOORS, IN THE HEAD beside the ✕ (Akshil, 2026-09-05: "move them on
+      // top where we have the close button"), each an icon WITH its word — an
+      // icon alone was not clear — in the app's own small secondary button, the
+      // one the toolbar above this popup wears. Order: the folder, then Archive.
+      headActions={
+        <>
+          {explorer && (
+            <a
+              // A real link with a real href, so ⌘-click and middle-click open
+              // the folder in a tab — the rule every row on this page follows.
+              className="btn btn-secondary modal-head-act"
+              href={explorer}
+              title={tildePath(task.target || task.project, home)}
+              onClick={(e) => {
+                if (opensElsewhere(e)) return;
+                e.preventDefault();
+                onClose();
+                navigateUrl(explorer);
+              }}
+            >
+              {ICON_FOLDER}
+              Open in Explorer
+            </a>
+          )}
+          {filing && (
+            <button
+              type="button"
+              className="btn btn-secondary modal-head-act"
+              disabled={acting}
+              title={filing.title}
+              onClick={refile}
+            >
+              {filing.kind === "archive" ? ICON_ARCHIVE : ICON_UNARCHIVE}
+              {filing.label}
+            </button>
+          )}
+        </>
+      }
+      // The footer exists only while there is a sentence for it: a refused
+      // archive, in the List row's quiet voice.
+      footer={
+        note ? (
+          <span className="task-peek-note" role="status">
+            {note}
+          </span>
+        ) : undefined
+      }
+    >
+      {src ? (
+        <iframe
+          ref={frameRef}
+          className="task-peek-frame"
+          src={src}
+          title={`${task.task_id} ${title}`}
+          // No `sandbox`, for the card frame's reason (TaskCard, above).
+        />
+      ) : (
+        <p className="task-card-starting">
+          {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}
+        </p>
+      )}
+    </Modal>
+  );
+}
+
+// The head's icons, in MenuIcons' own stroke (platform/ui/MenuIcons: 16px,
+// 24-grid, 1.5 stroke, round joins) so they sit in the app's buttons at the
+// weight its menus draw. Inline rather than added to that record because they
+// are this popup's and nothing else's — a folder, an archive box.
+const ICON_PROPS = {
+  width: 16,
+  height: 16,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.5,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  "aria-hidden": true,
+};
+
+/** Open in Explorer — the folder (MenuIcons.folder's outline). */
+const ICON_FOLDER = (
+  <svg {...ICON_PROPS}>
+    <path d="M3.5 7.5A1.5 1.5 0 0 1 5 6h4.2l1.8 2h8a1.5 1.5 0 0 1 1.5 1.5v8A1.5 1.5 0 0 1 19 19H5a1.5 1.5 0 0 1-1.5-1.5z" />
+  </svg>
+);
+
+/** Archive — the box with its lid. */
+const ICON_ARCHIVE = (
+  <svg {...ICON_PROPS}>
+    <path d="M3.5 5.5h17v3.5h-17z" />
+    <path d="M5 9v9.5A1.5 1.5 0 0 0 6.5 20h11a1.5 1.5 0 0 0 1.5-1.5V9" />
+    <path d="M10 13h4" />
+  </svg>
+);
+
+/** Unarchive — the same box, the lid open and an arrow out of it. */
+const ICON_UNARCHIVE = (
+  <svg {...ICON_PROPS}>
+    <path d="M5 9v9.5A1.5 1.5 0 0 0 6.5 20h11a1.5 1.5 0 0 0 1.5-1.5V9" />
+    <path d="M3.5 9h17" />
+    <path d="M12 16v-6M9.5 12.5 12 10l2.5 2.5" />
+  </svg>
+);

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -114,11 +114,20 @@ export function TaskCards({
   onReload?: () => void;
 }) {
   // THE POPUP (Akshil, 2026-09-05): one task at a time, opened from a card's
-  // head. Held as the Task itself and not a key — a task that leaves the set
-  // (archived from inside the popup, or filtered away) keeps its popup until
-  // the reader closes it, because the frame in it is a real session and
+  // head. Held as the Task the head was clicked with, then REFRESHED from every
+  // poll below: a popup opened in the "Starting…" window — the usual moment,
+  // right after creating a task — has no session id yet, and the one that
+  // arrives two seconds later has to reach it or the popup never frames the
+  // chat (Bugbot, #1009). The clicked Task stays as the fallback so a task that
+  // leaves the set (archived from inside the popup, or filtered away) keeps its
+  // popup until the reader closes it: the frame in it is a real session, and
   // closing it under them would lose whatever they were typing.
   const [peek, setPeek] = useState<Task | null>(null);
+  const peekLive = useMemo(() => {
+    if (!peek) return null;
+    const id = cardKey(peek);
+    return tasks.find((t) => cardKey(t) === id) ?? peek;
+  }, [peek, tasks]);
   // HOW MANY PAGES THE READER HAS ASKED FOR. Nine cards to begin with, and each
   // press of the trailing card adds nine (Akshil, 2026-09-05). Never wound back
   // by a poll: the list refreshes every 20 seconds, and a wall that collapsed to
@@ -162,10 +171,29 @@ export function TaskCards({
     };
   }, []);
 
+  // The popup outlives the wall it was opened from: a failed poll empties
+  // `tasks`, and a filter can drop the last card, while someone is typing into
+  // the frame — so it is rendered beside whichever of the two the wall draws,
+  // never inside the branch that has cards (Bugbot, #1009).
+  const popup = peekLive && (
+    <TaskPeek
+      task={peekLive}
+      home={home}
+      template={templates[peekLive.target || peekLive.project] ?? null}
+      onClose={() => setPeek(null)}
+      onReload={onReload}
+    />
+  );
+
   if (cards.length === 0) {
     // The Board's empty styling, deliberately — one page, one way of saying
     // there is nothing here.
-    return <p className="schedule-tv-empty">{CARDS_EMPTY}</p>;
+    return (
+      <>
+        <p className="schedule-tv-empty">{CARDS_EMPTY}</p>
+        {popup}
+      </>
+    );
   }
 
   return (
@@ -200,15 +228,7 @@ export function TaskCards({
         />
       ))}
       </div>
-      {peek && (
-        <TaskPeek
-          task={peek}
-          home={home}
-          template={templates[peek.target || peek.project] ?? null}
-          onClose={() => setPeek(null)}
-          onReload={onReload}
-        />
-      )}
+      {popup}
       {hidden > 0 && (
         <button
           type="button"
@@ -419,6 +439,12 @@ function TaskPeek({
       width="54vw"
       dialogClassName="task-peek"
       plainBody
+      // The caret goes to the CHAT, not to the head's first button: the popup
+      // exists so a reader can type, and a keyboard Enter after opening it must
+      // not follow "Open in Explorer" instead (Bugbot, #1009). Null while the
+      // frame is not there yet ("Starting…"), and the chassis then falls back
+      // to its first focusable as every other dialog does.
+      initialFocus={frameRef}
       // THE DOORS, IN THE HEAD beside the ✕ (Akshil, 2026-09-05: "move them on
       // top where we have the close button"), each an icon WITH its word — an
       // icon alone was not clear — in the app's own small secondary button, the

--- a/frontend/src/shell/schedule-lib.ts
+++ b/frontend/src/shell/schedule-lib.ts
@@ -591,6 +591,23 @@ export function cardFrameSrc(template: string, target: string, sessionId: string
   );
 }
 
+/** The same chat, framed at FULL size for the card's popup (TaskCards
+ *  `TaskPeek`; Akshil, 2026-09-05: a preview "so the user can directly type in
+ *  a message"). `chat_only` still — the popup is about the conversation, not
+ *  the folder — but NOT `compact`: compact is the card's read-only cut of the
+ *  template and hides its composer (`#inputbox`), which is the one thing the
+ *  popup exists to give back. `peek=1` instead, the template's third host cut:
+ *  its own strip (← Chats, ⋮) and top bar go, because the popup's head already
+ *  says which task this is and carries the doors (template.html `PEEK`). */
+export function peekFrameSrc(template: string, target: string, sessionId: string): string {
+  return (
+    `/render?path=${encodeURIComponent(template)}` +
+    `&_file=${encodeURIComponent(target)}` +
+    `&chat_only=1&peek=1` +
+    `&session_id=${encodeURIComponent(sessionId)}`
+  );
+}
+
 // ---- Calendar: the task chip grid ---------------------------------------------
 // The calendar shows the same unit the List and the Board show — a TASK — and
 // what the time axis adds is placement:

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6904,6 +6904,14 @@ describe("the Cards view's frame", () => {
     expect(acts.indexOf("Open in Explorer")).toBeLessThan(acts.indexOf("{filing.label}"));
     expect((acts.match(/className="btn btn-secondary modal-head-act"/g) ?? []).length).toBe(2);
     expect(acts).toContain("{ICON_FOLDER}\n              Open in Explorer");
+    // Bugbot, #1009: the popup follows the polls (a "Starting…" task gains its
+    // session), survives an empty wall (a failed poll, a filter), and puts the
+    // caret in the chat.
+    expect(CARDS).toContain("return tasks.find((t) => cardKey(t) === id) ?? peek;");
+    const emptyBranch = CARDS.slice(CARDS.indexOf("if (cards.length === 0) {"), CARDS.indexOf("return (\n    // The SCROLLER"));
+    expect(emptyBranch).toContain("{popup}");
+    expect(CARDS).toContain("initialFocus={frameRef}");
+    expect(readFileSync(join(SHELL, "../platform/ui/modal/Modal.tsx"), "utf8")).toContain("select:not([disabled]),iframe,");
     // The dialog clips its own corners: the frame must not paint over the radius.
     expect(block(CARDS_CSS, ".modal-dialog.task-peek")).toContain("overflow: hidden");
     // The title shrinks to its words, so the hint is not over empty head.

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Task, TaskMessage } from "@platform/lib/api";
-import { BOARD_COLUMNS, BOARD_LANES, cardFrameSrc, laneOf } from "./schedule-lib";
+import { BOARD_COLUMNS, BOARD_LANES, cardFrameSrc, laneOf, peekFrameSrc } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 import {
   ALL_MESSAGES,
@@ -21,7 +21,7 @@ import {
   filingIntent,
   basename,
   canCancel,
-  CARD_CAP,
+  CARD_PAGE,
   CARD_LANES,
   cardKey,
   cardsForTasks,
@@ -6596,13 +6596,14 @@ function asking(key: string, at: number, over: Partial<Task> = {}): Task {
 }
 
 describe("cardsForTasks", () => {
-  it("draws the two running lanes, waiting first, and nothing else", () => {
-    // CARD_LANES is both the membership test and the rank order (see
-    // LIVE_LANE_NAMES), which is why this asserts the ORDER of the list and not
-    // merely its contents: change it and the wall re-sorts, with nothing else to
-    // keep in step. Every name in it is still a real board column, so a lane
-    // renamed out from under us fails here rather than silently drawing nothing.
-    expect(CARD_LANES).toEqual(["needs_attention", "in_progress"]);
+  it("draws every lane but Archive, in the List's own rank order", () => {
+    // Akshil, 2026-09-05: "we show all tasks here except archived". CARD_LANES is
+    // both the membership test and the rank order, and it is LIST_ORDER minus
+    // Archive rather than a second list — so the wall and the List can never
+    // disagree about which lane comes first. Every name in it is still a real
+    // board column.
+    expect(CARD_LANES).toEqual(LIST_ORDER.filter((k) => k !== "archived"));
+    expect(CARD_LANES).toEqual(["needs_attention", "blocked", "upcoming", "in_progress", "done"]);
     for (const key of CARD_LANES) expect(BOARD_COLUMNS.map((c) => c.key)).toContain(key);
     const rows = [
       running("a", 100),
@@ -6613,7 +6614,8 @@ describe("cardsForTasks", () => {
       asking("f", 50),
     ];
     // "f" is OLDER than "a" and still comes first: the lane outranks the clock.
-    expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["f", "a"]);
+    // "e" — archived — is the one row not drawn.
+    expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["f", "d", "c", "a", "b"]);
   });
 
   it("groups by lane before it sorts, blocked first, then in progress", () => {
@@ -6710,17 +6712,23 @@ describe("cardsForTasks", () => {
     expect(cardsForTasks(older).cards.map((t) => t.key)).toEqual(["a", "b"]);
   });
 
-  it("caps the wall and counts what it left out", () => {
-    const rows = Array.from({ length: CARD_CAP + 3 }, (_, i) =>
+  it("draws a page of nine and counts what is behind it", () => {
+    // Nine: six in view and one more row loaded under the fold (Akshil,
+    // 2026-09-05: "6 in view, and 3 more loaded if user wants to scroll").
+    expect(CARD_PAGE).toBe(9);
+    const rows = Array.from({ length: CARD_PAGE + 3 }, (_, i) =>
       running(`t${i}`, 1000 - i),
     );
     const set = cardsForTasks(rows);
-    expect(set.cards).toHaveLength(CARD_CAP);
+    expect(set.cards).toHaveLength(CARD_PAGE);
     expect(set.hidden).toBe(3);
-    // The cap keeps the TOP of the order, not an arbitrary slice.
+    // The page keeps the TOP of the order, not an arbitrary slice.
     expect(set.cards[0].key).toBe("t0");
-    // Exactly at the cap nothing is hidden, so no trailing card is drawn.
-    expect(cardsForTasks(rows.slice(0, CARD_CAP)).hidden).toBe(0);
+    // Exactly at the page nothing is hidden, so no trailing card is drawn.
+    expect(cardsForTasks(rows.slice(0, CARD_PAGE)).hidden).toBe(0);
+    // A second page is the same call with twice the cap — what the view does
+    // when "Show 9 more" is pressed.
+    expect(cardsForTasks(rows, 2 * CARD_PAGE).hidden).toBe(0);
   });
 
   it("never mutates the list React is still holding", () => {
@@ -6763,26 +6771,42 @@ describe("the Cards view's frame", () => {
   });
 
   it("says the empty state in the Board's own words and styling", () => {
-    expect(CARDS).toContain('"Nothing running right now."');
+    expect(CARDS).toContain('"Nothing to show here."');
+    // A task with no session yet: "Starting…" for a run in flight, and the
+    // honest phrase for a scheduled one that is simply not due.
+    expect(CARDS).toContain('taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"');
     expect(CARDS).toContain('className="schedule-tv-empty"');
   });
 
   it("lays the wall out three across, two down, and scrolls the rest — never sideways", () => {
-    // Six in view, then scroll (Akshil, 2026-09-04) — the frame inside is scaled
-    // so a third column stays readable. The wall is the scroll
+    // Six in view, nine loaded, then scroll (Akshil, 2026-09-04/05) — the frame
+    // inside is scaled so a third column stays readable. The wall is the scroll
     // container, in the List's own shape, and the rows are sized from it so two
     // rows fill the height the toolbar leaves on ANY monitor.
-    expect(CARDS_CSS).toContain(".schedule-page .schedule-main > .task-cards {\n  flex: 1 1 auto;\n  min-height: 0;\n  overflow-y: auto;\n}");
+    // The scroller is a pane in the List's own shape and the List's own column
+    // — same bar, same place, when switching views (Akshil, 2026-09-05). Nothing
+    // here widens `.schedule-main` or pads the column back in.
+    expect(block(CARDS_CSS, ".schedule-page .schedule-main > .task-cards-scroll")).toContain(
+      "flex: 1 1 auto;\n  min-height: 0;\n  overflow-y: auto;",
+    );
+    expect(CARDS_CSS).not.toContain("max-width: none");
+    expect(CARDS_CSS).not.toContain("padding-inline");
+    // ...and it wears the same 10px non-overlay bar as the List and the Board
+    // (schedule.css, "The scrollbar the Tasks page's ... scrollers wear").
+    const SCHED_CSS = readFileSync(join(SHELL, "../styles/schedule.css"), "utf8");
+    expect(SCHED_CSS).toContain(".tasks-list,\n.task-cards-scroll {\n  scrollbar-gutter: stable;");
+    expect(SCHED_CSS).toContain(".tasks-list::-webkit-scrollbar,\n.task-cards-scroll::-webkit-scrollbar {\n  width: 10px;");
+    expect(CARDS).toContain('<div className="task-cards-scroll" ref={wallRef}>');
+    // ...and a wheel in the margins reaches it, by the List's own rule — ONE
+    // hook for both views (useMarginWheel), not a second forwarding rule.
+    expect(CARDS).toContain("useMarginWheel(wallRef);");
+    expect(VIEWS).toContain("useMarginWheel(listRef);");
+    expect(VIEWS).not.toContain('addEventListener("wheel"');
     // ...and the page grows to the fold for THIS view only — every other view is
-    // content-sized, and the rows here are sized from the page.
-    expect(CARDS_CSS).toContain(".schedule-page:has(> .schedule-main > .task-cards) {\n  flex: 1 1 auto;\n}");
+    // content-sized, and the rows here are sized from the pane.
+    expect(CARDS_CSS).toContain(".schedule-page:has(> .schedule-main > .task-cards-scroll) {\n  flex: 1 1 auto;\n}");
+    expect(block(CARDS_CSS, ".schedule-page .schedule-main > .task-cards-scroll")).toContain("container-type: size");
     expect(CARDS_CSS).toContain("grid-template-columns: repeat(3, minmax(0, 1fr));");
-    // The wheel works in the gutters: the section spans the window on this view
-    // and the 1050px column is re-made as padding on the scroller itself
-    // (Akshil, 2026-09-04).
-    expect(CARDS_CSS).toContain(".schedule-page:has(> .schedule-main > .task-cards) > .schedule-main {\n  max-width: none;\n}");
-    expect(block(CARDS_CSS, ".task-cards")).toContain("padding-inline: max(0px, calc((100% - 1050px) / 2));");
-    expect(CARDS_CSS).toContain("> .schedule-main > .schedule-toolbar {\n  width: 100%;\n  max-width: 1050px;\n  margin-inline: auto;");
     // The chat inside is drawn at 3/4 and laid out at 4/3, so the product is
     // exactly the body — no clipping, no gap, readable at a third of the width.
     const frame = block(CARDS_CSS, ".task-card-frame");
@@ -6794,17 +6818,21 @@ describe("the Cards view's frame", () => {
     // not a native `title` that arrives a second later.
     expect(CARDS).toContain('<span className="task-card-title" data-hint={task.title}>');
     expect(CARDS).not.toContain('className="task-card-title" title=');
-    // Two rows: ring then id top-left (the List row's order), time and Open at
-    // the right, the title alone below (Akshil, 2026-09-04).
+    // Two rows: ring then id top-left (the List row's order), the time at the
+    // right, the title alone below (Akshil, 2026-09-04). No Open button
+    // (Akshil, 2026-09-05).
+    expect(CARDS).not.toContain("task-card-open");
+    expect(CARDS_CSS).not.toContain("task-card-open");
     expect(CARDS).toContain('<span className="tasks-id tasks-id--task">{task.task_id}</span>');
-    const head = CARDS.slice(CARDS.indexOf('<header className="task-card-head">'), CARDS.indexOf("</header>"));
+    const head = CARDS.slice(CARDS.indexOf('<header\n        className="task-card-head"'), CARDS.indexOf("</header>"));
+    expect(head.length).toBeGreaterThan(0);
     const row = head.slice(head.indexOf('<div className="task-card-head-row">'), head.indexOf("</div>"));
     expect(row.indexOf("<StatusIcon")).toBeLessThan(row.indexOf("tasks-id--task"));
     expect(row.indexOf("tasks-id--task")).toBeLessThan(row.indexOf("task-card-when"));
     expect(head.indexOf("</div>")).toBeLessThan(head.indexOf('className="task-card-title"'));
     expect(block(CARDS_CSS, ".task-card-head")).toContain("flex-direction: column");
     expect(block(CARDS_CSS, ".task-card-head-row > .task-card-when")).toContain("margin-left: auto");
-    expect(CARDS_CSS).toContain("grid-auto-rows: max(260px, calc((100% - 12px) / 2));");
+    expect(CARDS_CSS).toContain("grid-auto-rows: max(260px, calc((100cqh - 12px) / 2));");
     // A fixed COUNT, not auto-fill/auto-fit: the wall must not re-flow every time
     // the window grows by a card's worth.
     expect(CARDS_CSS).not.toMatch(/repeat\(auto-/);
@@ -6821,22 +6849,74 @@ describe("the Cards view's frame", () => {
     // (Akshil, 2026-09-03).
     expect(SCHEDULED.indexOf('data-view="cards"')).toBeLessThan(SCHEDULED.indexOf('data-view="calendar"'));
     expect(TASK_VIEWS).toEqual(["list", "board", "cards", "calendar"]);
-    // Open is a BUTTON — the app's own small secondary skin on a real link.
-    expect(CARDS).toContain('className="btn btn-secondary task-card-open"');
-    expect(CARDS_CSS).toContain(".schedule-main .task-card-head .task-card-open {");
     expect(SCHEDULED).toContain('pickView("cards")');
     expect(SCHEDULED).toContain('view === "cards" ? (');
     // The same filtered set every other view is handed.
     expect(SCHEDULED).toContain("<TaskCards");
   });
 
-  // bugbot, PR #969: CARD_LANES already includes needs_attention, but the
-  // overflow's "+N more running" handoff to the List filtered to a hardcoded
-  // ["in_progress"] — a waiting card that was on the grid vanished from the
-  // List it was handed off to. It has to hand off the SAME set the grid drew.
-  it("hands the overflow to the List filtered to every lane Cards drew, not just in_progress", () => {
-    expect(SCHEDULED).toContain("statuses: CARD_LANES");
-    expect(SCHEDULED).not.toContain('statuses: ["in_progress"]');
+  it("grows by a page of nine on the trailing card, and never navigates away", () => {
+    // "Show 9 more" adds the next page in place (Akshil, 2026-09-05). The old
+    // trailing card handed the overflow to the List; this one stays on the wall.
+    expect(CARDS).toContain("const [pages, setPages] = useState(1);");
+    expect(CARDS).toContain("cardsForTasks(tasks, pages * CARD_PAGE)");
+    expect(CARDS).toContain("onClick={() => setPages((n) => n + 1)}");
+    // A full-width strip UNDER the grid, not a cell in it (one card wide and a
+    // chat tall, with the rest of the row empty beneath).
+    expect(CARDS).toContain('className="task-cards-more"');
+    expect(CARDS).not.toContain("task-card--more");
+    expect(block(CARDS_CSS, ".task-cards-more")).toContain("width: 100%");
+    // Just "Show more" (Akshil, 2026-09-05) — the count is the wall's business.
+    expect(CARDS).toContain(">\n          Show more\n        </button>");
+    expect(CARDS).not.toContain("onShowRunning");
+    expect(SCHEDULED).not.toContain("onShowRunning");
+  });
+
+  it("opens the task's popup from the head, and the popup frames the chat with its composer", () => {
+    // Akshil, 2026-09-05: click the head → a 60%-of-the-window preview you can
+    // type into, with buttons for the List, the Explorer and Archive.
+    const head = CARDS.slice(CARDS.indexOf("<header"), CARDS.indexOf("</header>"));
+    expect(head).toContain('role="button"');
+    expect(head).toContain("onClick={() => onPeek(task)}");
+    expect(head).toContain('e.key === "Enter" || e.key === " "');
+    // The head has no Open of its own any more — the popup carries the doors.
+    expect(head).not.toContain("href");
+    // The app's one modal chassis, at 60vw, with the matching height in CSS.
+    expect(CARDS).toContain('import { Modal } from "@platform/ui/modal/Modal";');
+    expect(CARDS).toContain('width="54vw"');
+    expect(CARDS).toContain('dialogClassName="task-peek"');
+    // Narrower than it is tall (Akshil, 2026-09-05: "reduce the width a little
+    // bit but increase it in height").
+    expect(block(CARDS_CSS, ".modal-dialog.task-peek")).toContain("height: 82vh");
+    // Full-size chat WITH the composer: chat_only, never compact (compact hides
+    // the template's input box — it is the card's read-only cut).
+    // ...and `peek=1`, which takes the template's own strip and top bar away
+    // (the popup's head says all of that already).
+    expect(peekFrameSrc("/tpl/claude.html", "/Users/me/proj", "sess-9")).toBe(
+      "/render?path=%2Ftpl%2Fclaude.html&_file=%2FUsers%2Fme%2Fproj&chat_only=1&peek=1&session_id=sess-9",
+    );
+    // The two doors, folder then Archive, in the head beside the ✕ as the app's
+    // own buttons — icon AND word (Akshil, 2026-09-05: an icon alone "is not
+    // clear"). No "Open in Tasks": we are already in Tasks.
+    const acts = CARDS.slice(CARDS.indexOf("headActions={"), CARDS.indexOf("footer={"));
+    expect(acts).not.toContain("Open in Tasks");
+    expect(acts.indexOf("Open in Explorer")).toBeGreaterThan(-1);
+    expect(acts.indexOf("Open in Explorer")).toBeLessThan(acts.indexOf("{filing.label}"));
+    expect((acts.match(/className="btn btn-secondary modal-head-act"/g) ?? []).length).toBe(2);
+    expect(acts).toContain("{ICON_FOLDER}\n              Open in Explorer");
+    // The dialog clips its own corners: the frame must not paint over the radius.
+    expect(block(CARDS_CSS, ".modal-dialog.task-peek")).toContain("overflow: hidden");
+    // The title shrinks to its words, so the hint is not over empty head.
+    expect(block(CARDS_CSS, ".task-card-title")).toContain("width: fit-content");
+    expect(block(CARDS_CSS, ".task-peek-name")).toContain("flex: 0 1 auto");
+    // Archive is the List row's own decision (filingIntent) and calls.
+    expect(CARDS).toContain("const filing = filingIntent(task);");
+    expect(CARDS).toContain('if (filing.kind === "archive") await archiveTask(task.key);');
+    // Esc closes even with the caret in the chat: the frame's own document gets
+    // the listener, since the chassis's listener on this document never hears
+    // a key pressed inside the frame (measured, 2026-09-05).
+    expect(CARDS).toContain('doc?.addEventListener("keydown", onKey);');
+    expect(CARDS).toContain('if (e.key === "Escape") onClose();');
   });
 });
 

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2836,59 +2836,49 @@ export function sortByLane(tasks: Task[], now: number = Date.now()): Task[] {
 
 // ---- the Cards view's set ----------------------------------------------------
 // The fourth view (Akshil, 2026-09-03: "a eagle eye view of all chats streaming
-// in at the same time"). It is not another arrangement of the same rows — it is
-// a DIFFERENT SET: every task whose work is happening right now, each one
-// showing its live conversation rather than a title and a time.
+// in at the same time"). It is not another arrangement of the same rows — each
+// card shows the task's live conversation rather than a title and a time.
 //
-// So the only three decisions it makes are here, out of the component, because
-// they are the ones worth testing and a grid of iframes is the last place to
-// test anything.
+// EVERY TASK BUT THE ARCHIVED ONES (Akshil, 2026-09-05: "we show all tasks here
+// except archived"). The wall began as the running set alone; a finished run's
+// transcript is as much worth a glance as a live one, and Archive is the one
+// lane whose whole meaning is "not on any wall". So the membership test is the
+// List's own rank order minus that lane, and the RANK is the List's too: which
+// lane comes first is written down exactly once (LIST_ORDER) and this view reads
+// it rather than keeping a second table in step. Needs attention at the top,
+// because a parked run is the one card that needs a person; Done at the bottom.
 //
-// WHICH LANES COUNT AS RUNNING is checked against BOARD_COLUMNS rather than
-// trusted on its own. Today that is two lanes — In Progress, the server's word
-// for "a turn is in flight or queued" (api.ts `Task.status`), and Needs
-// attention, the same turn parked on a question — but this is a NAME LIST
-// intersected with the board's columns, so a lane added there under one of these
-// names joins this view by existing, and a lane renamed out from under us drops
-// out of it instead of silently filtering to nothing. A hardcoded
-// `status === "in_progress"` would have to be found and edited on that day, and
-// the symptom of missing it is an empty page rather than an error.
+// The one decision that is this view's own is the clock inside a lane: `started`
+// rather than `last_active`, because `last_active` climbs on every write and
+// reaches this page within a second, so cards traded places for as long as
+// anything was talking (cardsForTasks, below).
 //
-// AN ORDERED LIST, NOT A SET (Akshil, 2026-09-03: cards sorted "the same way we
-// have in list … blocked first and then in progress"). The list's own order IS
-// the wall's rank order — `cardsForTasks` reads the index of a card's lane in
-// `CARD_LANES` — so which lane comes first is written down exactly once, here,
-// instead of in a second rank table that would have to be kept in step with
-// this one. That is also why the order is no longer BOARD_COLUMNS': the board
-// draws its columns left to right for its own reasons (In Progress before Needs
-// attention, which shares Blocked's lane anyway — schedule-lib.laneOf), and a
-// wall of live chats wants the one that has STOPPED to ask something at the top.
-const LIVE_LANE_NAMES: readonly string[] = [
-  "needs_attention",
-  "in_progress",
-];
+// So the only decisions it makes are here, out of the component, because they
+// are the ones worth testing and a grid of iframes is the last place to test
+// anything.
 
-/** The lanes a Cards view draws, top rank first — see LIVE_LANE_NAMES. */
-export const CARD_LANES: BoardColumn[] = LIVE_LANE_NAMES.filter(
-  (name): name is BoardColumn => BOARD_COLUMNS.some((c) => c.key === name),
-);
+/** The lanes a Cards view draws, top rank first — LIST_ORDER without Archive. */
+export const CARD_LANES: BoardColumn[] = LIST_ORDER.filter((key) => key !== "archived");
 
 /**
- * HOW MANY LIVE CHATS AT ONCE. Each card is an iframe running the chat template,
- * and that template polls its run every 400ms — so the cap is not a layout
- * choice, it is the budget: twelve documents polling four times what one does is
- * already the most a laptop should be asked for to answer "what is running".
+ * HOW MANY LIVE CHATS PER PAGE. Each card is an iframe running the chat template,
+ * and that template polls its run every 400ms — so the wall does not draw every
+ * running task at once. It draws NINE, and a "Show 9 more" card at the end adds
+ * the next nine on request (Akshil, 2026-09-05: "a show more button that shows
+ * nine more, nine more, nine more"). The budget is the reader's, taken a page at
+ * a time, rather than a ceiling the view imposes.
  *
- * Twelve rather than a rounder eight because the grid is 1-4 columns wide
- * (task-cards.css), and twelve is the number that fills every one of those
- * widths flush — a cap that leaves a ragged final row of one looks like a bug in
- * the grid rather than a limit that was chosen.
+ * Nine because the grid is three across and two rows deep before the fold
+ * (task-cards.css): six in view and a third row already loaded underneath for
+ * whoever scrolls, and every page after it three more full rows — so no page
+ * ends on a ragged row that would read as a bug in the grid.
  */
-export const CARD_CAP = 12;
+export const CARD_PAGE = 9;
 
-/** What the Cards view draws: the live tasks it can afford, and how many it had
- * to leave out. `hidden` is 0 whenever nothing was dropped, so the trailing
- * "+N more running" card is drawn on a truthy number and never on a zero. */
+/** What the Cards view draws: the live tasks within the pages shown so far, and
+ * how many are still behind the fold. `hidden` is 0 whenever nothing was left
+ * out, so the trailing "Show N more" card is drawn on a truthy number and never
+ * on a zero. */
 export interface TaskCardSet {
   cards: Task[];
   hidden: number;
@@ -2949,12 +2939,10 @@ export function cardKey(task: Pick<Task, "key" | "task_id" | "project">): string
  * that buried the only card on it that needs a person: a run parked on a
  * question stops ticking `last_active` the moment it asks, so the longer it
  * waits the further down it sinks — exactly backwards. The rank is a card's
- * lane's index in `CARD_LANES`, which is the one place the order is written
- * (see LIVE_LANE_NAMES), so this cannot drift out of step with the set of lanes
- * the view draws. It is the LIST's rule too (`sortByLane`/`LIST_ORDER`), applied
- * to the two lanes this view has — the same rows in the same order in both
- * views, which is what makes switching between them a change of shape rather
- * than of subject.
+ * lane's index in `CARD_LANES`, which is LIST_ORDER without Archive, so this
+ * cannot drift out of step with the List: the same rows in the same lane order
+ * in both views, which is what makes switching between them a change of shape
+ * rather than of subject.
  *
  * NEWEST TASK FIRST WITHIN A LANE, and `started` is what that means — when the
  * conversation BEGAN (server `_place`: the earliest of the scheduled entry's
@@ -3004,7 +2992,7 @@ export function cardKey(task: Pick<Task, "key" | "task_id" | "project">): string
  * A new array; the input is never mutated (it is the polled list, which React is
  * still holding).
  */
-export function cardsForTasks(tasks: Task[], cap: number = CARD_CAP): TaskCardSet {
+export function cardsForTasks(tasks: Task[], cap: number = CARD_PAGE): TaskCardSet {
   // `indexOf` rather than a Set: membership AND rank come off the one list, and
   // -1 — "this lane is not drawn here" — is the filter.
   const rank = (task: Task) => CARD_LANES.indexOf(taskColumn(task));
@@ -3038,9 +3026,9 @@ export function cardsForTasks(tasks: Task[], cap: number = CARD_CAP): TaskCardSe
     seen.add(id);
     all.push(row.task);
   }
-  // A cap of 0 or less is "no cap" rather than an empty page: the argument
-  // exists so a test can shrink the budget, and the failure mode of a bad number
-  // reaching it should not be a view that shows nothing.
+  // A cap of 0 or less is "no cap" rather than an empty page: the view passes
+  // pages × CARD_PAGE and a test can shrink it, and the failure mode of a bad
+  // number reaching it should not be a view that shows nothing.
   if (cap <= 0 || all.length <= cap) return { cards: all, hidden: 0 };
   return { cards: all.slice(0, cap), hidden: all.length - cap };
 }

--- a/frontend/src/shell/useMarginWheel.ts
+++ b/frontend/src/shell/useMarginWheel.ts
@@ -1,0 +1,55 @@
+// ---- the wheel works in the margins too -------------------------------------
+// `.schedule-main` is capped at 1050px and centred, so a wide window leaves a
+// band of empty page either side of the content — and the content is the
+// scroller, so a wheel out in that band lands on `.schedule-page`, which is
+// `overflow: hidden` and scrolls nothing: the reader had to aim at the card
+// (Akshil, 2026-08-20 for the List; 2026-09-05 again for the Cards wall).
+//
+// Making the scroller full-width instead was tried, twice, and traded this for
+// worse bugs each time — on the List the card's frame scrolled away with its
+// content and the reserved scrollbar gutters pushed the card off the toolbar's
+// axis (bugbot, #678); on the Cards wall the bar landed at the window edge while
+// the List's sat at the column's, so the two views wore different scrollbars
+// (Akshil, 2026-09-05). So the geometry stays exactly as it is and the wheel is
+// forwarded: a wheel anywhere on the page that no scroller of its own claims is
+// handed to the view's scroller.
+//
+// ONE hook for every view that scrolls in that column, so the List and the
+// Cards wall cannot drift into two forwarding rules. Board and Calendar mount
+// their own components and do not call it, so nothing here touches theirs.
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+/** Forward wheel events that land on the page's margins to `ref`'s element.
+ *  Mount once per view; the ref is read per wheel, so it may still be null on
+ *  the mount this runs after (rows in flight) and simply does nothing then. */
+export function useMarginWheel(ref: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    // The page div, NOT via the ref: the page ancestor is the one element of
+    // this pair that is always there when the effect runs.
+    const page = document.querySelector<HTMLElement>(".schedule-page");
+    if (!page) return;
+    const onWheel = (e: WheelEvent) => {
+      const el = ref.current;
+      if (!el || !(e.target instanceof Element) || e.deltaY === 0) return;
+      // Pinch-zoom arrives as ctrl+wheel; that is a zoom, not a scroll.
+      if (e.ctrlKey) return;
+      // Anything between the pointer and the page that scrolls for itself —
+      // the scroller, a menu, a popover — keeps its native wheel untouched.
+      for (let n: Element | null = e.target; n && n !== page; n = n.parentElement) {
+        const s = getComputedStyle(n);
+        if (
+          (s.overflowY === "auto" || s.overflowY === "scroll") &&
+          n.scrollHeight > n.clientHeight
+        ) {
+          return;
+        }
+      }
+      // deltaMode 1 is lines (Firefox with a wheel mouse); everything else
+      // that reaches a web page is already pixels.
+      el.scrollTop += e.deltaMode === 1 ? e.deltaY * 16 : e.deltaY;
+    };
+    page.addEventListener("wheel", onWheel, { passive: true });
+    return () => page.removeEventListener("wheel", onWheel);
+  }, [ref]);
+}

--- a/frontend/src/styles/deploy.css
+++ b/frontend/src/styles/deploy.css
@@ -103,6 +103,29 @@
   color: var(--fg);
 }
 
+/* The head's action row (Modal `headActions`): between the title and the ✕,
+   pushed against the ✕ so the two read as one group of controls. The h2 keeps
+   `overflow: hidden` and gives way; the actions never wrap or shrink. The
+   buttons in it are the app's own `.btn` — icon and word — at the head's
+   height, so they match the page's toolbar behind the dialog rather than
+   inventing a third button. */
+.modal-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+  margin-left: auto;
+  margin-right: 4px;
+}
+
+.modal-head-actions > .btn.modal-head-act {
+  height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+  gap: 6px;
+  text-decoration: none;
+}
+
 .deploy-body {
   padding: 14px 16px 16px;
   overflow-y: auto;

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -3314,38 +3314,45 @@ input.schedule-when-field {
    the lane's fill in both themes. The track itself paints nothing: a groove
    would be a second column drawn beside the cards.
 
-   ONE rule for all three of the page's content scrollers, though `.tasks-list`'s
-   box belongs to tasks.css and the other two to this file. Scrollbar chrome is
-   one decision about one kind of furniture, and two copies of it is how the
-   List and the Board end up wearing different bars.
+   ONE rule for all four of the page's content scrollers, though `.tasks-list`'s
+   box belongs to tasks.css and the Cards wall's to task-cards.css. Scrollbar
+   chrome is one decision about one kind of furniture, and two copies of it is
+   how the List and the Board end up wearing different bars — which is exactly
+   what happened when the Cards wall shipped without this rule: an overlay bar
+   on one view and a 10px column on the next (Akshil, 2026-09-05).
 
-   The three are the Board's lane, the List, and the CALENDAR's popover thread —
-   the one calendar scroller that has a bar at all, since the week grid hides
-   its own (`.schedule-cal-scroll`, above: the hour lines say where you are).
+   The four are the Board's lane, the List, the Cards wall, and the CALENDAR's
+   popover thread — the one calendar scroller that has a bar at all, since the
+   week grid hides its own (`.schedule-cal-scroll`, above: the hour lines say
+   where you are).
    The page's remaining scrollers are dropdown menus and pickers, which are
    floating surfaces a few rows tall rather than columns of content, and are
    deliberately left alone. */
 .schedule-tv-lane-body,
 .schedule-cal-thread,
-.tasks-list {
+.tasks-list,
+.task-cards-scroll {
   scrollbar-gutter: stable;
 }
 
 .schedule-tv-lane-body::-webkit-scrollbar,
 .schedule-cal-thread::-webkit-scrollbar,
-.tasks-list::-webkit-scrollbar {
+.tasks-list::-webkit-scrollbar,
+.task-cards-scroll::-webkit-scrollbar {
   width: 10px;
 }
 
 .schedule-tv-lane-body::-webkit-scrollbar-track,
 .schedule-cal-thread::-webkit-scrollbar-track,
-.tasks-list::-webkit-scrollbar-track {
+.tasks-list::-webkit-scrollbar-track,
+.task-cards-scroll::-webkit-scrollbar-track {
   background: transparent;
 }
 
 .schedule-tv-lane-body::-webkit-scrollbar-thumb,
 .schedule-cal-thread::-webkit-scrollbar-thumb,
-.tasks-list::-webkit-scrollbar-thumb {
+.tasks-list::-webkit-scrollbar-thumb,
+.task-cards-scroll::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--fg-muted) 26%, transparent);
   background-clip: padding-box;
   border: 3px solid transparent;
@@ -3354,7 +3361,8 @@ input.schedule-when-field {
 
 .schedule-tv-lane-body::-webkit-scrollbar-thumb:hover,
 .schedule-cal-thread::-webkit-scrollbar-thumb:hover,
-.tasks-list::-webkit-scrollbar-thumb:hover {
+.tasks-list::-webkit-scrollbar-thumb:hover,
+.task-cards-scroll::-webkit-scrollbar-thumb:hover {
   background: color-mix(in srgb, var(--fg-muted) 48%, transparent);
   background-clip: padding-box;
 }

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -1,4 +1,4 @@
-/* Tasks → Cards: every running conversation, side by side, streaming.
+/* Tasks → Cards: every task's conversation, side by side, the live ones streaming.
    (shell/TaskCards.tsx — the page's fourth view.)
 
    The other three views draw ROWS about tasks. This one draws the tasks
@@ -17,69 +17,55 @@
    §1). Only what is new to it lives here. */
 
 /* -- the wall ----------------------------------------------------------------- */
-/* THREE ACROSS, TWO DOWN, THEN SCROLL (Akshil, 2026-09-04: six cards in view,
-   scroll for the rest — back up from four once the frame inside was scaled to
-   stay readable at that width, below). The wall is the page's scroll container —
-   the same `flex: 1; min-height: 0; overflow-y: auto` shape the List uses — and
-   the rows are sized from the container, not from the content, so exactly two
-   rows fill whatever height the toolbar leaves and the third row is the first
-   thing under the fold. A fixed pixel height would be six cards on one monitor
-   and four-and-a-half on another.
+/* THREE ACROSS, TWO DOWN, THEN SCROLL (Akshil, 2026-09-04: six cards in view;
+   2026-09-05: nine LOADED a page, so the third row is already there under the
+   fold for whoever scrolls). The SCROLLER is `.task-cards-scroll`, in exactly
+   the List's shape — the same `flex: 1; min-height: 0; overflow-y: auto` in the
+   same 1050px content column, so the bar stands where the List's bar stands and
+   the two views line up when you switch between them (Akshil, 2026-09-05: "make
+   sure we have the same in both"). The grid inside it sizes its rows from the
+   SCROLLER's height — `cqh`, with the scroller as the size container — so
+   exactly two rows fill whatever height the toolbar leaves and the third is the
+   first thing under the fold. A fixed pixel height would be six cards on one
+   monitor and four-and-a-half on another. The 260px floor wins on a short
+   window, where the wall simply scrolls sooner.
 
    Fixed column COUNT rather than auto-fill: the number of monitors on the wall
    is the thing the reader gets used to, and a wall that re-flows from three to
    four columns when the window grows by 60px is a wall whose cards have all
    moved. Narrow windows step down to two and one, at breakpoints chosen where a
    card would otherwise fall under ~300px — the width below which a chat turn
-   stops being a paragraph. Below one row's worth of height (a short window) the
-   row floor keeps a card readable and the wall simply scrolls sooner. */
+   stops being a paragraph. */
 /* The page itself is content-sized (`flex: 0 1 auto`, so a short List is a short
    page), which for every other view is right: their content is rows, and rows
-   have a height of their own. A wall's rows are sized FROM the page, so the page
+   have a height of their own. A wall's rows are sized FROM the pane, so the page
    has to reach the bottom first or "two rows fill the height" resolves against a
    height of nothing. Scoped with `:has()` so the other three views keep their
    shape — a Board with two cards must not become a full-height Board. */
-.schedule-page:has(> .schedule-main > .task-cards) {
+.schedule-page:has(> .schedule-main > .task-cards-scroll) {
   flex: 1 1 auto;
 }
 
-/* THE WHEEL WORKS IN THE GUTTERS. The page's content column is capped at 1050px
-   and centred (schedule.css), which for a List is right: rows are read, and a
-   line of text wider than that is not. But when the scroller IS that column,
-   the space either side of it is dead — the pointer resting there scrolls
-   nothing (Akshil, 2026-09-04: "i should be able to scroll when my mouse is in
-   left and right space"). So on this view the section spans the window and the
-   wall is the scroller edge to edge, with the 1050px column re-made INSIDE it
-   as padding — the cards sit exactly where they did, the toolbar keeps its
-   column, and the scrollbar moves to the window edge (preferences.css makes
-   the same argument for the settings page). */
-.schedule-page:has(> .schedule-main > .task-cards) > .schedule-main {
-  max-width: none;
-}
-
-.schedule-page:has(> .schedule-main > .task-cards) > .schedule-main > .schedule-toolbar {
-  width: 100%;
-  max-width: 1050px;
-  margin-inline: auto;
-  box-sizing: border-box;
-}
-
-.schedule-page .schedule-main > .task-cards {
+.schedule-page .schedule-main > .task-cards-scroll {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  /* The List's rule, for the List's reason (tasks.css): a wheel that reaches
+     the end stops there instead of bouncing the page. */
+  overscroll-behavior: contain;
+  /* The grid's row height is a fraction of THIS box (`cqh` below). */
+  container-type: size;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .task-cards {
+  flex: none;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  grid-auto-rows: max(260px, calc((100% - 12px) / 2));
+  grid-auto-rows: max(260px, calc((100cqh - 12px) / 2));
   gap: 12px;
-  /* The content column, as padding on the scroller (see the gutter note above):
-     zero until the window is wider than the column, then half the surplus each
-     side. `%` here is the wall's own width, which is the window's. */
-  padding-inline: max(0px, calc((100% - 1050px) / 2));
-  box-sizing: border-box;
   /* Belt and braces against the one failure this view must not have: a page that
      scrolls sideways. A grid item's default `min-width: auto` lets a wide child
      (an iframe with its own layout in it) push its track past `1fr`, and the
@@ -109,7 +95,7 @@
    so a wall of them is a grid and not a staircase and six of them are what fits
    before the fold. About a dozen lines of transcript on a laptop — enough to see
    what a run is DOING and not enough to invite reading it here. Reading happens
-   behind Open. */
+   on the List, one segment away. */
 .task-card {
   display: flex;
   flex-direction: column;
@@ -134,11 +120,24 @@
   min-width: 0;
   padding: 8px 10px;
   border-bottom: 1px solid var(--border);
+  /* The head is a button (TaskCards: it opens the task's popup) and says so
+     the way every pressable strip on this page does — the pointer, and a wash
+     on hover at the row's own weight (tasks.css `.tasks-row:hover`). */
+  cursor: pointer;
+  user-select: none;
 }
 
-/* Row one: ring then id at the left edge (the List row's order), the time and
-   Open at the right. `margin-left: auto` on the time is what pushes the
-   right-hand pair over. */
+.task-card-head:hover {
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+
+.task-card-head:focus-visible {
+  outline: 2px solid var(--focus, var(--fg-muted));
+  outline-offset: -2px;
+}
+
+/* Row one: ring then id at the left edge (the List row's order), the time at
+   the right. `margin-left: auto` on the time is what pushes it over. */
 .task-card-head-row {
   display: flex;
   align-items: center;
@@ -154,7 +153,12 @@
    the card's whole width is its own now, so it no longer competes with the id
    and the time for one strip. Ellipsed; the full text rides `data-hint`. */
 .task-card-title {
+  /* Shrink-to-fit inside the row, not a full-width block: the hint rides
+     `data-hint` on THIS element, so a block would show the title's tooltip
+     over the empty run to its right (Akshil, 2026-09-05). */
   display: block;
+  width: fit-content;
+  max-width: 100%;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -170,24 +174,6 @@
   font-size: 11px;
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
-}
-
-/* Open wears the app's `.btn btn-secondary` skin and only its SIZE is overridden
-   here: a 32px button in a 33px header is a header that is all button. The
-   selector carries `.schedule-main` so it outranks the `.prefs-section .btn`
-   grouping in buttons-modal.css (0,2,x) whatever the stylesheet order. */
-.schedule-main .task-card-head .task-card-open {
-  flex: none;
-  height: 22px;
-  padding: 0 8px;
-  font-size: 11px;
-  border-radius: 4px;
-  text-decoration: none;
-}
-
-.task-card-open:hover {
-  background: color-mix(in srgb, var(--fg) 6%, transparent);
-  text-decoration: none;
 }
 
 /* -- the live pane ------------------------------------------------------------ */
@@ -231,27 +217,106 @@
   color: var(--fg-muted);
 }
 
-/* -- the trailing card -------------------------------------------------------- */
-/* Past the cap (tasks-lib.CARD_CAP) the wall stops embedding and starts
-   counting. It is a card and not a footnote under the grid on purpose: it sits
-   in the flow of the thing it is talking about, so the wall reads as "these
-   twelve, and N more" rather than as a page with a caveat at the bottom. */
-.task-card--more {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  padding: 12px;
+/* -- show more ---------------------------------------------------------------- */
+/* Past the page (tasks-lib.CARD_PAGE) the wall stops embedding and offers the
+   next nine: one full-width strip under the grid, in the card's own dashed
+   voice, sized like a control and not like a card — it used to be a grid cell,
+   which made it one card wide and a whole chat tall (Akshil, 2026-09-05).
+   Pressing it adds a page in place; it never navigates away. */
+.task-cards-more {
+  flex: none;
+  width: 100%;
+  height: 36px;
+  font: inherit;
   font-size: 12px;
   color: var(--fg-muted);
-  text-decoration: none;
   background: none;
-  border-style: dashed;
-  box-shadow: none;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  cursor: pointer;
 }
 
-.task-card--more:hover {
+.task-cards-more:hover {
   color: var(--fg);
   border-color: var(--fg-muted);
-  text-decoration: none;
+}
+
+/* -- the popup ---------------------------------------------------------------- */
+/* A card's head opens the task as a tall column — a little over half the
+   window wide and most of its height (Akshil, 2026-09-05: "reduce the width a
+   little bit but increase it in height"; a chat is read top to bottom) — on the
+   app's one modal chassis. The dialog's width is set by the component
+   (`width="54vw"`); this gives it the HEIGHT — a fixed one, not max-height,
+   because the body is a frame that fills whatever it is given and a dialog
+   sized by its content would size itself by nothing. Floors and ceilings keep
+   it usable on a laptop and sane on a 5K display. */
+.modal-dialog.task-peek {
+  height: 82vh;
+  min-height: 420px;
+  min-width: min(640px, 100%);
+  max-width: 1100px;
+  max-height: 92vh;
+  /* The frame is a square document painted to the body's edges, and the body
+     is the dialog's last child: without this the frame's corners paint over
+     the dialog's 10px radius and the popup has square feet (Akshil,
+     2026-09-05, screenshot). Nothing in this dialog needs to overflow it. */
+  overflow: hidden;
+}
+
+/* The title is the card head's own row — ring, id chip, name — so the popup
+   reads as the card grown, not as a different thing about the same task. */
+.task-peek-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.task-peek-name {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The chassis's h2 is the head's flexible cell; it must not stretch the title
+   group to the actions, or the group's empty right half would wear the hint. */
+.task-peek .modal-head > h2 {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+/* The body is the frame and nothing else: no padding (the chat has its own
+   margins), no scrolling of its own (the transcript scrolls inside the frame),
+   and it takes every pixel the head and footer leave. */
+.task-peek > .modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 0;
+  overflow: hidden;
+  display: flex;
+  background: var(--bg);
+}
+
+.task-peek-frame {
+  display: block;
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.task-peek > .modal-body > .task-card-starting {
+  flex: 1 1 auto;
+  margin: 0;
+}
+
+/* A refused archive says so in the footer, in the List row's quiet voice, and
+   pushes the buttons right by taking the free space. */
+.task-peek-note {
+  margin-right: auto;
+  font-size: 12px;
+  color: var(--fg-muted);
 }

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -1176,6 +1176,22 @@
      border — it is dead space above the first line of the only thing the card is
      for. Halved rather than dropped: the turns still need to start off the edge. */
   body.chat-compact #log { padding-top: 12px; }
+  /* CHAT ONLY, from the first paint (see the const of that name): the pane
+     column and the divider between it and the chat are hidden by the class the
+     boot stamps synchronously, so the chat is full width before enterNoPane has
+     had its await and removes them for good. */
+  body.chat-only #left,
+  body.chat-only #divider {
+    display: none;
+  }
+  /* PEEK (`?peek=1`, see the const of that name) — the transcript and the
+     composer under a head the HOST draws. The strip and the top bar go; the
+     composer stays, which is the whole difference from compact. */
+  body.chat-peek #anntools,
+  body.chat-peek #topbar {
+    display: none;
+  }
+  body.chat-peek #log { padding-top: 12px; }
   /* TASK-023 (see showSession) — tabular figures for the same reason the
      composer block's `.sb-id` has them: the same identifier must not shift
      width as its digits change. */
@@ -4301,6 +4317,28 @@ const CHAT_ONLY = new URLSearchParams(location.search).get("chat_only") === "1";
 // frame and then took it away would be the one flicker on a wall of twelve.
 const COMPACT = new URLSearchParams(location.search).get("compact") === "1";
 if (COMPACT) document.body.classList.add("chat-compact");
+
+// CHAT_ONLY's FIRST PAINT. enterNoPane (below) takes the pane column out of the
+// document, but it runs once the boot has asked the server what this folder is
+// — an await away — and until then the layout was the two-column one: the chat
+// drawn at pane-width on the left of an empty column, then jumping to the full
+// width a moment later. On the Tasks page's popup that was the whole show
+// (Akshil, 2026-09-05: "first it opened only on the left side, then it made it
+// full screen"). CHAT_ONLY is a host fact already known here, so the stylesheet
+// is told now, the same way `chat-compact` is: the pane column and its divider
+// are hidden from the first frame, and the teardown later removes what was
+// never seen.
+if (CHAT_ONLY) document.body.classList.add("chat-only");
+
+// PEEK (`?peek=1`) — the Tasks page's card popup (TaskCards `TaskPeek`). The
+// chat at full size WITH its composer, unlike compact, but under a head the
+// host owns: the popup's own bar already says which task this is (ring, id,
+// title) and carries the doors — the List, the folder in Explorer, Archive — so
+// this document's strip (← Chats, the ⋮ menu) and its top bar would be a second
+// bar of the same facts under the first (Akshil, 2026-09-05). A host fact read
+// off this frame's own URL and stamped as a class, for compact's reasons.
+const PEEK = new URLSearchParams(location.search).get("peek") === "1";
+if (PEEK) document.body.classList.add("chat-peek");
 
 // A one-shot prompt the git sidebar's "Fix with AI" button built for a failed
 // operation is NOT read off this document's URL at all (review #804 round 2 —

--- a/tests/test_claude_peek.py
+++ b/tests/test_claude_peek.py
@@ -1,0 +1,77 @@
+"""The `claude` template's two host-fact classes for the Tasks page's Cards view.
+
+* ``body.chat-only`` — stamped synchronously from ``?chat_only=1``. The pane
+  column used to leave the document only when ``enterNoPane`` ran, which is an
+  await into the boot, so a chat-only frame drew the two-column layout first and
+  jumped to full width a moment later (Akshil, 2026-09-05, on the card popup:
+  "first it opened only on the left side, then it made it full screen"). The
+  class hides the column and its divider from the first paint.
+* ``body.chat-peek`` — stamped from ``?peek=1``, the card POPUP's cut: the strip
+  (← Chats, ⋮) and the top bar go, the composer stays. The popup's own head says
+  which task this is and carries the doors, so those would be a second bar of
+  the same facts under the first.
+
+Pinned the way tests/test_claude_compact.py pins compact, for the same reasons:
+a host fact is read off THIS frame's URL (never ``fused.params``), the hiding is
+a stylesheet rule keyed on one class, and nothing else changes.
+"""
+import os
+import re
+
+import pytest
+
+TEMPLATE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "templates", "claude", "template.html")
+
+
+@pytest.fixture(scope="module")
+def html():
+    with open(TEMPLATE, encoding="utf-8") as f:
+        return f.read()
+
+
+def _style_block(html):
+    start = html.index("<style>")
+    return html[start:html.index("</style>", start)]
+
+
+def _code(html):
+    src = re.sub(r"/\*.*?\*/", "", html, flags=re.S)
+    src = re.sub(r"<!--.*?-->", "", src, flags=re.S)
+    return "\n".join(ln for ln in src.splitlines() if not ln.strip().startswith("//"))
+
+
+def test_chat_only_is_stamped_synchronously_beside_compact(html):
+    code = _code(html)
+    assert 'if (CHAT_ONLY) document.body.classList.add("chat-only");' in code
+    # In the same synchronous run as compact's stamp — before any boot await —
+    # which is what makes it a first-paint fact rather than a later correction.
+    assert code.index('classList.add("chat-only")') < code.index("function enterNoPane()")
+    assert code.index('classList.add("chat-compact")') < code.index('classList.add("chat-only")')
+
+
+def test_chat_only_hides_the_pane_column_from_the_stylesheet(html):
+    css = _style_block(html)
+    rule = re.search(r"body\.chat-only #left,\s*body\.chat-only #divider \{\s*display: none;\s*\}", css)
+    assert rule, "the pane column and divider must be hidden by the class, not by script"
+
+
+def test_peek_is_a_host_fact_read_off_this_frames_url(html):
+    code = _code(html)
+    assert 'const PEEK = new URLSearchParams(location.search).get("peek") === "1";' in code
+    assert 'if (PEEK) document.body.classList.add("chat-peek");' in code
+    # Never through fused.params: that would land on the host's URL and outlive
+    # the popup that chose it.
+    assert 'fused.params.get("peek")' not in code
+
+
+def test_peek_hides_strip_and_topbar_but_keeps_the_composer(html):
+    css = _style_block(html)
+    rule = re.search(r"body\.chat-peek #anntools,\s*body\.chat-peek #topbar \{\s*display: none;\s*\}", css)
+    assert rule
+    # The composer is the whole point of the popup over the card: compact hides
+    # #inputbox and #home; peek must not.
+    peek_rules = "\n".join(m.group(0) for m in re.finditer(r"body\.chat-peek[^{]*\{[^}]*\}", css))
+    assert "#inputbox" not in peek_rules
+    assert "#home" not in peek_rules


### PR DESCRIPTION
## What
- **Every lane but Archive** on the Cards wall, ranked by the List's own lane order (`CARD_LANES = LIST_ORDER` minus Archive), newest `started` first within a lane. Done cards say nothing new; upcoming ones with no session read "Not started yet".
- **Six in view, nine loaded**; a full-width **Show more** strip under the grid adds nine in place. The old "+N more running" handoff to the List is gone.
- **Card head opens a popup** (ring · id · time · title is one button): the app's modal chassis, 54vw x 82vh, framing the same chat at full size **with its composer**. Head doors beside the close button, as the app's `.btn btn-secondary` with icon + word: **Open in Explorer** (folder with the Claude pane) and **Archive/Unarchive** (the List row's `filingIntent` rule and calls). Esc closes even with the caret inside the frame. New `headActions` slot on `Modal`.
- **Template**: `chat_only=1` now stamps `body.chat-only` synchronously so the pane column is hidden from the first paint (it drew two-column and jumped to full width after the boot's await); `peek=1` (`body.chat-peek`) hides the strip and top bar for the popup.
- **Scroller** back in the List's shape and column with the same 10px bar; the wheel works in the gutters through one shared `useMarginWheel` hook (extracted from the List).
- Card **Open** button removed; the title shrinks to its words so the hover hint is not over empty head.

## Why
Akshil's Cards-view feedback, 2026-09-05.

## Tests
- `tasks-lib.test.ts`: lanes, page size, scroller/scrollbar match, popup markup + CSS, head-as-button, Esc-in-frame listener.
- `tests/test_claude_peek.py`: the two template classes are stamped synchronously from this frame's URL and hide only what they should.
- `bun run typecheck` clean, `bun test` 3042 pass; `pytest tests/test_claude_{peek,compact,narrow,kind}.py` 88 pass.
- Browser (cmux): scroller box identical to the List's; Show more 9 -> 18; popup opens from head, composer present, Esc/backdrop/close work, doors present per lane, corners clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches modal focus trapping, same-origin iframe keyboard handling, and task archive API calls from a new surface, plus live iframe budget and polling behavior on the Cards wall.
> 
> **Overview**
> Expands the Tasks **Cards** view from “running chats only” to **every lane except Archive**, using the List’s lane order. Pagination is **nine cards at a time** with an in-place **Show more** strip (replacing the old cap and “+N more running” jump to List).
> 
> **Card head → preview modal:** The whole header opens a **`TaskPeek`** dialog on the shared **`Modal`** chassis: full-height chat iframe with composer via new **`peekFrameSrc`** (`chat_only` + `peek=1`), **Open in Explorer** and **Archive/Unarchive** in a new **`headActions`** slot, focus into the iframe (with **`iframe`** in the focus trap), and Esc handled inside the frame document. Card **Open** is removed; upcoming tasks without a session show **Not started yet**.
> 
> **Scrolling polish:** Margin wheel forwarding moves into shared **`useMarginWheel`** (List + Cards wall); Cards scroller matches the List column/scrollbar styling instead of full-width gutter hacks.
> 
> **Claude template:** Synchronous **`body.chat-only`** and **`body.chat-peek`** classes fix first-paint layout flicker and hide chrome appropriate to card vs popup embeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f3187fd6417262c952a4c1aaad3e26c468385f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->