### PR TITLE
Cards: hover doors on the head, Show more above the fold, Status filter by lane; deleted folder says so

### DIFF
--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -760,9 +760,14 @@ export function TaskFilterControls({
         : [...filters.statuses, key],
     });
 
+  // LANES, not statuses (Akshil, 2026-09-06: "blocked should be clubbed and
+  // needs attention"): the Board draws a parked run in the Blocked lane, and
+  // the filter offers the lanes the Board draws, so one Blocked tick brings
+  // both the broken run and the one waiting on you. taskMatches matches by
+  // lane for the same reason.
   const statusColumns = hideArchiveStatus
-    ? BOARD_COLUMNS.filter((c) => c.key !== "archived")
-    : BOARD_COLUMNS;
+    ? BOARD_LANES.filter((c) => c.key !== "archived")
+    : BOARD_LANES;
   // Excludes Archive from the badge for the same reason the row is hidden: a
   // count that includes a facet the popover will not even show would read as
   // a filter this menu cannot explain.

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -254,7 +254,7 @@ const ICON_MSG = icon(
 const ICON_MARK_READ = icon(
   <><path d="M18 6 7 17l-5-5" /><path d="m22 10-7.5 7.5L13 16" /></>, 13);
 // Filing away. lucide `archive`: a lidded box with a pull-slot in the front.
-const ICON_ARCHIVE = icon(
+export const ICON_ARCHIVE = icon(
   <><rect x="2" y="3" width="20" height="5" rx="1" />
     <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
     <path d="M10 12h4" /></>, 13);
@@ -268,7 +268,7 @@ const ICON_ARCHIVE = icon(
 // The box's walls are two short paths rather than one closed body, which is what
 // leaves the gap the arrow comes through. Same 13px, same stroke, same lid as
 // above, so the two glyphs sit on each other exactly.
-const ICON_UNARCHIVE = icon(
+export const ICON_UNARCHIVE = icon(
   <><rect x="2" y="3" width="20" height="5" rx="1" />
     <path d="M4 8v11a2 2 0 0 0 2 2h2" />
     <path d="M20 8v11a2 2 0 0 1-2 2h-2" />

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -752,11 +752,16 @@ export function TaskFilterControls({
    */
   hideArchiveStatus?: boolean;
 }) {
+  // By LANE, like taskMatches: a tick is on when any stored status draws in
+  // this lane, and turning it off removes every status of that lane — so a
+  // stray `needs_attention` can never leave a filter applied that no checkbox
+  // shows (review, #1018).
+  const laneOn = (key: BoardColumn) => filters.statuses.some((s) => laneOf(s) === laneOf(key));
   const toggleStatus = (key: BoardColumn) =>
     onChange({
       ...filters,
-      statuses: filters.statuses.includes(key)
-        ? filters.statuses.filter((s) => s !== key)
+      statuses: laneOn(key)
+        ? filters.statuses.filter((s) => laneOf(s) !== laneOf(key))
         : [...filters.statuses, key],
     });
 
@@ -807,7 +812,7 @@ export function TaskFilterControls({
       >
         {() =>
           statusColumns.map((col) => {
-            const on = filters.statuses.includes(col.key);
+            const on = laneOn(col.key);
             return (
               <button
                 type="button"

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -40,7 +40,6 @@ import {
   basename,
   cardKey,
   cardsForTasks,
-  emptyPaneText,
   filingIntent,
   firstLine,
   opensElsewhere,
@@ -67,11 +66,8 @@ export const CARDS_EMPTY = "Nothing to show here.";
  *
  *  One request per DISTINCT folder, and most walls are one or two folders' worth
  *  of work, so this is a call or two rather than one per card. */
-/** Per folder: the claude template's path; `null` when the folder cannot be
- *  stat'ed at all (deleted, unmounted — the scratch dir of an old run); absent
- *  while the stat is still out, or when the folder answered with no chat mode. */
-function useChatTemplates(dirs: string[]): Record<string, string | null> {
-  const [paths, setPaths] = useState<Record<string, string | null>>({});
+function useChatTemplates(dirs: string[]): Record<string, string> {
+  const [paths, setPaths] = useState<Record<string, string>>({});
   // Folders already asked about — including the ones that ANSWERED with no
   // claude mode at all, which is why this is a set of asked and not a check of
   // `paths`: a folder with no chat template must be asked once, not once per
@@ -93,13 +89,9 @@ function useChatTemplates(dirs: string[]): Record<string, string | null> {
           if (found) setPaths((m) => ({ ...m, [dir]: found }));
         })
         .catch(() => {
-          // A folder that has gone away, or a stat that failed. Recorded as
-          // `null` so the card can SAY so: it used to fall through to
-          // "Starting…" and sat there for ever — a done run whose scratch
-          // folder was deleted is not starting anything (Akshil, 2026-09-06:
-          // "some cards are stuck at starting").
-          if (cancelled) return;
-          setPaths((m) => ({ ...m, [dir]: null }));
+          // A folder that has gone away, or a stat that failed: the card falls
+          // back to its "Starting…" pane rather than the page failing. There is
+          // nothing to say here that the card does not already show.
         });
     }
     return () => {
@@ -233,7 +225,7 @@ export function TaskCards({
     <TaskPeek
       task={peekLive}
       home={home}
-      template={templates[peekLive.target || peekLive.project]}
+      template={templates[peekLive.target || peekLive.project] ?? null}
       onClose={() => setPeek(null)}
       onReload={onReload}
     />
@@ -276,7 +268,7 @@ export function TaskCards({
           key={cardKey(task)}
           task={task}
           home={home}
-          template={templates[task.target || task.project]}
+          template={templates[task.target || task.project] ?? null}
           onPeek={setPeek}
           onReload={onReload}
           project={
@@ -311,7 +303,7 @@ function TaskCard({
 }: {
   task: Task;
   home: string;
-  template: string | null | undefined;
+  template: string | null;
   onPeek: (task: Task) => void;
   /** After a door archives or unarchives: the card's lane changed, so the page
    * re-reads (the popup's own rule, TaskPeek). */
@@ -480,7 +472,9 @@ function TaskCard({
           // "we know which chat that is" (schedule-lib, above `folderHref`) — a
           // real state, a few seconds to a few minutes long. Either way the card
           // says which rather than framing the wrong thing or an empty box.
-          <p className="task-card-starting">{emptyPaneText(task, template)}</p>
+          <p className="task-card-starting">
+            {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}
+          </p>
         )}
       </div>
     </section>
@@ -506,7 +500,7 @@ function TaskPeek({
 }: {
   task: Task;
   home: string;
-  template: string | null | undefined;
+  template: string | null;
   onClose: () => void;
   onReload?: () => void;
 }) {
@@ -654,7 +648,9 @@ function TaskPeek({
           // No `sandbox`, for the card frame's reason (TaskCard, above).
         />
       ) : (
-        <p className="task-card-starting">{emptyPaneText(task, template)}</p>
+        <p className="task-card-starting">
+          {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}
+        </p>
       )}
     </Modal>
   );

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -40,6 +40,7 @@ import {
   basename,
   cardKey,
   cardsForTasks,
+  emptyPaneText,
   filingIntent,
   firstLine,
   opensElsewhere,
@@ -106,14 +107,6 @@ function useChatTemplates(dirs: string[]): Record<string, string | null> {
     };
   }, [key]);
   return paths;
-}
-
-/** What the empty pane says when there is no frame to draw. `template === null`
- *  is a folder the server could not stat: nothing will ever be framed for it,
- *  and "Starting…" would be a promise the card cannot keep. */
-export function emptyPaneText(task: Task, template: string | null | undefined): string {
-  if (template === null) return "Folder no longer exists";
-  return taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…";
 }
 
 export function TaskCards({

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -34,7 +34,7 @@ import type { Task } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
 import { Modal } from "@platform/ui/modal/Modal";
 import { cardFrameSrc, folderHref, peekFrameSrc } from "./schedule-lib";
-import { IdentityChip, StatusIcon } from "./ScheduleTaskViews";
+import { ICON_ARCHIVE, ICON_UNARCHIVE, IdentityChip, StatusIcon } from "./ScheduleTaskViews";
 import {
   CARD_PAGE,
   basename,
@@ -66,8 +66,11 @@ export const CARDS_EMPTY = "Nothing to show here.";
  *
  *  One request per DISTINCT folder, and most walls are one or two folders' worth
  *  of work, so this is a call or two rather than one per card. */
-function useChatTemplates(dirs: string[]): Record<string, string> {
-  const [paths, setPaths] = useState<Record<string, string>>({});
+/** Per folder: the claude template's path; `null` when the folder cannot be
+ *  stat'ed at all (deleted, unmounted — the scratch dir of an old run); absent
+ *  while the stat is still out, or when the folder answered with no chat mode. */
+function useChatTemplates(dirs: string[]): Record<string, string | null> {
+  const [paths, setPaths] = useState<Record<string, string | null>>({});
   // Folders already asked about — including the ones that ANSWERED with no
   // claude mode at all, which is why this is a set of asked and not a check of
   // `paths`: a folder with no chat template must be asked once, not once per
@@ -89,9 +92,13 @@ function useChatTemplates(dirs: string[]): Record<string, string> {
           if (found) setPaths((m) => ({ ...m, [dir]: found }));
         })
         .catch(() => {
-          // A folder that has gone away, or a stat that failed: the card falls
-          // back to its "Starting…" pane rather than the page failing. There is
-          // nothing to say here that the card does not already show.
+          // A folder that has gone away, or a stat that failed. Recorded as
+          // `null` so the card can SAY so: it used to fall through to
+          // "Starting…" and sat there for ever — a done run whose scratch
+          // folder was deleted is not starting anything (Akshil, 2026-09-06:
+          // "some cards are stuck at starting").
+          if (cancelled) return;
+          setPaths((m) => ({ ...m, [dir]: null }));
         });
     }
     return () => {
@@ -99,6 +106,14 @@ function useChatTemplates(dirs: string[]): Record<string, string> {
     };
   }, [key]);
   return paths;
+}
+
+/** What the empty pane says when there is no frame to draw. `template === null`
+ *  is a folder the server could not stat: nothing will ever be framed for it,
+ *  and "Starting…" would be a promise the card cannot keep. */
+export function emptyPaneText(task: Task, template: string | null | undefined): string {
+  if (template === null) return "Folder no longer exists";
+  return taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…";
 }
 
 export function TaskCards({
@@ -225,7 +240,7 @@ export function TaskCards({
     <TaskPeek
       task={peekLive}
       home={home}
-      template={templates[peekLive.target || peekLive.project] ?? null}
+      template={templates[peekLive.target || peekLive.project]}
       onClose={() => setPeek(null)}
       onReload={onReload}
     />
@@ -268,7 +283,7 @@ export function TaskCards({
           key={cardKey(task)}
           task={task}
           home={home}
-          template={templates[task.target || task.project] ?? null}
+          template={templates[task.target || task.project]}
           onPeek={setPeek}
           onReload={onReload}
           project={
@@ -303,7 +318,7 @@ function TaskCard({
 }: {
   task: Task;
   home: string;
-  template: string | null;
+  template: string | null | undefined;
   onPeek: (task: Task) => void;
   /** After a door archives or unarchives: the card's lane changed, so the page
    * re-reads (the popup's own rule, TaskPeek). */
@@ -472,9 +487,7 @@ function TaskCard({
           // "we know which chat that is" (schedule-lib, above `folderHref`) — a
           // real state, a few seconds to a few minutes long. Either way the card
           // says which rather than framing the wrong thing or an empty box.
-          <p className="task-card-starting">
-            {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}
-          </p>
+          <p className="task-card-starting">{emptyPaneText(task, template)}</p>
         )}
       </div>
     </section>
@@ -500,7 +513,7 @@ function TaskPeek({
 }: {
   task: Task;
   home: string;
-  template: string | null;
+  template: string | null | undefined;
   onClose: () => void;
   onReload?: () => void;
 }) {
@@ -648,9 +661,7 @@ function TaskPeek({
           // No `sandbox`, for the card frame's reason (TaskCard, above).
         />
       ) : (
-        <p className="task-card-starting">
-          {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}
-        </p>
+        <p className="task-card-starting">{emptyPaneText(task, template)}</p>
       )}
     </Modal>
   );
@@ -659,7 +670,7 @@ function TaskPeek({
 // The head's icons, in MenuIcons' own stroke (platform/ui/MenuIcons: 16px,
 // 24-grid, 1.5 stroke, round joins) so they sit in the app's buttons at the
 // weight its menus draw. Inline rather than added to that record because they
-// are this popup's and nothing else's — a folder, an archive box.
+// are this popup's and nothing else's — the folder.
 const ICON_PROPS = {
   width: 16,
   height: 16,
@@ -679,20 +690,7 @@ const ICON_FOLDER = (
   </svg>
 );
 
-/** Archive — the box with its lid. */
-const ICON_ARCHIVE = (
-  <svg {...ICON_PROPS}>
-    <path d="M3.5 5.5h17v3.5h-17z" />
-    <path d="M5 9v9.5A1.5 1.5 0 0 0 6.5 20h11a1.5 1.5 0 0 0 1.5-1.5V9" />
-    <path d="M10 13h4" />
-  </svg>
-);
-
-/** Unarchive — the same box, the lid open and an arrow out of it. */
-const ICON_UNARCHIVE = (
-  <svg {...ICON_PROPS}>
-    <path d="M5 9v9.5A1.5 1.5 0 0 0 6.5 20h11a1.5 1.5 0 0 0 1.5-1.5V9" />
-    <path d="M3.5 9h17" />
-    <path d="M12 16v-6M9.5 12.5 12 10l2.5 2.5" />
-  </svg>
-);
+// Archive and Unarchive are the List row's own glyphs (ScheduleTaskViews:
+// lucide `archive` / `archive-restore`), imported, not redrawn: the same box a
+// reader learned on the row is the box on the card and in the popup (Akshil,
+// 2026-09-06: "why is it different from the list unarchive icon").

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -492,7 +492,7 @@ function TaskCard({
                 type="button"
                 className="task-card-door"
                 disabled={acting}
-                title={note || filing.title}
+                title={note || filing.label}
                 aria-label={filing.label}
                 onClick={refile}
               >

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -32,6 +32,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { archiveTask, statPath, unarchiveTask } from "@platform/lib/api";
 import type { Task } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
+import { pushToast } from "@platform/lib/toast";
 import { ChatFrame, ChatFramePlaceholder } from "@platform/ui/ChatFrame";
 import { Modal } from "@platform/ui/modal/Modal";
 import { cardFrameSrc, folderHref, peekFrameSrc } from "./schedule-lib";
@@ -393,9 +394,12 @@ function TaskCard({
       else await unarchiveTask(task.key);
       onReload?.();
     } catch (e) {
-      // No footer on a card: the server's sentence rides the door's own hint
-      // until the next attempt.
-      setNote((e as Error).message);
+      // No footer on a card: the server's sentence goes up as a toast — the
+      // pointer may have left the door by the time the refusal lands — and
+      // stays on the door's hint for the next attempt.
+      const said = (e as Error).message;
+      setNote(said);
+      pushToast({ msg: said, tone: "error" });
     } finally {
       setActing(false);
     }

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -270,6 +270,7 @@ export function TaskCards({
           home={home}
           template={templates[task.target || task.project] ?? null}
           onPeek={setPeek}
+          onReload={onReload}
           project={
             showProject
               ? { pinned: pinnedProjects.includes(task.project), onPick: onPickProject }
@@ -297,12 +298,16 @@ function TaskCard({
   home,
   template,
   onPeek,
+  onReload,
   project,
 }: {
   task: Task;
   home: string;
   template: string | null;
   onPeek: (task: Task) => void;
+  /** After a door archives or unarchives: the card's lane changed, so the page
+   * re-reads (the popup's own rule, TaskPeek). */
+  onReload?: () => void;
   /** Draw the folder chip, and how: null hides it (one folder, nothing to tell
    * apart); otherwise whether the page is pinned to it and the tag's handler. */
   project: { pinned: boolean; onPick?: (project: string) => void } | null;
@@ -315,6 +320,31 @@ function TaskCard({
   const src = task.session_id && template
     ? cardFrameSrc(template, task.target || task.project, task.session_id)
     : null;
+  // THE DOORS ON THE HEAD (Akshil, 2026-09-06): the popup's two, Archive (or
+  // Unarchive) and the folder, shown on hover over the title's right end so a
+  // reader can file a card or step into its folder without opening the popup
+  // first. Same intent, same href, same calls as TaskPeek's head — one set of
+  // doors drawn in two places, not two sets.
+  const explorer = taskHref(task) ?? folderHref(task);
+  const filing = filingIntent(task);
+  const [acting, setActing] = useState(false);
+  const [note, setNote] = useState("");
+  const refile = async () => {
+    if (!filing || acting) return;
+    setActing(true);
+    setNote("");
+    try {
+      if (filing.kind === "archive") await archiveTask(task.key);
+      else await unarchiveTask(task.key);
+      onReload?.();
+    } catch (e) {
+      // No footer on a card: the server's sentence rides the door's own hint
+      // until the next attempt.
+      setNote((e as Error).message);
+    } finally {
+      setActing(false);
+    }
+  };
 
   return (
     <section className="task-card" aria-label={`${task.task_id} ${title}`}>
@@ -385,6 +415,43 @@ function TaskCard({
         <span className="task-card-title" data-hint={task.title}>
           {title}
         </span>
+        {/* Inside the head (so hovering them keeps the head hovered) but not OF
+            it: a press here stops before the head's onClick, so a door never
+            also opens the popup. Keys are already the head's concern only when
+            pressed on the head itself (onKeyDown above). */}
+        {(filing || explorer) && (
+          <span className="task-card-doors" onClick={(e) => e.stopPropagation()}>
+            {filing && (
+              <button
+                type="button"
+                className="task-card-door"
+                disabled={acting}
+                title={note || filing.title}
+                aria-label={filing.label}
+                onClick={refile}
+              >
+                {filing.kind === "archive" ? ICON_ARCHIVE : ICON_UNARCHIVE}
+              </button>
+            )}
+            {explorer && (
+              <a
+                // A real link with a real href, so ⌘-click and middle-click open
+                // the folder in a tab — the rule every row on this page follows.
+                className="task-card-door"
+                href={explorer}
+                title={`Open in Explorer — ${tildePath(task.target || task.project, home)}`}
+                aria-label="Open in Explorer"
+                onClick={(e) => {
+                  if (opensElsewhere(e)) return;
+                  e.preventDefault();
+                  navigateUrl(explorer);
+                }}
+              >
+                {ICON_FOLDER}
+              </a>
+            )}
+          </span>
+        )}
       </header>
       <div className="task-card-body">
         {src ? (

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -109,6 +109,7 @@ import {
   viewUrl,
   mergeTaskChanges,
 } from "./tasks-lib";
+import { emptyPaneText } from "./TaskCards";
 
 // 2026-08-16 is a Sunday; 2026-08-10 a Monday.
 const NOW = Date.parse("2026-08-16T12:00:00");
@@ -6925,6 +6926,26 @@ describe("the Cards view's frame", () => {
     expect(CARDS_CSS).toContain(".task-card-doors > .task-card-door {");
     expect(CARDS_CSS).not.toMatch(/\n\.task-card-door[:\s{]/);
     expect(block(CARDS_CSS, ".task-card-doors > .task-card-door")).toContain("padding: 0");
+  });
+
+  it("wears the List's archive glyphs, hovers both doors alike, fades in at the left, and names a folder that is gone", () => {
+    // Akshil, 2026-09-06: same icon as the List row; same hover for the button
+    // and the <a>; a gradient on the strip's left edge; and a card whose folder
+    // the server cannot stat says so instead of "Starting…" for ever.
+    expect(CARDS).toContain('import { ICON_ARCHIVE, ICON_UNARCHIVE, IdentityChip, StatusIcon } from "./ScheduleTaskViews";');
+    expect(CARDS).not.toContain("const ICON_ARCHIVE =");
+    expect(VIEWS).toContain("export const ICON_ARCHIVE = icon(");
+    expect(VIEWS).toContain("export const ICON_UNARCHIVE = icon(");
+    expect(block(CARDS_CSS, ".task-card-doors > .task-card-door:hover:not(:disabled)")).toContain("background: transparent");
+    const fade = block(CARDS_CSS, ".task-card-doors::before");
+    expect(fade).toContain("right: 100%");
+    expect(fade).toContain("linear-gradient(");
+    expect(fade).toContain("pointer-events: none");
+    expect(CARDS).toContain("setPaths((m) => ({ ...m, [dir]: null }));");
+    expect(emptyPaneText(task({ status: "done" }), null)).toBe("Folder no longer exists");
+    expect(emptyPaneText(task({ status: "done" }), undefined)).toBe("Starting…");
+    expect(emptyPaneText(task({ status: "upcoming" }), undefined)).toBe("Not started yet");
+    expect(CARDS.split("{emptyPaneText(task, template)}").length).toBe(3);
   });
 
   it("filters by LANE: one Blocked tick brings the broken run and the parked one", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6905,7 +6905,10 @@ describe("the Cards view's frame", () => {
     const doors = block(CARDS_CSS, ".task-card-doors");
     expect(doors).toContain("position: absolute");
     expect(doors).toContain("visibility: hidden");
-    expect(CARDS_CSS).toContain(".task-card-head:hover .task-card-doors,\n.task-card-head:focus-within .task-card-doors {");
+    // Keyboard focus, not any focus: a click leaves focus in the head too, and
+    // `:focus-within` would pin the doors up after the pointer left (Bugbot).
+    expect(CARDS_CSS).toContain(".task-card-head:hover .task-card-doors,\n.task-card-head:has(:focus-visible) .task-card-doors {");
+    expect(CARDS_CSS).not.toContain(":focus-within .task-card-doors");
     // Same calls as the popup's doors — one set drawn in two places.
     expect(CARDS.split("await archiveTask(task.key)").length).toBe(3);
     expect(CARDS.split("await unarchiveTask(task.key)").length).toBe(3);

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6907,7 +6907,11 @@ describe("the Cards view's frame", () => {
     expect(doors).toContain("visibility: hidden");
     // Keyboard focus, not any focus: a click leaves focus in the head too, and
     // `:focus-within` would pin the doors up after the pointer left (Bugbot).
-    expect(CARDS_CSS).toContain(".task-card-head:hover .task-card-doors,\n.task-card-head:has(:focus-visible) .task-card-doors {");
+    // ...and the head's OWN keyboard focus, since `:has()` sees descendants
+    // only and a hidden strip is out of the tab order (Bugbot, round two).
+    expect(CARDS_CSS).toContain(
+      ".task-card-head:hover .task-card-doors,\n.task-card-head:focus-visible .task-card-doors,\n.task-card-head:has(:focus-visible) .task-card-doors {",
+    );
     expect(CARDS_CSS).not.toContain(":focus-within .task-card-doors");
     // Same calls as the popup's doors — one set drawn in two places.
     expect(CARDS.split("await archiveTask(task.key)").length).toBe(3);

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6918,6 +6918,29 @@ describe("the Cards view's frame", () => {
     expect(CARDS.split("await unarchiveTask(task.key)").length).toBe(3);
   });
 
+  it("draws each door through the strip, so the page's button rule cannot blank it", () => {
+    // `.prefs-section button` (padding 5px 12px) outranks a lone class; under it
+    // the 24px Archive button was 24px of padding and 0px of icon (Akshil,
+    // 2026-09-06, screenshot). Every door rule goes through the parent.
+    expect(CARDS_CSS).toContain(".task-card-doors > .task-card-door {");
+    expect(CARDS_CSS).not.toMatch(/\n\.task-card-door[:\s{]/);
+    expect(block(CARDS_CSS, ".task-card-doors > .task-card-door")).toContain("padding: 0");
+  });
+
+  it("filters by LANE: one Blocked tick brings the broken run and the parked one", () => {
+    // Akshil, 2026-09-06: "blocked should be clubbed and needs attention". The
+    // Status menu offers the Board's lanes, and a stored needs_attention from an
+    // older session still means the Blocked lane.
+    expect(VIEWS).toContain("? BOARD_LANES.filter((c) => c.key !== \"archived\")\n    : BOARD_LANES;");
+    const blocked = task({ key: "s1", status: "blocked" });
+    const parked = task({ key: "s2", status: "needs_attention" });
+    const running = task({ key: "s3", status: "in_progress" });
+    const byBlocked = { ...EMPTY_FILTERS, statuses: ["blocked" as const] };
+    expect(filterTasks([blocked, parked, running], byBlocked).map((t) => t.key)).toEqual(["s1", "s2"]);
+    const byParked = { ...EMPTY_FILTERS, statuses: ["needs_attention" as const] };
+    expect(filterTasks([blocked, parked, running], byParked).map((t) => t.key)).toEqual(["s1", "s2"]);
+  });
+
   it("opens the task's popup from the head, and the popup frames the chat with its composer", () => {
     // Akshil, 2026-09-05: click the head → a 60%-of-the-window preview you can
     // type into, with buttons for the List, the Explorer and Archive.

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -108,7 +108,6 @@ import {
   viewFromSearch,
   viewUrl,
   mergeTaskChanges,
-  emptyPaneText,
 } from "./tasks-lib";
 
 // 2026-08-16 is a Sunday; 2026-08-10 a Monday.
@@ -6775,7 +6774,7 @@ describe("the Cards view's frame", () => {
     expect(CARDS).toContain('"Nothing to show here."');
     // A task with no session yet: "Starting…" for a run in flight, and the
     // honest phrase for a scheduled one that is simply not due.
-    expect(LIB).toContain('taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"');
+    expect(CARDS).toContain('taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"');
     expect(CARDS).toContain('className="schedule-tv-empty"');
   });
 
@@ -6928,10 +6927,9 @@ describe("the Cards view's frame", () => {
     expect(block(CARDS_CSS, ".task-card-doors > .task-card-door")).toContain("padding: 0");
   });
 
-  it("wears the List's archive glyphs, hovers both doors alike, fades in at the left, and names a folder that is gone", () => {
+  it("wears the List's archive glyphs, hovers both doors alike, and fades in at the left", () => {
     // Akshil, 2026-09-06: same icon as the List row; same hover for the button
-    // and the <a>; a gradient on the strip's left edge; and a card whose folder
-    // the server cannot stat says so instead of "Starting…" for ever.
+    // and the <a>; a gradient on the strip's left edge.
     expect(CARDS).toContain('import { ICON_ARCHIVE, ICON_UNARCHIVE, IdentityChip, StatusIcon } from "./ScheduleTaskViews";');
     expect(CARDS).not.toContain("const ICON_ARCHIVE =");
     expect(VIEWS).toContain("export const ICON_ARCHIVE = icon(");
@@ -6941,12 +6939,6 @@ describe("the Cards view's frame", () => {
     expect(fade).toContain("right: 100%");
     expect(fade).toContain("linear-gradient(");
     expect(fade).toContain("pointer-events: none");
-    expect(CARDS).toContain("setPaths((m) => ({ ...m, [dir]: null }));");
-    expect(CARDS).not.toContain("export function emptyPaneText");
-    expect(emptyPaneText(task({ status: "done" }), null)).toBe("Folder no longer exists");
-    expect(emptyPaneText(task({ status: "done" }), undefined)).toBe("Starting…");
-    expect(emptyPaneText(task({ status: "upcoming" }), undefined)).toBe("Not started yet");
-    expect(CARDS.split("{emptyPaneText(task, template)}").length).toBe(3);
   });
 
   it("filters by LANE: one Blocked tick brings the broken run and the parked one", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -108,8 +108,8 @@ import {
   viewFromSearch,
   viewUrl,
   mergeTaskChanges,
+  emptyPaneText,
 } from "./tasks-lib";
-import { emptyPaneText } from "./TaskCards";
 
 // 2026-08-16 is a Sunday; 2026-08-10 a Monday.
 const NOW = Date.parse("2026-08-16T12:00:00");
@@ -6775,7 +6775,7 @@ describe("the Cards view's frame", () => {
     expect(CARDS).toContain('"Nothing to show here."');
     // A task with no session yet: "Starting…" for a run in flight, and the
     // honest phrase for a scheduled one that is simply not due.
-    expect(CARDS).toContain('taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"');
+    expect(LIB).toContain('taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"');
     expect(CARDS).toContain('className="schedule-tv-empty"');
   });
 
@@ -6942,6 +6942,7 @@ describe("the Cards view's frame", () => {
     expect(fade).toContain("linear-gradient(");
     expect(fade).toContain("pointer-events: none");
     expect(CARDS).toContain("setPaths((m) => ({ ...m, [dir]: null }));");
+    expect(CARDS).not.toContain("export function emptyPaneText");
     expect(emptyPaneText(task({ status: "done" }), null)).toBe("Folder no longer exists");
     expect(emptyPaneText(task({ status: "done" }), undefined)).toBe("Starting…");
     expect(emptyPaneText(task({ status: "upcoming" }), undefined)).toBe("Not started yet");

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6882,6 +6882,35 @@ describe("the Cards view's frame", () => {
     expect(SCHEDULED).not.toContain("onShowRunning");
   });
 
+  it("keeps Show more above the fold, and puts the popup's two doors on the head on hover", () => {
+    // Akshil, 2026-09-06: "to see show more button I need to scroll" — when the
+    // strip is there the two rows give up its 36px and one gap; without it the
+    // rows take the pane as before.
+    expect(CARDS_CSS).toContain(
+      ".task-cards-scroll:has(> .task-cards-more) > .task-cards {\n  grid-auto-rows: max(260px, calc((100cqh - 12px * 2 - 36px) / 2));\n}",
+    );
+    expect(block(CARDS_CSS, ".task-cards-more")).toContain("height: 36px");
+    // The doors: Archive (or Unarchive) then the folder, icons only, absolutely
+    // placed over the title's right end — the head's height and the title's
+    // width never move — shown on hover and on keyboard focus, and taking no
+    // clicks while hidden.
+    const head = CARDS.slice(CARDS.indexOf("<header"), CARDS.indexOf("</header>"));
+    expect(head.indexOf('className="task-card-title"')).toBeLessThan(head.indexOf("task-card-doors"));
+    expect(head).toContain('{filing.kind === "archive" ? ICON_ARCHIVE : ICON_UNARCHIVE}');
+    expect(head).toContain("{ICON_FOLDER}");
+    expect(head.indexOf("ICON_ARCHIVE")).toBeLessThan(head.indexOf("ICON_FOLDER"));
+    expect(head).toContain("href={explorer}");
+    expect(head).toContain("if (opensElsewhere(e)) return;");
+    expect(block(CARDS_CSS, ".task-card-head")).toContain("position: relative");
+    const doors = block(CARDS_CSS, ".task-card-doors");
+    expect(doors).toContain("position: absolute");
+    expect(doors).toContain("visibility: hidden");
+    expect(CARDS_CSS).toContain(".task-card-head:hover .task-card-doors,\n.task-card-head:focus-within .task-card-doors {");
+    // Same calls as the popup's doors — one set drawn in two places.
+    expect(CARDS.split("await archiveTask(task.key)").length).toBe(3);
+    expect(CARDS.split("await unarchiveTask(task.key)").length).toBe(3);
+  });
+
   it("opens the task's popup from the head, and the popup frames the chat with its composer", () => {
     // Akshil, 2026-09-05: click the head → a 60%-of-the-window preview you can
     // type into, with buttons for the List, the Explorer and Archive.
@@ -6892,8 +6921,10 @@ describe("the Cards view's frame", () => {
     // ...for keys pressed on the head itself: the folder chip inside it is a
     // button whose Enter/Space bubble up (Bugbot, #1011).
     expect(head).toContain("if (e.target !== e.currentTarget) return;");
-    // The head has no Open of its own any more — the popup carries the doors.
-    expect(head).not.toContain("href");
+    // The head has no Open of its own — the head IS the open. Its only link is
+    // the folder door (below), which stops its own press.
+    expect(head).not.toContain("task-card-open");
+    expect(head).toContain('className="task-card-doors" onClick={(e) => e.stopPropagation()}');
     // The app's one modal chassis, at 60vw, with the matching height in CSS.
     expect(CARDS).toContain('import { Modal } from "@platform/ui/modal/Modal";');
     expect(CARDS).toContain('width="54vw"');

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6953,6 +6953,11 @@ describe("the Cards view's frame", () => {
     expect(filterTasks([blocked, parked, running], byBlocked).map((t) => t.key)).toEqual(["s1", "s2"]);
     const byParked = { ...EMPTY_FILTERS, statuses: ["needs_attention" as const] };
     expect(filterTasks([blocked, parked, running], byParked).map((t) => t.key)).toEqual(["s1", "s2"]);
+    // ...and the menu's tick and toggle read and clear by lane too, so a stored
+    // needs_attention lights Blocked and Blocked-off removes it (review).
+    expect(VIEWS).toContain("const laneOn = (key: BoardColumn) => filters.statuses.some((s) => laneOf(s) === laneOf(key));");
+    expect(VIEWS).toContain("const on = laneOn(col.key);");
+    expect(VIEWS).toContain("? filters.statuses.filter((s) => laneOf(s) !== laneOf(key))");
   });
 
   it("opens the task's popup from the head, and the popup frames the chat with its composer", () => {

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2897,16 +2897,6 @@ export interface TaskCardSet {
 }
 
 
-/** What a Cards-view pane says when there is no frame to draw (TaskCards).
- *  `template === null` is a folder the server could not stat — deleted, or
- *  unmounted: nothing will ever be framed for it, and "Starting…" would be a
- *  promise the card cannot keep (Akshil, 2026-09-06: "some cards are stuck at
- *  starting"). `undefined` is a stat still out, or a folder with no chat mode. */
-export function emptyPaneText(task: Pick<Task, "status">, template: string | null | undefined): string {
-  if (template === null) return "Folder no longer exists";
-  return taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…";
-}
-
 /**
  * WHAT A CARD IS: the server's row key — the session id once there is one, the
  * `pending:<entry>` key before it.

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2896,6 +2896,17 @@ export interface TaskCardSet {
   hidden: number;
 }
 
+
+/** What a Cards-view pane says when there is no frame to draw (TaskCards).
+ *  `template === null` is a folder the server could not stat — deleted, or
+ *  unmounted: nothing will ever be framed for it, and "Starting…" would be a
+ *  promise the card cannot keep (Akshil, 2026-09-06: "some cards are stuck at
+ *  starting"). `undefined` is a stat still out, or a folder with no chat mode. */
+export function emptyPaneText(task: Pick<Task, "status">, template: string | null | undefined): string {
+  if (template === null) return "Folder no longer exists";
+  return taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…";
+}
+
 /**
  * WHAT A CARD IS: the server's row key — the session id once there is one, the
  * `pending:<entry>` key before it.

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2192,9 +2192,9 @@ export function projectOptions(tasks: Task[]): string[] {
 export function taskMatches(task: Task, filters: TaskFilters): boolean {
   // By LANE (schedule-lib.laneOf): the Status menu offers the Board's lanes,
   // and a Blocked tick means everything the Blocked lane holds — the run that
-  // broke and the run parked on a card (`needs_attention`). Comparing lanes on
-  // both sides also keeps a stored "needs_attention" from an older session
-  // meaning what it meant.
+  // broke and the run parked on a card (`needs_attention`). Lanes on BOTH
+  // sides, so a `needs_attention` in `statuses` — nothing writes one today, the
+  // type still admits it — means the same lane the menu would have ticked.
   if (filters.statuses.length) {
     const lane = laneOf(taskColumn(task));
     if (!filters.statuses.some((s) => laneOf(s) === lane)) return false;
@@ -2895,7 +2895,6 @@ export interface TaskCardSet {
   cards: Task[];
   hidden: number;
 }
-
 
 /**
  * WHAT A CARD IS: the server's row key — the session id once there is one, the

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2190,8 +2190,15 @@ export function projectOptions(tasks: Task[]): string[] {
 }
 
 export function taskMatches(task: Task, filters: TaskFilters): boolean {
-  if (filters.statuses.length && !filters.statuses.includes(taskColumn(task)))
-    return false;
+  // By LANE (schedule-lib.laneOf): the Status menu offers the Board's lanes,
+  // and a Blocked tick means everything the Blocked lane holds — the run that
+  // broke and the run parked on a card (`needs_attention`). Comparing lanes on
+  // both sides also keeps a stored "needs_attention" from an older session
+  // meaning what it meant.
+  if (filters.statuses.length) {
+    const lane = laneOf(taskColumn(task));
+    if (!filters.statuses.some((s) => laneOf(s) === lane)) return false;
+  }
   if (filters.projects.length && !filters.projects.includes(task.project)) return false;
   const q = filters.search.trim().toLowerCase();
   if (!q) return true;

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -230,8 +230,12 @@
    the title row so the head's height and the title's width never move; the
    strip wears the head's hover ground so a long title is masked under it
    rather than showing through. `visibility` and not `display`, so the fade
-   can run and a hidden strip takes no clicks. `:focus-within` for the keyboard:
-   Tab reaches the doors, and reaching them shows them. */
+   can run and a hidden strip takes no clicks. For the keyboard, `:has(
+   :focus-visible)` and NOT `:focus-within`: a mouse click on the head or the
+   folder chip leaves focus inside the head too, and `:focus-within` kept the
+   doors up after the pointer left (Bugbot, #1018) — the same stuck reveal the
+   List rows rejected. `:focus-visible` is true only for focus the keyboard
+   gave, so Tab reaches the doors and shows them, and a click does neither. */
 .task-card-doors {
   position: absolute;
   right: 8px;
@@ -247,7 +251,7 @@
 }
 
 .task-card-head:hover .task-card-doors,
-.task-card-head:focus-within .task-card-doors {
+.task-card-head:has(:focus-visible) .task-card-doors {
   opacity: 1;
   visibility: visible;
 }

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -235,7 +235,11 @@
    folder chip leaves focus inside the head too, and `:focus-within` kept the
    doors up after the pointer left (Bugbot, #1018) — the same stuck reveal the
    List rows rejected. `:focus-visible` is true only for focus the keyboard
-   gave, so Tab reaches the doors and shows them, and a click does neither. */
+   gave, so Tab reaches the doors and shows them, and a click does neither.
+   The head's OWN `:focus-visible` too (Bugbot, #1018, round two): `:has()`
+   sees descendants only, and a hidden strip is out of the tab order — so the
+   doors have to be up the moment Tab lands on the head, or Tab could never
+   land on them. */
 .task-card-doors {
   position: absolute;
   right: 8px;
@@ -251,6 +255,7 @@
 }
 
 .task-card-head:hover .task-card-doors,
+.task-card-head:focus-visible .task-card-doors,
 .task-card-head:has(:focus-visible) .task-card-doors {
   opacity: 1;
   visibility: visible;

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -78,6 +78,16 @@
   min-width: 0;
 }
 
+/* SHOW MORE ABOVE THE FOLD (Akshil, 2026-09-06: "to see show more button I
+   need to scroll"). When the strip is there, the two rows give up its 36px and
+   the gap before it, so a first visit sees six cards AND the way to the next
+   six without touching the wheel. Without the strip (six or fewer tasks) the
+   rows take the whole pane as before. The 260px floor still wins on a short
+   window, where the wall scrolls sooner either way. */
+.task-cards-scroll:has(> .task-cards-more) > .task-cards {
+  grid-auto-rows: max(260px, calc((100cqh - 12px * 2 - 36px) / 2));
+}
+
 /* COLUMNS FOLLOW THE WIDTH THE WALL HAS, not the window's (Akshil, 2026-09-05:
    with the sidebar collapsed the wall stepped from three to two exactly right,
    and with it open — 232px narrower — it did not, because a media query cannot
@@ -125,6 +135,8 @@
   flex-direction: column;
   gap: 4px;
   min-width: 0;
+  /* The doors below anchor to the head's corner. */
+  position: relative;
   padding: 8px 10px;
   border-bottom: 1px solid var(--border);
   /* Its OWN ground, a step up from the card's: the frame under it is the chat
@@ -209,6 +221,69 @@
   font-weight: 600;
   line-height: 1.3;
   color: var(--fg);
+}
+
+/* THE DOORS, ON HOVER, OVER THE TITLE'S RIGHT END (Akshil, 2026-09-06: "archive
+   and explorer button right side of the title … don't cover or shift, make
+   extra space, just show them on hover … overlap"). The popup's two doors —
+   Archive (or Unarchive) and the folder — as icons only, absolutely placed on
+   the title row so the head's height and the title's width never move; the
+   strip wears the head's hover ground so a long title is masked under it
+   rather than showing through. `visibility` and not `display`, so the fade
+   can run and a hidden strip takes no clicks. `:focus-within` for the keyboard:
+   Tab reaches the doors, and reaching them shows them. */
+.task-card-doors {
+  position: absolute;
+  right: 8px;
+  bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-left: 8px;
+  background: color-mix(in srgb, var(--fg) 5%, var(--row-bg-hover));
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 120ms ease;
+}
+
+.task-card-head:hover .task-card-doors,
+.task-card-head:focus-within .task-card-doors {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* One door: a 24px square in the app's secondary-button skin (buttons-modal.css
+   `.btn-secondary`: transparent, 1px border, the border lifts on hover), icon
+   only, the word on `title`. */
+.task-card-door {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: var(--fg);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.task-card-door:hover:not(:disabled) {
+  border-color: var(--fg-muted);
+}
+
+.task-card-door:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.task-card-door:focus-visible {
+  outline: 2px solid var(--focus, var(--fg-muted));
+  outline-offset: 1px;
 }
 
 .task-card-when {

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -263,8 +263,12 @@
 
 /* One door: a 24px square in the app's secondary-button skin (buttons-modal.css
    `.btn-secondary`: transparent, 1px border, the border lifts on hover), icon
-   only, the word on `title`. */
-.task-card-door {
+   only, the word on `title`. Addressed THROUGH the strip, not by its class
+   alone: the page's `.prefs-section button` (padding 5px 12px, the page's
+   ground) outranks a lone class, and under it the Archive button was a blank
+   24px box — 24px of padding left the icon 0px wide (Akshil, 2026-09-06,
+   screenshot). The folder is an <a> and never met that rule. */
+.task-card-doors > .task-card-door {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -281,16 +285,16 @@
   text-decoration: none;
 }
 
-.task-card-door:hover:not(:disabled) {
+.task-card-doors > .task-card-door:hover:not(:disabled) {
   border-color: var(--fg-muted);
 }
 
-.task-card-door:disabled {
+.task-card-doors > .task-card-door:disabled {
   opacity: 0.5;
   cursor: default;
 }
 
-.task-card-door:focus-visible {
+.task-card-doors > .task-card-door:focus-visible {
   outline: 2px solid var(--focus, var(--fg-muted));
   outline-offset: 1px;
 }

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -247,11 +247,29 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding-left: 8px;
+  padding-left: 6px;
   background: color-mix(in srgb, var(--fg) 5%, var(--row-bg-hover));
   opacity: 0;
   visibility: hidden;
   transition: opacity 120ms ease;
+}
+
+/* The strip's left edge FADES IN over the title instead of cutting it (Akshil,
+   2026-09-06: "add a fading thing so it looks like it is fading in"): a 24px
+   run from transparent to the strip's own ground, hung off the left edge. */
+.task-card-doors::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 100%;
+  width: 24px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in srgb, var(--fg) 5%, var(--row-bg-hover))
+  );
+  pointer-events: none;
 }
 
 .task-card-head:hover .task-card-doors,
@@ -285,7 +303,11 @@
   text-decoration: none;
 }
 
+/* Both doors hover ALIKE — the page's `.prefs-section button:hover` fills a
+   button with --bg-alt and an accent border, and the folder is an <a> it never
+   touches, so without saying so here the two doors lit up differently. */
 .task-card-doors > .task-card-door:hover:not(:disabled) {
+  background: transparent;
   border-color: var(--fg-muted);
 }
 

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -70,8 +70,8 @@
      in the same breath (Akshil, 2026-09-06: "club it in with x lines saved").
      The dot belongs to the pair: it goes when either half is empty (the
      conflict banner blanks the status; a file that has not loaded has no count). */
-  #lines { color: var(--fg-muted); white-space: nowrap; }
-  #lines:not(:empty) + #status-text:not(:empty)::before { content: "\00b7 "; }
+  #state { display: inline-flex; align-items: baseline; white-space: nowrap; color: var(--fg-muted); }
+  #lines:not(:empty) + #status-text:not(:empty)::before { content: "\00b7 "; margin-left: 4px; }
   #status-text.error { color: var(--error); }
   #conflict {
     display: none;
@@ -147,8 +147,7 @@
       <button id="overwrite">Overwrite</button>
     </span>
     <span id="ro" hidden></span>
-    <span id="lines"></span>
-    <span id="status-text">Saved</span>
+    <span id="state"><span id="lines"></span><span id="status-text">Saved</span></span>
     <button id="save" disabled>Save</button>
   </div>
   <div id="root"><div id="skel-code" aria-hidden="true">

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -65,14 +65,6 @@
   }
   #bar .grow { flex: 1 1 auto; }
   #status-text { color: var(--fg-muted); }
-  /* The buffer's size rides beside the save state — "12 lines Saved" — one
-     muted phrase, so the bar says what the file is and what has happened to it
-     in the same breath (Akshil, 2026-09-06: "club it in with x lines saved";
-     no dot between them, same day). One span, so the bar's 12px gap does not
-     split the pair; a word-space between the halves only while both are there
-     (the conflict banner blanks the status; an unloaded file has no count). */
-  #state { display: inline-flex; align-items: baseline; white-space: nowrap; color: var(--fg-muted); }
-  #lines:not(:empty) + #status-text:not(:empty) { margin-left: 0.4em; }
   #status-text.error { color: var(--error); }
   #conflict {
     display: none;
@@ -148,7 +140,7 @@
       <button id="overwrite">Overwrite</button>
     </span>
     <span id="ro" hidden></span>
-    <span id="state"><span id="lines"></span><span id="status-text">Saved</span></span>
+    <span id="status-text">Saved</span>
     <button id="save" disabled>Save</button>
   </div>
   <div id="root"><div id="skel-code" aria-hidden="true">
@@ -173,7 +165,6 @@
     const statusTextEl = document.getElementById("status-text");
     const conflictEl = document.getElementById("conflict");
     const saveBtn = document.getElementById("save");
-    const linesEl = document.getElementById("lines");
     const reloadBtn = document.getElementById("reload");
     const overwriteBtn = document.getElementById("overwrite");
     const root = document.getElementById("root");
@@ -213,16 +204,6 @@
         case "toml": return CM.tomlLang;
         default: return null; // unknown → plain text, no highlighting
       }
-    }
-
-    // The line count the bar prints, from the live document (CM's Text keeps it
-    // as a field, so this is a read and not a scan). Painted on load and on
-    // every edit that changed the doc; blank while nothing is loaded.
-    function paintLines() {
-      if (!linesEl) return;
-      if (!view) { linesEl.textContent = ""; return; }
-      const n = view.state.doc.lines;
-      linesEl.textContent = n + (n === 1 ? " line" : " lines");
     }
 
     function setDirty(d) {
@@ -381,7 +362,6 @@
         // docChanged fires on any user edit → mark the buffer modified.
         CM.EditorView.updateListener.of((update) => {
           if (update.docChanged) {
-            paintLines();
             setDirty(true);
             clearTimeout(saveTimer);
             saveTimer = setTimeout(autosave, 250);
@@ -402,7 +382,6 @@
 
       root.innerHTML = "";
       view = new CM.EditorView({ doc: text, extensions, parent: root });
-      paintLines();
       // A live appearance change (the shell's menu, or the OS flipping while
       // the setting is System) reconfigures the RUNNING view — rebuilding it
       // would throw away unsaved edits, the caret and the scroll position.

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -65,6 +65,13 @@
   }
   #bar .grow { flex: 1 1 auto; }
   #status-text { color: var(--fg-muted); }
+  /* The buffer's size rides beside the save state — "12 lines · Saved" — one
+     muted phrase, so the bar says what the file is and what has happened to it
+     in the same breath (Akshil, 2026-09-06: "club it in with x lines saved").
+     The dot belongs to the pair: it goes when either half is empty (the
+     conflict banner blanks the status; a file that has not loaded has no count). */
+  #lines { color: var(--fg-muted); white-space: nowrap; }
+  #lines:not(:empty) + #status-text:not(:empty)::before { content: "\00b7 "; }
   #status-text.error { color: var(--error); }
   #conflict {
     display: none;
@@ -140,6 +147,7 @@
       <button id="overwrite">Overwrite</button>
     </span>
     <span id="ro" hidden></span>
+    <span id="lines"></span>
     <span id="status-text">Saved</span>
     <button id="save" disabled>Save</button>
   </div>
@@ -165,6 +173,7 @@
     const statusTextEl = document.getElementById("status-text");
     const conflictEl = document.getElementById("conflict");
     const saveBtn = document.getElementById("save");
+    const linesEl = document.getElementById("lines");
     const reloadBtn = document.getElementById("reload");
     const overwriteBtn = document.getElementById("overwrite");
     const root = document.getElementById("root");
@@ -204,6 +213,16 @@
         case "toml": return CM.tomlLang;
         default: return null; // unknown → plain text, no highlighting
       }
+    }
+
+    // The line count the bar prints, from the live document (CM's Text keeps it
+    // as a field, so this is a read and not a scan). Painted on load and on
+    // every edit that changed the doc; blank while nothing is loaded.
+    function paintLines() {
+      if (!linesEl) return;
+      if (!view) { linesEl.textContent = ""; return; }
+      const n = view.state.doc.lines;
+      linesEl.textContent = n + (n === 1 ? " line" : " lines");
     }
 
     function setDirty(d) {
@@ -362,6 +381,7 @@
         // docChanged fires on any user edit → mark the buffer modified.
         CM.EditorView.updateListener.of((update) => {
           if (update.docChanged) {
+            paintLines();
             setDirty(true);
             clearTimeout(saveTimer);
             saveTimer = setTimeout(autosave, 250);
@@ -382,6 +402,7 @@
 
       root.innerHTML = "";
       view = new CM.EditorView({ doc: text, extensions, parent: root });
+      paintLines();
       // A live appearance change (the shell's menu, or the OS flipping while
       // the setting is System) reconfigures the RUNNING view — rebuilding it
       // would throw away unsaved edits, the caret and the scroll position.

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -65,13 +65,14 @@
   }
   #bar .grow { flex: 1 1 auto; }
   #status-text { color: var(--fg-muted); }
-  /* The buffer's size rides beside the save state — "12 lines · Saved" — one
+  /* The buffer's size rides beside the save state — "12 lines Saved" — one
      muted phrase, so the bar says what the file is and what has happened to it
-     in the same breath (Akshil, 2026-09-06: "club it in with x lines saved").
-     The dot belongs to the pair: it goes when either half is empty (the
-     conflict banner blanks the status; a file that has not loaded has no count). */
+     in the same breath (Akshil, 2026-09-06: "club it in with x lines saved";
+     no dot between them, same day). One span, so the bar's 12px gap does not
+     split the pair; a word-space between the halves only while both are there
+     (the conflict banner blanks the status; an unloaded file has no count). */
   #state { display: inline-flex; align-items: baseline; white-space: nowrap; color: var(--fg-muted); }
-  #lines:not(:empty) + #status-text:not(:empty)::before { content: "\00b7 "; margin-left: 4px; }
+  #lines:not(:empty) + #status-text:not(:empty) { margin-left: 0.4em; }
   #status-text.error { color: var(--error); }
   #conflict {
     display: none;


### PR DESCRIPTION
## Summary
- **Cards head doors**: Archive/Unarchive and Open in Explorer appear on hover (and keyboard focus) over the right end of the card title, icon-only, with the List row's own archive glyphs. Overlay with a fade-in edge — the head's height and the title's width never change. Both doors hover alike. Clicking a door does not open the popup.
- **Show more above the fold**: when the "Show more" strip is present, the two card rows shrink by its 36px + gap so six cards and the strip fit the pane without scrolling.
- **Status filter by lane**: Needs attention and Blocked are one **Blocked** tick (the Board already clubs them); matching compares lanes, so a stored `needs_attention` filter still works.

## Test plan
- Tasks → Cards: hover a card title → doors fade in at the right; Archive icon matches the List row's; both doors hover the same. Click folder → Explorer; click Archive on a Done card → card leaves. Click head elsewhere → popup.
- Cards with >6 tasks on a laptop → "Show more" visible under row two without scrolling.
- Status menu lists Upcoming · In Progress · Blocked · Done · Archive; Blocked tick shows failed **and** parked rows in List/Board/Cards/Calendar.
- `bun test` (3046) + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly Tasks UI (cards, filters, CSS) with matching test coverage; archive still goes through existing API calls and reload hooks.
> 
> **Overview**
> **Cards** gain **Archive/Unarchive** and **Open in Explorer** on the card title’s right edge, shown on hover and keyboard focus without shifting layout; clicks use the same APIs as the peek modal, stop propagation so the head doesn’t open the popup, and archive errors surface via **toasts**. Archive icons are **shared** with the List row (`ICON_ARCHIVE` / `ICON_UNARCHIVE` exported from `ScheduleTaskViews`).
> 
> When **Show more** is visible, the card grid **shrinks row height** so six cards plus the control fit without scrolling (`task-cards.css`).
> 
> **Status filtering** is **lane-based**: the menu lists `BOARD_LANES`, one **Blocked** tick covers both `blocked` and `needs_attention`, and `taskMatches` / toggle logic use `laneOf` so stored filters stay consistent with the checkboxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65410b7707e1139f2ab09a852ea218e31e1ad626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->