### PR TITLE
Code editor: caret line and column beside the save state (instead of total lines)

### DIFF
--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -65,13 +65,13 @@
   }
   #bar .grow { flex: 1 1 auto; }
   #status-text { color: var(--fg-muted); }
-  /* The buffer's size rides beside the save state — "433 lines │ Saved" — the
-     way an editor's status bar is read: two facts, two segments, a hairline
+  /* The caret's place rides beside the save state — "Ln 12, Col 4 │ Saved" —
+     the way an editor's status bar is read: two facts, two segments, a hairline
      between them (VS Code, Cursor, Zed all segment the bar; none joins the two
      into a sentence). One span, so the bar's own 12px gap does not push them
      apart further; the divider is the status's left border and goes when
      either half is empty (the conflict banner blanks the status; an unloaded
-     file has no count). */
+     file has no caret). */
   #state { display: inline-flex; align-items: center; white-space: nowrap; color: var(--fg-muted); }
   #lines:not(:empty) + #status-text:not(:empty) {
     margin-left: 8px;
@@ -221,14 +221,18 @@
       }
     }
 
-    // The line count the bar prints, from the live document (CM's Text keeps it
-    // as a field, so this is a read and not a scan). Painted on load and on
-    // every edit that changed the doc; blank while nothing is loaded.
+    // The caret's place, as every editor's status bar prints it — "Ln 12, Col 4"
+    // (VS Code, Cursor, Zed): where you ARE, which is what a reader glances at
+    // the bar for, rather than how long the file is. Column is 1-based and
+    // counted in characters from the line start (CM's `head - line.from`).
+    // Painted on load and on every update that moved the selection or changed
+    // the doc; blank while nothing is loaded.
     function paintLines() {
       if (!linesEl) return;
       if (!view) { linesEl.textContent = ""; return; }
-      const n = view.state.doc.lines;
-      linesEl.textContent = n + (n === 1 ? " line" : " lines");
+      const head = view.state.selection.main.head;
+      const line = view.state.doc.lineAt(head);
+      linesEl.textContent = "Ln " + line.number + ", Col " + (head - line.from + 1);
     }
 
     function setDirty(d) {
@@ -386,8 +390,8 @@
         ...(wantsDark() ? [CM.oneDark] : []),
         // docChanged fires on any user edit → mark the buffer modified.
         CM.EditorView.updateListener.of((update) => {
+          if (update.selectionSet || update.docChanged) paintLines();
           if (update.docChanged) {
-            paintLines();
             setDirty(true);
             clearTimeout(saveTimer);
             saveTimer = setTimeout(autosave, 250);


### PR DESCRIPTION
Stacked on #1020.

## Summary
- Replaces the total line count with the caret's position: `Ln 12, Col 4 │ Saved`.
- This is the status-bar convention (VS Code, Cursor, Zed): where you are, not how long the file is.
- Repaints on every selection move and every edit; column is 1-based characters from line start.

## Test plan
- Open a file → `Ln 1, Col 1 │ Saved`. Click around / arrow keys → Ln/Col follow the caret without editing.
- Type → `Ln N, Col M │ Modified`, then `Saved` after autosave.
- Cmd-End → last line; Home → Col 1.
- Conflict banner → status blank, divider gone, Ln/Col stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only status bar display and refresh timing in the code editor template; no save, auth, or server behavior changes.
> 
> **Overview**
> The code editor status bar now shows **caret position** (`Ln 12, Col 4`) next to the save state instead of the document’s **total line count**, matching common editor status bars.
> 
> **`paintLines()`** reads the main selection head from CodeMirror, resolves the line, and formats a 1-based column from `head - line.from`. Comments/CSS copy were updated to describe caret vs. line-count behavior.
> 
> The editor **update listener** repaints that segment when the **selection moves** (`selectionSet`) as well as on document edits, so Ln/Col updates on click and arrow keys without typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831bd7e8b8cd448cd1ad05b1ecd9eaa180a66017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->