### PR TITLE
Cards: every status on the wall, Archive included

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,6 +61,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2008,6 +2009,7 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2252,6 +2254,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -3035,6 +3038,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3422,6 +3426,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.4.tgz",
       "integrity": "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4861,6 +4866,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4873,6 +4879,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5679,6 +5686,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5801,6 +5809,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5957,6 +5966,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -630,10 +630,11 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
             <TaskBoard tasks={shown} home={home} onReload={reload} />
           ) : view === "cards" ? (
             <TaskCards
-              // The FILTERED set, like every other view: Cards narrows it again
-              // (tasks-lib.cardsForTasks drops Archive), and a Project or a
-              // Search the reader set on another view is a lens they meant to
-              // keep — the same argument that put the toolbar on the calendar.
+              // The FILTERED set, like every other view: Cards only ORDERS it
+              // (tasks-lib.cardsForTasks — every lane, Archive last), and a
+              // Project, Status or Search the reader set on another view is a
+              // lens they meant to keep — the same argument that put the
+              // toolbar on the calendar.
               tasks={shown}
               home={home}
               onReload={reload}

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -1,7 +1,7 @@
 // The Tasks page's fourth view: CARDS — every task's conversation, side by
 // side, the running ones streaming (Akshil, 2026-09-03: "like a eagle eye view
-// of all chats streaming in at the same time"; 2026-09-05: "all tasks here
-// except archived").
+// of all chats streaming in at the same time"; 2026-09-05: every status,
+// "even archived ones").
 //
 // It is the one view on this page that does not draw ROWS ABOUT tasks. The List,
 // the Board and the Calendar all answer "what is there and where does it sit";
@@ -108,8 +108,8 @@ export function TaskCards({
   onPickProject,
   pinnedProjects = [],
 }: {
-  /** Already filtered, in the SERVER's order — `cardsForTasks` drops the
-   * archived ones and orders the rest, which is the one thing this view does to
+  /** Already filtered, in the SERVER's order — `cardsForTasks` orders it by
+   * lane (every lane, Archive last), which is the one thing this view does to
    * the set it is handed and the one place it is decided. */
   tasks: Task[];
   home?: string;

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6596,14 +6596,14 @@ function asking(key: string, at: number, over: Partial<Task> = {}): Task {
 }
 
 describe("cardsForTasks", () => {
-  it("draws every lane but Archive, in the List's own rank order", () => {
-    // Akshil, 2026-09-05: "we show all tasks here except archived". CARD_LANES is
-    // both the membership test and the rank order, and it is LIST_ORDER minus
-    // Archive rather than a second list — so the wall and the List can never
-    // disagree about which lane comes first. Every name in it is still a real
-    // board column.
-    expect(CARD_LANES).toEqual(LIST_ORDER.filter((k) => k !== "archived"));
-    expect(CARD_LANES).toEqual(["needs_attention", "blocked", "upcoming", "in_progress", "done"]);
+  it("draws every lane, Archive included, in the List's own rank order", () => {
+    // Akshil, 2026-09-05: "show all status tasks in cards even archived ones"
+    // (that morning it was every lane but Archive). CARD_LANES is both the
+    // membership test and the rank order, and it is LIST_ORDER itself rather
+    // than a second list — so the wall and the List can never disagree about
+    // which lane comes first. Every name in it is still a real board column.
+    expect(CARD_LANES).toEqual(LIST_ORDER);
+    expect(CARD_LANES).toEqual(["needs_attention", "blocked", "upcoming", "in_progress", "done", "archived"]);
     for (const key of CARD_LANES) expect(BOARD_COLUMNS.map((c) => c.key)).toContain(key);
     const rows = [
       running("a", 100),
@@ -6614,8 +6614,8 @@ describe("cardsForTasks", () => {
       asking("f", 50),
     ];
     // "f" is OLDER than "a" and still comes first: the lane outranks the clock.
-    // "e" — archived — is the one row not drawn.
-    expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["f", "d", "c", "a", "b"]);
+    // "e" — archived — is drawn too, in the bottom lane.
+    expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["f", "d", "c", "a", "b", "e"]);
   });
 
   it("groups by lane before it sorts, blocked first, then in progress", () => {

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2839,14 +2839,16 @@ export function sortByLane(tasks: Task[], now: number = Date.now()): Task[] {
 // in at the same time"). It is not another arrangement of the same rows — each
 // card shows the task's live conversation rather than a title and a time.
 //
-// EVERY TASK BUT THE ARCHIVED ONES (Akshil, 2026-09-05: "we show all tasks here
-// except archived"). The wall began as the running set alone; a finished run's
-// transcript is as much worth a glance as a live one, and Archive is the one
-// lane whose whole meaning is "not on any wall". So the membership test is the
-// List's own rank order minus that lane, and the RANK is the List's too: which
-// lane comes first is written down exactly once (LIST_ORDER) and this view reads
-// it rather than keeping a second table in step. Needs attention at the top,
-// because a parked run is the one card that needs a person; Done at the bottom.
+// EVERY TASK, EVERY STATUS (Akshil, 2026-09-05, later the same day: "show all
+// status tasks in cards even archived ones"). The wall began as the running set
+// alone, grew to every lane but Archive that morning, and now draws Archive too:
+// an archived conversation is still a conversation worth a glance, and the
+// Status filter — not the view — is where a reader narrows the wall. So the
+// membership test is the List's own rank order, whole, and the RANK is the
+// List's too: which lane comes first is written down exactly once (LIST_ORDER)
+// and this view reads it rather than keeping a second table in step. Needs
+// attention at the top, because a parked run is the one card that needs a
+// person; Archive at the bottom, under Done.
 //
 // The one decision that is this view's own is the clock inside a lane: `started`
 // rather than `last_active`, because `last_active` climbs on every write and
@@ -2857,8 +2859,10 @@ export function sortByLane(tasks: Task[], now: number = Date.now()): Task[] {
 // are the ones worth testing and a grid of iframes is the last place to test
 // anything.
 
-/** The lanes a Cards view draws, top rank first — LIST_ORDER without Archive. */
-export const CARD_LANES: BoardColumn[] = LIST_ORDER.filter((key) => key !== "archived");
+/** The lanes a Cards view draws, top rank first — LIST_ORDER, whole. Kept as
+ * its own name so the view's membership test reads as a decision, not a
+ * coincidence of the List's table. */
+export const CARD_LANES: BoardColumn[] = LIST_ORDER;
 
 /**
  * HOW MANY LIVE CHATS PER PAGE. Each card is an iframe running the chat template,
@@ -2940,7 +2944,7 @@ export function cardKey(task: Pick<Task, "key" | "task_id" | "project">): string
  * that buried the only card on it that needs a person: a run parked on a
  * question stops ticking `last_active` the moment it asks, so the longer it
  * waits the further down it sinks — exactly backwards. The rank is a card's
- * lane's index in `CARD_LANES`, which is LIST_ORDER without Archive, so this
+ * lane's index in `CARD_LANES`, which is LIST_ORDER whole, so this
  * cannot drift out of step with the List: the same rows in the same lane order
  * in both views, which is what makes switching between them a change of shape
  * rather than of subject.

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -130,10 +130,14 @@
   /* Its OWN ground, a step up from the card's: the frame under it is the chat
      template, whose page colour is within a shade of the card's, so a head on
      the card's ground read as one more line of the transcript (Akshil,
-     2026-09-05: "the card heading doesn't have enough contrast"). A wash of
-     the ink over the card colour rather than a token of its own, so the step
-     is the same size on both themes. */
-  background: color-mix(in srgb, var(--fg) 8%, var(--tasks-card-bg));
+     2026-09-05: "the card heading doesn't have enough contrast"). The colour
+     is BORROWED, not new (Akshil, same day: "borrow a color ... so it feels
+     consistent"): --row-bg-hover is the Tasks page's one raised strip — the
+     List row, the Board's lane head and the calendar's rows all lift to it —
+     and it is the only ground in the palette that clears both the card and
+     the frame on both themes (--bg-alt and --tasks-lane-bg sit within a shade
+     of the frame in the dark). */
+  background: var(--row-bg-hover);
   /* The head is a button (TaskCards: it opens the task's popup) and says so
      the way every pressable strip on this page does — the pointer, and a wash
      on hover at the row's own weight (tasks.css `.tasks-row:hover`). */
@@ -142,7 +146,9 @@
 }
 
 .task-card-head:hover {
-  background: color-mix(in srgb, var(--fg) 12%, var(--tasks-card-bg));
+  /* One more step of the same wash the token itself is made of (tokens.css:
+     "--bg-alt under the neutral 0.06 wash"). */
+  background: color-mix(in srgb, var(--fg) 5%, var(--row-bg-hover));
 }
 
 .task-card-head:focus-visible {

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -127,6 +127,13 @@
   min-width: 0;
   padding: 8px 10px;
   border-bottom: 1px solid var(--border);
+  /* Its OWN ground, a step up from the card's: the frame under it is the chat
+     template, whose page colour is within a shade of the card's, so a head on
+     the card's ground read as one more line of the transcript (Akshil,
+     2026-09-05: "the card heading doesn't have enough contrast"). A wash of
+     the ink over the card colour rather than a token of its own, so the step
+     is the same size on both themes. */
+  background: color-mix(in srgb, var(--fg) 8%, var(--tasks-card-bg));
   /* The head is a button (TaskCards: it opens the task's popup) and says so
      the way every pressable strip on this page does — the pointer, and a wash
      on hover at the row's own weight (tasks.css `.tasks-row:hover`). */
@@ -135,7 +142,7 @@
 }
 
 .task-card-head:hover {
-  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  background: color-mix(in srgb, var(--fg) 12%, var(--tasks-card-bg));
 }
 
 .task-card-head:focus-visible {


### PR DESCRIPTION
## What

The Tasks **Cards** view now draws tasks of every status, archived ones included. This morning's #1011 made it "every lane but Archive"; the follow-up asks for Archive too.

- `CARD_LANES` is `LIST_ORDER` whole (was `LIST_ORDER` minus `archived`) — one shared table for membership and rank, so the wall and the List can never disagree on lane order.
- Archived cards land in the bottom lane, under Done. The **Status** filter remains the way to narrow the wall.
- Comments in `TaskCards.tsx`, `Scheduled.tsx` and `tasks-lib.ts` updated; the `cardsForTasks` test now expects the archived row drawn last.

## Verified
- `bun test` — 3042 pass; `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI and ordering change for Cards with updated tests; lockfile-only npm metadata elsewhere.
> 
> **Overview**
> The Tasks **Cards** view now includes **archived** tasks instead of hiding that lane. **`CARD_LANES`** is **`LIST_ORDER`** end-to-end (Archive last), so membership and rank stay aligned with the List; narrowing by status stays on the **Status** filter. **`cardsForTasks`** and its test expect archived rows in the wall order.
> 
> Card headers get clearer separation from the embedded chat: **`--row-bg-hover`** on **`.task-card-head`**, with a slightly stronger hover wash.
> 
> **`frontend/package-lock.json`** only adds **`peer: true`** metadata on several packages (lockfile churn, no app logic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ea063ca0574a664430f4d88f2ccefdcf3c1573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->