### PR TITLE
Cards: six a page, the folder chip in the head, columns from the wall's width

### DIFF
--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -397,6 +397,22 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     };
   }, []);
 
+  // A folder chip pressed on a row or a card: filter the page to that
+  // project, pressing the pinned one again clears it. It REPLACES the project
+  // selection rather than adding to it — the gesture means "show me this
+  // folder", and a press that quietly widened an existing selection would be
+  // the opposite of what it looks like. Everything else about the filters is
+  // left alone, so a status or a search already on stays on. A TOGGLE, because
+  // the chip stays on screen wearing the state: pressing the folder you are
+  // already filtered to is the obvious way to let it go. ONE handler for the
+  // List and the Cards wall (Akshil, 2026-09-05: the card's chip must filter
+  // like the List's), so the two cannot drift.
+  const pickProject = (project: string) =>
+    setFilters((f) => ({
+      ...f,
+      projects: f.projects.length === 1 && f.projects[0] === project ? [] : [project],
+    }));
+
   const pickView = (v: TaskView) => {
     setView(v);
     // Into the URL, so the view is a thing you can link to and reload onto.
@@ -621,6 +637,10 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               tasks={shown}
               home={home}
               onReload={reload}
+              // The folder chip in a card's head is the List row's filter tag
+              // (Akshil, 2026-09-05): same handler, same pinned state.
+              onPickProject={pickProject}
+              pinnedProjects={filters.projects}
             />
           ) : (
             <TaskList
@@ -639,20 +659,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               // an existing selection would be the opposite of what it looks
               // like. Everything else about the filters is left alone, so a
               // status or a search already on stays on.
-              onPickProject={(project) =>
-                setFilters((f) => ({
-                  ...f,
-                  // A TOGGLE, because the chip stays on screen wearing the
-                  // state: pressing the folder you are already filtered to is
-                  // the obvious way to let it go, and it is the only way that
-                  // does not send the reader to the toolbar popover to undo a
-                  // gesture they made in the list.
-                  projects:
-                    f.projects.length === 1 && f.projects[0] === project
-                      ? []
-                      : [project],
-                }))
-              }
+              onPickProject={pickProject}
               // Which project the page is pinned to — so the chip survives the
               // filter that makes every row agree, and shows that it is on.
               pinnedProjects={filters.projects}

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -43,6 +43,7 @@ import {
   filingIntent,
   firstLine,
   opensElsewhere,
+  spansProjects,
   taskColumn,
   taskHref,
   taskWhen,
@@ -104,6 +105,8 @@ export function TaskCards({
   tasks,
   home = "",
   onReload,
+  onPickProject,
+  pinnedProjects = [],
 }: {
   /** Already filtered, in the SERVER's order — `cardsForTasks` drops the
    * archived ones and orders the rest, which is the one thing this view does to
@@ -113,6 +116,13 @@ export function TaskCards({
   /** After the popup archives or unarchives: the card's lane changed, so the
    * page re-reads — the same call the Board's drops and the List's row make. */
   onReload?: () => void;
+  /** The folder chip is the List row's FILTER TAG (Akshil, 2026-09-05): pressed,
+   * it narrows the page to that project; pressed again, lets it go. The same
+   * handler the List is handed, so the two chips cannot mean different things. */
+  onPickProject?: (project: string) => void;
+  /** Which projects the page is pinned to — the chip wears the ON state, and
+   * survives the filter that makes every card agree (see `showProject`). */
+  pinnedProjects?: string[];
 }) {
   // THE POPUP (Akshil, 2026-09-05): one task at a time, opened from a card's
   // head. Held as the Task the head was clicked with, then REFRESHED from every
@@ -135,6 +145,13 @@ export function TaskCards({
   // its first page each time would undo the reader's own gesture under them.
   const [pages, setPages] = useState(1);
   const { cards, hidden } = useMemo(() => cardsForTasks(tasks, pages * CARD_PAGE), [tasks, pages]);
+  // The List's rule for whether the chip is worth its pixels: only when the
+  // cards span more than one folder — or the page is pinned to one, in which
+  // case the chip is the thing that says so and the way to let it go.
+  const showProject = useMemo(
+    () => spansProjects(cards) || pinnedProjects.length > 0,
+    [cards, pinnedProjects],
+  );
   // The wheel works in the gutters either side of the column (Akshil,
   // 2026-09-05: "when I try to scroll, it does not scroll") — forwarded to the
   // wall, the List's own rule, rather than by widening the scroller, which is
@@ -227,6 +244,11 @@ export function TaskCards({
           home={home}
           template={templates[task.target || task.project] ?? null}
           onPeek={setPeek}
+          project={
+            showProject
+              ? { pinned: pinnedProjects.includes(task.project), onPick: onPickProject }
+              : null
+          }
         />
       ))}
       </div>
@@ -249,11 +271,15 @@ function TaskCard({
   home,
   template,
   onPeek,
+  project,
 }: {
   task: Task;
   home: string;
   template: string | null;
   onPeek: (task: Task) => void;
+  /** Draw the folder chip, and how: null hides it (one folder, nothing to tell
+   * apart); otherwise whether the page is pinned to it and the tag's handler. */
+  project: { pinned: boolean; onPick?: (project: string) => void } | null;
 }) {
   const when = taskWhen(task);
   const title = firstLine(task.title) || "(untitled)";
@@ -305,10 +331,18 @@ function TaskCard({
               (Akshil, 2026-09-05: "same here, top right corner, left side of
               time"). The List's order too: folder first, time last, because
               the last thing before the edge is the one a reader lands on and
-              the time is what changes. A plain label here, not the List's
-              filter tag: a card is opened by its head, and a button inside
-              that head would compete with the press that opens it. */}
-          <IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />
+              the time is what changes. And the List's TAG, not a label
+              (Akshil, 2026-09-05: "when we click on them they filter?"): the
+              chip stops its own press (IdentityChip's shield), so pressing the
+              folder filters the page and does not also open the popup. */}
+          {project && (
+            <IdentityChip
+              name={basename(task.project)}
+              title={tildePath(task.project, home)}
+              onPick={project.onPick && (() => project.onPick?.(task.project))}
+              active={project.pinned}
+            />
+          )}
           <span className="task-card-when" title={when.title}>
             {when.text}
           </span>

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -495,9 +495,22 @@ function TaskPeek({
       // THE DOORS, IN THE HEAD beside the ✕ (Akshil, 2026-09-05: "move them on
       // top where we have the close button"), each an icon WITH its word — an
       // icon alone was not clear — in the app's own small secondary button, the
-      // one the toolbar above this popup wears. Order: the folder, then Archive.
+      // one the toolbar above this popup wears. Order: Archive, then the folder
+      // (Akshil, 2026-09-05: "switch archive and open explorer buttons").
       headActions={
         <>
+          {filing && (
+            <button
+              type="button"
+              className="btn btn-secondary modal-head-act"
+              disabled={acting}
+              title={filing.title}
+              onClick={refile}
+            >
+              {filing.kind === "archive" ? ICON_ARCHIVE : ICON_UNARCHIVE}
+              {filing.label}
+            </button>
+          )}
           {explorer && (
             <a
               // A real link with a real href, so ⌘-click and middle-click open
@@ -515,18 +528,6 @@ function TaskPeek({
               {ICON_FOLDER}
               Open in Explorer
             </a>
-          )}
-          {filing && (
-            <button
-              type="button"
-              className="btn btn-secondary modal-head-act"
-              disabled={acting}
-              title={filing.title}
-              onClick={refile}
-            >
-              {filing.kind === "archive" ? ICON_ARCHIVE : ICON_UNARCHIVE}
-              {filing.label}
-            </button>
           )}
         </>
       }

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -305,6 +305,11 @@ function TaskCard({
         aria-label={`Preview ${task.task_id}`}
         onClick={() => onPeek(task)}
         onKeyDown={(e) => {
+          // Only a key pressed ON THE HEAD. The folder chip inside it is a real
+          // button of its own; its Enter and Space bubble here, and answering
+          // them would cancel the chip's press and open the popup instead of
+          // filtering (Bugbot, #1011).
+          if (e.target !== e.currentTarget) return;
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             onPeek(task);

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -23,7 +23,7 @@
 //     array. A card keyed by anything but the task would remount its iframe on
 //     each poll, which is a reload of a live conversation every 20 seconds.
 //   * A BUDGET. Live documents are not free, so the wall is drawn a page of
-//     nine at a time (tasks-lib.CARD_PAGE) and grows only when asked.
+//     six at a time (tasks-lib.CARD_PAGE) and grows only when asked.
 //
 // Everything about WHICH tasks and in WHAT ORDER is tasks-lib.cardsForTasks —
 // pure, tested, and out of here, because a wall of iframes is the last place
@@ -34,9 +34,10 @@ import type { Task } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
 import { Modal } from "@platform/ui/modal/Modal";
 import { cardFrameSrc, folderHref, peekFrameSrc } from "./schedule-lib";
-import { StatusIcon } from "./ScheduleTaskViews";
+import { IdentityChip, StatusIcon } from "./ScheduleTaskViews";
 import {
   CARD_PAGE,
+  basename,
   cardKey,
   cardsForTasks,
   filingIntent,
@@ -128,8 +129,8 @@ export function TaskCards({
     const id = cardKey(peek);
     return tasks.find((t) => cardKey(t) === id) ?? peek;
   }, [peek, tasks]);
-  // HOW MANY PAGES THE READER HAS ASKED FOR. Nine cards to begin with, and each
-  // press of the trailing card adds nine (Akshil, 2026-09-05). Never wound back
+  // HOW MANY PAGES THE READER HAS ASKED FOR. Six cards to begin with, and each
+  // press of the trailing strip adds six (Akshil, 2026-09-05). Never wound back
   // by a poll: the list refreshes every 20 seconds, and a wall that collapsed to
   // its first page each time would undo the reader's own gesture under them.
   const [pages, setPages] = useState(1);
@@ -223,6 +224,7 @@ export function TaskCards({
           // a card that has a session to frame.
           key={cardKey(task)}
           task={task}
+          home={home}
           template={templates[task.target || task.project] ?? null}
           onPeek={setPeek}
         />
@@ -244,10 +246,12 @@ export function TaskCards({
 
 function TaskCard({
   task,
+  home,
   template,
   onPeek,
 }: {
   task: Task;
+  home: string;
   template: string | null;
   onPeek: (task: Task) => void;
 }) {
@@ -296,6 +300,15 @@ function TaskCard({
           {/* The same relative unit every task row on this page prints, from the
               same function — so a card and its row agree about when this last
               moved (tasks-lib.taskWhen). */}
+          {/* The folder, as the List row prints it — the same chip, the same
+              basename, the full path on hover — at the right, before the time
+              (Akshil, 2026-09-05: "same here, top right corner, left side of
+              time"). The List's order too: folder first, time last, because
+              the last thing before the edge is the one a reader lands on and
+              the time is what changes. A plain label here, not the List's
+              filter tag: a card is opened by its head, and a button inside
+              that head would compete with the press that opens it. */}
+          <IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />
           <span className="task-card-when" title={when.title}>
             {when.text}
           </span>

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6712,10 +6712,10 @@ describe("cardsForTasks", () => {
     expect(cardsForTasks(older).cards.map((t) => t.key)).toEqual(["a", "b"]);
   });
 
-  it("draws a page of nine and counts what is behind it", () => {
-    // Nine: six in view and one more row loaded under the fold (Akshil,
-    // 2026-09-05: "6 in view, and 3 more loaded if user wants to scroll").
-    expect(CARD_PAGE).toBe(9);
+  it("draws a page of six and counts what is behind it", () => {
+    // Six: exactly the two rows in view (Akshil, 2026-09-05: "6 cards loaded
+    // instead of nine, and show 6 more cards when we click on show more").
+    expect(CARD_PAGE).toBe(6);
     const rows = Array.from({ length: CARD_PAGE + 3 }, (_, i) =>
       running(`t${i}`, 1000 - i),
     );
@@ -6779,7 +6779,7 @@ describe("the Cards view's frame", () => {
   });
 
   it("lays the wall out three across, two down, and scrolls the rest — never sideways", () => {
-    // Six in view, nine loaded, then scroll (Akshil, 2026-09-04/05) — the frame
+    // Six in view, six loaded, then Show more (Akshil, 2026-09-04/05) — the frame
     // inside is scaled so a third column stays readable. The wall is the scroll
     // container, in the List's own shape, and the rows are sized from it so two
     // rows fill the height the toolbar leaves on ANY monitor.
@@ -6831,7 +6831,7 @@ describe("the Cards view's frame", () => {
     expect(row.indexOf("tasks-id--task")).toBeLessThan(row.indexOf("task-card-when"));
     expect(head.indexOf("</div>")).toBeLessThan(head.indexOf('className="task-card-title"'));
     expect(block(CARDS_CSS, ".task-card-head")).toContain("flex-direction: column");
-    expect(block(CARDS_CSS, ".task-card-head-row > .task-card-when")).toContain("margin-left: auto");
+    expect(block(CARDS_CSS, ".task-card-head-row > .schedule-tv-id")).toContain("margin-left: auto");
     expect(CARDS_CSS).toContain("grid-auto-rows: max(260px, calc((100cqh - 12px) / 2));");
     // A fixed COUNT, not auto-fill/auto-fit: the wall must not re-flow every time
     // the window grows by a card's worth.
@@ -6855,7 +6855,7 @@ describe("the Cards view's frame", () => {
     expect(SCHEDULED).toContain("<TaskCards");
   });
 
-  it("grows by a page of nine on the trailing card, and never navigates away", () => {
+  it("grows by a page of six on the trailing strip, and never navigates away", () => {
     // "Show 9 more" adds the next page in place (Akshil, 2026-09-05). The old
     // trailing card handed the overflow to the List; this one stays on the wall.
     expect(CARDS).toContain("const [pages, setPages] = useState(1);");
@@ -6903,6 +6903,20 @@ describe("the Cards view's frame", () => {
     expect(acts.indexOf("Open in Explorer")).toBeGreaterThan(-1);
     expect(acts.indexOf("Open in Explorer")).toBeLessThan(acts.indexOf("{filing.label}"));
     expect((acts.match(/className="btn btn-secondary modal-head-act"/g) ?? []).length).toBe(2);
+    // The folder chip, the List row's own, at the right before the time
+    // (Akshil, 2026-09-05) — a plain label, never the List's filter tag.
+    const headRow = CARDS.slice(CARDS.indexOf('<div className="task-card-head-row">'), CARDS.indexOf("</div>", CARDS.indexOf('<div className="task-card-head-row">')));
+    expect(headRow).toContain("<IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />");
+    expect(headRow).not.toContain("onPick");
+    expect(headRow.indexOf("<IdentityChip")).toBeLessThan(headRow.indexOf("task-card-when"));
+    expect(headRow.indexOf("tasks-id--task")).toBeLessThan(headRow.indexOf("<IdentityChip"));
+    expect(block(CARDS_CSS, ".task-card-head-row > .schedule-tv-id")).toContain("margin-left: auto");
+    // Columns step on the WALL's width, not the window's: container queries
+    // against the scroller, never a media query (Akshil, 2026-09-05: the
+    // sidebar's 232px were invisible to a media query).
+    expect(CARDS_CSS).not.toContain("@media");
+    expect(CARDS_CSS).toContain("@container (max-width: 920px)");
+    expect(CARDS_CSS).toContain("@container (max-width: 600px)");
     expect(acts).toContain("{ICON_FOLDER}\n              Open in Explorer");
     // Bugbot, #1009: the popup follows the polls (a "Starting…" task gains its
     // session), survives an empty wall (a failed poll, a filter), and puts the

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6889,6 +6889,9 @@ describe("the Cards view's frame", () => {
     expect(head).toContain('role="button"');
     expect(head).toContain("onClick={() => onPeek(task)}");
     expect(head).toContain('e.key === "Enter" || e.key === " "');
+    // ...for keys pressed on the head itself: the folder chip inside it is a
+    // button whose Enter/Space bubble up (Bugbot, #1011).
+    expect(head).toContain("if (e.target !== e.currentTarget) return;");
     // The head has no Open of its own any more — the popup carries the doors.
     expect(head).not.toContain("href");
     // The app's one modal chassis, at 60vw, with the matching height in CSS.

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6832,6 +6832,12 @@ describe("the Cards view's frame", () => {
     expect(head.indexOf("</div>")).toBeLessThan(head.indexOf('className="task-card-title"'));
     expect(block(CARDS_CSS, ".task-card-head")).toContain("flex-direction: column");
     expect(block(CARDS_CSS, ".task-card-head-row > .schedule-tv-id")).toContain("margin-left: auto");
+    // The tag wears the List row's skin, widened to this row in tasks.css — not
+    // a copy of it here (Akshil, 2026-09-05: "project name ui as is from list").
+    const TASKS_CSS = readFileSync(join(SHELL, "../styles/tasks.css"), "utf8");
+    expect(TASKS_CSS).toContain(".task-card-head-row .schedule-tv-id--tag,\n.tasks-row .schedule-tv-id--tag {");
+    expect(TASKS_CSS).toContain(".task-card-head-row .schedule-tv-id--tag.is-on,\n.tasks-row .schedule-tv-id--tag.is-on {");
+    expect(CARDS_CSS).not.toContain("schedule-tv-id--tag");
     expect(CARDS_CSS).toContain("grid-auto-rows: max(260px, calc((100cqh - 12px) / 2));");
     // A fixed COUNT, not auto-fill/auto-fit: the wall must not re-flow every time
     // the window grows by a card's worth.
@@ -6919,6 +6925,12 @@ describe("the Cards view's frame", () => {
     expect(headRow.indexOf("<IdentityChip")).toBeLessThan(headRow.indexOf("task-card-when"));
     expect(headRow.indexOf("tasks-id--task")).toBeLessThan(headRow.indexOf("<IdentityChip"));
     expect(block(CARDS_CSS, ".task-card-head-row > .schedule-tv-id")).toContain("margin-left: auto");
+    // The tag wears the List row's skin, widened to this row in tasks.css — not
+    // a copy of it here (Akshil, 2026-09-05: "project name ui as is from list").
+    const TASKS_CSS = readFileSync(join(SHELL, "../styles/tasks.css"), "utf8");
+    expect(TASKS_CSS).toContain(".task-card-head-row .schedule-tv-id--tag,\n.tasks-row .schedule-tv-id--tag {");
+    expect(TASKS_CSS).toContain(".task-card-head-row .schedule-tv-id--tag.is-on,\n.tasks-row .schedule-tv-id--tag.is-on {");
+    expect(CARDS_CSS).not.toContain("schedule-tv-id--tag");
     // Columns step on the WALL's width, not the window's: container queries
     // against the scroller, never a media query (Akshil, 2026-09-05: the
     // sidebar's 232px were invisible to a media query).

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6905,13 +6905,14 @@ describe("the Cards view's frame", () => {
     expect(peekFrameSrc("/tpl/claude.html", "/Users/me/proj", "sess-9")).toBe(
       "/render?path=%2Ftpl%2Fclaude.html&_file=%2FUsers%2Fme%2Fproj&chat_only=1&peek=1&session_id=sess-9",
     );
-    // The two doors, folder then Archive, in the head beside the ✕ as the app's
+    // The two doors, Archive then folder, in the head beside the ✕ as the app's
     // own buttons — icon AND word (Akshil, 2026-09-05: an icon alone "is not
     // clear"). No "Open in Tasks": we are already in Tasks.
     const acts = CARDS.slice(CARDS.indexOf("headActions={"), CARDS.indexOf("footer={"));
     expect(acts).not.toContain("Open in Tasks");
     expect(acts.indexOf("Open in Explorer")).toBeGreaterThan(-1);
-    expect(acts.indexOf("Open in Explorer")).toBeLessThan(acts.indexOf("{filing.label}"));
+    // Archive first, the folder last, beside the close button (Akshil, 2026-09-05).
+    expect(acts.indexOf("{filing.label}")).toBeLessThan(acts.indexOf("Open in Explorer"));
     expect((acts.match(/className="btn btn-secondary modal-head-act"/g) ?? []).length).toBe(2);
     // The folder chip, the List row's own, at the right before the time — and
     // the List's TAG: pressed, it filters the page (Akshil, 2026-09-05), through

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6837,7 +6837,11 @@ describe("the Cards view's frame", () => {
     const TASKS_CSS = readFileSync(join(SHELL, "../styles/tasks.css"), "utf8");
     expect(TASKS_CSS).toContain(".task-card-head-row .schedule-tv-id--tag,\n.tasks-row .schedule-tv-id--tag {");
     expect(TASKS_CSS).toContain(".task-card-head-row .schedule-tv-id--tag.is-on,\n.tasks-row .schedule-tv-id--tag.is-on {");
-    expect(CARDS_CSS).not.toContain("schedule-tv-id--tag");
+    // ...except the ROW's vertical trick, which this one-line head undoes: no
+    // negative margin, no stretched shield, so the name sits on the same line
+    // as the id and the time (Akshil, 2026-09-05, screenshot).
+    expect(block(CARDS_CSS, ".task-card-head-row .schedule-tv-id--tag")).toContain("margin-block: 0");
+    expect(block(CARDS_CSS, ".task-card-head-row .schedule-tv-id-shield")).toContain("align-self: center");
     expect(CARDS_CSS).toContain("grid-auto-rows: max(260px, calc((100cqh - 12px) / 2));");
     // A fixed COUNT, not auto-fill/auto-fit: the wall must not re-flow every time
     // the window grows by a card's worth.
@@ -6930,7 +6934,11 @@ describe("the Cards view's frame", () => {
     const TASKS_CSS = readFileSync(join(SHELL, "../styles/tasks.css"), "utf8");
     expect(TASKS_CSS).toContain(".task-card-head-row .schedule-tv-id--tag,\n.tasks-row .schedule-tv-id--tag {");
     expect(TASKS_CSS).toContain(".task-card-head-row .schedule-tv-id--tag.is-on,\n.tasks-row .schedule-tv-id--tag.is-on {");
-    expect(CARDS_CSS).not.toContain("schedule-tv-id--tag");
+    // ...except the ROW's vertical trick, which this one-line head undoes: no
+    // negative margin, no stretched shield, so the name sits on the same line
+    // as the id and the time (Akshil, 2026-09-05, screenshot).
+    expect(block(CARDS_CSS, ".task-card-head-row .schedule-tv-id--tag")).toContain("margin-block: 0");
+    expect(block(CARDS_CSS, ".task-card-head-row .schedule-tv-id-shield")).toContain("align-self: center");
     // Columns step on the WALL's width, not the window's: container queries
     // against the scroller, never a media query (Akshil, 2026-09-05: the
     // sidebar's 232px were invisible to a media query).

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6903,11 +6903,19 @@ describe("the Cards view's frame", () => {
     expect(acts.indexOf("Open in Explorer")).toBeGreaterThan(-1);
     expect(acts.indexOf("Open in Explorer")).toBeLessThan(acts.indexOf("{filing.label}"));
     expect((acts.match(/className="btn btn-secondary modal-head-act"/g) ?? []).length).toBe(2);
-    // The folder chip, the List row's own, at the right before the time
-    // (Akshil, 2026-09-05) — a plain label, never the List's filter tag.
+    // The folder chip, the List row's own, at the right before the time — and
+    // the List's TAG: pressed, it filters the page (Akshil, 2026-09-05), through
+    // the one handler Scheduled hands both views, wearing the pinned state.
     const headRow = CARDS.slice(CARDS.indexOf('<div className="task-card-head-row">'), CARDS.indexOf("</div>", CARDS.indexOf('<div className="task-card-head-row">')));
-    expect(headRow).toContain("<IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />");
-    expect(headRow).not.toContain("onPick");
+    expect(headRow).toContain("name={basename(task.project)}");
+    expect(headRow).toContain("onPick={project.onPick && (() => project.onPick?.(task.project))}");
+    expect(headRow).toContain("active={project.pinned}");
+    expect(SCHEDULED).toContain("const pickProject = (project: string) =>");
+    expect((SCHEDULED.match(/onPickProject=\{pickProject\}/g) ?? []).length).toBe(2);
+    expect((SCHEDULED.match(/pinnedProjects=\{filters\.projects\}/g) ?? []).length).toBe(2);
+    // ...and shown by the List's rule: only when the cards span folders, or the
+    // page is pinned to one.
+    expect(CARDS).toContain("spansProjects(cards) || pinnedProjects.length > 0");
     expect(headRow.indexOf("<IdentityChip")).toBeLessThan(headRow.indexOf("task-card-when"));
     expect(headRow.indexOf("tasks-id--task")).toBeLessThan(headRow.indexOf("<IdentityChip"));
     expect(block(CARDS_CSS, ".task-card-head-row > .schedule-tv-id")).toContain("margin-left: auto");

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2863,17 +2863,18 @@ export const CARD_LANES: BoardColumn[] = LIST_ORDER.filter((key) => key !== "arc
 /**
  * HOW MANY LIVE CHATS PER PAGE. Each card is an iframe running the chat template,
  * and that template polls its run every 400ms — so the wall does not draw every
- * running task at once. It draws NINE, and a "Show 9 more" card at the end adds
- * the next nine on request (Akshil, 2026-09-05: "a show more button that shows
- * nine more, nine more, nine more"). The budget is the reader's, taken a page at
- * a time, rather than a ceiling the view imposes.
+ * task at once. It draws SIX, and a "Show more" strip under the grid adds the
+ * next six on request (Akshil, 2026-09-05: "have 6 cards loaded instead of
+ * nine, and show 6 more cards when we click on show more"). The budget is the
+ * reader's, taken a page at a time, rather than a ceiling the view imposes.
  *
- * Nine because the grid is three across and two rows deep before the fold
- * (task-cards.css): six in view and a third row already loaded underneath for
- * whoever scrolls, and every page after it three more full rows — so no page
- * ends on a ragged row that would read as a bug in the grid.
+ * Six because the grid is three across and two rows deep before the fold
+ * (task-cards.css): one page is exactly what is in view, and every page after
+ * it two more full rows — so no page ends on a ragged row that would read as a
+ * bug in the grid. (Nine was tried first: the third row sat under the fold,
+ * loading, for a wall nobody had asked to scroll yet.)
  */
-export const CARD_PAGE = 9;
+export const CARD_PAGE = 6;
 
 /** What the Cards view draws: the live tasks within the pages shown so far, and
  * how many are still behind the fold. `hidden` is 0 whenever nothing was left

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -18,7 +18,7 @@
 
 /* -- the wall ----------------------------------------------------------------- */
 /* THREE ACROSS, TWO DOWN, THEN SCROLL (Akshil, 2026-09-04: six cards in view;
-   2026-09-05: nine LOADED a page, so the third row is already there under the
+   2026-09-05: six a page — one page is what is in view, Show more adds the
    fold for whoever scrolls). The SCROLLER is `.task-cards-scroll`, in exactly
    the List's shape — the same `flex: 1; min-height: 0; overflow-y: auto` in the
    same 1050px content column, so the bar stands where the List's bar stands and
@@ -78,13 +78,20 @@
   min-width: 0;
 }
 
-@media (max-width: 1000px) {
+/* COLUMNS FOLLOW THE WIDTH THE WALL HAS, not the window's (Akshil, 2026-09-05:
+   with the sidebar collapsed the wall stepped from three to two exactly right,
+   and with it open — 232px narrower — it did not, because a media query cannot
+   see the sidebar). The scroller is already a size container (for the rows,
+   above), so the steps are container queries against it: three across while a
+   card keeps ~300px — the width below which a chat turn stops being a
+   paragraph — then two, then one. */
+@container (max-width: 920px) {
   .task-cards {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 680px) {
+@container (max-width: 600px) {
   .task-cards {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -136,8 +143,10 @@
   outline-offset: -2px;
 }
 
-/* Row one: ring then id at the left edge (the List row's order), the time at
-   the right. `margin-left: auto` on the time is what pushes it over. */
+/* Row one: ring then id at the left edge (the List row's order), the folder
+   chip and the time at the right. `margin-left: auto` on the chip is what
+   pushes the right-hand pair over; the chip gives way first when the row is
+   short, the time never does. */
 .task-card-head-row {
   display: flex;
   align-items: center;
@@ -145,8 +154,10 @@
   min-width: 0;
 }
 
-.task-card-head-row > .task-card-when {
+.task-card-head-row > .schedule-tv-id {
   margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Row two: the title, ONE LINE, at a size that reads across a wall of six —
@@ -219,7 +230,7 @@
 
 /* -- show more ---------------------------------------------------------------- */
 /* Past the page (tasks-lib.CARD_PAGE) the wall stops embedding and offers the
-   next nine: one full-width strip under the grid, in the card's own dashed
+   next six: one full-width strip under the grid, in the card's own dashed
    voice, sized like a control and not like a card — it used to be a grid cell,
    which made it one card wide and a whole chat tall (Akshil, 2026-09-05).
    Pressing it adds a page in place; it never navigates away. */

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -154,10 +154,12 @@
   min-width: 0;
 }
 
+/* The chip arrives inside IdentityChip's shield when it is a tag (and bare
+   when it is a label), so both shapes take the auto margin. Its skin is the
+   List row's, widened to this row in tasks.css. */
+.task-card-head-row > .schedule-tv-id-shield,
 .task-card-head-row > .schedule-tv-id {
   margin-left: auto;
-  min-width: 0;
-  overflow: hidden;
 }
 
 /* Row two: the title, ONE LINE, at a size that reads across a wall of six —

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -162,6 +162,22 @@
   margin-left: auto;
 }
 
+/* CENTRED ON THE ROW'S OWN LINE. The List row pays for the tag's 3px of padding
+   with `margin-block: -3px` and lets the shield stretch to the row's height,
+   which is right in a 36px row and wrong here: this row is one text line tall,
+   the stretched shield is shorter than the tag, and centring a negative-margin
+   box in it landed the folder name 1.5px above the id and the time (Akshil,
+   2026-09-05, screenshot). No negative margin and no stretch: the tag stands at
+   its own height, the shield takes that height, and the row centres it with
+   everything else. */
+.task-card-head-row .schedule-tv-id-shield {
+  align-self: center;
+}
+
+.task-card-head-row .schedule-tv-id--tag {
+  margin-block: 0;
+}
+
 /* Row two: the title, ONE LINE, at a size that reads across a wall of six —
    the card's whole width is its own now, so it no longer competes with the id
    and the time for one strip. Ellipsed; the full text rides `data-hint`. */

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -680,6 +680,12 @@ button.tasks-caret,
    focus. `-4px/-6px` negative margins with matching padding, so growing the box
    costs no layout — the chip occupies the same space it did as a bare label and
    nothing beside it moves when the pointer arrives. */
+/* AND THE CARDS WALL'S HEAD ROW, on every rule of this tag from here down: the
+   folder chip in a card's head is this same tag (Akshil, 2026-09-05: "project
+   name ui as is from list view"), and a skin scoped to `.tasks-row` alone left
+   it a bare button there. One skin, two hosts; only the row's `::after` band
+   stays the row's, because its reach is the row's own padding. */
+.task-card-head-row .schedule-tv-id--tag,
 .tasks-row .schedule-tv-id--tag {
   appearance: none;
   border: 0;
@@ -746,6 +752,7 @@ button.tasks-caret,
    (so the pill keeps its own hover, cursor and press) while the shield's own
    `z-index: 2` keeps the whole subtree above `.tasks-rowlink` at `z-index: 1`.
    That is the entire mechanism by which a near-miss stops opening the task. */
+.task-card-head-row .schedule-tv-id-shield,
 .tasks-row .schedule-tv-id-shield {
   flex: 0 0 auto;
   display: inline-flex;
@@ -771,11 +778,14 @@ button.tasks-caret,
    a row rather than on a bar. On the BUTTON, which is the pill: the wash and the
    target are the same box again, and the shield above it is what keeps a
    near-miss from doing anything at all. */
+.task-card-head-row .schedule-tv-id--tag:hover,
+.task-card-head-row .schedule-tv-id--tag:focus-visible,
 .tasks-row .schedule-tv-id--tag:hover,
 .tasks-row .schedule-tv-id--tag:focus-visible {
   background: var(--ctl-quiet-bg-hover);
 }
 
+.task-card-head-row .schedule-tv-id--tag:focus-visible,
 .tasks-row .schedule-tv-id--tag:focus-visible {
   outline: 1px solid var(--accent);
   outline-offset: 0;
@@ -803,6 +813,7 @@ button.tasks-caret,
 
    ON THE BUTTON, which is the pill again since the shield took over the target
    (2026-08-24): the state and the thing it is a state OF are one box. */
+.task-card-head-row .schedule-tv-id--tag.is-on,
 .tasks-row .schedule-tv-id--tag.is-on {
   background: color-mix(in srgb, var(--accent) 18%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
@@ -810,6 +821,8 @@ button.tasks-caret,
 
 /* Hover must not wash the accent away — the quiet rule above is a plain
    `background`, and on the ON chip it would win by source order. */
+.task-card-head-row .schedule-tv-id--tag.is-on:hover,
+.task-card-head-row .schedule-tv-id--tag.is-on:focus-visible,
 .tasks-row .schedule-tv-id--tag.is-on:hover,
 .tasks-row .schedule-tv-id--tag.is-on:focus-visible {
   background: color-mix(in srgb, var(--accent) 26%, transparent);
@@ -820,6 +833,7 @@ button.tasks-caret,
    so the chip's only child is its name. The class itself is still live for the
    OTHER folder rows in this file's neighbour (the recents list), which draw their
    own glyph. */
+.task-card-head-row .schedule-tv-id--tag.is-on .schedule-tv-id-name,
 .tasks-row .schedule-tv-id--tag.is-on .schedule-tv-id-name {
   color: var(--fg);
   opacity: 1;
@@ -829,6 +843,7 @@ button.tasks-caret,
    board card it is the thing that must shrink. On a task ROW it is not: the title
    is, and a chip that shrank alongside it would ellipsise a folder name while the
    title still had room. Scoped here so the card keeps its own answer. */
+.task-card-head-row .schedule-tv-id,
 .tasks-row .schedule-tv-id {
   flex: 0 0 auto;
 }
@@ -845,6 +860,7 @@ button.tasks-caret,
    is deliberately untouched here (it keeps `.tasks-msg-time`'s register, which the
    thread below shares — two weights for one fact is how a row and its thread part
    company). */
+.task-card-head-row .schedule-tv-id-name,
 .tasks-row .schedule-tv-id-name {
   color: var(--fg);
 }


### PR DESCRIPTION
## What
- **Six cards a page** (was nine): one page = the two rows in view; **Show more** adds six.
- **Folder chip in the card head**, right side before the time — the List row's own `IdentityChip` (basename, full path on hover), as the List's **filter tag** (press to pin the page to that folder, press again to clear; the chip's shield keeps the press from opening the popup).
- **Columns follow the wall's width, not the window's**: `@container` queries against the scroller (already a size container) replace the media queries. Three across while a card keeps ~300px (wall > 920px), two down to 600px, then one. With the sidebar open the wall is 232px narrower and now steps the same way it did collapsed.

## Why
Akshil, 2026-09-05, after using the wall from #1009.

## Tests
- `tasks-lib.test.ts`: `CARD_PAGE` = 6; chip present, plain, ordered before the time; no `@media` left in task-cards.css, the two `@container` steps present.
- `bun run typecheck` clean, `bun test` 3042 pass.
- Browser (cmux): 6 cards → Show more → 12; chip "fused-render" with `~/…` hint; forcing the wall to 1040/900/700/600px gives 3/2/2/1 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to the Tasks Cards view (filtering, pagination, responsive layout) with no auth or data-model changes; regression risk is localized to scheduled-task views.
> 
> **Overview**
> **Cards view** now matches the List for project filtering: a shared `pickProject` handler in `Scheduled.tsx` toggles a single-folder filter (press again to clear) for both List and Cards. Card heads show the same `IdentityChip` tag (before the time), with keyboard handling so Enter/Space on the chip filters instead of opening the peek popup.
> 
> **Pagination** drops from nine to **six** cards per page (`CARD_PAGE`); **Show more** adds six at a time so one page equals the two visible rows.
> 
> **Layout** replaces viewport `@media` breakpoints with **`@container`** queries on the cards scroller so column count (3 → 2 → 1) follows the wall width when the sidebar is open. Shared folder-chip styles in `tasks.css` cover card heads; popup head actions are reordered to **Archive** then **Open in Explorer**.
> 
> Tests in `tasks-lib.test.ts` are updated for the new page size, chip behavior, and CSS expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f670c66b547a2c9191ac0891b9a8d7b2d0d3d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->