### PR TITLE
Cards: the popup's head stands on the card head's ground

### DIFF
--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -323,6 +323,14 @@
   white-space: nowrap;
 }
 
+/* The popup's head is the card head grown, so it stands on the same ground
+   (.task-card-head: --row-bg-hover) — the chassis's head is transparent over
+   the dialog, which here is the chat frame's own colour (Akshil, 2026-09-06:
+   "inside the modal the heading contrast color change is not applied"). */
+.task-peek .modal-head {
+  background: var(--row-bg-hover);
+}
+
 /* The chassis's h2 is the head's flexible cell; it must not stretch the title
    group to the actions, or the group's empty right half would wear the hint. */
 .task-peek .modal-head > h2 {


### PR DESCRIPTION
## What

The card head gained its own ground in #1013 (`--row-bg-hover`), but the popup's head — the modal chassis's `.modal-head`, transparent over a dialog the colour of the chat frame — did not, so the contrast fix never reached the modal (Akshil, 2026-09-06). One rule: `.task-peek .modal-head { background: var(--row-bg-hover); }`.

Verified live: card head and popup head both rgb(38, 40, 44) in dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single scoped CSS rule for modal header appearance with no logic, auth, or data changes.
> 
> **Overview**
> The task **peek modal** header now uses the same **`--row-bg-hover`** background as the card head, so the heading contrast fix from #1013 applies inside the popup instead of leaving a transparent head over the chat frame colour.
> 
> Adds **`.task-peek .modal-head { background: var(--row-bg-hover); }`** in `task-cards.css` so the enlarged card header reads consistently in dark (and other) themes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4efa42dba798ae46110b4d8ce58cf94e017ed715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->