### PR TITLE
Claude chat: strip keeps three seats, trash moves onto the annotation bar

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -295,8 +295,13 @@
      glyphs and words stay baked into the markup, never shown. */
   #annbtn .cmt-stop, #annbtn .cmt-done, #annbtn .done-word { display: none; }
   /* ONE active seat: while a walkthrough records the mic is the live control,
-     so the Comment seat (armed underneath, annRecBegin arms the mode) rests. */
-  #anncta:has(#annrec.on) #annbtn.on { color: var(--dim); border-color: var(--border); }
+     so the Comment seat (armed underneath, annRecBegin arms the mode) rests —
+     and keeps resting through Stopping…/Transcribing… (`.busy`), when the
+     mic's `.on` is already down but the mode is still armed until the settle
+     disarms it (Akshil, 2026-09-06: "for a moment comment also becomes
+     active"). The Annotate seat carries the status through that window. */
+  #anncta:has(#annrec.on) #annbtn.on,
+  #anncta.busy #annbtn.on { color: var(--dim); border-color: var(--border); }
   /* #annreclbl is status, not the clock (the bar's ■ carries that): it shows
      only through Stopping…/Transcribing…, when annCta wears .busy, and then
      it stands ALONE on the ANNOTATE seat — the walkthrough's own seat, so the

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -7879,7 +7879,6 @@ async function annRecEnd() {
   const handle = annRecHandle;
   const ids = annRecIds;
   const armed = annArmEpoch;
-  const left = annLeaveGen;   // the conversation this walkthrough belongs to
   clearInterval(annRecTimerId);
   annRecTimerId = null;
   annRecIds = [];
@@ -7893,8 +7892,11 @@ async function annRecEnd() {
   // Point into the next typed comment is a visible fact, not a trap.
   annRecBtn.classList.remove("on");
   annRecBtn.setAttribute("aria-pressed", "false");
-  annRecBtn.setAttribute("aria-label", "Annotate with a spoken walkthrough");
-  annRecBtn.title = "Annotate with a spoken walkthrough — talk while you click, and each click becomes a note";
+  // The settle's status is THIS seat's (2026-09-06, #annreclbl lives here):
+  // named for what is happening, idle-named again by annRecIdleName when the
+  // settle ends. The Comment seat is merely unavailable meanwhile.
+  annRecBtn.setAttribute("aria-label", "Stopping the recording");
+  annRecBtn.title = "Stopping the recording…";
   // The settle window is a STATUS, not a Done button (Bugbot, PR #665): with
   // #annrec.on gone the armed CSS would show an enabled ✓ Done for however
   // long the stop takes — milliseconds where the app records natively, longer
@@ -7904,8 +7906,8 @@ async function annRecEnd() {
   // treatment the transcription below gets: disabled, .busy (the face yields
   // to #annreclbl), named for what is happening.
   annBtn.disabled = true;
-  annBtn.setAttribute("aria-label", "Stopping the recording");
-  annBtn.title = "Stopping the recording…";
+  annBtn.setAttribute("aria-label", "Comment — unavailable while the recording settles");
+  annBtn.title = "Unavailable while the recording settles";
   annCta.classList.add("busy");
   annRecLbl.textContent = "Stopping…";
   annBarPaint();   // the clicks are over: the bar goes with them
@@ -7938,6 +7940,7 @@ async function annRecEnd() {
     // no-op disarm below is already epoch-guarded.
     if (!annRecOn) {
       annCta.classList.remove("busy");
+      annRecIdleName();
       annRecLbl.textContent = "";
       annBtn.disabled = false;
       // Derived from the state, not assumed armed (Bugbot, PR #665): an Esc
@@ -7961,9 +7964,11 @@ async function annRecEnd() {
   // quietly in the background.
   if (!annRecOn) {
     annRecBtn.disabled = true;
+    annRecBtn.setAttribute("aria-label", "Transcribing the walkthrough");
+    annRecBtn.title = "Transcribing the walkthrough — the notes send themselves when the words land";
     annBtn.disabled = true;
-    annBtn.setAttribute("aria-label", "Transcribing the walkthrough");
-    annBtn.title = "Transcribing the walkthrough — the notes send themselves when the words land";
+    annBtn.setAttribute("aria-label", "Comment — unavailable while the recording settles");
+    annBtn.title = "Unavailable while the recording settles";
     annCta.classList.add("busy");
     annRecLbl.textContent = "Transcribing…";
   }
@@ -8010,9 +8015,7 @@ async function annRecEnd() {
     // The intro is seeded even when a live run blocks the auto-send: the words
     // wait in the composer (beside the pending notes) and ride the user's next
     // send, instead of evaporating because the walkthrough ended mid-turn.
-    // ...unless the user LEFT the conversation while the words were on their
-    // way (annLeave bumped the generation): then they are nobody's to send.
-    if ((spoke || intro) && annLeaveGen === left) {
+    if (spoke || intro) {
       annPrefillComposer(intro);
       if (activeRun || !sending) annAutoSubmit();  // a live run gets it as a follow-up — see annDone
     }
@@ -8029,6 +8032,7 @@ async function annRecEnd() {
       annRecBtn.disabled = false;
       annBtn.disabled = false;
       annCta.classList.remove("busy");
+      annRecIdleName();
       annRecLbl.textContent = "";   // "Transcribing…" only ever describes now
       // The disarm below renames the seat on the normal path; when the guards
       // skip it (re-armed mid-transcription, or Esc already disarmed) the
@@ -8082,11 +8086,11 @@ async function annRecDiscard() {
   // the same disabled status annRecEnd shows — never an enabled Done.
   annRecBtn.classList.remove("on");
   annRecBtn.setAttribute("aria-pressed", "false");
-  annRecBtn.setAttribute("aria-label", "Annotate with a spoken walkthrough");
-  annRecBtn.title = "Annotate with a spoken walkthrough — talk while you click, and each click becomes a note";
+  annRecBtn.setAttribute("aria-label", "Discarding the recording");
+  annRecBtn.title = "Discarding the recording…";
   annBtn.disabled = true;
-  annBtn.setAttribute("aria-label", "Discarding the recording");
-  annBtn.title = "Discarding the recording…";
+  annBtn.setAttribute("aria-label", "Comment — unavailable while the recording settles");
+  annBtn.title = "Unavailable while the recording settles";
   annCta.classList.add("busy");
   annRecLbl.textContent = "Discarding…";
   annBarPaint();   // the clicks are over: the bar goes with them
@@ -8100,6 +8104,7 @@ async function annRecDiscard() {
   // busy state, labels and clock alone (Bugbot, PR #665).
   if (!annRecOn) {
     annCta.classList.remove("busy");
+      annRecIdleName();
     annRecLbl.textContent = "";
     annBtn.disabled = false;
     // Derived, same reason as annRecEnd's restores: Esc during this settle
@@ -8141,19 +8146,13 @@ function annNotesDiscard() {
 }
 // One dispatcher for the bar's trash, whichever mode is on.
 function annDiscard() { return annRecOn ? annRecDiscard() : annNotesDiscard(); }
-// Leaving the conversation — ← Chats, or a chat opened from the landing —
-// takes an armed mode down with it (Akshil, 2026-09-06). A LIVE walkthrough
-// is DISCARDED, not ended: annRecEnd keeps, transcribes and auto-sends, and
-// with the page already on another chat that send would open a conversation
-// nobody asked for (Bugbot, PR #1022). The generation covers the settle: a
-// transcription already in flight when the user leaves lands after this
-// bump, and annRecEnd sees a stale generation and keeps its words to itself.
-let annLeaveGen = 0;
-function annLeave() {
-  annLeaveGen += 1;
-  if (annRecOn) annRecDiscard();
-  else if (annOn) annSetMode(false);
+// The Annotate seat's resting name, restored when a settle (stop, transcribe,
+// discard) ends — the settle named the seat for its status (2026-09-06).
+function annRecIdleName() {
+  annRecBtn.setAttribute("aria-label", "Annotate with a spoken walkthrough");
+  annRecBtn.title = "Annotate with a spoken walkthrough — talk while you click, and each click becomes a note";
 }
+
 
 // ── hosted only: keeping up with a target this document cannot hear ────────
 // The split layout is told about its pane by the pane itself — one iframe, one
@@ -12695,9 +12694,6 @@ function consumeAnchor() {
 // Clear the session param so a reload lands on the landing page,
 // wipe the visible transcript, and rebuild the session list.
 document.getElementById("back").onclick = () => {
-  // Leaving the chat leaves the mode too (Akshil, 2026-09-06): an armed
-  // Comment or a live walkthrough has nothing to point at on the landing.
-  annLeave();
   // Live even mid-turn (Akshil, 2026-08-19 — "when it is working I can't
   // click back"). The old `if (sending) return` guarded against orphaning the
   // streaming run's UI, but the architecture already survives leaving: the
@@ -12792,10 +12788,6 @@ document.getElementById("back").onclick = () => {
 };
 
 function enterChat() {
-  // Entering a chat leaves an armed mode behind, exactly as ← Chats does
-  // (Akshil, 2026-09-06): the pins belonged to the screen the reader is
-  // leaving. Nothing is armed at boot, so the resume path is a no-op here.
-  annLeave();
   chatEl.classList.remove("home");
   stopWatchRecent();
   // The strip belongs to ONE conversation. Chips from the previous chat are

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -284,52 +284,21 @@
      Idle faces: 💬 Comment · 🎙 Annotate. A mode ON means ONE control (Akshil,
      2026-08-19): the mic hides outright, and the Comment seat morphs into
      the mode's exit. */
+  /* The three seats STAY while a mode is on (Akshil, 2026-09-06): the strip
+     is Screenshot · Comment · Annotate in every state, and the armed one is
+     simply drawn active — the accent outline on Comment, the --error pulse on
+     Annotate. The mode's EXITS (✓ Done / ■ clock, and the trash) live on the
+     annotation bar over the app (annBarNode), not here. The seat's spare
+     glyphs and words stay baked into the markup, never shown. */
   #annbtn .cmt-stop, #annbtn .cmt-done, #annbtn .done-word { display: none; }
-  #anncta:has(#annbtn.on) #annrec { display: none; }
-  /* The camera goes with the mic: a mode takes the strip down to ONE control. */
-  #anncta:has(#annbtn.on) #viewshot { display: none; }
-  /* Comment armed (and no recording): the seat IS ✓ Done, in the armed
-     accent — send the notes and finish. `:not(.busy)` on the SHOW rules, so
-     the transcribing state below is one word, not "✓ Done Transcribing…"
-     (Akshil, 2026-08-19) — the hide rules stay unconditional because busy
-     wants the bubble and the word gone too. */
-  #anncta:has(#annbtn.on):not(:has(#annrec.on)) #annbtn .cmt-bubble,
-  #anncta:has(#annbtn.on):not(:has(#annrec.on)) #annbtn .cmt-word { display: none; }
-  #anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on)) #annbtn .cmt-done { display: block; }
-  #anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on)) #annbtn .done-word { display: var(--annlbl, inline); }
-  /* The discard seat exists while a MODE is on — an outline trash beside the
-     ■/clock or the ✓ Done, for throwing the walkthrough or the round's notes
-     away instead of sending them (Akshil, 2026-09-04: the strip keeps the
-     two exits, keep and discard, in both modes; what a click pins moved onto
-     the bar over the app). Derived from the same state class as every other
-     face. `:not(.busy)`: through Stopping…/Transcribing… the mode is still
-     armed but the recording's marks are waiting for their words, and a
-     discard there would delete them (Bugbot, PR #1008) — the old
-     #annrec.on gate hid the seat then, and so does this.
-     `#anncta #anndiscard`, two ids, because a bare `#anndiscard` LOSES to
-     the base `#anncta button` display rule on specificity and the trash sat
-     on the strip in every state (Akshil, 2026-08-19). */
-  #anncta #anndiscard { display: none; }
-  #anncta:not(.busy):has(#annbtn.on) #anndiscard { display: inline-flex; padding: 0 8px; }
-  /* Two ids + the same pseudo-class count as the base hover above, or the
-     resting brighten wins and the destructive hint never paints. */
-  #anncta #anndiscard:hover:not(:disabled):not(.on) { color: var(--error); border-color: var(--error); }
-  /* Recording: the seat is ■ plus the live clock, in the recording's own
-     --error ink rather than the armed accent (the accent says "commenting",
-     and what this seat says now is "stop"). */
-  #anncta:has(#annrec.on) #annbtn .cmt-bubble,
-  #anncta:has(#annrec.on) #annbtn .cmt-word { display: none; }
-  #anncta:has(#annrec.on) #annbtn .cmt-stop { display: block; }
-  #anncta:has(#annrec.on) #annbtn.on {
-    color: var(--error);
-    background: transparent;
-    border-color: var(--error);
-  }
-  /* Transcribing (recording over, words on their way): the seat carries the
-     one word of status in #annreclbl ALONE. No rules of its own: the armed
-     hide above already took the bubble and the word (the mode is still on),
-     and the `:not(.busy)` guards keep ✓ Done from joining the status text.
-     annRecEnd owns the .busy class. */
+  /* ONE active seat: while a walkthrough records the mic is the live control,
+     so the Comment seat (armed underneath, annRecBegin arms the mode) rests. */
+  #anncta:has(#annrec.on) #annbtn.on { color: var(--dim); border-color: var(--border); }
+  /* #annreclbl is status, not the clock (the bar's ■ carries that): it shows
+     only through Stopping…/Transcribing…, when annCta wears .busy, and then
+     it stands ALONE on the seat — the word "Comment" yields to it. */
+  #anncta:not(.busy) #annreclbl { display: none; }
+  #anncta.busy #annbtn .cmt-word { display: none; }
   /* Empty label must not hold a gap seat open beside the icon. */
   #annreclbl:empty { display: none; }
 
@@ -744,6 +713,23 @@
      strip's seat carries, in the recording's --error, so the walkthrough can
      be ended from the bar the user is looking at (Akshil, 2026-09-05). The
      clock is state, not a label: it never folds. */
+  /* The trash: the strip's resting seat (hairline, muted ink), icon only,
+     red on hover — destructive, and the quiet one beside the accent Done. */
+  .annbar .discard {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: transparent;
+    color: var(--dim);
+    height: 26px;
+    padding: 0 8px;
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: color .12s, border-color .12s;
+  }
+  .annbar .discard:hover { color: var(--error); border-color: var(--error); }
+  .annbar .discard svg { width: 14px; height: 14px; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; }
   .annbar.rec .done { display: none; }
   .annbar .stop { display: none; }
   .annbar.rec .stop {
@@ -3838,29 +3824,19 @@
                 aria-label="Point"
                 title="Clicks pin the exact spot, with a marked screenshot"><svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="3.25"/><line x1="8" y1="1.5" x2="8" y2="4"/><line x1="8" y1="12" x2="8" y2="14.5"/><line x1="1.5" y1="8" x2="4" y2="8"/><line x1="12" y1="8" x2="14.5" y2="8"/></svg><span class="lbl">Point</span></button>
       </div>
-      <!-- TWO buttons at rest, ONE while a mode is on (Akshil, 2026-08-19):
-           Comment on the left, Record on the right, each an icon plus a word
-           (annFitStrip drops the words when the row runs out of room). A mode
-           takes the strip down to a single control — the mic hides, and the
-           Comment seat ITSELF morphs into the mode's exit: ✓ Done while a
-           typed comment mode is armed (send the notes, leave the mode), ■
-           plus the live clock while a walkthrough records (stop it). Ending a
-           recording still puts the whole mode away by itself, and Esc still
-           cancels. Both buttons are gated and hidden exactly like the old
-           pill's seats (annCapable() / annPollTarget / enterNoPane's removal
-           list) — the wrapper hides itself when it has no visible button.
-           Every glyph and word is baked into the markup; the stylesheet swaps
-           faces off the two state classes (#annbtn.on, #annrec.on), and
-           #annreclbl is the one text the writers touch — the clock while
-           recording, "Transcribing…" after — so no writer ever overwrites an
-           icon. -->
+      <!-- THREE buttons in every state (Akshil, 2026-09-06): Screenshot,
+           Comment, Annotate, each an icon plus a word (annFitStrip drops the
+           words when the row runs out of room). Arming a mode draws its seat
+           active and changes nothing else here — the way OUT of the mode
+           (✓ Done / ■ clock, and the trash) is on the annotation bar over the
+           app (annBarNode). A click on the active Comment seat is still Done,
+           on the recording mic still stop, and Esc still cancels. Both are
+           gated and hidden exactly like the old pill's seats (annCapable() /
+           annPollTarget / enterNoPane's removal list) — the wrapper hides
+           itself when it has no visible button. Every glyph and word is baked
+           into the markup; #annreclbl is the one text the writers touch —
+           "Transcribing…" while the words are on their way. -->
       <div id="anncta">
-        <!-- Discard, recording only (Akshil, 2026-08-19): an outline trash
-             seat LEFT of the ■/clock — click throws the walkthrough away
-             (recording stopped, nothing transcribed or sent, the clicks'
-             empty marks deleted) where the stop seat keeps it. -->
-        <button id="anndiscard" type="button" aria-label="Discard the recording"
-                title="Discard the recording — nothing is transcribed or sent"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 4h11"/><path d="M5.5 4V2.75a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1V4"/><path d="M3.75 4l.6 9a1 1 0 0 0 1 .95h5.3a1 1 0 0 0 1-.95l.6-9"/><line x1="6.5" y1="7" x2="6.5" y2="10.5"/><line x1="9.5" y1="7" x2="9.5" y2="10.5"/></svg></button>
         <!-- Screenshot, FIRST of the three (Akshil, 2026-09-04; it sat between
              Comment and Record from 2026-08-27). It
              was a camera pill beside Send in BOTH composers; it moved up
@@ -3871,7 +3847,8 @@
              chat both keep. Hidden while a mode is armed, like the mic — a
              mode takes the strip down to a single control — and gated
              exactly like its neighbours (annPollTarget, enterNoPane). The
-             `viewshot` class is the narrow layout's hook (body.view-chat). -->
+             `viewshot` class is the narrow layout's hook (body.view-chat).
+             Stays while a mode is armed (2026-09-06). -->
         <button id="viewshot" class="viewshot" type="button"
                 aria-label="Screenshot the preview and attach it to this message"
                 title="Screenshot the preview and attach it to this message"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.6 5.4h2.1l1-1.6h4.6l1 1.6h2.1a1 1 0 0 1 1 1v5.6a1 1 0 0 1-1 1H2.6a1 1 0 0 1-1-1V6.4a1 1 0 0 1 1-1Z" stroke-linejoin="round"/><circle cx="8" cy="9" r="2.4"/></svg><span class="lbl">Screenshot</span></button>
@@ -5784,7 +5761,6 @@ document.getElementById("divider").addEventListener("mousedown", (e) => {
 // rewritten — the posture every other stale param gets (see enterNoPane).
 const annBtn = document.getElementById("annbtn");
 const annRecBtn = document.getElementById("annrec");
-const annDiscardBtn = document.getElementById("anndiscard");
 // The buttons' wrapper: annRecEnd stamps `.busy` on it while a transcription
 // runs, the one state the two buttons' own classes cannot express (recording
 // over, mode still armed, words on their way).
@@ -6068,7 +6044,19 @@ function annBarNode(doc) {
   stop.setAttribute("aria-label", "Stop the recording");
   stop.innerHTML = '<svg viewBox="0 0 16 16" aria-hidden="true"><rect x="4" y="4" width="8" height="8" rx="1.5"/></svg><span class="clk"></span>';
   stop.addEventListener("click", () => annRecEnd());
-  bar.append(lead, slot, done, stop);
+  // Discard (Akshil, 2026-09-06, moved here from the strip): an outline
+  // trash LEFT of ✓ Done / ■ — throw the round's notes or the walkthrough
+  // away instead of sending them. annDiscard picks by mode; the bar is
+  // hidden through Stopping…/Transcribing… (annBarPaint's busy gate), so
+  // the recording's waiting marks can never be thrown from here.
+  const discard = doc.createElement("button");
+  discard.className = "discard";
+  discard.type = "button";
+  discard.title = "Discard — nothing is sent";
+  discard.setAttribute("aria-label", "Discard the notes and leave the mode");
+  discard.innerHTML = '<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 4h11"/><path d="M5.5 4V2.75a1 1 0 0 1 1-1h3a1 1 0 0 1 1 1V4"/><path d="M3.75 4l.6 9a1 1 0 0 0 1 .95h5.3a1 1 0 0 0 1-.95l.6-9"/><line x1="6.5" y1="7" x2="6.5" y2="10.5"/><line x1="9.5" y1="7" x2="9.5" y2="10.5"/></svg>';
+  discard.addEventListener("click", () => annDiscard());
+  bar.append(lead, slot, discard, done, stop);
   // The bar's box changes with the pane (the divider drags, the window
   // resizes) — refit the words on every change. The observer is the bar's
   // OWN window's: the node may live in another document.
@@ -6231,6 +6219,12 @@ const ANN_LAYER_CSS = [
   + " align-items: center; gap: 6px; cursor: pointer; flex-shrink: 0; }",
   ".annbar .done:hover { background: color-mix(in srgb, var(--accent, #d97757) 14%, transparent); }",
   ".annbar .done svg { width: 14px; height: 14px; fill: none; stroke: currentColor;"
+  + " stroke-width: 1.5; stroke-linecap: round; }",
+  ".annbar .discard { border: 1px solid var(--border, #34363e); border-radius: 8px;"
+  + " background: transparent; color: var(--dim, #9a9fa9); height: 26px; padding: 0 8px; margin: 0;"
+  + " display: inline-flex; align-items: center; cursor: pointer; flex-shrink: 0; }",
+  ".annbar .discard:hover { color: var(--error, #f26d6d); border-color: var(--error, #f26d6d); }",
+  ".annbar .discard svg { width: 14px; height: 14px; fill: none; stroke: currentColor;"
   + " stroke-width: 1.5; stroke-linecap: round; }",
   ".annbar.rec .done { display: none; }",
   ".annbar .stop { display: none; }",
@@ -6556,10 +6550,10 @@ function annBarFit() {
   const box = annBar.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
   const tag = annBar.querySelector(".tag"), txt = annBar.querySelector(".txt");
   const slot = annBar.querySelector(".slot"), done = annBar.querySelector(".done");
-  const stop = annBar.querySelector(".stop");
-  // tag + picker + Done/■, with the row's gaps between whichever are present.
+  const stop = annBar.querySelector(".stop"), discard = annBar.querySelector(".discard");
+  // tag + picker + trash + Done/■, with the row's gaps between whichever are present.
   const need = () => {
-    const parts = [slot.offsetWidth, done.offsetWidth, stop.offsetWidth].filter(Boolean);
+    const parts = [slot.offsetWidth, discard.offsetWidth, done.offsetWidth, stop.offsetWidth].filter(Boolean);
     return tag.offsetWidth + parts.reduce((a, b) => a + b, 0) + gap * parts.length;
   };
   const words = need();
@@ -6624,6 +6618,12 @@ function annBarPaint() {
   annBarTheme();
   annBarClock();
   annBar.querySelector(".tag b").textContent = words[0];
+  // The trash names what it throws — the round's notes, or the walkthrough.
+  const discard = annBar.querySelector(".discard");
+  discard.setAttribute("aria-label", annRecOn ? "Discard the recording" : "Discard the notes");
+  discard.title = annRecOn
+    ? "Discard the recording — nothing is transcribed or sent"
+    : "Discard the notes — nothing is sent";
   annBar.querySelector(".txt").textContent = words[1];
   annBar.classList.toggle("show", show);
   if (!show) annBar.classList.remove("t1", "t2", "t3");   // a fresh fit on the next show
@@ -7412,8 +7412,6 @@ function annSetMode(on) {
     annBtn.setAttribute("aria-label", annOn
       ? "Done — send the notes and finish commenting"
       : "Comment on the " + paneNoun);
-    annDiscardBtn.setAttribute("aria-label", "Discard the notes");
-    annDiscardBtn.title = "Discard the notes — nothing is sent";
   }
   // Arming over a cross-origin target is the natural moment to raise the ONE
   // share prompt the tab-capture screenshots need (annXOStreamGet keeps the
@@ -7630,8 +7628,6 @@ async function annRecBegin() {
   annRecBtn.title = "Recording — click to stop · Esc also stops it";
   annBtn.setAttribute("aria-label", "Stop the recording");
   annBtn.title = "Stop the recording · Esc also stops it";
-  annDiscardBtn.setAttribute("aria-label", "Discard the recording");
-  annDiscardBtn.title = "Discard the recording — nothing is transcribed or sent";
   annRecPaint();
   annRecTimerId = setInterval(annRecPaint, 250);
 }
@@ -8105,7 +8101,8 @@ function annNotesDiscard() {
   }
   annSetMode(false);
 }
-annDiscardBtn.addEventListener("click", () => (annRecOn ? annRecDiscard() : annNotesDiscard()));
+// One dispatcher for the bar's trash, whichever mode is on.
+function annDiscard() { return annRecOn ? annRecDiscard() : annNotesDiscard(); }
 
 // ── hosted only: keeping up with a target this document cannot hear ────────
 // The split layout is told about its pane by the pane itself — one iframe, one

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -244,7 +244,9 @@
   /* The recording state borrows --error, the one token already meant for
      "something the user should notice is live" (it colours a failed run) —
      no new token to keep in step across the two palettes. */
-  #annrec.on { color: var(--error); border-color: var(--error); animation: annrecpulse 1.1s infinite; }
+  /* Steady, no pulse (Akshil, 2026-09-06: "don't do fancy flashing") — the
+     live clock on the bar already says the recording is running. */
+  #annrec.on { color: var(--error); border-color: var(--error); }
   /* The icons: stroke glyphs in the button's own ink, so state colours (the
      hover brighten, the recording --error) reach them for free. `.fill` seats
      are the solid parts — the picker's inner square, the stop block. */
@@ -299,6 +301,15 @@
      it stands ALONE on the seat — the word "Comment" yields to it. */
   #anncta:not(.busy) #annreclbl { display: none; }
   #anncta.busy #annbtn .cmt-word { display: none; }
+  /* The OTHER two seats go inert while a mode is on (Akshil, 2026-09-06: "if
+     I click on the other one it shouldn't work"): dimmed like a disabled seat,
+     no hover, no pointer. Their click handlers refuse the same states, so a
+     keyboard press is a no-op too — the way OUT of a mode is the bar's (and
+     Esc, and ← Chats), never a neighbouring seat. Derived from the two state
+     classes like every other face here. */
+  #anncta:has(#annbtn.on) #viewshot,
+  #anncta:has(#annbtn.on):not(:has(#annrec.on)) #annrec,
+  #anncta:has(#annrec.on) #annbtn { opacity: .55; cursor: default; pointer-events: none; }
   /* Empty label must not hold a gap seat open beside the icon. */
   #annreclbl:empty { display: none; }
 
@@ -1551,8 +1562,7 @@
   }
   .turn { margin: 0 0 20px; animation: rise .18s ease-out; }
   @keyframes rise { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
-  @keyframes annrecpulse { 0%, 100% { opacity: 1; } 50% { opacity: .45; } }
-  @media (prefers-reduced-motion: reduce) { .turn, #annrec.on { animation: none; } }
+  @media (prefers-reduced-motion: reduce) { .turn { animation: none; } }
 
   /* The turn a `?msg=` link asked for (see MESSAGE_ANCHOR). A HALO that fades,
      not a selection state: the flare answers "this one" and then leaves, where
@@ -6605,7 +6615,16 @@ function annBarPush(doc) {
   annPushedDoc = doc;
   if (doc) doc.documentElement.style.setProperty("margin-top", "43px", "important");
 }
+// The strip's inert seats, spoken: aria-disabled follows the same two state
+// classes the stylesheet dims by (Akshil, 2026-09-06). One writer, here,
+// because every mode transition already ends in annBarPaint.
+function annSeatsAria() {
+  annBtn.setAttribute("aria-disabled", annRecOn ? "true" : "false");
+  annRecBtn.setAttribute("aria-disabled", annOn && !annRecOn ? "true" : "false");
+  for (const b of shotBtns()) b.setAttribute("aria-disabled", annOn ? "true" : "false");
+}
 function annBarPaint() {
+  annSeatsAria();
   // No bar (the hosted target went away, or is showing nothing marked) still
   // hands a pushed document its margin back (Bugbot, PR #1008): the frame the
   // shell keeps mounted must not keep a 43px gap with no bar on it.
@@ -7451,12 +7470,12 @@ function annSetMode(on) {
   }
 }
 
-// The seat's three answers, matching its three faces: stop a live recording
-// (■ plus the clock), finish an armed comment mode (✓ Done — send and
-// leave), or arm the mode from rest. Cancelling without sending is Esc's
-// job now — the seat that used to toggle the mode off IS the Done button.
+// The seat's two answers: finish an armed comment mode (Done — send and
+// leave), or arm the mode from rest. While a walkthrough records the seat is
+// inert (2026-09-06): the stop is the bar's ■, not a neighbouring seat.
+// Cancelling without sending is Esc's job (and ← Chats').
 annBtn.addEventListener("click",
-  () => (annRecOn ? annRecEnd() : annOn ? annDone() : annSetMode(true)));
+  () => (annRecOn ? null : annOn ? annDone() : annSetMode(true)));
 // Done: the typed-comment mode's exit that also delivers — and the ONLY send
 // the typed mode has (annCommit saves, never sends). A composer still open
 // with words in it is committed FIRST — Done means "send what I said", and the
@@ -7567,7 +7586,10 @@ function annWarmTranscriber() {
 })();
 
 async function annRecBegin() {
-  if (annRecOn || !annCapable()) return;
+  // `.busy` too (Bugbot, PR #1022): through Stopping…/Transcribing… the mic
+  // seat is drawn inert, and a keyboard press must not start a second
+  // walkthrough on the epoch the in-flight annRecEnd is about to disarm.
+  if (annRecOn || annCta.classList.contains("busy") || !annCapable()) return;
   annWarmTranscriber();
   // Disabled for the width of the start request too, not just while a
   // recording runs — otherwise a second click before the app answers the
@@ -7626,8 +7648,11 @@ async function annRecBegin() {
   // "Done" reads as finished (Bugbot, PR #664).
   annRecBtn.setAttribute("aria-label", "Stop the recording");
   annRecBtn.title = "Recording — click to stop · Esc also stops it";
-  annBtn.setAttribute("aria-label", "Stop the recording");
-  annBtn.title = "Stop the recording · Esc also stops it";
+  // The Comment seat is INERT while the walkthrough runs (its click handler
+  // returns null on annRecOn; the stylesheet dims it) — so it is not named
+  // "Stop" any more (Bugbot, PR #1022): the stop is the bar's ■ and the mic.
+  annBtn.setAttribute("aria-label", "Comment — unavailable while recording");
+  annBtn.title = "Unavailable while a walkthrough records";
   annRecPaint();
   annRecTimerId = setInterval(annRecPaint, 250);
 }
@@ -8009,11 +8034,11 @@ async function annRecEnd() {
   if (annOn && annArmEpoch === armed) annSetMode(false);
 }
 
-// The mic hides whenever a mode is on (the stylesheet's :has rule), so from
-// where it can be clicked it only ever starts a walkthrough; the recording
-// leg is a guard against a click racing the hide, not a second stop control.
+// From rest the mic starts a walkthrough; while one records it stops it (the
+// pulsing seat IS the live control). While a typed comment mode is armed the
+// mic is inert (2026-09-06) — one mode at a time, leave it first.
 annRecBtn.addEventListener("click",
-  () => (annRecOn ? annRecEnd() : annRecBegin()));
+  () => (annRecOn ? annRecEnd() : annOn ? null : annRecBegin()));
 
 // Discard: the walkthrough thrown away instead of sent (Akshil, 2026-08-19).
 // The recording stops with nothing kept — no upload, no transcription, no
@@ -10926,7 +10951,9 @@ async function shotAttachPane() {
   // hosted, the pane is the host's and this is live fact rather than layout. The
   // button is hidden when it answers false, so this is the belt to that braces —
   // a keyboard user can still reach a control the poll has not caught up with.
-  if (shotBusy || !annCapable()) return;
+  // `annOn`: the camera is inert while a mode is armed (2026-09-06) — the
+  // stylesheet dims it, this refuses the keyboard press.
+  if (shotBusy || annOn || !annCapable()) return;
   shotBusy = true;
   // BEFORE the capture, not after: the whole point is that the click is answered
   // immediately, and the capture can take a second on a large page. It is also
@@ -12642,6 +12669,10 @@ function consumeAnchor() {
 // Clear the session param so a reload lands on the landing page,
 // wipe the visible transcript, and rebuild the session list.
 document.getElementById("back").onclick = () => {
+  // Leaving the chat leaves the mode too (Akshil, 2026-09-06): an armed
+  // Comment or a live walkthrough has nothing to point at on the landing.
+  // The Esc path — a recording is ended by annSetMode's own branch.
+  if (annOn) annSetMode(false);
   // Live even mid-turn (Akshil, 2026-08-19 — "when it is working I can't
   // click back"). The old `if (sending) return` guarded against orphaning the
   // streaming run's UI, but the architecture already survives leaving: the

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -244,9 +244,10 @@
   /* The recording state borrows --error, the one token already meant for
      "something the user should notice is live" (it colours a failed run) —
      no new token to keep in step across the two palettes. */
-  /* Steady, no pulse (Akshil, 2026-09-06: "don't do fancy flashing") — the
-     live clock on the bar already says the recording is running. */
-  #annrec.on { color: var(--error); border-color: var(--error); }
+  /* Armed the same way Comment is — accent outline, steady, no pulse (Akshil,
+     2026-09-06: "don't do fancy flashing", "why red? why not same as
+     others"). The bar's ■ and clock carry the recording's own red. */
+  #annrec.on { color: var(--accent); border-color: var(--accent); }
   /* The icons: stroke glyphs in the button's own ink, so state colours (the
      hover brighten, the recording --error) reach them for free. `.fill` seats
      are the solid parts — the picker's inner square, the stop block. */
@@ -298,9 +299,13 @@
   #anncta:has(#annrec.on) #annbtn.on { color: var(--dim); border-color: var(--border); }
   /* #annreclbl is status, not the clock (the bar's ■ carries that): it shows
      only through Stopping…/Transcribing…, when annCta wears .busy, and then
-     it stands ALONE on the seat — the word "Comment" yields to it. */
+     it stands ALONE on the ANNOTATE seat — the walkthrough's own seat, so the
+     word "Annotate" yields to it and the seat keeps its armed accent while
+     the words are on their way (Akshil, 2026-09-06: the status sat on the
+     Comment seat, "why does the comment button say transcribing"). */
   #anncta:not(.busy) #annreclbl { display: none; }
-  #anncta.busy #annbtn .cmt-word { display: none; }
+  #anncta.busy #annrec .rec-word { display: none; }
+  #anncta.busy #annrec { color: var(--accent); border-color: var(--accent); }
   /* The OTHER two seats go inert while a mode is on (Akshil, 2026-09-06: "if
      I click on the other one it shouldn't work"): dimmed like a disabled seat,
      no hover, no pointer. Their click handlers refuse the same states, so a
@@ -308,7 +313,7 @@
      Esc, and ← Chats), never a neighbouring seat. Derived from the two state
      classes like every other face here. */
   #anncta:has(#annbtn.on) #viewshot,
-  #anncta:has(#annbtn.on):not(:has(#annrec.on)) #annrec,
+  #anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on)) #annrec,
   #anncta:has(#annrec.on) #annbtn { opacity: .55; cursor: default; pointer-events: none; }
   /* Empty label must not hold a gap seat open beside the icon. */
   #annreclbl:empty { display: none; }
@@ -3863,10 +3868,10 @@
                 aria-label="Screenshot the preview and attach it to this message"
                 title="Screenshot the preview and attach it to this message"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2.6 5.4h2.1l1-1.6h4.6l1 1.6h2.1a1 1 0 0 1 1 1v5.6a1 1 0 0 1-1 1H2.6a1 1 0 0 1-1-1V6.4a1 1 0 0 1 1-1Z" stroke-linejoin="round"/><circle cx="8" cy="9" r="2.4"/></svg><span class="lbl">Screenshot</span></button>
         <button id="annbtn" type="button" aria-pressed="false" aria-label="Comment on the preview"
-                title="Comment on the preview, then send the notes to Claude"><svg class="cmt-bubble" viewBox="0 0 16 16" aria-hidden="true"><path d="M13.5 2.5h-11a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2.5v2.9l3.4-2.9h5.1a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z"/></svg><svg class="cmt-stop" viewBox="0 0 16 16" aria-hidden="true"><rect class="fill" x="4" y="4" width="8" height="8" rx="1.5"/></svg><svg class="cmt-done" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 8.5l3.5 3.5 7-8"/></svg><span class="lbl cmt-word">Comment</span><span class="lbl done-word">Done</span><span id="annreclbl"></span></button>
+                title="Comment on the preview, then send the notes to Claude"><svg class="cmt-bubble" viewBox="0 0 16 16" aria-hidden="true"><path d="M13.5 2.5h-11a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2.5v2.9l3.4-2.9h5.1a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z"/></svg><svg class="cmt-stop" viewBox="0 0 16 16" aria-hidden="true"><rect class="fill" x="4" y="4" width="8" height="8" rx="1.5"/></svg><svg class="cmt-done" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 8.5l3.5 3.5 7-8"/></svg><span class="lbl cmt-word">Comment</span><span class="lbl done-word">Done</span></button>
         <button id="annrec" type="button" aria-pressed="false"
                 aria-label="Annotate with a spoken walkthrough"
-                title="Annotate with a spoken walkthrough — talk while you click, and each click becomes a note"><svg class="rec-mic" viewBox="0 0 16 16" aria-hidden="true"><rect x="6" y="1.5" width="4" height="7.5" rx="2"/><path d="M3.5 7.5a4.5 4.5 0 0 0 9 0"/><line x1="8" y1="12" x2="8" y2="14.5"/></svg><span class="lbl rec-word">Annotate</span></button>
+                title="Annotate with a spoken walkthrough — talk while you click, and each click becomes a note"><svg class="rec-mic" viewBox="0 0 16 16" aria-hidden="true"><rect x="6" y="1.5" width="4" height="7.5" rx="2"/><path d="M3.5 7.5a4.5 4.5 0 0 0 9 0"/><line x1="8" y1="12" x2="8" y2="14.5"/></svg><span class="lbl rec-word">Annotate</span><span id="annreclbl"></span></button>
       </div>
       <!-- More options (⋮), beside the annotate switch. One item today: hand
            this session to a real terminal. The LABEL is decided at open time
@@ -7869,6 +7874,7 @@ async function annRecEnd() {
   const handle = annRecHandle;
   const ids = annRecIds;
   const armed = annArmEpoch;
+  const left = annLeaveGen;   // the conversation this walkthrough belongs to
   clearInterval(annRecTimerId);
   annRecTimerId = null;
   annRecIds = [];
@@ -7999,7 +8005,9 @@ async function annRecEnd() {
     // The intro is seeded even when a live run blocks the auto-send: the words
     // wait in the composer (beside the pending notes) and ride the user's next
     // send, instead of evaporating because the walkthrough ended mid-turn.
-    if (spoke || intro) {
+    // ...unless the user LEFT the conversation while the words were on their
+    // way (annLeave bumped the generation): then they are nobody's to send.
+    if ((spoke || intro) && annLeaveGen === left) {
       annPrefillComposer(intro);
       if (activeRun || !sending) annAutoSubmit();  // a live run gets it as a follow-up — see annDone
     }
@@ -8128,6 +8136,19 @@ function annNotesDiscard() {
 }
 // One dispatcher for the bar's trash, whichever mode is on.
 function annDiscard() { return annRecOn ? annRecDiscard() : annNotesDiscard(); }
+// Leaving the conversation — ← Chats, or a chat opened from the landing —
+// takes an armed mode down with it (Akshil, 2026-09-06). A LIVE walkthrough
+// is DISCARDED, not ended: annRecEnd keeps, transcribes and auto-sends, and
+// with the page already on another chat that send would open a conversation
+// nobody asked for (Bugbot, PR #1022). The generation covers the settle: a
+// transcription already in flight when the user leaves lands after this
+// bump, and annRecEnd sees a stale generation and keeps its words to itself.
+let annLeaveGen = 0;
+function annLeave() {
+  annLeaveGen += 1;
+  if (annRecOn) annRecDiscard();
+  else if (annOn) annSetMode(false);
+}
 
 // ── hosted only: keeping up with a target this document cannot hear ────────
 // The split layout is told about its pane by the pane itself — one iframe, one
@@ -12671,8 +12692,7 @@ function consumeAnchor() {
 document.getElementById("back").onclick = () => {
   // Leaving the chat leaves the mode too (Akshil, 2026-09-06): an armed
   // Comment or a live walkthrough has nothing to point at on the landing.
-  // The Esc path — a recording is ended by annSetMode's own branch.
-  if (annOn) annSetMode(false);
+  annLeave();
   // Live even mid-turn (Akshil, 2026-08-19 — "when it is working I can't
   // click back"). The old `if (sending) return` guarded against orphaning the
   // streaming run's UI, but the architecture already survives leaving: the
@@ -12767,6 +12787,10 @@ document.getElementById("back").onclick = () => {
 };
 
 function enterChat() {
+  // Entering a chat leaves an armed mode behind, exactly as ← Chats does
+  // (Akshil, 2026-09-06): the pins belonged to the screen the reader is
+  // leaving. Nothing is armed at boot, so the resume path is a no-op here.
+  annLeave();
   chatEl.classList.remove("home");
   stopWatchRecent();
   // The strip belongs to ONE conversation. Chips from the previous chat are

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -317,12 +317,22 @@ def test_the_other_two_seats_are_inert_while_a_mode_is_on(html):
     assert ("() => (annRecOn ? null : annOn ? annDone() : annSetMode(true)));") in html
     assert ("() => (annRecOn ? annRecEnd() : annOn ? null : annRecBegin()));") in html
     assert ("#anncta:has(#annbtn.on) #viewshot,\n"
-            "  #anncta:has(#annbtn.on):not(:has(#annrec.on)) #annrec,\n"
+            "  #anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on)) #annrec,\n"
             "  #anncta:has(#annrec.on) #annbtn { opacity: .55; cursor: default; pointer-events: none; }") in html
     shot = _block(html, "async function shotAttachPane()", "\n}\n")
     assert "if (shotBusy || annOn || !annCapable()) return;" in shot
     back = _block(html, 'document.getElementById("back").onclick = () => {', "\n};")
-    assert "if (annOn) annSetMode(false);" in back
+    assert "annLeave();" in back
+    # a LIVE walkthrough is discarded, not ended — ending would transcribe and
+    # auto-send into whatever chat the page is on by then (Bugbot, PR #1022);
+    # and a transcription already in flight keeps its words once the user left
+    leave = _block(html, "function annLeave() {", "\n}\n")
+    assert "annLeaveGen += 1;" in leave
+    assert "if (annRecOn) annRecDiscard();" in leave
+    assert "else if (annOn) annSetMode(false);" in leave
+    end = _block(html, "async function annRecEnd()", "\n}\n")
+    assert "const left = annLeaveGen;" in end
+    assert "if ((spoke || intro) && annLeaveGen === left) {" in end
     # Bugbot, PR #1022: the mic refuses the settle too, the resting Comment
     # seat is not named "Stop", and aria-disabled follows the dimming
     begin = _block(html, "async function annRecBegin()", "\n}\n")
@@ -456,13 +466,21 @@ def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
     assert ".cmt-stop { display: block; }" not in html
     assert "#annbtn .cmt-stop, #annbtn .cmt-done, #annbtn .done-word { display: none; }" in html
     assert "#annbtn.on { color: var(--accent); background: transparent; border-color: var(--accent); }" in html
-    assert "#annrec.on { color: var(--error); border-color: var(--error); }" in html
+    assert "#annrec.on { color: var(--accent); border-color: var(--accent); }" in html
     assert "annrecpulse" not in html   # steady, no flashing (2026-09-06)
     assert "#anncta:has(#annrec.on) #annbtn.on { color: var(--dim); border-color: var(--border); }" in html
     # transcribing: annRecEnd stamps .busy and the status stands ALONE on the
-    # Comment seat — the clock itself is the bar's, never the strip's
+    # ANNOTATE seat (2026-09-06) — the clock itself is the bar's, never the strip's
     assert "#anncta:not(.busy) #annreclbl { display: none; }" in html
-    assert "#anncta.busy #annbtn .cmt-word { display: none; }" in html
+    assert "#anncta.busy #annrec .rec-word { display: none; }" in html
+    assert "#anncta.busy #annrec { color: var(--accent); border-color: var(--accent); }" in html
+    rec = _block(html, '<button id="annrec"', "</button>")
+    assert 'id="annreclbl"' in rec
+    cmt = _block(html, '<button id="annbtn"', "</button>")
+    assert 'id="annreclbl"' not in cmt
+    # entering a chat from the landing leaves the mode, like ← Chats
+    enter = _block(html, "function enterChat() {", "\n}\n")
+    assert "annLeave();" in enter
     end = _block(html, "async function annRecEnd()", "\n}\n")
     assert 'annCta.classList.add("busy");' in end
     assert 'annCta.classList.remove("busy");' in end
@@ -511,7 +529,7 @@ def test_a_transcribed_walkthrough_autosends_only_when_words_landed(html):
     body = _block(html, "async function annRecEnd()", "\n}\n")
     assign = body.index("annRecAssign(ids, rec.segments)")
     gate = body.index("c && c.content && !c.sent")
-    send = body.index("if (spoke || intro) {")
+    send = body.index("if ((spoke || intro) && annLeaveGen === left) {")
     assert assign < gate < send
     # the intro is seeded OUTSIDE the !sending gate: a walkthrough that ends
     # during a live run parks its words in the composer to ride the next send

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -468,7 +468,8 @@ def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
     assert "#annbtn.on { color: var(--accent); background: transparent; border-color: var(--accent); }" in html
     assert "#annrec.on { color: var(--accent); border-color: var(--accent); }" in html
     assert "annrecpulse" not in html   # steady, no flashing (2026-09-06)
-    assert "#anncta:has(#annrec.on) #annbtn.on { color: var(--dim); border-color: var(--border); }" in html
+    assert ("#anncta:has(#annrec.on) #annbtn.on,\n"
+            "  #anncta.busy #annbtn.on { color: var(--dim); border-color: var(--border); }") in html
     # transcribing: annRecEnd stamps .busy and the status stands ALONE on the
     # ANNOTATE seat (2026-09-06) — the clock itself is the bar's, never the strip's
     assert "#anncta:not(.busy) #annreclbl { display: none; }" in html

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -355,19 +355,18 @@ def test_a_mousedown_on_the_strip_does_not_drop_the_open_draft(html):
 
 
 def test_discard_throws_the_walkthrough_away(html):
-    """An outline trash seat, recording only, LEFT of the ■/clock (Akshil,
-    2026-08-19): the recording stops with nothing kept — no transcription, no
-    auto-send — and the clicks' empty marks are deleted with it. annRecEnd
-    no-ops after it, so a stop click racing the discard cannot resurrect the
-    walkthrough."""
-    assert "#anncta:not(.busy):has(#annbtn.on) #anndiscard { display: inline-flex;" in html
-    # two ids on the hide: a bare #anndiscard loses to the base
-    # `#anncta button` display rule on specificity, and the trash sat on the
-    # strip in every state
-    assert "#anncta #anndiscard { display: none; }" in html
-    assert "\n  #anndiscard { display: none; }" not in html
-    view = _block(html, '<div id="anncta">', "</div>")
-    assert view.index('id="anndiscard"') < view.index('id="annbtn"')
+    """An outline trash on the annotation bar, LEFT of ✓ Done / ■ (Akshil,
+    2026-09-06; it was a strip seat from 2026-08-19): the recording stops with
+    nothing kept — no transcription, no auto-send — and the clicks' empty
+    marks are deleted with it. annRecEnd no-ops after it, so a stop click
+    racing the discard cannot resurrect the walkthrough. The strip has no
+    trash of its own any more."""
+    assert 'id="anndiscard"' not in html
+    assert "annDiscardBtn" not in html
+    node = _block(html, "function annBarNode(doc)", "\n}\n")
+    assert 'discard.className = "discard";' in node
+    assert "bar.append(lead, slot, discard, done, stop);" in node
+    assert 'discard.addEventListener("click", () => annDiscard());' in node
     body = _block(html, "async function annRecDiscard()", "\n}\n")
     # cancel(), not stop(): the capture handle's cancel is the ending that
     # DELETES the file (SPEC CP-4), which is what a discard means — a stop
@@ -395,7 +394,7 @@ def test_discard_throws_the_walkthrough_away(html):
     assert "fused.ai.transcribe" not in body and "annAutoSubmit" not in body
     assert "if (annOn && annArmEpoch === armed) annSetMode(false);" in body, \
         "a new arming that slipped into the settle is not this discard's to close"
-    assert 'annDiscardBtn.addEventListener("click", () => (annRecOn ? annRecDiscard() : annNotesDiscard()));' in html
+    assert "function annDiscard() { return annRecOn ? annRecDiscard() : annNotesDiscard(); }" in html
 
 
 def test_the_busy_seat_is_a_status_not_a_button(html):
@@ -430,26 +429,24 @@ def test_the_live_recording_is_never_announced_as_done(html):
     assert 'annRecBtn.setAttribute("aria-label", "Annotate with a spoken walkthrough");' in end
 
 
-def test_the_seat_swaps_faces_off_the_two_state_classes(html):
-    """Every glyph and word is baked into the markup; the stylesheet derives
-    the seat's face from #annbtn.on / #annrec.on via :has on the wrapper —
-    no third writer to fall out of step. The mic hides whenever a mode is on,
-    so the strip is ONE control while armed or recording."""
-    assert "#anncta:has(#annbtn.on) #annrec { display: none; }" in html
-    # comment armed (and only then, and not while transcribing): ✓ Done
-    assert ("#anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on))"
-            " #annbtn .cmt-done { display: block; }") in html
-    # recording: the seat wears ■ plus the clock, in --error ink
-    assert "#anncta:has(#annrec.on) #annbtn .cmt-stop { display: block; }" in html
-    stop = _block(html, "#anncta:has(#annrec.on) #annbtn.on {", "}")
-    assert "var(--error)" in stop
-    # transcribing: annRecEnd stamps .busy and the status stands ALONE — the
-    # Done face is gated off busy at its own (higher-specificity) show rules,
-    # not fought with a weaker hide ("✓ Done Transcribing…", 2026-08-19)
-    assert ("#anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on))"
-            " #annbtn .cmt-done { display: block; }") in html
-    assert ("#anncta:not(.busy):has(#annbtn.on):not(:has(#annrec.on))"
-            " #annbtn .done-word { display: var(--annlbl, inline); }") in html
+def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
+    """Screenshot · Comment · Annotate stay on the strip in every state
+    (Akshil, 2026-09-06); arming only draws the armed seat active. No face
+    swap: the ✓ Done / ■ exits are the bar's (annBarNode). Recording is the
+    mic's state, so the Comment seat underneath rests while it runs — one
+    active seat at a time."""
+    assert "#anncta:has(#annbtn.on) #annrec { display: none; }" not in html
+    assert "#anncta:has(#annbtn.on) #viewshot { display: none; }" not in html
+    assert ".cmt-done { display: block; }" not in html
+    assert ".cmt-stop { display: block; }" not in html
+    assert "#annbtn .cmt-stop, #annbtn .cmt-done, #annbtn .done-word { display: none; }" in html
+    assert "#annbtn.on { color: var(--accent); background: transparent; border-color: var(--accent); }" in html
+    assert "#annrec.on { color: var(--error); border-color: var(--error);" in html
+    assert "#anncta:has(#annrec.on) #annbtn.on { color: var(--dim); border-color: var(--border); }" in html
+    # transcribing: annRecEnd stamps .busy and the status stands ALONE on the
+    # Comment seat — the clock itself is the bar's, never the strip's
+    assert "#anncta:not(.busy) #annreclbl { display: none; }" in html
+    assert "#anncta.busy #annbtn .cmt-word { display: none; }" in html
     end = _block(html, "async function annRecEnd()", "\n}\n")
     assert 'annCta.classList.add("busy");' in end
     assert 'annCta.classList.remove("busy");' in end
@@ -958,10 +955,15 @@ def test_the_bar_folds_by_measure_not_breakpoint(html):
 
 
 def test_discard_covers_the_typed_round_too(html):
-    """The strip keeps BOTH exits in both modes (Akshil, 2026-09-04): the
-    trash beside ✓ Done throws this round's unsent notes away — an open draft
-    with them — and leaves the mode; earlier rounds' and sent notes stay."""
-    assert "#anncta:not(.busy):has(#annbtn.on) #anndiscard { display: inline-flex;" in html
+    """The bar keeps BOTH exits in both modes (Akshil, 2026-09-04; onto the
+    bar 2026-09-06): the trash beside ✓ Done throws this round's unsent notes
+    away — an open draft with them — and leaves the mode; earlier rounds' and
+    sent notes stay. The label names what it throws, written by annBarPaint."""
+    paint = _block(html, "function annBarPaint(", "\n}\n")
+    assert 'annRecOn ? "Discard the recording" : "Discard the notes"' in paint
+    assert ".annbar .discard {\n    border: 1px solid var(--border);" in html
+    assert ".annbar .discard:hover { color: var(--error); border-color: var(--error); }" in html
+    assert '".annbar .discard { border: 1px solid var(--border, #34363e);' in html
     body = _block(html, "function annNotesDiscard(", "\n}\n")
     # not through Stopping…/Transcribing… either: annRecOn is already down and
     # the marks are the recording's, waiting for words (Bugbot, PR #1008)
@@ -969,4 +971,4 @@ def test_discard_covers_the_typed_round_too(html):
     assert "annCloseComposer();" in body
     assert "a.sent || (a.createdAt || 0) < annRoundStart" in body
     assert "annSetMode(false);" in body
-    assert "(annRecOn ? annRecDiscard() : annNotesDiscard())" in html
+    assert "return annRecOn ? annRecDiscard() : annNotesDiscard();" in html

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -307,16 +307,31 @@ def test_a_note_saves_without_any_capture_of_its_own(html):
 
 # ------------------------------------------ two buttons, one mode at a time
 
-def test_the_comment_seat_is_the_modes_one_control(html):
-    """A mode ON takes the strip down to one button (Akshil, 2026-08-19): the
-    mic hides, and the Comment seat's click matches its face — stop a live
-    recording, Done for an armed comment mode, arm from rest. Cancelling
-    without sending is Esc's job now."""
-    assert ("() => (annRecOn ? annRecEnd() :"
-            " annOn ? annDone() : annSetMode(true)));") in html
-    # the mic only ever starts a walkthrough (the recording leg guards a
-    # click racing the hide, it is not a second stop control)
-    assert ("() => (annRecOn ? annRecEnd() : annRecBegin()));") in html
+def test_the_other_two_seats_are_inert_while_a_mode_is_on(html):
+    """One mode at a time (Akshil, 2026-09-06): while Comment is armed the
+    camera and the mic are inert; while a walkthrough records the camera and
+    the Comment seat are. Dimmed and pointer-less by the stylesheet, refused
+    by the handlers so a keyboard press is a no-op too. The Comment seat's
+    click is Done when armed and arm from rest; the mic's is stop when
+    recording and start from rest. ← Chats leaves the mode with the chat."""
+    assert ("() => (annRecOn ? null : annOn ? annDone() : annSetMode(true)));") in html
+    assert ("() => (annRecOn ? annRecEnd() : annOn ? null : annRecBegin()));") in html
+    assert ("#anncta:has(#annbtn.on) #viewshot,\n"
+            "  #anncta:has(#annbtn.on):not(:has(#annrec.on)) #annrec,\n"
+            "  #anncta:has(#annrec.on) #annbtn { opacity: .55; cursor: default; pointer-events: none; }") in html
+    shot = _block(html, "async function shotAttachPane()", "\n}\n")
+    assert "if (shotBusy || annOn || !annCapable()) return;" in shot
+    back = _block(html, 'document.getElementById("back").onclick = () => {', "\n};")
+    assert "if (annOn) annSetMode(false);" in back
+    # Bugbot, PR #1022: the mic refuses the settle too, the resting Comment
+    # seat is not named "Stop", and aria-disabled follows the dimming
+    begin = _block(html, "async function annRecBegin()", "\n}\n")
+    assert 'if (annRecOn || annCta.classList.contains("busy") || !annCapable()) return;' in begin
+    assert 'annBtn.setAttribute("aria-label", "Stop the recording");' not in html
+    aria = _block(html, "function annSeatsAria()", "\n}\n")
+    assert 'annRecBtn.setAttribute("aria-disabled", annOn && !annRecOn ? "true" : "false");' in aria
+    paint = _block(html, "function annBarPaint(", "\n}\n")
+    assert "annSeatsAria();" in paint
 
 
 def test_done_flushes_pending_notes_before_disarming(html):
@@ -441,7 +456,8 @@ def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
     assert ".cmt-stop { display: block; }" not in html
     assert "#annbtn .cmt-stop, #annbtn .cmt-done, #annbtn .done-word { display: none; }" in html
     assert "#annbtn.on { color: var(--accent); background: transparent; border-color: var(--accent); }" in html
-    assert "#annrec.on { color: var(--error); border-color: var(--error);" in html
+    assert "#annrec.on { color: var(--error); border-color: var(--error); }" in html
+    assert "annrecpulse" not in html   # steady, no flashing (2026-09-06)
     assert "#anncta:has(#annrec.on) #annbtn.on { color: var(--dim); border-color: var(--border); }" in html
     # transcribing: annRecEnd stamps .busy and the status stands ALONE on the
     # Comment seat — the clock itself is the bar's, never the strip's

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -321,18 +321,6 @@ def test_the_other_two_seats_are_inert_while_a_mode_is_on(html):
             "  #anncta:has(#annrec.on) #annbtn { opacity: .55; cursor: default; pointer-events: none; }") in html
     shot = _block(html, "async function shotAttachPane()", "\n}\n")
     assert "if (shotBusy || annOn || !annCapable()) return;" in shot
-    back = _block(html, 'document.getElementById("back").onclick = () => {', "\n};")
-    assert "annLeave();" in back
-    # a LIVE walkthrough is discarded, not ended — ending would transcribe and
-    # auto-send into whatever chat the page is on by then (Bugbot, PR #1022);
-    # and a transcription already in flight keeps its words once the user left
-    leave = _block(html, "function annLeave() {", "\n}\n")
-    assert "annLeaveGen += 1;" in leave
-    assert "if (annRecOn) annRecDiscard();" in leave
-    assert "else if (annOn) annSetMode(false);" in leave
-    end = _block(html, "async function annRecEnd()", "\n}\n")
-    assert "const left = annLeaveGen;" in end
-    assert "if ((spoke || intro) && annLeaveGen === left) {" in end
     # Bugbot, PR #1022: the mic refuses the settle too, the resting Comment
     # seat is not named "Stop", and aria-disabled follows the dimming
     begin = _block(html, "async function annRecBegin()", "\n}\n")
@@ -412,8 +400,9 @@ def test_discard_throws_the_walkthrough_away(html):
         assert fn.index("const armed = annArmEpoch;") < stop
         assert fn.index("annRecIds = [];") < stop
         assert fn.index("annRecHandle = null;") < stop
-    assert body.index('annRecBtn.setAttribute("aria-label", "Annotate with a spoken walkthrough");') \
-        < body.index("await handle.cancel()")
+    # the mic is named for the settle BEFORE the cancel, idle again after it
+    assert body.index('annRecBtn.setAttribute("aria-label", "Discarding the recording");') \
+        < body.index("await handle.cancel()") < body.index("annRecIdleName();")
     assert "annotations = annotations.filter((a) => !ids.has(a.id));" in body
     assert "renderAnn();" in body, "discarded pins leave the screen even if Esc already disarmed"
     assert "fused.ai.transcribe" not in body and "annAutoSubmit" not in body
@@ -428,7 +417,17 @@ def test_the_busy_seat_is_a_status_not_a_button(html):
     finally re-enables it and the disarm renames it."""
     end = _block(html, "async function annRecEnd()", "\n}\n")
     assert "annBtn.disabled = true;" in end
-    assert 'annBtn.setAttribute("aria-label", "Transcribing the walkthrough");' in end
+    # the status is the ANNOTATE seat's (2026-09-06, Bugbot PR #1022): it is
+    # the seat that shows #annreclbl, so it is the seat named for it; the
+    # Comment seat is merely unavailable, and the settle's end idle-names the mic
+    assert 'annRecBtn.setAttribute("aria-label", "Transcribing the walkthrough");' in end
+    assert 'annRecBtn.setAttribute("aria-label", "Stopping the recording");' in end
+    assert 'annBtn.setAttribute("aria-label", "Comment — unavailable while the recording settles");' in end
+    assert 'annBtn.setAttribute("aria-label", "Transcribing the walkthrough");' not in html
+    assert "annRecIdleName();" in end
+    disc = _block(html, "async function annRecDiscard()", "\n}\n")
+    assert 'annRecBtn.setAttribute("aria-label", "Discarding the recording");' in disc
+    assert "annRecIdleName();" in disc
     assert "annBtn.disabled = false;" in end
     # ...and any mode TRANSITION ends the status's claim early: Esc during a
     # transcription disarms through annSetMode, which must not leave the seat
@@ -451,7 +450,7 @@ def test_the_live_recording_is_never_announced_as_done(html):
     begin = _block(html, "async function annRecBegin()", "\n}\n")
     assert 'annRecBtn.setAttribute("aria-label", "Stop the recording");' in begin
     end = _block(html, "async function annRecEnd()", "\n}\n")
-    assert 'annRecBtn.setAttribute("aria-label", "Annotate with a spoken walkthrough");' in end
+    assert "annRecIdleName();" in end   # the idle name comes back when the settle ends
 
 
 def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
@@ -479,9 +478,9 @@ def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
     assert 'id="annreclbl"' in rec
     cmt = _block(html, '<button id="annbtn"', "</button>")
     assert 'id="annreclbl"' not in cmt
-    # entering a chat from the landing leaves the mode, like ← Chats
-    enter = _block(html, "function enterChat() {", "\n}\n")
-    assert "annLeave();" in enter
+    # a mode SURVIVES switching chats for now (Akshil, 2026-09-06) — the
+    # discard-on-leave lands in its own PR
+    assert "annLeave" not in html
     end = _block(html, "async function annRecEnd()", "\n}\n")
     assert 'annCta.classList.add("busy");' in end
     assert 'annCta.classList.remove("busy");' in end
@@ -530,7 +529,7 @@ def test_a_transcribed_walkthrough_autosends_only_when_words_landed(html):
     body = _block(html, "async function annRecEnd()", "\n}\n")
     assign = body.index("annRecAssign(ids, rec.segments)")
     gate = body.index("c && c.content && !c.sent")
-    send = body.index("if ((spoke || intro) && annLeaveGen === left) {")
+    send = body.index("if (spoke || intro) {")
     assert assign < gate < send
     # the intro is seeded OUTSIDE the !sending gate: a walkthrough that ends
     # during a live run parks its words in the composer to ride the next send

--- a/tests/test_claude_shots.py
+++ b/tests/test_claude_shots.py
@@ -2636,14 +2636,14 @@ def test_the_strip_carries_the_one_button_between_comment_and_record(html):
     and Record, so it sits with them — first of the three: Screenshot, Comment, Record.
     The strip is the one row the home card and the chat both keep, so one copy
     serves both composers, and the chip still lands above whichever is showing.
-    Hidden while a mode is armed, like the mic."""
+    Stays while a mode is armed (2026-09-06), like its two neighbours."""
     assert 'id="hviewshot"' not in html
     assert 'class="pill viewshot"' not in html
     strip = _between(html, '<div id="anncta">', "\n      </div>")
     assert 'id="viewshot"' in strip
     # Screenshot · Comment · Annotate (Akshil, 2026-09-04)
     assert strip.index('id="viewshot"') < strip.index('id="annbtn"') < strip.index('id="annrec"')
-    assert "#anncta:has(#annbtn.on) #viewshot { display: none; }" in html
+    assert "#anncta:has(#annbtn.on) #viewshot { display: none; }" not in html
     btns = _between(html, "function shotBtns()", "\n}\n")
     assert '"viewshot"' in btns and "hviewshot" not in btns
     # the spoken strings are the pane-noun writer's, not two hardcoded literals

--- a/tests/test_claude_shots.py
+++ b/tests/test_claude_shots.py
@@ -2534,7 +2534,7 @@ def test_a_second_click_replaces_the_picture_and_releases_the_first(html):
     # ONE pane seat, found by kind — a pasted picture is the other kind and stacks
     assert 'const seat = shotAttached.findIndex((s) => s.kind === "pane");' in click
     # and a double-click cannot start a second capture at all
-    assert "if (shotBusy || !annCapable()) return;" in click
+    assert "if (shotBusy || annOn || !annCapable()) return;" in click
     assert "shotBusy = true;" in click
 
 


### PR DESCRIPTION
## What

Arming **Comment** or **Annotate** no longer collapses the chat pane's strip to one exit control (Akshil, 2026-09-06).

- **Strip**: `Screenshot · Comment · Annotate` stay in every state. The armed seat is drawn active — accent outline on Comment, `--error` pulse on Annotate. While a walkthrough records the Comment seat rests, so exactly one seat reads active.
- **No face swap**: the ✓ Done / ■ clock faces are gone from the strip; those exits are the annotation bar's over the app.
- **Trash moves onto the bar**, left of ✓ Done / ■, in both modes. `annBarPaint` writes its label per mode ("Discard the notes" / "Discard the recording"); the bar's existing busy gate keeps it away through Stopping…/Transcribing….
- `#annreclbl` on the strip now shows only the busy status, standing alone on the Comment seat; the live clock is the bar's.

## Verified
- cmux browser (sine.html, dark): armed Comment → three seats visible, Comment accent-outlined; bar shows `[Element|Point] [🗑] [✓ Done]`; bar trash disarms the mode, clears the 43px push. Simulated recording classes → Annotate red, Comment rests. Narrow bar folds t1/t2/t3 with the trash counted.
- `pytest tests/test_claude*.py tests/test_theme.py`: 1768 passed; the 7 `test_claude_health` failures pre-exist on main, remaining errors are the unbuilt-shell env in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core annotation mode wiring (click handlers, aria, bar vs strip) and recording settle races; behavior is heavily test-locked but user-facing interaction paths changed materially.
> 
> **Overview**
> **Annotation strip UX** no longer collapses to a single control when Comment or Annotate is armed. **Screenshot · Comment · Annotate** stay visible; the active mode is shown with an accent outline (recording mic matches Comment styling—no red pulse). Other seats are **dimmed and non-interactive** (`pointer-events`, handler no-ops, `annSeatsAria`), including screenshot while any mode is on and mic while comment mode is armed.
> 
> **Done / stop / trash** are no longer morphed onto strip buttons. Exits live on the **annotation bar** (existing ✓ Done / ■ clock); **discard** is added there (left of Done/stop), with mode-specific labels from `annBarPaint`. Strip `#anndiscard` is removed; `annDiscard()` dispatches bar clicks.
> 
> **Busy status** (`Stopping…` / `Transcribing…`) moves to **`#annreclbl` on the Annotate seat** (not Comment). Comment stays disabled/unavailable during recording and settle; mic refuses starts during `.busy` (PR #1022).
> 
> Tests in `test_claude_annotation_modes.py` and `test_claude_shots.py` are updated for the new strip, bar discard, and inert-seat rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81866e3cd6cf4ebda5f074c4b2cc653226bb101a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->