### PR TITLE
Cards: List's archive glyphs on doors, one hover skin, fade-in edge; deleted folder no longer reads Starting…

### DIFF
--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -254,7 +254,7 @@ const ICON_MSG = icon(
 const ICON_MARK_READ = icon(
   <><path d="M18 6 7 17l-5-5" /><path d="m22 10-7.5 7.5L13 16" /></>, 13);
 // Filing away. lucide `archive`: a lidded box with a pull-slot in the front.
-const ICON_ARCHIVE = icon(
+export const ICON_ARCHIVE = icon(
   <><rect x="2" y="3" width="20" height="5" rx="1" />
     <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
     <path d="M10 12h4" /></>, 13);
@@ -268,7 +268,7 @@ const ICON_ARCHIVE = icon(
 // The box's walls are two short paths rather than one closed body, which is what
 // leaves the gap the arrow comes through. Same 13px, same stroke, same lid as
 // above, so the two glyphs sit on each other exactly.
-const ICON_UNARCHIVE = icon(
+export const ICON_UNARCHIVE = icon(
   <><rect x="2" y="3" width="20" height="5" rx="1" />
     <path d="M4 8v11a2 2 0 0 0 2 2h2" />
     <path d="M20 8v11a2 2 0 0 1-2 2h-2" />

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -40,6 +40,7 @@ import {
   basename,
   cardKey,
   cardsForTasks,
+  emptyPaneText,
   filingIntent,
   firstLine,
   opensElsewhere,
@@ -106,14 +107,6 @@ function useChatTemplates(dirs: string[]): Record<string, string | null> {
     };
   }, [key]);
   return paths;
-}
-
-/** What the empty pane says when there is no frame to draw. `template === null`
- *  is a folder the server could not stat: nothing will ever be framed for it,
- *  and "Starting…" would be a promise the card cannot keep. */
-export function emptyPaneText(task: Task, template: string | null | undefined): string {
-  if (template === null) return "Folder no longer exists";
-  return taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…";
 }
 
 export function TaskCards({

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -34,7 +34,7 @@ import type { Task } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
 import { Modal } from "@platform/ui/modal/Modal";
 import { cardFrameSrc, folderHref, peekFrameSrc } from "./schedule-lib";
-import { IdentityChip, StatusIcon } from "./ScheduleTaskViews";
+import { ICON_ARCHIVE, ICON_UNARCHIVE, IdentityChip, StatusIcon } from "./ScheduleTaskViews";
 import {
   CARD_PAGE,
   basename,
@@ -66,8 +66,11 @@ export const CARDS_EMPTY = "Nothing to show here.";
  *
  *  One request per DISTINCT folder, and most walls are one or two folders' worth
  *  of work, so this is a call or two rather than one per card. */
-function useChatTemplates(dirs: string[]): Record<string, string> {
-  const [paths, setPaths] = useState<Record<string, string>>({});
+/** Per folder: the claude template's path; `null` when the folder cannot be
+ *  stat'ed at all (deleted, unmounted — the scratch dir of an old run); absent
+ *  while the stat is still out, or when the folder answered with no chat mode. */
+function useChatTemplates(dirs: string[]): Record<string, string | null> {
+  const [paths, setPaths] = useState<Record<string, string | null>>({});
   // Folders already asked about — including the ones that ANSWERED with no
   // claude mode at all, which is why this is a set of asked and not a check of
   // `paths`: a folder with no chat template must be asked once, not once per
@@ -89,9 +92,13 @@ function useChatTemplates(dirs: string[]): Record<string, string> {
           if (found) setPaths((m) => ({ ...m, [dir]: found }));
         })
         .catch(() => {
-          // A folder that has gone away, or a stat that failed: the card falls
-          // back to its "Starting…" pane rather than the page failing. There is
-          // nothing to say here that the card does not already show.
+          // A folder that has gone away, or a stat that failed. Recorded as
+          // `null` so the card can SAY so: it used to fall through to
+          // "Starting…" and sat there for ever — a done run whose scratch
+          // folder was deleted is not starting anything (Akshil, 2026-09-06:
+          // "some cards are stuck at starting").
+          if (cancelled) return;
+          setPaths((m) => ({ ...m, [dir]: null }));
         });
     }
     return () => {
@@ -99,6 +106,14 @@ function useChatTemplates(dirs: string[]): Record<string, string> {
     };
   }, [key]);
   return paths;
+}
+
+/** What the empty pane says when there is no frame to draw. `template === null`
+ *  is a folder the server could not stat: nothing will ever be framed for it,
+ *  and "Starting…" would be a promise the card cannot keep. */
+export function emptyPaneText(task: Task, template: string | null | undefined): string {
+  if (template === null) return "Folder no longer exists";
+  return taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…";
 }
 
 export function TaskCards({
@@ -225,7 +240,7 @@ export function TaskCards({
     <TaskPeek
       task={peekLive}
       home={home}
-      template={templates[peekLive.target || peekLive.project] ?? null}
+      template={templates[peekLive.target || peekLive.project]}
       onClose={() => setPeek(null)}
       onReload={onReload}
     />
@@ -268,7 +283,7 @@ export function TaskCards({
           key={cardKey(task)}
           task={task}
           home={home}
-          template={templates[task.target || task.project] ?? null}
+          template={templates[task.target || task.project]}
           onPeek={setPeek}
           onReload={onReload}
           project={
@@ -303,7 +318,7 @@ function TaskCard({
 }: {
   task: Task;
   home: string;
-  template: string | null;
+  template: string | null | undefined;
   onPeek: (task: Task) => void;
   /** After a door archives or unarchives: the card's lane changed, so the page
    * re-reads (the popup's own rule, TaskPeek). */
@@ -472,9 +487,7 @@ function TaskCard({
           // "we know which chat that is" (schedule-lib, above `folderHref`) — a
           // real state, a few seconds to a few minutes long. Either way the card
           // says which rather than framing the wrong thing or an empty box.
-          <p className="task-card-starting">
-            {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}
-          </p>
+          <p className="task-card-starting">{emptyPaneText(task, template)}</p>
         )}
       </div>
     </section>
@@ -500,7 +513,7 @@ function TaskPeek({
 }: {
   task: Task;
   home: string;
-  template: string | null;
+  template: string | null | undefined;
   onClose: () => void;
   onReload?: () => void;
 }) {
@@ -648,9 +661,7 @@ function TaskPeek({
           // No `sandbox`, for the card frame's reason (TaskCard, above).
         />
       ) : (
-        <p className="task-card-starting">
-          {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}
-        </p>
+        <p className="task-card-starting">{emptyPaneText(task, template)}</p>
       )}
     </Modal>
   );
@@ -659,7 +670,7 @@ function TaskPeek({
 // The head's icons, in MenuIcons' own stroke (platform/ui/MenuIcons: 16px,
 // 24-grid, 1.5 stroke, round joins) so they sit in the app's buttons at the
 // weight its menus draw. Inline rather than added to that record because they
-// are this popup's and nothing else's — a folder, an archive box.
+// are this popup's and nothing else's — the folder.
 const ICON_PROPS = {
   width: 16,
   height: 16,
@@ -679,20 +690,7 @@ const ICON_FOLDER = (
   </svg>
 );
 
-/** Archive — the box with its lid. */
-const ICON_ARCHIVE = (
-  <svg {...ICON_PROPS}>
-    <path d="M3.5 5.5h17v3.5h-17z" />
-    <path d="M5 9v9.5A1.5 1.5 0 0 0 6.5 20h11a1.5 1.5 0 0 0 1.5-1.5V9" />
-    <path d="M10 13h4" />
-  </svg>
-);
-
-/** Unarchive — the same box, the lid open and an arrow out of it. */
-const ICON_UNARCHIVE = (
-  <svg {...ICON_PROPS}>
-    <path d="M5 9v9.5A1.5 1.5 0 0 0 6.5 20h11a1.5 1.5 0 0 0 1.5-1.5V9" />
-    <path d="M3.5 9h17" />
-    <path d="M12 16v-6M9.5 12.5 12 10l2.5 2.5" />
-  </svg>
-);
+// Archive and Unarchive are the List row's own glyphs (ScheduleTaskViews:
+// lucide `archive` / `archive-restore`), imported, not redrawn: the same box a
+// reader learned on the row is the box on the card and in the popup (Akshil,
+// 2026-09-06: "why is it different from the list unarchive icon").

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -109,6 +109,7 @@ import {
   viewUrl,
   mergeTaskChanges,
 } from "./tasks-lib";
+import { emptyPaneText } from "./TaskCards";
 
 // 2026-08-16 is a Sunday; 2026-08-10 a Monday.
 const NOW = Date.parse("2026-08-16T12:00:00");
@@ -6925,6 +6926,26 @@ describe("the Cards view's frame", () => {
     expect(CARDS_CSS).toContain(".task-card-doors > .task-card-door {");
     expect(CARDS_CSS).not.toMatch(/\n\.task-card-door[:\s{]/);
     expect(block(CARDS_CSS, ".task-card-doors > .task-card-door")).toContain("padding: 0");
+  });
+
+  it("wears the List's archive glyphs, hovers both doors alike, fades in at the left, and names a folder that is gone", () => {
+    // Akshil, 2026-09-06: same icon as the List row; same hover for the button
+    // and the <a>; a gradient on the strip's left edge; and a card whose folder
+    // the server cannot stat says so instead of "Starting…" for ever.
+    expect(CARDS).toContain('import { ICON_ARCHIVE, ICON_UNARCHIVE, IdentityChip, StatusIcon } from "./ScheduleTaskViews";');
+    expect(CARDS).not.toContain("const ICON_ARCHIVE =");
+    expect(VIEWS).toContain("export const ICON_ARCHIVE = icon(");
+    expect(VIEWS).toContain("export const ICON_UNARCHIVE = icon(");
+    expect(block(CARDS_CSS, ".task-card-doors > .task-card-door:hover:not(:disabled)")).toContain("background: transparent");
+    const fade = block(CARDS_CSS, ".task-card-doors::before");
+    expect(fade).toContain("right: 100%");
+    expect(fade).toContain("linear-gradient(");
+    expect(fade).toContain("pointer-events: none");
+    expect(CARDS).toContain("setPaths((m) => ({ ...m, [dir]: null }));");
+    expect(emptyPaneText(task({ status: "done" }), null)).toBe("Folder no longer exists");
+    expect(emptyPaneText(task({ status: "done" }), undefined)).toBe("Starting…");
+    expect(emptyPaneText(task({ status: "upcoming" }), undefined)).toBe("Not started yet");
+    expect(CARDS.split("{emptyPaneText(task, template)}").length).toBe(3);
   });
 
   it("filters by LANE: one Blocked tick brings the broken run and the parked one", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -108,8 +108,8 @@ import {
   viewFromSearch,
   viewUrl,
   mergeTaskChanges,
+  emptyPaneText,
 } from "./tasks-lib";
-import { emptyPaneText } from "./TaskCards";
 
 // 2026-08-16 is a Sunday; 2026-08-10 a Monday.
 const NOW = Date.parse("2026-08-16T12:00:00");
@@ -6775,7 +6775,7 @@ describe("the Cards view's frame", () => {
     expect(CARDS).toContain('"Nothing to show here."');
     // A task with no session yet: "Starting…" for a run in flight, and the
     // honest phrase for a scheduled one that is simply not due.
-    expect(CARDS).toContain('taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"');
+    expect(LIB).toContain('taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"');
     expect(CARDS).toContain('className="schedule-tv-empty"');
   });
 
@@ -6942,6 +6942,7 @@ describe("the Cards view's frame", () => {
     expect(fade).toContain("linear-gradient(");
     expect(fade).toContain("pointer-events: none");
     expect(CARDS).toContain("setPaths((m) => ({ ...m, [dir]: null }));");
+    expect(CARDS).not.toContain("export function emptyPaneText");
     expect(emptyPaneText(task({ status: "done" }), null)).toBe("Folder no longer exists");
     expect(emptyPaneText(task({ status: "done" }), undefined)).toBe("Starting…");
     expect(emptyPaneText(task({ status: "upcoming" }), undefined)).toBe("Not started yet");

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2896,6 +2896,17 @@ export interface TaskCardSet {
   hidden: number;
 }
 
+
+/** What a Cards-view pane says when there is no frame to draw (TaskCards).
+ *  `template === null` is a folder the server could not stat — deleted, or
+ *  unmounted: nothing will ever be framed for it, and "Starting…" would be a
+ *  promise the card cannot keep (Akshil, 2026-09-06: "some cards are stuck at
+ *  starting"). `undefined` is a stat still out, or a folder with no chat mode. */
+export function emptyPaneText(task: Pick<Task, "status">, template: string | null | undefined): string {
+  if (template === null) return "Folder no longer exists";
+  return taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…";
+}
+
 /**
  * WHAT A CARD IS: the server's row key — the session id once there is one, the
  * `pending:<entry>` key before it.

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -247,11 +247,29 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding-left: 8px;
+  padding-left: 6px;
   background: color-mix(in srgb, var(--fg) 5%, var(--row-bg-hover));
   opacity: 0;
   visibility: hidden;
   transition: opacity 120ms ease;
+}
+
+/* The strip's left edge FADES IN over the title instead of cutting it (Akshil,
+   2026-09-06: "add a fading thing so it looks like it is fading in"): a 24px
+   run from transparent to the strip's own ground, hung off the left edge. */
+.task-card-doors::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 100%;
+  width: 24px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in srgb, var(--fg) 5%, var(--row-bg-hover))
+  );
+  pointer-events: none;
 }
 
 .task-card-head:hover .task-card-doors,
@@ -285,7 +303,11 @@
   text-decoration: none;
 }
 
+/* Both doors hover ALIKE — the page's `.prefs-section button:hover` fills a
+   button with --bg-alt and an accent border, and the folder is an <a> it never
+   touches, so without saying so here the two doors lit up differently. */
 .task-card-doors > .task-card-door:hover:not(:disabled) {
+  background: transparent;
   border-color: var(--fg-muted);
 }
 


### PR DESCRIPTION
Stacked on #1018 (base is its branch; retargets to `main` when it merges).

## Summary
- **Icons**: card doors and popup use the List row's own Archive / Unarchive glyphs (lucide `archive` / `archive-restore`), exported from `ScheduleTaskViews` — no second drawing of the box.
- **Hover**: both doors hover identically. `.prefs-section button:hover` was filling the button with `--bg-alt` + accent border while the folder link stayed transparent.
- **Fade**: the door strip gets a 24px gradient on its left edge so it fades in over the title instead of cutting it.
- **Stuck "Starting…"**: cards (and the popup) for a task whose folder no longer exists sat on "Starting…" for ever — `statPath` failed and the fallback text assumed a run in flight. A failed stat is now recorded and the pane says **Folder no longer exists**.

## Test plan
- Cards: hover a Done/archived card → Archive/Unarchive icon matches the List row's; hover each door → same transparent bg, border lifts, no accent fill on the button.
- Long title → doors fade in over the text at the left edge, no hard cut.
- A task whose project folder was deleted → card body and popup body say "Folder no longer exists"; cards for live folders unchanged ("Starting…" only while the session is genuinely pending).
- `bun test` (3046) + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to task cards (icons, CSS, empty-state copy) with no auth, API, or data-model changes.
> 
> **Overview**
> Task Cards and the peek modal now reuse the List row’s **Archive / Unarchive** icons from `ScheduleTaskViews` instead of separate SVGs, so filing controls look the same everywhere.
> 
> **Door strip UI:** a left-edge gradient fades the hover strip over long titles, and CSS makes archive (button) and folder (link) doors share the same hover (transparent background) so prefs-page button styles don’t fill only one door.
> 
> **Stuck “Starting…” fix:** `useChatTemplates` records a failed `statPath` as `null` (not “still loading”). New `emptyPaneText` in `tasks-lib` drives card and popup placeholders—**Folder no longer exists** when the folder is gone; otherwise the existing upcoming vs in-flight messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fcd27c7bd0b277642fc6ccad23b090859fa0aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->