### PR TITLE
Claude chat: switching chats closes and discards unsent annotation work

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -7888,6 +7888,7 @@ async function annRecEnd() {
   const handle = annRecHandle;
   const ids = annRecIds;
   const armed = annArmEpoch;
+  const left = annLeaveGen;   // the conversation this walkthrough belongs to
   clearInterval(annRecTimerId);
   annRecTimerId = null;
   annRecIds = [];
@@ -8005,6 +8006,17 @@ async function annRecEnd() {
     // that swallowed the framing. A walkthrough with NO clicks is the
     // degenerate case of the same rule — everything came before the first
     // click, so the whole transcript is the prompt.
+    // The user LEFT the conversation while the words were on their way
+    // (annLeave bumped the generation): the marks are deleted like a discard's
+    // and nothing is assigned or sent — see annLeave.
+    if (annLeaveGen !== left) {
+      if (ids.length) {
+        annotations = annotations.filter((a) => !ids.includes(a.id));
+        annSave();
+        renderAnn();
+      }
+      return;
+    }
     const intro = ids.length
       ? annRecAssign(ids, rec.segments)
       : (rec.segments || []).map((s) => s.text).join(" ")
@@ -8155,6 +8167,29 @@ function annNotesDiscard() {
 }
 // One dispatcher for the bar's trash, whichever mode is on.
 function annDiscard() { return annRecOn ? annRecDiscard() : annNotesDiscard(); }
+// Leaving the conversation — ← Chats, or a chat opened from the landing —
+// CLOSES AND DISCARDS whatever annotation work is unsent (Akshil,
+// 2026-09-06): the notes pointed at this conversation's screen and are not
+// the next chat's to send. A live walkthrough is discarded (annRecDiscard:
+// mic released, marks deleted, nothing transcribed); an armed Comment mode
+// drops every unsent note — all rounds, not only the current one — and
+// disarms; a transcription already in flight (Stopping…/Transcribing…) lands
+// after the generation bump, and annRecEnd then deletes its marks and keeps
+// the words to itself instead of assigning and auto-sending them (Bugbot,
+// PR #1022). Unsent notes left behind by an already-closed mode go too:
+// pending chips are part of the same payload.
+let annLeaveGen = 0;
+function annLeave() {
+  annLeaveGen += 1;
+  if (annRecOn) { annRecDiscard(); return; }
+  annCloseComposer();
+  const keep = annotations.filter((a) => a.sent);
+  if (keep.length !== annotations.length) {
+    annotations = keep;
+    annSave();
+  }
+  if (annOn) annSetMode(false);
+}
 // The Annotate seat's resting name, restored when a settle (stop, transcribe,
 // discard) ends — the settle named the seat for its status (2026-09-06).
 function annRecIdleName() {
@@ -12703,6 +12738,9 @@ function consumeAnchor() {
 // Clear the session param so a reload lands on the landing page,
 // wipe the visible transcript, and rebuild the session list.
 document.getElementById("back").onclick = () => {
+  // Leaving the chat closes and discards unsent annotation work (Akshil,
+  // 2026-09-06) — see annLeave.
+  annLeave();
   // Live even mid-turn (Akshil, 2026-08-19 — "when it is working I can't
   // click back"). The old `if (sending) return` guarded against orphaning the
   // streaming run's UI, but the architecture already survives leaving: the
@@ -12797,6 +12835,10 @@ document.getElementById("back").onclick = () => {
 };
 
 function enterChat() {
+  // Entering a chat from the landing closes and discards unsent annotation
+  // work, exactly as ← Chats does (Akshil, 2026-09-06) — see annLeave.
+  // Nothing is armed or pending at boot, so the resume path is a no-op here.
+  annLeave();
   chatEl.classList.remove("home");
   stopWatchRecent();
   // The strip belongs to ONE conversation. Chips from the previous chat are

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -8186,6 +8186,20 @@ function annLeave() {
   // round left behind (Bugbot, PR #1025). annRecDiscard's own disarm is
   // epoch-guarded, so the one below does not echo.
   if (annRecOn) annRecDiscard();
+  // A settle already in flight (Stopping…/Transcribing…) belongs to the
+  // conversation being left: its words will be dropped on landing (the stale
+  // generation above), so its STATUS ends now too — otherwise the Annotate
+  // seat reads Transcribing… and annRecBegin refuses a new walkthrough until
+  // work nobody wants any more finishes (Bugbot, PR #1025). annRecEnd's own
+  // finally repeats this harmlessly, and its `!annRecOn` guard steps aside
+  // for a walkthrough started in the new chat meanwhile.
+  if (!annRecOn && annCta.classList.contains("busy")) {
+    annCta.classList.remove("busy");
+    annRecLbl.textContent = "";
+    annRecIdleName();
+    annRecBtn.disabled = false;
+    annBtn.disabled = false;
+  }
   annCloseComposer();
   const keep = annotations.filter((a) => a.sent);
   if (keep.length !== annotations.length) {

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -8181,7 +8181,11 @@ function annDiscard() { return annRecOn ? annRecDiscard() : annNotesDiscard(); }
 let annLeaveGen = 0;
 function annLeave() {
   annLeaveGen += 1;
-  if (annRecOn) { annRecDiscard(); return; }
+  // A live walkthrough: discarded (its own marks go with it, async), and the
+  // sweep below still drops any OTHER unsent notes — chips an earlier, closed
+  // round left behind (Bugbot, PR #1025). annRecDiscard's own disarm is
+  // epoch-guarded, so the one below does not echo.
+  if (annRecOn) annRecDiscard();
   annCloseComposer();
   const keep = annotations.filter((a) => a.sent);
   if (keep.length !== annotations.length) {
@@ -12835,10 +12839,6 @@ document.getElementById("back").onclick = () => {
 };
 
 function enterChat() {
-  // Entering a chat from the landing closes and discards unsent annotation
-  // work, exactly as ← Chats does (Akshil, 2026-09-06) — see annLeave.
-  // Nothing is armed or pending at boot, so the resume path is a no-op here.
-  annLeave();
   chatEl.classList.remove("home");
   stopWatchRecent();
   // The strip belongs to ONE conversation. Chips from the previous chat are
@@ -17732,6 +17732,11 @@ function addChatRow(list, s) {
     // move, and the same URL, "open this task" makes from the Tasks list.
     if (pane) return openPaneChat(pane, s.id);
     fused.params.set("session_id", s.id);
+    // Opening a PAST chat closes and discards unsent annotation work, exactly
+    // as ← Chats does (Akshil, 2026-09-06) — see annLeave. HERE and not in
+    // enterChat (Bugbot, PR #1025): a send from the home composer enters chat
+    // too, and its notes are the message — annPending is read after this.
+    annLeave();
     showSession();
     enterChat();
     await loadHistory(s.id);

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -478,9 +478,28 @@ def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
     assert 'id="annreclbl"' in rec
     cmt = _block(html, '<button id="annbtn"', "</button>")
     assert 'id="annreclbl"' not in cmt
-    # a mode SURVIVES switching chats for now (Akshil, 2026-09-06) — the
-    # discard-on-leave lands in its own PR
-    assert "annLeave" not in html
+    # leaving the conversation CLOSES AND DISCARDS unsent annotation work
+    # (Akshil, 2026-09-06): ← Chats and entering a chat both go through annLeave
+    back = _block(html, 'document.getElementById("back").onclick = () => {', "\n};")
+    assert "annLeave();" in back
+    enter = _block(html, "function enterChat() {", "\n}\n")
+    assert "annLeave();" in enter
+    leave = _block(html, "function annLeave() {", "\n}\n")
+    assert "annLeaveGen += 1;" in leave
+    # a live walkthrough is discarded, never ended — ending would transcribe
+    # and auto-send into whatever chat the page is on by then (Bugbot, PR #1022)
+    assert "if (annRecOn) { annRecDiscard(); return; }" in leave
+    # every unsent note goes, all rounds, and an open draft with them
+    assert "annCloseComposer();" in leave
+    assert "const keep = annotations.filter((a) => a.sent);" in leave
+    assert "if (annOn) annSetMode(false);" in leave
+    # a transcription already in flight deletes its marks and sends nothing
+    end = _block(html, "async function annRecEnd()", "\n}\n")
+    assert "const left = annLeaveGen;" in end
+    stale = _block(end, "if (annLeaveGen !== left) {", "\n    }\n")
+    assert "annotations = annotations.filter((a) => !ids.includes(a.id));" in stale
+    assert "return;" in stale
+    assert end.index("if (annLeaveGen !== left) {") < end.index("annRecAssign(ids, rec.segments)")
     end = _block(html, "async function annRecEnd()", "\n}\n")
     assert 'annCta.classList.add("busy");' in end
     assert 'annCta.classList.remove("busy");' in end

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -494,6 +494,13 @@ def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
     # and auto-send into whatever chat the page is on by then (Bugbot, PR #1022)
     assert "if (annRecOn) annRecDiscard();" in leave
     assert "return" not in leave   # the sweep below runs in every case
+    # a settle in flight ends its status now, not when the dropped transcription
+    # lands (Bugbot, PR #1025): the mic is free for a new walkthrough at once
+    assert 'if (!annRecOn && annCta.classList.contains("busy")) {' in leave
+    settle = _block(leave, 'if (!annRecOn && annCta.classList.contains("busy")) {', "\n  }\n")
+    assert 'annCta.classList.remove("busy");' in settle
+    assert "annRecIdleName();" in settle
+    assert "annRecBtn.disabled = false;" in settle
     # every unsent note goes, all rounds, and an open draft with them
     assert "annCloseComposer();" in leave
     assert "const keep = annotations.filter((a) => a.sent);" in leave

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -482,13 +482,18 @@ def test_the_three_seats_stay_and_the_armed_one_reads_active(html):
     # (Akshil, 2026-09-06): ← Chats and entering a chat both go through annLeave
     back = _block(html, 'document.getElementById("back").onclick = () => {', "\n};")
     assert "annLeave();" in back
+    # opening a PAST chat leaves; a send from the home composer must NOT — its
+    # notes are the message (Bugbot, PR #1025)
     enter = _block(html, "function enterChat() {", "\n}\n")
-    assert "annLeave();" in enter
+    assert "annLeave" not in enter
+    open_ = _block(html, '    fused.params.set("session_id", s.id);', "enterChat();")
+    assert "annLeave();" in open_
     leave = _block(html, "function annLeave() {", "\n}\n")
     assert "annLeaveGen += 1;" in leave
     # a live walkthrough is discarded, never ended — ending would transcribe
     # and auto-send into whatever chat the page is on by then (Bugbot, PR #1022)
-    assert "if (annRecOn) { annRecDiscard(); return; }" in leave
+    assert "if (annRecOn) annRecDiscard();" in leave
+    assert "return" not in leave   # the sweep below runs in every case
     # every unsent note goes, all rounds, and an open draft with them
     assert "annCloseComposer();" in leave
     assert "const keep = annotations.filter((a) => a.sent);" in leave


### PR DESCRIPTION
## What

**Stacked on #1022** (merge that first; this diff includes its commits until then). Only the last commit is this PR's.

Leaving the conversation — `← Chats`, or opening a chat from the landing (Recent chat row, or sending from the home composer) — now **closes and discards** unsent annotation work via one `annLeave`:

- **Live walkthrough** → `annRecDiscard`: mic released, marks deleted, nothing transcribed, nothing sent.
- **Armed Comment mode** → every unsent note dropped (all rounds), open draft closed, mode disarmed, bar + 43px push cleared.
- **Unsent chips from an already-closed mode** → dropped too (they are the same payload, persisted in the `annotations` URL param, which otherwise survives a chat switch).
- **Transcription in flight** (Stopping…/Transcribing…) → the leave bumps a generation; `annRecEnd` sees it stale, deletes the recording's marks and neither assigns nor auto-sends the words. Addresses the High finding Bugbot raised on #1022's earlier attempt.

Not touched: pending **screenshot** chips (`shotAttached`, memory-only) still carry across; sent notes stay.

## Verified
- cmux browser: arm Comment → `enterChat()` → mode off, pending notes 0, push cleared.
- `pytest tests/test_claude*.py tests/test_theme.py`: green except the 7 pre-existing `test_claude_health` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async walkthrough settle and navigation timing; wrong placement of `annLeave` could drop notes on first send or leak auto-sends into the wrong chat, but generation guards and test coverage target those cases.
> 
> **Overview**
> **Leaving or switching chats** now runs a single **`annLeave()`** path so unsent annotation work does not carry into another conversation or auto-send after navigation.
> 
> **← Chats** and **opening a past chat from the landing** call `annLeave()` before clearing the session. **`enterChat()` is unchanged** so notes attached to a first message from the home composer are still read after entry (Bugbot PR #1025).
> 
> `annLeave()` bumps **`annLeaveGen`**, discards an active walkthrough via **`annRecDiscard`** (no transcribe/send), immediately clears **Transcribing…/Stopping…** UI when nothing is recording, drops every **unsent** annotation and closes the composer, and disarms Comment mode. **`annRecEnd`** snapshots that generation at settle start; if the user left while transcription was in flight, it removes the walkthrough marks and **returns** without assign or auto-send.
> 
> Tests in **`test_claude_annotation_modes.py`** now assert this wiring and stale-transcription behavior instead of expecting modes to survive chat switches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f437623fcfc22045fb052942c8a259818a8497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->