### PR TITLE
Chat frames: one host-owned cover from mount to painted transcript

### DIFF
--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -28,6 +28,7 @@
 // shows.
 import { modeTitle } from "@platform/lib/mode-name";
 import { withNoFocus } from "@platform/lib/frame-focus";
+import { ChatFrame } from "@platform/ui/ChatFrame";
 import { usePaneFocusGuard } from "@apps/explorer/listing/usePaneFocusGuard";
 import { SideCloseButton, paneSideIcon } from "@apps/explorer/SideChrome";
 import { ModeMenu } from "@apps/explorer/BarMenu";
@@ -170,24 +171,30 @@ export default function ListingPreviewPane({
     // `_fusedClaudeAskTake`), and this component's `key` (Listing.tsx, folded
     // with `claudeAskInstance` for exactly the claude case) is what makes sure
     // a fresh ask gets a fresh mount to pull it into.
+    // `_noopen=1`, not `_preview=1` (D622): this pane is fully interactive —
+    // you type in it — so it must not carry the display-only stamp
+    // `runtime.js`'s `IS_THUMBNAIL` reads off `_preview`, which would silently
+    // disable `fused.daemon.*` for every app it frames (its own left preview
+    // pane included, two levels down). `_noopen=1` says only the one thing this
+    // call site actually wants: don't record this render as an app open.
+    const src = withNoFocus(
+      `/render?path=${encodeURIComponent(sideEntry.path)}` +
+        `&_file=${encodeURIComponent(folder)}${chatOnly}&_noopen=1`
+    );
+    // The claude companion is the one whose document restores a transcript
+    // before it has anything to show, so it is the one framed behind a cover
+    // that waits for `data-chat-ready` (platform/ui/ChatFrame — same as the
+    // Cards wall and its popup). git and mcp paint their own first frame and
+    // stamp nothing, so they stay plain: a cover revealed only by the 8s
+    // fallback would be a new wait, not a fix.
     return (
       <div className="listing-pane" ref={rootRef} {...guardProps}>
         {strip()}
-        <iframe
-          className="pane-frame"
-          src={withNoFocus(
-            // `_noopen=1`, not `_preview=1` (D622): this pane is fully
-            // interactive — you type in it — so it must not carry the
-            // display-only stamp `runtime.js`'s `IS_THUMBNAIL` reads off
-            // `_preview`, which would silently disable `fused.daemon.*` for
-            // every app it frames (its own left preview pane included, two
-            // levels down). `_noopen=1` says only the one thing this call
-            // site actually wants: don't record this render as an app open.
-            `/render?path=${encodeURIComponent(sideEntry.path)}` +
-              `&_file=${encodeURIComponent(folder)}${chatOnly}&_noopen=1`
-          )}
-          title={modeTitle(side)}
-        />
+        {side === "claude" ? (
+          <ChatFrame className="pane-frame" src={src} title={modeTitle(side)} />
+        ) : (
+          <iframe className="pane-frame" src={src} title={modeTitle(side)} />
+        )}
       </div>
     );
   }

--- a/frontend/src/apps/explorer/PreviewSidebar.tsx
+++ b/frontend/src/apps/explorer/PreviewSidebar.tsx
@@ -35,6 +35,7 @@
 // flex children of the split container.
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { modeTitle } from "@platform/lib/mode-name";
+import { ChatFrame } from "@platform/ui/ChatFrame";
 import { ModeMenu } from "@apps/explorer/BarMenu";
 import { SideCloseButton } from "@apps/explorer/SideChrome";
 import {
@@ -60,6 +61,12 @@ import { committedWidth, resizeWidth } from "@platform/lib/panel-drag";
 // different components now (StatView owns the container, this owns the handle),
 // and a ref would have to be threaded through the portal to get here.
 const SPLIT_SEL = ".stat-split";
+
+// The one companion whose document is a CHAT, and so the one that reports when
+// its transcript is painted (`data-chat-ready`, platform/ui/ChatFrame). Named
+// here rather than compared inline so the gate below reads as a fact about that
+// mode and not as a string that happened to match.
+const CHAT_MODE = "claude";
 
 // The page-level split's right-hand slot, rendered by StatView beside the left
 // column. `display: contents` (explorer.css) so the portaled divider and column
@@ -334,13 +341,32 @@ export default function PreviewSidebar({
           /* Keyed on the mode, so a switch replaces the document outright. No
              held-frame cross-fade here (unlike the content pane): the sidebar is
              a narrow column of chrome-heavy tools, and the two of them look
-             nothing alike — there is no illusion of continuity to protect. */
-          <iframe
-            key={frameKey}
-            className="preview-side-frame"
-            src={src}
-            title={modeTitle(active)}
-          />
+             nothing alike — there is no illusion of continuity to protect.
+
+             THE CLAUDE COMPANION IS THE ONE MODE THAT COVERS ITS OWN BOOT
+             (platform/ui/ChatFrame): it is the only one of the three that
+             restores a transcript before it has anything to show, so it is the
+             only one whose cold document was a visible black pane. The cover
+             waits on `data-chat-ready`, which only the chat template stamps —
+             the gate is the MODE and not the 8s fallback, because a `git` or
+             `mcp` column revealed by a timeout would be a whole new bug in
+             exchange for a fix nobody asked for there. The key stays on the
+             outer component, so a mode switch still replaces the document. */
+          active === CHAT_MODE ? (
+            <ChatFrame
+              key={frameKey}
+              className="preview-side-frame"
+              src={src}
+              title={modeTitle(active)}
+            />
+          ) : (
+            <iframe
+              key={frameKey}
+              className="preview-side-frame"
+              src={src}
+              title={modeTitle(active)}
+            />
+          )
         )}
       </aside>
     </>

--- a/frontend/src/platform/ui/ChatFrame.test.tsx
+++ b/frontend/src/platform/ui/ChatFrame.test.tsx
@@ -116,16 +116,19 @@ test("an unready frame is mounted invisible under the cover, with the caller's c
   expect(String(cover?.props.className).split(" ")).not.toContain("is-out");
 });
 
-test("a document already carrying the stamp at mount is revealed without waiting for load", () => {
-  // The warm case: the frame finished (and painted) before this component's
-  // effect ran. Nothing will fire a `load` for it any more, so the mount-time
-  // read is the only thing that can uncover it.
+test("a stamp on the document at mount is NOT trusted — only this src's own load is", () => {
+  // Whatever `contentDocument` holds before `load` is not this src's document:
+  // `about:blank` on a fresh mount, the previous conversation on a src change.
+  // A stamp read there would uncover a document that is still navigating.
   const node = frameNode(doc({ chatReady: "1" }));
   const r = mount(<ChatFrame src="/render?a=1" title="Chat" />, node);
-  const tree = r.toJSON() as ReactTestRendererJSON;
+  let tree = r.toJSON() as ReactTestRendererJSON;
+  expect(String(find(tree, "chat-frame-iframe")?.props.className)).not.toContain("is-ready");
+  expect(find(tree, "chat-frame-placeholder")).toBeDefined();
+  // The load lands and the (stamped) document is read: revealed, cover fading.
+  act(() => node.fire("load"));
+  tree = r.toJSON() as ReactTestRendererJSON;
   expect(String(find(tree, "chat-frame-iframe")?.props.className).split(" ")).toContain("is-ready");
-  // Still mounted, now fading: the cover leaves in two beats so the crossfade
-  // has something to cross with.
   expect(String(find(tree, "chat-frame-placeholder")?.props.className).split(" ")).toContain(
     "is-out",
   );
@@ -159,20 +162,31 @@ test("load with no readable document reveals at once — a cross-origin frame ne
 
 test("a new src starts a new wait — the previous document's answer does not uncover it", () => {
   // One iframe element, as React keeps it across a src change, navigated to a
-  // second conversation: the element is the same, the document is not.
+  // second conversation: the element is the same, the document is not — and
+  // until the new one loads, `contentDocument` is STILL the old, stamped one.
   const node = frameNode(doc({ chatReady: "1" }));
   const r = mount(<ChatFrame src="/render?s=1" title="Chat" />, node);
+  act(() => node.fire("load"));
   expect(
     String(find(r.toJSON() as ReactTestRendererJSON, "chat-frame-iframe")?.props.className),
   ).toContain("is-ready");
-  node.contentDocument = doc({});
   act(() => {
     r.update(<ChatFrame src="/render?s=2" title="Chat" />);
   });
-  const tree = r.toJSON() as ReactTestRendererJSON;
+  let tree = r.toJSON() as ReactTestRendererJSON;
   expect(String(find(tree, "chat-frame-iframe")?.props.className)).not.toContain("is-ready");
   // And the cover is back over it, not left behind by the previous reveal.
   expect(find(tree, "chat-frame-placeholder")).toBeDefined();
+  // The new document arrives unready: still covered. Then it stamps: revealed.
+  const next = doc({}) as Document & { documentElement: { dataset: Record<string, string> } };
+  node.contentDocument = next;
+  act(() => node.fire("load"));
+  tree = r.toJSON() as ReactTestRendererJSON;
+  expect(String(find(tree, "chat-frame-iframe")?.props.className)).not.toContain("is-ready");
+  next.documentElement.dataset.chatReady = "1";
+  act(() => node.fire("load"));
+  tree = r.toJSON() as ReactTestRendererJSON;
+  expect(String(find(tree, "chat-frame-iframe")?.props.className).split(" ")).toContain("is-ready");
 });
 
 test("frameRef reaches the iframe element itself, not the box around it", () => {

--- a/frontend/src/platform/ui/ChatFrame.test.tsx
+++ b/frontend/src/platform/ui/ChatFrame.test.tsx
@@ -1,0 +1,195 @@
+// The chat frame's contract with the template it hosts: `data-chat-ready="1"`
+// on the framed document's <html>, and nothing else. Two things are worth a
+// test here and the rest is browser behaviour — the READ of that attribute
+// (pure, exhaustively checkable) and the REVEAL it drives (a class on the
+// iframe, a cover that leaves), which react-test-renderer can drive with a
+// mocked frame node.
+//
+// Not tested here: the 8s fallback timer and the MutationObserver path. The
+// first is real time nobody should spend in a suite (and bun's runtime has no
+// fake-timer contract this file can lean on); the second needs a live
+// MutationObserver, which bun does not have — both are exercised in the browser
+// pass instead.
+import { afterEach, expect, test } from "bun:test";
+import { act, create, type ReactTestRendererJSON } from "react-test-renderer";
+
+import { ChatFrame, ChatFramePlaceholder, isChatDocReady } from "./ChatFrame";
+
+/** A document whose <html> carries whatever `dataset` this is handed. */
+function doc(dataset: Record<string, string>): Document {
+  return { documentElement: { dataset } } as unknown as Document;
+}
+
+/** An iframe node standing in for the DOM one react-test-renderer never makes.
+ *  `contentDocument` is what the component reads; the listeners are recorded so
+ *  a test can fire `load` the way a browser would. */
+function frameNode(contentDocument: Document | null) {
+  const listeners: Record<string, Array<() => void>> = {};
+  return {
+    contentDocument,
+    addEventListener(type: string, fn: () => void) {
+      (listeners[type] ??= []).push(fn);
+    },
+    removeEventListener(type: string, fn: () => void) {
+      listeners[type] = (listeners[type] ?? []).filter((f) => f !== fn);
+    },
+    fire(type: string) {
+      for (const fn of [...(listeners[type] ?? [])]) fn();
+    },
+  };
+}
+
+function find(
+  node: ReactTestRendererJSON | null,
+  cls: string,
+): ReactTestRendererJSON | undefined {
+  if (!node) return undefined;
+  if (String(node.props?.className ?? "").split(" ").includes(cls)) return node;
+  for (const k of node.children ?? []) {
+    if (typeof k === "string") continue;
+    const hit = find(k as ReactTestRendererJSON, cls);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** Mount a ChatFrame over `node`, effects flushed, and register it for
+ *  teardown — every mounted frame holds at least the fallback timer, and a
+ *  renderer left up fires it (and the fade timer) into a finished test, which
+ *  React reports as an unwrapped state update. */
+const mounted: Array<ReturnType<typeof create>> = [];
+function mount(el: React.ReactElement, node: unknown): ReturnType<typeof create> {
+  let r!: ReturnType<typeof create>;
+  act(() => {
+    r = create(el, { createNodeMock: () => node });
+  });
+  mounted.push(r);
+  return r;
+}
+afterEach(() => {
+  for (const r of mounted.splice(0)) act(() => r.unmount());
+});
+
+// ---- the read -------------------------------------------------------------
+
+test("only the exact stamp reads as ready", () => {
+  expect(isChatDocReady(doc({ chatReady: "1" }))).toBe(true);
+  expect(isChatDocReady(doc({}))).toBe(false);
+  // Anything else on the attribute is a template that has not finished (or one
+  // saying something this host does not understand): not ready either way.
+  expect(isChatDocReady(doc({ chatReady: "" }))).toBe(false);
+  expect(isChatDocReady(doc({ chatReady: "0" }))).toBe(false);
+  expect(isChatDocReady(doc({ chatReady: "true" }))).toBe(false);
+});
+
+test("no document is NOT ready — the cross-origin case is decided on load, not here", () => {
+  expect(isChatDocReady(null)).toBe(false);
+  expect(isChatDocReady(undefined)).toBe(false);
+  // A document mid-teardown, whose documentElement is already gone.
+  expect(isChatDocReady({} as Document)).toBe(false);
+});
+
+test("a document that throws on read answers false rather than propagating", () => {
+  const hostile = {
+    get documentElement(): never {
+      throw new Error("gone");
+    },
+  } as unknown as Document;
+  expect(isChatDocReady(hostile)).toBe(false);
+});
+
+// ---- the reveal -----------------------------------------------------------
+
+test("an unready frame is mounted invisible under the cover, with the caller's class on it", () => {
+  const node = frameNode(doc({}));
+  const r = mount(<ChatFrame src="/render?a=1" title="Chat" className="task-card-frame" />, node);
+  const tree = r.toJSON() as ReactTestRendererJSON;
+  const iframe = find(tree, "chat-frame-iframe");
+  expect(iframe?.type).toBe("iframe");
+  // The consumer's own class rides the iframe — that is what keeps the card's
+  // scaled fit working — and `is-ready` is absent, so the CSS holds opacity 0.
+  expect(String(iframe?.props.className).split(" ")).toContain("task-card-frame");
+  expect(String(iframe?.props.className).split(" ")).not.toContain("is-ready");
+  const cover = find(tree, "chat-frame-placeholder");
+  expect(cover?.props["aria-busy"]).toBe("true");
+  expect(cover?.props.role).toBe("status");
+  expect(String(cover?.props.className).split(" ")).not.toContain("is-out");
+});
+
+test("a document already carrying the stamp at mount is revealed without waiting for load", () => {
+  // The warm case: the frame finished (and painted) before this component's
+  // effect ran. Nothing will fire a `load` for it any more, so the mount-time
+  // read is the only thing that can uncover it.
+  const node = frameNode(doc({ chatReady: "1" }));
+  const r = mount(<ChatFrame src="/render?a=1" title="Chat" />, node);
+  const tree = r.toJSON() as ReactTestRendererJSON;
+  expect(String(find(tree, "chat-frame-iframe")?.props.className).split(" ")).toContain("is-ready");
+  // Still mounted, now fading: the cover leaves in two beats so the crossfade
+  // has something to cross with.
+  expect(String(find(tree, "chat-frame-placeholder")?.props.className).split(" ")).toContain(
+    "is-out",
+  );
+});
+
+test("load with a readable-but-unready document keeps the cover; the stamp then reveals", () => {
+  const d = doc({}) as Document & { documentElement: { dataset: Record<string, string> } };
+  const node = frameNode(d);
+  const r = mount(<ChatFrame src="/render?a=1" title="Chat" />, node);
+  act(() => node.fire("load"));
+  expect(
+    String(find(r.toJSON() as ReactTestRendererJSON, "chat-frame-iframe")?.props.className),
+  ).not.toContain("is-ready");
+  // The template finishes and stamps; in a browser the observer catches this,
+  // and a second `load` (a re-navigation of the same frame) must too.
+  d.documentElement.dataset.chatReady = "1";
+  act(() => node.fire("load"));
+  expect(
+    String(find(r.toJSON() as ReactTestRendererJSON, "chat-frame-iframe")?.props.className),
+  ).toContain("is-ready");
+});
+
+test("load with no readable document reveals at once — a cross-origin frame never stamps", () => {
+  const node = frameNode(null);
+  const r = mount(<ChatFrame src="https://elsewhere/x" title="Chat" />, node);
+  act(() => node.fire("load"));
+  expect(
+    String(find(r.toJSON() as ReactTestRendererJSON, "chat-frame-iframe")?.props.className),
+  ).toContain("is-ready");
+});
+
+test("a new src starts a new wait — the previous document's answer does not uncover it", () => {
+  // One iframe element, as React keeps it across a src change, navigated to a
+  // second conversation: the element is the same, the document is not.
+  const node = frameNode(doc({ chatReady: "1" }));
+  const r = mount(<ChatFrame src="/render?s=1" title="Chat" />, node);
+  expect(
+    String(find(r.toJSON() as ReactTestRendererJSON, "chat-frame-iframe")?.props.className),
+  ).toContain("is-ready");
+  node.contentDocument = doc({});
+  act(() => {
+    r.update(<ChatFrame src="/render?s=2" title="Chat" />);
+  });
+  const tree = r.toJSON() as ReactTestRendererJSON;
+  expect(String(find(tree, "chat-frame-iframe")?.props.className)).not.toContain("is-ready");
+  // And the cover is back over it, not left behind by the previous reveal.
+  expect(find(tree, "chat-frame-placeholder")).toBeDefined();
+});
+
+test("frameRef reaches the iframe element itself, not the box around it", () => {
+  // TaskPeek attaches an Esc listener to the framed document and hands this ref
+  // to the modal chassis as its initial focus — both want the iframe.
+  const node = frameNode(doc({}));
+  const ref = { current: null } as React.MutableRefObject<HTMLIFrameElement | null>;
+  mount(<ChatFrame src="/render?a=1" title="Chat" frameRef={ref} />, node);
+  expect(ref.current).toBe(node as unknown as HTMLIFrameElement);
+});
+
+test("the standalone placeholder is the same skeleton, in its own box and with no frame", () => {
+  const tree = create(<ChatFramePlaceholder />).toJSON() as ReactTestRendererJSON;
+  expect(String(tree.props.className).split(" ")).toContain("chat-frame");
+  expect(find(tree, "chat-frame-placeholder")?.props["aria-label"]).toBe("Loading chat");
+  expect(find(tree, "chat-frame-iframe")).toBeUndefined();
+  // The template's own two turns: the user pill, then the avatar and its lines.
+  expect(find(tree, "chat-frame-skel-user")).toBeDefined();
+  expect(find(tree, "chat-frame-skel-assistant")).toBeDefined();
+});

--- a/frontend/src/platform/ui/ChatFrame.tsx
+++ b/frontend/src/platform/ui/ChatFrame.tsx
@@ -155,9 +155,12 @@ export function ChatFrame({
     const reveal = () => setReadyFor(src);
 
     // Read the attribute if it is already there; otherwise watch for it. Called
-    // both at mount (the document may have loaded — even finished painting —
-    // before this effect ran, e.g. a warm frame or a synchronous re-key) and on
-    // every `load`.
+    // on `load` ONLY — never at mount. Until this src's own document has loaded,
+    // `contentDocument` is whatever the element held before: `about:blank` on
+    // a fresh mount, and on a src CHANGE the previous conversation, which is
+    // already stamped and would uncover the new src over a stale, still
+    // navigating document (Bugbot, #1024). A frame that somehow loaded before
+    // this effect attached is what the fallback timer is for.
     const inspect = () => {
       const el = ownRef.current;
       if (!el) return;
@@ -206,7 +209,6 @@ export function ChatFrame({
       inspect();
     };
 
-    inspect();
     frame?.addEventListener("load", onFrameLoad);
     // The backstop. Cleared on unmount and restarted per src, so a wall of
     // cards carries one timer each and none outlive their frame.

--- a/frontend/src/platform/ui/ChatFrame.tsx
+++ b/frontend/src/platform/ui/ChatFrame.tsx
@@ -1,0 +1,252 @@
+// ONE WAIT, ONE LOOK: the host-owned placeholder that covers a chat frame from
+// the moment it mounts until the framed document says its transcript is painted.
+//
+// The problem it exists for: an embedded chat used to show FOUR states on three
+// clocks — the host's "Starting…" text, the iframe's own blank/black cold
+// document, the template's skeleton, then the chat. On a wall of twelve cards
+// they popcorn, and two of the four are pure overhead. Here the host draws ONE
+// skeleton, shaped like the template's own (`renderLogSkeleton`), and holds it
+// over an `opacity: 0` iframe until the frame reports ready — so the only
+// visible transition is skeleton → chat, a crossfade of identical geometry
+// rather than a redraw.
+//
+// THE READY SIGNAL IS AN ATTRIBUTE, NOT A MESSAGE (D3/D4). /render is always
+// same-origin, so the sanctioned channel between a host and a framed template
+// in this app is a direct `contentDocument` read — the same thing Preview.tsx
+// does to lift a rendered page's <title>. The chat template stamps
+// `document.documentElement.dataset.chatReady = "1"` once its transcript is
+// painted (and immediately on the landing / no-session paths, which have
+// nothing to restore). This component reads that attribute on `load` and, if it
+// is not there yet, watches for it with a MutationObserver. No postMessage, no
+// handshake, nothing for a template author to remember to answer.
+//
+// NEVER BROKEN outranks the wait: a frame that never stamps — a cross-origin
+// document, a template that does not know the contract, a boot that threw — is
+// revealed anyway, by the null-contentDocument branch on `load` or by the 8s
+// fallback timer. The worst case is the old behaviour, never a permanently
+// blank pane.
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** The attribute the framed chat stamps on its `<html>` when its transcript is
+ *  on screen. Written by fused_render/templates/claude/template.html; read
+ *  here. The pair is the whole contract. */
+export const CHAT_READY_ATTR = "data-chat-ready";
+
+/** Reveal the frame regardless after this long. Generous on purpose: it is a
+ *  backstop for a template that cannot answer, not a budget for a slow one —
+ *  a transcript that takes six seconds to restore should still crossfade
+ *  rather than tear. */
+export const CHAT_FRAME_FALLBACK_MS = 8000;
+
+/** How long the crossfade runs. Matches the CSS transition in chat-frame.css;
+ *  the placeholder is unmounted just after it ends. */
+export const CHAT_FRAME_FADE_MS = 160;
+
+/** Has this document said its transcript is painted?
+ *
+ *  Pure, and the one piece of the contract worth testing directly: everything
+ *  else in this file is timers and listeners around this single question. A
+ *  missing document answers `false` — "not ready yet", not "ready" — because
+ *  the CROSS-ORIGIN case (where there is no document to ask, ever) is decided
+ *  at the call site on `load`, where it is knowable; here it would only mean
+ *  the frame has not navigated yet. */
+export function isChatDocReady(doc: Document | null | undefined): boolean {
+  try {
+    return doc?.documentElement?.dataset?.chatReady === "1";
+  } catch {
+    // A document that has gone away mid-read. Not ready; the fallback covers it.
+    return false;
+  }
+}
+
+/** The skeleton itself, without the frame — the `resolving` state, where the
+ *  template path is not known yet so there is nothing to mount an iframe for.
+ *  Same box, same shapes: a card that is still resolving its folder and a card
+ *  whose frame is still booting look identical, because to a reader they ARE
+ *  the same thing (a chat that is not on screen yet) and were only ever two
+ *  states to the code. */
+export function ChatFramePlaceholder({ className }: { className?: string }) {
+  return (
+    <div className={className ? `chat-frame ${className}` : "chat-frame"}>
+      <PlaceholderBody />
+    </div>
+  );
+}
+
+/** One user turn and one assistant turn, in the template's own geometry
+ *  (`renderLogSkeleton`: a 34%-wide 34px pill hard right, then a 24px avatar
+ *  beside three lines at 88/72/50%), in the app's own shimmer (`.skel-bar`,
+ *  explorer.css — one animation for every skeleton in the shell).
+ *
+ *  Two turns and no more: it is a stand-in for "a conversation", not a guess at
+ *  how long this one is, and a taller stack of bars reads as a claim about the
+ *  content (design.md, out of scope: matching the real turn count). */
+function PlaceholderBody({ out = false }: { out?: boolean }) {
+  return (
+    <div
+      className={out ? "chat-frame-placeholder is-out" : "chat-frame-placeholder"}
+      // A status region, not an alert: it says "this is coming", it does not
+      // interrupt. `aria-busy` is the machine-readable half of the same claim.
+      role="status"
+      aria-busy="true"
+      aria-label="Loading chat"
+    >
+      <div className="chat-frame-skel">
+        <div className="chat-frame-skel-turn chat-frame-skel-user">
+          <span className="skel-bar" />
+        </div>
+        <div className="chat-frame-skel-turn chat-frame-skel-assistant">
+          <span className="chat-frame-skel-dot" />
+          <span className="chat-frame-skel-lines">
+            <span className="skel-bar" style={{ width: "88%" }} />
+            <span className="skel-bar" style={{ width: "72%" }} />
+            <span className="skel-bar" style={{ width: "50%" }} />
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ChatFrame({
+  src,
+  title,
+  className,
+  frameRef,
+  onLoad,
+}: {
+  /** The /render URL. A CHANGE here is a different conversation, so the wait
+   *  starts over — see the `src`-keyed state below. */
+  src: string;
+  title: string;
+  /** The consumer's own iframe class — `.task-card-frame`, `.task-peek-frame`,
+   *  `.preview-side-frame`. Kept ON THE IFRAME so the sizing rules those files
+   *  already own (the card's 133% + scale(0.75) fit, chiefly) still apply. */
+  className?: string;
+  /** For a caller that needs the element itself — TaskPeek attaches an Esc
+   *  listener to the framed document and hands the ref to the modal chassis as
+   *  its initial focus. Filled through the callback ref below rather than
+   *  `forwardRef`, because this component needs the node too. */
+  frameRef?: React.MutableRefObject<HTMLIFrameElement | null>;
+  onLoad?: () => void;
+}) {
+  const ownRef = useRef<HTMLIFrameElement | null>(null);
+  // STATE KEYED BY `src`, not booleans reset in an effect: a new src is a new
+  // wait, and comparing against the src that was revealed makes that automatic
+  // — no reset render, and no window where a fresh iframe is uncovered because
+  // the previous document's answer is still in state.
+  const [readyFor, setReadyFor] = useState<string | null>(null);
+  const [fadedFor, setFadedFor] = useState<string | null>(null);
+  const ready = readyFor === src;
+  const showPlaceholder = fadedFor !== src;
+
+  const setFrame = useCallback(
+    (el: HTMLIFrameElement | null) => {
+      ownRef.current = el;
+      if (frameRef) frameRef.current = el;
+    },
+    [frameRef],
+  );
+
+  useEffect(() => {
+    const frame = ownRef.current;
+    let observer: MutationObserver | null = null;
+    let watched: Element | null = null;
+    const reveal = () => setReadyFor(src);
+
+    // Read the attribute if it is already there; otherwise watch for it. Called
+    // both at mount (the document may have loaded — even finished painting —
+    // before this effect ran, e.g. a warm frame or a synchronous re-key) and on
+    // every `load`.
+    const inspect = () => {
+      const el = ownRef.current;
+      if (!el) return;
+      let doc: Document | null = null;
+      try {
+        doc = el.contentDocument;
+      } catch {
+        // Not ours to read. Nothing to wait for; show it.
+        reveal();
+        return;
+      }
+      if (isChatDocReady(doc)) {
+        reveal();
+        return;
+      }
+      const root = doc?.documentElement ?? null;
+      // `about:blank` before the real navigation has its own documentElement,
+      // and the observer on it would never fire — hence re-inspecting on load,
+      // and hence comparing roots so a second load does not stack observers.
+      if (!root || root === watched) return;
+      // A host with no MutationObserver (a non-DOM renderer, a test) cannot
+      // watch for the stamp — the fallback timer is what uncovers those.
+      if (typeof MutationObserver === "undefined") return;
+      observer?.disconnect();
+      watched = root;
+      observer = new MutationObserver(() => {
+        if (isChatDocReady(ownRef.current?.contentDocument ?? null)) reveal();
+      });
+      observer.observe(root, { attributes: true, attributeFilter: [CHAT_READY_ATTR] });
+    };
+
+    const onFrameLoad = () => {
+      let doc: Document | null = null;
+      try {
+        doc = ownRef.current?.contentDocument ?? null;
+      } catch {
+        doc = null;
+      }
+      // A loaded frame with no readable document is cross-origin: it will never
+      // stamp, and holding a skeleton over a document that is already painted
+      // is the worse failure. Reveal.
+      if (!doc) {
+        reveal();
+        return;
+      }
+      inspect();
+    };
+
+    inspect();
+    frame?.addEventListener("load", onFrameLoad);
+    // The backstop. Cleared on unmount and restarted per src, so a wall of
+    // cards carries one timer each and none outlive their frame.
+    const fallback = setTimeout(reveal, CHAT_FRAME_FALLBACK_MS);
+    return () => {
+      frame?.removeEventListener("load", onFrameLoad);
+      observer?.disconnect();
+      clearTimeout(fallback);
+    };
+  }, [src]);
+
+  // The placeholder leaves in two beats: opacity to 0 (CSS), then unmounted, so
+  // a wall of revealed cards is not a wall of retained skeleton DOM. The extra
+  // frame's worth of delay keeps the node alive until the transition it is
+  // running has actually finished.
+  useEffect(() => {
+    if (!ready) return;
+    const t = setTimeout(() => setFadedFor(src), CHAT_FRAME_FADE_MS + 20);
+    return () => clearTimeout(t);
+  }, [ready, src]);
+
+  return (
+    <div className="chat-frame">
+      <iframe
+        ref={setFrame}
+        className={
+          className
+            ? `chat-frame-iframe ${className}${ready ? " is-ready" : ""}`
+            : `chat-frame-iframe${ready ? " is-ready" : ""}`
+        }
+        src={src}
+        title={title}
+        onLoad={onLoad}
+        // NO `sandbox`, like every other /render frame in this app: the template
+        // reads its own URL and talks to its host through the runtime, so it
+        // would need `allow-same-origin allow-scripts` — a sandbox granting both
+        // grants everything, at the cost of being the one frame whose contract
+        // differs from the rest.
+      />
+      {showPlaceholder && <PlaceholderBody out={ready} />}
+    </div>
+  );
+}

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -9,6 +9,12 @@
 @import "./styles/sidebar.css";
 @import "./styles/explorer.css";
 @import "./styles/preview.css";
+/* After preview.css and before task-cards.css, and the order is load-bearing
+   both ways: the chat frame's iframe rule must beat `.preview-side-frame`'s
+   flex-derived height (the frame is a child of the new box now, not a flex
+   item) and must LOSE to `.task-card-frame`'s scaled fit. Its skeleton bars are
+   explorer.css's `.skel-bar`, imported above. */
+@import "./styles/chat-frame.css";
 @import "./styles/context-menu.css";
 @import "./styles/dialogs.css";
 @import "./styles/notifications.css";

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -32,6 +32,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { archiveTask, statPath, unarchiveTask } from "@platform/lib/api";
 import type { Task } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
+import { ChatFrame, ChatFramePlaceholder } from "@platform/ui/ChatFrame";
 import { Modal } from "@platform/ui/modal/Modal";
 import { cardFrameSrc, folderHref, peekFrameSrc } from "./schedule-lib";
 import { IdentityChip, StatusIcon } from "./ScheduleTaskViews";
@@ -56,7 +57,7 @@ import { useMarginWheel } from "./useMarginWheel";
  *  view's claim is about the set it was handed and it cannot tell those apart. */
 export const CARDS_EMPTY = "Nothing to show here.";
 
-/** The claude template's path for one folder, cached for this mounting.
+/** The claude template's path for one folder, cached for the LIFE OF THE PAGE.
  *
  *  It is a per-FOLDER answer and not a constant: the mode registry lets a user
  *  put their own template in front of `claude` for a path (§16), and a view that
@@ -64,35 +65,82 @@ export const CARDS_EMPTY = "Nothing to show here.";
  *  surface where it is most visible. Resolved through the same call the canvas
  *  workspace uses for the same reason (/api/fs/stat → `templates`).
  *
- *  One request per DISTINCT folder, and most walls are one or two folders' worth
- *  of work, so this is a call or two rather than one per card. */
-function useChatTemplates(dirs: string[]): Record<string, string> {
-  const [paths, setPaths] = useState<Record<string, string>>({});
-  // Folders already asked about — including the ones that ANSWERED with no
-  // claude mode at all, which is why this is a set of asked and not a check of
-  // `paths`: a folder with no chat template must be asked once, not once per
-  // poll for as long as the card is up.
-  const asked = useRef<Set<string>>(new Set());
+ *  MODULE LEVEL, not a ref inside the hook, because the answer outlives the
+ *  mounting that asked for it. This view remounts constantly — List → Cards and
+ *  back, the popup opening, the app page's Tasks tab — and a cache scoped to one
+ *  mounting meant every re-entry re-resolved every folder and drew a whole wall
+ *  of "Starting…" for a few hundred milliseconds first. A stat's answer about
+ *  which template serves a folder does not change under us often enough to be
+ *  worth that; a reload re-reads it.
+ *
+ *  `null` in the map is a real answer — "asked, and this folder has no claude
+ *  mode at all" — and must be kept, or a folder without a chat template is
+ *  re-asked once per poll for as long as a card is up. `undefined` (absent) is
+ *  therefore the ONLY "not known yet", which is what lets a card tell resolving
+ *  apart from nothing-to-frame (see TaskCard). */
+const chatTemplateCache = new Map<string, string | null>();
+/** Folders being stat'd right now, so two mountings (the wall and its popup, or
+ *  a remount landing mid-flight) share one request instead of racing two. */
+const chatTemplateInFlight = new Map<string, Promise<void>>();
+
+function resolveChatTemplate(dir: string): Promise<void> {
+  const running = chatTemplateInFlight.get(dir);
+  if (running) return running;
+  const p = statPath(dir)
+    .then((st) => {
+      chatTemplateCache.set(dir, st.templates?.find((t) => t.mode === "claude")?.path ?? null);
+    })
+    .catch(() => {
+      // A folder that has gone away, or a stat that failed. Recorded as "no
+      // chat template here" rather than left unknown: unknown means a skeleton
+      // forever, and there is nothing this card can frame either way.
+      chatTemplateCache.set(dir, null);
+    })
+    .finally(() => {
+      chatTemplateInFlight.delete(dir);
+    });
+  chatTemplateInFlight.set(dir, p);
+  return p;
+}
+
+/** The template path per folder: a string, `null` for "no chat template here",
+ *  or ABSENT while the folder is still being resolved.
+ *
+ *  Seeded from the cache SYNCHRONOUSLY on the first render, which is the whole
+ *  point of the cache being module-level: a remount frames its cards on the
+ *  render that mounts them, with no resolving beat in between. */
+function useChatTemplates(dirs: string[]): Record<string, string | null> {
+  const seed = () => {
+    const known: Record<string, string | null> = {};
+    for (const dir of dirs) {
+      if (chatTemplateCache.has(dir)) known[dir] = chatTemplateCache.get(dir) ?? null;
+    }
+    return known;
+  };
+  const [paths, setPaths] = useState<Record<string, string | null>>(seed);
   // `dirs` is a fresh array on every poll; the effect must fire on its
-  // CONTENTS, or it re-runs 20 seconds apart forever (harmlessly, thanks to
-  // `asked`, but it is a loop nobody should have to reason about).
+  // CONTENTS, or it re-runs 20 seconds apart forever (harmlessly, thanks to the
+  // cache, but it is a loop nobody should have to reason about).
   const key = dirs.join("\u0000");
   useEffect(() => {
     let cancelled = false;
+    const publish = (dir: string) => {
+      if (cancelled) return;
+      setPaths((m) =>
+        dir in m && m[dir] === (chatTemplateCache.get(dir) ?? null)
+          ? m
+          : { ...m, [dir]: chatTemplateCache.get(dir) ?? null },
+      );
+    };
     for (const dir of key.split("\u0000")) {
-      if (!dir || asked.current.has(dir)) continue;
-      asked.current.add(dir);
-      void statPath(dir)
-        .then((st) => {
-          if (cancelled) return;
-          const found = st.templates?.find((t) => t.mode === "claude")?.path;
-          if (found) setPaths((m) => ({ ...m, [dir]: found }));
-        })
-        .catch(() => {
-          // A folder that has gone away, or a stat that failed: the card falls
-          // back to its "Starting…" pane rather than the page failing. There is
-          // nothing to say here that the card does not already show.
-        });
+      if (!dir) continue;
+      // Already answered — including by another mounting since this one's state
+      // was seeded, which is why this publishes rather than skipping.
+      if (chatTemplateCache.has(dir)) {
+        publish(dir);
+        continue;
+      }
+      void resolveChatTemplate(dir).then(() => publish(dir));
     }
     return () => {
       cancelled = true;
@@ -225,7 +273,9 @@ export function TaskCards({
     <TaskPeek
       task={peekLive}
       home={home}
-      template={templates[peekLive.target || peekLive.project] ?? null}
+      // NOT `?? null`: absent means the folder is still being resolved and
+      // the body shows a skeleton, where null means there is nothing to frame.
+      template={templates[peekLive.target || peekLive.project]}
       onClose={() => setPeek(null)}
       onReload={onReload}
     />
@@ -268,7 +318,9 @@ export function TaskCards({
           key={cardKey(task)}
           task={task}
           home={home}
-          template={templates[task.target || task.project] ?? null}
+          // Absent while the folder resolves, null when it has no chat
+          // template — the card draws a different body for each.
+          template={templates[task.target || task.project]}
           onPeek={setPeek}
           project={
             showProject
@@ -301,7 +353,10 @@ function TaskCard({
 }: {
   task: Task;
   home: string;
-  template: string | null;
+  /** The folder's chat template: a path, `null` when the folder has none, and
+   * `undefined` while the stat behind it is still in flight — three states,
+   * because the body says something different for each (below). */
+  template: string | null | undefined;
   onPeek: (task: Task) => void;
   /** Draw the folder chip, and how: null hides it (one folder, nothing to tell
    * apart); otherwise whether the page is pinned to it and the tag's handler. */
@@ -310,11 +365,18 @@ function TaskCard({
   const when = taskWhen(task);
   const title = firstLine(task.title) || "(untitled)";
   // Both halves have to be there before anything can be framed: no session means
-  // there is no conversation yet, and no template means the folder's stat has not
-  // answered (or has no chat mode at all).
+  // there is no conversation yet, and no template means the folder's stat has
+  // not answered (or has no chat mode at all).
   const src = task.session_id && template
     ? cardFrameSrc(template, task.target || task.project, task.session_id)
     : null;
+  // THE THIRD STATE, and the reason `template` is not just a path-or-null: the
+  // task HAS a session, so there is a conversation to show, and the only thing
+  // missing is which template shows it — a fact this card is a few hundred
+  // milliseconds from having. That is a chat that has not arrived yet, not a
+  // run that has not started, so it wears the frame's own skeleton and says
+  // nothing. "Starting…" here was the wall's popcorn (design.md).
+  const resolving = !src && !!task.session_id && template === undefined;
 
   return (
     <section className="task-card" aria-label={`${task.task_id} ${title}`}>
@@ -388,17 +450,17 @@ function TaskCard({
       </header>
       <div className="task-card-body">
         {src ? (
-          <iframe
+          // The frame and its cover, one component (platform/ui/ChatFrame): the
+          // iframe stays invisible until the chat inside it says its transcript
+          // is painted, with the skeleton over it until then. The card's own
+          // class rides the iframe, so the scaled fit below is untouched.
+          <ChatFrame
             className="task-card-frame"
             src={src}
             title={`${task.task_id} ${title}`}
-            // NO `sandbox`, like every other /render frame in this app. It would
-            // have to carry `allow-same-origin allow-scripts` to work at all —
-            // the template is a script that reads its own URL and talks to this
-            // window through the runtime — and a sandbox holding both grants is
-            // a sandbox that grants everything, with the side effect of being
-            // the one frame in the app whose contract differs from the rest.
           />
+        ) : resolving ? (
+          <ChatFramePlaceholder />
         ) : (
           // No session to frame. For a scheduled task that is simply not due yet;
           // for anything else it is the window between "claimed and sent" and
@@ -433,7 +495,8 @@ function TaskPeek({
 }: {
   task: Task;
   home: string;
-  template: string | null;
+  /** As TaskCard's: path, `null` for none, `undefined` while resolving. */
+  template: string | null | undefined;
   onClose: () => void;
   onReload?: () => void;
 }) {
@@ -441,6 +504,8 @@ function TaskPeek({
   const src = task.session_id && template
     ? peekFrameSrc(template, task.target || task.project, task.session_id)
     : null;
+  // The card's third state, for the card's reason (TaskCard, above).
+  const resolving = !src && !!task.session_id && template === undefined;
   // The List row's own fallback: a run with no session yet is still reachable
   // through its folder (schedule-lib, above `folderHref`).
   const explorer = taskHref(task) ?? folderHref(task);
@@ -573,13 +638,17 @@ function TaskPeek({
       }
     >
       {src ? (
-        <iframe
-          ref={frameRef}
+        // The card's wrapper, at full size. `frameRef` still reaches the iframe
+        // itself — the Esc listener above and the chassis's `initialFocus` both
+        // want the element, not the box around it.
+        <ChatFrame
+          frameRef={frameRef}
           className="task-peek-frame"
           src={src}
           title={`${task.task_id} ${title}`}
-          // No `sandbox`, for the card frame's reason (TaskCard, above).
         />
+      ) : resolving ? (
+        <ChatFramePlaceholder />
       ) : (
         <p className="task-card-starting">
           {taskColumn(task) === "upcoming" ? "Not started yet" : "Starting…"}

--- a/frontend/src/styles/chat-frame.css
+++ b/frontend/src/styles/chat-frame.css
@@ -42,16 +42,24 @@
   height: 100%;
   border: 0;
   opacity: 0;
+  /* Invisible AND unreachable: an opacity-0 frame still takes the wheel and
+     the click, so a wall scrolled over a loading card lost the scroll to a
+     document nobody could see, and a pane could be focused before it was
+     shown (Bugbot, #1024). */
+  pointer-events: none;
   transition: opacity 160ms ease;
 }
 
 .chat-frame-iframe.is-ready {
   opacity: 1;
+  pointer-events: auto;
 }
 
 /* The cover. On top of the frame, the page's own background under it so the
-   iframe's cold document never shows through, and inert — nothing here is
-   clickable, and the frame beneath it is not meant to be reached yet either. */
+   iframe's cold document never shows through. It TAKES pointer input (the
+   default) rather than passing it through: nothing here is clickable, and a
+   wheel over it bubbles to the host — the wall scrolls — instead of being
+   eaten by the hidden frame underneath. */
 .chat-frame-placeholder {
   position: absolute;
   top: 0;
@@ -61,12 +69,14 @@
   z-index: 1;
   overflow: hidden;
   background: var(--bg);
-  pointer-events: none;
   transition: opacity 160ms ease;
 }
 
+/* Fading out over a frame that is now live: step aside so the first click
+   lands in the chat, not on a ghost. */
 .chat-frame-placeholder.is-out {
   opacity: 0;
+  pointer-events: none;
 }
 
 /* The transcript column, in the template's own measurements (#log: 720px max,

--- a/frontend/src/styles/chat-frame.css
+++ b/frontend/src/styles/chat-frame.css
@@ -1,0 +1,136 @@
+/* ---- the chat frame and its one placeholder (platform/ui/ChatFrame.tsx) ----
+   Three surfaces frame the Claude chat template — the Cards wall, that wall's
+   popup, and the explorer's companion sidebar — and all three used to show the
+   iframe's own cold document before the template's first paint. These rules are
+   the cover: a box that fills whatever the consumer gives it, an iframe that is
+   invisible until the framed document says it is painted, and one skeleton laid
+   over it in the meantime, shaped like the skeleton the template itself draws.
+
+   ORDER IS LOAD-BEARING, twice, which is why this file sits exactly here in the
+   barrel (shell.css):
+     * AFTER explorer.css, whose `.skel-bar` and `@keyframes skel-shimmer` the
+       placeholder's bars are;
+     * AFTER preview.css, so `.chat-frame-iframe`'s size wins over
+       `.preview-side-frame`'s `height: auto` — that height was flex-derived
+       and the frame is no longer a flex item, it is a child of this box;
+     * BEFORE task-cards.css, so the card's `.task-card-frame` fit (133% drawn
+       at 0.75) still overrides the plain 100% here. */
+
+/* The box. Fills its parent whether that parent is a block with a resolved
+   height (the card's body) or a flex line (the popup's body, the sidebar
+   column) — hence both the percentages and the flex shorthand. `overflow:
+   hidden` because the card's frame is deliberately larger than this box and
+   scaled back into it. */
+.chat-frame {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* Invisible until ready, then a fade of the same length as the placeholder's —
+   the two cross, they do not queue. No `visibility`/`display` games: the
+   document must be laid out and painting the whole time, or revealing it would
+   be its own reflow. */
+.chat-frame-iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+
+.chat-frame-iframe.is-ready {
+  opacity: 1;
+}
+
+/* The cover. On top of the frame, the page's own background under it so the
+   iframe's cold document never shows through, and inert — nothing here is
+   clickable, and the frame beneath it is not meant to be reached yet either. */
+.chat-frame-placeholder {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  overflow: hidden;
+  background: var(--bg);
+  pointer-events: none;
+  transition: opacity 160ms ease;
+}
+
+.chat-frame-placeholder.is-out {
+  opacity: 0;
+}
+
+/* The transcript column, in the template's own measurements (#log: 720px max,
+   centred, 24/20/12 padding) so the two skeletons sit in the same place and the
+   crossfade moves nothing. */
+.chat-frame-skel {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px 20px 12px;
+}
+
+.chat-frame-skel-turn {
+  margin: 0 0 20px;
+}
+
+/* The user turn: one pill, hard right, at the template's `.skel-turn-user`
+   proportions. */
+.chat-frame-skel-user {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.chat-frame-skel-user .skel-bar {
+  width: 34%;
+  height: 34px;
+  border-radius: 16px;
+}
+
+/* The assistant turn: the avatar disc and three ragged lines. */
+.chat-frame-skel-assistant {
+  display: flex;
+  gap: 10px;
+}
+
+.chat-frame-skel-dot {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+}
+
+.chat-frame-skel-lines {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 4px;
+}
+
+/* The template's line metrics, not the listing's (`.skel-bar` is 10px/3px for a
+   table row) — these stand in for prose. */
+.chat-frame-skel-lines .skel-bar {
+  height: 11px;
+  border-radius: 4px;
+}
+
+/* Reduced motion: the reveal is a state change, not a movement. reduced-motion.css
+   already collapses every transition to nothing, and this states the intent at
+   the rule that has it — the placeholder still unmounts, it just does not fade. */
+@media (prefers-reduced-motion: reduce) {
+  .chat-frame-iframe,
+  .chat-frame-placeholder {
+    transition: none;
+  }
+}

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -246,6 +246,19 @@
   border: 0;
 }
 
+/* The card's placeholder is SCALED WITH the frame it stands in for. The chat
+   inside the frame draws its own skeleton at 4/3 size and the browser paints it
+   at 3/4 (the fit above), so a host skeleton at 1:1 would be a third too big and
+   the crossfade would jump. Same trick, same numbers, on the cover — which is
+   why the two are one geometry rather than two similar pictures.
+   (platform/ui/ChatFrame.tsx, styles/chat-frame.css.) */
+.task-card-body .chat-frame-placeholder {
+  width: 133.3334%;
+  height: 133.3334%;
+  transform: scale(0.75);
+  transform-origin: 0 0;
+}
+
 /* A run that has been claimed but has not reported a session yet (schedule-lib,
    above `folderHref`: the window between "sent" and "we know which chat that
    is"). There is nothing to embed, so the pane says so in the page's own quiet

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -4360,6 +4360,15 @@ const log = document.getElementById("log");
 const logwrap = document.getElementById("logwrap");
 const box = document.getElementById("box");
 const chatEl = document.getElementById("chat");
+
+// READY, FOR THE HOST. The shell frames this page (TaskCards, TaskPeek, the
+// Explorer's Claude pane) behind a placeholder of its own and needs to know
+// when there is something worth uncovering: the transcript painted, or the
+// landing list drawn. Same-origin attribute, read by the host through
+// contentDocument (D3/D4 — no postMessage). Stamped once; never cleared.
+function markChatReady() {
+  document.documentElement.dataset.chatReady = "1";
+}
 const sessionEl = document.getElementById("session");
 const homebox = document.getElementById("homebox");
 
@@ -17508,6 +17517,8 @@ async function loadHistory(session_id, opts) {
     console.warn("history restore failed:", err.message);
   } finally {
     if (sendSeq === seat) sending = false;
+    // Painted or failed, the host has seen what there is to see.
+    if (!refresh) markChatReady();
   }
 }
 
@@ -18703,11 +18714,13 @@ const ASK_DETECTION_TIMEOUT_MS = 1500;
     } else {
       sendMessage(ask);
     }
+    markChatReady();
   } else if (session_id || run_id) {
     // A bare `run` param (frame died before the first poll saw the session id)
     // still means an in-flight conversation — enter chat and re-attach.
     enterChat();
     if (session_id) await loadHistory(session_id);
+    else markChatReady();  // a bare `run`: nothing to restore, the chat itself is the view
     // The chips this session already earned. The poll loop rebuilds them while a
     // run streams, but a resumed conversation with nothing in flight never
     // reaches that loop — and its pages are no less published for it.
@@ -18722,6 +18735,7 @@ const ASK_DETECTION_TIMEOUT_MS = 1500;
     // No conversation to belong to, so nothing to restore.
     focusBox(homebox);
     await loadRecent();
+    markChatReady();
     // And keep it fresh from here on — this is the landing most people arrive
     // at cold, and the Back handler's own watchRecent() call only covers a
     // landing reached by LEAVING a chat (cmux-ux-tester, PR #892).


### PR DESCRIPTION
## What

Opening a Claude chat iframe (Tasks → Cards wall, the card's popup, the explorer's Claude pane) showed four states on three clocks: the host's **"Starting…"** text while the folder's template path was stat'd → the iframe's cold **black** document → the template's own **skeleton** → the chat. On a wall of twelve cards they popcorned.

Now the host owns one cover from mount until the framed transcript is painted, so the visible sequence is **skeleton → chat**.

## How

**Host** — `platform/ui/ChatFrame.tsx` (new)
- Wraps the iframe (opacity 0) under a skeleton cover shaped like the template's own (`renderLogSkeleton` geometry, the app's `.skel-bar` shimmer).
- Reveals when the framed `<html>` carries `data-chat-ready="1"` — read same-origin via `contentDocument` on `load` + a `MutationObserver` (D3/D4: no postMessage). Cross-origin / no document → reveal on load. 8 s fallback reveal. Reset per `src`.
- Used by `TaskCard`, `TaskPeek`, the explorer folder pane's Claude companion (`ListingPreviewPane`) and the file sidebar's Claude mode (`PreviewSidebar`). git/mcp companions stay plain iframes.
- `TaskCards.useChatTemplates`: per-folder template lookup cached at module level with in-flight dedupe, so List→Cards / popup remounts frame at once. "Starting…" is kept only for its true meaning: a claimed run with no session yet.

**Template** — `templates/claude/template.html`
- `markChatReady()` stamps the attribute after `loadHistory` (success or failure), after the landing list, on the ask path, and for a bare `run`. Nothing else: the file stays a single `<script>` (three tests slice on it), and `runtime.js` already resolves the theme pre-paint.

## Test plan

- [x] `npm run typecheck`, `check:boundaries`, `bun test` (3052 pass; +10 ChatFrame tests)
- [x] pytest: template suites green; full run 11649 pass, remaining failures pre-existing (geo stack not in venv)
- [x] cmux browser QA: Cards wall first load + List↔Cards re-entry (no "Starting…"), popup (interactive after reveal, Esc closes, no rect shift), explorer folder pane Claude + git↔claude switch, file sidebar, light + dark (`--bg` everywhere, no flash), direct `/render` open stamps `data-chat-ready`, console clean
- [ ] Manual: `/tasks` Cards view — each card skeleton → chat only; popup; explorer → Claude pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI loading polish and a same-origin iframe attribute contract; git/mcp paths unchanged and fallbacks prevent permanently blank panes.
> 
> **Overview**
> Embedded Claude chats no longer flash through **"Starting…"**, a cold iframe, and the template skeleton in sequence. The shell now shows **one host skeleton → chat** crossfade everywhere a chat is framed.
> 
> **`ChatFrame`** (`platform/ui/ChatFrame.tsx`) keeps the iframe at `opacity: 0` under a template-shaped placeholder until the framed document sets `data-chat-ready="1"` (read on `load` + `MutationObserver`, with cross-origin and 8s fallbacks). **`markChatReady()`** in the Claude template stamps that attribute after history restore, landing, and related boot paths.
> 
> **Consumers:** Tasks **Cards** wall and **TaskPeek** swap plain iframes for `ChatFrame`; **ListingPreviewPane** and **PreviewSidebar** use it only for **`claude`** (git/mcp stay plain iframes). **Task template lookup** is cached module-wide with in-flight dedupe so remounts don’t replay resolving; **`ChatFramePlaceholder`** covers the “session exists but template path not known yet” case instead of **"Starting…"**.
> 
> Adds **`chat-frame.css`** (load order in `shell.css` is intentional) and scaled placeholder rules on task cards; **+10** unit tests for the ready contract and reveal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcec03e053913267eade2653ab43245656efa5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->