### PR TITLE
Cards: a card is a row, not a task number

### DIFF
--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -137,7 +137,24 @@ export function TaskCards({
   const peekLive = useMemo(() => {
     if (!peek) return null;
     const id = cardKey(peek);
-    return tasks.find((t) => cardKey(t) === id) ?? peek;
+    const byKey = tasks.find((t) => cardKey(t) === id);
+    if (byKey) return byKey;
+    // THE HANDOVER (Bugbot, #1015). A popup opened on a "Starting…" card holds
+    // a `pending:<entry>` row, and the row that replaces it two seconds later
+    // is keyed by the session — a different cardKey now — so by key alone the
+    // popup would keep the placeholder and never frame the chat. The task
+    // NUMBER is what usually carries across that moment (ensure_ids' rekeys
+    // pass), so a peek WITHOUT a session may follow its number to the row that
+    // has one. Only a session-less peek: a peek with a session has a key that
+    // never changes, and following the number from THERE is exactly how a twin
+    // — two sessions under one number — got opened in the first place (cardKey).
+    if (!peek.session_id && peek.task_id) {
+      const settled = tasks.find(
+        (t) => t.session_id && t.project === peek.project && t.task_id === peek.task_id,
+      );
+      if (settled) return settled;
+    }
+    return peek;
   }, [peek, tasks]);
   // HOW MANY PAGES THE READER HAS ASKED FOR. Six cards to begin with, and each
   // press of the trailing strip adds six (Akshil, 2026-09-05). Never wound back

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -231,14 +231,12 @@ export function TaskCards({
           // reload). This is what makes a poll a re-render and not twelve
           // reloads.
           //
-          // And not `task.key` either, which is what this was and which is a
-          // key that CHANGES under one task: a scheduled run is listed as
-          // `pending:<entry>` until its session reports, then relisted under the
-          // session id (§5), so every card was being torn down and rebuilt about
-          // two seconds after it appeared. `cardKey` carries across that
-          // handover, and it says at length why the task NUMBER is the half that
-          // does — and why the one case where even the number moves cannot reach
-          // a card that has a session to frame.
+          // `cardKey` — the row key, since 2026-09-06 — rather than the task
+          // NUMBER it was for three days: two sessions can share a number (the
+          // rekey at the pending → session handover is refused when the session
+          // already holds one), and a wall keyed on the number drew one of the
+          // two and opened the other. cardKey says why the handover remount
+          // this gives back only ever rebuilds a "Starting…" placeholder.
           key={cardKey(task)}
           task={task}
           home={home}

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -156,6 +156,17 @@ export function TaskCards({
     }
     return peek;
   }, [peek, tasks]);
+  // ...and the settled row is WRITTEN BACK as the peek (Bugbot, #1015, round
+  // 2): left as the pending snapshot, every later poll would re-resolve by the
+  // number this view stopped trusting, and a failed poll (`tasks` empty) or a
+  // filter dropping the row would fall back to the placeholder and tear down
+  // the framed chat. Adopted once, the popup matches by key from then on and
+  // keeps the settled snapshot as its fallback like any other peek.
+  useEffect(() => {
+    if (peek && peekLive && peekLive !== peek && !peek.session_id && peekLive.session_id) {
+      setPeek(peekLive);
+    }
+  }, [peek, peekLive]);
   // HOW MANY PAGES THE READER HAS ASKED FOR. Six cards to begin with, and each
   // press of the trailing strip adds six (Akshil, 2026-09-05). Never wound back
   // by a poll: the list refreshes every 20 seconds, and a wall that collapsed to

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6662,25 +6662,25 @@ describe("cardsForTasks", () => {
     expect(cardsForTasks(after).cards.map((t) => t.key)).toEqual(order);
   });
 
-  it("is one card per identity, across the pending → session handover", () => {
-    // A scheduled run is listed under `pending:<entry>` until its session
-    // reports, then under the session id — one task, two keys, and keying a card
-    // on `task.key` tore the whole card down two seconds after it appeared.
-    // `cardKey` is what carries across that (see its own note for the one case
-    // where even the number moves, and why that case cannot reach a card that is
-    // already streaming), and the set is deduplicated on it so a server that
-    // ever did list both at once would draw one card rather than two fighting
-    // over a slot.
+  it("is one card per ROW: two sessions sharing a task number are two cards", () => {
+    // The identity was the (project, number) pair until 2026-09-06, when a live
+    // list showed two different sessions under one TASK-007 — the wall drew one
+    // of them and the popup could open the other (Akshil: a card "says different
+    // task on card but open different task in modal"). The row key is unique by
+    // construction; see cardKey for why the handover it stops smoothing only ever
+    // rebuilt a "Starting…" placeholder.
+    const a = task({ key: "sess-a", task_id: "TASK-007", status: "archived", project: "/p" });
+    const b = task({ key: "sess-b", task_id: "TASK-007", status: "done", project: "/p" });
+    expect(cardKey(a)).not.toBe(cardKey(b));
+    expect(cardsForTasks([a, b]).cards.map((t) => t.key)).toEqual(["sess-b", "sess-a"]);
+    // The handover: the pending row and the settled row are two identities now,
+    // and a server that listed both at once would draw both — the dedupe is a
+    // guard against a same-key pair only.
     const pending = running("pending:e1", 100, { task_id: "TASK-097", session_id: "" });
     const settled = running("sess-9", 100, { task_id: "TASK-097" });
-    expect(cardKey(pending)).toBe(cardKey(settled));
-    expect(cardsForTasks([pending, settled]).cards.map((t) => t.key))
-      .toEqual(["pending:e1"]);
-    // Two projects may each hold a TASK-097 — the number is allocated per
-    // project — so the pair, not the number, is the identity.
-    expect(cardKey({ key: "k", task_id: "TASK-097", project: "/a" }))
-      .not.toBe(cardKey({ key: "k", task_id: "TASK-097", project: "/b" }));
-    // No number at all (a read-only state dir): the row's own key stands in.
+    expect(cardKey(pending)).not.toBe(cardKey(settled));
+    expect(cardsForTasks([settled, settled]).cards.map((t) => t.key)).toEqual(["sess-9"]);
+    // No number at all (a read-only state dir): still the row's own key.
     expect(cardKey({ key: "sess-3", task_id: "", project: "/a" })).toBe("sess-3");
   });
 

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6953,7 +6953,14 @@ describe("the Cards view's frame", () => {
     // Bugbot, #1009: the popup follows the polls (a "Starting…" task gains its
     // session), survives an empty wall (a failed poll, a filter), and puts the
     // caret in the chat.
-    expect(CARDS).toContain("return tasks.find((t) => cardKey(t) === id) ?? peek;");
+    expect(CARDS).toContain("const byKey = tasks.find((t) => cardKey(t) === id);");
+    // ...and across the pending → session handover, a popup opened on a
+    // "Starting…" card follows its NUMBER to the row that gained a session —
+    // only a session-less peek does (Bugbot, #1015): a peek with a session has
+    // a key that never changes, and following the number from there is how a
+    // twin got opened.
+    expect(CARDS).toContain("if (!peek.session_id && peek.task_id) {");
+    expect(CARDS).toContain("(t) => t.session_id && t.project === peek.project && t.task_id === peek.task_id,");
     const emptyBranch = CARDS.slice(CARDS.indexOf("if (cards.length === 0) {"), CARDS.indexOf("return (\n    // The SCROLLER"));
     expect(emptyBranch).toContain("{popup}");
     expect(CARDS).toContain("initialFocus={frameRef}");

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6961,6 +6961,12 @@ describe("the Cards view's frame", () => {
     // twin got opened.
     expect(CARDS).toContain("if (!peek.session_id && peek.task_id) {");
     expect(CARDS).toContain("(t) => t.session_id && t.project === peek.project && t.task_id === peek.task_id,");
+    // ...and adopts the settled row as the peek, so later polls match by key
+    // and an empty poll keeps the framed chat (Bugbot, #1015, round 2).
+    expect(CARDS).toContain(
+      "if (peek && peekLive && peekLive !== peek && !peek.session_id && peekLive.session_id) {",
+    );
+    expect(CARDS).toContain("setPeek(peekLive);");
     const emptyBranch = CARDS.slice(CARDS.indexOf("if (cards.length === 0) {"), CARDS.indexOf("return (\n    // The SCROLLER"));
     expect(emptyBranch).toContain("{popup}");
     expect(CARDS).toContain("initialFocus={frameRef}");

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2890,49 +2890,39 @@ export interface TaskCardSet {
 }
 
 /**
- * WHAT A CARD IS, ACROSS THE ONE MOMENT ITS ROW CHANGES IDENTITY.
+ * WHAT A CARD IS: the server's row key — the session id once there is one, the
+ * `pending:<entry>` key before it.
  *
- * A scheduled run is claimed and sent before anything knows which Claude session
- * it opened, so for that whole window the task is listed under `pending:<entry>`
- * — and the moment the session reports, the SAME task is relisted under the
- * session id and the pending key is declared gone (§5, routers/tasks.py). Keyed
- * on `task.key`, React sees that as one card leaving and another arriving: the
- * whole card is torn down and rebuilt. Measured on this branch, about two
- * seconds after every new task appeared — one of the "multiple" shifts the user
- * reported (Akshil, 2026-09-03).
+ * It was the (project, task number) pair from 2026-09-03 to 2026-09-06, so a
+ * scheduled run's card could carry across the pending → session handover
+ * without a remount (`task_id` is moved onto the session key by that
+ * transition — tasks_store.ensure_ids' `rekeys` pass). That rested on ONE NUMBER
+ * NAMING ONE TASK, and a live list showed it does not: four (project, number)
+ * pairs each held two different sessions — an archived "Current worktrees" and
+ * a done "Investigate Python 3.12" both as TASK-007, say — because the rekey is
+ * refused when the session key already holds a number and the pending row's
+ * number is respent. Keyed on the pair, the wall drew ONE of each twin (the
+ * dedupe below kept the first) and the popup, resolving the clicked card by the
+ * same pair, could land on the OTHER — a card saying one task and a modal
+ * opening another (Akshil, 2026-09-06). Showing Archive on the wall is what
+ * surfaced it: that is where the twins live.
  *
- * THE NUMBER IS WHAT USUALLY SURVIVES IT. `task_id` is allocated once and then
- * MOVED onto the session key by that same transition (tasks_store.ensure_ids'
- * `rekeys` pass, which exists for exactly this), so "TASK-097" names one task
- * across the handover while `key` does not.
+ * WHAT THE PAIR BOUGHT IS NOT WORTH THAT. The handover it smoothed happens only
+ * while the task has no session — while its card is a "Starting…" placeholder
+ * with nothing to frame — so what is torn down and rebuilt at the handover is a
+ * placeholder, in the same grid slot, and no streaming conversation is ever
+ * touched: a card that has a frame has a session key, and a session key never
+ * changes. The row key, on the other hand, is unique by construction (it IS the
+ * server's row identity), so two sessions are two cards and a click resolves to
+ * the card it landed on and nothing else.
  *
- * NOT ALWAYS, AND IT DOES NOT NEED TO BE — this is the part worth knowing. The
- * rekey is refused when the session key ALREADY holds a number, which happens
- * when the transcript is listed before the scheduled entry has been joined to
- * it: the session is numbered on its own, and the pending row's number is
- * SPENT (`ensure_ids` says so, and a live task_ids.json shows both outcomes —
- * three tasks whose number moved onto the session id, and one left stranded
- * under `pending:…` while its session took the next number). So the identity can
- * still change once.
- *
- * WHAT MAKES THAT HARMLESS is WHEN it can happen: only while the task has no
- * session id, which is exactly while its card has nothing to frame and is
- * showing "Starting…" (TaskCards). Once a card is streaming, its key is a
- * session key with a number already on it, and `ensure_ids` never renumbers what
- * it has numbered — so no conversation on this wall can be torn down. The worst
- * case is a placeholder replaced by a placeholder, in the same grid slot.
- *
- * THE PAIR, not the number alone: numbers are allocated per PROJECT, so two
- * projects may each hold a TASK-097 and the wall can show both. `\u0000` as the
- * joiner because it is the one character neither a path nor a task number can
- * contain, so no pair can be spelled two ways.
- *
- * FALLS BACK TO `key` when there is no number: `ensure_ids` answers `{}` on a
- * read-only state dir (the numbers stay blank until it is writable again), and a
- * card with no identity at all is worse than one that remounts.
+ * Still a function of its own rather than `task.key` at the call sites, because
+ * the identity is a decision this view makes and one that has already changed
+ * once; the seams that read it (the React key, the dedupe, the popup's lookup)
+ * should keep reading one name.
  */
 export function cardKey(task: Pick<Task, "key" | "task_id" | "project">): string {
-  return task.task_id ? `${task.project}\u0000${task.task_id}` : task.key;
+  return task.key;
 }
 
 /**
@@ -2989,10 +2979,10 @@ export function cardKey(task: Pick<Task, "key" | "task_id" | "project">): string
  *
  * ONE CARD PER IDENTITY. Deduplicated on `cardKey`, which is what the view keys
  * its iframes on — two rows resolving to one card would be a React duplicate key
- * and two iframes fighting over one slot. The server does not emit such a pair
- * (a pending row is gone the moment its entry has a session — routers/tasks.py
- * on `/api/tasks/changes`), so this is a guard rather than a fix, and it keeps
- * the FIRST of the two, which is the one the sort already placed.
+ * and two iframes fighting over one slot. With the identity the row key (see
+ * cardKey) the server cannot emit such a pair, so this is a guard rather than a
+ * fix, and it keeps the FIRST of the two, which is the one the sort already
+ * placed.
  *
  * A new array; the input is never mutated (it is the polled list, which React is
  * still holding).


### PR DESCRIPTION
## What

Clicking a card on the Tasks **Cards** wall could open a **different task** in the popup.

**Why:** card identity was the (project, task number) pair. A live task list has four numbers shared by two different sessions each (e.g. TASK-007 is both an archived "Current worktrees" and a done "Investigate Python 3.12") — the pending → session rekey is refused when the session already holds a number, so the pending row's number gets respent. Keyed on the pair, the wall drew one twin and dropped the other, and the popup re-resolved the clicked card by the same pair — landing on the twin, whose `session_id` differs. The List never had this: its rows are keyed by the server row key and never re-resolve by number.

**Fix:** `cardKey` is the server row key (the session id; `pending:<entry>` before one exists) — unique by construction, the same identity the List uses. Both twins now draw; the popup can only open the card that was clicked.

**Trade-off:** the pending → session handover now remounts the card. That card is a "Starting…" placeholder with no frame at that moment, so nothing streaming is ever torn down (see the `cardKey` note).

Split out of #1013 at Akshil's request; independent of it (that PR is what surfaced the twins by drawing Archive).

## Verified
- `bun test` 3042 pass (the identity test rewritten for two sessions sharing a number), `npm run typecheck` clean.
- Live: clicking a card opens a popup with the same task id; 4 previously-dropped cards now on the wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task/card identity and popup resolution on a live-iframe surface; wrong logic would remount chats or open mismatched sessions, though streaming cards are explicitly protected.
> 
> **Overview**
> Fixes **Cards wall clicks opening the wrong task in the popup** when two sessions share the same task number (e.g. both TASK-007). **`cardKey` now returns the server row key** (`task.key` — session id or `pending:…`) instead of the `(project, task_id)` pair, so twins both appear on the wall and peek resolves to the row you clicked.
> 
> **Trade-off:** pending → session handover **remounts** the card (React key changes); that only affects the “Starting…” placeholder, not live iframes.
> 
> **Popup handover (#1015):** for a peek opened before a session exists, **`peekLive` briefly follows `(project, task_id)`** to the settled row, then a **`useEffect` replaces `peek` with that row** so later polls match by key and empty polls don’t revert to the placeholder and tear down the chat.
> 
> Tests and source-string guards updated for the new identity rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b8246e050f4052e00f7ca5b780b42f4fababbac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->