### PR TITLE
Design scale: one set of type, spacing, radius and motion primitives for CSS and components

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,0 +1,430 @@
+# fused-render design system
+
+## 1. Overview
+
+fused-render is dark-first: a cool near-black ground, hairline borders, and
+off-white ink, with exactly one loud colour — Fused Lime (`--accent`,
+`#E5FF44`) — reserved as a signal (selection edge, focus ring, active state),
+never a fill except the brand mark and the one primary button per screen.
+Type is dense and OS-native (the system sans stack, not a webfont); radii are
+quiet and small; motion is short and always has a reduced-motion escape.
+
+The system has exactly one set of tokens with two consumers: hand-written CSS
+reads them as `var(--token)`, and `platform/ui` composites (Tailwind + shadcn)
+read the same values through named utility classes (`text-dense`, `p-3`,
+`rounded-card`). A legacy rule and a composite therefore always resolve to the
+same pixel, the same millisecond — there is no second source of truth.
+
+Two guard tests hold this together:
+- `tests/test_theme.py` — every colour is a token, the light palette redefines
+  every dark token, and no colour literal survives outside the two palette
+  blocks (`tokens.css`, plus each tier-1 built-in template's own copy).
+- `tests/test_design_scale.py` — every font-size, radius, spacing and
+  duration is a token from `scale.css`; a raw px/ms literal for one of those
+  properties anywhere else fails the suite unless it is a genuine one-off in
+  `tests/design_scale_allowlist.txt`.
+
+## 2. Tokens: where they live
+
+| File | Carries | Theme-aware? | Consumers |
+|---|---|---|---|
+| `frontend/src/styles/tokens.css` | Colour — `--fg`, `--bg`, `--border`, `--accent`, status colours, series colours, icon colours, scrims, shadow ink | Yes — dark `:root` + `:root[data-theme="light"]`, one-for-one | Legacy CSS (`var(--fg)`), the shadcn bridge |
+| `frontend/src/styles/scale.css` | Rhythm — type roles, spacing, radius, control heights, motion durations/easings, fonts | No — deliberately outside the palette blocks, so `test_theme.py` never asks a font-size for a light twin | Legacy CSS (`var(--text-dense)`), Tailwind `@theme inline` |
+| `frontend/src/styles/tailwind.css` | The shadcn→token bridge, the `@theme inline` mapping of `scale.css` names into Tailwind utilities, the four names Tailwind and the app both claim (`--shadow-*`, `--ease-out`) | Inherits theme from the tokens it aliases | shadcn primitives, Playground composites |
+
+**Rule: never a literal outside these three files.** A rule that needs a
+colour, a size, a radius or a duration reaches for a token; if the value
+doesn't exist yet, it is added to `tokens.css` or `scale.css`, not inlined.
+`scale.css` and `tailwind.css` are the two files `test_design_scale.py`
+exempts from the no-literal check (they *are* the scale); the vendored
+`platform/shadcn/ui/*` primitives are exempt too, as installed, unmodified
+code.
+
+## 3. Colour
+
+All values from `frontend/src/styles/tokens.css`. Dark is the default
+`:root`; light is `:root[data-theme="light"]`.
+
+| Token | Dark | Light | Role |
+|---|---|---|---|
+| `--fg` | `#e8eaed` | `#1f2023` | body text |
+| `--fg-muted` | `#9aa0a6` | `#61656c` | secondary text, labels, metadata |
+| `--border` | `#2a2d33` | `#d8dade` | every hairline |
+| `--bg` | `#131417` | `#ffffff` | page ground |
+| `--bg-alt` | `#1b1d21` | `#f4f5f7` | raised surfaces, row hover ancestry |
+| `--bg-card` | `#0f1013` | `#ffffff` | raised card (dark: one shade *below* `--bg`) |
+| `--bg-panel` | `#202329` | `#ffffff` | pickers, tooltips |
+| `--bg-popover` | `#1c1e24` | `#ffffff` | popovers |
+| `--sel` | `#2b3a52` | `#cfe0f7` | text selection |
+| `--accent` | `#E5FF44` | `#5f7300` | the one signal colour (see below) |
+| `--on-accent` | `#10131a` | `#ffffff` | ink on an `--accent` fill |
+| `--accent-soft` | `#c9d95e` | `#5f7300` | accent as readable body text |
+| `--success` / `-bright` / `-soft` | `#3fb950` / `#3fca6b` / `#86d786` | `#1a7f37` / `#1a8f45` / `#1f7a3a` | success states |
+| `--warning` / `-soft` / `-strong` | `#d29922` / `#dfb054` / `#e0a33e` | `#8f6a10` / `#8a6410` / `#9a6a10` | warning states |
+| `--error` | `#ff6b6b` | `#c62828` | error states (also shadcn `--destructive`) |
+| `--row-bg-hover` | `#26282c` | `#e5e6e8` | opaque hover fill (pre-composited) |
+| `--row-bg-active` | `#353a25` | `#e1e4d7` | opaque selected-row fill (accent wash, pre-composited) |
+| `--shadow-ink` / `-soft` / `-deep` | `rgba(0,0,0,.4/.2/.6)` | `rgba(0,0,0,.1/.05/.25)` | shadow colour (geometry lives in Tailwind, see §7) |
+| `--scrim` | `rgba(0,0,0,.55)` | `rgba(0,0,0,.4)` | modal backdrop |
+| `--series-1..6` | blue/orange/green/purple/teal/red | deepened, same order | chart lines — meaning is "this one, not that one", never sentiment |
+| `--icon-folder/-code/-data/-json/-html/-image/-doc/-media/-geo/-archive/-db/-file` | tuned bright for dark | darkened to the same weight | file-type icon hues |
+
+**The signal rule.** `--accent` is a signal, not a fill: the selection edge,
+the focus ring, an active/checked state. It is never a large fill or body
+text — the light palette's `--accent` (`#5f7300`, a deep olive-lime) exists
+*because* raw `#E5FF44` fails contrast as text/border on white; using it as
+prose or a big panel would fail exactly the same way it was designed not to.
+The one exception is the brand mark itself.
+
+**Hover.** The default hover treatment across the app is the `--row-bg-hover`
+wash — a pre-composited opaque fill, not a translucent overlay, because a
+stretched-link row cannot stack a translucent wash over its own background.
+`--row-bg-active` is the same idea for a selected row (the accent wash, at
+weight, pre-composited per theme).
+
+**Status colours.** `--success` / `--warning` / `--error` (plus their
+`-bright`/`-soft`/`-strong` variants) are the only colours that carry
+*meaning*; they are never repurposed for anything decorative. `--activity`
+(`#60a5fa` dark / `#2563eb` light) is a fourth, separate hue for "something is
+in flight" (a live turn, an unread dot, a run-now affordance) — it used to be
+the status colour for "upcoming" and was pulled out once that lane went grey.
+
+**Scrim family.** `--scrim-fg`, `--scrim-bg` / `-hover`, `--scrim-border` /
+`-hover`, `--scrim-veil`, `--scrim-lift`, `--scrim-chip-bg` / `-hover`,
+`--scrim-letterbox` — the one token group that is **identical in both
+themes**. These paint controls sitting on arbitrary pixels (a photo, a map
+tile, a webcam frame) where the app's own theme says nothing about what's
+underneath; white-on-dark-wash reads over anything, and a token that flipped
+with the theme would put light ink on a light photo half the time.
+
+**The shadcn bridge** (`tailwind.css`, one un-themed `:root` block — theme
+comes for free from the tokens it aliases):
+
+| shadcn var | → app token | Note |
+|---|---|---|
+| `--background` / `--foreground` | `--bg` / `--fg` | |
+| `--card` / `--card-foreground` | `--bg-card` / `--fg` | |
+| `--popover` / `--popover-foreground` | `--bg-popover` / `--fg` | |
+| `--primary` / `--primary-foreground` | `--fg` / `--bg` | the filled button is fg-on-bg, **not** the brand lime |
+| `--secondary`, `--muted` | `--bg-alt` | |
+| `--muted-foreground` | `--fg-muted` | |
+| `--sh-accent` (shadcn "accent") | `--row-bg-hover` | the **hover wash**, not the brand accent |
+| `--destructive` | `--error` | |
+| `--sh-border`, `--input` | `--border` | |
+| `--ring` | `--fg-muted` | shadcn's own hover/focus halo — quiet, not lime; the app's own controls draw their own lime focus-visible outline separately |
+| `--chart-1..5` | `--series-1..5` | |
+| `--sidebar*` | `--bg` / `--fg` / `--accent` / `--on-accent` / `--row-bg-hover` / `--border` / `--fg-muted` | |
+
+**The Bridge Rule:** a shadcn semantic variable is only ever an alias onto an
+app token (`var(--<app-token>)`), never a literal — and the bridge itself
+carries no light/dark branch, because the tokens it points at already flip
+with `data-theme`. A second light block here would be a second place for the
+two palettes to drift apart.
+
+## 4. Typography
+
+Fonts (`scale.css`):
+- `--font-sans`: `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+  Helvetica, Arial, sans-serif` — the system stack; the product's voice is
+  the OS's voice.
+- `--font-mono`: `ui-monospace, SFMono-Regular, Menlo, Consolas,
+  "Liberation Mono", monospace` — measurements only.
+
+Nine type roles, each `size / line-height / weight`:
+
+| Role | Size | Line-height | Weight | Use when |
+|---|---|---|---|---|
+| `micro` | 10px | 1.3 | 500 | badges, uppercase tags, sub-captions |
+| `caption` | 11px | 1.4 | 500 | secondary labels, footnotes |
+| `meta` | 12px | 1.4 | 400 | labels, hints, measurements |
+| `dense` | 13px | 1.4 | 400 | list rows, controls in dense surfaces, composer text |
+| `body` | 14px | 1.5 | 400 | default document size (set on `<body>`) |
+| `control` | 14px | 1.0 | 500 | buttons, tabs, card titles — single line |
+| `title` | 15px | 1.3 | 600 | section / stage titles |
+| `heading` | 16px | 1.3 | 600 | page-level headings inside a panel |
+| `display` | 20px | 1.2 | 600 | the one big number, or the page title |
+
+Each role is three CSS custom properties (`--text-<role>`,
+`--text-<role>--line-height`, `--text-<role>--font-weight`), mapped 1:1 into
+Tailwind's `@theme inline` so `text-dense` etc. set all three at once.
+
+**The mono-for-measurement rule.** Anything measured — file sizes, byte
+counts, timestamps, durations — renders in `--font-mono`, at `meta` (12px,
+one size down from `dense`'s 13px), muted, with `font-variant-numeric:
+tabular-nums`. Prose and names never take mono; measurements never take the
+sans voice.
+
+**Snap table** (old size → scale role/size, applied by the legacy-CSS sweep;
+UI may shift up to 2px):
+
+| Old | New |
+|---|---|
+| 9px | 10 (`micro`) |
+| 10.5px | 10 (`micro`) |
+| 11.5px | 12 (`meta`) |
+| 12.5px | 13 (`dense`) |
+| 13.5px | 14 (`body`/`control`) — sidebar nav rows included |
+| 22px | 20 (`display`) |
+
+## 5. Spacing
+
+A 4px base scale with halves, defined once and read two ways.
+
+| Name | px | Tailwind number |
+|---|---|---|
+| `--space-0-5` | 2 | `0.5` |
+| `--space-1` | 4 | `1` |
+| `--space-1-5` | 6 | `1.5` |
+| `--space-2` | 8 | `2` |
+| `--space-2-5` | 10 | `2.5` |
+| `--space-3` | 12 | `3` |
+| `--space-3-5` | 14 | `3.5` |
+| `--space-4` | 16 | `4` |
+| `--space-5` | 20 | `5` |
+| `--space-6` | 24 | `6` |
+| `--space-7` | 28 | `7` |
+| `--space-8` | 32 | `8` |
+| `--space-10` | 40 | `10` |
+| `--space-12` | 48 | `12` |
+
+Tailwind's own numeric scale *is* the scale — `p-3` already equals
+`--space-3` (12px) — so a composite writes `p-3`/`gap-2`/`px-4` directly;
+hand-written CSS writes `var(--space-3)` for the identical value. The
+`--space-*` names exist only so CSS that can't reach a Tailwind class can
+still say the same number.
+
+Common rhythms: row padding `8×12` (`--space-2 --space-3`), card padding
+`16` (`--space-4`), section gap `24` (`--space-6`), control gap `8`
+(`--space-2`).
+
+**Snap rule for odd values** (legacy-CSS sweep): odd spacing (3/5/7/9px) →
+nearest even step; 15px → 16; 18px → 16 or 20 depending on context (e.g. a
+rail's own padding vs. a column gap); 22px → 24.
+
+## 6. Shape
+
+| Token | px | Sits at |
+|---|---|---|
+| `--radius-hairline` | 2 | progress tracks, meters |
+| `--radius-xs` | 4 | checkboxes, tiny chips, thumbnails |
+| `--radius-control` | 6 | buttons, inputs, menu items, tabs |
+| `--radius-md` | 8 | rows, attach chips, small cards |
+| `--radius-card` | 10 | model rows, cards |
+| `--radius-panel` | 12 | composer, result cards, dialogs |
+| `--radius-pill` | 999 | pills, switches |
+
+`--radius-hairline` is also the smallest structural border width concept in
+the ladder's spirit, but the app's actual hairline *border* is always `1px`
+(exempt from the no-literal rule, alongside `0`).
+
+shadcn keeps its own separate `--radius` ladder (`0.625rem` = 10px base, with
+`sm`/`md`/`lg`/`xl`/`2xl`/`3xl`/`4xl` as fractions/multiples of it, declared
+on the bare `:root` in `tailwind.css` since radius is not a theme concern).
+The two ladders coexist deliberately: shadcn primitives keep using their own
+`rounded-lg` etc. so they don't drift from upstream shadcn conventions, while
+composites prefer the named app radii (`rounded-card`, `rounded-control`)
+when a value belongs to *this* system rather than to shadcn's.
+
+## 7. Elevation
+
+Shadow **colour** is themed (`--shadow-ink-soft` / `--shadow-ink` /
+`--shadow-ink-deep` in `tokens.css`, deeper in dark, softer in light — a drop
+that reads as depth on a dark page reads as dirt on a light one). Shadow
+**geometry** is Tailwind's own published `shadow-sm/md/lg/xl` box-shadow
+values. Because these are two different vocabularies claiming the same four
+names, `tailwind.css` re-declares them, unlayered, scoped to `[data-slot]`
+(the attribute every shadcn component stamps on its root):
+
+```
+--shadow-sm: 0 1px 3px 0 var(--shadow-ink), 0 1px 2px -1px var(--shadow-ink);
+--shadow-md: 0 4px 6px -1px var(--shadow-ink), 0 2px 4px -2px var(--shadow-ink);
+--shadow-lg: 0 10px 15px -3px var(--shadow-ink), 0 4px 6px -4px var(--shadow-ink);
+```
+
+Tailwind's raw geometry stays; only the ink is swapped for the app's own
+`--shadow-ink*`, so a shadcn component's shadow deepens in dark and softens
+in light instead of wearing a hardcoded light-mode shadow on a dark page.
+
+**When a border beats a shadow:** resting, in-flow surfaces (rows, cards
+sitting flush on the page) separate by ground step (`--bg` → `--bg-alt` →
+`--bg-card`) plus a `--border` hairline — never a shadow. A shadow is
+reserved for something that actually floats above the page: a popover,
+dialog, dropdown menu, tooltip — anything a click or hover raised off the
+document flow.
+
+## 8. Motion
+
+| Token | ms | For |
+|---|---|---|
+| `--dur-instant` | 80 | hover colour/border change |
+| `--dur-fast` | 120 | reveal/hide a control, swap an icon |
+| `--dur-base` | 160 | fade a panel in/out |
+| `--dur-glide` | 240 | move layout (rail fold, grid tracks) |
+
+| Easing | Curve | For |
+|---|---|---|
+| `--ease-out` | `cubic-bezier(0, 0, 0.2, 1)` | most transitions; also the value Tailwind's own `ease-out` re-declares on `[data-slot]` |
+| `--ease-glide` | `cubic-bezier(0.2, 0.7, 0.3, 1)` | layout-moving transitions (paired with `--dur-glide`) |
+
+**Mandatory:** no animation ships without a `prefers-reduced-motion: reduce`
+guard (or the Tailwind `motion-reduce:` variant). The guard doesn't have to
+zero every duration to nothing meaningful for the user — see the Playground
+settings fold (`tailwind.css`), which drops the animation but keeps the JS
+exit delay so state changes stay correct — but *something* must acknowledge
+reduced motion, every time.
+
+## 9. Controls
+
+| Token | px | shadcn Button size |
+|---|---|---|
+| `--h-control-xs` | 24 | `xs` |
+| `--h-control-sm` | 28 | `sm` |
+| `--h-control-md` | 32 | default |
+| `--h-control-lg` | 36 | `lg` |
+
+- **focus-visible:** a 2px `--accent` outline, offset 2px — this is one of
+  the sanctioned lime signals (see §3).
+- **disabled:** `opacity: .5` (plus `pointer-events: none` where the element
+  would otherwise still be interactive).
+- **hover:** the grey `--row-bg-hover` wash — never lime; lime hover is
+  reserved for the one primary-fill button.
+
+## 10. Components
+
+Three layers, thin boundaries between them:
+
+1. **shadcn primitives** — `frontend/src/platform/shadcn/ui/*`, installed
+   with `npx shadcn@latest add <name>` and left unmodified. They paint only
+   through shadcn semantic classes (`bg-primary`, `border-input`,
+   `text-muted-foreground`), which the bridge (§3) resolves to app tokens.
+   Never hand-edit a file in this directory — regenerate it if shadcn ships a
+   fix, don't patch around it.
+2. **`platform/ui/<page>` composites** — hand-written, Tailwind + `cva` +
+   `cn()`, no CSS files of their own. One file per composite plus an
+   `index.ts` and a `README.md` mapping every old class to its
+   composite/prop (see `platform/ui/playground/README.md` for the live
+   example — 78 rows of `old class → composite`). A composite that is
+   still specific to one page's needs lives under that page's own directory
+   (`platform/ui/playground/` today).
+3. **Page files** hold *behaviour* — handlers, hooks, timers, URL sync,
+   aria wiring, refs. They import composites and wire className-only; they
+   do not carry their own CSS.
+
+**Promotion rule:** a composite moves from a page-specific directory into
+`platform/ui/` (the shared layer) the moment a **second** page needs it —
+not before, so nothing is prematurely generalized against a single caller's
+assumptions.
+
+**Behaviour-frozen rule** (from the shadcn migration playbook): moving a
+piece of UI onto composites is a skin swap, never a redesign. Handlers,
+hooks, timers, URL sync, `aria-*`, `title`, `disabled`, `role`, `tabIndex`,
+`stopPropagation`, measuring refs are byte-identical before and after; only
+JSX wrappers and `className` change. The one accepted class of additive
+change is where shadcn's own primitive comes with behaviour the old markup
+lacked (e.g. a `Dialog`'s focus trap, `Progress`'s aria role) — never invent
+new behaviour beyond what the primitive already provides for free.
+
+**Tour hooks convention:** `platform/lib/tours/*` drives onboarding tours off
+live CSS selectors, and a test (`registry.test.ts`) pins specific class names
+(e.g. `.pg-side`, `.pg-composer`, `.pg-send`, `.pg-answer-block`). When a
+component migrates off its old class name, keep the tour-hook class on the
+new element as a **style-free selector** — it carries no rules, it exists
+only so the tour still finds the element — until the tour itself is
+retargeted to a new selector.
+
+## 11. How to add
+
+**A token:** add it to `scale.css` (rhythm) or both palette blocks of
+`tokens.css` (colour — dark and light, same key, in `tokens.css`'s existing
+order). If it's a rhythm token consumed by Tailwind, add the matching line
+to `tailwind.css`'s `@theme inline` block. Run `tests/test_theme.py` (colour)
+or `tests/test_design_scale.py` (rhythm) — the latter's
+`test_scale_declares_every_role_tailwind_maps` fails loudly if the Tailwind
+mapping points at a name `scale.css` never declared.
+
+**A composite:** put it in the owning page's `platform/ui/<page>/` directory
+(or `platform/ui/` directly if it's already shared), give it its own file, no
+CSS file, only tokens/Tailwind names from §2–9, and record it in that
+directory's `README.md`.
+
+**A page:** follow `docs/SHADCN_MIGRATION_PLAYBOOK.md` — inventory
+(`parity-events.md` / `parity-css.md`), a `design.md` reviewed before
+building, primitives/bridge changes if the page needs new shadcn components,
+composites, then stage files migrated one at a time with computed-style
+probes and a screenshot diff against `main`.
+
+## 12. Do / Don't
+
+**Do:**
+- Paint every colour with `var(--token)` from `tokens.css`; give any new
+  dark token a light counterpart.
+- Reach for the shadcn component first and style it with semantic classes,
+  never a canon token name or a literal in `className`.
+- Keep measurements in `--font-mono`, `meta` size, muted, `tabular-nums`.
+- Use `--row-bg-hover` for hover; reserve `--accent` for selection edge,
+  focus ring, and the one primary fill per screen.
+- Guard every animation with `motion-reduce:` / `prefers-reduced-motion`.
+- Snap an odd legacy value onto the nearest scale step (§4/§5) rather than
+  keeping it exact.
+
+**Don't:**
+- Write a raw hex, `rgb()`/`rgba()` literal, or arbitrary Tailwind value like
+  `text-[13px]` / `p-[15px]` / `rounded-[8px]` / `duration-[110ms]` — both
+  guard tests fail on these outside `scale.css`/`tailwind.css`.
+- Use lime as a fill for anything but the brand mark and the single primary
+  button on a screen; never as prose colour or a decorative wash.
+- Reach for `ToggleGroup` (or any roving-tabindex primitive) to replace a row
+  of plain, independently-tabbable buttons — that's a behaviour change, not
+  a skin swap.
+- Ship an animation with no reduced-motion guard.
+- Use `shadow-md` or heavier on a resting, in-flow surface — that's what
+  the ground-step + hairline border is for (§7).
+- Invent a new spacing/radius/type size instead of picking the nearest scale
+  step, even under deadline pressure.
+- Hand-edit a file under `platform/shadcn/ui/` — it's vendored, unmodified
+  code.
+- Add a CSS file for a page — behaviour lives in the page file, style lives
+  in composites, and a CSS file for a page is a second, drifting source of
+  the tokens it should just be reading.
+- Give a shadcn bridge var (`tailwind.css`) a literal or a light/dark branch
+  of its own — it must always be `var(--<app-token>)`, and the theme split
+  belongs only to `tokens.css`.
+
+## 13. Guards
+
+**`tests/test_theme.py`** — the whole colour contract:
+- every built-in template is classified tier-1 / exempt / self-toggling /
+  deferred, exhaustively (no template escapes classification);
+- the shell resolves theme in an inline `<head>` script, before first paint,
+  reading a single storage key spelled identically in `theme.ts`,
+  `index.html`, and `static/runtime.js`;
+- `tokens.css`'s light `:root[data-theme="light"]` block redefines *every*
+  key the dark `:root` block defines (no missing, no extra);
+- no colour literal exists in any `styles/*.css` file outside the two
+  palette blocks, and the same holds per-file for every tier-1 built-in
+  template and for `templates/shared/*.js` scripts that inject CSS into a
+  host template;
+- a `var()` a tier-1 template reads must resolve to something the template
+  (or the shell) actually defines — an undefined token is silently inert,
+  not an error, so this is checked explicitly;
+- `templates/shared/folder-picker.js` paints only through its own `--fp-*`
+  namespace, never a host token directly.
+
+**`tests/test_design_scale.py`** — the whole rhythm contract:
+- every `styles/*.css` file except `scale.css`/`tailwind.css`: no px literal
+  in font-size, border-radius (all corners), padding/margin (all sides,
+  inline/block), gap/row-gap/column-gap, or a duration in
+  transition/animation — `1px` (hairlines/borders) and `0` are allowed;
+- every `.tsx`/`.ts` file outside `platform/shadcn/`: no Tailwind arbitrary
+  value restating one of those properties (`text-[…px]`, `p-[…px]`,
+  `rounded-[…px]`, `duration-[…ms]`, etc.);
+- every `--text-*` / `--radius-*` / `--font-*` / `--ease-glide` name
+  `tailwind.css` maps must actually be declared in `scale.css`;
+- every allowlist entry must still match something real, so the allowlist
+  can't silently accumulate dead debt.
+
+**Allowlist format** (`tests/design_scale_allowlist.txt`, both guards use the
+same shape): one entry per line, `path::literal  # why` — e.g.
+`styles/ai-playground.css::border-radius: …14px  # svg ring geometry, not
+rhythm`. The `#` comment explaining *why* is required; a line without one is
+rejected by the allowlist parser itself.

--- a/docs/SHADCN_MIGRATION_PLAYBOOK.md
+++ b/docs/SHADCN_MIGRATION_PLAYBOOK.md
@@ -21,6 +21,15 @@ what the user sees or does**. Written from the AI Models Playground migration
 
 ## Layers (already in place, extend — don't fork)
 
+0. **Design scale** — `frontend/src/styles/scale.css` (type roles, 4px
+   spacing, radius ladder, control heights, durations, easings, fonts) with
+   `tailwind.css` mapping the same vars to `text-<role>`, `rounded-<name>`,
+   `ease-glide`. Composites say `text-dense p-3 rounded-card`; legacy CSS says
+   `var(--text-dense) var(--space-3) var(--radius-card)`; both resolve to one
+   value. `tests/test_design_scale.py` refuses px literals for those
+   properties anywhere else (allowlist: `tests/design_scale_allowlist.txt`).
+   Full reference: `docs/DESIGN_SYSTEM.md`.
+
 1. **Token bridge** — `frontend/src/styles/tailwind.css`. Every shadcn
    semantic var aliases a `tokens.css` token in one `:root` block; light/dark
    comes free from `tokens.css`. `primary` = the app's filled button

--- a/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
+++ b/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
@@ -586,7 +586,7 @@ export default function PlaygroundTab() {
                     // where a figure goes reads as "unmeasured", which is
                     // not the fact. The badge says what IS the fact.
                     <ModelSize
-                      className="text-[10.5px] uppercase tracking-[0.06em]"
+                      className="text-micro uppercase tracking-[0.06em]"
                       title={model.note ?? undefined}
                     >
                       system
@@ -686,7 +686,7 @@ export default function PlaygroundTab() {
                   // Where the apple row WOULD be, when it is not: the reason,
                   // in the group it belongs to, so a reader looking for it
                   // finds an answer rather than an absence.
-                  <CapabilityGroupNote className="mt-[6px]">{appleNote}</CapabilityGroupNote>
+                  <CapabilityGroupNote className="mt-1.5">{appleNote}</CapabilityGroupNote>
                 )}
             </CapabilityGroup>
           );

--- a/frontend/src/apps/ai_models/playground/controls.tsx
+++ b/frontend/src/apps/ai_models/playground/controls.tsx
@@ -152,7 +152,7 @@ export function ConfigPanel({
           (styles/tailwind.css, next to the keyframes) keep landing on it. */}
       <Card className={configCardClass + " flex-none"}>
         <CardHeader>
-          <CardTitle className="text-[10.5px] font-semibold tracking-[0.06em] text-muted-foreground uppercase">
+          <CardTitle className="text-micro font-semibold tracking-[0.06em] text-muted-foreground uppercase">
             Settings
           </CardTitle>
         </CardHeader>
@@ -301,7 +301,7 @@ export function RailReset({
   return (
     <button
       type="button"
-      className="cursor-pointer appearance-none border-0 bg-transparent p-0 text-[11px] text-muted-foreground underline decoration-dotted underline-offset-2 transition-colors hover:text-foreground"
+      className="cursor-pointer appearance-none border-0 bg-transparent p-0 text-caption text-muted-foreground underline decoration-dotted underline-offset-2 transition-colors hover:text-foreground"
       title={title}
       onClick={onClick}
     >

--- a/frontend/src/apps/explorer/listing/column-shedding.test.ts
+++ b/frontend/src/apps/explorer/listing/column-shedding.test.ts
@@ -111,7 +111,10 @@ test("SIZE's header reserves berth for the folder ⋮ while MODIFIED is shed", (
   const wide = shedding.find((b) => /th\.col-mtime[^{]*\{[^}]*width:\s*0/s.test(b.body));
   expect(wide).toBeDefined();
   const berth = ruleFor(wide!.body, "th.col-size");
-  expect(berth).toMatch(/padding-right:\s*\d+px/);
+  // The 96/116/210px column-reservation literals below stayed literals by design
+  // (allowlisted); this berth rule now reads var(--space-8) after the design-scale
+  // rewrite, so accept either form (2026-09-06).
+  expect(berth).toMatch(/padding-right:\s*(\d+px|var\(--space-[\w-]+\))/);
   expect(berth).not.toMatch(/width:/);
 });
 

--- a/frontend/src/lan/App.tsx
+++ b/frontend/src/lan/App.tsx
@@ -161,7 +161,7 @@ export function LanApp() {
             keeps only the search and filters. */}
         {!IN_APP && (
           <div className="flex items-baseline justify-between gap-3 pb-3">
-            <h1 className="text-[22px] font-semibold tracking-[-0.01em]">Apps</h1>
+            <h1 className="text-display tracking-[-0.01em]">Apps</h1>
             <span className="lan-mono text-xs text-[var(--fg-muted)]">
               {apps ? `${shown.length}/${apps.length}` : ""}
             </span>
@@ -210,7 +210,7 @@ export function LanApp() {
               {tags.map((t) => (
                 <ToggleGroupItem key={t.value} value={t.value} className="rounded-full px-3">
                   {t.label}
-                  <span className="lan-mono ml-1.5 text-[11px] opacity-60">{t.count}</span>
+                  <span className="lan-mono ml-1.5 text-caption opacity-60">{t.count}</span>
                 </ToggleGroupItem>
               ))}
             </ToggleGroup>
@@ -268,7 +268,7 @@ export function LanApp() {
 
       {groups.map((g) => (
         <section key={g.label} className="pt-4">
-          <h2 className="lan-mono mb-2 text-[11px] font-medium tracking-[0.08em] text-[var(--fg-muted)] uppercase">
+          <h2 className="lan-mono mb-2 text-caption tracking-[0.08em] text-[var(--fg-muted)] uppercase">
             {g.label}
           </h2>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
@@ -307,16 +307,16 @@ function AppCard({ app, now }: { app: LanAppRow; now: number }) {
         )}
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-2 p-3">
-        <div className="line-clamp-2 text-[15px] leading-snug font-medium">{label}</div>
+        <div className="line-clamp-2 text-title leading-snug font-medium">{label}</div>
         <div className="mt-auto flex items-center justify-between gap-2">
           {app.tag ? (
-            <Badge variant="secondary" className="max-w-[70%] truncate rounded-full px-2 text-[11px]">
+            <Badge variant="secondary" className="max-w-[70%] truncate rounded-full px-2 text-caption">
               {app.linked ? "linked" : app.tag}
             </Badge>
           ) : (
             <span />
           )}
-          <span className="lan-mono text-[11px] text-[var(--fg-muted)]">{ago(app.recency, now)}</span>
+          <span className="lan-mono text-caption text-[var(--fg-muted)]">{ago(app.recency, now)}</span>
         </div>
       </div>
     </a>

--- a/frontend/src/platform/lib/utils.ts
+++ b/frontend/src/platform/lib/utils.ts
@@ -1,5 +1,34 @@
 import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { extendTailwindMerge } from "tailwind-merge"
+
+// The design scale (styles/scale.css) adds named text-size and radius
+// utilities on top of Tailwind's own (`text-dense`, `rounded-panel`, …).
+// Vanilla tailwind-merge has never heard of them, so when a composite
+// overrides a shadcn primitive's own Tailwind-native class in the SAME
+// conflict group (Button's `text-sm`/`rounded-lg`, Empty's `rounded-xl`,
+// Skeleton's `rounded-md`, Badge's `text-xs`, …) merge left both classes in
+// the string and the winner came down to generated-CSS order, not to which
+// one a caller wrote last — silently reverting the override. Teaching merge
+// these class names restores "last one wins" for them, the same guarantee
+// every other Tailwind utility already gets.
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        "text-micro",
+        "text-caption",
+        "text-meta",
+        "text-dense",
+        "text-body",
+        "text-control",
+        "text-title",
+        "text-heading",
+        "text-display",
+      ],
+      rounded: ["rounded-hairline", "rounded-control", "rounded-card", "rounded-panel", "rounded-pill"],
+    },
+  },
+})
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))

--- a/frontend/src/platform/ui/playground/AnswerBlock.tsx
+++ b/frontend/src/platform/ui/playground/AnswerBlock.tsx
@@ -22,7 +22,7 @@ export function AnswerLabel({ className, ...props }: ComponentProps<"p">) {
   return (
     <p
       className={cn(
-        "m-0 flex min-w-0 items-baseline gap-2 text-[12px] font-semibold text-[var(--fg-muted)]",
+        "m-0 flex min-w-0 items-baseline gap-2 text-meta font-semibold text-[var(--fg-muted)]",
         className,
       )}
       {...props}
@@ -39,7 +39,7 @@ export function AnswerProvenance({ className, ...props }: ComponentProps<"span">
   return (
     <span
       className={cn(
-        "min-w-0 truncate text-[12px] font-normal text-[var(--fg-muted)] opacity-75 tabular-nums",
+        "min-w-0 truncate text-meta text-[var(--fg-muted)] opacity-75 tabular-nums",
         className,
       )}
       {...props}
@@ -53,7 +53,7 @@ export function AnswerCard({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "relative rounded-[12px] border border-solid border-[var(--border)] bg-[var(--bg-alt)] py-[14px] pr-[44px] pl-4 text-[13.5px] leading-[1.6] [overflow-wrap:anywhere]",
+        "relative rounded-panel border border-solid border-[var(--border)] bg-[var(--bg-alt)] py-3.5 pr-12 pl-4 text-body leading-[1.6] [overflow-wrap:anywhere]",
         className,
       )}
       {...props}
@@ -66,7 +66,7 @@ export function TurnFoot({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "mt-1.5 flex items-baseline gap-3 text-[11.5px] text-[var(--fg-muted)] tabular-nums",
+        "mt-1.5 flex items-baseline gap-3 text-meta text-[var(--fg-muted)] tabular-nums",
         className,
       )}
       {...props}
@@ -79,7 +79,7 @@ export function TurnFoot({ className, ...props }: ComponentProps<"div">) {
 export function ThinkBlock({ className, ...props }: ComponentProps<"details">) {
   return (
     <details
-      className={cn("mb-2 text-[12px] text-[var(--fg-muted)] [&>summary]:cursor-pointer", className)}
+      className={cn("mb-2 text-meta text-[var(--fg-muted)] [&>summary]:cursor-pointer", className)}
       {...props}
     />
   );
@@ -96,12 +96,12 @@ export function ThinkBody({ className, ...props }: ComponentProps<"div">) {
 
 /** What the run is doing, said plainly. */
 export function StageStatus({ className, ...props }: ComponentProps<"p">) {
-  return <p className={cn("m-0 text-[12.5px] text-[var(--fg-muted)]", className)} {...props} />;
+  return <p className={cn("m-0 text-dense text-[var(--fg-muted)]", className)} {...props} />;
 }
 
 /** What went wrong. */
 export function StageError({ className, ...props }: ComponentProps<"p">) {
-  return <p className={cn("m-0 text-[12.5px] text-[var(--error)]", className)} {...props} />;
+  return <p className={cn("m-0 text-dense text-[var(--error)]", className)} {...props} />;
 }
 
 /** The URL asked for a capability this machine cannot run, and the stage below
@@ -109,7 +109,7 @@ export function StageError({ className, ...props }: ComponentProps<"p">) {
 export function BlockedAsk({ className, ...props }: ComponentProps<"p">) {
   return (
     <p
-      className={cn("mt-0 mr-0 mb-2.5 ml-0 text-[12.5px] leading-[1.45] text-[var(--fg-muted)]", className)}
+      className={cn("mt-0 mr-0 mb-2.5 ml-0 text-dense leading-[1.45] text-[var(--fg-muted)]", className)}
       {...props}
     />
   );

--- a/frontend/src/platform/ui/playground/AttachButton.tsx
+++ b/frontend/src/platform/ui/playground/AttachButton.tsx
@@ -9,7 +9,7 @@ import { cn } from "@platform/lib/utils";
 import { INHERIT_FONT } from "./classes";
 
 export const attachButtonVariants = cva(
-  "inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-[999px] border border-solid px-2.5 text-xs " +
+  "inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-pill border border-solid px-2.5 text-xs " +
     INHERIT_FONT +
     " [&_input[type=file]]:hidden",
   {

--- a/frontend/src/platform/ui/playground/AttachChip.tsx
+++ b/frontend/src/platform/ui/playground/AttachChip.tsx
@@ -19,7 +19,7 @@ export function AttachChip({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
       className={cn(
-        "mr-auto inline-flex items-center gap-1 rounded-[8px] border border-solid border-[var(--border)] bg-[var(--bg)] p-[3px]",
+        "mr-auto inline-flex items-center gap-1 rounded-md border border-solid border-[var(--border)] bg-[var(--bg)] p-1",
         className,
       )}
       {...props}
@@ -39,8 +39,8 @@ export function AttachOpen({ className, ...props }: ComponentProps<"button">) {
   return (
     <button
       className={cn(
-        "block cursor-zoom-in rounded-[5px] border-none bg-transparent p-0 leading-none",
-        "[&_img]:h-7 [&_img]:w-7 [&_img]:rounded-[5px] [&_img]:bg-[rgba(var(--tint),0.08)] [&_img]:object-cover",
+        "block cursor-zoom-in rounded-control border-none bg-transparent p-0 leading-none",
+        "[&_img]:h-7 [&_img]:w-7 [&_img]:rounded-control [&_img]:bg-[rgba(var(--tint),0.08)] [&_img]:object-cover",
         "hover:[&_img]:opacity-[0.82]",
         className,
       )}
@@ -54,7 +54,7 @@ export function AttachDrop({ className, ...props }: ComponentProps<"button">) {
   return (
     <button
       className={cn(
-        "h-[22px] w-[22px] flex-none cursor-pointer rounded-[5px] border-none bg-transparent text-xs leading-none text-[var(--fg-muted)]",
+        "h-[22px] w-[22px] flex-none cursor-pointer rounded-control border-none bg-transparent text-xs leading-none text-[var(--fg-muted)]",
         INHERIT_FONT_FACE,
         "hover:bg-[rgba(var(--tint),0.1)] hover:text-[var(--fg)]",
         className,
@@ -65,5 +65,5 @@ export function AttachDrop({ className, ...props }: ComponentProps<"button">) {
 }
 
 export function AttachNote({ className, ...props }: ComponentProps<"span">) {
-  return <span className={cn("text-[11.5px] text-[var(--fg-muted)]", className)} {...props} />;
+  return <span className={cn("text-meta text-[var(--fg-muted)]", className)} {...props} />;
 }

--- a/frontend/src/platform/ui/playground/AudioRow.tsx
+++ b/frontend/src/platform/ui/playground/AudioRow.tsx
@@ -9,7 +9,7 @@ export function AudioRow({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center gap-x-4 gap-y-2.5 rounded-[10px] border border-solid border-[var(--border)] bg-[var(--bg-alt)] px-[14px] py-2.5",
+        "flex flex-wrap items-center gap-x-4 gap-y-2.5 rounded-card border border-solid border-[var(--border)] bg-[var(--bg-alt)] px-3.5 py-2.5",
         className,
       )}
       {...props}
@@ -27,7 +27,7 @@ export function AudioLabel({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
       className={cn(
-        "text-[11px] font-semibold tracking-[0.05em] text-[var(--fg-muted)] uppercase",
+        "text-caption font-semibold tracking-[0.05em] text-[var(--fg-muted)] uppercase",
         className,
       )}
       {...props}
@@ -40,7 +40,7 @@ export function AudioLabel({ className, ...props }: ComponentProps<"span">) {
 export function AudioName({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
-      className={cn("max-w-[220px] truncate text-[12px] text-[var(--fg-muted)]", className)}
+      className={cn("max-w-[220px] truncate text-meta text-[var(--fg-muted)]", className)}
       {...props}
     />
   );

--- a/frontend/src/platform/ui/playground/CapabilityGroup.tsx
+++ b/frontend/src/platform/ui/playground/CapabilityGroup.tsx
@@ -60,7 +60,7 @@ export function CapabilityGroup({
         <span className="inline-flex flex-none [&_svg]:h-[18px] [&_svg]:w-[18px]">{icon}</span>
         {/* The label as written — "Text generation", "Not supported" — instead
             of tracked-out caps. */}
-        <span className="text-[14px] font-semibold">{title}</span>
+        <span className="text-body font-semibold">{title}</span>
       </summary>
       {children}
     </details>

--- a/frontend/src/platform/ui/playground/Chips.tsx
+++ b/frontend/src/platform/ui/playground/Chips.tsx
@@ -22,7 +22,7 @@ import { cn } from "@platform/lib/utils";
 import { INHERIT_FONT } from "./classes";
 
 export const chipVariants = cva(
-  "flex-none cursor-pointer rounded-[999px] border border-solid bg-transparent px-2.5 py-1 text-xs tabular-nums transition-none " +
+  "flex-none cursor-pointer rounded-pill border border-solid bg-transparent px-2.5 py-1 text-xs tabular-nums transition-none " +
     INHERIT_FONT + " " +
     "hover:border-[var(--ctl-quiet-border-hover)] hover:bg-transparent hover:text-[var(--fg)]",
   {

--- a/frontend/src/platform/ui/playground/Composer.tsx
+++ b/frontend/src/platform/ui/playground/Composer.tsx
@@ -24,7 +24,7 @@ export const TOUR_COMPOSER = "pg-composer";
 export const TOUR_SEND = "pg-send";
 
 export const composerVariants = cva(
-  `${TOUR_COMPOSER} flex gap-2 rounded-[12px] border border-solid border-[var(--border)] bg-[var(--bg-alt)] p-2 ` +
+  `${TOUR_COMPOSER} flex gap-2 rounded-panel border border-solid border-[var(--border)] bg-[var(--bg-alt)] p-2 ` +
     "focus-within:border-[var(--accent)] focus-within:shadow-[0_0_0_3px_rgba(var(--accent-rgb),0.12)]",
   {
     variants: {
@@ -56,7 +56,7 @@ export function Composer({
  *  an inline height: this is the backstop that keeps the box scrollable rather
  *  than unbounded if that inline height is ever stale. */
 const composerFieldBase =
-  `min-w-0 flex-1 resize-none border-none bg-transparent px-1 py-1.5 text-[13.5px] leading-[1.5] text-[var(--fg)] outline-none max-h-[calc(15em_+_12px)] ${INHERIT_FONT_FACE}`;
+  `min-w-0 flex-1 resize-none border-none bg-transparent px-1 py-1.5 text-body text-[var(--fg)] outline-none max-h-[calc(15em_+_12px)] ${INHERIT_FONT_FACE}`;
 
 /** A three-line floor, because a prompt worth running is usually two or three
  *  lines and a box that starts at one makes it look like a search field. It has
@@ -156,7 +156,7 @@ export const clearVariants = cva("", {
       inline: "mr-2 mb-auto inline-flex h-8 flex-none items-center px-1.5",
       bare: "mr-2 mb-0 inline-flex h-8 flex-none items-center px-1.5",
       corner:
-        "absolute top-2.5 right-2.5 m-0 h-auto rounded-[8px] px-2.5 py-[5px] " +
+        "absolute top-2.5 right-2.5 m-0 h-auto rounded-md px-2.5 py-1.5 " +
         "[&:hover:not(:disabled)]:bg-[rgba(var(--tint),0.08)]",
     },
   },
@@ -183,7 +183,7 @@ export function ClearButton({
  *  2px accent OUTLINE at a 2px offset), its `transition-all` (`.btn` has none)
  *  and its 1px press nudge (`.btn` does not move). */
 export const stageButtonVariants = cva(
-  `${TOUR_SEND} h-8 flex-none gap-[7px] rounded-[6px] border border-solid px-3.5 py-0 text-[13px] transition-none ` +
+  `${TOUR_SEND} h-8 flex-none gap-2 rounded-control border border-solid px-3.5 py-0 text-dense transition-none ` +
     INHERIT_FONT_FAMILY +
     " focus-visible:ring-0 focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:outline-offset-2 " +
     "active:not-aria-[haspopup]:translate-y-0 disabled:opacity-50",

--- a/frontend/src/platform/ui/playground/CopyButton.tsx
+++ b/frontend/src/platform/ui/playground/CopyButton.tsx
@@ -12,7 +12,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@platform/lib/utils";
 
 export const copyButtonVariants = cva(
-  "absolute top-2.5 right-2.5 grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-[6px] border border-solid p-0 " +
+  "absolute top-2.5 right-2.5 grid h-[26px] w-[26px] cursor-pointer place-items-center rounded-control border border-solid p-0 " +
     "[&_svg]:h-3.5 [&_svg]:w-3.5",
   {
     variants: {

--- a/frontend/src/platform/ui/playground/DownloadSwap.tsx
+++ b/frontend/src/platform/ui/playground/DownloadSwap.tsx
@@ -22,7 +22,7 @@ export function DownloadSwapRoot({ className, ...props }: ComponentProps<"div">)
   return (
     <div
       className={cn(
-        "group flex items-center gap-2 self-center text-[12px] text-[var(--fg-muted)]",
+        "group flex items-center gap-2 self-center text-meta text-[var(--fg-muted)]",
         className,
       )}
       {...props}
@@ -55,7 +55,7 @@ export function DownloadSwapLive({ className, ...props }: ComponentProps<"span">
   return (
     <span
       className={cn(
-        "flex items-center gap-2 transition-opacity duration-[120ms] ease-[ease]",
+        "flex items-center gap-2 transition-opacity duration-(--dur-fast) ease-[ease]",
         "group-hover:pointer-events-none group-hover:opacity-0",
         "group-focus-within:pointer-events-none group-focus-within:opacity-0",
         className,
@@ -78,7 +78,7 @@ export function DownloadSwapStop({ className, ...props }: ComponentProps<"button
         "pointer-events-none cursor-pointer border-none bg-transparent p-0 opacity-0",
         INHERIT_FONT_ALL,
         "text-[rgba(var(--error-rgb),0.85)] underline underline-offset-2 hover:text-[var(--error)]",
-        "transition-opacity duration-[120ms] ease-[ease]",
+        "transition-opacity duration-(--dur-fast) ease-[ease]",
         "group-hover:pointer-events-auto group-hover:opacity-100",
         "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
         className,

--- a/frontend/src/platform/ui/playground/Dropzone.tsx
+++ b/frontend/src/platform/ui/playground/Dropzone.tsx
@@ -8,7 +8,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@platform/lib/utils";
 
 export const dropzoneVariants = cva(
-  "flex items-center gap-4 rounded-[12px] border-[1.5px] p-[18px]",
+  "flex items-center gap-4 rounded-panel border-[1.5px] p-4",
   {
     variants: {
       dragging: {
@@ -39,11 +39,11 @@ export function DropCopy({ className, ...props }: ComponentProps<"div">) {
 }
 
 export function DropTitle({ className, ...props }: ComponentProps<"p">) {
-  return <p className={cn("m-0 text-[13.5px] font-semibold", className)} {...props} />;
+  return <p className={cn("m-0 text-body font-semibold", className)} {...props} />;
 }
 
 export function DropSub({ className, ...props }: ComponentProps<"p">) {
-  return <p className={cn("m-0 text-[12.5px] text-[var(--fg-muted)]", className)} {...props} />;
+  return <p className={cn("m-0 text-dense text-[var(--fg-muted)]", className)} {...props} />;
 }
 
 /** A <label> lying over a file input that covers it completely — the whole word

--- a/frontend/src/platform/ui/playground/EmbedRow.tsx
+++ b/frontend/src/platform/ui/playground/EmbedRow.tsx
@@ -9,7 +9,7 @@ import { cn } from "@platform/lib/utils";
 
 /** The embed stage's own column gap — wider than the other four, because its
  *  result is a LIST and a list needs air above it. */
-export const embedStageClass = "gap-[14px]";
+export const embedStageClass = "gap-3.5";
 
 export function EmbedResults({ className, ...props }: ComponentProps<"ol">) {
   return (
@@ -27,7 +27,7 @@ export function EmbedRow({
   return (
     <li
       className={cn(
-        "relative flex gap-3 overflow-hidden rounded-[8px] border border-solid border-[var(--border)] px-3 py-2 text-[13px]",
+        "relative flex gap-3 overflow-hidden rounded-md border border-solid border-[var(--border)] px-3 py-2 text-dense",
         media ? "items-center" : "items-baseline",
         className,
       )}
@@ -58,7 +58,7 @@ export function EmbedScore({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
       className={cn(
-        "relative flex-none text-[11.5px] text-[var(--fg-muted)] tabular-nums",
+        "relative flex-none text-meta text-[var(--fg-muted)] tabular-nums",
         className,
       )}
       {...props}
@@ -76,7 +76,7 @@ export function EmbedPictures({ className, ...props }: ComponentProps<"div">) {
 
 export function EmbedPictureRow({ className, ...props }: ComponentProps<"div">) {
   return (
-    <div className={cn("flex w-full items-center gap-2 text-[12px]", className)} {...props} />
+    <div className={cn("flex w-full items-center gap-2 text-meta", className)} {...props} />
   );
 }
 
@@ -87,4 +87,4 @@ export function EmbedPictureName({ className, ...props }: ComponentProps<"span">
 }
 
 export const embedThumbClass =
-  "relative h-10 w-10 flex-none rounded-[5px] bg-[var(--bg-subtle)] object-cover";
+  "relative h-10 w-10 flex-none rounded-control bg-[var(--bg-subtle)] object-cover";

--- a/frontend/src/platform/ui/playground/LevelMeter.tsx
+++ b/frontend/src/platform/ui/playground/LevelMeter.tsx
@@ -8,7 +8,7 @@ import { cn } from "@platform/lib/utils";
 export function LevelMeter({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
-      className={cn("inline-flex h-5 items-center gap-[3px]", className)}
+      className={cn("inline-flex h-5 items-center gap-1", className)}
       aria-hidden="true"
       {...props}
     />
@@ -17,7 +17,7 @@ export function LevelMeter({ className, ...props }: ComponentProps<"span">) {
 
 export function levelMeterBarClass(lit: boolean, className?: string): string {
   return cn(
-    "w-1 rounded-[2px]",
+    "w-1 rounded-hairline",
     lit ? "h-4 bg-[var(--success-bright)]" : "h-2 bg-[rgba(var(--tint),0.15)]",
     className,
   );

--- a/frontend/src/platform/ui/playground/Lightbox.tsx
+++ b/frontend/src/platform/ui/playground/Lightbox.tsx
@@ -68,7 +68,7 @@ export function Lightbox({
  *  it, and the click is swallowed there too (by the caller's own
  *  `stopPropagation`). */
 export const lightboxImageClass =
-  "max-h-full max-w-full cursor-default rounded-[8px] shadow-[0_18px_48px_var(--scrim-lift)]";
+  "max-h-full max-w-full cursor-default rounded-md shadow-[0_18px_48px_var(--scrim-lift)]";
 
 /** Fixed scrim colours, not theme ones: this chip sits on arbitrary photo
  *  pixels, so the values are the same in both palettes by design — and they are
@@ -77,7 +77,7 @@ export function LightboxClose({ className, ...props }: ComponentProps<"button">)
   return (
     <button
       className={cn(
-        "absolute top-4 right-5 h-[34px] w-[34px] cursor-pointer rounded-[8px] border-none bg-[var(--scrim-chip-bg)] text-[15px] leading-none text-[var(--scrim-fg)]",
+        "absolute top-4 right-5 h-[34px] w-[34px] cursor-pointer rounded-md border-none bg-[var(--scrim-chip-bg)] text-title leading-none text-[var(--scrim-fg)]",
         INHERIT_FONT_FACE,
         "hover:bg-[var(--scrim-chip-bg-hover)]",
         className,
@@ -94,7 +94,7 @@ export function LightboxBox({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "flex max-h-full min-h-0 max-w-full cursor-default flex-col items-center gap-[14px]",
+        "flex max-h-full min-h-0 max-w-full cursor-default flex-col items-center gap-3.5",
         className,
       )}
       {...props}
@@ -107,4 +107,4 @@ export function LightboxBox({ className, ...props }: ComponentProps<"div">) {
  *  the capture draws the raw frame, so what lands on disk is what the lens
  *  saw. */
 export const webcamVideoClass =
-  "max-h-[calc(100vh_-_180px)] max-w-full rounded-[8px] bg-[var(--scrim-letterbox)] shadow-[0_18px_48px_var(--scrim-lift)] [transform:scaleX(-1)]";
+  "max-h-[calc(100vh_-_180px)] max-w-full rounded-md bg-[var(--scrim-letterbox)] shadow-[0_18px_48px_var(--scrim-lift)] [transform:scaleX(-1)]";

--- a/frontend/src/platform/ui/playground/MediaFrame.tsx
+++ b/frontend/src/platform/ui/playground/MediaFrame.tsx
@@ -28,14 +28,14 @@ export function MediaFrame({ className, ...props }: ComponentProps<"div">) {
  *  `<video controls>` left unstyled sizes to its own intrinsic pixels rather
  *  than to the aspect-ratio box the frame just set. */
 export const mediaClass =
-  "block h-full w-full rounded-[12px] border border-solid border-[var(--border)] bg-[var(--bg-alt)] object-contain";
+  "block h-full w-full rounded-panel border border-solid border-[var(--border)] bg-[var(--bg-alt)] object-contain";
 
 /** The "gone means done" fallback failing its own artefact check — the same
  *  muted-note treatment the transcript stage's empty result gets. */
 export function MediaReadFailed({ className, ...props }: ComponentProps<"p">) {
   return (
     <p
-      className={cn("m-0 px-4 py-6 text-[13px] leading-[1.5] text-[var(--fg-muted)]", className)}
+      className={cn("m-0 px-4 py-6 text-dense leading-[1.5] text-[var(--fg-muted)]", className)}
       {...props}
     />
   );
@@ -48,7 +48,7 @@ export function MediaWait({ className, ...props }: ComponentProps<"div">) {
   return (
     <Skeleton
       className={cn(
-        "h-full w-full rounded-[12px] border border-solid border-[var(--border)]",
+        "h-full w-full rounded-panel border border-solid border-[var(--border)]",
         "bg-[linear-gradient(100deg,var(--bg-alt)_40%,var(--bg)_50%,var(--bg-alt)_60%)] [background-size:200%_100%]",
         "animate-pg-shimmer motion-reduce:animate-none",
         className,
@@ -63,7 +63,7 @@ export function MediaWait({ className, ...props }: ComponentProps<"div">) {
 export function MediaCaption({ className, ...props }: ComponentProps<"figcaption">) {
   return (
     <figcaption
-      className={cn("flex flex-col gap-1.5 text-[12px] text-[var(--fg-muted)] tabular-nums", className)}
+      className={cn("flex flex-col gap-1.5 text-meta text-[var(--fg-muted)] tabular-nums", className)}
       {...props}
     />
   );

--- a/frontend/src/platform/ui/playground/MediaStrip.tsx
+++ b/frontend/src/platform/ui/playground/MediaStrip.tsx
@@ -11,7 +11,7 @@ export function MediaStrip({ className, ...props }: ComponentProps<"div">) {
 }
 
 export const mediaStripItemVariants = cva(
-  "h-[84px] cursor-pointer rounded-[8px] border border-solid",
+  "h-[84px] cursor-pointer rounded-md border border-solid",
   {
     variants: {
       active: {

--- a/frontend/src/platform/ui/playground/ModelRow.tsx
+++ b/frontend/src/platform/ui/playground/ModelRow.tsx
@@ -14,7 +14,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@platform/lib/utils";
 
 export const modelRowVariants = cva(
-  "flex flex-col gap-0.5 rounded-[10px] border border-solid p-[15px] text-left text-[13px]",
+  "flex flex-col gap-0.5 rounded-card border border-solid p-4 text-left text-dense",
   {
     variants: {
       /** `off` is a downloaded model nothing here runs: no pointer (there is
@@ -80,7 +80,7 @@ export function ModelLive({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
       className={cn(
-        "mr-1.5 inline-block h-[7px] w-[7px] rounded-[50%] bg-[var(--success-bright)] [vertical-align:1px]",
+        "mr-1.5 inline-block h-[7px] w-[7px] rounded-full bg-[var(--success-bright)] [vertical-align:1px]",
         className,
       )}
       {...props}
@@ -93,7 +93,7 @@ export function ModelLive({ className, ...props }: ComponentProps<"span">) {
 export function ModelSize({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
-      className={cn("flex-none text-[11.5px] text-[var(--fg-muted)] tabular-nums", className)}
+      className={cn("flex-none text-meta text-[var(--fg-muted)] tabular-nums", className)}
       {...props}
     />
   );
@@ -102,7 +102,7 @@ export function ModelSize({ className, ...props }: ComponentProps<"span">) {
 /** The full repo id, quiet under the nickname. */
 export function ModelFull({ className, ...props }: ComponentProps<"span">) {
   return (
-    <span className={cn("truncate text-[11.5px] text-[var(--fg-muted)]", className)} {...props} />
+    <span className={cn("truncate text-meta text-[var(--fg-muted)]", className)} {...props} />
   );
 }
 
@@ -110,7 +110,7 @@ export function ModelFull({ className, ...props }: ComponentProps<"span">) {
 export function ModelFoot({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
-      className={cn("mt-1.5 flex items-center gap-2 text-[11.5px] text-[var(--fg-muted)]", className)}
+      className={cn("mt-1.5 flex items-center gap-2 text-meta text-[var(--fg-muted)]", className)}
       {...props}
     />
   );
@@ -127,7 +127,7 @@ export function ModelTask({ className, ...props }: ComponentProps<"span">) {
 export function ModelWhy({ className, ...props }: ComponentProps<"p">) {
   return (
     <p
-      className={cn("mt-1.5 mr-0 mb-0 ml-0 text-[11.5px] leading-[1.45] text-[var(--fg-muted)]", className)}
+      className={cn("mt-1.5 mr-0 mb-0 ml-0 text-meta leading-[1.45] text-[var(--fg-muted)]", className)}
       {...props}
     />
   );
@@ -148,7 +148,7 @@ export function ModelDownloadButton({
   return (
     <button
       className={cn(
-        "inline-flex flex-none cursor-pointer items-center justify-center rounded-[999px] border-none bg-transparent p-[3px] text-[var(--fg-muted)]",
+        "inline-flex flex-none cursor-pointer items-center justify-center rounded-pill border-none bg-transparent p-1 text-[var(--fg-muted)]",
         // 14px, not MenuIcons' own 16: the glyph sits beside 13px text, and at
         // 16 it was the biggest thing on the row.
         "[&_svg]:h-3.5 [&_svg]:w-3.5",

--- a/frontend/src/platform/ui/playground/ProgressBar.tsx
+++ b/frontend/src/platform/ui/playground/ProgressBar.tsx
@@ -21,7 +21,7 @@ export function ProgressBar({
       value={value}
       className={cn(
         "block w-[min(320px,100%)] gap-0",
-        "[&_[data-slot=progress-track]]:h-1 [&_[data-slot=progress-track]]:overflow-hidden [&_[data-slot=progress-track]]:rounded-[2px] [&_[data-slot=progress-track]]:bg-[rgba(var(--tint),0.1)]",
+        "[&_[data-slot=progress-track]]:h-1 [&_[data-slot=progress-track]]:overflow-hidden [&_[data-slot=progress-track]]:rounded-hairline [&_[data-slot=progress-track]]:bg-[rgba(var(--tint),0.1)]",
         "[&_[data-slot=progress-indicator]]:bg-[var(--accent)] [&_[data-slot=progress-indicator]]:transition-[width] [&_[data-slot=progress-indicator]]:duration-[.4s] [&_[data-slot=progress-indicator]]:ease-[ease]",
         "motion-reduce:[&_[data-slot=progress-indicator]]:transition-none",
         className,

--- a/frontend/src/platform/ui/playground/RecordButton.tsx
+++ b/frontend/src/platform/ui/playground/RecordButton.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@platform/lib/utils";
 
 export const recordButtonVariants = cva(
-  "inline-flex h-[52px] w-[52px] flex-none cursor-pointer items-center justify-center rounded-[50%] border-2 border-solid bg-[var(--bg-alt)] " +
+  "inline-flex h-[52px] w-[52px] flex-none cursor-pointer items-center justify-center rounded-full border-2 border-solid bg-[var(--bg-alt)] " +
     "disabled:cursor-default disabled:opacity-50",
   {
     variants: {
@@ -30,7 +30,7 @@ export function RecordButton({
 export function RecordDot({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
-      className={cn("h-[18px] w-[18px] rounded-[50%] bg-[var(--error)]", className)}
+      className={cn("h-[18px] w-[18px] rounded-full bg-[var(--error)]", className)}
       {...props}
     />
   );
@@ -38,7 +38,7 @@ export function RecordDot({ className, ...props }: ComponentProps<"span">) {
 
 export function RecordSquare({ className, ...props }: ComponentProps<"span">) {
   return (
-    <span className={cn("h-4 w-4 rounded-[3px] bg-[var(--error)]", className)} {...props} />
+    <span className={cn("h-4 w-4 rounded-xs bg-[var(--error)]", className)} {...props} />
   );
 }
 
@@ -48,7 +48,7 @@ export function RecordingRow({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "flex items-center gap-4 rounded-[12px] border-[1.5px] border-solid border-[var(--error)] bg-[rgba(var(--error-rgb),0.05)] p-[18px]",
+        "flex items-center gap-4 rounded-panel border-[1.5px] border-solid border-[var(--error)] bg-[rgba(var(--error-rgb),0.05)] p-4",
         className,
       )}
       {...props}
@@ -58,18 +58,18 @@ export function RecordingRow({ className, ...props }: ComponentProps<"div">) {
 
 export function RecordInfo({ className, ...props }: ComponentProps<"div">) {
   return (
-    <div className={cn("flex flex-wrap items-center gap-[14px]", className)} {...props} />
+    <div className={cn("flex flex-wrap items-center gap-3.5", className)} {...props} />
   );
 }
 
 export function RecordTime({ className, ...props }: ComponentProps<"span">) {
   return (
-    <span className={cn("text-[16px] font-semibold tabular-nums", className)} {...props} />
+    <span className={cn("text-heading tabular-nums", className)} {...props} />
   );
 }
 
 export function RecordHint({ className, ...props }: ComponentProps<"span">) {
   return (
-    <span className={cn("text-[12.5px] text-[var(--fg-muted)]", className)} {...props} />
+    <span className={cn("text-dense text-[var(--fg-muted)]", className)} {...props} />
   );
 }

--- a/frontend/src/platform/ui/playground/ResultSlot.tsx
+++ b/frontend/src/platform/ui/playground/ResultSlot.tsx
@@ -31,7 +31,7 @@ export function ResultSlot({
   return (
     <Empty
       className={cn(
-        "min-h-[200px] flex-none gap-2.5 rounded-[12px] border border-[var(--border)] p-6 text-wrap",
+        "min-h-[200px] flex-none gap-2.5 rounded-panel border border-[var(--border)] p-6 text-wrap",
         className,
       )}
       {...props}
@@ -46,7 +46,7 @@ export function ResultSlot({
       >
         {icon}
       </span>
-      <p className="m-0 max-w-[34ch] text-[12.5px] leading-[1.5] text-[var(--fg-muted)]">{note}</p>
+      <p className="m-0 max-w-[34ch] text-dense leading-[1.5] text-[var(--fg-muted)]">{note}</p>
     </Empty>
   );
 }

--- a/frontend/src/platform/ui/playground/SegmentList.tsx
+++ b/frontend/src/platform/ui/playground/SegmentList.tsx
@@ -11,7 +11,7 @@ export function SegmentList({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "relative flex min-h-[140px] flex-1 flex-col gap-[5px] overflow-y-auto rounded-[12px] border border-solid border-[var(--border)] bg-[var(--bg-alt)] pt-3 pr-[44px] pb-3 pl-[14px]",
+        "relative flex min-h-[140px] flex-1 flex-col gap-1.5 overflow-y-auto rounded-panel border border-solid border-[var(--border)] bg-[var(--bg-alt)] pt-3 pr-12 pb-3 pl-3.5",
         className,
       )}
       {...props}
@@ -21,7 +21,7 @@ export function SegmentList({ className, ...props }: ComponentProps<"div">) {
 
 export function Segment({ className, ...props }: ComponentProps<"div">) {
   return (
-    <div className={cn("flex gap-3 text-[13px] leading-[1.55]", className)} {...props} />
+    <div className={cn("flex gap-3 text-dense leading-[1.55]", className)} {...props} />
   );
 }
 
@@ -31,7 +31,7 @@ export function SegmentTime({ className, ...props }: ComponentProps<"span">) {
   return (
     <span
       className={cn(
-        "w-[42px] flex-none pt-0.5 text-[11.5px] text-[var(--fg-muted)] tabular-nums",
+        "w-[42px] flex-none pt-0.5 text-meta text-[var(--fg-muted)] tabular-nums",
         className,
       )}
       {...props}
@@ -53,7 +53,7 @@ export function TranscriptText({
   return (
     <p
       className={cn(
-        "m-0 text-[13px] leading-[1.6] whitespace-pre-wrap",
+        "m-0 text-dense leading-[1.6] whitespace-pre-wrap",
         empty && "text-[var(--fg-muted)]",
         className,
       )}

--- a/frontend/src/platform/ui/playground/StageHeader.tsx
+++ b/frontend/src/platform/ui/playground/StageHeader.tsx
@@ -15,7 +15,7 @@ export function StageHeader({ className, ...props }: ComponentProps<"div">) {
 /** One line naming the action — the hero card above carries the model. */
 export function StageTitle({ className, ...props }: ComponentProps<"h2">) {
   return (
-    <h2 className={cn("m-0 text-[15px] font-semibold tracking-[-0.01em]", className)} {...props} />
+    <h2 className={cn("m-0 text-title tracking-[-0.01em]", className)} {...props} />
   );
 }
 
@@ -28,7 +28,7 @@ export function StageTitle({ className, ...props }: ComponentProps<"h2">) {
  *  tilted icon left behind. It rides `--pg-glide`, the same beat as the track
  *  it opens, so the two read as one movement. */
 export const configCogVariants = cva(
-  "inline-flex h-[26px] w-[26px] flex-none cursor-pointer items-center justify-center rounded-[6px] border-none bg-transparent p-0 " +
+  "inline-flex h-[26px] w-[26px] flex-none cursor-pointer items-center justify-center rounded-control border-none bg-transparent p-0 " +
     "hover:bg-[rgba(var(--tint),0.07)] hover:text-[var(--fg)] " +
     "[&_svg]:transition-[transform] [&_svg]:duration-[var(--pg-glide)] [&_svg]:ease-[cubic-bezier(0.2,0.7,0.3,1)] " +
     "motion-reduce:[&_svg]:transition-none",

--- a/frontend/src/platform/ui/playground/StageShell.tsx
+++ b/frontend/src/platform/ui/playground/StageShell.tsx
@@ -20,13 +20,13 @@ export const TOUR_MODEL_RAIL = "pg-side";
  *  16px because a viewport-filling tab has nothing below the composer, and the
  *  22px gap under the head row that every other tab gets from its caption. */
 export const playgroundFillClass =
-  "flex flex-col overflow-y-hidden pb-4! [&>.cc-page-head]:mb-[22px]";
+  "flex flex-col overflow-y-hidden pb-4! [&>.cc-page-head]:mb-6";
 
 export function PlaygroundBody({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "flex min-h-0 flex-1 items-stretch gap-[22px] pg-narrow:flex-col",
+        "flex min-h-0 flex-1 items-stretch gap-6 pg-narrow:flex-col",
         className,
       )}
       {...props}
@@ -41,7 +41,7 @@ export function ModelRail({ className, ...props }: ComponentProps<"aside">) {
     <aside
       className={cn(
         TOUR_MODEL_RAIL,
-        "flex min-h-0 flex-[0_0_300px] flex-col gap-[14px] overflow-y-auto border-r border-[var(--border)] pr-[18px]",
+        "flex min-h-0 flex-[0_0_300px] flex-col gap-3.5 overflow-y-auto border-r border-[var(--border)] pr-4",
         "pg-narrow:max-h-[38vh] pg-narrow:w-full pg-narrow:flex-none pg-narrow:border-r-0 pg-narrow:border-b pg-narrow:pr-0 pg-narrow:pb-3",
         className,
       )}
@@ -77,7 +77,7 @@ export function StageScroller({ className, ...props }: ComponentProps<"div">) {
     <div
       className={cn(
         "@container flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-x-clip overflow-y-auto",
-        "[--pg-gap:16px] [--pg-card:240px] [--pg-glide:240ms] [--pg-fade:160ms]",
+        "[--pg-gap:16px] [--pg-card:240px] [--pg-glide:var(--dur-glide)] [--pg-fade:var(--dur-base)]",
         className,
       )}
       {...props}

--- a/frontend/src/platform/ui/playground/StarterPills.tsx
+++ b/frontend/src/platform/ui/playground/StarterPills.tsx
@@ -36,9 +36,9 @@ export function StarterPill({ className, ...props }: ComponentProps<"button">) {
   return (
     <button
       className={cn(
-        "group/starter flex flex-none cursor-pointer items-center gap-2 rounded-[999px] border border-solid border-[var(--border)] bg-transparent px-3.5 py-[7px] text-left text-[12.5px] whitespace-nowrap text-[var(--fg-muted)]",
+        "group/starter flex flex-none cursor-pointer items-center gap-2 rounded-pill border border-solid border-[var(--border)] bg-transparent px-3.5 py-2 text-left text-dense whitespace-nowrap text-[var(--fg-muted)]",
         INHERIT_FONT,
-        "transition-[color,border-color] duration-[.12s] ease-[ease]",
+        "transition-[color,border-color] duration-(--dur-fast) ease-[ease]",
         "hover:border-[var(--accent)] hover:text-[var(--fg)]",
         className,
       )}
@@ -69,7 +69,7 @@ export function StarterRotate({ className, ...props }: ComponentProps<"button">)
   return (
     <button
       className={cn(
-        "flex h-[33px] w-[33px] flex-none cursor-pointer items-center justify-center rounded-[50%] border border-solid border-[var(--border)] bg-transparent p-0 text-[var(--fg-muted)]",
+        "flex h-[33px] w-[33px] flex-none cursor-pointer items-center justify-center rounded-full border border-solid border-[var(--border)] bg-transparent p-0 text-[var(--fg-muted)]",
         "[&_svg]:h-[15px] [&_svg]:w-[15px]",
         "hover:border-[var(--accent)] hover:bg-[rgba(var(--accent-rgb),0.08)] hover:text-[var(--fg)]",
         className,

--- a/frontend/src/platform/ui/playground/classes.ts
+++ b/frontend/src/platform/ui/playground/classes.ts
@@ -5,9 +5,10 @@
 // `font: 400 13.333px Arial` — which is why nearly every hand-written control
 // in ai-playground.css opens with `font: inherit`. The composites need the same
 // reset, and they cannot spell it as the `font` SHORTHAND: a shorthand and a
-// `text-[13px]` beside it are two declarations in one Tailwind layer, and which
-// of them wins is a question about utility sort order rather than about the
-// design. Longhands only, split so a control that sets its OWN size or leading
+// size utility (e.g. `text-dense`) beside it are two declarations in one
+// Tailwind layer, and which of them wins is a question about utility sort
+// order rather than about the design. Longhands only, split so a control that
+// sets its OWN size or leading
 // takes just the part it needs and `text-*` / `leading-*` stays the one thing
 // setting it.
 

--- a/frontend/src/platform/ui/playground/markdownClasses.ts
+++ b/frontend/src/platform/ui/playground/markdownClasses.ts
@@ -19,28 +19,28 @@ export const markdownClass = [
   // `whitespace-pre-wrap`, because a model's own line breaks inside a paragraph
   // are content.
   "[&_p]:mx-0 [&_p]:mt-0 [&_p]:mb-2.5 [&_p]:whitespace-pre-wrap",
-  "[&_h3]:mx-0 [&_h3]:mt-3.5 [&_h3]:mb-1.5 [&_h3]:text-[15px] [&_h3]:leading-[1.3]",
-  "[&_h4]:mx-0 [&_h4]:mt-3.5 [&_h4]:mb-1.5 [&_h4]:text-[14px] [&_h4]:leading-[1.3]",
-  "[&_h5]:mx-0 [&_h5]:mt-3.5 [&_h5]:mb-1.5 [&_h5]:text-[13px] [&_h5]:leading-[1.3]",
-  "[&_ul]:mx-0 [&_ul]:mt-0 [&_ul]:mb-2.5 [&_ul]:pl-[22px]",
-  "[&_ol]:mx-0 [&_ol]:mt-0 [&_ol]:mb-2.5 [&_ol]:pl-[22px]",
+  "[&_h3]:mx-0 [&_h3]:mt-3.5 [&_h3]:mb-1.5 [&_h3]:text-title",
+  "[&_h4]:mx-0 [&_h4]:mt-3.5 [&_h4]:mb-1.5 [&_h4]:text-body [&_h4]:leading-[1.3]",
+  "[&_h5]:mx-0 [&_h5]:mt-3.5 [&_h5]:mb-1.5 [&_h5]:text-dense [&_h5]:leading-[1.3]",
+  "[&_ul]:mx-0 [&_ul]:mt-0 [&_ul]:mb-2.5 [&_ul]:pl-6",
+  "[&_ol]:mx-0 [&_ol]:mt-0 [&_ol]:mb-2.5 [&_ol]:pl-6",
   "[&_li]:mx-0 [&_li]:my-0.5",
-  `[&_code]:${MONO} [&_code]:rounded-[4px] [&_code]:bg-[rgba(var(--tint),0.08)] [&_code]:px-[5px] [&_code]:py-px [&_code]:text-[12px]`,
+  `[&_code]:${MONO} [&_code]:rounded-xs [&_code]:bg-[rgba(var(--tint),0.08)] [&_code]:px-1.5 [&_code]:py-px [&_code]:text-meta`,
   "[&_a]:text-[var(--accent-soft)]",
 ].join(" ");
 
 /** A fenced block: its own bordered surface on the page's ground, so it reads
  *  as a quoted file rather than as part of the sentence above it. */
 export const markdownCodeClass = [
-  "mx-0 mt-0 mb-2.5 overflow-hidden rounded-[8px] border border-solid border-[var(--border)] bg-[var(--bg)]",
-  `[&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:px-3 [&_pre]:py-2.5 [&_pre]:text-[12px] [&_pre]:leading-[1.55] [&_pre]:${MONO}`,
+  "mx-0 mt-0 mb-2.5 overflow-hidden rounded-md border border-solid border-[var(--border)] bg-[var(--bg)]",
+  `[&_pre]:m-0 [&_pre]:overflow-x-auto [&_pre]:px-3 [&_pre]:py-2.5 [&_pre]:text-meta [&_pre]:leading-[1.55] [&_pre]:${MONO}`,
 ].join(" ");
 
 /** The language name and the Copy button. The button is bare — a bordered
  *  control in a 20px strip would out-weigh the code under it. */
 export const markdownCodeHeadClass = [
-  "flex items-center justify-between border-b border-[var(--border)] bg-[rgba(var(--tint),0.03)] px-2.5 py-1 text-[11px] text-[var(--fg-muted)]",
-  "[&_button]:cursor-pointer [&_button]:border-none [&_button]:bg-transparent [&_button]:p-0 [&_button]:text-[11px] [&_button]:text-[var(--fg-muted)]",
+  "flex items-center justify-between border-b border-[var(--border)] bg-[rgba(var(--tint),0.03)] px-2.5 py-1 text-caption text-[var(--fg-muted)]",
+  "[&_button]:cursor-pointer [&_button]:border-none [&_button]:bg-transparent [&_button]:p-0 [&_button]:text-caption [&_button]:text-[var(--fg-muted)]",
   "[&_button]:[font-family:inherit] [&_button]:[font-style:inherit] [&_button]:[font-weight:inherit] [&_button]:[font-variant:inherit] [&_button]:[line-height:inherit]",
   "[&_button:hover]:text-[var(--fg)]",
 ].join(" ");

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -5,6 +5,7 @@
  * Palette tokens live in styles/tokens.css (tests/test_theme.py). */
 @import "./styles/tailwind.css";
 @import "./styles/tokens.css";
+@import "./styles/scale.css";
 @import "./styles/base.css";
 @import "./styles/sidebar.css";
 @import "./styles/explorer.css";

--- a/frontend/src/shell/AppApi.tsx
+++ b/frontend/src/shell/AppApi.tsx
@@ -120,7 +120,7 @@ function KindGlyph({ kind }: { kind: EndpointKind }) {
   );
 }
 
-const MONO = "font-mono text-[12.5px]";
+const MONO = "font-mono text-dense";
 
 export default function AppApi({
   dir,
@@ -251,7 +251,7 @@ export default function AppApi({
               apart on the right — what the folder needs installed. The engine
               is not named: nobody chooses it on this page. */}
           {endpoints.length > 0 && (
-            <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 px-1 text-[13px] text-muted-foreground">
+            <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 px-1 text-dense text-muted-foreground">
               <p className="m-0">
                 {callable === 0
                   ? "Nothing to run yet"
@@ -285,7 +285,7 @@ export default function AppApi({
           )}
 
           {endpoints.length === 0 && (
-            <div className="flex flex-1 flex-col items-center justify-center gap-2 rounded-xl border border-border py-16 text-[13px] text-muted-foreground">
+            <div className="flex flex-1 flex-col items-center justify-center gap-2 rounded-xl border border-border py-16 text-dense text-muted-foreground">
               <FileCode2 className="size-7 opacity-60" aria-hidden />
               <p className="m-0">No Python files in this app yet.</p>
               <p className="m-0">
@@ -316,7 +316,7 @@ export default function AppApi({
                 ))}
               </ul>
               {data.truncated && (
-                <p className="m-0 px-4 py-3 text-[12px] text-muted-foreground">
+                <p className="m-0 px-4 py-3 text-meta text-muted-foreground">
                   Showing the first {endpoints.length} files.{" "}
                   <a href={folderHref} className="text-inherit underline">
                     Open the folder
@@ -421,11 +421,11 @@ function EndpointRow({
               {name}
             </span>
             {kindNote && (
-              <span className="flex-none text-[11px] tracking-[0.04em] text-muted-foreground uppercase">
+              <span className="flex-none text-caption tracking-[0.04em] text-muted-foreground uppercase">
                 {kindNote}
               </span>
             )}
-            <span className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground">
+            <span className="min-w-0 flex-1 truncate text-dense text-muted-foreground">
               {summary || paramHint}
             </span>
           </span>
@@ -446,7 +446,7 @@ function EndpointRow({
             onClick={copyCurl}
             title="Copy this call as a curl command"
             className={cn(
-              "absolute inset-y-0 right-[42px] my-auto rounded-md border-border bg-transparent px-1.5 font-normal text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
+              "absolute inset-y-0 right-10 my-auto rounded-md border-border bg-transparent px-1.5 font-normal text-muted-foreground hover:bg-transparent hover:text-foreground dark:hover:bg-transparent transition-opacity",
               "group-hover/row:pointer-events-auto group-hover/row:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 motion-reduce:transition-none",
               // Hidden means hidden: no hit-testing, so a tap in the gap on a
               // collapsed row (touch has no hover) reaches the toggle beneath.
@@ -489,7 +489,7 @@ function EndpointRow({
           )}
 
           {(ep.module_docstring || fn?.docstring) && (
-            <div className="flex flex-col gap-2 text-[13px] leading-relaxed text-foreground/85">
+            <div className="flex flex-col gap-2 text-dense leading-relaxed text-foreground/85">
               {ep.module_docstring && (
                 <p className="m-0 whitespace-pre-wrap">
                   {ep.module_docstring.trim()}
@@ -502,7 +502,7 @@ function EndpointRow({
           )}
 
           {kind === "none" && (
-            <p className="m-0 text-[12.5px] text-muted-foreground">
+            <p className="m-0 text-dense text-muted-foreground">
               No <code className={MONO}>main()</code> here — a helper module,
               imported by the others rather than called on its own. Define{" "}
               <code className={MONO}>main()</code> to make it an endpoint.
@@ -510,7 +510,7 @@ function EndpointRow({
           )}
 
           {kind === "result" && (
-            <p className="m-0 text-[12.5px] text-muted-foreground">
+            <p className="m-0 text-dense text-muted-foreground">
               Static script — assigns <code className={MONO}>result</code> at
               the top level, no parameters.
             </p>
@@ -520,7 +520,7 @@ function EndpointRow({
             <section className="flex flex-col gap-2">
               <Eyebrow>Parameters</Eyebrow>
               {params.length === 0 && (
-                <p className="m-0 text-[12.5px] text-muted-foreground">None.</p>
+                <p className="m-0 text-dense text-muted-foreground">None.</p>
               )}
               {params.length > 0 && (
                 <div className="grid grid-cols-[minmax(120px,max-content)_minmax(80px,max-content)_1fr] items-start gap-x-5 gap-y-2.5">
@@ -551,12 +551,12 @@ function EndpointRow({
                 {run?.kind === "running" ? "Running…" : "Execute"}
               </Button>
               {run?.kind === "failed" && (
-                <span className="text-[12.5px] text-destructive">
+                <span className="text-dense text-destructive">
                   {run.message}
                 </span>
               )}
               {run?.kind === "done" && (
-                <span className="text-[12px] text-muted-foreground tabular-nums">
+                <span className="text-meta text-muted-foreground tabular-nums">
                   {run.result.ok ? "Returned" : "Failed"} in{" "}
                   {formatMs(run.result.duration_ms ?? run.ms)}
                 </span>
@@ -629,7 +629,7 @@ function ParamRow({
       <div
         className={cn(
           MONO,
-          "flex flex-col gap-0.5 pt-1.5 text-[11.5px] leading-snug",
+          "flex flex-col gap-0.5 pt-1.5 text-meta leading-snug",
         )}
       >
         <span className="text-primary">{p.annotation ?? "any"}</span>
@@ -704,7 +704,7 @@ function Response({
             variant="outline"
             className={cn(
               MONO,
-              "h-[18px] rounded-md border-transparent px-1.5 text-[10.5px] font-semibold tracking-[0.06em]",
+              "h-[18px] rounded-md border-transparent px-1.5 text-micro font-semibold tracking-[0.06em]",
               result.ok
                 ? "bg-primary/10 text-primary"
                 : "bg-destructive/10 text-destructive",
@@ -717,7 +717,7 @@ function Response({
               {result.error.type}
             </span>
           )}
-          <span className="ml-auto text-[11.5px] text-muted-foreground tabular-nums">
+          <span className="ml-auto text-meta text-muted-foreground tabular-nums">
             {formatMs(result.duration_ms ?? run.ms)}
           </span>
         </div>
@@ -755,7 +755,7 @@ function Fold({
 }) {
   return (
     <details className="border-t border-border" open={open}>
-      <summary className="cursor-pointer select-none px-3 py-1.5 text-[12px] text-muted-foreground hover:text-foreground">
+      <summary className="cursor-pointer select-none px-3 py-1.5 text-meta text-muted-foreground hover:text-foreground">
         {label}
       </summary>
       <pre
@@ -772,7 +772,7 @@ function Fold({
 
 function Eyebrow({ children }: { children: string }) {
   return (
-    <h3 className="m-0 text-[11px] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+    <h3 className="m-0 text-caption font-semibold tracking-[0.08em] text-muted-foreground uppercase">
       {children}
     </h3>
   );

--- a/frontend/src/shell/onboarding/ClaudeStep.tsx
+++ b/frontend/src/shell/onboarding/ClaudeStep.tsx
@@ -163,7 +163,7 @@ export function ClaudeStep({ setup, eyebrow }: { setup: ClaudeSetup; eyebrow: st
                       {row.label}
                     </span>
                     {row.optional && (
-                      <span className="rounded-full border border-border px-1.5 py-px text-[11px] font-normal text-muted-foreground">
+                      <span className="rounded-full border border-border px-1.5 py-px text-caption font-normal text-muted-foreground">
                         optional
                       </span>
                     )}

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -211,7 +211,7 @@ export function OnboardingWizard({ config }: { config: Config }) {
           the ✕). In flow, so a squeeze shrinks the side tracks instead of
           painting the pills over the wordmark. */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 border-b border-border px-5 py-3">
-        <div className="flex min-w-0 items-center gap-2 text-[13.5px] font-semibold tracking-[0.01em]">
+        <div className="flex min-w-0 items-center gap-2 text-body font-semibold tracking-[0.01em]">
           <span className="flex shrink-0 items-center text-[var(--accent)]">
             <FusedMark size={20} />
           </span>
@@ -249,7 +249,7 @@ export function OnboardingWizard({ config }: { config: Config }) {
                 >
                   <span
                     className={cn(
-                      "grid size-4 place-items-center rounded-full text-[10px] font-semibold tabular-nums",
+                      "grid size-4 place-items-center rounded-full text-micro font-semibold tabular-nums",
                       current && "bg-foreground text-background",
                       done && "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
                       !current && !done && "bg-muted-foreground/15 text-muted-foreground",

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -467,11 +467,13 @@ describe("one nav dot, worn by two rows", () => {
     const chip = SIDEBAR_CSS.slice(SIDEBAR_CSS.indexOf(".sidebar-count-chip {"));
     const body = chip.slice(0, chip.indexOf("}"));
     for (const decl of [
-      "font-size: 10.5px",
+      // Rhythm reads the design scale (styles/scale.css): micro type, md
+      // radius, 4×6 padding (3px snapped to the 4px step).
+      "font-size: var(--text-micro)",
       "color: var(--fg-muted)",
       "background: rgba(var(--tint), 0.07)",
-      "border-radius: 8px",
-      "padding: 3px 6px",
+      "border-radius: var(--radius-md)",
+      "padding: var(--space-1) var(--space-1-5)",
     ]) {
       expect(body).toContain(decl);
     }

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -2343,8 +2343,10 @@ describe("the unread mark", () => {
     // The LEFT term is the whole claim: the full indent, not indent-minus-1, so
     // the row lands in the column the rule used to leave room beside. The vertical
     // term is the breathing-room variable and is free to move (2026-08-18).
+    // The horizontal term now reads var(--space-2-5), the design-scale rewrite's
+    // snap of the old 9px to 10px (2026-09-06).
     expect(body).toMatch(
-      /\.tasks-msg\s*\{[^}]*padding: var\(--tasks-msg-pad-y\) 10px var\(--tasks-msg-pad-y\) var\(--tasks-msg-indent\)/,
+      /\.tasks-msg\s*\{[^}]*padding: var\(--tasks-msg-pad-y\) var\(--space-2-5\) var\(--tasks-msg-pad-y\) var\(--tasks-msg-indent\)/,
     );
   });
 
@@ -2366,8 +2368,10 @@ describe("the unread mark", () => {
     // The Board took the same step, so a card does not read as the cramped view of
     // the two — and the action strip's `top`, which is derived from the card's own
     // padding, moved with it rather than being left riding high on the head.
+    // padding rewritten to the design-scale vars carrying the same 12px/14px
+    // (2026-09-06); `top` below is a positional prop and stayed a literal.
     expect(SCHEDULE_CSS).toMatch(
-      /\.prefs-section \.schedule-tv-board \.schedule-tv-card \{[^}]*padding: 12px 14px/,
+      /\.prefs-section \.schedule-tv-board \.schedule-tv-card \{[^}]*padding: var\(--space-3\) var\(--space-3-5\)/,
     );
     expect(block(TASKS_CSS, ".tasks-card-acts")).toContain("top: 9px");
   });
@@ -2628,7 +2632,7 @@ describe("the board's surfaces", () => {
     // And NO visible edge: an open column is an invisible panel, not a box.
     expect(lane).not.toContain("border: 1px solid var(--border)");
     expect(lane).toContain("border: 1px solid transparent");
-    expect(lane).toContain("border-radius: 8px");
+    expect(lane).toContain("border-radius: var(--radius-md)"); // rewritten from 8px (2026-09-06)
     // Stated with it, so `min-height: 120px` stays the floor the board actually has.
     expect(lane).toContain("box-sizing: border-box");
     // One box all the way round, not a rule down one side.
@@ -2642,7 +2646,7 @@ describe("the board's surfaces", () => {
     const rail = block(SCHEDULE_CSS, ".schedule-tv-rail");
     expect(rail).toContain("background: transparent");
     expect(rail).toContain("border: 1px solid var(--border)");
-    expect(rail).toContain("border-radius: 8px");
+    expect(rail).toContain("border-radius: var(--radius-md)"); // rewritten from 8px (2026-09-06)
   });
 
   it("makes the card lift off the LANE, in both themes, from tokens", () => {
@@ -2707,8 +2711,9 @@ describe("the board's surfaces", () => {
     // The lane keeps the geometry those states are drawn with — the padding that
     // insets the outline off the top card, and the radius the wash takes.
     const lane = block(SCHEDULE_CSS, ".schedule-tv-lane-body");
-    expect(lane).toContain("padding: 6px");
-    expect(lane).toContain("border-radius: 8px");
+    // Rewritten to design-scale vars carrying the same 6px/8px (2026-09-06).
+    expect(lane).toContain("padding: var(--space-1-5)");
+    expect(lane).toContain("border-radius: var(--radius-md)");
     // And it keeps a floor, so an EMPTY lane — which now shows its header and
     // nothing else, because "nothing scheduled" should look like nothing — is still
     // something a card can be dragged into.
@@ -2771,10 +2776,11 @@ describe("the board's surfaces", () => {
     // 8px/5px at first, then 10px/6px, and 12px/8px on 2026-08-18 alongside the
     // List's rows — one step for both views, so neither becomes the cramped one.
     // On the repo's even scale, and no type size moved with it.
-    expect(card).toContain("padding: 12px 14px");
-    expect(card).toContain("gap: 8px");
-    expect(block(SCHEDULE_CSS, ".schedule-tv-card-head")).toContain("gap: 8px");
-    expect(block(SCHEDULE_CSS, ".schedule-tv-lane-body")).toContain("gap: 8px");
+    // Rewritten to design-scale vars carrying the same 12px/14px/8px (2026-09-06).
+    expect(card).toContain("padding: var(--space-3) var(--space-3-5)");
+    expect(card).toContain("gap: var(--space-2)");
+    expect(block(SCHEDULE_CSS, ".schedule-tv-card-head")).toContain("gap: var(--space-2)");
+    expect(block(SCHEDULE_CSS, ".schedule-tv-lane-body")).toContain("gap: var(--space-2)");
     // The action strip is centred on the head off the card's TOP PADDING (plus half
     // the head's line, less half a 22px button), so loosening the card without
     // moving this leaves the strip riding high over the head: 12 + 8 - 11 = 9.
@@ -4625,8 +4631,8 @@ describe("the time a task row prints", () => {
     expect(block(TASKS_CSS, ".tasks-row-time")).toContain("font-variant-numeric: tabular-nums");
     expect(block(TASKS_CSS, ".tasks-msg-time")).toContain("font-variant-numeric: tabular-nums");
     // Same weight and colour as a message row's time — one kind of fact, one
-    // register.
-    for (const decl of ["font-size: 11px", "color: var(--fg-muted)"]) {
+    // register. font-size rewritten to var(--text-caption), still 11px (2026-09-06).
+    for (const decl of ["font-size: var(--text-caption)", "color: var(--fg-muted)"]) {
       expect(block(TASKS_CSS, ".tasks-row-time")).toContain(decl);
       expect(block(TASKS_CSS, ".tasks-msg-time")).toContain(decl);
     }
@@ -6338,7 +6344,7 @@ describe("the tasks toolbar", () => {
     const lane = block(SCHEDULE_CSS, ".schedule-tv-lane");
     expect(lane).toContain("flex: 0 0 260px");
     const board = block(SCHEDULE_CSS, ".schedule-tv-board");
-    expect(board).toContain("gap: 12px");
+    expect(board).toContain("gap: var(--space-3)"); // rewritten from 12px (2026-09-06)
     const page = block(SCHEDULE_CSS, ".prefs-page.schedule-page > *");
     expect(page).toContain(`max-width: ${measure}px`);
     // Centred, and applied to every child so the header travels with the views — a
@@ -7103,7 +7109,7 @@ describe("the outcome pill, beside the id in both views", () => {
     // alarm (the red ring is the alarm).
     expect(TASKS_CSS).toContain(".tasks-outcome-pill");
     const rule = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-outcome-pill"));
-    expect(rule).toMatch(/border-radius: 999px/);
+    expect(rule).toMatch(/border-radius: var\(--radius-pill\)/); // rewritten from 999px (2026-09-06)
     expect(rule).toMatch(/border: 1px solid/);
   });
 });
@@ -7597,7 +7603,7 @@ describe("the list row's message count", () => {
     // digits so a count going 9 → 10 does not shift the column.
     const rule = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-msgs {"));
     const body = rule.slice(0, rule.indexOf("}"));
-    expect(body).toContain("font-size: 11px");
+    expect(body).toContain("font-size: var(--text-caption)"); // rewritten from 11px (2026-09-06)
     expect(body).toContain("color: var(--fg-muted)");
     expect(body).toContain("flex: 0 0 auto");
     expect(body).toContain("font-variant-numeric: tabular-nums");
@@ -7655,12 +7661,15 @@ describe("the folder chip as a filter tag", () => {
     // target and the WASH grew together into a slab around an 11px word — "that
     // is such a bad design and hover … keep the tag/button size same". The
     // enlarged target moved to the shield around it (next test).
-    expect(body).toContain("padding: 3px 5px");
-    expect(body).toContain("border-radius: 5px");
-    // …and its 3px must not grow the ROW: the shield is stretched, so the flex
+    // Rewritten to design-scale vars: 3px/5px snapped up to --space-1/--space-1-5
+    // (4px/6px), and the 5px radius snapped up to --radius-control (6px) (2026-09-06).
+    expect(body).toContain("padding: var(--space-1) var(--space-1-5)");
+    expect(body).toContain("border-radius: var(--radius-control)");
+    // …and its margin must not grow the ROW: the shield is stretched, so the flex
     // line is sized from this element plus the shield's box, which made every row
     // 39px instead of 36px until this went in. Verified in the browser after: 36.
-    expect(body).toContain("margin-block: -3px");
+    // margin-block derives from the same --space-1 the padding snapped to.
+    expect(body).toContain("margin-block: calc(-1 * var(--space-1))");
     // The wash and the focus ring are on the pill, not on a child — one box for
     // the thing a reader sees, presses, and gets feedback from.
     expect(TASKS_CSS).toContain(".tasks-row .schedule-tv-id--tag:hover,");

--- a/frontend/src/styles/ai-models.css
+++ b/frontend/src/styles/ai-models.css
@@ -23,7 +23,7 @@
   flex-direction: column;
   gap: var(--am-gap-card);
   max-width: 760px;
-  font-size: 13px;
+  font-size: var(--text-dense);
   /* The row grid's two fixed tracks, named once so the lines UNDER a row can
      start where its control does. A note about the engine that belongs to the
      card's left edge instead reads as a sentence about the capability. */
@@ -55,7 +55,7 @@
   display: grid;
   grid-template-columns: var(--am-engine-cap-col) minmax(0, 260px) minmax(0, 1fr);
   align-items: center;
-  gap: 8px var(--am-engine-col-gap);
+  gap: var(--space-2) var(--am-engine-col-gap);
 }
 
 @media (max-width: 620px) {
@@ -110,7 +110,7 @@
   align-items: center;
   text-align: left;
   appearance: none;
-  padding-right: 30px;
+  padding-right: var(--space-8);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 4.5l3 3 3-3' fill='none' stroke='%239aa0a6' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 10px center;
@@ -165,9 +165,9 @@
 .am-engine-option {
   display: flex;
   align-items: flex-start;
-  gap: 6px;
-  padding: 8px 10px;
-  border-radius: 6px;
+  gap: var(--space-1-5);
+  padding: var(--space-2) var(--space-2-5);
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -181,7 +181,7 @@
 
 .am-engine-option-check {
   flex: 0 0 14px;
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 19px;
   color: var(--accent);
 }
@@ -194,7 +194,7 @@
 }
 
 .am-engine-option-label {
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   white-space: normal;
 }
@@ -208,7 +208,7 @@
 }
 
 .am-engine-option-desc {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   white-space: normal;
 }
@@ -229,7 +229,7 @@
      rather than about the capability naming the row. */
   margin-left: calc(var(--am-engine-cap-col) + var(--am-engine-col-gap));
   max-width: 60ch;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -286,13 +286,13 @@
 .am-subgroup-head {
   display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .am-section-head {
   justify-content: space-between;
   border-bottom: 1px solid var(--border);
-  padding-bottom: 6px;
+  padding-bottom: var(--space-1-5);
   margin-bottom: var(--am-gap-head);
 }
 
@@ -305,7 +305,7 @@
 
 .am-section-title {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--text-title);
   font-weight: 600;
 }
 
@@ -317,7 +317,7 @@
    the parent from the child. */
 .am-subgroup-title {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -347,7 +347,7 @@
 
 .am-subgroup-size {
   flex: 0 0 auto;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -370,7 +370,7 @@
 .am-group-note {
   margin: 0 0 var(--am-gap-head);
   max-width: 110ch;
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.5;
   color: var(--fg-muted);
 }
@@ -402,7 +402,7 @@
   scroll-snap-type: x proximity;
   /* Room for the scrollbar under the cards rather than over them, so an
      overlay scrollbar does not come to rest on a footer's Download button. */
-  padding-bottom: 6px;
+  padding-bottom: var(--space-1-5);
 }
 
 /* Same family as the Kanban board's lanes (schedule.css, its "one decision
@@ -460,7 +460,7 @@
   background: transparent;
   background-clip: padding-box;
   border: 2px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 /* A second arm besides `is-scrolling`, so a keyboard user tabbing through
@@ -590,7 +590,7 @@
   border: 0;
   background: transparent;
   color: var(--fg-muted);
-  font-size: 20px;
+  font-size: var(--text-display);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -663,14 +663,14 @@
 .am-hub-host:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 .am-head-actions {
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* The head now holds the MODEL half of the id only (`RepoCard.modelName`), so
@@ -681,7 +681,7 @@
    overflow the plate. */
 .am-card-name {
   min-width: 0;
-  font-size: 14px;
+  font-size: var(--text-body);
   color: inherit;
   text-decoration: none;
   white-space: normal;
@@ -696,7 +696,7 @@
 .am-card-name:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 /* -- the caption line: which repo it is, then what it costs -----------------
@@ -719,10 +719,10 @@
 .am-card-sub {
   display: flex;
   align-items: baseline;
-  gap: 7px;
+  gap: var(--space-2);
   min-width: 0;
-  margin-top: 3px;
-  font-size: 11.5px;
+  margin-top: var(--space-1);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -746,7 +746,7 @@
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  margin-left: -2px;
+  margin-left: calc(-1 * var(--space-0-5));
   color: var(--accent);
   cursor: default;
 }
@@ -754,7 +754,7 @@
 .am-card-pick:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 /* The (i), pinned to the head's right corner whatever the name's length —
@@ -790,8 +790,8 @@
  * (.btn-primary). An accent OUTLINE was never the exception; the fill was. */
 .am-card-try {
   width: auto;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 0 var(--space-2);
+  font-size: var(--text-meta);
   font-weight: 600;
   text-decoration: none;
   background: transparent;
@@ -876,8 +876,8 @@
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 4px 10px;
-  font-size: 12px;
+  gap: var(--space-1) var(--space-2-5);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   /* One line's worth, reserved. The row is rendered for every card now (the
      engine tag is a fact about all of them), and a dataset with nothing to say
@@ -890,14 +890,14 @@
    in the slot the engine tag used to occupy and wear its chrome — a small
    outlined pill, the same vocabulary as the facts that used to sit beside it. */
 .am-card-engine {
-  padding: 1px 6px;
-  font-size: 11px;
+  padding: 1px var(--space-1-5);
+  font-size: var(--text-caption);
   /* Muted, flatly: the two tags left wearing this base are a stopped download
      and a component, and both are quiet facts. The per-family hues that used to
      override it are gone with the tags that carried them. */
   color: var(--fg-muted);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   white-space: nowrap;
   /* A long label in a narrow column ellipsizes rather than pushing the card's
      other facts onto a third line. The title attribute carries the full one. */
@@ -974,17 +974,17 @@
 /* The stored weight width — the difference between a 7GB download and a 24GB
    one of the same model, so it reads as a property, not an aside. */
 .am-card-quant {
-  padding: 1px 6px;
-  font-size: 11px;
+  padding: 1px var(--space-1-5);
+  font-size: var(--text-caption);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 .am-card-library::before {
   /* A separator that belongs to the optional item, so the line has no dangling
      middot when the library is unknown. */
   content: "·";
-  margin-right: 10px;
+  margin-right: var(--space-2-5);
 }
 
 /* -- the (i) panel: everything the face gave up (2026-08-24) -----------------
@@ -1009,12 +1009,12 @@
   z-index: 60;
   min-width: 184px;
   max-width: 280px;
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--bg-popover);
   box-shadow: 0 8px 24px var(--shadow-md);
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   line-height: 1.5;
   color: var(--fg-muted);
 }
@@ -1026,7 +1026,7 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .am-info-label {
@@ -1051,8 +1051,8 @@
    control that says where it goes. */
 .am-info-more {
   display: block;
-  margin-top: 7px;
-  padding-top: 7px;
+  margin-top: var(--space-2);
+  padding-top: var(--space-2);
   border-top: 1px solid var(--border);
   color: var(--accent);
   text-decoration: none;
@@ -1091,9 +1091,9 @@
    buttons appear and disappear beside it. */
 .am-tabs {
   display: inline-flex;
-  margin-right: 4px;
+  margin-right: var(--space-1);
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -1104,9 +1104,9 @@
    text-decoration line the strip renders as five underlined links inside a
    pill, which reads as prose rather than as a control. */
 .am-tab {
-  padding: 5px 12px;
+  padding: var(--space-1-5) var(--space-3);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   background: transparent;
   border: 0;
@@ -1150,7 +1150,7 @@
 .am-hub-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   /* A section's worth of air under it, not a card's. This row CHANGES which
      view is below it, and at 8px it sat flush against the heading of the thing
      it changes — reading as part of that section rather than as the control
@@ -1175,13 +1175,13 @@
   min-width: 0;
   /* Room on the right for the ✕, always — reserving it only while the button
      is there would shift the text under the cursor on the first keystroke. */
-  padding: 7px 30px 7px 10px;
+  padding: var(--space-2) var(--space-8) var(--space-2) var(--space-2-5);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
 }
 
 /* The platform's own clear button, removed. It empties the TEXT and leaves the
@@ -1206,12 +1206,12 @@
   height: 20px;
   padding: 0;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1;
   color: var(--fg-muted);
   background: transparent;
   border: 0;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   cursor: pointer;
 }
 
@@ -1240,15 +1240,15 @@
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   height: 32px;
-  padding: 0 10px;
+  padding: 0 var(--space-2-5);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -1317,7 +1317,7 @@
    like the page is breaking. */
 .am-hub-stale {
   opacity: 0.55;
-  transition: opacity 120ms ease-out;
+  transition: opacity var(--dur-fast) ease-out;
 }
 
 /* Signing in to Hugging Face, offered where a gated result needs it (D426).
@@ -1332,7 +1332,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   margin: 0 0 var(--am-gap-head);
 }
 
@@ -1350,7 +1350,7 @@
   flex: 0 0 auto;
   color: var(--fg-muted);
   text-decoration: none;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .am-card-explore-link:hover {
@@ -1361,7 +1361,7 @@
 .am-card-explore-link:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 /* -- what a model is doing right now (SPEC §40) ------------------------------
@@ -1372,9 +1372,9 @@
 .am-card-runtime {
   display: flex;
   align-items: center;
-  gap: 7px;
-  margin-top: 8px;
-  font-size: 12px;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -1441,11 +1441,11 @@
    misalignment in the screenshot. */
 .am-card-fix {
   flex: 0 0 auto;
-  padding: 2px 7px;
+  padding: var(--space-0-5) var(--space-2);
   border: 1px solid color-mix(in srgb, var(--warning) 45%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in srgb, var(--warning) 12%, transparent);
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 500;
   line-height: 1.5;
   white-space: nowrap;
@@ -1466,14 +1466,14 @@
 .am-card-why {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--space-1-5);
   /* The one thing in this strip that gives up width. Every button beside it is
      `flex: 0 0 auto`, so the sentence absorbs the whole remainder and shrinks to
      nothing before a control does. */
   flex: 1 1 auto;
   min-width: 0;
-  margin-right: 2px;
-  font-size: 11px;
+  margin-right: var(--space-0-5);
+  font-size: var(--text-caption);
   line-height: 1.35;
   color: var(--fg-muted);
 }
@@ -1578,7 +1578,7 @@
    squeezing both. `margin-left: auto` still holds it right on a wide one. */
 .am-card-runtime {
   flex-wrap: wrap;
-  row-gap: 2px;
+  row-gap: var(--space-0-5);
 }
 
 /* -- loaded, said loudly -----------------------------------------------------
@@ -1720,13 +1720,13 @@
 
 .am-loaded-badge {
   flex: 0 0 auto;
-  padding: 2px 8px;
-  font-size: 10.5px;
+  padding: var(--space-0-5) var(--space-2);
+  font-size: var(--text-micro);
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   /* The .am-suggest-have pattern: a filled pill whose text is the PAGE background,
      which stays readable in both themes without a second token — dark text on
      the bright green above, white on the darker green below. */
@@ -1747,7 +1747,7 @@
   flex: 1 1 auto;
   min-width: 40px;
   height: 3px;
-  border-radius: 2px;
+  border-radius: var(--radius-hairline);
   background: var(--border);
   overflow: hidden;
 }
@@ -1756,7 +1756,7 @@
   display: block;
   height: 100%;
   background: var(--accent);
-  transition: width 200ms linear;
+  transition: width var(--dur-base) linear;
 }
 
 /* The measureless fill: a short stripe that travels the track. It says "moving"
@@ -1793,8 +1793,8 @@
   flex: 0 0 auto;
   width: 22px;
   height: 22px;
-  margin-right: -4px;
-  font-size: 13px;
+  margin-right: calc(-1 * var(--space-1));
+  font-size: var(--text-dense);
   line-height: 1;
 }
 
@@ -1810,13 +1810,13 @@
    opacity still dims it for a refused or busy card. */
 .am-card-power {
   flex: 0 0 auto;
-  padding: 4px 10px;
+  padding: var(--space-1) var(--space-2-5);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg);
   background: transparent;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   white-space: nowrap;
 }
@@ -1905,7 +1905,7 @@
    reason: it qualifies the heading rather than competing with it. */
 .am-discover-summary {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -1916,7 +1916,7 @@
   display: flex;
   flex: 0 1 auto;
   align-items: baseline;
-  gap: 12px;
+  gap: var(--space-3);
   min-width: 0;
 }
 
@@ -1930,7 +1930,7 @@
   flex: 0 0 auto;
   padding: 0;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg);
   background: transparent;
   border: 0;
@@ -1945,7 +1945,7 @@
 .am-hub-back:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
 
 /* Why a capability cannot run here, and which backend serves it when it can.
@@ -1954,7 +1954,7 @@
 .am-suggested-why,
 .am-suggested-runner {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -1973,17 +1973,17 @@
    was here is now the `:has` rule's job for every note on both tabs. */
 
 .am-suggest-note {
-  margin-top: 6px;
-  font-size: 12px;
+  margin-top: var(--space-1-5);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 /* The checkmark is the whole reason this list is here rather than in a doc:
    "you already have this one" is what turns a shortlist into a decision. */
 .am-suggest-have {
-  padding: 1px 7px;
-  font-size: 11px;
-  border-radius: 999px;
+  padding: 1px var(--space-2);
+  font-size: var(--text-caption);
+  border-radius: var(--radius-pill);
   color: var(--bg);
   background: var(--accent);
   white-space: nowrap;
@@ -1997,10 +1997,10 @@
    that one sat beside a Download button that would 403 and this one replaces
    that button with the link that opens the gate (`gateChrome`). */
 .am-card-gate {
-  padding: 0 6px;
-  font-size: 11px;
+  padding: 0 var(--space-1-5);
+  font-size: var(--text-caption);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--fg-muted);
   white-space: nowrap;
 }
@@ -2027,31 +2027,31 @@
 .am-usage {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: var(--space-3-5);
 }
 
 .am-usage-card {
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .am-usage-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   flex-wrap: wrap;
 }
 
 /* The window's headline figure. Tabular so the number does not jiggle its own
    caption sideways as it grows during a generation. */
 .am-usage-headline {
-  font-size: 15px;
+  font-size: var(--text-title);
   font-variant-numeric: tabular-nums;
 }
 
 .am-usage-sub {
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 /* The picker rides .am-tabs, but it is a control inside a card rather than the
@@ -2134,36 +2134,36 @@
 .am-usage-axis {
   display: flex;
   justify-content: space-between;
-  margin-top: 4px;
-  font-size: 11px;
+  margin-top: var(--space-1);
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
 }
 
 .am-usage-heading {
-  margin-top: 6px;
-  font-size: 13px;
+  margin-top: var(--space-1-5);
+  font-size: var(--text-dense);
   color: var(--fg-muted);
 }
 
 .am-usage-tiles {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .am-usage-tile {
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .am-usage-tile-value {
-  font-size: 22px;
+  font-size: var(--text-display);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 
 .am-usage-tile-label {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -2172,13 +2172,13 @@
 .am-usage-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-variant-numeric: tabular-nums;
 }
 
 .am-usage-table th,
 .am-usage-table td {
-  padding: 6px 8px;
+  padding: var(--space-1-5) var(--space-2);
   text-align: right;
   border-bottom: 1px solid var(--border);
   white-space: nowrap;
@@ -2204,12 +2204,12 @@
 }
 
 .am-usage-empty p {
-  margin: 0 0 6px;
+  margin: 0 0 var(--space-1-5);
 }
 
 .am-usage-note {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -2223,8 +2223,8 @@
 .am-usage-tierlines {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 24px;
-  font-size: 12px;
+  gap: var(--space-1-5) var(--space-6);
+  font-size: var(--text-meta);
   font-variant-numeric: tabular-nums;
 }
 
@@ -2233,7 +2233,7 @@
 }
 
 .am-usage-failtypes {
-  margin-top: -4px;
+  margin-top: calc(-1 * var(--space-1));
 }
 
 /* The $/million box on a model row. Sized to the number it holds — a full-width
@@ -2242,15 +2242,15 @@
    left to the browser: they are how a rate gets nudged. */
 .am-usage-rate {
   width: 72px;
-  padding: 2px 4px;
+  padding: var(--space-0-5) var(--space-1);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-variant-numeric: tabular-nums;
   text-align: right;
   color: var(--fg);
   background: var(--ctl-quiet-bg);
   border: 1px solid var(--ctl-quiet-border);
-  border-radius: 5px;
+  border-radius: var(--radius-control);
 }
 
 .am-usage-rate:focus-visible {
@@ -2261,7 +2261,7 @@
 /* The estimated total. A footer, not another tile: it is the sum of the column
    above it and belongs at the bottom of that column. */
 .am-usage-table tfoot td {
-  padding: 6px 8px;
+  padding: var(--space-1-5) var(--space-2);
   font-weight: 600;
   border-top: 1px solid var(--border);
 }
@@ -2276,13 +2276,13 @@
    not a status, and the id beside it already implies the answer. */
 .am-usage-tier {
   display: inline-block;
-  margin-right: 6px;
-  padding: 0 5px;
-  font-size: 10px;
+  margin-right: var(--space-1-5);
+  padding: 0 var(--space-1-5);
+  font-size: var(--text-micro);
   line-height: 16px;
   color: var(--fg-muted);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   vertical-align: 1px;
 }
 
@@ -2349,10 +2349,10 @@
    changing `.am-section` itself, which the rest of the page's own sections
    (not panels) still use. */
 .am-bench .am-section {
-  padding: 16px 20px 20px;
+  padding: var(--space-4) var(--space-5) var(--space-5);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
 }
 
 /* The border-bottom rule `.am-section-head` normally draws would sit oddly
@@ -2392,7 +2392,7 @@
 .am-bench-section-heading {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 /* The info glyph itself — icon-only, the same reset every other icon-only
@@ -2421,7 +2421,7 @@
 .am-bench-workload-info:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 /* The section head's control group — the Metric select and the Share button.
@@ -2447,7 +2447,7 @@
      select is a glyph with no text baseline at all. */
   align-items: center;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* Share (D480): the chart, this machine's hardware and the fused render mark
@@ -2465,8 +2465,8 @@
 .am-bench-metricsel {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 12px;
+  gap: var(--space-2);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -2508,7 +2508,7 @@
 
 .am-bench-compare-body {
   display: flex;
-  gap: 10px;
+  gap: var(--space-2-5);
 }
 
 /* Shared by the name column AND the empty spacer in the axis row below it —
@@ -2522,14 +2522,14 @@
 .am-bench-compare-names {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .am-bench-compare-name {
   height: 22px;
   display: flex;
   align-items: center;
-  font-size: 11px;
+  font-size: var(--text-caption);
   overflow: hidden;
   white-space: nowrap;
 }
@@ -2563,7 +2563,7 @@
 .am-bench-compare-rows {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .am-bench-compare-row {
@@ -2579,13 +2579,13 @@
 .am-bench-compare-bar {
   height: 10px;
   min-width: 2px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   background: var(--accent);
 }
 
 .am-bench-compare-value {
-  margin-left: 6px;
-  font-size: 11px;
+  margin-left: var(--space-1-5);
+  font-size: var(--text-caption);
   font-variant-numeric: tabular-nums;
   color: var(--fg-muted);
   white-space: nowrap;
@@ -2593,8 +2593,8 @@
 
 .am-bench-compare-foot {
   display: flex;
-  gap: 10px;
-  margin-top: 4px;
+  gap: var(--space-2-5);
+  margin-top: var(--space-1);
 }
 
 .am-bench-compare-axis {
@@ -2602,7 +2602,7 @@
   flex: 1 1 auto;
   min-width: 0;
   height: 14px;
-  font-size: 10px;
+  font-size: var(--text-micro);
   font-variant-numeric: tabular-nums;
   color: var(--fg-muted);
 }
@@ -2635,9 +2635,9 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   margin-top: var(--am-gap-head);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 /* The idle Run All button (D479) — see the long comment in BenchmarkTab.tsx
@@ -2653,15 +2653,15 @@
 .am-bench-runall-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 10px 5px 8px;
-  font-size: 12px;
+  gap: var(--space-1-5);
+  padding: var(--space-1-5) var(--space-2-5) var(--space-1-5) var(--space-2);
+  font-size: var(--text-meta);
   font-weight: 600;
   font-family: inherit;
   background: transparent;
   color: var(--fg);
   border: 1px solid var(--fg);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -2687,7 +2687,7 @@
 .am-bench-runall-progress {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   color: var(--fg-muted);
 }
 
@@ -2704,7 +2704,7 @@
 .am-bench-rows {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1-5);
   margin-top: var(--am-gap-head);
 }
 
@@ -2716,7 +2716,7 @@
    `.am-bench-runall` entirely, and in that case the rows keep their full
    head gap under the chart above, same as always. */
 .am-bench-runall + .am-bench-rows {
-  margin-top: 6px;
+  margin-top: var(--space-1-5);
 }
 
 /* One model, one line: who, the bar, the number, the button. Compacted from a
@@ -2749,11 +2749,11 @@
      column already flexes), so widening this one costs nothing. */
   grid-template-columns: 16px minmax(0, 30ch) minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px;
-  padding: 6px 10px;
+  gap: var(--space-3);
+  padding: var(--space-1-5) var(--space-2-5);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   /* No `cursor`/focus ring here any more — those are conditional on
      `.expandable` (below) and on the row's own focusable descendant
      respectively. This is a plain container: BenchmarkTab.tsx puts NO
@@ -2814,7 +2814,7 @@
 
 .am-bench-model {
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--text-meta);
   /* `middleEllipsis` (lib/benchmark.ts) does the truncating now, to a budget
      matching this column's width — the middle, not the tail, is what it
      elides, because two names sharing a long prefix differ at the END. This
@@ -2856,7 +2856,7 @@ button.am-bench-model:focus-visible {
    the name, since the name column is now too narrow to fit both. */
 .am-bench-gone {
   display: block;
-  font-size: 10px;
+  font-size: var(--text-micro);
   color: var(--fg-muted);
 }
 
@@ -2877,8 +2877,8 @@ button.am-bench-model:focus-visible {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 4px 10px;
-  font-size: 12px;
+  gap: var(--space-1) var(--space-2-5);
+  font-size: var(--text-meta);
 }
 
 /* No `white-space: nowrap` here (there used to be one) — below roughly
@@ -2911,7 +2911,7 @@ button.am-bench-model:focus-visible {
 .am-bench-busy {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   color: var(--fg-muted);
 }
 
@@ -2961,11 +2961,11 @@ button.am-bench-model:focus-visible {
    whose headline already gave the answer, not something that needs to shout
    once it is finally visible. */
 .am-bench-rowexpand-detail {
-  margin: 0 0 10px;
+  margin: 0 0 var(--space-2-5);
   max-width: 60ch;
   color: var(--fg-muted);
   white-space: pre-wrap;
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 /* -- icon-only buttons: the spinner glyph's motion (SPEC AI-14) --------------
@@ -2992,7 +2992,7 @@ button.am-bench-model:focus-visible {
    not the ErrorBanner for the same reason. */
 .am-bench-stopped {
   margin: 0 0 var(--am-gap-head);
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -3002,7 +3002,7 @@ button.am-bench-model:focus-visible {
 .am-bench-delta {
   flex: 0 0 auto;
   font-variant-numeric: tabular-nums;
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 .am-bench-delta.better {
@@ -3030,7 +3030,7 @@ button.am-bench-model:focus-visible {
 .am-bench-controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: var(--space-4);
   margin-bottom: var(--am-gap-head);
 }
 
@@ -3072,16 +3072,16 @@ button.am-bench-model:focus-visible {
   /* Full row width for free: this is a SIBLING of `.am-bench-row`'s grid, not
      a cell inside it, so it never has to fight that row's
      `grid-template-columns` for room the chart needs in full. */
-  padding: 10px 12px 12px;
+  padding: var(--space-2-5) var(--space-3) var(--space-3);
   /* Cancels `.am-bench-rows`' own 6px flex `gap` between this and the row
      above it — a negative margin equal to the gap is the standard way to
      opt ONE pair of flex/grid siblings out of an otherwise-uniform gap
      without touching the container itself (the gap must still separate
      every OTHER pair of rows normally). */
-  margin-top: -6px;
+  margin-top: calc(-1 * var(--space-1-5));
   border: 1px solid var(--accent);
   border-top: none;
-  border-radius: 0 0 6px 6px;
+  border-radius: 0 0 var(--radius-control) var(--radius-control);
   background: color-mix(in srgb, var(--accent) 10%, var(--bg));
 }
 
@@ -3133,17 +3133,17 @@ button.am-bench-model:focus-visible {
 .am-bench-trend-single {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: var(--space-2-5);
 }
 
 .am-bench-trend-value {
-  font-size: 20px;
+  font-size: var(--text-display);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 
 .am-bench-trend-note {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -3157,7 +3157,7 @@ button.am-bench-model:focus-visible {
   /* Tight on purpose: the tick labels are meant to read as PART of the axis
      they name, not a separate column floating beside it — a wider gap here
      is what made the y-axis numbers look detached from the plot's left edge. */
-  gap: 3px;
+  gap: var(--space-1);
 }
 
 .am-bench-yaxis {
@@ -3175,7 +3175,7 @@ button.am-bench-model:focus-visible {
      as "this line" and not "the line below me". */
   transform: translateY(-50%);
   text-align: right;
-  font-size: 10px;
+  font-size: var(--text-micro);
   font-variant-numeric: tabular-nums;
   color: var(--fg-muted);
 }
@@ -3265,7 +3265,7 @@ button.am-bench-model:focus-visible {
 .am-bench-endlabel {
   position: absolute;
   white-space: nowrap;
-  font-size: 10px;
+  font-size: var(--text-micro);
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   pointer-events: none;
@@ -3279,10 +3279,10 @@ button.am-bench-model:focus-visible {
 .am-bench-axis {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
-  margin-top: 4px;
-  padding-left: 39px; /* clears the y-axis label column (36px + 3px gap) */
-  font-size: 11px;
+  gap: var(--space-3);
+  margin-top: var(--space-1);
+  padding-left: var(--space-10); /* clears the y-axis label column (36px + 3px gap) */
+  font-size: var(--text-caption);
   font-variant-numeric: tabular-nums;
   color: var(--fg-muted);
 }
@@ -3294,9 +3294,9 @@ button.am-bench-model:focus-visible {
    things, and a fourth would either crowd the middle tick or (if excluded
    from the distribution) sit at an arbitrary offset from it. */
 .am-bench-axis-caption {
-  margin-top: 2px;
-  padding-left: 39px;
-  font-size: 10px;
+  margin-top: var(--space-0-5);
+  padding-left: var(--space-10);
+  font-size: var(--text-micro);
   color: var(--fg-muted);
 }
 
@@ -3307,20 +3307,20 @@ button.am-bench-model:focus-visible {
    what keeps "collapsed" from meaning "hidden". */
 .am-bench-history {
   margin-top: var(--am-gap-head);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .am-bench-history > summary {
   cursor: pointer;
   color: var(--fg-muted);
-  padding: 4px 0;
+  padding: var(--space-1) 0;
 }
 
 /* The table is wider than a narrow window on purpose (eight columns of facts),
    so it scrolls INSIDE this box rather than making the page scroll sideways. */
 .am-bench-tablewrap {
   overflow-x: auto;
-  margin-top: 6px;
+  margin-top: var(--space-1-5);
 }
 
 .am-bench-table {
@@ -3331,7 +3331,7 @@ button.am-bench-model:focus-visible {
 
 .am-bench-table th,
 .am-bench-table td {
-  padding: 5px 8px;
+  padding: var(--space-1-5) var(--space-2);
   text-align: left;
   border-bottom: 1px solid var(--border);
 }
@@ -3354,7 +3354,7 @@ button.am-bench-model:focus-visible {
    heading rather than a few pixels of text inside it. */
 .am-bench-sort {
   width: 100%;
-  padding: 5px 8px;
+  padding: var(--space-1-5) var(--space-2);
   border: 0;
   background: none;
   color: inherit;
@@ -3382,13 +3382,13 @@ button.am-bench-model:focus-visible {
    Marked so a reader knows why no delta is drawn across it. */
 .am-bench-rev {
   color: var(--warning-soft);
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 .am-bench-forget {
-  padding: 0 6px;
+  padding: 0 var(--space-1-5);
   border: 1px solid transparent;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--fg-muted);
   font: inherit;

--- a/frontend/src/styles/app-page.css
+++ b/frontend/src/styles/app-page.css
@@ -19,24 +19,24 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   /* Same column as .app-page-body below, so the heading lines up with the
      tab strip and the frame instead of hugging the window edge. */
   width: min(1050px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 14px 0 10px;
+  padding: var(--space-3-5) 0 var(--space-2-5);
 }
 
 .app-page-title {
   min-width: 0;
   display: flex;
   align-items: baseline;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .app-page-title h1 {
   margin: 0;
-  font-size: 18px;
+  font-size: var(--text-heading);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -47,7 +47,7 @@
 .app-page-folder {
   flex: 0 1 auto;
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   text-decoration: none;
   overflow: hidden;
@@ -71,7 +71,7 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* The gutter frame — the same width story as the playground's `StageFrame`
@@ -88,8 +88,8 @@
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 16px 0 16px;
+  gap: var(--space-3-5);
+  padding: var(--space-4) 0 var(--space-4);
 }
 /* The tab strip is shadcn's Tabs (line variant, AppPage.tsx) — the anchors
    under the triggers only need to lose the underline. NOT the colour: this
@@ -130,7 +130,7 @@
   min-height: 0;
   width: 100%;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   background: var(--bg);
 }
 
@@ -147,8 +147,8 @@
 
 .app-page-empty {
   margin: 0;
-  padding: 24px 0;
-  font-size: 13px;
+  padding: var(--space-6) 0;
+  font-size: var(--text-dense);
   color: var(--fg-muted);
 }
 
@@ -166,7 +166,7 @@
   min-height: 0;
   display: flex;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   overflow: hidden;
   background: var(--bg);
 }
@@ -187,16 +187,16 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
   border-bottom: 1px solid var(--border);
 }
 
 .app-files-tree-head {
-  padding: 0 12px 0 14px;
+  padding: 0 var(--space-3) 0 var(--space-3-5);
 }
 
 .app-files-eyebrow {
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -207,8 +207,8 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
-  padding: 6px;
-  font-size: 13px;
+  padding: var(--space-1-5);
+  font-size: var(--text-dense);
 }
 
 .app-files-tree ul {
@@ -220,8 +220,8 @@
 /* The indent guide: each nested branch is one rule, 7px in from its parent's
    twist — depth reads as lines, not as a growing left margin. */
 .app-files-tree ul.app-files-branch {
-  margin-left: 15px;
-  padding-left: 6px;
+  margin-left: var(--space-4);
+  padding-left: var(--space-1-5);
   border-left: 1px solid var(--border);
 }
 
@@ -229,13 +229,13 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   width: 100%;
   min-width: 0;
   height: 28px;
-  padding: 0 8px 0 4px;
+  padding: 0 var(--space-2) 0 var(--space-1);
   border: 0;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   color: var(--fg);
   font: inherit;
@@ -285,7 +285,7 @@
 .app-files-twist svg {
   width: 14px;
   height: 14px;
-  transition: transform 120ms ease;
+  transition: transform var(--dur-fast) ease;
 }
 
 .app-files-twist svg.is-open {
@@ -323,7 +323,7 @@
    selected so the column stays a list of names first. */
 .app-files-meta {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-variant-numeric: tabular-nums;
   color: var(--fg-muted);
 }
@@ -339,8 +339,8 @@
 }
 
 .app-files-caption {
-  margin: 10px 8px 4px;
-  font-size: 12px;
+  margin: var(--space-2-5) var(--space-2) var(--space-1);
+  font-size: var(--text-meta);
   line-height: 1.5;
   color: var(--fg-muted);
 }
@@ -358,20 +358,20 @@
 }
 
 .app-files-head {
-  padding: 0 10px 0 16px;
+  padding: 0 var(--space-2-5) 0 var(--space-4);
 }
 
 .app-files-title {
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .app-files-title h2 {
   margin: 0;
   min-width: 0;
-  font-size: 13px;
+  font-size: var(--text-dense);
   font-weight: 500;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   overflow: hidden;
@@ -386,7 +386,7 @@
 }
 
 .app-files-slash {
-  margin: 0 3px;
+  margin: 0 var(--space-1);
   opacity: 0.6;
 }
 
@@ -395,7 +395,7 @@
    trick the page strip uses with its own border-b. */
 .app-files-modes {
   align-self: flex-end;
-  padding-bottom: 5px;
+  padding-bottom: var(--space-1-5);
 }
 
 .app-files-mode-icon {
@@ -409,7 +409,7 @@
 .app-files-mode-icon svg {
   width: 14px;
   height: 14px;
-  font-size: 10px;
+  font-size: var(--text-micro);
 }
 
 .app-files-stage {
@@ -421,7 +421,7 @@
 
 .app-files-stage > .skeleton-lines,
 .app-files-stage > .error-banner {
-  margin: 16px;
+  margin: var(--space-4);
 }
 
 .app-files-frame {
@@ -439,9 +439,9 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 24px;
-  font-size: 13px;
+  gap: var(--space-2-5);
+  padding: var(--space-6);
+  font-size: var(--text-dense);
   color: var(--fg-muted);
 }
 

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -11,7 +11,7 @@
 .apps-inner {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 36px 28px 72px;
+  padding: var(--space-10) var(--space-7) var(--space-18);
 }
 
 /* Facet selector at the left edge (its own `margin-right: auto`), then the
@@ -26,8 +26,8 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
-  gap: 10px;
-  margin-bottom: 14px;
+  gap: var(--space-2-5);
+  margin-bottom: var(--space-3-5);
 }
 
 /* Search is the last item in the toolbar's right-aligned group (see
@@ -39,14 +39,14 @@
 .apps-search {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 0 1 240px;
   max-width: 340px;
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   height: 34px;
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   color: var(--fg-muted);
 }
 
@@ -58,7 +58,7 @@
   flex: 1;
   min-width: 0;
   height: 100%;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   background: none;
   border: none;
@@ -76,17 +76,17 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .apps-tag-chip {
-  padding: 5px 12px;
-  font-size: 12px;
+  padding: var(--space-1-5) var(--space-3);
+  font-size: var(--text-meta);
   font-family: ui-monospace, Menlo, Consolas, monospace;
   color: var(--fg-muted);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
 }
 
@@ -118,8 +118,8 @@
 }
 
 .apps-count {
-  margin-bottom: 12px;
-  font-size: 12px;
+  margin-bottom: var(--space-3);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -127,14 +127,14 @@
    page's error banner: the local apps in the grid below loaded fine, so this
    states what is missing without claiming the page failed. */
 .apps-showcase-note {
-  margin-bottom: 12px;
-  padding: 8px 10px;
-  font-size: 12px;
+  margin-bottom: var(--space-3);
+  padding: var(--space-2) var(--space-2-5);
+  font-size: var(--text-meta);
   line-height: 1.5;
   color: var(--fg-muted);
   background: color-mix(in srgb, var(--fg) 4%, var(--bg));
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 /* Filter facet selector (Category | Folders): a small segmented control that
@@ -148,19 +148,19 @@
 .apps-filter-mode {
   display: inline-flex;
   margin-right: auto;
-  padding: 2px;
+  padding: var(--space-0-5);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 .apps-filter-mode-btn {
-  padding: 4px 12px;
-  font-size: 12.5px;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-dense);
   color: var(--fg-muted);
   background: none;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -182,7 +182,7 @@
 .apps-cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 18px;
+  gap: var(--space-5);
 }
 
 /* An <a>, not a button: middle-click / Cmd-click / "Open in new tab" have to
@@ -201,13 +201,13 @@
   text-decoration: none;
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-panel);
   overflow: hidden;
   cursor: pointer;
   transition:
-    border-color 0.12s ease,
-    box-shadow 0.12s ease,
-    transform 0.12s ease;
+    border-color var(--dur-fast) ease,
+    box-shadow var(--dur-fast) ease,
+    transform var(--dur-fast) ease;
 }
 
 .app-pcard:hover {
@@ -301,12 +301,12 @@
   height: 26px;
   padding: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg-alt);
   color: var(--fg-muted);
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.12s ease;
+  transition: opacity var(--dur-fast) ease;
 }
 .app-pcard:hover .app-pcard-export,
 .app-pcard-export:focus-visible {
@@ -327,13 +327,13 @@ body[data-capture-shooting] .app-pcard-export {
 .app-pcard-body {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 11px 14px 12px;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-3-5) var(--space-3);
   min-width: 0;
 }
 
 .app-pcard-title {
-  font-size: 13.5px;
+  font-size: var(--text-body);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -343,19 +343,19 @@ body[data-capture-shooting] .app-pcard-export {
 .app-pcard-meta {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .app-pcard-tag {
   flex: 0 0 auto;
-  padding: 1px 8px;
+  padding: 1px var(--space-2);
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 .app-pcard-name {

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -9,12 +9,8 @@
    theme contract (tests/test_theme.py) requires every token in the dark
    palette to have a light counterpart, and a duration has no light value.
    prefers-reduced-motion (bottom of this file) collapses all of them. */
-:root {
-  --dur-fast: 80ms;
-  --dur-med: 150ms;
-  --dur-slow: 200ms;
-  --ease-out: ease-out;
-}
+/* Motion tokens live in styles/scale.css (--dur-instant/fast/base/glide,
+   --ease-out/--ease-glide, plus --dur-med/--dur-slow aliases for older rules). */
 
 /* ---- Shared hover/press easing ------------------------------------------- */
 /* One rule for every interactive surface in the shell, grouped here rather than

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -78,10 +78,10 @@ html, body {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--font-sans);
   color: var(--fg);
   background: var(--bg);
-  font-size: 14px;
+  font-size: var(--text-body);
 }
 
 #app {
@@ -132,14 +132,14 @@ iframe {
   top: 0;
   z-index: 9000;
   max-width: min(46ch, 80vw);
-  padding: 4px 8px;
-  font-size: 11.5px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-meta);
   line-height: 1.35;
   font-weight: 500;
   color: var(--fg);
   background: var(--bg-popover);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   box-shadow: 0 4px 14px var(--shadow-sm);
   pointer-events: none;
   /* Hidden by DISPLAY rather than opacity: an invisible panel that still has a

--- a/frontend/src/styles/buttons-modal.css
+++ b/frontend/src/styles/buttons-modal.css
@@ -8,15 +8,15 @@
 .deploy-body .btn,
 .prefs-section .btn {
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   height: 32px;
-  padding: 0 14px;
+  padding: 0 var(--space-3-5);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
+  gap: var(--space-2);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg);
   color: var(--fg);
   cursor: pointer;
@@ -113,16 +113,16 @@
 .modal-footer {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   justify-content: flex-end;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   border-top: 1px solid var(--border);
 }
 
 .modal-dirty-hint {
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   margin-right: auto;
 }
 
@@ -139,6 +139,6 @@
 .deploy-close.is-armed:hover:not(:disabled) {
   background: rgba(var(--warning-rgb), 0.16);
   color: var(--warning);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 

--- a/frontend/src/styles/canvases.css
+++ b/frontend/src/styles/canvases.css
@@ -14,34 +14,34 @@
 .canvases-inner {
   max-width: 1180px;
   margin: 0 auto;
-  padding: 32px 28px 64px;
+  padding: var(--space-8) var(--space-7) var(--space-16);
 }
 
 .canvases-head {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 8px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
 }
 
 .canvases-title {
   margin: 0;
-  font-size: 22px;
+  font-size: var(--text-display);
   font-weight: 600;
   letter-spacing: -0.02em;
 }
 
 .canvases-sub {
-  margin: 0 0 20px;
+  margin: 0 0 var(--space-5);
   color: var(--fg-muted);
-  font-size: 13px;
+  font-size: var(--text-dense);
 }
 
 .canvases-head-actions {
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .canvases-search {
@@ -52,9 +52,9 @@
 .canvases-account {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 /* Card grid ---------------------------------------------------------------- */
@@ -66,13 +66,13 @@
 .canvases-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 34px 24px;
+  gap: var(--space-8) var(--space-6);
 }
 
 .canvas-card {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2-5);
   text-align: left;
   padding: 0;
   background: none;
@@ -100,8 +100,8 @@
   overflow: hidden;
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  transition: border-color 120ms ease;
+  border-radius: var(--radius-control);
+  transition: border-color var(--dur-fast) ease;
 }
 
 /* The border+name shift is the whole hover affordance now that the card has no
@@ -117,7 +117,7 @@
 .canvas-card:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
 }
 
 /* Server-provided preview image filling the frame. */
@@ -136,7 +136,7 @@
   position: absolute;
   inset: 0;
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   align-items: stretch;
   justify-items: stretch;
 }
@@ -147,39 +147,39 @@
   min-width: 0;
   min-height: 0;
   object-fit: cover;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 /* Only a canvas with zero UDFs lands here — there is nothing to tile. */
 .canvas-card-noshot {
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg-muted);
 }
 
 .canvas-card-body {
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: var(--space-2);
 }
 
 .canvas-card-name {
-  font-size: 20px;
+  font-size: var(--text-display);
   font-weight: 400;
   letter-spacing: -0.01em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  transition: color 120ms ease;
+  transition: color var(--dur-fast) ease;
 }
 
 /* UDF count (or the clone hint) — the louder of the two stat lines. */
 .canvas-card-stat {
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
 }
 
 .canvas-card-meta {
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg-muted);
 }
 
@@ -187,10 +187,10 @@
 .canvases-new-form {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .canvases-empty {
   color: var(--fg-muted);
-  padding: 32px 0;
+  padding: var(--space-8) 0;
 }

--- a/frontend/src/styles/chat-frame.css
+++ b/frontend/src/styles/chat-frame.css
@@ -47,7 +47,7 @@
      document nobody could see, and a pane could be focused before it was
      shown (Bugbot, #1024). */
   pointer-events: none;
-  transition: opacity 160ms ease;
+  transition: opacity var(--dur-base) ease;
 }
 
 .chat-frame-iframe.is-ready {
@@ -69,7 +69,7 @@
   z-index: 1;
   overflow: hidden;
   background: var(--bg);
-  transition: opacity 160ms ease;
+  transition: opacity var(--dur-base) ease;
 }
 
 /* Fading out over a frame that is now live: step aside so the first click
@@ -85,11 +85,11 @@
 .chat-frame-skel {
   max-width: 720px;
   margin: 0 auto;
-  padding: 24px 20px 12px;
+  padding: var(--space-6) var(--space-5) var(--space-3);
 }
 
 .chat-frame-skel-turn {
-  margin: 0 0 20px;
+  margin: 0 0 var(--space-5);
 }
 
 /* The user turn: one pill, hard right, at the template's `.skel-turn-user`
@@ -102,13 +102,13 @@
 .chat-frame-skel-user .skel-bar {
   width: 34%;
   height: 34px;
-  border-radius: 16px;
+  border-radius: var(--radius-tile);
 }
 
 /* The assistant turn: the avatar disc and three ragged lines. */
 .chat-frame-skel-assistant {
   display: flex;
-  gap: 10px;
+  gap: var(--space-2-5);
 }
 
 .chat-frame-skel-dot {
@@ -124,15 +124,15 @@
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding-top: 4px;
+  gap: var(--space-2);
+  padding-top: var(--space-1);
 }
 
 /* The template's line metrics, not the listing's (`.skel-bar` is 10px/3px for a
    table row) — these stand in for prose. */
 .chat-frame-skel-lines .skel-bar {
   height: 11px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 /* Reduced motion: the reveal is a state change, not a movement. reduced-motion.css

--- a/frontend/src/styles/claude-config.css
+++ b/frontend/src/styles/claude-config.css
@@ -66,7 +66,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   background: var(--bg);
-  font-size: 13px;
+  font-size: var(--text-dense);
 }
 
 /* No longer its own bounded, clipped box: .cc-root is the scroll container
@@ -102,10 +102,10 @@
   align-items: center;
   justify-content: space-between;
   flex: 0 0 auto;
-  gap: 12px;
+  gap: var(--space-3);
   height: 49px;
   box-sizing: border-box;
-  padding: 0 14px 0 16px;
+  padding: 0 var(--space-3-5) 0 var(--space-4);
   background: var(--bg-alt);
   border-bottom: 1px solid var(--border);
 }
@@ -115,7 +115,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: var(--text-title);
   font-weight: 600;
 }
 
@@ -128,18 +128,18 @@
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-weight: 500;
   white-space: nowrap;
-  padding: 5px 10px;
+  padding: var(--space-1-5) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   background: none;
   color: var(--fg-muted);
   cursor: pointer;
-  transition: border-color 120ms var(--ease-out), color 120ms var(--ease-out);
+  transition: border-color var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out);
 }
 
 .cc-gitchip:hover {
@@ -206,8 +206,8 @@
   display: flex;
   align-items: center;
   min-width: 0;
-  gap: 4px;
-  padding: 0 16px;
+  gap: var(--space-1);
+  padding: 0 var(--space-4);
   overflow-x: auto;
   scrollbar-width: none;
   -webkit-mask-image: linear-gradient(to right, black calc(100% - 28px), transparent 100%);
@@ -232,12 +232,12 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   flex: 0 0 auto;
   font: inherit;
-  font-size: 12.5px;
+  font-size: var(--text-dense);
   white-space: nowrap;
-  padding: 9px 10px 8px;
+  padding: var(--space-2-5) var(--space-2-5) var(--space-2);
   border: none;
   border-bottom: 2px solid transparent;
   background: none;
@@ -260,7 +260,7 @@
 .cc-tab:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 /* -- content column -------------------------------------------------------- */
@@ -303,20 +303,20 @@
   min-width: 0;
   box-sizing: border-box;
   overflow-x: clip;
-  padding: 24px 28px 40px;
+  padding: var(--space-6) var(--space-7) var(--space-10);
 }
 
 .cc-heading {
-  margin: 0 0 2px;
-  font-size: 20px;
+  margin: 0 0 var(--space-0-5);
+  font-size: var(--text-display);
   font-weight: 600;
 }
 
 /* The file (or git object) the section actually edits — the one thing a settings
    UI over someone's dotfiles owes them. */
 .cc-caption {
-  margin-bottom: 22px;
-  font-size: 12px;
+  margin-bottom: var(--space-6);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   overflow-wrap: anywhere;
 }
@@ -329,8 +329,8 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 22px;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
 }
 
 .cc-caption-row .cc-caption {
@@ -353,7 +353,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 /* Sticky, so a long list scrolls under the one row that names it, filters it
@@ -378,10 +378,10 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  row-gap: 8px;
-  column-gap: 10px;
-  margin: 0 0 18px;
-  padding: 10px 0;
+  row-gap: var(--space-2);
+  column-gap: var(--space-2-5);
+  margin: 0 0 var(--space-5);
+  padding: var(--space-2-5) 0;
   background: var(--bg);
 }
 
@@ -396,7 +396,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -411,7 +411,7 @@
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   max-width: 100%;
   margin-left: auto;
   overflow-x: auto;
@@ -455,12 +455,12 @@
 }
 
 .cc-group {
-  margin-bottom: 26px;
+  margin-bottom: var(--space-7);
 }
 
 .cc-group-title {
-  margin: 0 0 10px;
-  font-size: 11px;
+  margin: 0 0 var(--space-2-5);
+  font-size: var(--text-caption);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -473,30 +473,30 @@
    folder-level actions (Reveal, Clear) on the right, then a .cc-list card of
    its files underneath. */
 .cc-memgroup {
-  margin-bottom: 22px;
+  margin-bottom: var(--space-6);
 }
 
 .cc-memgroup-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 8px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
 }
 
 .cc-memgroup-title {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: var(--space-2-5);
   min-width: 0;
-  font-size: 12.5px;
+  font-size: var(--text-dense);
   font-weight: 500;
   overflow-wrap: anywhere;
 }
 
 .cc-memgroup-count {
   flex: 0 0 auto;
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   font-weight: 400;
   color: var(--fg-muted);
 }
@@ -505,7 +505,7 @@
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 /* Clear used to be a red outlined .btn, always visible, repeated on every one
@@ -524,7 +524,7 @@
 }
 
 .cc-empty {
-  padding: 30px 0;
+  padding: var(--space-8) 0;
   text-align: center;
   color: var(--fg-muted);
 }
@@ -533,7 +533,7 @@
 .cc-empty-action {
   display: flex;
   justify-content: center;
-  margin-top: 12px;
+  margin-top: var(--space-3);
 }
 
 .cc-mono {
@@ -545,8 +545,8 @@
 .cc-row {
   display: flex;
   align-items: flex-start;
-  gap: 14px;
-  padding: 10px 0;
+  gap: var(--space-3-5);
+  padding: var(--space-2-5) 0;
   border-bottom: 1px solid var(--border);
 }
 
@@ -574,7 +574,7 @@
 .cc-row-meta {
   flex: 1 1 auto;
   min-width: 0;
-  padding-top: 3px;
+  padding-top: var(--space-1);
 }
 
 .cc-row-label {
@@ -582,8 +582,8 @@
 }
 
 .cc-row-doc {
-  margin-top: 2px;
-  font-size: 12px;
+  margin-top: var(--space-0-5);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -624,7 +624,7 @@
   display: grid;
   grid-template-columns: 22px minmax(0, 1fr);
   align-items: center;
-  column-gap: 6px;
+  column-gap: var(--space-1-5);
 }
 
 .cc-row-control select.field-control,
@@ -648,7 +648,7 @@
    "Select all", an empty CLAUDE.md's placeholder) — just not in the
    Preferences control column any more (see .cc-row-hint below). */
 .cc-unset {
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-style: italic;
   color: var(--fg-muted);
   overflow: hidden;
@@ -702,7 +702,7 @@
   .cc-row {
     flex-direction: column;
     align-items: stretch;
-    gap: 6px;
+    gap: var(--space-1-5);
   }
 
   .cc-row-meta {
@@ -725,11 +725,11 @@
    History page's "Uncommitted changes" statement. */
 
 .cc-card {
-  padding: 14px 16px;
-  margin-bottom: 10px;
+  padding: var(--space-3-5) var(--space-4);
+  margin-bottom: var(--space-2-5);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 .cc-card-title {
@@ -738,8 +738,8 @@
 }
 
 .cc-card-sub {
-  margin-top: 3px;
-  font-size: 12px;
+  margin-top: var(--space-1);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   overflow-wrap: anywhere;
 }
@@ -748,8 +748,8 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  margin-top: 12px;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
 }
 
 /* -- segmented switch (Plugins: Installed / Discover) ---------------------- */
@@ -761,14 +761,14 @@
   display: inline-flex;
   flex: 0 0 auto;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .cc-seg-btn {
-  padding: 5px 12px;
+  padding: var(--space-1-5) var(--space-3);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   background: transparent;
   border: 0;
@@ -804,7 +804,7 @@
 .cc-split {
   display: flex;
   align-items: flex-start;
-  gap: 20px;
+  gap: var(--space-5);
   width: 100%;
 }
 
@@ -835,8 +835,8 @@
    left, number right) and made a label look like a control. See the comment at
    its call site for why the count went rather than the shape. */
 .cc-index-header {
-  padding: 0 8px 6px;
-  font-size: 11px;
+  padding: 0 var(--space-2) var(--space-1-5);
+  font-size: var(--text-caption);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -852,8 +852,8 @@
 .cc-index-item {
   display: flex;
   align-items: center;
-  gap: 2px;
-  border-radius: 6px;
+  gap: var(--space-0-5);
+  border-radius: var(--radius-control);
   color: var(--fg-muted);
 }
 
@@ -871,15 +871,15 @@
 .cc-index-filter {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 1 1 auto;
   min-width: 0;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   text-align: left;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   color: inherit;
   cursor: pointer;
@@ -895,8 +895,8 @@
    now identical to theirs (both render through the same .cc-index-item +
    .cc-index-filter shape). */
 .cc-index-item.cc-index-all {
-  margin-bottom: 4px;
-  padding-bottom: 4px;
+  margin-bottom: var(--space-1);
+  padding-bottom: var(--space-1);
   border-bottom: 1px solid var(--border);
 }
 
@@ -912,14 +912,14 @@
 .cc-index-add {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-top: 10px;
-  padding: 5px 8px;
+  gap: var(--space-1-5);
+  margin-top: var(--space-2-5);
+  padding: var(--space-1-5) var(--space-2);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   text-align: left;
   color: var(--fg-muted);
   cursor: pointer;
@@ -993,8 +993,8 @@
 .cc-pager {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding-top: 14px;
+  gap: var(--space-2);
+  padding-top: var(--space-3-5);
 }
 
 .cc-pager > :first-child {
@@ -1022,21 +1022,21 @@
 .cc-list {
   width: 100%;
   box-sizing: border-box;
-  margin-bottom: 10px;
+  margin-bottom: var(--space-2-5);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .cc-list .cc-lrow-line {
-  padding-left: 14px;
-  padding-right: 14px;
+  padding-left: var(--space-3-5);
+  padding-right: var(--space-3-5);
 }
 
 .cc-list .cc-lrow-details {
-  padding-left: 34px;
-  padding-right: 14px;
+  padding-left: var(--space-8);
+  padding-right: var(--space-3-5);
 }
 
 .cc-list .cc-lrow:last-child {
@@ -1050,8 +1050,8 @@
 .cc-lrow-line {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 7px 0;
+  gap: var(--space-2-5);
+  padding: var(--space-2) 0;
   white-space: nowrap;
 }
 
@@ -1072,7 +1072,7 @@
 .cc-lrow-body {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   flex: 1 1 auto;
   min-width: 0;
   font: inherit;
@@ -1091,7 +1091,7 @@
 .cc-lrow-body:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 .cc-lrow-name {
@@ -1104,7 +1104,7 @@
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -1154,7 +1154,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 3px;
+  gap: var(--space-1);
   max-width: 100%;
 }
 
@@ -1171,7 +1171,7 @@
 
 .cc-lrow-meta {
   flex: 0 0 auto;
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -1179,7 +1179,7 @@
   display: flex;
   flex: 0 0 auto;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
   margin-left: auto;
 }
 
@@ -1197,7 +1197,7 @@
 .cc-lrow-inline-actions {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 /* A column, not a label: versions run from "v1.0.0" to a 12-char commit sha,
@@ -1215,8 +1215,8 @@
 /* The expanded panel: prose, so it wraps and drops the row's nowrap. Indented
    to the row's text column and quiet — it is the same item, not a new one. */
 .cc-lrow-details {
-  padding: 2px 0 12px 10px;
-  font-size: 12px;
+  padding: var(--space-0-5) 0 var(--space-3) var(--space-2-5);
+  font-size: var(--text-meta);
   line-height: 1.55;
   white-space: normal;
   color: var(--fg-muted);
@@ -1232,8 +1232,8 @@
 .cc-lrow-dl {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: 2px 10px;
-  margin-top: 6px;
+  gap: var(--space-0-5) var(--space-2-5);
+  margin-top: var(--space-1-5);
 }
 
 .cc-lrow-dt {
@@ -1264,8 +1264,8 @@
 .cc-modal-field {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: var(--space-2-5);
+  margin-bottom: var(--space-2-5);
 }
 
 .cc-modal-field:last-child {
@@ -1274,7 +1274,7 @@
 
 .cc-modal-field > label {
   flex: 0 0 100px;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -1312,8 +1312,8 @@
   display: grid;
   grid-template-columns: fit-content(16rem) 1fr;
   align-content: start;
-  margin-top: 4px;
-  padding-left: 12px;
+  margin-top: var(--space-1);
+  padding-left: var(--space-3);
   border-left: 1px solid var(--border);
 }
 
@@ -1339,11 +1339,11 @@
    the last line of the paragraph. */
 .cc-lrow-details .cc-pblurb {
   max-width: 68ch;
-  margin: 0 0 14px;
+  margin: 0 0 var(--space-3-5);
 }
 
 .cc-pgroup + .cc-pgroup {
-  margin-top: 14px;
+  margin-top: var(--space-3-5);
 }
 
 /* The app's established eyebrow (.cc-index-header's size, weight, tracking and
@@ -1351,9 +1351,9 @@
 .cc-pgroup-title {
   display: flex;
   align-items: baseline;
-  gap: 6px;
-  margin: 0 0 3px;
-  font-size: 11px;
+  gap: var(--space-1-5);
+  margin: 0 0 var(--space-1);
+  font-size: var(--text-caption);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -1370,10 +1370,10 @@
 }
 
 .cc-pitem {
-  gap: 12px;
-  padding: 2px 6px;
-  margin-left: -6px;
-  border-radius: 4px;
+  gap: var(--space-3);
+  padding: var(--space-0-5) var(--space-1-5);
+  margin-left: calc(-1 * var(--space-1-5));
+  border-radius: var(--radius-xs);
   color: inherit;
   text-decoration: none;
   white-space: nowrap;
@@ -1405,9 +1405,9 @@
 .cc-pfiles {
   display: flex;
   align-items: baseline;
-  gap: 10px;
-  margin-top: 14px;
-  padding-top: 8px;
+  gap: var(--space-2-5);
+  margin-top: var(--space-3-5);
+  padding-top: var(--space-2);
   border-top: 1px solid var(--border);
   color: var(--fg-muted);
   text-decoration: none;
@@ -1416,7 +1416,7 @@
 
 .cc-pfiles-label {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -1446,8 +1446,8 @@
    opens the panel) — same specificity, so the more specific selector here
    rather than !important is what wins it back. */
 .cc-lrow-details .cc-ptruncated {
-  margin: 10px 0 0;
-  font-size: 12px;
+  margin: var(--space-2-5) 0 0;
+  font-size: var(--text-meta);
   font-style: italic;
   color: var(--fg-muted);
 }
@@ -1472,24 +1472,24 @@
 .cc-mdgrid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .cc-mdcard {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
-  padding: 16px 18px;
+  padding: var(--space-4) var(--space-5);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 .cc-mdcard-head {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   min-width: 0;
 }
 
@@ -1504,19 +1504,19 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: auto;
 }
 
 .cc-mdcard-meta {
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   white-space: nowrap;
 }
 
 .cc-mdcard-actions {
   display: flex;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 /* Icon-only quiet action button; the label lives in title/aria-label. */
@@ -1528,7 +1528,7 @@
   height: 26px;
   padding: 0;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   color: var(--fg-muted);
   cursor: pointer;
@@ -1566,13 +1566,13 @@
 }
 
 .cc-count {
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 400;
   color: var(--fg-muted);
 }
 
 .cc-change {
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--warning);
 }
 
@@ -1581,11 +1581,11 @@
 .cc-pill {
   display: inline-block;
   vertical-align: middle;
-  padding: 2px 7px;
-  font-size: 10px;
+  padding: var(--space-0-5) var(--space-2);
+  font-size: var(--text-micro);
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: var(--border);
   color: var(--fg-muted);
 }
@@ -1641,7 +1641,7 @@
   position: absolute;
   inset: 0;
   background: var(--border);
-  border-radius: 22px;
+  border-radius: var(--radius-pill);
   transition: background var(--dur-med) var(--ease-out);
   cursor: pointer;
 }
@@ -1711,12 +1711,12 @@
 /* -- preformatted output (statusline preview, file view/edit) --------------- */
 
 .cc-pre {
-  margin: 12px 0 0;
-  padding: 10px 12px;
-  font-size: 12px;
+  margin: var(--space-3) 0 0;
+  padding: var(--space-2-5) var(--space-3);
+  font-size: var(--text-meta);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   white-space: pre-wrap;
   word-break: break-word;
   overflow-x: auto;
@@ -1726,8 +1726,8 @@
    roomier padding and no top margin, since it is the first thing on the page. */
 .cc-statusline {
   margin-top: 0;
-  padding: 14px 16px;
-  font-size: 13px;
+  padding: var(--space-3-5) var(--space-4);
+  font-size: var(--text-dense);
 }
 
 /* -- definition list (statusline metadata) --------------------------------- */
@@ -1737,9 +1737,9 @@
 .cc-dl {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: 8px 16px;
-  margin: 20px 0 0;
-  font-size: 12.5px;
+  gap: var(--space-2) var(--space-4);
+  margin: var(--space-5) 0 0;
+  font-size: var(--text-dense);
 }
 
 .cc-dl-key {
@@ -1755,13 +1755,13 @@
 
 .cc-note {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--text-dense);
   line-height: 1.5;
 }
 
 .cc-delta-head {
-  margin: 14px 0 6px;
-  font-size: 12px;
+  margin: var(--space-3-5) 0 var(--space-1-5);
+  font-size: var(--text-meta);
   font-weight: 600;
   color: var(--fg-muted);
 }
@@ -1771,8 +1771,8 @@
 }
 
 .cc-delta {
-  padding: 6px 0;
-  font-size: 13px;
+  padding: var(--space-1-5) 0;
+  font-size: var(--text-dense);
   border-bottom: 1px solid var(--border);
   overflow-wrap: anywhere;
 }
@@ -1782,7 +1782,7 @@
 }
 
 .cc-delta-fromto {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -1814,20 +1814,20 @@
 .cc-pick {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 0;
-  font-size: 13px;
+  gap: var(--space-2);
+  padding: var(--space-1-5) 0;
+  font-size: var(--text-dense);
   border-bottom: 1px solid var(--border);
   cursor: pointer;
   overflow-wrap: anywhere;
 }
 
 .cc-pick-all {
-  margin-top: 12px;
+  margin-top: var(--space-3);
 }
 
 .cc-pick-group {
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 .cc-pick-grouplabel {
@@ -1836,7 +1836,7 @@
 
 /* Children sit under their group's checkbox. */
 .cc-pick-file {
-  padding-left: 24px;
+  padding-left: var(--space-6);
 }
 
 /* -- ANSI (statusline preview) --------------------------------------------- */
@@ -1949,7 +1949,7 @@
   .cc-skills-list .cc-lrow-body {
     flex-direction: column;
     align-items: stretch;
-    gap: 4px;
+    gap: var(--space-1);
   }
 
   .cc-skills-list .cc-lrow-name {

--- a/frontend/src/styles/context-menu.css
+++ b/frontend/src/styles/context-menu.css
@@ -11,10 +11,10 @@
      it's mounted under (e.g. the right-aligned .row-actions-cell). */
   text-align: left;
   min-width: 220px;
-  padding: 5px;
+  padding: var(--space-1-5);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 8px 28px var(--shadow-lg);
   user-select: none;
 }
@@ -29,7 +29,7 @@
 /* Grows out of whichever corner sits under the cursor; ContextMenu sets
    transform-origin inline from the clamp result. */
 .context-menu.placed {
-  animation: context-menu-in 110ms var(--ease-out);
+  animation: context-menu-in var(--dur-fast) var(--ease-out);
 }
 
 @keyframes context-menu-in {
@@ -47,11 +47,11 @@
 .context-menu-item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   min-height: 28px;
-  padding: 4px 10px;
-  border-radius: 6px;
-  font-size: 13px;
+  padding: var(--space-1) var(--space-2-5);
+  border-radius: var(--radius-control);
+  font-size: var(--text-dense);
   color: var(--fg);
   cursor: pointer;
   white-space: nowrap;
@@ -126,10 +126,10 @@ a.context-menu-item {
 }
 
 .context-menu-arrow {
-  font-size: 14px;
+  font-size: var(--text-body);
   line-height: 1;
   color: var(--fg-muted);
-  margin-left: 12px;
+  margin-left: var(--space-3);
 }
 
 .context-menu-item.open .context-menu-arrow {
@@ -138,7 +138,7 @@ a.context-menu-item {
 
 .context-menu-sep {
   height: 1px;
-  margin: 5px 10px;
+  margin: var(--space-1-5) var(--space-2-5);
   background: var(--border);
 }
 
@@ -149,7 +149,7 @@ a.context-menu-item {
   position: absolute;
   top: -5px;
   left: 100%;
-  margin-left: 2px;
+  margin-left: var(--space-0-5);
   /* Grows out of the parent row's edge, i.e. the side it's attached to. */
   transform-origin: left top;
 }
@@ -158,7 +158,7 @@ a.context-menu-item {
   left: auto;
   right: 100%;
   margin-left: 0;
-  margin-right: 2px;
+  margin-right: var(--space-0-5);
   transform-origin: right top;
 }
 

--- a/frontend/src/styles/deploy.css
+++ b/frontend/src/styles/deploy.css
@@ -10,7 +10,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 8vh 16px 16px;
+  padding: 8vh var(--space-4) var(--space-4);
   z-index: 1000;
 }
 
@@ -64,7 +64,7 @@
 .deploy-dialog {
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   width: min(600px, 100%);
   max-height: 85vh;
   display: flex;
@@ -76,14 +76,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 12px 16px;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border);
 }
 
 .deploy-head h2 {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--text-title);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -94,9 +94,9 @@
   background: none;
   border: none;
   color: var(--fg-muted);
-  font-size: 14px;
+  font-size: var(--text-body);
   cursor: pointer;
-  padding: 4px 6px;
+  padding: var(--space-1) var(--space-1-5);
 }
 
 .deploy-close:hover {
@@ -112,27 +112,27 @@
 .modal-head-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   flex: none;
   margin-left: auto;
-  margin-right: 4px;
+  margin-right: var(--space-1);
 }
 
 .modal-head-actions > .btn.modal-head-act {
   height: 28px;
-  padding: 0 10px;
-  font-size: 12px;
-  gap: 6px;
+  padding: 0 var(--space-2-5);
+  font-size: var(--text-meta);
+  gap: var(--space-1-5);
   text-decoration: none;
 }
 
 .deploy-body {
-  padding: 14px 16px 16px;
+  padding: var(--space-3-5) var(--space-4) var(--space-4);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  font-size: 13px;
+  gap: var(--space-3);
+  font-size: var(--text-dense);
 }
 
 /* The chassis body WITHOUT the form vocabulary (Modal `plainBody`, D489): the
@@ -140,7 +140,7 @@
    descendant skins above and in fields.css, for a component hosted verbatim
    from a page that arrives already designed (the /apps composer). */
 .modal-body-plain {
-  padding: 14px 16px 16px;
+  padding: var(--space-3-5) var(--space-4) var(--space-4);
   overflow-y: auto;
 }
 
@@ -152,12 +152,12 @@
    still win. */
 .modal-body :where(input:not([type="checkbox"], [type="radio"], [type="file"]), select, textarea) {
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 7px 10px;
+  border-radius: var(--radius-control);
+  padding: var(--space-2) var(--space-2-5);
 }
 
 .modal-body :where(input:not([type="checkbox"], [type="radio"], [type="file"]), select, textarea):focus {

--- a/frontend/src/styles/dialogs.css
+++ b/frontend/src/styles/dialogs.css
@@ -9,12 +9,12 @@
 .fs-dialog-input {
   width: 100%;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 7px 10px;
+  border-radius: var(--radius-control);
+  padding: var(--space-2) var(--space-2-5);
 }
 
 .fs-dialog-input:focus {
@@ -25,7 +25,7 @@
 .fs-dialog-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* Override .deploy-body button's align-self:flex-start so the action row's
@@ -48,13 +48,13 @@
  * card would say "this is broken" about the wrong subject. */
 .trouble-card {
   max-width: 640px;
-  margin: 12px 0;
-  padding: 14px 16px;
+  margin: var(--space-3) 0;
+  padding: var(--space-3-5) var(--space-4);
   border: 1px solid rgba(var(--warning-rgb), 0.5);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   background: rgba(var(--warning-rgb), 0.06);
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-dense);
   line-height: 1.5;
 }
 
@@ -63,17 +63,17 @@
 .trouble-page {
   display: flex;
   justify-content: center;
-  padding: 48px 24px;
+  padding: var(--space-12) var(--space-6);
 }
 
 .trouble-title {
   font-weight: 600;
-  font-size: 14px;
-  margin-bottom: 6px;
+  font-size: var(--text-body);
+  margin-bottom: var(--space-1-5);
 }
 
 .trouble-explain {
-  margin: 0 0 10px;
+  margin: 0 0 var(--space-2-5);
   color: var(--fg-muted);
 }
 
@@ -81,34 +81,34 @@
    the half that does not say what happened — and caps its height so a long one
    cannot push the actions below the fold. */
 .trouble-error {
-  margin: 0 0 12px;
-  padding: 8px 10px;
+  margin: 0 0 var(--space-3);
+  padding: var(--space-2) var(--space-2-5);
   max-height: 220px;
   overflow: auto;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
+  font-size: var(--text-meta);
   white-space: pre-wrap;
   word-break: break-word;
 }
 
 .trouble-install {
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-3);
 }
 
 .trouble-label {
   font-weight: 600;
-  font-size: 12px;
-  margin-bottom: 6px;
+  font-size: var(--text-meta);
+  margin-bottom: var(--space-1-5);
 }
 
 .trouble-actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* ONE look for the whole row, links and buttons alike. They are three peers —
@@ -118,13 +118,13 @@
    design, correct in a 300px popover and wrong in a row. */
 .trouble-actions > a,
 .trouble-actions > button {
-  padding: 3px 10px;
+  padding: var(--space-1) var(--space-2-5);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg);
   background: var(--ctl-quiet-bg);
   border: 1px solid var(--ctl-quiet-border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   text-decoration: none;
   cursor: pointer;
 }
@@ -138,19 +138,19 @@
 /* The notification-stack variant: no plate of its own (the activity card is
    already one), just the title, a clamped error and the two links. */
 .trouble-compact {
-  padding: 6px 10px 10px;
-  font-size: 11px;
+  padding: var(--space-1-5) var(--space-2-5) var(--space-2-5);
+  font-size: var(--text-caption);
   line-height: 1.45;
 }
 .trouble-compact .trouble-title {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--warning-soft);
 }
 /* Clamped rather than scrolled: this sits in a 340px column where a long
    traceback would own the whole card, and the copy button carries the full
    text anyway. */
 .trouble-compact-error {
-  margin-bottom: 6px;
+  margin-bottom: var(--space-1-5);
   color: var(--fg-muted);
   overflow: hidden;
   display: -webkit-box;
@@ -176,13 +176,13 @@
  * as a band, and a narrow plate floating over wide content reads as a stray
  * dialog rather than as the page telling you something. */
 .claude-health {
-  margin: 0 0 20px;
-  padding: 14px 16px;
+  margin: 0 0 var(--space-5);
+  padding: var(--space-3-5) var(--space-4);
   border: 1px solid rgba(var(--warning-rgb), 0.5);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   background: rgba(var(--warning-rgb), 0.06);
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-dense);
   line-height: 1.5;
 }
 
@@ -191,21 +191,21 @@
   flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 10px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2-5);
 }
 
 .claude-health-title {
   margin: 0;
   font-weight: 600;
-  font-size: 14px;
+  font-size: var(--text-body);
   color: var(--warning-soft);
 }
 
 .claude-health-head-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 /* Same quiet-control treatment as .trouble-actions — see the note there on why
@@ -218,13 +218,13 @@
  * out-specifying it there keeps the intent readable: this is the treatment for
  * the ACTION buttons, and the ✕ is not one. */
 .claude-health-head-actions > button:not(.claude-health-close) {
-  padding: 3px 10px;
+  padding: var(--space-1) var(--space-2-5);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg);
   background: var(--ctl-quiet-bg);
   border: 1px solid var(--ctl-quiet-border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -242,14 +242,14 @@
    declines the whole notice rather than acting on it, so it stays a bare glyph
    instead of taking the bordered pill treatment. */
 .claude-health-close {
-  padding: 3px 7px;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid transparent;
   background: none;
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1;
   cursor: pointer;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
 }
 
 .claude-health-close:hover {
@@ -263,24 +263,24 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* Hairline between stacked problems, never above the first: on the common
    one-problem strip there is nothing to separate, and a rule there would read as
    an empty row. */
 .claude-health-issue + .claude-health-issue {
-  padding-top: 12px;
+  padding-top: var(--space-3);
   border-top: 1px solid rgba(var(--warning-rgb), 0.25);
 }
 
 .claude-health-issue-title {
   font-weight: 600;
-  margin-bottom: 3px;
+  margin-bottom: var(--space-1);
 }
 
 .claude-health-issue-detail {
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-2);
   color: var(--fg-muted);
 }
 
@@ -291,7 +291,7 @@
 .claude-health .update-badge-command,
 .onboarding-issue .update-badge-command {
   flex-wrap: wrap;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
 }
 
 /* The first-run wizard's Claude step reuses IssueRow (shell/onboarding); the
@@ -314,8 +314,8 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 8px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
 }
 
 /* The one affirmative control in the strip, so it takes the accent fill while
@@ -328,8 +328,8 @@
   display: inline-block;
   font: inherit;
   font-weight: 600;
-  padding: 5px 12px;
-  border-radius: 6px;
+  padding: var(--space-1-5) var(--space-3);
+  border-radius: var(--radius-control);
   border: 1px solid transparent;
   background: var(--accent);
   color: var(--on-accent);
@@ -366,24 +366,24 @@
    label is the part that would not be OK. */
 .claude-health-action-cmd {
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 3px 7px;
+  border-radius: var(--radius-xs);
+  padding: var(--space-1) var(--space-2);
   overflow-wrap: anywhere;
 }
 
 .claude-health-progress {
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-2);
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   overflow-wrap: anywhere;
 }
 
 .claude-health-error {
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-2);
   color: var(--warning-strong);
   overflow-wrap: anywhere;
 }
@@ -392,33 +392,33 @@
    cause is, and a clamped "curl: (22) The requested URL returned error: 403" is
    worth nothing to the person who has to search for it. */
 .claude-health-output {
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-2);
 }
 
 .claude-health-output-label {
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-weight: 600;
   color: var(--warning-strong);
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 
 .claude-health-output pre {
   margin: 0;
   max-height: 180px;
   overflow: auto;
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2-5);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.5;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 
 .claude-health-doctor {
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-2);
 }
 
 .claude-health-doctor-list {
@@ -427,21 +427,21 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .claude-health-doctor-list li {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 6px 10px;
+  gap: var(--space-0-5);
+  padding: var(--space-1-5) var(--space-2-5);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
 }
 
 .claude-health-doctor-problem {
-  font-size: 12px;
+  font-size: var(--text-meta);
   overflow-wrap: anywhere;
 }
 
@@ -449,7 +449,7 @@
    answers — it is advice from Claude Code about Claude Code, not from us. */
 .claude-health-doctor-fix {
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   overflow-wrap: anywhere;
 }

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -76,8 +76,8 @@
   color: var(--fg-muted);
   cursor: pointer;
   transition:
-    color var(--dur-fast) var(--ease-out),
-    background-color var(--dur-fast) var(--ease-out);
+    color var(--dur-instant) var(--ease-out),
+    background-color var(--dur-instant) var(--ease-out);
 }
 
 /* Optical, not geometric: the star box centres on the crumb row's centre
@@ -828,7 +828,7 @@
      the bar portals into the listing's left column and fades in with the
      content it now belongs to. Replays because App keys this node on the nav
      epoch (an iframe's param write doesn't bump it). */
-  animation: content-in var(--dur-fast) var(--ease-out);
+  animation: content-in var(--dur-instant) var(--ease-out);
 }
 
 @keyframes content-in {
@@ -1486,7 +1486,7 @@ table.listing-table tr.skel-row:hover {
      `flex-grow` is the animated property because grow, not `width`, is what
      spans the strip; the row's own grow above is instant, so the field opens
      leftward from the bar's right edge (`justify-content: flex-end`). */
-  transition: flex-grow var(--dur-fast) ease-out;
+  transition: flex-grow var(--dur-instant) ease-out;
 }
 
 /* Terse now ("1.2K · 45.1K…" rather than the full sentence — Listing.tsx keeps
@@ -1639,7 +1639,7 @@ table.listing-table tr.skel-row:hover {
    value) is catching up to the latest keystroke on a large search. */
 .listing-stale {
   opacity: 0.6;
-  transition: opacity var(--dur-fast) ease-out;
+  transition: opacity var(--dur-instant) ease-out;
 }
 
 /* Results a generation behind, with nothing on its way to replace them: the
@@ -1826,8 +1826,8 @@ table.listing-table .sort-arrow {
   display: inline-block;
   margin-left: var(--space-1-5);
   font-size: var(--text-micro);
-  transition: transform var(--dur-fast) var(--ease-out);
-  animation: sort-arrow-in var(--dur-fast) var(--ease-out);
+  transition: transform var(--dur-instant) var(--ease-out);
+  animation: sort-arrow-in var(--dur-instant) var(--ease-out);
 }
 
 table.listing-table .sort-arrow.desc {

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -35,8 +35,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  padding: var(--topbar-pad-y) 16px;
+  gap: var(--space-2-5);
+  padding: var(--topbar-pad-y) var(--space-4);
   border-bottom: 1px solid var(--border);
   background: var(--bg-alt);
   /* Exact, so the bar neither grows when the portaled mode control lands after
@@ -54,7 +54,7 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 /* ★ bookmark button, at the tail of the path. Subtle: bare glyph, no box —
@@ -69,9 +69,9 @@
   justify-content: center;
   /* 5px around a 14px glyph = the same 24px box (and hover pill) the 16px
      glyph used to make, so shrinking the star cost no hit area. */
-  padding: 5px;
+  padding: var(--space-1-5);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   color: var(--fg-muted);
   cursor: pointer;
@@ -106,7 +106,7 @@
    read as the star touching it (Akshil: "a little more padding"). 13px of
    air: looser than the 8px crumb gap, still inside the path's zone. */
 #breadcrumb .bookmark-star-btn {
-  margin-left: -6px;
+  margin-left: calc(-1 * var(--space-1-5));
 }
 
 .bookmark-star-btn:hover {
@@ -134,7 +134,7 @@
   overflow-x: auto;
   white-space: nowrap;
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 /* GNOME-path-bar behaviour, main bar only (the panel pane does the same at
@@ -216,10 +216,10 @@
   flex: 1 1 auto;
   min-width: 0;
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 12px;
-  padding: 2px 6px;
+  font-size: var(--text-meta);
+  padding: var(--space-0-5) var(--space-1-5);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: var(--bg-alt);
   color: var(--fg);
 }
@@ -242,8 +242,8 @@
   color: color-mix(in srgb, var(--fg) 60%, var(--fg-muted));
   text-decoration: none;
   cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 6px;
+  padding: var(--space-0-5) var(--space-1);
+  border-radius: var(--radius-control);
 }
 
 /* GNOME-style compress-then-scroll truncation, main bar only (the panel pane
@@ -280,7 +280,7 @@
      reason, and only for that reason. */
   --crumb-hit: 20px;
   position: relative;
-  padding-block: calc(2px + var(--crumb-hit));
+  padding-block: calc(var(--space-0-5) + var(--crumb-hit));
   margin-block: calc(-1 * var(--crumb-hit));
 }
 
@@ -292,7 +292,7 @@
   content: "";
   position: absolute;
   inset: var(--crumb-hit) 0;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   pointer-events: none;
 }
 
@@ -385,7 +385,7 @@
 .path-crumb-sep,
 .panel-crumb-sep {
   color: var(--fg-muted);
-  margin: 0 4px;
+  margin: 0 var(--space-1);
 }
 
 /* Crumb hover, both bars — fg brighten + underline, no accent yellow. The
@@ -401,7 +401,7 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* The portal target collapses entirely when no view has filled it (loading,
@@ -463,14 +463,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   height: 28px;
-  padding: 0 8px;
+  padding: 0 var(--space-2);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1;
   color: var(--fg-muted);
   cursor: pointer;
@@ -529,7 +529,7 @@
   flex: 0 0 auto;
   width: 1px;
   height: 18px;
-  margin: 0 10px;
+  margin: 0 var(--space-2-5);
   background: var(--border);
 }
 
@@ -537,7 +537,7 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 /* ---- a side column's HEADER STRIP, and there are two of them --------------
@@ -567,7 +567,7 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin-left: auto;
 }
 
@@ -658,10 +658,10 @@
   flex-direction: column;
   gap: 1px;
   width: max-content;
-  padding: 4px;
+  padding: var(--space-1);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 8px 24px var(--shadow-md);
 }
 
@@ -676,14 +676,14 @@
 .bar-menu-item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   width: 100%;
-  padding: 6px 8px;
+  padding: var(--space-1-5) var(--space-2);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   font: inherit;
-  font-size: 12.5px;
+  font-size: var(--text-dense);
   color: var(--fg);
   text-align: left;
   cursor: pointer;
@@ -753,18 +753,18 @@
 .bar-menu-sep {
   flex: 0 0 auto;
   height: 1px;
-  margin: 4px 8px;
+  margin: var(--space-1) var(--space-2);
   background: var(--border);
 }
 
 .star-btn {
   flex: 0 0 auto;
   font: inherit;
-  font-size: 12.5px;
+  font-size: var(--text-dense);
   white-space: nowrap;
-  padding: 4px 10px;
+  padding: var(--space-1) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg);
   color: var(--fg-muted);
   cursor: pointer;
@@ -828,7 +828,7 @@
      the bar portals into the listing's left column and fades in with the
      content it now belongs to. Replays because App keys this node on the nav
      epoch (an iframe's param write doesn't bump it). */
-  animation: content-in 110ms var(--ease-out);
+  animation: content-in var(--dur-fast) var(--ease-out);
 }
 
 @keyframes content-in {
@@ -941,7 +941,7 @@
      figures don't share the cell with the button, so they keep the full
      width. */
   table.listing-table thead th.col-size {
-    padding-right: 34px;
+    padding-right: var(--space-8);
   }
 }
 
@@ -972,7 +972,7 @@
   flex: 0 0 5px;
   cursor: col-resize;
   background: transparent;
-  margin: 0 -2px;
+  margin: 0 calc(-1 * var(--space-0-5));
   z-index: 2;
   /* The drag is pointer-captured; without this, touch scrolling fights it. */
   touch-action: none;
@@ -1070,12 +1070,12 @@
   margin: auto;
   text-align: center;
   color: var(--fg-muted);
-  padding: 32px;
+  padding: var(--space-8);
 }
 
 .listing-pane .pane-big-icon {
   display: inline-flex;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 
 .listing-pane .pane-big-icon .file-icon {
@@ -1086,21 +1086,21 @@
 
 .listing-pane .pane-title {
   color: var(--fg);
-  font-size: 15px;
-  margin-bottom: 4px;
+  font-size: var(--text-title);
+  margin-bottom: var(--space-1);
   word-break: break-all;
 }
 
 .listing-pane .pane-hint {
-  font-size: 12.5px;
+  font-size: var(--text-dense);
 }
 
 .listing-pane .pane-open-btn {
-  margin-top: 14px;
+  margin-top: var(--space-3-5);
   font: inherit;
-  padding: 6px 14px;
+  padding: var(--space-1-5) var(--space-3-5);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg);
   color: var(--fg);
   cursor: pointer;
@@ -1140,8 +1140,8 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 8px;
-  padding: var(--topbar-pad-y) 10px;
+  gap: var(--space-2);
+  padding: var(--topbar-pad-y) var(--space-2-5);
   height: var(--topbar-h);
   box-sizing: border-box;
   border-bottom: 1px solid var(--border);
@@ -1162,7 +1162,7 @@ table.pane-mini-list {
 }
 
 table.pane-mini-list td {
-  padding: 6px 10px;
+  padding: var(--space-1-5) var(--space-2-5);
   border-bottom: 1px solid var(--border);
   white-space: nowrap;
   overflow: hidden;
@@ -1184,7 +1184,7 @@ table.pane-mini-list tr.row.ignored td.name {
 table.pane-mini-list td.name {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 table.pane-mini-list td.name .label {
@@ -1200,7 +1200,7 @@ table.pane-mini-list td.size {
 }
 
 table.pane-mini-list td.status-message {
-  padding: 14px 10px;
+  padding: var(--space-3-5) var(--space-2-5);
 }
 
 /* Skeleton loading state: shimmering bars shaped like the real listing rows
@@ -1209,7 +1209,7 @@ table.pane-mini-list td.status-message {
 .skel-bar {
   display: inline-block;
   height: 10px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   background: linear-gradient(90deg, var(--bg-alt) 25%, var(--border) 50%, var(--bg-alt) 75%);
   background-size: 200% 100%;
   animation: skel-shimmer 1.2s ease-in-out infinite;
@@ -1218,7 +1218,7 @@ table.pane-mini-list td.status-message {
 .skel-bar.icon-skel {
   width: 16px;
   height: 16px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   flex: 0 0 auto;
 }
 
@@ -1244,15 +1244,15 @@ table.listing-table tr.skel-row:hover {
 .skel-lines {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2-5);
   max-width: 420px;
-  padding: 6px 0;
+  padding: var(--space-1-5) 0;
 }
 
 .listing-pane .pane-skel {
   flex: 1 1 auto;
-  margin: 14px;
-  border-radius: 8px;
+  margin: var(--space-3-5);
+  border-radius: var(--radius-md);
   background: linear-gradient(90deg, var(--bg-alt) 25%, var(--border) 50%, var(--bg-alt) 75%);
   background-size: 200% 100%;
   animation: skel-shimmer 1.2s ease-in-out infinite;
@@ -1269,10 +1269,10 @@ table.listing-table tr.skel-row:hover {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   height: var(--topbar-h);
   box-sizing: border-box;
-  padding: var(--topbar-pad-y) 16px;
+  padding: var(--topbar-pad-y) var(--space-4);
   border-bottom: 1px solid var(--border);
   background: var(--bg);
 }
@@ -1284,7 +1284,7 @@ table.listing-table tr.skel-row:hover {
    above them ends on. Hang the button into the padding so the glyph, not the
    box, lines up; the 28px hit area is unchanged. */
 .listing-search > .bar-overflow:last-child {
-  margin-right: -6px;
+  margin-right: calc(-1 * var(--space-1-5));
 }
 
 /* ---- …and the same row once it has moved INTO the crumb bar --------------
@@ -1411,7 +1411,7 @@ table.listing-table tr.skel-row:hover {
   flex: 0 0 0px;
   width: 0;
   min-width: 0;
-  margin-left: -8px;
+  margin-left: calc(-1 * var(--space-2));
   overflow: hidden;
   opacity: 0;
 }
@@ -1486,7 +1486,7 @@ table.listing-table tr.skel-row:hover {
      `flex-grow` is the animated property because grow, not `width`, is what
      spans the strip; the row's own grow above is instant, so the field opens
      leftward from the bar's right edge (`justify-content: flex-end`). */
-  transition: flex-grow 130ms ease-out;
+  transition: flex-grow var(--dur-fast) ease-out;
 }
 
 /* Terse now ("1.2K · 45.1K…" rather than the full sentence — Listing.tsx keeps
@@ -1536,11 +1536,11 @@ table.listing-table tr.skel-row:hover {
 
 .listing-search .listing-search-input {
   width: 100%;
-  padding-right: 10px;
+  padding-right: var(--space-2-5);
   /* Room for the magnifier below: 9px gutter + a 14px glyph + 5px before the
      text. The glyph is out of flow, so this padding is the only thing keeping
      the placeholder and the caret off it. */
-  padding-left: 28px;
+  padding-left: var(--space-7);
 }
 
 /* The magnifier INSIDE the field's left edge — the same glyph the tight-bar
@@ -1589,7 +1589,7 @@ table.listing-table tr.skel-row:hover {
   top: 50%;
   transform: translateY(-50%);
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   white-space: nowrap;
   pointer-events: none;
 }
@@ -1621,7 +1621,7 @@ table.listing-table tr.skel-row:hover {
   top: 50%;
   width: 11px;
   height: 11px;
-  margin-top: -5.5px;
+  margin-top: calc(-1 * var(--space-1-5));
   border: 1.5px solid var(--border);
   border-top-color: var(--fg-muted);
   border-radius: 50%;
@@ -1639,7 +1639,7 @@ table.listing-table tr.skel-row:hover {
    value) is catching up to the latest keystroke on a large search. */
 .listing-stale {
   opacity: 0.6;
-  transition: opacity 0.1s ease-out;
+  transition: opacity var(--dur-fast) ease-out;
 }
 
 /* Results a generation behind, with nothing on its way to replace them: the
@@ -1657,12 +1657,12 @@ table.listing-table tr.skel-row:hover {
 .listing-search-input {
   width: 100%;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 6px 10px;
+  border-radius: var(--radius-control);
+  padding: var(--space-1-5) var(--space-2-5);
 }
 
 .listing-search-input::placeholder {
@@ -1680,7 +1680,7 @@ table.listing-table tr.skel-row:hover {
 .search-mark {
   background: rgba(var(--accent-rgb), 0.22);
   color: var(--fg);
-  border-radius: 2px;
+  border-radius: var(--radius-hairline);
 }
 
 /* Relative path shown in an explorer search row, in place of a bare name. */
@@ -1744,17 +1744,17 @@ table.listing-table th.col-size {
    so the label and its sort arrow have to stop short of it. */
 table.listing-table th.col-mtime {
   width: 172px;
-  padding-right: 34px;
+  padding-right: var(--space-8);
 }
 
 table.listing-table th {
   text-align: left;
   font-weight: 600;
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  padding: 8px 16px;
+  padding: var(--space-2) var(--space-4);
   position: sticky;
   top: 0;
   z-index: 1; /* stay above rows scrolling underneath */
@@ -1785,11 +1785,11 @@ table.listing-table .listing-head-menu {
   height: 22px;
   padding: 0;
   border: none;
-  border-radius: 5px;
+  border-radius: var(--radius-control);
   background: transparent;
   color: var(--fg-muted);
   cursor: pointer;
-  transition: background 90ms var(--ease-out), color 90ms var(--ease-out);
+  transition: background var(--dur-instant) var(--ease-out), color var(--dur-instant) var(--ease-out);
 }
 
 /* The same wash every other quiet icon button in the chrome uses (.bar-ctl). */
@@ -1824,10 +1824,10 @@ table.listing-table th.sorted {
    to a different column DOES replace it — that one fades in. */
 table.listing-table .sort-arrow {
   display: inline-block;
-  margin-left: 5px;
-  font-size: 9px;
-  transition: transform 100ms var(--ease-out);
-  animation: sort-arrow-in 100ms var(--ease-out);
+  margin-left: var(--space-1-5);
+  font-size: var(--text-micro);
+  transition: transform var(--dur-fast) var(--ease-out);
+  animation: sort-arrow-in var(--dur-fast) var(--ease-out);
 }
 
 table.listing-table .sort-arrow.desc {
@@ -1868,7 +1868,7 @@ table.listing-table tr.row.flip-animating {
 }
 
 table.listing-table td {
-  padding: 9px 16px;
+  padding: var(--space-2-5) var(--space-4);
   border-bottom: 1px solid var(--border);
   white-space: nowrap;
   overflow: hidden;
@@ -2018,14 +2018,14 @@ body.fs-dragging.fs-drag-refused * {
   will-change: transform;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   max-width: 260px;
-  padding: 5px 10px;
+  padding: var(--space-1-5) var(--space-2-5);
   border: 1px solid var(--accent);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg-panel);
   color: var(--fg);
-  font-size: 12px;
+  font-size: var(--text-meta);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2035,11 +2035,11 @@ body.fs-dragging.fs-drag-refused * {
 .fs-drag-count {
   flex: none;
   min-width: 18px;
-  padding: 0 5px;
-  border-radius: 9px;
+  padding: 0 var(--space-1-5);
+  border-radius: var(--radius-card);
   background: var(--accent);
   color: var(--on-accent);
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 600;
   text-align: center;
 }
@@ -2047,8 +2047,8 @@ body.fs-dragging.fs-drag-refused * {
 table.listing-table td.name {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 14px;
+  gap: var(--space-2);
+  font-size: var(--text-body);
   /* Positioning context for .clip-mark below. */
   position: relative;
 }
@@ -2068,7 +2068,7 @@ table.listing-table td.name {
 table.listing-table td.name .row-handle {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
@@ -2107,14 +2107,14 @@ table.listing-table tr.row.selected {
   right: 10px;
   top: 50%;
   transform: translateY(-50%);
-  font-size: 10px;
+  font-size: var(--text-micro);
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   line-height: 1;
   /* 2px + the 1px border = the 3px the pill reads as */
-  padding: 2px 5px;
-  border-radius: 4px;
+  padding: var(--space-0-5) var(--space-1-5);
+  border-radius: var(--radius-xs);
   border: 1px solid var(--border);
   color: var(--fg-muted);
   background: var(--bg-alt);

--- a/frontend/src/styles/fields.css
+++ b/frontend/src/styles/fields.css
@@ -5,11 +5,11 @@
 .field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .field-label {
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-weight: 500;
   color: var(--fg-muted);
 }
@@ -19,18 +19,18 @@
 }
 
 .field-hint {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .field-control {
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 7px 10px;
+  border-radius: var(--radius-control);
+  padding: var(--space-2) var(--space-2-5);
 }
 
 input.field-control,
@@ -58,7 +58,7 @@ select.field-control {
    (muted-gray inline SVG) so it sits flush with sibling inputs. */
 select.field-control {
   appearance: none;
-  padding-right: 30px;
+  padding-right: var(--space-8);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 4.5l3 3 3-3' fill='none' stroke='%239aa0a6' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 10px center;
@@ -76,16 +76,16 @@ select.field-control:has(option[value=""]:checked) {
 .deploy-body code {
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 5px;
-  font-size: 12px;
+  border-radius: var(--radius-xs);
+  padding: 1px var(--space-1-5);
+  font-size: var(--text-meta);
 }
 
 .deploy-body button {
   font: inherit;
-  padding: 5px 12px;
+  padding: var(--space-1-5) var(--space-3);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg);
   color: var(--fg);
   cursor: pointer;
@@ -112,9 +112,9 @@ select.field-control:has(option[value=""]:checked) {
 .error-banner {
   color: var(--error);
   border: 1px solid var(--error);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: rgba(var(--error-rgb), 0.07);
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2-5);
   white-space: pre-wrap;
   word-break: break-word;
   max-height: 180px;

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -16,7 +16,7 @@
 .home-inner {
   max-width: 880px;
   margin: 0 auto;
-  padding: 40px 28px 72px;
+  padding: var(--space-10) var(--space-7) var(--space-18);
 }
 
 /* Hero: no card around it any more (the bordered panel and its accent wash are
@@ -25,8 +25,8 @@
 .home-hero {
   position: relative;
   overflow: hidden;
-  padding: 36px 64px 34px;
-  margin-bottom: 22px;
+  padding: var(--space-10) var(--space-16) var(--space-8);
+  margin-bottom: var(--space-6);
 }
 
 .home-hero > * {
@@ -46,8 +46,8 @@
      the mark reads as attached to the headline rather than adrift left of it.
      Small because the PNG's own baked-in canvas padding is doing most of the
      spacing already. */
-  gap: 4px 2px;
-  margin: 0 0 18px;
+  gap: var(--space-1) var(--space-0-5);
+  margin: 0 0 var(--space-5);
   text-align: center;
 }
 
@@ -70,7 +70,7 @@
 /* The headline itself now that the wordmark is gone: title-sized, muted, with
    the accent span carrying the only colour. */
 .home-hero-tagline {
-  font-size: 22px;
+  font-size: var(--text-display);
   font-weight: 500;
   letter-spacing: -0.02em;
   color: var(--fg-muted);
@@ -91,18 +91,18 @@
    footer bar with the keyboard hint and the round send button. */
 .home-composer-wrap {
   width: 100%;
-  margin-bottom: 18px;
+  margin-bottom: var(--space-5);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2-5);
 }
 
 .home-composer {
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: var(--radius-panel);
   box-shadow: 0 2px 10px color-mix(in srgb, var(--fg) 5%, transparent);
-  transition: border-color 120ms ease;
+  transition: border-color var(--dur-fast) ease;
 }
 
 .home-composer:focus-within {
@@ -116,19 +116,19 @@
 .home-composer-annots {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  padding: 12px 16px 0;
+  gap: var(--space-1-5);
+  padding: var(--space-3) var(--space-4) 0;
 }
 
 .home-composer-annot {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 6px 3px 8px;
-  border-radius: 8px;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-1-5) var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--fg) 10%, transparent);
   color: var(--fg);
-  font-size: 12.5px;
+  font-size: var(--text-dense);
   font-weight: 500;
   line-height: 1.4;
 }
@@ -140,9 +140,9 @@
 .home-composer-annot-x {
   border: none;
   background: none;
-  padding: 0 2px;
-  margin-left: 2px;
-  font-size: 11px;
+  padding: 0 var(--space-0-5);
+  margin-left: var(--space-0-5);
+  font-size: var(--text-caption);
   line-height: 1;
   color: inherit;
   opacity: 0.55;
@@ -166,8 +166,8 @@
   box-shadow: none;
   background: transparent;
   resize: none;
-  padding: 14px 16px 6px;
-  font-size: 14px;
+  padding: var(--space-3-5) var(--space-4) var(--space-1-5);
+  font-size: var(--text-body);
   line-height: 1.5;
   /* 3 to 10 lines of 21px plus the 20px vertical padding; the height itself is
      written inline by `useAutoGrow` (platform/lib/autoGrow.ts), these are only
@@ -184,8 +184,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  padding: 6px 10px 10px 16px;
+  gap: var(--space-2-5);
+  padding: var(--space-1-5) var(--space-2-5) var(--space-2-5) var(--space-4);
 }
 
 /* The bar's left end: the model/effort pickers, then the create phase text.
@@ -196,7 +196,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-1-5);
   min-width: 0;
 }
 
@@ -209,14 +209,14 @@
 .home-composer-pick {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding-left: 6px;
-  border-radius: 999px;
+  gap: var(--space-1);
+  padding-left: var(--space-1-5);
+  border-radius: var(--radius-pill);
   color: var(--fg-muted);
   cursor: pointer;
   transition:
-    color 120ms ease,
-    background-color 120ms ease;
+    color var(--dur-fast) ease,
+    background-color var(--dur-fast) ease;
 }
 
 .home-composer-pick:hover:not(:has(:disabled)) {
@@ -241,13 +241,13 @@
    right padding is the space that glyph is drawn in. */
 .home-composer .home-composer-pick-sel {
   height: auto;
-  padding: 3px 18px 3px 2px;
-  font-size: 12px;
+  padding: var(--space-1) var(--space-5) var(--space-1) var(--space-0-5);
+  font-size: var(--text-meta);
   color: inherit;
   background-color: transparent;
   background-position: right 4px center;
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: inherit;
 }
 
@@ -271,7 +271,7 @@
 }
 
 .home-composer-hint {
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -289,8 +289,8 @@
   color: var(--bg);
   cursor: pointer;
   transition:
-    opacity 120ms ease,
-    transform 120ms ease;
+    opacity var(--dur-fast) ease,
+    transform var(--dur-fast) ease;
 }
 
 .home-composer-send:hover:not(:disabled) {
@@ -315,14 +315,14 @@
      so a row narrower than the composer sits centred and only goes edge-to-edge
      once the chips actually overflow. */
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
 .home-composer-sample-strip {
   display: flex;
   flex-wrap: nowrap;
-  gap: 8px;
+  gap: var(--space-2);
   /* min-width:0 so the strip is allowed to be narrower than its content —
      without it a flex item's auto min-size keeps it at full content width and
      the row overflows the composer instead of scrolling. */
@@ -346,22 +346,22 @@
 .home-composer-sample {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   /* Never shrink or wrap a chip: the strip scrolls instead. */
   flex: 0 0 auto;
   white-space: nowrap;
   scroll-snap-align: start;
-  padding: 5px 12px;
+  padding: var(--space-1-5) var(--space-3);
   font: inherit;
-  font-size: 12.5px;
+  font-size: var(--text-dense);
   color: var(--fg-muted);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
   transition:
-    color 120ms ease,
-    border-color 120ms ease;
+    color var(--dur-fast) ease,
+    border-color var(--dur-fast) ease;
 }
 
 .home-composer-sample:hover:not(:disabled) {
@@ -382,12 +382,12 @@
 /* Icon-only round chip that advances to the next batch of ideas. Outside the
    scrolling strip, so it holds its place at the end of the row. */
 .home-composer-shuffle {
-  padding: 5px 8px;
+  padding: var(--space-1-5) var(--space-2);
   flex: 0 0 auto;
 }
 
 .home-section {
-  margin-top: 36px;
+  margin-top: var(--space-10);
 }
 
 /* ---- AI Playground strip cards ------------------------------------------- */
@@ -407,11 +407,11 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   aspect-ratio: 16 / 10;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   overflow: hidden;
 }
 
@@ -435,7 +435,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .home-pg-glyph {
@@ -445,7 +445,7 @@
   justify-content: center;
   width: 60px;
   height: 60px;
-  border-radius: 16px;
+  border-radius: var(--radius-tile);
   border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
   background: color-mix(in srgb, var(--accent) 9%, var(--bg-alt));
   color: var(--accent);
@@ -472,7 +472,7 @@
 .home-pg-blurb {
   position: relative;
   max-width: 85%;
-  font-size: 12.5px;
+  font-size: var(--text-dense);
   text-align: center;
   color: var(--fg-muted);
 }
@@ -484,8 +484,8 @@
 /* Empty voice. */
 .home-empty {
   color: var(--fg-muted);
-  font-size: 13px;
-  padding: 18px 0;
+  font-size: var(--text-dense);
+  padding: var(--space-5) 0;
 }
 
 /* The ask-for-a-name row (HomeHero.tsx, phase "askName"): shown in the
@@ -495,21 +495,21 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   flex: 1;
 }
 
 .home-composer-name-why {
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .home-composer .home-composer-name-input {
   height: auto;
   width: 180px;
-  padding: 3px 8px;
-  font-size: 12px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-meta);
   font-family: var(--font-mono, ui-monospace, monospace);
 }
 
@@ -521,9 +521,9 @@
   border: none;
   background: transparent;
   color: var(--fg-muted);
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   cursor: pointer;
-  padding: 2px 4px;
+  padding: var(--space-0-5) var(--space-1);
 }
 
 .home-composer-name-cancel:hover {

--- a/frontend/src/styles/mounts.css
+++ b/frontend/src/styles/mounts.css
@@ -6,13 +6,13 @@
 .mount-add-form {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: var(--space-3-5);
 }
 
 .mount-hero {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 /* Primary by SIZE AND WEIGHT, never by a bigger font: the page holds exactly
@@ -26,7 +26,7 @@
 .mount-hero .field-control {
   width: 100%;
   height: 40px;
-  padding: 0 14px;
+  padding: 0 var(--space-3-5);
 }
 
 .mount-hero .field-control:focus {
@@ -40,9 +40,9 @@
 .mount-grid {
   display: grid;
   grid-template-columns: minmax(110px, 0.9fr) minmax(150px, 1.1fr) minmax(150px, 1.4fr) auto;
-  gap: 10px;
+  gap: var(--space-2-5);
   align-items: end;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   outline: 2px solid transparent;
   outline-offset: 6px;
 }
@@ -73,7 +73,7 @@
    the connected-remote line, and the single explainer. */
 .mount-note {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.5;
   color: var(--fg-muted);
 }
@@ -92,13 +92,13 @@
 .mount-providers {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding-top: 14px;
+  gap: var(--space-2-5);
+  padding-top: var(--space-3-5);
   border-top: 1px solid var(--border);
 }
 
 .mount-providers-head {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -125,7 +125,7 @@
    shared 10px, so a section boundary and a line of hint text were spaced the
    same and nothing grouped. */
 .mounts-page .prefs-section {
-  gap: 14px;
+  gap: var(--space-3-5);
 }
 
 /* Page header — title + one-line intro on the left, global actions on the
@@ -134,39 +134,39 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-4);
   flex-wrap: wrap;
 }
 
 .mounts-title,
 .prefs-title {
   margin: 0;
-  font-size: 18px;
+  font-size: var(--text-heading);
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
 .prefs-title {
-  margin-bottom: 14px;
+  margin-bottom: var(--space-3-5);
 }
 
 .mounts-subtitle {
-  margin: 4px 0 0;
+  margin: var(--space-1) 0 0;
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.45;
   max-width: 54ch;
 }
 
 .mounts-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   flex-shrink: 0;
 }
 
 /* Refresh glyph in the Restart button — sized independently of the label. */
 .mounts-restart-icon {
-  font-size: 14px;
+  font-size: var(--text-body);
   line-height: 1;
 }
 
@@ -176,10 +176,10 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 10px;
-  padding: 14px 16px;
+  gap: var(--space-2-5);
+  padding: var(--space-3-5) var(--space-4);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--bg-alt);
 }
 
@@ -199,7 +199,7 @@
    own spacing via the adjacent-sibling margin below. */
 .mount-callout-body {
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.5;
 }
 
@@ -208,7 +208,7 @@
 }
 
 .mount-callout-body p + p {
-  margin-top: 3px;
+  margin-top: var(--space-1);
 }
 
 .mount-callout-body code {
@@ -219,18 +219,18 @@
 .mount-list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2-5);
 }
 
 .mount-card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px 14px;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-3-5);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--bg-alt);
-  transition: border-color 0.12s ease;
+  transition: border-color var(--dur-fast) ease;
 }
 
 .mount-card:not(.mount-card--skeleton):hover {
@@ -269,11 +269,11 @@
 .mount-card-main {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   /* Wrap on a narrow pane: the name block (flex:1) keeps the first row and the
      action buttons drop to a second row rather than crushing the name. */
   flex-wrap: wrap;
-  row-gap: 10px;
+  row-gap: var(--space-2-5);
 }
 
 /* The name/remote block is the flexible column; never let it shrink to zero
@@ -287,7 +287,7 @@
    ride to the next line as a group. */
 .mount-card-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
   margin-left: auto;
 }
@@ -333,7 +333,7 @@
 
 .mount-card-name .mount-dot {
   display: inline-block;
-  margin-right: 8px;
+  margin-right: var(--space-2);
   vertical-align: middle;
 }
 
@@ -357,7 +357,7 @@
 /* Inline qualifier after a mount name ("— read-only", "— disconnected"). */
 .mount-hint {
   font-weight: 400;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 .mount-hint.warn {
@@ -366,7 +366,7 @@
 
 /* The remote spec shown under a mount name, clipped to one line. */
 .mount-remote {
-  font-size: 12px;
+  font-size: var(--text-meta);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -378,7 +378,7 @@
 
 /* Live preview of the rclone spec the Add button will mount. */
 .mount-spec {
-  font-size: 12px;
+  font-size: var(--text-meta);
   margin: 0;
 }
 .mount-spec .warn {
@@ -387,9 +387,9 @@
 
 /* Empty state — a quiet dashed panel pointing at the Add-mount form. */
 .mount-empty {
-  padding: 16px 18px;
+  padding: var(--space-4) var(--space-5);
   border: 1px dashed var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   text-align: center;
   color: var(--fg-muted);
 }
@@ -402,7 +402,7 @@
 .mount-picker {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(196px, 1fr));
-  gap: 8px;
+  gap: var(--space-2);
   align-items: stretch;
   /* Every row the same height, not just every card within a row. Grid sizes
      rows independently by default, so a one-line row sat visibly shorter than
@@ -426,12 +426,12 @@
   display: flex;
   /* Mark on the left, name over cost to its right. */
   flex-direction: row;
-  gap: 10px;
+  gap: var(--space-2-5);
   align-items: center;
   text-align: left;
-  padding: 10px 12px;
+  padding: var(--space-2-5) var(--space-3);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--bg-alt);
   cursor: pointer;
   font: inherit;
@@ -461,7 +461,7 @@
 .mount-provider-text {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: var(--space-1);
   min-width: 0;
   flex: 1;
 }
@@ -488,7 +488,7 @@
    page's one secondary size: this was the last `em` left on the page, and at
    0.8em it rendered at 10.4px, a ninth size nothing else used. */
 .mount-provider-cost {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   line-height: 1.4;
 }

--- a/frontend/src/styles/new-task.css
+++ b/frontend/src/styles/new-task.css
@@ -26,9 +26,9 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   flex: none;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg-muted);
   cursor: pointer;
   user-select: none;
@@ -61,12 +61,12 @@
   width: 16px;
   height: 16px;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: var(--bg-alt);
   color: var(--on-accent);
   /* Pinned properties, never `transition: all` — the box changes exactly two
      things when it is ticked. */
-  transition: background-color 0.12s ease-out, border-color 0.12s ease-out;
+  transition: background-color var(--dur-fast) ease-out, border-color var(--dur-fast) ease-out;
 }
 
 /* Two class names deep on purpose: `.schedule-form-line svg` paints every glyph
@@ -102,13 +102,13 @@
 /* The Repeat tick sits on the when-row, hard against its right edge — the
    date and time chips keep the row's stretch. */
 .new-task-check--repeat {
-  margin-left: 2px;
+  margin-left: var(--space-0-5);
 }
 
 /* …and "New task each run" sits beside the repeat dropdown on the sub-row,
    which is a flex row of its own. */
 .schedule-form-line--sub .new-task-check {
-  margin-left: 4px;
+  margin-left: var(--space-1);
 }
 
 /* The thread note under the repeat sub-row: which chat the runs land in. Quiet
@@ -150,7 +150,7 @@
 .new-task-run-pair {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .new-task-run-pair > .field {
@@ -189,7 +189,7 @@
   flex-direction: column;
   /* Tight, and tighter than the form's own 12px rhythm: the description hangs
      off the title as its second line, not as the next row of a form. */
-  gap: 2px;
+  gap: var(--space-0-5);
   /* The block's vertical space belongs to the two fields, and the description
      is the one that stretches into whatever is spare (see .new-task-ask). */
   flex: 1 1 auto;
@@ -221,7 +221,7 @@
      No `caret-color` either. The caret takes `color` — var(--fg) above — which
      is what every other field in the app gets, `.field-control` included; the
      --accent override drew a yellow-green cursor found nowhere else. */
-  padding: 6px 0;
+  padding: var(--space-1-5) 0;
   /* Both fields are stretched flex children, but an <input> carries an
      intrinsic `size` width that would otherwise fight a 460px card. */
   min-width: 0;
@@ -291,7 +291,7 @@
    and its rules went with it: the big field IS the description, so there is no
    third piece of prose to style.) */
 .new-task-write .new-task-title {
-  font-size: 20px;
+  font-size: var(--text-display);
   font-weight: 500;
   line-height: 1.35;
   /* One line. `pre` rather than `nowrap` so a pasted value's own spacing is not
@@ -328,7 +328,7 @@
    scrolls. Both clamp the inline height JS writes, so the measured value only
    ever picks a size between them. */
 .new-task-write .new-task-ask {
-  font-size: 13px;
+  font-size: var(--text-dense);
   font-weight: 400;
   line-height: 1.55;
   resize: none;
@@ -373,11 +373,11 @@
 .new-task-delete {
   /* Tighter than .btn's 7px: the trash glyph reads as part of the label, not
      as a separate affordance. */
-  gap: 6px;
+  gap: var(--space-1-5);
   /* Pinned properties, never `transition: all` — arming changes exactly these
      three, and the button must not animate its width or position. */
-  transition: background-color 0.12s ease-out, border-color 0.12s ease-out,
-    color 0.12s ease-out;
+  transition: background-color var(--dur-fast) ease-out, border-color var(--dur-fast) ease-out,
+    color var(--dur-fast) ease-out;
 }
 
 /* The glyph takes the button's own --error rather than any ambient icon
@@ -433,11 +433,11 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .new-task-images:not(:empty) {
-  padding: 0 0 8px;
+  padding: 0 0 var(--space-2);
 }
 
 .nt-img {
@@ -450,7 +450,7 @@
   padding: 0;
   background: none;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   overflow: hidden;
   line-height: 0;
   cursor: zoom-in;
@@ -493,7 +493,7 @@
   align-items: center;
   justify-content: center;
   padding: 0;
-  font-size: 9px;
+  font-size: var(--text-micro);
   line-height: 1;
   color: var(--scrim-fg);
   background: var(--scrim-bg);
@@ -523,9 +523,9 @@
      row share one top and one bottom edge. */
   height: 38px;
   box-sizing: border-box;
-  padding-right: 3px;
+  padding-right: var(--space-1);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
 }
 
 .nt-img:has(.nt-img-doc):hover,
@@ -536,16 +536,16 @@
 .deploy-body button.nt-img-doc {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   height: 36px;
   box-sizing: border-box;
-  padding: 0 4px 0 8px;
+  padding: 0 var(--space-1) 0 var(--space-2);
   border: 0;
   border-radius: 0;
   background: none;
   align-self: auto;
   line-height: 1;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   cursor: pointer;
 }
@@ -558,7 +558,7 @@
 }
 
 .nt-img-glyph {
-  font-size: 13px;
+  font-size: var(--text-dense);
   line-height: 1;
 }
 
@@ -577,7 +577,7 @@
   position: static;
   width: 18px;
   height: 18px;
-  font-size: 10px;
+  font-size: var(--text-micro);
   color: var(--fg-muted);
   background: transparent;
   border: 0;
@@ -611,7 +611,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: var(--space-6);
 }
 
 .nt-shotview-scrim {
@@ -627,11 +627,11 @@
   max-height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 10px;
+  border-radius: var(--radius-card);
+  padding: var(--space-2-5);
   box-shadow: 0 18px 50px var(--shadow-lg);
 }
 
@@ -641,7 +641,7 @@
   min-height: 0;
   max-width: 100%;
   object-fit: contain;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   cursor: zoom-in;
 }
 
@@ -668,14 +668,14 @@
   position: sticky;
   bottom: 0;
   background: var(--bg-alt);
-  padding-top: 6px;
+  padding-top: var(--space-1-5);
 }
 
 .nt-shotview-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 11.5px;
+  gap: var(--space-2);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -692,7 +692,7 @@
   direction: rtl;
   text-align: left;
   min-width: 0;
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 /* ---- a file's own preview, framed (D616) ---------------------------------- */
@@ -710,7 +710,7 @@
   height: min(70vh, 620px);
   min-height: 0;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: var(--bg);
 }
 
@@ -719,9 +719,9 @@
    flight, which is what keeps the dialog from opening onto an empty rectangle. */
 .nt-shotview-load {
   margin: 0;
-  padding: 24px 0;
+  padding: var(--space-6) 0;
   text-align: center;
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 

--- a/frontend/src/styles/new-task.css
+++ b/frontend/src/styles/new-task.css
@@ -335,9 +335,9 @@
   overflow-wrap: anywhere;
   /* Six lines of the 13px face plus the shared padding: the block the reference
      image gives the description, and the slack it takes. */
-  min-height: calc(13px * 1.55 * 6 + 12px);
+  min-height: calc(var(--text-dense) * 1.55 * 6 + var(--space-3));
   /* Ten, then it scrolls. */
-  max-height: calc(13px * 1.55 * 10 + 12px);
+  max-height: calc(var(--text-dense) * 1.55 * 10 + var(--space-3));
   overflow-y: auto;
   flex: 1 1 auto;
 }

--- a/frontend/src/styles/notifications.css
+++ b/frontend/src/styles/notifications.css
@@ -13,7 +13,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
   max-width: min(360px, calc(100vw - 32px));
   pointer-events: none;
 }
@@ -47,20 +47,20 @@
 
 .toast-slot.leaving {
   grid-template-rows: 0fr;
-  margin-bottom: -8px; /* cancels .notif-host's gap as the row closes */
+  margin-bottom: calc(-1 * var(--space-2)); /* cancels .notif-host's gap as the row closes */
 }
 
 .toast {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   max-width: 100%;
-  padding: 8px 10px 8px 12px;
-  font-size: 12px;
+  padding: var(--space-2) var(--space-2-5) var(--space-2) var(--space-3);
+  font-size: var(--text-meta);
   color: var(--fg);
   background: var(--bg-alt);
   border: 1px solid var(--error);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 6px 20px var(--shadow-lg);
   animation: toast-in var(--dur-med) var(--ease-out);
 }
@@ -105,9 +105,9 @@
   background: none;
   border: none;
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   cursor: pointer;
-  padding: 0 2px;
+  padding: 0 var(--space-0-5);
 }
 
 .toast-close:hover {
@@ -119,11 +119,11 @@
   flex: 0 0 auto;
   background: none;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   color: var(--fg);
-  font-size: 12px;
+  font-size: var(--text-meta);
   cursor: pointer;
-  padding: 3px 8px;
+  padding: var(--space-1) var(--space-2);
 }
 
 .toast-action:hover {
@@ -174,7 +174,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 0;
-  padding: 0 var(--status-bar-gutter) 0 8px;
+  padding: 0 var(--status-bar-gutter) 0 var(--space-2);
   /* FIXED 22px, VS Code's own status-bar height (D576, user: "lets follow
      exactly what vscode is doing for the status bar") — `height`, not
      `min-height`, because every item is now full-height and nothing inside
@@ -275,7 +275,7 @@
   flex: 0 0 auto;
   width: 1px;
   height: 11px;
-  margin: 0 3px;
+  margin: 0 var(--space-1);
   background: var(--fg-muted);
   opacity: 0.5;
 }
@@ -293,7 +293,7 @@
 .dl-toggle {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   min-width: 0;
   /* A FULL-HEIGHT SQUARE RECTANGLE (D576) — the single biggest difference from
      round 4, which drew an inset pill: `padding: 3px 8px` with a compensating
@@ -303,12 +303,12 @@
      runs edge to edge vertically. The negative margin is gone along with the
      inset it was compensating for. */
   height: 100%;
-  padding: 0 5px;
+  padding: 0 var(--space-1-5);
   border-radius: 0;
   font: inherit;
   /* 12px regular — VS Code's status bar runs 12px at normal weight; round 4's
      11px was a guess at "denser". `.dl-summary`'s weight goes with it, below. */
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg);
   background: none;
   border: none;
@@ -350,7 +350,7 @@
    "Models 2" = two. */
 .dl-toggle.sc {
   position: relative;
-  gap: 5px;
+  gap: var(--space-1-5);
   /* No overflow clip here: the progress line sits 1px ABOVE the chip's box
      (into the bar's top border) and would lose that pixel. The label clips
      itself (`.dl-summary`'s ellipsis). */
@@ -367,13 +367,13 @@
    and a second colour on the numeral would be the same fact said twice. */
 .sc-num {
   flex: 0 0 auto;
-  font-size: 10px;
+  font-size: var(--text-micro);
   font-weight: 650;
   line-height: 1;
   color: var(--accent);
   background: rgba(var(--accent-rgb), 0.12);
-  border-radius: 8px;
-  padding: 2px 5px;
+  border-radius: var(--radius-md);
+  padding: var(--space-0-5) var(--space-1-5);
   font-variant-numeric: tabular-nums;
 }
 
@@ -500,13 +500,13 @@
   position: absolute;
   bottom: 100%;
   right: var(--status-bar-gutter);
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
   width: max-content;
   max-width: min(340px, calc(100vw - 32px));
   color: var(--fg);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 6px 20px var(--shadow-lg);
   animation: toast-in var(--dur-med) var(--ease-out);
   overflow: hidden;
@@ -560,9 +560,9 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
-  padding: 6px 10px;
-  font-size: 12px;
+  gap: var(--space-2);
+  padding: var(--space-1-5) var(--space-2-5);
+  font-size: var(--text-meta);
   border-top: 1px solid var(--border);
 }
 
@@ -655,7 +655,7 @@
    one. */
 .dl-panel-empty {
   min-width: min(238px, calc(100vw - 34px));
-  padding: 10px;
+  padding: var(--space-2-5);
   /* Centred (D592, user: "also make the 'no jobs' etc text center aligned in
      the popover"). One rule covers all four sections because they already
      share this class — `No models loaded` / `No engines running` / `No jobs` /
@@ -663,7 +663,7 @@
      stranded fragment left-aligned; centred it reads as the panel's own
      state. */
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -703,12 +703,12 @@
 .dl-clear,
 .dl-jobs-clear {
   flex: 0 0 auto;
-  padding: 2px 8px;
-  font-size: 11px;
+  padding: var(--space-0-5) var(--space-2);
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   background: none;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -735,8 +735,8 @@
    principle D604 already applied to Clear/Cancel queued. Quiet on purpose:
    this is a sub-heading inside an already-labelled chip, not a second chip. */
 .dl-section-head {
-  padding: 6px 10px 0;
-  font-size: 10px;
+  padding: var(--space-1-5) var(--space-2-5) 0;
+  font-size: var(--text-micro);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -805,7 +805,7 @@
    correctness argument as deleting dead branches. */
 .dl-row {
   min-width: min(238px, calc(100vw - 34px));
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2-5);
 }
 
 /* A reporter that went away: dimmed, because the numbers below are the last
@@ -818,9 +818,9 @@
 .dl-row-head {
   display: flex;
   align-items: baseline;
-  gap: 8px;
-  font-size: 12px;
-  margin-bottom: 5px;
+  gap: var(--space-2);
+  font-size: var(--text-meta);
+  margin-bottom: var(--space-1-5);
 }
 
 /* THE TITLE WRAPS INSTEAD OF COMPETING (D596, user: "we have a ton of free
@@ -906,11 +906,11 @@
    token and wrapping one mid-word reads worse than truncating it; at full panel
    width it now almost never reaches that. Full id stays on hover. */
 .dl-model {
-  margin-bottom: 5px;
+  margin-bottom: var(--space-1-5);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -936,7 +936,7 @@
    `.dl-amount`/`.dl-mem-live`, which already carry their own overflow rules,
    and neither of those changes here. */
 .dl-row-figures {
-  margin-bottom: 5px;
+  margin-bottom: var(--space-1-5);
 }
 
 /* ZEROED WHEN IT IS THE LAST CHILD — the common case, since most rows carry
@@ -978,7 +978,7 @@
    not under pressure at all. */
 .dl-amount {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -1023,7 +1023,7 @@
    D577, `.dl-pct` did not). */
 .dl-pct {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums; /* the percentage must not jitter as it counts */
 }
@@ -1050,12 +1050,12 @@
    does not exist between them. */
 .dl-row-cancel {
   flex: 0 0 auto;
-  padding: 3px 10px;
-  font-size: 11px;
+  padding: var(--space-1) var(--space-2-5);
+  font-size: var(--text-caption);
   color: var(--fg);
   background: var(--row-bg-hover);
   border: 1px solid var(--fg-muted);
-  border-radius: 5px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -1105,8 +1105,8 @@
   align-items: center;
   justify-content: center;
   min-width: 16px;
-  padding: 0 2px;
-  font-size: 11px;
+  padding: 0 var(--space-0-5);
+  font-size: var(--text-caption);
   line-height: 1;
   color: var(--fg-muted);
   background: none;
@@ -1130,8 +1130,8 @@
 }
 
 .dl-status {
-  margin-top: 5px;
-  font-size: 11px;
+  margin-top: var(--space-1-5);
+  font-size: var(--text-caption);
   line-height: 1.4;
   color: var(--fg-muted);
   /* Clamped, not clipped to one line: the two longest things that land here are
@@ -1184,7 +1184,7 @@ button.dl-row:hover {
 
 .dl-bar {
   height: 4px;
-  border-radius: 2px;
+  border-radius: var(--radius-hairline);
   background: rgba(var(--fg-muted-rgb), 0.22);
   overflow: hidden;
 }
@@ -1241,12 +1241,12 @@ button.dl-row:hover {
    verb family (Unload/Stop/Cancel), so it was not a fit for Update/Switch. */
 .q-all {
   flex: 0 0 auto;
-  padding: 2px 8px;
-  font-size: 11px;
+  padding: var(--space-0-5) var(--space-2);
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   background: none;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -1279,14 +1279,14 @@ button.dl-row:hover {
    .notif-host — this only describes the card. */
 .server-status {
   max-width: 100%;
-  padding: 10px 12px;
-  font-size: 12px;
+  padding: var(--space-2-5) var(--space-3);
+  font-size: var(--text-meta);
   color: var(--fg);
   background: var(--bg-alt);
   border: 1px solid var(--error);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 6px 20px var(--shadow-lg);
-  animation: server-status-in 0.15s ease-out;
+  animation: server-status-in var(--dur-base) ease-out;
 }
 
 @keyframes server-status-in {
@@ -1303,7 +1303,7 @@ button.dl-row:hover {
 .server-status-title {
   font-weight: 600;
   color: var(--error);
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 
 .server-status-body {
@@ -1313,13 +1313,13 @@ button.dl-row:hover {
 
 .server-status-retry,
 .server-status-launch {
-  margin-top: 8px;
-  padding: 3px 10px;
-  font-size: 12px;
+  margin-top: var(--space-2);
+  padding: var(--space-1) var(--space-2-5);
+  font-size: var(--text-meta);
   color: var(--fg);
   background: none;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
 }
 
@@ -1332,7 +1332,7 @@ button.dl-row:hover {
    dressed as the sibling button; inline-block so padding/margin apply. */
 .server-status-launch {
   display: inline-block;
-  margin-right: 8px;
+  margin-right: var(--space-2);
   color: inherit;
   text-decoration: none;
 }
@@ -1356,7 +1356,7 @@ button.dl-row:hover {
 /* The FDA strip's (FdaStrip.tsx) how-to, an ordered list in the strip body. */
 .fda-steps {
   margin: 0;
-  padding-left: 18px;
+  padding-left: var(--space-5);
 }
 
 .fda-steps li {
@@ -1369,8 +1369,8 @@ button.dl-row:hover {
   border: none;
   color: var(--fg-muted);
   cursor: pointer;
-  padding: 4px 8px;
-  font-size: 15px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-title);
   line-height: 1;
 }
 

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -9,11 +9,11 @@
    entry needed. */
 .sidebar-footer {
   margin-top: auto;
-  padding: 6px;
+  padding: var(--space-1-5);
   border-top: 1px solid var(--border);
   flex: 0 0 auto;
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .sidebar-footer .prefs-link {
@@ -22,9 +22,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 8px 4px;
-  border-radius: 6px;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-1);
+  border-radius: var(--radius-control);
   background: none;
   border: none;
   font: inherit;
@@ -38,7 +38,7 @@
 }
 
 .sidebar-footer .prefs-label {
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   line-height: 1;
   max-width: 100%;
   overflow: hidden;
@@ -57,7 +57,7 @@
    list treatment as the sub-app list at the top. */
 .sidebar-settings {
   margin-top: auto;
-  padding-top: 6px;
+  padding-top: var(--space-1-5);
   border-top: 1px solid var(--border);
   flex: 0 0 auto;
 }
@@ -75,7 +75,7 @@
 .files-home-inner {
   max-width: 1120px;
   margin: 0 auto;
-  padding: 36px 28px 72px;
+  padding: var(--space-10) var(--space-7) var(--space-18);
 }
 
 /* Doubled selector: home.css loads after this file, so plain .files-hero
@@ -88,8 +88,8 @@
   border-color: transparent;
   /* With the card invisible and no brand row above the box, its padding reads
      as dead air on both sides of the one control here. */
-  padding-top: 18px;
-  padding-bottom: 10px;
+  padding-top: var(--space-5);
+  padding-bottom: var(--space-2-5);
   margin-bottom: 0;
 }
 
@@ -101,17 +101,17 @@
    right edge. Quiet on purpose: an outlined pill, no accent fill, so it sits
    beside the tabs as a peer instead of shouting over them. */
 .files-hero-cta {
-  margin: 0 0 6px auto;
+  margin: 0 0 var(--space-1-5) auto;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 12px;
-  font-size: 12.5px;
+  gap: var(--space-2);
+  padding: var(--space-1-5) var(--space-3);
+  font-size: var(--text-dense);
   font-weight: 600;
   color: var(--fg-muted);
   background: none;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
@@ -134,13 +134,13 @@
 .files-search {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 0 12px;
+  gap: var(--space-2-5);
+  padding: 0 var(--space-3);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-panel);
   box-shadow: 0 2px 10px color-mix(in srgb, var(--fg) 5%, transparent);
-  transition: border-color 120ms ease;
+  transition: border-color var(--dur-fast) ease;
 }
 
 .files-search:focus-within {
@@ -159,12 +159,12 @@
 .files-search-input:focus {
   flex: 1 1 auto;
   min-width: 0;
-  padding: 12px 0;
+  padding: var(--space-3) 0;
   border: none;
   outline: none;
   box-shadow: none;
   background: transparent;
-  font-size: 14px;
+  font-size: var(--text-body);
   line-height: 1.4;
   color: inherit;
 }
@@ -178,11 +178,11 @@
 
 .files-search-clear {
   flex: none;
-  padding: 3px 10px;
-  font-size: 11.5px;
+  padding: var(--space-1) var(--space-2-5);
+  font-size: var(--text-meta);
   font-weight: 600;
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-alt);
   color: var(--fg-muted);
   cursor: pointer;
@@ -195,14 +195,14 @@
 /* The results panel: attached to the bar, not a separate card floating below
    it — hence the small gap and no border of its own. */
 .fh-panel {
-  margin-top: 10px;
+  margin-top: var(--space-2-5);
 }
 
 /* The line above the list: match count and the keys that drive it, or why
    there is no count (index still building, a failure, a scan in flight). */
 .fh-result-note {
-  margin: 0 0 8px;
-  font-size: 12px;
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-meta);
   line-height: 16px;
   min-height: 16px;
   color: var(--fg-muted);
@@ -224,13 +224,13 @@
 .fh-index-chip {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  margin-left: 8px;
-  padding: 1px 7px 1px 6px;
+  gap: var(--space-1-5);
+  margin-left: var(--space-2);
+  padding: 1px var(--space-2) 1px var(--space-1-5);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-alt);
-  font-size: 11px;
+  font-size: var(--text-caption);
   line-height: 16px;
   color: var(--fg-muted);
   vertical-align: baseline;
@@ -285,16 +285,16 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: var(--space-3);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  padding: var(--space-2-5) var(--space-3);
   background: var(--bg-alt);
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
 }
 
 .fh-index-cta-text {
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
 }
 
@@ -309,15 +309,15 @@
 
 .fh-result-note kbd {
   font: inherit;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   margin: 0 1px;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: var(--bg-alt);
 }
 
 .fh-section {
-  margin-top: 30px;
+  margin-top: var(--space-8);
 }
 
 /* -- Home page sections (shell/Home.tsx) --------------------------------------
@@ -331,7 +331,7 @@
   max-width: none;
   /* Tighter than the explorer home's 36px: the search bar is the first thing
      on the front door, so it sits closer to the top. */
-  padding-top: 8px;
+  padding-top: var(--space-2);
 }
 
 .home-wide .files-search-wrap {
@@ -343,13 +343,13 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3-5);
 }
 
 .home-sec-title {
   margin: 0;
-  font-size: 17px;
+  font-size: var(--text-heading);
   font-weight: 700;
 }
 
@@ -365,8 +365,8 @@
 .home-sec-more {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 12.5px;
+  gap: var(--space-1);
+  font-size: var(--text-dense);
   font-weight: 600;
   color: var(--fg-muted);
   text-decoration: none;
@@ -389,7 +389,7 @@
 
 .home-row {
   display: flex;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .home-row > * {
@@ -411,13 +411,13 @@
    room to not read as a stray line of text, nowhere near a card's worth of
    empty box. */
 .home-section .fh-empty {
-  padding: 20px 0;
+  padding: var(--space-5) 0;
   text-align: center;
 }
 
 .fh-empty {
   margin: 0;
-  font-size: 13.5px;
+  font-size: var(--text-body);
   color: var(--fg-muted);
 }
 
@@ -551,7 +551,7 @@
   max-height: max(440px, calc(100dvh - 11rem));
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
 }
 
 .fh-results li + li {
@@ -564,8 +564,8 @@
   display: flex;
   width: 100%;
   align-items: center;
-  gap: 10px;
-  padding: 8px 14px;
+  gap: var(--space-2-5);
+  padding: var(--space-2) var(--space-3-5);
   text-align: left;
   text-decoration: none;
   color: inherit;
@@ -600,7 +600,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--text-dense);
   font-weight: 600;
 }
 
@@ -610,15 +610,15 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .fh-result-meta {
   flex: none;
   display: inline-flex;
-  gap: 12px;
-  font-size: 11.5px;
+  gap: var(--space-3);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -670,8 +670,8 @@
 }
 
 .fh-ai-action {
-  padding-top: 12px;
-  padding-bottom: 12px;
+  padding-top: var(--space-3);
+  padding-bottom: var(--space-3);
 }
 
 .fh-ai-action .fh-result-name {
@@ -707,7 +707,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-style: italic;
   color: var(--fg-muted);
 }
@@ -727,15 +727,15 @@
   flex: none;
   width: 52px;
   text-align: right;
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .fh-ai-hint kbd {
   font: inherit;
-  padding: 0 4px;
+  padding: 0 var(--space-1);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: var(--bg-alt);
 }
 
@@ -744,11 +744,11 @@
 .fh-ai-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  margin-right: 8px;
-  padding: 1px 7px 1px 5px;
-  border-radius: 999px;
-  font-size: 11px;
+  gap: var(--space-1);
+  margin-right: var(--space-2);
+  padding: 1px var(--space-2) 1px var(--space-1-5);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-caption);
   font-weight: 700;
   letter-spacing: 0.04em;
   color: var(--accent);
@@ -763,8 +763,8 @@
 
 /* The "Understood as: …" echo line above AI search results. */
 .fh-search-summary {
-  margin: 0 0 8px;
-  font-size: 12.5px;
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-dense);
   color: var(--fg-muted);
 }
 
@@ -774,19 +774,19 @@
 .fh-tabs {
   display: flex;
   align-items: flex-end;
-  margin-bottom: 14px;
+  margin-bottom: var(--space-3-5);
   border-bottom: 1px solid var(--border);
 }
 
 .fh-tablist {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .fh-tab {
-  padding: 0 2px 10px;
-  margin-right: 14px;
-  font-size: 13px;
+  padding: 0 var(--space-0-5) var(--space-2-5);
+  margin-right: var(--space-3-5);
+  font-size: var(--text-dense);
   font-weight: 600;
   color: var(--fg-muted);
   background: none;
@@ -812,25 +812,25 @@
   justify-content: center;
   width: 34px;
   height: 34px;
-  border-radius: 9px;
+  border-radius: var(--radius-card);
   background: color-mix(in srgb, var(--fg) 5%, transparent);
   color: var(--accent);
 }
 
 .fh-card-emoji {
-  font-size: 17px;
+  font-size: var(--text-heading);
   line-height: 1;
 }
 
 .fh-card-text {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
   min-width: 0;
 }
 
 .fh-card-name {
-  font-size: 13.5px;
+  font-size: var(--text-body);
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -838,7 +838,7 @@
 }
 
 .fh-card-path {
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   white-space: nowrap;
   overflow: hidden;
@@ -854,7 +854,7 @@
 .fhb-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .fhb-card {
@@ -865,17 +865,17 @@
   text-decoration: none;
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: var(--radius-tile);
   /* The card carries the padding and the body well brings its own radius, so
      the body reads as an inset floating panel (the ref design) rather than a
      full-bleed border-top split. */
-  padding: 6px;
+  padding: var(--space-1-5);
   box-shadow: 0 1px 2px var(--shadow-sm);
   overflow: hidden;
   transition:
-    border-color 0.15s ease,
-    box-shadow 0.15s ease,
-    transform 0.15s ease;
+    border-color var(--dur-base) ease,
+    box-shadow var(--dur-base) ease,
+    transform var(--dur-base) ease;
 }
 
 .fhb-card:hover {
@@ -887,8 +887,8 @@
 .fhb-card-head {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 7px 8px 11px;
+  gap: var(--space-2-5);
+  padding: var(--space-2) var(--space-2) var(--space-3);
   min-width: 0;
 }
 
@@ -897,12 +897,12 @@
 .fhb-card .fh-card-icon {
   width: 36px;
   height: 36px;
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   border: 1px solid color-mix(in srgb, var(--fg) 7%, transparent);
 }
 
 .fhb-card .fh-card-name {
-  font-size: 14px;
+  font-size: var(--text-body);
   font-weight: 650;
 }
 
@@ -918,7 +918,7 @@
   aspect-ratio: 16 / 10;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   overflow: hidden;
 }
 
@@ -968,11 +968,11 @@
   flex-direction: column;
   align-items: stretch;
   aspect-ratio: 16 / 10;
-  padding: 10px 10px 0;
+  padding: var(--space-2-5) var(--space-2-5) 0;
   /* The base --bg (a step darker than the card's --bg-alt) so the sheets —
      lifted toward --fg below — read clearly against the well they sit in. */
   background: var(--bg);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   overflow: hidden;
 }
 
@@ -983,30 +983,30 @@
   flex: 0 0 auto;
   /* A step below .fh-card-path (11.5px) — the sheet labels must read smaller
      than the card's own path line. */
-  font-size: 10px;
+  font-size: var(--text-micro);
   /* Lifted a step above --bg-panel so the sheets separate from the stack's
      --bg well; separation is carried by shadow, the hairline only stops
      same-value surfaces from fusing. */
   background: color-mix(in srgb, var(--fg) 7%, var(--bg-panel));
   border: 1px solid color-mix(in srgb, var(--fg) 13%, var(--bg-panel));
-  border-radius: 12px;
+  border-radius: var(--radius-panel);
   box-shadow: 0 1px 2px var(--shadow-sm), 0 4px 12px var(--shadow-sm);
-  transition: margin 0.18s ease;
+  transition: margin var(--dur-base) ease;
 }
 
 .fhb-sheet-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
-  padding: 11px;
-  transition: padding 0.18s ease;
+  padding: var(--space-3);
+  transition: padding var(--dur-base) ease;
 }
 
 /* Hover breathes the title rows open a hair along with the fan. */
 .fhb-card:hover .fhb-sheet-row {
-  padding-top: 12px;
-  padding-bottom: 12px;
+  padding-top: var(--space-3);
+  padding-bottom: var(--space-3);
 }
 
 /* Depth cascade: the front sheet (d0) is full width and holds the body; each
@@ -1018,17 +1018,17 @@
   min-height: 0;
   z-index: 3;
   border-bottom: none;
-  border-radius: 12px 12px 0 0;
+  border-radius: var(--radius-panel) var(--radius-panel) 0 0;
   overflow: hidden;
 }
 
 .fhb-sheet-d1 {
-  margin: 0 10px -33px;
+  margin: 0 var(--space-2-5) calc(-1 * var(--space-8));
   z-index: 2;
 }
 
 .fhb-sheet-d2 {
-  margin: 0 20px -33px;
+  margin: 0 var(--space-5) calc(-1 * var(--space-8));
   z-index: 1;
 }
 
@@ -1038,7 +1038,7 @@
 .fhb-sheet-d1,
 .fhb-sheet-d2 {
   border-bottom: none;
-  border-radius: 12px 12px 0 0;
+  border-radius: var(--radius-panel) var(--radius-panel) 0 0;
 }
 
 /* The back sheet's page body: a blank strip a step off the sheet's own fill,
@@ -1081,7 +1081,7 @@
    move apart, not just a page-edge sliver. */
 .fhb-card:hover .fhb-sheet-d1,
 .fhb-card:hover .fhb-sheet-d2 {
-  margin-bottom: -18px;
+  margin-bottom: calc(-1 * var(--space-5));
 }
 
 .fhb-sheet-icon {
@@ -1125,8 +1125,8 @@
   align-items: center;
   justify-content: center;
   min-height: 60px;
-  padding: 12px;
-  font-size: 12px;
+  padding: var(--space-3);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -1136,11 +1136,11 @@
   align-items: center;
   justify-content: center;
   aspect-ratio: 16 / 10;
-  padding: 12px;
-  font-size: 12px;
+  padding: var(--space-3);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   background: rgba(var(--tint), 0.04);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   text-align: center;
 }
 
@@ -1156,7 +1156,7 @@
    this card is not. */
 .fhb-empty {
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2-5);
 }
 
 .fhb-empty-mark {
@@ -1181,16 +1181,16 @@
 .fhb-more {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin: 14px auto 0;
-  padding: 5px 14px;
-  font-size: 12px;
+  gap: var(--space-1-5);
+  margin: var(--space-3-5) auto 0;
+  padding: var(--space-1-5) var(--space-3-5);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
-  transition: color 0.12s ease, border-color 0.12s ease;
+  transition: color var(--dur-fast) ease, border-color var(--dur-fast) ease;
 }
 
 .fhb-more:hover {
@@ -1203,7 +1203,7 @@
   background: var(--bg-popover);
   color: var(--tour-fg);
   border: 1px solid rgba(var(--tint), 0.12);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   box-shadow: 0 8px 30px var(--shadow-lg);
 }
 
@@ -1246,7 +1246,7 @@
   background: transparent;
   color: var(--tour-desc);
   border: 1px solid rgba(var(--tint), 0.12);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   text-shadow: none;
 }
 
@@ -1269,16 +1269,16 @@
 }
 
 .prefs-page {
-  padding: 18px 22px 32px;
+  padding: var(--space-5) var(--space-6) var(--space-8);
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--space-6);
   /* Full-width scroll container so the scrollbar sits at the window edge, not
      inset at the 760px content boundary. The content column is capped by the
      child rule below (previously max-width lived here, which made the narrow
      760px box itself the scroller — a mid-page scrollbar). */
   overflow-y: auto;
-  font-size: 13px;
+  font-size: var(--text-dense);
 }
 
 /* Cap the settings/mounts content column while the scroller stays full-width.
@@ -1292,15 +1292,15 @@
    Templates page's bindings/library tabs. */
 .prefs-tabs {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
   border-bottom: 1px solid var(--border);
 }
 
 .prefs-tab {
   font: inherit;
-  font-size: 13px;
-  padding: 9px 4px;
-  margin-right: 20px;
+  font-size: var(--text-dense);
+  padding: var(--space-2-5) var(--space-1);
+  margin-right: var(--space-5);
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
@@ -1320,20 +1320,20 @@
 .prefs-tabpanel {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--space-6);
 }
 
 .prefs-section {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2-5);
 }
 
 .prefs-section h2 {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--text-body);
   font-weight: 600;
-  padding-bottom: 6px;
+  padding-bottom: var(--space-1-5);
   border-bottom: 1px solid var(--border);
 }
 
@@ -1344,9 +1344,9 @@
 .prefs-section code {
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 5px;
-  font-size: 12px;
+  border-radius: var(--radius-xs);
+  padding: 1px var(--space-1-5);
+  font-size: var(--text-meta);
   /* `anywhere`, not `word-break: break-all`: both stop a long path or client ID
      from overflowing, but break-all also split short tokens that would have fit
      on the next line — "env_auth" rendered as "en / v_auth" mid-sentence in the
@@ -1356,9 +1356,9 @@
 
 .prefs-section button {
   font: inherit;
-  padding: 5px 12px;
+  padding: var(--space-1-5) var(--space-3);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg);
   color: var(--fg);
   cursor: pointer;
@@ -1381,7 +1381,7 @@
 .prefs-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
 }
 
@@ -1389,13 +1389,13 @@
    is a path or glob, where a mistaken space matters. */
 .prefs-textarea {
   font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.5;
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2-5);
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   resize: vertical;
 }
 
@@ -1415,8 +1415,8 @@
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 7px 10px;
+  border-radius: var(--radius-control);
+  padding: var(--space-2) var(--space-2-5);
 }
 
 /* ---- the index Query panel (shell/Indexing.tsx) ------------------------- */
@@ -1435,14 +1435,14 @@
    what actually ran, and read-only text rather than a second editable box —
    editing it means putting it in the box above and re-running. */
 .index-query-sql {
-  margin: 10px 0 0;
-  padding: 8px 10px;
+  margin: var(--space-2-5) 0 0;
+  padding: var(--space-2) var(--space-2-5);
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-left: 2px solid var(--accent);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.5;
   /* A compiled statement can be one long line; it scrolls rather than reflowing
      the panel, which is the same trade the input above makes. */
@@ -1455,11 +1455,11 @@
    predicted, and letting it size the panel would push the rest of Preferences
    sideways. */
 .index-query-results {
-  margin-top: 10px;
+  margin-top: var(--space-2-5);
   max-height: 420px;
   overflow: auto;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
 }
 
 .index-query-results table {
@@ -1469,12 +1469,12 @@
   width: max-content;
   min-width: 100%;
   font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .index-query-results th,
 .index-query-results td {
-  padding: 4px 10px;
+  padding: var(--space-1) var(--space-2-5);
   text-align: left;
   white-space: nowrap;
   border-bottom: 1px solid var(--border);
@@ -1499,18 +1499,18 @@
 /* Share on local network: QR pairing + paired devices (Preferences ▸ Render). */
 .lan-pair {
   display: flex;
-  gap: 20px;
+  gap: var(--space-5);
   align-items: flex-start;
-  margin-top: 14px;
+  margin-top: var(--space-3-5);
 }
 .lan-pair-qr {
   flex: 0 0 168px;
   width: 168px;
   height: 168px;
-  padding: 10px;
+  padding: var(--space-2-5);
   background: var(--qr-paper); /* a QR is read by a camera: always dark-on-white */
-  border-radius: 10px;
-  transition: opacity 160ms ease;
+  border-radius: var(--radius-card);
+  transition: opacity var(--dur-base) ease;
 }
 .lan-pair-qr svg {
   display: block;
@@ -1522,16 +1522,16 @@
   min-width: 0;
 }
 .lan-pair-text p {
-  margin: 0 0 10px;
+  margin: 0 0 var(--space-2-5);
 }
 .lan-devices {
-  margin-top: 18px;
+  margin-top: var(--space-5);
 }
 .lan-devices-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 6px;
+  margin-bottom: var(--space-1-5);
 }
 .lan-devices ul {
   list-style: none;
@@ -1542,8 +1542,8 @@
 .lan-devices li {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 8px 0;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
   border-bottom: 1px solid var(--border);
 }
 .lan-device-name {
@@ -1552,5 +1552,5 @@
 }
 .lan-devices li .deploy-muted {
   flex: 1;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -11,9 +11,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
+  padding: var(--space-2-5) var(--space-4);
   border-bottom: 1px solid var(--border);
-  gap: 12px;
+  gap: var(--space-3);
   /* Pin the height to the tallest state (28px mode control + 10px×2
      padding + 1px border) so the header can't grow when the loading spinner is
      replaced by the real switcher on stat resolve — otherwise the name and the
@@ -28,13 +28,13 @@
 .preview-title {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   min-width: 0;
   flex: 1 1 auto;
 }
 
 .preview-header h1 {
-  font-size: 15px;
+  font-size: var(--text-title);
   font-weight: 600;
   margin: 0;
   overflow: hidden;
@@ -45,7 +45,7 @@
 .preview-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 0 0 auto;
 }
 
@@ -65,9 +65,9 @@
 .preview-actions button:not(.bar-ctl):not(.bar-menu-item),
 .preview-actions a {
   font: inherit;
-  padding: 5px 10px;
+  padding: var(--space-1-5) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg);
   color: var(--fg);
   text-decoration: none;
@@ -120,8 +120,8 @@
   width: 16px;
   height: 16px;
   border: 1.5px solid currentColor;
-  border-radius: 4px;
-  font-size: 9px;
+  border-radius: var(--radius-xs);
+  font-size: var(--text-micro);
   font-weight: 700;
   line-height: 1;
 }
@@ -159,9 +159,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: var(--space-2-5);
   color: var(--fg-muted);
-  font-size: 13px;
+  font-size: var(--text-dense);
 }
 
 
@@ -229,7 +229,7 @@
   flex: 0 0 5px;
   cursor: col-resize;
   background: transparent;
-  margin: 0 -2px;
+  margin: 0 calc(-1 * var(--space-0-5));
   z-index: 2;
   /* The drag is pointer-captured; without this, touch scrolling fights it. */
   touch-action: none;
@@ -358,8 +358,8 @@ html.side-reopening iframe {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 8px;
-  padding: var(--topbar-pad-y) 10px;
+  gap: var(--space-2);
+  padding: var(--topbar-pad-y) var(--space-2-5);
   height: var(--topbar-h);
   box-sizing: border-box;
   border-bottom: 1px solid var(--border);
@@ -379,10 +379,10 @@ html.side-reopening iframe {
 }
 
 .metadata-card {
-  margin: 24px;
-  padding: 20px;
+  margin: var(--space-6);
+  padding: var(--space-5);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   background: var(--bg-alt);
   max-width: 480px;
 }
@@ -390,8 +390,8 @@ html.side-reopening iframe {
 .metadata-card dl {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 6px 16px;
-  margin: 0 0 16px 0;
+  gap: var(--space-1-5) var(--space-4);
+  margin: 0 0 var(--space-4) 0;
 }
 
 .metadata-card dt {
@@ -412,7 +412,7 @@ html.side-reopening iframe {
 .metadata-stack {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 /* The "get me out of this" panel FallbackPreview shows above the plain
@@ -425,28 +425,28 @@ html.side-reopening iframe {
 }
 
 .registry-fix-notice p {
-  margin: 0 0 10px 0;
+  margin: 0 0 var(--space-2-5) 0;
 }
 
 .registry-fix-notice code {
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 5px;
+  border-radius: var(--radius-xs);
+  padding: 1px var(--space-1-5);
 }
 
 .registry-fix-hint {
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .registry-fix-error {
   color: var(--error);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .status-message {
-  padding: 24px;
+  padding: var(--space-6);
   color: var(--fg-muted);
 }
 
@@ -454,18 +454,18 @@ html.side-reopening iframe {
    whose listing hit the server cap. Its Load more button fetches the next
    page (resumable S3-direct route only). */
 .listing-truncated .status-message {
-  padding: 10px 16px;
-  font-size: 12px;
+  padding: var(--space-2-5) var(--space-4);
+  font-size: var(--text-meta);
   border-top: 1px solid var(--border);
 }
 .listing-load-more {
-  margin-left: 10px;
-  padding: 3px 10px;
+  margin-left: var(--space-2-5);
+  padding: var(--space-1) var(--space-2-5);
   background: transparent;
   color: var(--accent);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 12px;
+  border-radius: var(--radius-control);
+  font-size: var(--text-meta);
   cursor: pointer;
 }
 .listing-load-more:hover:not(:disabled) {
@@ -484,11 +484,11 @@ html.side-reopening iframe {
 .status-message.error {
   background: var(--error-page-bg);
   border: 2px solid var(--error-page-border);
-  border-radius: 10px;
-  padding: 14px 16px;
+  border-radius: var(--radius-card);
+  padding: var(--space-3-5) var(--space-4);
   color: var(--error-page-fg);
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 13px;
+  font-size: var(--text-dense);
   white-space: pre-wrap;
   word-break: break-word;
   overflow: visible;
@@ -570,11 +570,11 @@ body.embed:not(.snapshot) .preview-browse-chip {
   display: inline-flex;
   align-items: center;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--text-caption);
   line-height: 1;
-  padding: 5px 9px;
+  padding: var(--space-1-5) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--bg-alt);
   color: var(--fg-muted);
   cursor: pointer;
@@ -594,7 +594,7 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   position: relative;
   flex: 1 1 auto;
   min-height: 0;
-  padding: 6px;
+  padding: var(--space-1-5);
 }
 
 .panel-root > * {
@@ -604,7 +604,7 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
 
 .panel-split {
   display: flex;
-  gap: 6px;
+  gap: var(--space-1-5);
   width: 100%;
   height: 100%;
 }
@@ -628,7 +628,7 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   flex-direction: column;
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -641,11 +641,11 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
 .panel-bar {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
   /* Pins to the tallest state (24px control + 4px x 2 padding) so the bar
      can't grow when the mode control lands after the pane's stat resolves. */
   min-height: 32px;
-  padding: 4px 6px;
+  padding: var(--space-1) var(--space-1-5);
   background: var(--bg);
   border-bottom: 1px solid var(--border);
   user-select: none;
@@ -660,7 +660,7 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
 .panel-crumbs {
   flex: 1 1 auto;
   scrollbar-width: none;
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 .panel-crumbs::-webkit-scrollbar {
@@ -672,8 +672,8 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
    feel like a different app, and the size was most of the reason. */
 .panel-bar .bar-ctl {
   height: 24px;
-  padding: 0 6px;
-  font-size: 11px;
+  padding: 0 var(--space-1-5);
+  font-size: var(--text-caption);
 }
 
 .panel-bar .bar-ctl-icon {
@@ -704,13 +704,13 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
 }
 
 .panel-bar .bar-rule {
-  margin: 0 6px;
+  margin: 0 var(--space-1-5);
 }
 
 /* The layout bookmark's ★, at the pane bar's left edge — pane scale, and it
    must not be squeezed by the flex:1 crumbs beside it. */
 .panel-bar .bookmark-star-btn {
-  padding: 3px;
+  padding: var(--space-1);
 }
 
 .panel-bar .bookmark-star-btn svg {
@@ -719,8 +719,8 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
 }
 
 .panel-bar .star-btn {
-  font-size: 11px;
-  padding: 2px 8px;
+  font-size: var(--text-caption);
+  padding: var(--space-0-5) var(--space-2);
 }
 
 /* Close keeps the right-most slot and its error-red hover. */
@@ -756,9 +756,9 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
 .tabs-bar {
   display: flex;
   align-items: stretch;
-  gap: 2px;
+  gap: var(--space-0-5);
   min-height: 30px;
-  padding: 3px 6px 0;
+  padding: var(--space-1) var(--space-1-5) 0;
   background: var(--bg);
   border-bottom: 1px solid var(--border);
   overflow-x: auto;
@@ -774,7 +774,7 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
 .tab {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   flex: 0 0 auto;
   max-width: 200px;
   background: none;
@@ -782,9 +782,9 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   border-bottom: 2px solid transparent;
   color: var(--fg-muted);
   cursor: pointer;
-  padding: 5px 8px;
+  padding: var(--space-1-5) var(--space-2);
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .tab:hover {
@@ -810,7 +810,7 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   flex: 0 0 auto;
   width: 15px;
   height: 15px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   color: var(--fg-muted);
 }
 
@@ -826,9 +826,9 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   flex: 0 0 auto;
   width: 15px;
   height: 15px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   color: var(--fg-muted);
-  font-size: 14px;
+  font-size: var(--text-body);
   line-height: 1;
 }
 
@@ -853,8 +853,8 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   flex: 0 0 auto;
   color: var(--fg-muted);
   cursor: pointer;
-  padding: 4px 5px;
-  border-radius: 4px;
+  padding: var(--space-1) var(--space-1-5);
+  border-radius: var(--radius-xs);
 }
 
 .pane-mode-btn:hover {
@@ -883,20 +883,20 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   flex-direction: column;
   gap: 1px;
   min-width: 120px;
-  padding: 4px;
+  padding: var(--space-1);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   box-shadow: 0 4px 16px var(--shadow-md);
 }
 
 .pane-mode-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 12px;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-xs);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   cursor: pointer;
   white-space: nowrap;
@@ -920,21 +920,21 @@ body.embed:not(.snapshot) .preview-browse-chip:hover {
   /* Full width of the listing like the strip is on Home (a band, not a
      floating plate). Side gutters: the cell's own 24px of padding plus 40px
      here — wider than Home's 28px on purpose, the listing is a wider column. */
-  margin: 8px 40px 16px;
+  margin: var(--space-2) var(--space-10) var(--space-4);
   /* The listing's td is `white-space: nowrap` (one entry per line); this cell
      holds prose and a card, both of which must wrap inside the 640px. */
   white-space: normal;
 }
 .access-denied-text {
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-3);
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-dense);
   line-height: 1.5;
   overflow-wrap: anywhere;
 }
 .access-denied-text code {
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 .access-denied .claude-health {
   margin-bottom: 0;

--- a/frontend/src/styles/scale.css
+++ b/frontend/src/styles/scale.css
@@ -1,0 +1,100 @@
+/* The design SCALE: type roles, spacing, radius, control heights, motion,
+ * fonts. Theme-agnostic — colour lives in tokens.css, and this file is
+ * deliberately outside the dark/light palette blocks so the theme contract
+ * (tests/test_theme.py) does not ask for a light twin of a font size.
+ *
+ * Two consumers read these, and only these:
+ *   - styles/*.css        → var(--text-dense), var(--space-3), var(--radius-card)
+ *   - Tailwind utilities  → text-dense, p-3, rounded-card (mapped in tailwind.css)
+ * so a legacy rule and a composite resolve to the same px, the same ms.
+ *
+ * tests/test_design_scale.py refuses a px literal for any of these
+ * properties outside this file. Add a step here, never a literal there.
+ * Spacing is Tailwind's own 4px scale (p-3 = 12px); the --space-* names exist
+ * so hand-written CSS can say the same thing. */
+:root {
+  /* ---- Fonts ---------------------------------------------------------- */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+
+  /* ---- Type roles: size / line-height / weight -------------------------
+     micro    10  badges, uppercase tags, sub-captions
+     caption  11  secondary labels, footnotes
+     meta     12  labels, hints, measurements (mono + tabular-nums)
+     dense    13  list rows, controls in dense surfaces, composer text
+     body     14  default document size (set on <body>)
+     control  14  buttons, tabs, card titles — medium weight, single line
+     title    15  section / stage titles
+     heading  16  page-level headings inside a panel
+     display  20  the one big number or the page title                     */
+  --text-micro: 10px;
+  --text-micro--line-height: 1.3;
+  --text-micro--font-weight: 500;
+  --text-caption: 11px;
+  --text-caption--line-height: 1.4;
+  --text-caption--font-weight: 500;
+  --text-meta: 12px;
+  --text-meta--line-height: 1.4;
+  --text-meta--font-weight: 400;
+  --text-dense: 13px;
+  --text-dense--line-height: 1.4;
+  --text-dense--font-weight: 400;
+  --text-body: 14px;
+  --text-body--line-height: 1.5;
+  --text-body--font-weight: 400;
+  --text-control: 14px;
+  --text-control--line-height: 1;
+  --text-control--font-weight: 500;
+  --text-title: 15px;
+  --text-title--line-height: 1.3;
+  --text-title--font-weight: 600;
+  --text-heading: 16px;
+  --text-heading--line-height: 1.3;
+  --text-heading--font-weight: 600;
+  --text-display: 20px;
+  --text-display--line-height: 1.2;
+  --text-display--font-weight: 600;
+
+  /* ---- Spacing (4px base, halves allowed) ------------------------------ */
+  --space-0-5: 2px;
+  --space-1: 4px;
+  --space-1-5: 6px;
+  --space-2: 8px;
+  --space-2-5: 10px;
+  --space-3: 12px;
+  --space-3-5: 14px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-7: 28px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-14: 56px; /* empty-state / hero padding */
+  --space-16: 64px;
+  --space-18: 72px;
+
+  /* ---- Radius ---------------------------------------------------------- */
+  --radius-hairline: 2px; /* progress tracks, meters */
+  --radius-xs: 4px; /* checkboxes, tiny chips, thumbnails */
+  --radius-control: 6px; /* buttons, inputs, menu items, tabs */
+  --radius-md: 8px; /* rows, attach chips, small cards */
+  --radius-card: 10px; /* model rows, cards */
+  --radius-panel: 12px; /* composer, result cards, dialogs */
+  --radius-tile: 16px; /* large tiles, hero cards, app thumbnails */
+  --radius-pill: 999px;
+
+  /* ---- Control heights ------------------------------------------------- */
+  --h-control-xs: 24px;
+  --h-control-sm: 28px;
+  --h-control-md: 32px;
+  --h-control-lg: 36px;
+
+  /* ---- Motion ---------------------------------------------------------- */
+  --dur-instant: 80ms; /* hover colour/border */
+  --dur-fast: 120ms; /* reveal/hide a control, swap an icon */
+  --dur-base: 160ms; /* fade a panel in/out */
+  --dur-glide: 240ms; /* move layout (rail fold, grid tracks) */
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --ease-glide: cubic-bezier(0.2, 0.7, 0.3, 1);
+}

--- a/frontend/src/styles/scale.css
+++ b/frontend/src/styles/scale.css
@@ -95,6 +95,9 @@
   --dur-fast: 120ms; /* reveal/hide a control, swap an icon */
   --dur-base: 160ms; /* fade a panel in/out */
   --dur-glide: 240ms; /* move layout (rail fold, grid tracks) */
-  --ease-out: cubic-bezier(0, 0, 0.2, 1);
+  /* Older rules still say --dur-med / --dur-slow: they are the base / glide steps. */
+  --dur-med: var(--dur-base);
+  --dur-slow: var(--dur-glide);
+  --ease-out: ease-out; /* the CSS keyword the app has always used; shadcn's own curve is restated on [data-slot] in tailwind.css */
   --ease-glide: cubic-bezier(0.2, 0.7, 0.3, 1);
 }

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -7,13 +7,13 @@
 .schedule-form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .schedule-quick {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
 }
 
@@ -97,11 +97,11 @@
    a flex child allowed to be SHORTER than its content; without it each one
    floors at its content height and the inner scroller never engages. */
 .schedule-page {
-  padding-top: 12px;
+  padding-top: var(--space-3);
   /* `.prefs-page`'s 32px bottom padding was breathing room under a stack of
      cards; under a full-height pane it is just a strip of dead page. */
-  padding-bottom: 12px;
-  gap: 12px;
+  padding-bottom: var(--space-3);
+  gap: var(--space-3);
   overflow: hidden;
   min-height: 0;
 }
@@ -115,7 +115,7 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* The three views, each filling what the toolbar leaves and scrolling inside. */
@@ -143,8 +143,8 @@
 .schedule-card-head {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 12px;
+  gap: var(--space-2-5);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -154,7 +154,7 @@
 }
 
 .schedule-card-why {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   /* Server errors arrive as prose of any length (a traceback line, a long
      path in a 400) — cap and scroll rather than let one bad run stretch its
@@ -169,9 +169,9 @@
 .schedule-card-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-2);
   margin-top: auto;
-  padding-top: 2px;
+  padding-top: var(--space-0-5);
 }
 
 .schedule-card-actions:empty {
@@ -180,8 +180,8 @@
 
 .schedule-state {
   font-weight: 600;
-  padding: 1px 8px;
-  border-radius: 999px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border);
   background: var(--bg);
 }
@@ -212,7 +212,7 @@
 .schedule-toolbar {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 /* The toggle owns the row's single auto margin, so everything after it —
@@ -235,7 +235,7 @@
 .schedule-form-seg {
   display: inline-flex;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   overflow: hidden;
 }
 
@@ -301,7 +301,7 @@
 .prefs-section .schedule-view-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .schedule-view-btn > svg {
@@ -324,7 +324,7 @@
 
 .schedule-form-row {
   display: flex;
-  gap: 10px;
+  gap: var(--space-2-5);
 }
 
 .schedule-form-row .field {
@@ -356,7 +356,7 @@
   --cal-days: 7;
   --cal-gutter: 56px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-panel);
   background: var(--bg-alt);
   overflow: hidden;
 }
@@ -373,14 +373,14 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px 12px;
-  padding: 10px 12px;
+  gap: var(--space-2) var(--space-3);
+  padding: var(--space-2-5) var(--space-3);
   border-bottom: 1px solid var(--border);
 }
 
 .schedule-cal-nav {
   display: inline-flex;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 /* THE RIGHT-HAND END OF THE BAR: the range toggle, then the month. It exists to
@@ -405,7 +405,7 @@
 .schedule-cal-bar-end {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   margin-left: auto;
 }
 
@@ -415,7 +415,7 @@
    label cannot buy room by breaking "Aug 30 – Sep 2, 2026" across two lines: a
    tight bar is meant to wrap the flex line above, not to shred this label. */
 .schedule-cal-range {
-  font-size: 16px;
+  font-size: var(--text-heading);
   color: var(--fg);
   white-space: nowrap;
 }
@@ -424,7 +424,7 @@
    stray text. The chevrons only widen a touch for a decent hit target. */
 .schedule-cal-nav .btn {
   min-width: 32px;
-  padding: 0 10px;
+  padding: 0 var(--space-2-5);
 }
 
 .schedule-cal-head,
@@ -444,20 +444,20 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  padding: 8px 0 6px;
+  gap: var(--space-0-5);
+  padding: var(--space-2) 0 var(--space-1-5);
   border-left: 1px solid transparent;
 }
 
 .schedule-cal-day-name {
-  font-size: 11px;
+  font-size: var(--text-caption);
   letter-spacing: 0.8px;
   text-transform: uppercase;
   color: var(--fg-muted);
 }
 
 .schedule-cal-day-num {
-  font-size: 22px;
+  font-size: var(--text-display);
   line-height: 1;
   color: var(--fg);
   width: 36px;
@@ -465,7 +465,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 .schedule-cal-day-head.is-today .schedule-cal-day-name {
@@ -508,7 +508,7 @@
 
 .schedule-cal-gutter {
   position: relative;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -517,7 +517,7 @@
   right: 8px;
   transform: translateY(-50%);
   background: var(--bg-alt);
-  padding: 0 2px;
+  padding: 0 var(--space-0-5);
 }
 
 .schedule-cal-col {
@@ -553,7 +553,7 @@
   top: -5px;
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--error);
 }
 
@@ -574,30 +574,30 @@
      inline is what lets the :hover rule below outrank it. */
   z-index: calc(var(--lane, 0) + 1);
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
   align-items: center;
   height: 21px;
-  padding: 0 6px;
+  padding: 0 var(--space-1-5);
   border: none;
   border-left: 3px solid var(--chip, var(--accent));
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   background: color-mix(in srgb, var(--chip, var(--accent)) 22%, var(--bg-alt));
   color: var(--fg);
   font: inherit;
-  font-size: 11px;
+  font-size: var(--text-caption);
   line-height: 1.5;
   text-align: left;
   overflow: hidden;
   cursor: pointer;
-  transition: filter 0.1s ease;
+  transition: filter var(--dur-fast) ease;
 }
 
 /* The 4-day range exists for WIDTH — four columns are wide enough to read a
    task title, so the label gets a step of size and a little more room. */
 .schedule-cal.is-wide .schedule-cal-chip {
   height: 23px;
-  font-size: 12px;
-  padding: 0 8px;
+  font-size: var(--text-meta);
+  padding: 0 var(--space-2);
 }
 
 /* Emil's rule for a surface touched dozens of times a day: the hover is a
@@ -636,7 +636,7 @@
 .schedule-cal .schedule-cal-chip-rep {
   flex: none;
   opacity: 0.8;
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 /* The `+N`: how many MORE of this task's messages fall on this day, nested
@@ -644,11 +644,11 @@
    column with 24 identical chips. */
 .schedule-cal .schedule-cal-chip-more {
   flex: none;
-  padding: 0 4px;
-  border-radius: 999px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-pill);
   background: color-mix(in srgb, var(--chip, var(--accent)) 55%, var(--bg-alt));
   color: var(--fg);
-  font-size: 10px;
+  font-size: var(--text-micro);
   font-weight: 600;
 }
 
@@ -798,19 +798,19 @@
   max-height: min(70vh, 560px);
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px;
+  gap: var(--space-3);
+  padding: var(--space-4);
   /* Nothing escapes the card; everything that could overflow scrolls inside it
      (the thread) or clamps (the title). */
   overflow: hidden;
   background: var(--bg-popover, var(--bg-alt));
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-panel);
   box-shadow: 0 8px 30px var(--shadow-sm);
   /* One short settle from where the click happened — opened often enough that
      anything slower than ~120ms would start to feel like waiting. */
   transform-origin: top left;
-  animation: schedule-popover-in 0.12s ease-out;
+  animation: schedule-popover-in var(--dur-fast) ease-out;
 }
 
 @keyframes schedule-popover-in {
@@ -828,7 +828,7 @@
   flex: none;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* The task's colour, restated where the thread is read — so the popover and the
@@ -837,12 +837,12 @@
   width: 10px;
   height: 10px;
   flex: none;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   background: var(--chip, var(--accent));
 }
 
 .schedule-cal-pop-id {
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-weight: 600;
   letter-spacing: 0.4px;
   color: var(--fg-muted);
@@ -867,7 +867,7 @@
   flex: none;
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 /* Scoped under the rail, not bare: the Tasks page wraps this popover in
@@ -883,7 +883,7 @@
   height: 24px;
   padding: 0;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: transparent;
   color: var(--fg-muted);
   cursor: pointer;
@@ -933,7 +933,7 @@
    very long title stops. */
 .schedule-pop-title {
   flex: none;
-  font-size: 14px;
+  font-size: var(--text-body);
   font-weight: 500;
   line-height: 1.4;
   color: var(--fg);
@@ -959,10 +959,10 @@
   flex: none;
   display: flex;
   align-items: baseline;
-  gap: 6px;
+  gap: var(--space-1-5);
   min-width: 0;
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -985,7 +985,7 @@
 .schedule-cal-thread {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1-5);
   /* The ONLY part of the popover that scrolls, and the only one that gives: it
      takes whatever height the pinned parts leave (`1 1 auto`) and `min-height:
      0` is what actually lets it go below its content — without it a flex child
@@ -1004,9 +1004,9 @@
      sibling at 0 wins on DOM order, so the ring showed through the sticky
      label's own background (QA 2026-08-17). */
   z-index: 1;
-  padding: 2px 0;
+  padding: var(--space-0-5) 0;
   background: var(--bg-popover, var(--bg-alt));
-  font-size: 11px;
+  font-size: var(--text-caption);
   letter-spacing: 0.6px;
   text-transform: uppercase;
   color: var(--fg-muted);
@@ -1015,7 +1015,7 @@
 .schedule-cal-msgs {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -1024,7 +1024,7 @@
 .schedule-cal-msg {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
   min-width: 0;
 }
 
@@ -1040,18 +1040,18 @@
   flex: 1 1 auto;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
-  padding: 4px 6px;
+  padding: var(--space-1) var(--space-1-5);
   border: none;
-  border-radius: 5px;
+  border-radius: var(--radius-control);
   background: transparent;
   color: var(--fg);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   text-align: left;
   cursor: pointer;
-  transition: background-color 0.1s ease;
+  transition: background-color var(--dur-fast) ease;
 }
 
 .schedule-cal-popover .schedule-cal-msg-open:hover:not(:disabled),
@@ -1159,7 +1159,7 @@
    flush against the label without this (Bugbot, PR #541). */
 .schedule-card-actions .btn svg,
 .schedule-cal-popover .btn svg {
-  margin-right: 5px;
+  margin-right: var(--space-1-5);
   transform: translateY(2px);
 }
 
@@ -1185,8 +1185,8 @@
    shared `.btn:focus-visible` ring already outlines it. */
 .schedule-cal-pop-run,
 .prefs-section .schedule-cal-pop-run {
-  transition: color 0.08s ease, background-color 0.08s ease,
-    border-color 0.08s ease;
+  transition: color var(--dur-instant) ease, background-color var(--dur-instant) ease,
+    border-color var(--dur-instant) ease;
 }
 
 .schedule-cal-pop-run:hover:not(:disabled),
@@ -1249,7 +1249,7 @@
 .schedule-form-line {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .schedule-form-line svg {
@@ -1266,7 +1266,7 @@
    column (14px icon + 12px gap). */
 .schedule-form-line--sub,
 .schedule-form-sub {
-  margin-left: 26px;
+  margin-left: var(--space-7);
 }
 
 /* The native disclosure marker is the platform's, not ours: a black WebKit
@@ -1283,9 +1283,9 @@
 .schedule-form-more summary {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg-muted);
   user-select: none;
   list-style: none;
@@ -1309,7 +1309,7 @@
   flex: none;
   /* transform alone: the summary's colour transitions on hover, and one rule
      owning both smears the mark. */
-  transition: transform 0.12s ease-out;
+  transition: transform var(--dur-fast) ease-out;
 }
 
 .schedule-form-more[open] .schedule-form-more-caret {
@@ -1325,7 +1325,7 @@
 .schedule-form-more summary:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 /* THE GAP UNDER THE WHEN-ROW (Akshil, 2026-08-23). More options holds two
@@ -1335,11 +1335,11 @@
    the size the card already spaces its blocks by; the first child never takes
    it, so a card whose fold contains only Permissions is unchanged. */
 .schedule-form-more > * + * {
-  margin-top: 12px;
+  margin-top: var(--space-3);
 }
 
 .schedule-form-more[open] summary {
-  margin-bottom: 10px;
+  margin-bottom: var(--space-2-5);
 }
 
 /* Reference-card refinements (Akshil, 2026-08-14, Google new-event screenshot):
@@ -1368,8 +1368,8 @@
 .prefs-section .schedule-cal-popover .btn,
 .deploy-body .schedule-cal-popover .btn {
   height: 28px;
-  font-size: 12px;
-  padding: 0 10px;
+  font-size: var(--text-meta);
+  padding: 0 var(--space-2-5);
 }
 
 /* -- Recent paths: the path field's dropdown ------------------------------
@@ -1396,14 +1396,14 @@
   z-index: 20;
   display: flex;
   flex-direction: column;
-  padding: 4px;
+  padding: var(--space-1);
   /* Same elevation as every other trigger-anchored panel (see .schedule-pop). */
   background: var(--bg-popover, var(--bg));
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   box-shadow: 0 8px 24px var(--shadow-sm);
   transform-origin: top;
-  animation: schedule-pop-in 0.1s ease-out;
+  animation: schedule-pop-in var(--dur-fast) ease-out;
 }
 
 .schedule-recents-path {
@@ -1422,7 +1422,7 @@
   height: 1px;
   flex: none;
   background: var(--border);
-  margin: 4px -4px;
+  margin: var(--space-1) calc(-1 * var(--space-1));
 }
 
 /* Plain text, not accent (Akshil, 2026-08-16): the separator and the position
@@ -1450,9 +1450,9 @@
    it is the mirror of Browse's: found-things above, existing things below. */
 .schedule-form .schedule-recents-new {
   align-items: flex-start;
-  padding-bottom: 8px;
+  padding-bottom: var(--space-2);
   border-bottom: 1px solid var(--border);
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 
 /* Same armor as Browse's hairline: the ambient button:hover skins repaint
@@ -1464,13 +1464,13 @@
 
 .schedule-form .schedule-recents-new svg {
   /* Pulled onto the first line's baseline now the row is two lines tall. */
-  margin-top: 2px;
+  margin-top: var(--space-0-5);
 }
 
 .schedule-recents-new-text {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
   min-width: 0;
   flex: 1;
 }
@@ -1478,14 +1478,14 @@
 .schedule-recents-new-top {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   min-width: 0;
 }
 
 /* The line that says WHEN the folder starts existing. Muted and small: the
    badge above already carried the fact, this only dates it. */
 .schedule-recents-new-why {
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -1503,7 +1503,7 @@
   display: flex;
   flex: 1;
   min-width: 0;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .schedule-pop-wrap {
@@ -1523,9 +1523,9 @@
 .prefs-section button.schedule-when-field,
 .prefs-section .schedule-when-field {
   height: 32px;
-  padding: 0 12px;
+  padding: 0 var(--space-3);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   text-align: left;
   color: var(--fg);
   background: var(--bg-alt);
@@ -1534,7 +1534,7 @@
      with no edges, read as text (audit 2026-08-16). The accent still takes
      over on :focus and --error on .is-invalid, below. */
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
@@ -1602,7 +1602,7 @@ input.schedule-when-field {
 .deploy-body .schedule-picker-crumb,
 .deploy-body .schedule-form-seg .btn,
 .prefs-section .schedule-form-seg .btn {
-  transition: background-color 0.08s ease;
+  transition: background-color var(--dur-instant) ease;
 }
 
 .schedule-when-field:focus,
@@ -1625,14 +1625,14 @@ input.schedule-when-field {
      dropdown — goes higher (audit 2026-08-16). */
   background: var(--bg-popover, var(--bg));
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   box-shadow: 0 8px 24px var(--shadow-sm);
-  padding: 10px;
+  padding: var(--space-2-5);
   /* 100ms is the whole budget: these open on a click the user already
      committed to, so the motion is only there to say WHERE the panel came
      from — the trigger's own edge. */
   transform-origin: top;
-  animation: schedule-pop-in 0.1s ease-out;
+  animation: schedule-pop-in var(--dur-fast) ease-out;
 }
 
 @keyframes schedule-pop-in {
@@ -1643,7 +1643,7 @@ input.schedule-when-field {
 }
 
 .schedule-pop--time {
-  padding: 4px;
+  padding: var(--space-1);
 }
 
 /* The custom select: same quiet chip as the when-fields, caret at the end.
@@ -1655,7 +1655,7 @@ input.schedule-when-field {
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -1697,7 +1697,7 @@ input.schedule-when-field {
    the chip that opened it and the units menu three times wider (audit
    2026-08-16). */
 .schedule-pop--menu {
-  padding: 5px;
+  padding: var(--space-1-5);
   display: flex;
   flex-direction: column;
   max-height: 300px;
@@ -1707,14 +1707,14 @@ input.schedule-when-field {
 .schedule-menu-item,
 .deploy-body .schedule-menu-item,
 .prefs-section .schedule-menu-item {
-  padding: 7px 12px;
+  padding: var(--space-2) var(--space-3);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   text-align: left;
   color: var(--fg);
   background: transparent;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   align-self: stretch;
   width: 100%;
@@ -1794,13 +1794,13 @@ input.schedule-when-field {
 .schedule-mini-cal-head {
   display: flex;
   align-items: center;
-  gap: 2px;
-  margin-bottom: 6px;
+  gap: var(--space-0-5);
+  margin-bottom: var(--space-1-5);
 }
 
 .schedule-mini-cal-title {
   flex: 1;
-  font-size: 13px;
+  font-size: var(--text-dense);
   font-weight: 600;
 }
 
@@ -1810,7 +1810,7 @@ input.schedule-when-field {
   width: 24px;
   height: 24px;
   padding: 0;
-  font-size: 14px;
+  font-size: var(--text-body);
   color: var(--fg-muted);
   background: transparent;
   border: none;
@@ -1830,11 +1830,11 @@ input.schedule-when-field {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   justify-items: center;
-  row-gap: 2px;
+  row-gap: var(--space-0-5);
 }
 
 .schedule-mini-cal-dow {
-  font-size: 10px;
+  font-size: var(--text-micro);
   color: var(--fg-muted);
   line-height: 24px;
 }
@@ -1849,7 +1849,7 @@ input.schedule-when-field {
   align-items: center;
   justify-content: center;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg);
   background: transparent;
   border: none;
@@ -1912,14 +1912,14 @@ input.schedule-when-field {
 .schedule-time-slot,
 .deploy-body .schedule-time-slot,
 .prefs-section .schedule-time-slot {
-  padding: 6px 12px;
+  padding: var(--space-1-5) var(--space-3);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   text-align: left;
   color: var(--fg);
   background: transparent;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   align-self: stretch;
   width: 100%;
@@ -1958,26 +1958,26 @@ input.schedule-when-field {
   z-index: 50;
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 14px 16px 16px;
+  gap: var(--space-3-5);
+  padding: var(--space-3-5) var(--space-4) var(--space-4);
   background: var(--bg-popover, var(--bg-alt));
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   box-shadow: 0 12px 40px var(--shadow-lg);
-  animation: schedule-explorer-in 0.18s ease-out;
+  animation: schedule-explorer-in var(--dur-base) ease-out;
 }
 
 .schedule-recur-title {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--text-title);
   font-weight: 600;
 }
 
 .schedule-recur-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 13px;
+  gap: var(--space-2-5);
+  font-size: var(--text-dense);
 }
 
 /* The number fields wear the when-chips' clothes: same height, same fill, same
@@ -1991,13 +1991,13 @@ input.schedule-when-field {
   width: 64px;
   flex: none;
   height: 32px;
-  padding: 0 10px;
+  padding: 0 var(--space-2-5);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg);
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   appearance: textfield;
   -moz-appearance: textfield;
 }
@@ -2026,7 +2026,7 @@ input.schedule-when-field {
 
 .schedule-recur-circles {
   display: flex;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 /* The seven weekday discs. aria-pressed carries the state; the fill says it.
@@ -2044,7 +2044,7 @@ input.schedule-when-field {
   align-items: center;
   justify-content: center;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 600;
   color: var(--fg-muted);
   background: var(--bg-alt);
@@ -2082,8 +2082,8 @@ input.schedule-when-field {
 .schedule-recur-ends {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  font-size: 13px;
+  gap: var(--space-2);
+  font-size: var(--text-dense);
 }
 
 .schedule-recur-ends-label {
@@ -2099,7 +2099,7 @@ input.schedule-when-field {
 .schedule-recur-detail {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* The end DATE is a chip that drops the same month grid the when-row uses —
@@ -2121,7 +2121,7 @@ input.schedule-when-field {
 
 .modal-overlay .modal-dialog {
   left: 0;
-  transition: left 0.18s ease-out;
+  transition: left var(--dur-base) ease-out;
 }
 
 .modal-dialog:has(.schedule-explorer:not(.is-closing)),
@@ -2144,15 +2144,15 @@ input.schedule-when-field {
   z-index: 50;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 14px 16px 16px;
+  gap: var(--space-2-5);
+  padding: var(--space-3-5) var(--space-4) var(--space-4);
   /* A panel, not a dropdown: the one surface in this feature that goes to the
      high elevation (audit 2026-08-16). */
   background: var(--bg-popover, var(--bg-alt));
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   box-shadow: 0 12px 40px var(--shadow-lg);
-  animation: schedule-explorer-in 0.18s ease-out;
+  animation: schedule-explorer-in var(--dur-base) ease-out;
 }
 
 @keyframes schedule-explorer-in {
@@ -2167,7 +2167,7 @@ input.schedule-when-field {
    faded end state for the frames between animation end and unmount. */
 .schedule-explorer.is-closing,
 .schedule-recur.is-closing {
-  animation: schedule-explorer-out 0.18s ease-in forwards;
+  animation: schedule-explorer-out var(--dur-base) ease-in forwards;
   pointer-events: none;
 }
 
@@ -2179,7 +2179,7 @@ input.schedule-when-field {
 }
 
 .schedule-explorer-title {
-  font-size: 15px;
+  font-size: var(--text-title);
   font-weight: 600;
 }
 
@@ -2191,7 +2191,7 @@ input.schedule-when-field {
 }
 
 .schedule-explorer .schedule-picker-foot {
-  margin-top: 2px;
+  margin-top: var(--space-0-5);
 }
 
 /* Files are answers, folders are places: same row, quieter glyph. */
@@ -2204,11 +2204,11 @@ input.schedule-when-field {
 .schedule-picker {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   background: var(--bg);
-  padding: 10px;
+  padding: var(--space-2-5);
 }
 
 /* Crumbs replace the old ‹-plus-path head: every ancestor is a click, the
@@ -2222,10 +2222,10 @@ input.schedule-when-field {
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
-  gap: 2px;
+  gap: var(--space-0-5);
   min-width: 0;
   overflow: hidden;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 /* The tail owns the leftover room; the ancestors shrink to their ellipsis. */
@@ -2241,14 +2241,14 @@ input.schedule-when-field {
    row has no room for. */
 .schedule-picker-crumb-ellipsis {
   flex: none;
-  padding: 2px 4px;
+  padding: var(--space-0-5) var(--space-1);
   color: var(--fg-muted);
 }
 
 .schedule-picker-crumb-seg {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
   min-width: 0;
 }
 
@@ -2263,13 +2263,13 @@ input.schedule-when-field {
 .schedule-picker-crumb,
 .deploy-body .schedule-picker-crumb,
 .prefs-section .schedule-picker-crumb {
-  padding: 2px 6px;
+  padding: var(--space-0-5) var(--space-1-5);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   background: transparent;
   border: none;
-  border-radius: 5px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   max-width: 160px;
   overflow: hidden;
@@ -2302,7 +2302,7 @@ input.schedule-when-field {
 }
 
 .schedule-picker-filter {
-  font-size: 12px;
+  font-size: var(--text-meta);
   height: 28px;
 }
 
@@ -2314,7 +2314,7 @@ input.schedule-when-field {
   display: flex;
   flex-direction: column;
   align-content: flex-start;
-  transition: opacity 0.1s ease;
+  transition: opacity var(--dur-fast) ease;
 }
 
 /* Mid-navigation: the outgoing listing stays put, dimmed, until the next one
@@ -2335,15 +2335,15 @@ input.schedule-when-field {
   align-self: stretch;
   width: 100%;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   text-align: left;
   color: var(--fg);
   background: transparent;
   border: none;
-  border-radius: 6px;
-  padding: 6px 8px;
+  border-radius: var(--radius-control);
+  padding: var(--space-1-5) var(--space-2);
   cursor: pointer;
 }
 
@@ -2387,7 +2387,7 @@ input.schedule-when-field {
 .schedule-picker-foot {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 /* -- Naming a folder that does not exist yet ------------------------------
@@ -2412,8 +2412,8 @@ input.schedule-when-field {
   align-self: stretch;
   width: 100%;
   align-items: center;
-  gap: 8px;
-  padding: 4px 8px 8px;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2) var(--space-2);
 }
 
 .schedule-picker-new-name {
@@ -2426,16 +2426,16 @@ input.schedule-when-field {
    two. */
 .schedule-picker-new-ok {
   flex: none;
-  padding: 4px 10px;
+  padding: var(--space-1) var(--space-2-5);
 }
 
 .schedule-new-badge {
   flex: none;
-  padding: 1px 6px;
-  border-radius: 999px;
+  padding: 1px var(--space-1-5);
+  border-radius: var(--radius-pill);
   border: 1px solid var(--border);
   background: var(--bg-alt);
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 600;
   letter-spacing: 0.01em;
   text-transform: none;
@@ -2448,8 +2448,8 @@ input.schedule-when-field {
 .schedule-save,
 .schedule-picker-foot .btn-primary,
 .deploy-body .schedule-picker-foot .btn-primary {
-  border-radius: 999px;
-  padding: 0 22px;
+  border-radius: var(--radius-pill);
+  padding: 0 var(--space-6);
 }
 
 /* The ⌘↩ pill inside Save. Drawn in the button's own ink at a lower alpha so
@@ -2458,8 +2458,8 @@ input.schedule-when-field {
 .schedule-save {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding-right: 14px;
+  gap: var(--space-2);
+  padding-right: var(--space-3-5);
 }
 .schedule-save-key {
   display: inline-flex;
@@ -2467,18 +2467,18 @@ input.schedule-when-field {
   /* Glyph, plus, glyph — with air between them (Akshil, screenshot,
      2026-08-27: "a little bit of space between these two icons and a plus
      icon"). Set glyph-to-glyph the two read as one unfamiliar ligature. */
-  gap: 3px;
+  gap: var(--space-1);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: var(--text-caption);
   line-height: 1;
-  padding: 3px 6px;
-  border-radius: 5px;
+  padding: var(--space-1) var(--space-1-5);
+  border-radius: var(--radius-control);
   background: color-mix(in srgb, currentColor 14%, transparent);
   color: inherit;
   opacity: 0.85;
 }
 .schedule-save-key-plus {
-  font-size: 9px;
+  font-size: var(--text-micro);
   opacity: 0.7;
 }
 
@@ -2489,7 +2489,7 @@ input.schedule-when-field {
 }
 
 .schedule-form-line--top svg {
-  margin-top: 9px;
+  margin-top: var(--space-2-5);
 }
 
 .schedule-form-description {
@@ -2569,7 +2569,7 @@ input.schedule-when-field {
   flex: 0 0 16px;
   box-sizing: border-box;
   border: 2px solid currentColor;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 /* The hues. One mark wears them — the status ring. A board card's unread dot
@@ -2636,7 +2636,7 @@ input.schedule-when-field {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 9px;
+  font-size: var(--text-micro);
   font-weight: 700;
   line-height: 1;
   color: currentColor;
@@ -2699,7 +2699,7 @@ input.schedule-when-field {
   margin: auto;
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: currentColor;
 }
 
@@ -2754,24 +2754,24 @@ input.schedule-when-field {
   top: 0;
   left: 0;
   z-index: 30;
-  padding: 3px 7px;
-  font-size: 11px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-caption);
   line-height: 1.3;
   font-weight: 500;
   white-space: nowrap;
   color: var(--fg);
   background: var(--bg-popover);
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius-control);
   box-shadow: 0 2px 8px var(--shadow-sm);
   opacity: 0;
   visibility: hidden;
   transition:
-    opacity 0.1s ease,
-    visibility 0.1s ease,
-    top 0s 0.1s,
-    left 0s 0.1s,
-    transform 0s 0.1s;
+    opacity var(--dur-fast) ease,
+    visibility var(--dur-fast) ease,
+    top 0s var(--dur-fast),
+    left 0s var(--dur-fast),
+    transform 0s var(--dur-fast);
   pointer-events: none;
 }
 
@@ -2842,7 +2842,7 @@ input.schedule-when-field {
 .schedule-tv-id {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--space-1-5);
   min-width: 0;
   flex: 0 1 auto;
 }
@@ -2856,7 +2856,7 @@ input.schedule-when-field {
 }
 
 .schedule-tv-id-name {
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   max-width: 160px;
   white-space: nowrap;
@@ -2878,7 +2878,7 @@ input.schedule-when-field {
 .schedule-tv-filters {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 0 1 auto;
   min-width: 0;
 }
@@ -2904,8 +2904,8 @@ input.schedule-when-field {
 .schedule-tv-search .schedule-tv-search-input {
   width: 100%;
   min-width: 0;
-  padding-left: 28px;
-  font-size: 12px;
+  padding-left: var(--space-7);
+  font-size: var(--text-meta);
 }
 
 .schedule-tv-pop-wrap {
@@ -2917,18 +2917,18 @@ input.schedule-when-field {
 .prefs-section .schedule-tv-filter-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   height: 32px;
-  padding: 0 10px;
+  padding: 0 var(--space-2-5);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg);
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   align-self: center;
-  transition: border-color 0.08s ease, background-color 0.08s ease;
+  transition: border-color var(--dur-instant) ease, background-color var(--dur-instant) ease;
 }
 
 .schedule-tv-filter-btn:hover:not(:disabled),
@@ -2943,11 +2943,11 @@ input.schedule-when-field {
 
 .schedule-tv-filter-count {
   min-width: 16px;
-  padding: 0 5px;
-  border-radius: 999px;
+  padding: 0 var(--space-1-5);
+  border-radius: var(--radius-pill);
   background: rgba(var(--accent-rgb), 0.16);
   color: var(--accent-soft);
-  font-size: 10px;
+  font-size: var(--text-micro);
   font-weight: 600;
   line-height: 16px;
   text-align: center;
@@ -2961,13 +2961,13 @@ input.schedule-when-field {
   left: 0;
   z-index: 40;
   width: 190px;
-  padding: 4px;
+  padding: var(--space-1);
   display: flex;
   flex-direction: column;
   gap: 1px;
   background: var(--bg-popover);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 8px 24px var(--shadow-md);
 }
 
@@ -2975,20 +2975,20 @@ input.schedule-when-field {
 .prefs-section .schedule-tv-pop-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
   align-self: stretch;
   box-sizing: border-box;
-  padding: 6px 8px;
+  padding: var(--space-1-5) var(--space-2);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   text-align: left;
   color: var(--fg);
   background: transparent;
   border: 0;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
-  transition: background-color 0.08s ease;
+  transition: background-color var(--dur-instant) ease;
 }
 
 .schedule-tv-pop-item:hover:not(:disabled),
@@ -3010,7 +3010,7 @@ input.schedule-when-field {
 .schedule-tv-note,
 .schedule-page .prefs-section > p.schedule-tv-note {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -3019,7 +3019,7 @@ input.schedule-when-field {
    runs are one thing, and ruling between them would break the group up. */
 .schedule-tv-tree {
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -3030,11 +3030,11 @@ input.schedule-when-field {
 .schedule-tv-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 12px;
-  font-size: 13px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-dense);
   cursor: pointer;
-  transition: background-color 0.08s ease;
+  transition: background-color var(--dur-instant) ease;
 }
 
 .schedule-tv-row:hover {
@@ -3058,11 +3058,11 @@ input.schedule-when-field {
   color: var(--fg-muted);
   background: transparent;
   border: 0;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   cursor: pointer;
   /* transform, not `all`: the row's own background is transitioning too, and
      one rule owning both made the caret smear on hover. */
-  transition: transform 0.12s ease, color 0.08s ease;
+  transition: transform var(--dur-fast) ease, color var(--dur-instant) ease;
 }
 
 .schedule-tv-caret.is-open {
@@ -3084,7 +3084,7 @@ input.schedule-when-field {
 .schedule-tv-label {
   flex: 0 0 auto;
   font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -3102,7 +3102,7 @@ input.schedule-when-field {
 
 .schedule-tv-meta {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   white-space: nowrap;
 }
@@ -3113,10 +3113,10 @@ input.schedule-when-field {
 .schedule-tv-acts {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
   flex: 0 0 auto;
   opacity: 0;
-  transition: opacity 0.08s ease;
+  transition: opacity var(--dur-instant) ease;
 }
 
 .schedule-tv-row:hover .schedule-tv-acts,
@@ -3136,9 +3136,9 @@ input.schedule-when-field {
   color: var(--fg-muted);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
-  transition: background-color 0.08s ease, color 0.08s ease;
+  transition: background-color var(--dur-instant) ease, color var(--dur-instant) ease;
 }
 
 .schedule-tv-act:hover:not(:disabled),
@@ -3157,16 +3157,16 @@ input.schedule-when-field {
    answer ("it already sent"), not a page-level fault. */
 .schedule-tv-row-error {
   margin: 0;
-  padding: 0 12px 8px 56px;
-  font-size: 11px;
+  padding: 0 var(--space-3) var(--space-2) var(--space-14);
+  font-size: var(--text-caption);
   color: var(--error);
 }
 
 .schedule-tv-empty {
   margin: 0;
-  padding: 40px 12px;
+  padding: var(--space-10) var(--space-3);
   text-align: center;
-  font-size: 13px;
+  font-size: var(--text-dense);
   color: var(--fg-muted);
 }
 
@@ -3178,12 +3178,12 @@ input.schedule-when-field {
 .schedule-tv-board {
   display: flex;
   align-items: stretch;
-  gap: 12px;
+  gap: var(--space-3);
   /* Height comes from the page's flex chain now, not a magic viewport calc
      that had to be re-guessed every time the header changed (2026-08-16). */
   min-height: 320px;
   overflow-x: auto;
-  padding-bottom: 8px;
+  padding-bottom: var(--space-2);
 }
 
 .schedule-tv-lane {
@@ -3199,20 +3199,20 @@ input.schedule-when-field {
 .prefs-section .schedule-tv-lane-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
   align-self: stretch;
   box-sizing: border-box;
-  padding: 6px 8px;
-  margin-bottom: 4px;
+  padding: var(--space-1-5) var(--space-2);
+  margin-bottom: var(--space-1);
   font: inherit;
   text-align: left;
   color: var(--fg);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
-  transition: background-color 0.08s ease;
+  transition: background-color var(--dur-instant) ease;
 }
 
 .schedule-tv-lane-head:hover:not(:disabled),
@@ -3222,7 +3222,7 @@ input.schedule-when-field {
 }
 
 .schedule-tv-lane-label {
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -3231,7 +3231,7 @@ input.schedule-when-field {
 
 .schedule-tv-lane-count {
   margin-left: auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-variant-numeric: tabular-nums;
   color: var(--fg-muted);
 }
@@ -3275,19 +3275,19 @@ input.schedule-when-field {
   /* Loosened from 4px on 2026-08-17: at 4px the cards read as one ribbed strip
      rather than as separate objects, which is half of what made the lane look
      like a panel full of rows. */
-  gap: 8px;
+  gap: var(--space-2);
   /* Stated with the border, as everywhere else on this page: the width is safe
      either way (a stretched flex item fits its margin box to the 260px lane, so
      the edge lands inside), but `min-height` below is not — content-box would
      make the floor 122px and the number here would stop being the number the
      board actually has. */
   box-sizing: border-box;
-  padding: 6px;
+  padding: var(--space-1-5);
   /* Transparent, not absent: the drag rules below still speak in `border-color`
      and the 1px is part of the box the `min-height` above is measured against,
      so removing the declaration would move the floor as well as the edge. */
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--tasks-lane-bg);
 }
 
@@ -3356,7 +3356,7 @@ input.schedule-when-field {
   background: color-mix(in srgb, var(--fg-muted) 26%, transparent);
   background-clip: padding-box;
   border: 3px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 .schedule-tv-lane-body::-webkit-scrollbar-thumb:hover,
@@ -3401,19 +3401,19 @@ input.schedule-when-field {
      on one dataset and a card that breathes less than a row makes the Board read
      as the cramped one. 6px/10px/12px went to 8px/12px/14px — the same step the
      rows took, so the change is one decision rather than two. */
-  gap: 8px;
+  gap: var(--space-2);
   width: 100%;
   box-sizing: border-box;
-  padding: 12px 14px;
+  padding: var(--space-3) var(--space-3-5);
   font: inherit;
   text-align: left;
   color: var(--fg);
   background: var(--tasks-card-bg);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 1px 2px var(--shadow-sm);
   cursor: pointer;
-  transition: background-color 0.08s ease, border-color 0.08s ease;
+  transition: background-color var(--dur-instant) ease, border-color var(--dur-instant) ease;
 }
 
 /* Hover now moves the FILL as well as the edge. It did not have to while the
@@ -3501,7 +3501,7 @@ input.schedule-when-field {
 .schedule-tv-card-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -3535,7 +3535,7 @@ input.schedule-when-field {
    overflow, deliberately; the lane body's `overflow-y` is a scroller for the
    column, which is a different thing and further out. */
 .schedule-tv-card-title {
-  font-size: 12.5px;
+  font-size: var(--text-dense);
   line-height: 1.35;
   overflow-wrap: anywhere;
   min-width: 0;
@@ -3584,14 +3584,14 @@ input.schedule-when-field {
    above, which still needs `overflow-wrap` for its own sake. */
 
 .schedule-tv-card-next {
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   color: var(--fg-muted);
 }
 
 .schedule-tv-card-foot {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -3600,17 +3600,17 @@ input.schedule-when-field {
   width: 100%;
   align-self: stretch;
   box-sizing: border-box;
-  margin-top: 2px;
-  padding: 6px 8px;
+  margin-top: var(--space-0-5);
+  padding: var(--space-1-5) var(--space-2);
   font: inherit;
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   font-weight: 500;
   color: var(--fg-muted);
   background: transparent;
   border: 1px dashed var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
-  transition: color 0.08s ease, border-color 0.08s ease;
+  transition: color var(--dur-instant) ease, border-color var(--dur-instant) ease;
 }
 
 .schedule-tv-more:hover:not(:disabled),
@@ -3622,8 +3622,8 @@ input.schedule-when-field {
 
 .schedule-tv-showing {
   margin: 0;
-  padding: 2px 4px 0;
-  font-size: 11px;
+  padding: var(--space-0-5) var(--space-1) 0;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -3649,15 +3649,15 @@ input.schedule-when-field {
   flex: 0 0 52px;
   min-height: 220px;
   box-sizing: border-box;
-  padding: 8px 6px;
+  padding: var(--space-2) var(--space-1-5);
   align-self: stretch;
   font: inherit;
   color: var(--fg);
   background: transparent;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   cursor: pointer;
-  transition: background-color 0.08s ease;
+  transition: background-color var(--dur-instant) ease;
 }
 
 /* `border-color` is restated here and it is NOT redundant: `.prefs-section
@@ -3689,10 +3689,10 @@ input.schedule-when-field {
 }
 
 .schedule-tv-rail-label {
-  margin-top: 8px;
+  margin-top: var(--space-2);
   writing-mode: vertical-rl;
   transform: rotate(180deg);
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -3707,10 +3707,10 @@ input.schedule-when-field {
    accent wash a drop puts under it. */
 .schedule-tv-rail-count {
   margin-top: auto;
-  padding: 1px 6px;
-  border-radius: 999px;
+  padding: 1px var(--space-1-5);
+  border-radius: var(--radius-pill);
   background: color-mix(in srgb, var(--fg-muted) 18%, transparent);
-  font-size: 10px;
+  font-size: var(--text-micro);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   color: var(--fg-muted);
@@ -3752,11 +3752,11 @@ input.schedule-when-field {
   flex: none;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .schedule-pop-write .schedule-pop-title {
-  font-size: 16px;
+  font-size: var(--text-heading);
   font-weight: 600;
   line-height: 1.3;
 }
@@ -3770,7 +3770,7 @@ input.schedule-when-field {
    earn their room only if the prose above them stays short too. */
 .schedule-pop-desc {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.45;
   color: var(--fg-muted);
   overflow-wrap: anywhere;

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -589,7 +589,7 @@
   text-align: left;
   overflow: hidden;
   cursor: pointer;
-  transition: filter var(--dur-fast) ease;
+  transition: filter var(--dur-instant) ease;
 }
 
 /* The 4-day range exists for WIDTH — four columns are wide enough to read a
@@ -810,7 +810,7 @@
   /* One short settle from where the click happened — opened often enough that
      anything slower than ~120ms would start to feel like waiting. */
   transform-origin: top left;
-  animation: schedule-popover-in var(--dur-fast) ease-out;
+  animation: schedule-popover-in var(--dur-instant) ease-out;
 }
 
 @keyframes schedule-popover-in {
@@ -888,8 +888,8 @@
   color: var(--fg-muted);
   cursor: pointer;
   transition:
-    background-color var(--dur-fast) var(--ease-out),
-    color var(--dur-fast) var(--ease-out);
+    background-color var(--dur-instant) var(--ease-out),
+    color var(--dur-instant) var(--ease-out);
 }
 
 .schedule-cal-pop-tools .schedule-cal-pop-tool:hover:not(:disabled),
@@ -1051,7 +1051,7 @@
   font-size: var(--text-meta);
   text-align: left;
   cursor: pointer;
-  transition: background-color var(--dur-fast) ease;
+  transition: background-color var(--dur-instant) ease;
 }
 
 .schedule-cal-popover .schedule-cal-msg-open:hover:not(:disabled),
@@ -1309,7 +1309,7 @@
   flex: none;
   /* transform alone: the summary's colour transitions on hover, and one rule
      owning both smears the mark. */
-  transition: transform var(--dur-fast) ease-out;
+  transition: transform var(--dur-instant) ease-out;
 }
 
 .schedule-form-more[open] .schedule-form-more-caret {
@@ -1403,7 +1403,7 @@
   border-radius: var(--radius-card);
   box-shadow: 0 8px 24px var(--shadow-sm);
   transform-origin: top;
-  animation: schedule-pop-in var(--dur-fast) ease-out;
+  animation: schedule-pop-in var(--dur-instant) ease-out;
 }
 
 .schedule-recents-path {
@@ -1632,7 +1632,7 @@ input.schedule-when-field {
      committed to, so the motion is only there to say WHERE the panel came
      from — the trigger's own edge. */
   transform-origin: top;
-  animation: schedule-pop-in var(--dur-fast) ease-out;
+  animation: schedule-pop-in var(--dur-instant) ease-out;
 }
 
 @keyframes schedule-pop-in {
@@ -2314,7 +2314,7 @@ input.schedule-when-field {
   display: flex;
   flex-direction: column;
   align-content: flex-start;
-  transition: opacity var(--dur-fast) ease;
+  transition: opacity var(--dur-instant) ease;
 }
 
 /* Mid-navigation: the outgoing listing stays put, dimmed, until the next one
@@ -2767,11 +2767,11 @@ input.schedule-when-field {
   opacity: 0;
   visibility: hidden;
   transition:
-    opacity var(--dur-fast) ease,
-    visibility var(--dur-fast) ease,
-    top 0s var(--dur-fast),
-    left 0s var(--dur-fast),
-    transform 0s var(--dur-fast);
+    opacity var(--dur-instant) ease,
+    visibility var(--dur-instant) ease,
+    top 0s var(--dur-instant),
+    left 0s var(--dur-instant),
+    transform 0s var(--dur-instant);
   pointer-events: none;
 }
 
@@ -3062,7 +3062,7 @@ input.schedule-when-field {
   cursor: pointer;
   /* transform, not `all`: the row's own background is transitioning too, and
      one rule owning both made the caret smear on hover. */
-  transition: transform var(--dur-fast) ease, color var(--dur-instant) ease;
+  transition: transform var(--dur-instant) ease, color var(--dur-instant) ease;
 }
 
 .schedule-tv-caret.is-open {

--- a/frontend/src/styles/setup-modal.css
+++ b/frontend/src/styles/setup-modal.css
@@ -8,7 +8,7 @@
 .mount-panel {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .mount-panel-lede {
@@ -20,7 +20,7 @@
 .mount-panel-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px 12px;
+  gap: var(--space-2-5) var(--space-3);
   align-items: end;
 }
 
@@ -44,7 +44,7 @@
 .mount-panel-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
+  gap: var(--space-2-5);
   align-items: end;
 }
 
@@ -56,7 +56,7 @@
 .mount-note-check {
   display: flex;
   align-items: flex-start;
-  gap: 4px;
+  gap: var(--space-1);
   cursor: pointer;
 }
 
@@ -64,7 +64,7 @@
 .mount-setup {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .mount-steps-head {
@@ -82,7 +82,7 @@
   list-style: none;
   counter-reset: mount-step;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 /* No font-size on the body text: a step's sentence IS body text, so it
@@ -92,8 +92,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 10px 12px 10px 34px;
+  gap: var(--space-1);
+  padding: var(--space-2-5) var(--space-3) var(--space-2-5) var(--space-8);
   line-height: 1.5;
 }
 
@@ -108,7 +108,7 @@
   top: 10px;
   width: 34px;
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.625; /* 12px × this = the 13px title's 19.5px line box */
   color: var(--fg-muted);
 }
@@ -117,7 +117,7 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .mount-step-title {
@@ -146,7 +146,7 @@
 }
 
 .mount-step-project {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   max-width: 420px;
 }
 
@@ -158,10 +158,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 22px 16px;
+  gap: var(--space-1);
+  padding: var(--space-6) var(--space-4);
   border: 1px dashed var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   text-align: center;
   cursor: pointer;
   background: rgba(var(--tint), 0.03);
@@ -182,18 +182,18 @@
 }
 
 .mount-drop-sub {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .mount-manual > summary {
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .mount-manual > .mount-panel-grid {
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 /* "Add a custom S3 remote …" — a quiet inline link-button. */
@@ -204,7 +204,7 @@
   cursor: pointer;
   padding: 0;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   text-decoration: underline;
 }
@@ -218,12 +218,12 @@
    in-between widths; this is the small-end polish. */
 @media (max-width: 560px) {
   .prefs-page {
-    padding: 14px 14px 24px;
-    gap: 18px;
+    padding: var(--space-3-5) var(--space-3-5) var(--space-6);
+    gap: var(--space-5);
   }
 
   .mounts-title {
-    font-size: 16px;
+    font-size: var(--text-heading);
   }
 
   .mounts-actions {
@@ -255,12 +255,12 @@
 .prefs-radio {
   display: flex;
   align-items: flex-start;
-  gap: 9px;
+  gap: var(--space-2-5);
   cursor: pointer;
 }
 
 .prefs-radio input {
-  margin-top: 3px;
+  margin-top: var(--space-1);
   accent-color: var(--accent);
 }
 
@@ -275,13 +275,13 @@
 .prefs-field {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: var(--space-1-5);
 }
 
 .prefs-field > label {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .prefs-field select:disabled {
@@ -292,17 +292,17 @@
 /* Registry table: pattern -> template chips (+ source badge). */
 .prefs-registry-table {
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .prefs-registry-table td {
-  padding: 5px 10px 5px 0;
+  padding: var(--space-1-5) var(--space-2-5) var(--space-1-5) 0;
   border-top: 1px solid var(--border);
   vertical-align: top;
 }
 
 .prefs-registry-table .registry-templates code + code {
-  margin-left: 5px;
+  margin-left: var(--space-1-5);
 }
 
 .prefs-registry-table .default-mode {
@@ -315,9 +315,9 @@
 
 .registry-source {
   display: inline-block;
-  padding: 1px 8px;
-  border-radius: 999px;
-  font-size: 11px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-caption);
   border: 1px solid var(--border);
   color: var(--fg-muted);
   white-space: nowrap;

--- a/frontend/src/styles/shortcuts.css
+++ b/frontend/src/styles/shortcuts.css
@@ -10,12 +10,12 @@
 .shortcuts-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 18px 28px;
+  gap: var(--space-5) var(--space-7);
 }
 
 .shortcuts-group-title {
-  margin: 0 0 8px;
-  font-size: 11px;
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-caption);
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -26,16 +26,16 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .shortcuts-row {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
-  padding: 4px 6px;
-  border-radius: 4px;
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-1-5);
+  border-radius: var(--radius-xs);
 }
 
 /* --row-bg-hover, not --bg-alt: the key pills are already --bg-alt filled, so
@@ -46,7 +46,7 @@
 
 .shortcuts-label {
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--text-dense);
   min-width: 0;
 }
 
@@ -55,19 +55,19 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   white-space: nowrap;
 }
 
 .shortcuts-key-wrap {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
 }
 
 .shortcuts-key-join {
   color: var(--fg-muted);
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 /* Reuses .templates-key-pill for the fill/border/radius; only the min-width

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -668,7 +668,7 @@ button.sidebar-prefs-trigger {
   border-right: 1.5px solid currentColor;
   border-bottom: 1.5px solid currentColor;
   transform: rotate(45deg);
-  transition: transform var(--dur-fast) ease;
+  transition: transform var(--dur-instant) ease;
   opacity: 0.8;
 }
 
@@ -838,7 +838,7 @@ button.sidebar-prefs-trigger {
      handover the sharpest pop in the sidebar. pointer-events go with the fade so
      the invisible chip can't eat clicks meant for the buttons. */
   opacity: 1;
-  transition: opacity var(--dur-fast) var(--ease-out);
+  transition: opacity var(--dur-instant) var(--ease-out);
 }
 
 .folder-row:hover .folder-count {
@@ -903,8 +903,8 @@ a.bookmark-name::after {
   visibility: hidden;
   opacity: 0;
   transition:
-    opacity var(--dur-fast) var(--ease-out),
-    visibility var(--dur-fast) var(--ease-out);
+    opacity var(--dur-instant) var(--ease-out),
+    visibility var(--dur-instant) var(--ease-out);
   gap: var(--space-0-5);
   z-index: 1;
   padding-left: var(--space-7);

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -97,8 +97,8 @@ body:has(.sidebar-resize-handle.resizing) {
   /* Puts the expand control's centre on 24px — the line the sidebar header,
      #breadcrumb and the app header all stand on — so the control keeps its
      position across collapse and expand, on every route. */
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: var(--space-2-5);
+  padding-bottom: var(--space-2-5);
 }
 
 /* 28px square, 16px glyph, .bar-ctl geometry and hover wash (explorer.css) —
@@ -112,7 +112,7 @@ body:has(.sidebar-resize-handle.resizing) {
   flex-shrink: 0;
   padding: 0;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: none;
   color: var(--fg-muted);
   cursor: pointer;
@@ -149,9 +149,9 @@ a.sidebar-rail-btn {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  margin-top: 8px;
-  padding-top: 8px;
+  gap: var(--space-1);
+  margin-top: var(--space-2);
+  padding-top: var(--space-2);
   border-top: 1px solid var(--border);
   flex: 1 1 auto;
   min-height: 0;
@@ -163,7 +163,7 @@ a.sidebar-rail-btn {
   width: 28px;
   height: 1px;
   flex-shrink: 0;
-  margin: 4px 0;
+  margin: var(--space-1) 0;
   background: var(--border);
 }
 
@@ -189,9 +189,9 @@ a.sidebar-rail-btn {
 .sidebar-brand {
   display: flex;
   align-items: center;
-  gap: 9px;
-  padding: 14px 16px;
-  font-size: 13.5px;
+  gap: var(--space-2-5);
+  padding: var(--space-3-5) var(--space-4);
+  font-size: var(--text-body);
   font-weight: 650;
   letter-spacing: 0.01em;
   border-bottom: 1px solid var(--border);
@@ -202,7 +202,7 @@ a.sidebar-rail-btn {
 .sidebar-brand .brand-home-link {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: var(--space-2-5);
   min-width: 0;
   color: inherit;
   text-decoration: none;
@@ -238,12 +238,12 @@ a.sidebar-rail-btn {
 .version-chip {
   display: inline-flex;
   align-items: center;
-  padding: 0 6px;
+  padding: 0 var(--space-1-5);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: rgba(var(--tint), 0.05);
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 9.5px;
+  font-size: var(--text-micro);
   line-height: 14px;
   letter-spacing: 0.01em;
   font-variant-numeric: tabular-nums;
@@ -252,7 +252,7 @@ a.sidebar-rail-btn {
 }
 
 .sidebar-section {
-  padding: 8px;
+  padding: var(--space-2);
 }
 
 /* Consecutive heading groups in the shell's app-switcher (shell/ShellSidebar):
@@ -267,13 +267,13 @@ a.sidebar-rail-btn {
 .sidebar-item {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 7px 10px;
-  border-radius: 8px;
+  gap: var(--space-2-5);
+  padding: var(--space-2) var(--space-2-5);
+  border-radius: var(--radius-md);
   color: var(--fg);
   text-decoration: none;
   cursor: pointer;
-  font-size: 13.5px;
+  font-size: var(--text-body);
   /* The expand glide lays these rows out at every width between the rail's
      44px and the settled one; a label allowed to wrap ("AI Models") spends
      those frames as two lines — a phantom extra row that flashes in and out
@@ -311,7 +311,7 @@ a.sidebar-rail-btn {
 .sidebar-item-trail {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   margin-left: auto;
   /* The row's `gap: 10px` already stands between the label and this; without
      shrink-0 a long label would squeeze the count instead of ellipsising. */
@@ -328,19 +328,19 @@ a.sidebar-rail-btn {
    hand-tuned 10.5px pill is exactly how two counts in one sidebar end up half a
    pixel and one shade apart. */
 .sidebar-count-chip {
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   line-height: 1;
   color: var(--fg-muted);
   background: rgba(var(--tint), 0.07);
-  border-radius: 8px;
-  padding: 3px 6px;
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-1-5);
   letter-spacing: normal;
 }
 
 /* The AI Models row's "Beta" tag: same chip element, recoloured to the accent
    so it reads as a label about the feature rather than a count of anything. */
 .sidebar-beta-chip {
-  font-size: 9px;
+  font-size: var(--text-micro);
   font-weight: 650;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -393,7 +393,7 @@ a.sidebar-rail-btn {
    Both are why the two rules below are load-bearing rather than cosmetic: no
    part of the cycle may leave any part of a letter unpainted. */
 .sidebar-running {
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   /* The CLIP BOX, not just the text's spacing: ascenders and descenders have to
      fall inside the painted area or they are not drawn at all. */
   line-height: 1.6;
@@ -555,7 +555,7 @@ button.sidebar-prefs-trigger {
   border: none;
   font: inherit;
   text-align: left;
-  font-size: 13.5px;
+  font-size: var(--text-body);
 }
 
 /* The pop-up it opens: the shared .context-menu chassis, pinned by its
@@ -593,8 +593,8 @@ button.sidebar-prefs-trigger {
    own surface; this override was the sidebar's and had nothing left to match. */
 
 .sidebar-heading {
-  padding: 10px 10px 6px;
-  font-size: 11px;
+  padding: var(--space-2-5) var(--space-2-5) var(--space-1-5);
+  font-size: var(--text-caption);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -625,14 +625,14 @@ button.sidebar-prefs-trigger {
   /* Above the rows' own stacking contexts (.bookmark-glyph/.bookmark-badge
      are position:relative + z-index:1, and later in the DOM). */
   z-index: 2;
-  padding-top: 18px;
+  padding-top: var(--space-5);
   box-shadow: 0 1px 0 var(--bg-alt);
 }
 
 .sidebar-empty {
-  padding: 6px 10px;
+  padding: var(--space-1-5) var(--space-2-5);
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 /* Recents (SPEC §29): sits between the bookmark tree and the pinned footer.
@@ -652,23 +652,23 @@ button.sidebar-prefs-trigger {
 .recents-heading {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   cursor: pointer;
   user-select: none;
   text-transform: none;
   letter-spacing: 0;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .sidebar-heading-chevron {
   flex: 0 0 auto;
   width: 6px;
   height: 6px;
-  margin: 0 1px 1px 2px;
+  margin: 0 1px 1px var(--space-0-5);
   border-right: 1.5px solid currentColor;
   border-bottom: 1.5px solid currentColor;
   transform: rotate(45deg);
-  transition: transform 120ms ease;
+  transition: transform var(--dur-fast) ease;
   opacity: 0.8;
 }
 
@@ -715,9 +715,9 @@ button.sidebar-prefs-trigger {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 6px 10px;
-  border-radius: 8px;
+  gap: var(--space-2);
+  padding: var(--space-1-5) var(--space-2-5);
+  border-radius: var(--radius-md);
   cursor: pointer;
   /* Opaque equivalent of this row's background, for the hover actions' fade
      mask (see .bookmark-actions). Kept in sync with the state rules below. */
@@ -741,7 +741,7 @@ button.sidebar-prefs-trigger {
 .bookmark-glyph {
   flex: 0 0 auto;
   color: var(--fg-muted);
-  font-size: 11px;
+  font-size: var(--text-caption);
   cursor: pointer;
   width: 14px;
   text-align: center;
@@ -751,7 +751,7 @@ button.sidebar-prefs-trigger {
 
 /* Custom emoji icons render at natural color, slightly larger than the star. */
 .bookmark-glyph.custom-icon {
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .bookmark-row.active .bookmark-glyph {
@@ -765,7 +765,7 @@ button.sidebar-prefs-trigger {
 .bookmark-missing-badge {
   flex: 0 0 auto;
   color: var(--error);
-  font-size: 11px;
+  font-size: var(--text-caption);
   cursor: help;
   /* a.bookmark-name::after stretches over the whole row (see below); without
      its own stacking context this badge would sit under that overlay and
@@ -852,13 +852,13 @@ button.sidebar-prefs-trigger {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  margin-left: 20px;
-  padding-left: 5px;
+  margin-left: var(--space-5);
+  padding-left: var(--space-1-5);
   border-left: 1px solid rgba(var(--tint), 0.13);
 }
 
 .child-row {
-  padding-left: 8px;
+  padding-left: var(--space-2);
 }
 
 .bookmark-name {
@@ -869,7 +869,7 @@ button.sidebar-prefs-trigger {
   white-space: nowrap;
   color: var(--fg);
   text-decoration: none;
-  font-size: 13px;
+  font-size: var(--text-dense);
 }
 
 /* Stretched-link pattern: the anchor's ::after covers the whole row so the
@@ -905,9 +905,9 @@ a.bookmark-name::after {
   transition:
     opacity var(--dur-fast) var(--ease-out),
     visibility var(--dur-fast) var(--ease-out);
-  gap: 2px;
+  gap: var(--space-0-5);
   z-index: 1;
-  padding-left: 26px;
+  padding-left: var(--space-7);
   background: linear-gradient(to right, transparent, var(--row-bg) 26px);
 }
 
@@ -924,10 +924,10 @@ a.bookmark-name::after {
   max-width: 340px;
   background: var(--bg-panel);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   box-shadow: 0 8px 24px var(--shadow-lg);
-  padding: 10px 12px;
-  font-size: 12px;
+  padding: var(--space-2-5) var(--space-3);
+  font-size: var(--text-meta);
   pointer-events: none;
   display: none;
 }
@@ -937,14 +937,14 @@ a.bookmark-name::after {
   font-weight: 600;
   word-break: break-all;
   font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 11.5px;
+  font-size: var(--text-meta);
 }
 
 #bookmark-tooltip .tip-params {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 3px 10px;
-  margin-top: 8px;
+  gap: var(--space-1) var(--space-2-5);
+  margin-top: var(--space-2);
 }
 
 #bookmark-tooltip .tip-key {
@@ -961,12 +961,12 @@ a.bookmark-name::after {
 #bookmark-tooltip .tip-none {
   color: var(--fg-muted);
   font-style: italic;
-  margin-top: 6px;
+  margin-top: var(--space-1-5);
 }
 
 #bookmark-tooltip .tip-missing {
   color: var(--error);
-  margin-top: 6px;
+  margin-top: var(--space-1-5);
 }
 
 .icon-btn {
@@ -975,9 +975,9 @@ a.bookmark-name::after {
   border: none;
   color: var(--fg-muted);
   cursor: pointer;
-  font-size: 12px;
-  padding: 2px 5px;
-  border-radius: 4px;
+  font-size: var(--text-meta);
+  padding: var(--space-0-5) var(--space-1-5);
+  border-radius: var(--radius-xs);
 }
 
 .icon-btn:hover {
@@ -1001,12 +1001,12 @@ a.bookmark-name::after {
   flex: 1 1 auto;
   min-width: 0;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--accent);
-  border-radius: 4px;
-  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  padding: var(--space-0-5) var(--space-1-5);
 }
 
 /* Icon picker popover (Notion-style): search + Remove header, categorized
@@ -1017,27 +1017,27 @@ a.bookmark-name::after {
   width: 264px;
   background: var(--bg-panel);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   box-shadow: 0 8px 24px var(--shadow-lg);
-  padding: 8px;
+  padding: var(--space-2);
 }
 
 .icon-picker-head {
   display: flex;
-  gap: 6px;
-  margin-bottom: 6px;
+  gap: var(--space-1-5);
+  margin-bottom: var(--space-1-5);
 }
 
 .icon-picker-search {
   flex: 1 1 auto;
   min-width: 0;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 4px 8px;
+  border-radius: var(--radius-control);
+  padding: var(--space-1) var(--space-2);
 }
 
 .icon-picker-search:focus {
@@ -1048,13 +1048,13 @@ a.bookmark-name::after {
 .icon-picker-remove {
   flex: 0 0 auto;
   font: inherit;
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   background: none;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   color: var(--fg-muted);
   cursor: pointer;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
 }
 
 .icon-picker-remove:hover {
@@ -1068,11 +1068,11 @@ a.bookmark-name::after {
 }
 
 .icon-picker-cat {
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--fg-muted);
-  padding: 6px 4px 3px;
+  padding: var(--space-1-5) var(--space-1) var(--space-1);
 }
 
 .icon-picker-grid {
@@ -1082,13 +1082,13 @@ a.bookmark-name::after {
 
 .icon-picker-cell {
   font: inherit;
-  font-size: 15px;
+  font-size: var(--text-title);
   line-height: 1;
   background: none;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
-  padding: 5px 0;
+  padding: var(--space-1-5) 0;
   text-align: center;
 }
 
@@ -1104,29 +1104,29 @@ a.bookmark-name::after {
 
 .icon-picker-empty {
   color: var(--fg-muted);
-  font-size: 12px;
-  padding: 10px 4px;
+  font-size: var(--text-meta);
+  padding: var(--space-2-5) var(--space-1);
 }
 
 
 /* -- Self-update badge (platform/ui/UpdateBadge, packaged mac app only) ----- */
 
 .update-badge {
-  margin: 2px 8px;
-  font-size: 12px;
+  margin: var(--space-0-5) var(--space-2);
+  font-size: var(--text-meta);
 }
 
 .update-badge-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   width: 100%;
-  padding: 6px 8px;
+  padding: var(--space-1-5) var(--space-2);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: rgba(var(--tint), 0.07);
   color: var(--fg);
-  font-size: 12px;
+  font-size: var(--text-meta);
   cursor: pointer;
   text-align: left;
 }
@@ -1151,10 +1151,10 @@ a.bookmark-name::after {
 }
 
 .update-badge-panel {
-  padding: 8px;
+  padding: var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .update-badge-text {
@@ -1168,19 +1168,19 @@ a.bookmark-name::after {
 
 .update-badge-action {
   align-self: flex-start;
-  padding: 4px 10px;
+  padding: var(--space-1) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--accent);
   color: var(--bg);
-  font-size: 12px;
+  font-size: var(--text-meta);
   cursor: pointer;
 }
 
 .update-badge-command {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .update-badge-command code {
@@ -1191,21 +1191,21 @@ a.bookmark-name::after {
      rather than pushing the button off it. */
   flex: 0 1 auto;
   min-width: 0;
-  padding: 4px 6px;
-  border-radius: 4px;
+  padding: var(--space-1) var(--space-1-5);
+  border-radius: var(--radius-xs);
   background: rgba(var(--tint), 0.09);
-  font-size: 11px;
+  font-size: var(--text-caption);
   overflow-x: auto;
   white-space: nowrap;
 }
 
 .update-badge-copy {
-  padding: 3px 8px;
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--fg-muted);
-  font-size: 11px;
+  font-size: var(--text-caption);
   cursor: pointer;
 }
 
@@ -1248,7 +1248,7 @@ a.bookmark-name::after {
 .current-app-unread {
   position: static;
   flex: 0 0 auto;
-  margin-left: 6px;
+  margin-left: var(--space-1-5);
 }
 
 .current-app-archive:disabled {
@@ -1276,7 +1276,7 @@ a.bookmark-name::after {
 }
 
 .current-app-new .current-app-glyph {
-  font-size: 14px;
+  font-size: var(--text-body);
   line-height: 1;
 }
 

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -13,6 +13,47 @@
 
 @theme inline {
     --font-heading: var(--font-sans);
+    /* ---- Design scale (styles/scale.css) — one source for CSS and utilities.
+       text-<role> sets size + line-height + weight; rounded-<name> and the
+       ease names read the same vars legacy rules use. Spacing is Tailwind's
+       own 4px scale, which IS the scale (p-3 = --space-3 = 12px). */
+    --font-sans: var(--font-sans);
+    --font-mono: var(--font-mono);
+    --text-micro: var(--text-micro);
+    --text-micro--line-height: var(--text-micro--line-height);
+    --text-micro--font-weight: var(--text-micro--font-weight);
+    --text-caption: var(--text-caption);
+    --text-caption--line-height: var(--text-caption--line-height);
+    --text-caption--font-weight: var(--text-caption--font-weight);
+    --text-meta: var(--text-meta);
+    --text-meta--line-height: var(--text-meta--line-height);
+    --text-meta--font-weight: var(--text-meta--font-weight);
+    --text-dense: var(--text-dense);
+    --text-dense--line-height: var(--text-dense--line-height);
+    --text-dense--font-weight: var(--text-dense--font-weight);
+    --text-body: var(--text-body);
+    --text-body--line-height: var(--text-body--line-height);
+    --text-body--font-weight: var(--text-body--font-weight);
+    --text-control: var(--text-control);
+    --text-control--line-height: var(--text-control--line-height);
+    --text-control--font-weight: var(--text-control--font-weight);
+    --text-title: var(--text-title);
+    --text-title--line-height: var(--text-title--line-height);
+    --text-title--font-weight: var(--text-title--font-weight);
+    --text-heading: var(--text-heading);
+    --text-heading--line-height: var(--text-heading--line-height);
+    --text-heading--font-weight: var(--text-heading--font-weight);
+    --text-display: var(--text-display);
+    --text-display--line-height: var(--text-display--line-height);
+    --text-display--font-weight: var(--text-display--font-weight);
+    --radius-hairline: var(--radius-hairline);
+    --radius-xs: var(--radius-xs);
+    --radius-control: var(--radius-control);
+    --radius-card: var(--radius-card);
+    --radius-panel: var(--radius-panel);
+    --radius-tile: var(--radius-tile);
+    --radius-pill: var(--radius-pill);
+    --ease-glide: var(--ease-glide);
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -57,7 +57,7 @@
   container-type: size;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .task-cards {
@@ -65,7 +65,7 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-auto-rows: max(260px, calc((100cqh - 12px) / 2));
-  gap: 12px;
+  gap: var(--space-3);
   /* Belt and braces against the one failure this view must not have: a page that
      scrolls sideways. A grid item's default `min-width: auto` lets a wide child
      (an iframe with its own layout in it) push its track past `1fr`, and the
@@ -121,7 +121,7 @@
   box-sizing: border-box;
   background: var(--tasks-card-bg);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 1px 2px var(--shadow-sm);
   overflow: hidden;
 }
@@ -133,11 +133,11 @@
 .task-card-head {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   min-width: 0;
   /* The doors below anchor to the head's corner. */
   position: relative;
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2-5);
   border-bottom: 1px solid var(--border);
   /* Its OWN ground, a step up from the card's: the frame under it is the chat
      template, whose page colour is within a shade of the card's, so a head on
@@ -175,7 +175,7 @@
 .task-card-head-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -217,7 +217,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 15px;
+  font-size: var(--text-title);
   font-weight: 600;
   line-height: 1.3;
   color: var(--fg);
@@ -246,12 +246,12 @@
   bottom: 6px;
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding-left: 6px;
+  gap: var(--space-1);
+  padding-left: var(--space-1-5);
   background: color-mix(in srgb, var(--fg) 5%, var(--row-bg-hover));
   opacity: 0;
   visibility: hidden;
-  transition: opacity 120ms ease;
+  transition: opacity var(--dur-fast) ease;
 }
 
 /* The strip's left edge FADES IN over the title instead of cutting it (Akshil,
@@ -298,7 +298,7 @@
   color: var(--fg);
   background: transparent;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   text-decoration: none;
 }
@@ -323,7 +323,7 @@
 
 .task-card-when {
   flex: none;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
 }
@@ -378,7 +378,7 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -393,11 +393,11 @@
   width: 100%;
   height: 36px;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
   background: none;
   border: 1px dashed var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
@@ -433,7 +433,7 @@
 .task-peek-title {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   max-width: 100%;
 }
@@ -482,6 +482,6 @@
    pushes the buttons right by taking the free space. */
 .task-peek-note {
   margin-right: auto;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -47,7 +47,7 @@
    stands beside the frame and the rows run edge to edge. */
 .tasks-list-frame {
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 /* The scroller used to clip the row washes to the corners. The frame must NOT
    do it with `overflow: hidden`: the ring's unread-count tooltip hangs below
@@ -55,15 +55,15 @@
    END rows round their own outer corners instead — one px inside the frame's
    8px so the wash meets the border's inner edge — and nothing is clipped. */
 .tasks-list-frame > .tasks-node:first-child > .tasks-row {
-  border-top-left-radius: 7px;
-  border-top-right-radius: 7px;
+  border-top-left-radius: var(--radius-md);
+  border-top-right-radius: var(--radius-md);
 }
 /* The last node's LAST CHILD, not its row: an open task's row is not the
    frame's bottom — its thread (or note, or loading line) is — and a curve on
    the row there would sit mid-group over square frame corners (Bugbot). */
 .tasks-list-frame > .tasks-node:last-child > :last-child {
-  border-bottom-left-radius: 7px;
-  border-bottom-right-radius: 7px;
+  border-bottom-left-radius: var(--radius-md);
+  border-bottom-right-radius: var(--radius-md);
 }
 
 /* Hairlines between TASKS only. A task and its thread are one thing, and a
@@ -130,9 +130,9 @@
   align-items: center;
   gap: var(--tasks-row-gap);
   padding: var(--tasks-row-pad-y) var(--tasks-row-pad);
-  font-size: 13px;
+  font-size: var(--text-dense);
   cursor: pointer;
-  transition: background-color 0.08s ease;
+  transition: background-color var(--dur-instant) ease;
   /* What `.tasks-rowlink` below is measured against. The row's navigation is a
      real <a> stretched over the whole row rather than a click handler on this
      div, so ⌘-click, middle click and "Open in new tab" are the browser's job
@@ -300,7 +300,7 @@ button.tasks-caret,
   justify-content: center;
   /* transform, not `all`: the row's background is transitioning too, and one
      rule owning both smears the caret on hover. */
-  transition: transform 0.12s ease;
+  transition: transform var(--dur-fast) ease;
 }
 
 .tasks-caret-glyph.is-open {
@@ -337,7 +337,7 @@ button.tasks-caret,
 .tasks-rowlink:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 .tasks-title {
@@ -394,7 +394,7 @@ button.tasks-caret,
    the title and finds the id when it goes looking (Akshil, 2026-08-18: the id
    should read gray and quiet, the title bright). */
 .tasks-id--task {
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 400;
 }
 
@@ -432,7 +432,7 @@ button.tasks-caret,
 }
 
 .tasks-id--message {
-  font-size: 10.5px;
+  font-size: var(--text-micro);
   opacity: 0.85;
 }
 
@@ -507,7 +507,7 @@ button.tasks-caret,
    it. */
 .tasks-row-time {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -573,8 +573,8 @@ button.tasks-caret,
   align-items: center;
   padding-block: var(--tasks-row-pad-y);
   margin-block: calc(var(--tasks-row-pad-y) * -1);
-  padding-inline: 5px;
-  margin-inline: -5px;
+  padding-inline: var(--space-1-5);
+  margin-inline: calc(-1 * var(--space-1-5));
 }
 
 /* The folder tag grows too, VERTICALLY ONLY — and it does it in its own rule
@@ -593,7 +593,7 @@ button.tasks-caret,
    jitters as it goes 9 → 10 reads as movement in a list that has not changed. */
 .tasks-row-msgs {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -602,7 +602,7 @@ button.tasks-caret,
      bare number beside a folder and a time would be unlabelled again. */
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  gap: var(--space-1);
 }
 
 /* Optically centred with the digits rather than sitting on their baseline: the
@@ -661,9 +661,9 @@ button.tasks-caret,
   align-self: stretch;
   padding-block: var(--tasks-row-pad-y);
   margin-block: calc(var(--tasks-row-pad-y) * -1);
-  padding-right: 4px;
-  padding-left: 4px;
-  margin-right: -4px;
+  padding-right: var(--space-1);
+  padding-left: var(--space-1);
+  margin-right: calc(-1 * var(--space-1));
 }
 /* NO HOVER SKIN OF ITS OWN (Akshil, 2026-08-27: "when I hover over the file
    icon, it changes color and it feels like a button"). It is a caption on the
@@ -701,16 +701,16 @@ button.tasks-caret,
      `.schedule-tv-id-shield` around it, which paints nothing at all — see its
      rule below. This element is back to being exactly the thing a reader sees
      and presses. */
-  padding: 3px 5px;
-  border-radius: 5px;
-  transition: background-color 120ms ease;
+  padding: var(--space-1) var(--space-1-5);
+  border-radius: var(--radius-control);
+  transition: background-color var(--dur-fast) ease;
   /* …and its 3px does not get to grow the ROW. The shield around it is
      `align-self: stretch`, so the flex line is sized from this element plus the
      shield's padding — which made every task row 39px instead of 36px. The
      negative margin puts this element's CONTRIBUTION back to its ink height and
      leaves the box it paints alone, the same trick every other mark on this row
      uses. */
-  margin-block: -3px;
+  margin-block: calc(-1 * var(--space-1));
   /* ABOVE THE STRETCHED ROW LINK, like the caret and the hover actions — and
      for the reason those two carry the same pair. `.tasks-rowlink` is an
      absolutely positioned <a> over the whole row at `z-index: 1`, so a control
@@ -896,10 +896,10 @@ button.tasks-caret,
   color: var(--fg-muted);
   background: transparent;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   opacity: 0;
-  transition: opacity 0.08s ease, background-color 0.08s ease, color 0.08s ease;
+  transition: opacity var(--dur-instant) ease, background-color var(--dur-instant) ease, color var(--dur-instant) ease;
   /* Above the row's stretched link, or the link would eat the press and every
      one of these buttons would navigate instead of acting. */
   position: relative;
@@ -1111,7 +1111,7 @@ button.tasks-caret,
   --tasks-archive-reach-l: 0px;
   inset: var(--tasks-archive-reach-y) var(--tasks-archive-reach-r)
     var(--tasks-archive-reach-y) var(--tasks-archive-reach-l);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 /* The handover. The ring fades as the button arrives — the same `opacity` swap,
@@ -1147,7 +1147,7 @@ button.tasks-caret,
 }
 
 .tasks-rowmark .schedule-ring {
-  transition: opacity 0.08s ease;
+  transition: opacity var(--dur-instant) ease;
 }
 
 /* THE PRESS'S RECEIPT (Akshil, 2026-08-19). Clicking Archive keeps the pointer on
@@ -1248,7 +1248,7 @@ button.tasks-caret,
   z-index: 1;
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
   pointer-events: none;
 }
 
@@ -1317,7 +1317,7 @@ button.tasks-caret,
    is "wait", not "broken". A red line here would report a working safeguard as
    a failure. */
 .tasks-row-note {
-  padding: 0 var(--tasks-row-pad) 6px var(--tasks-rail-x);
+  padding: 0 var(--tasks-row-pad) var(--space-1-5) var(--tasks-rail-x);
 }
 
 /* Mid-cancel. The row is by definition being pointed at, so the button is
@@ -1337,9 +1337,9 @@ button.tasks-caret,
    the common case and it is a real answer: the message sent while the user was
    reaching for the button. */
 .tasks-msg-error {
-  margin: 0 0 2px;
-  padding: 2px 8px 4px 12px;
-  font-size: 11px;
+  margin: 0 0 var(--space-0-5);
+  padding: var(--space-0-5) var(--space-2) var(--space-1) var(--space-3);
+  font-size: var(--text-caption);
   color: var(--error);
 }
 
@@ -1358,7 +1358,7 @@ button.tasks-caret,
 .tasks-thread {
   display: flex;
   flex-direction: column;
-  padding: 2px 12px 8px calc(var(--tasks-msg-ring-x) - var(--tasks-msg-indent));
+  padding: var(--space-0-5) var(--space-3) var(--space-2) calc(var(--tasks-msg-ring-x) - var(--tasks-msg-indent));
 }
 
 .tasks-msg {
@@ -1368,10 +1368,10 @@ button.tasks-caret,
   /* The full indent, not indent-minus-1: the 1px used to be the rule's own
      width, and the row has to keep landing in the same column now that the
      rule is gone. */
-  padding: var(--tasks-msg-pad-y) 10px var(--tasks-msg-pad-y) var(--tasks-msg-indent);
-  font-size: 12.5px;
+  padding: var(--tasks-msg-pad-y) var(--space-2-5) var(--tasks-msg-pad-y) var(--tasks-msg-indent);
+  font-size: var(--text-dense);
   cursor: pointer;
-  transition: background-color 0.08s ease;
+  transition: background-color var(--dur-instant) ease;
   /* Same stretched-link treatment as the task row above: a message row is a
      real link to its own turn in the transcript, so ⌘-click opens it in a tab. */
   position: relative;
@@ -1418,7 +1418,7 @@ button.tasks-caret,
    digits are one width. */
 .tasks-msg-time {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -1439,8 +1439,8 @@ button.tasks-caret,
   align-items: center;
   padding-block: var(--tasks-msg-pad-y);
   margin-block: calc(var(--tasks-msg-pad-y) * -1);
-  padding-inline: 5px;
-  margin-inline: -5px;
+  padding-inline: var(--space-1-5);
+  margin-inline: calc(-1 * var(--space-1-5));
 }
 
 /* No `.tasks-msg-ran` any more. It printed "ran 07:12 today" beside the due time
@@ -1456,9 +1456,9 @@ button.tasks-caret,
    and why none of them survived. */
 
 .tasks-thread-error {
-  margin: 4px 0 0;
-  padding-left: 12px;
-  font-size: 11px;
+  margin: var(--space-1) 0 0;
+  padding-left: var(--space-3);
+  font-size: var(--text-caption);
   color: var(--error);
 }
 
@@ -1522,9 +1522,9 @@ button.tasks-caret,
    so there is no spinner and no skeleton: a moving glyph for a sub-second wait is
    more motion than information. */
 .tasks-thread-loading {
-  margin: 4px 0 0;
+  margin: var(--space-1) 0 0;
   padding-left: var(--tasks-msg-indent);
-  font-size: 11.5px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -1602,12 +1602,12 @@ button.tasks-caret,
 }
 
 .tasks-run-hint {
-  margin: 0 0 2px;
-  padding: 3px 8px;
-  border-radius: 6px;
+  margin: 0 0 var(--space-0-5);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-control);
   background: color-mix(in srgb, var(--activity) 14%, transparent);
   color: var(--activity);
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 600;
   text-align: center;
   /* It appears mid-drag, and a pointer event on it would count as leaving the
@@ -1637,7 +1637,7 @@ button.tasks-caret,
    same tabular figures, so the pair still reads as one register. */
 .tasks-row-next {
   flex: 0 0 auto;
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -1682,11 +1682,11 @@ button.tasks-caret,
   display: inline-flex;
   align-items: center;
   height: 14px;
-  padding: 0 6px;
-  border-radius: 999px;
+  padding: 0 var(--space-1-5);
+  border-radius: var(--radius-pill);
   border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
   color: var(--fg-muted);
-  font-size: 10px;
+  font-size: var(--text-micro);
   line-height: 1;
   white-space: nowrap;
 }
@@ -1734,7 +1734,7 @@ button.tasks-caret,
   width: 26px;
   padding: 0;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--text-caption);
   line-height: 1;
   color: var(--fg-muted);
   background: var(--bg);
@@ -1745,9 +1745,9 @@ button.tasks-caret,
      the check has no way to tell a filter chip from a message row. Same result,
      and the guard it protects stays exact. */
   border-width: 1px 1px 1px 0;
-  border-radius: 0 6px 6px 0;
+  border-radius: 0 var(--radius-control) var(--radius-control) 0;
   cursor: pointer;
-  transition: color 0.08s ease, background-color 0.08s ease;
+  transition: color var(--dur-instant) ease, background-color var(--dur-instant) ease;
 }
 
 /* ONE CONTROL, ONE HOVER. The trigger and its ✕ are two boxes for geometry only

--- a/frontend/src/styles/templates.css
+++ b/frontend/src/styles/templates.css
@@ -7,12 +7,12 @@
   max-width: 880px;
   width: 100%;
   margin: 0 auto;
-  padding: 32px 24px;
+  padding: var(--space-8) var(--space-6);
 }
 
 .templates-header h1 {
-  margin: 0 0 6px;
-  font-size: 20px;
+  margin: 0 0 var(--space-1-5);
+  font-size: var(--text-display);
   font-weight: 600;
 }
 
@@ -24,16 +24,16 @@
 /* Tabs. */
 .templates-tabs {
   display: flex;
-  gap: 4px;
-  margin-top: 20px;
+  gap: var(--space-1);
+  margin-top: var(--space-5);
   border-bottom: 1px solid var(--border);
 }
 
 .templates-tab {
   font: inherit;
-  font-size: 13px;
-  padding: 9px 4px;
-  margin-right: 20px;
+  font-size: var(--text-dense);
+  padding: var(--space-2-5) var(--space-1);
+  margin-right: var(--space-5);
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
@@ -51,16 +51,16 @@
 }
 
 .templates-tabpanel {
-  padding-top: 18px;
+  padding-top: var(--space-5);
 }
 
 /* Toolbar (both tabs). */
 .templates-toolbar {
   display: flex;
   align-items: stretch;
-  gap: 10px;
+  gap: var(--space-2-5);
   flex-wrap: wrap;
-  margin-bottom: 14px;
+  margin-bottom: var(--space-3-5);
 }
 
 .templates-toolbar-push {
@@ -72,7 +72,7 @@
    floating onto its own row (margin-left:auto on a single wrapped flex item). */
 .templates-toolbar-actions {
   display: flex;
-  gap: 10px;
+  gap: var(--space-2-5);
   flex-wrap: wrap;
   align-items: stretch;
   margin-left: auto;
@@ -80,13 +80,13 @@
 
 .templates-search {
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   height: 32px;
   background: var(--bg-alt);
   color: var(--fg);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0 10px;
+  border-radius: var(--radius-control);
+  padding: 0 var(--space-2-5);
   flex: 1 1 200px;
   min-width: 150px;
 }
@@ -98,13 +98,13 @@
 
 .templates-toolbar select {
   font: inherit;
-  font-size: 13px;
+  font-size: var(--text-dense);
   height: 32px;
   background: var(--bg-alt);
   color: var(--fg);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0 8px;
+  border-radius: var(--radius-control);
+  padding: 0 var(--space-2);
 }
 
 /* Segmented control (filters, key-shape picker, import resolutions):
@@ -112,22 +112,22 @@
    no accent borders. */
 .templates-seg {
   display: inline-flex;
-  gap: 2px;
-  padding: 3px;
+  gap: var(--space-0-5);
+  padding: var(--space-1);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg-alt);
 }
 
 .templates-seg-btn {
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1;
-  padding: 6px 11px;
+  padding: var(--space-1-5) var(--space-3);
   background: none;
   color: var(--fg-muted);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   cursor: pointer;
 }
 
@@ -150,24 +150,24 @@
 .templates-delete-opts {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin: 2px 0 10px;
+  gap: var(--space-1-5);
+  margin: var(--space-0-5) 0 var(--space-2-5);
 }
 
 .templates-delete-opt {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
+  gap: var(--space-2);
+  font-size: var(--text-dense);
   cursor: pointer;
 }
 
 .templates-add-btn {
   font: inherit;
-  font-size: 12px;
-  padding: 5px 10px;
+  font-size: var(--text-meta);
+  padding: var(--space-1-5) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg-alt);
   color: var(--fg);
   cursor: pointer;
@@ -181,22 +181,22 @@
 .templates-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--text-dense);
 }
 
 .templates-table thead th {
   text-align: left;
-  font-size: 11px;
+  font-size: var(--text-caption);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--fg-muted);
-  padding: 0 10px 8px 0;
+  padding: 0 var(--space-2-5) var(--space-2) 0;
   border-bottom: 1px solid var(--border);
 }
 
 .templates-table td {
-  padding: 10px 10px 10px 0;
+  padding: var(--space-2-5) var(--space-2-5) var(--space-2-5) 0;
   border-bottom: 1px solid var(--border);
   vertical-align: middle;
 }
@@ -219,12 +219,12 @@
 }
 
 .templates-col-pattern .templates-dot {
-  margin-right: 7px;
+  margin-right: var(--space-2);
   vertical-align: middle;
 }
 
 .templates-col-templates .templates-chip {
-  margin: 2px 5px 2px 0;
+  margin: var(--space-0-5) var(--space-1-5) var(--space-0-5) 0;
   vertical-align: middle;
 }
 
@@ -240,9 +240,9 @@
 .templates-key-pill {
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-size: 12px;
+  border-radius: var(--radius-xs);
+  padding: var(--space-0-5) var(--space-1-5);
+  font-size: var(--text-meta);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
@@ -250,16 +250,16 @@
 .templates-chip {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 3px 9px;
+  gap: var(--space-1-5);
+  padding: var(--space-1) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-alt);
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .templates-chip.small {
-  padding: 2px 8px;
+  padding: var(--space-0-5) var(--space-2);
 }
 
 .templates-chip.default {
@@ -276,7 +276,7 @@
 }
 
 .templates-chip-badge {
-  font-size: 9px;
+  font-size: var(--text-micro);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--accent);
@@ -284,13 +284,13 @@
 
 .templates-chip-x {
   font: inherit;
-  font-size: 10px;
+  font-size: var(--text-micro);
   line-height: 1;
   border: none;
   background: none;
   color: var(--fg-muted);
   cursor: pointer;
-  padding: 0 0 0 2px;
+  padding: 0 0 0 var(--space-0-5);
 }
 
 .templates-chip-x:hover {
@@ -299,9 +299,9 @@
 
 .templates-pill {
   display: inline-block;
-  padding: 1px 8px;
-  border-radius: 999px;
-  font-size: 11px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-caption);
   border: 1px solid var(--border);
   color: var(--fg-muted);
   white-space: nowrap;
@@ -325,7 +325,7 @@
 .templates-editor .deploy-body,
 .templates-import .deploy-body,
 .templates-new .deploy-body {
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 /* The row-editor / import step content is wrapped in a <form> (so Enter
@@ -334,11 +334,11 @@
 .templates-import .deploy-body > form {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--space-4);
 }
 
 .templates-field-hint {
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 /* Quick-pick extensions already in the registry: chip buttons under the tag
@@ -346,13 +346,13 @@
 .templates-ext-suggest-wrap {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .templates-ext-suggestions {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-1-5);
   align-items: flex-start;
   align-content: flex-start;
   /* Truncate at exactly 3 chip rows: chips are pinned to 24px tall below, so
@@ -387,11 +387,11 @@
 .templates-chip-input {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-1-5);
   align-items: center;
-  padding: 6px 8px;
+  padding: var(--space-1-5) var(--space-2);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: var(--bg);
 }
 
@@ -406,7 +406,7 @@
   border: none;
   background: none;
   color: var(--fg);
-  padding: 2px 0;
+  padding: var(--space-0-5) 0;
 }
 
 .templates-chip-draft:focus {
@@ -425,33 +425,33 @@
 .templates-field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1-5);
 }
 
 .templates-field > label,
 .templates-field-label {
   color: var(--fg-muted);
-  font-size: 12px;
+  font-size: var(--text-meta);
   font-weight: 500;
 }
 
 .templates-key-fixed {
-  font-size: 13px;
+  font-size: var(--text-dense);
 }
 
 .templates-keybuilder {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .templates-key-input {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-0-5);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0 8px;
+  border-radius: var(--radius-control);
+  padding: 0 var(--space-2);
   background: var(--bg);
   align-self: flex-start;
 }
@@ -461,7 +461,7 @@
   background: none;
   color: var(--fg);
   border: none;
-  padding: 7px 2px;
+  padding: var(--space-2) var(--space-0-5);
   min-width: 120px;
 }
 
@@ -479,30 +479,30 @@
 }
 
 .templates-key-preview {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .templates-broken-note {
-  margin-top: 10px;
-  padding: 8px 10px;
+  margin-top: var(--space-2-5);
+  padding: var(--space-2) var(--space-2-5);
   border: 1px solid var(--error);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: rgba(var(--error-rgb), 0.08);
   color: var(--error);
-  font-size: 12px;
+  font-size: var(--text-meta);
   line-height: 1.45;
 }
 
 .templates-key-error {
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--error);
 }
 
 .templates-chiplist {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-1-5);
   align-items: center;
   min-height: 24px;
 }
@@ -513,7 +513,7 @@
 }
 
 .templates-reorder-hint {
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 /* Add-template picker popover (row editor). */
@@ -528,7 +528,7 @@
   flex-direction: column;
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   box-shadow: 0 8px 24px var(--shadow-lg);
 }
 
@@ -536,7 +536,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2-5);
   border-bottom: 1px solid var(--border);
 }
 
@@ -545,28 +545,28 @@
   min-height: 0; /* let the list scroll inside the bounded picker, not spill */
   max-height: 240px;
   overflow-y: auto;
-  padding: 6px;
+  padding: var(--space-1-5);
 }
 
 .templates-picker-cat {
-  font-size: 10px;
+  font-size: var(--text-micro);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--fg-muted);
-  padding: 6px 6px 3px;
+  padding: var(--space-1-5) var(--space-1-5) var(--space-1);
 }
 
 .templates-picker-cell {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: var(--space-2);
   width: 100%;
   text-align: left;
   font: inherit;
-  font-size: 13px;
-  padding: 6px 8px;
+  font-size: var(--text-dense);
+  padding: var(--space-1-5) var(--space-2);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   color: var(--fg);
   cursor: pointer;
@@ -590,8 +590,8 @@
 .templates-inv-group {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-top: 20px;
+  gap: var(--space-1);
+  margin-top: var(--space-5);
 }
 
 .templates-inv-group:first-child {
@@ -601,13 +601,13 @@
 .templates-inv-grouphead {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 11px;
+  gap: var(--space-2);
+  font-size: var(--text-caption);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--fg-muted);
-  padding-bottom: 8px;
+  padding-bottom: var(--space-2);
 }
 
 .templates-inv-count {
@@ -617,7 +617,7 @@
 }
 
 .templates-lock {
-  font-size: 11px;
+  font-size: var(--text-caption);
 }
 
 .templates-inv-check {
@@ -634,24 +634,24 @@
 }
 
 .templates-inv-name .templates-icon-dot {
-  margin-right: 7px;
+  margin-right: var(--space-2);
 }
 
 .templates-inv-name .templates-pill {
-  margin-left: 8px;
+  margin-left: var(--space-2);
 }
 
 .templates-inv-usedby .templates-usedby-chip {
   display: inline-block;
-  margin: 2px 4px 2px 0;
+  margin: var(--space-0-5) var(--space-1) var(--space-0-5) 0;
 }
 
 .templates-usedby-chip {
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 1px 5px;
-  font-size: 11px;
+  border-radius: var(--radius-xs);
+  padding: 1px var(--space-1-5);
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -662,16 +662,16 @@
 }
 
 .templates-inv-actions .templates-ghost-btn {
-  margin-left: 6px;
+  margin-left: var(--space-1-5);
 }
 
 /* Ghost action buttons. */
 .templates-ghost-btn {
   font: inherit;
-  font-size: 12px;
-  padding: 3px 8px;
+  font-size: var(--text-meta);
+  padding: var(--space-1) var(--space-2);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
   color: var(--fg-muted);
   cursor: pointer;
@@ -688,8 +688,8 @@
 }
 
 .templates-hint {
-  margin-top: 18px;
-  font-size: 12px;
+  margin-top: var(--space-5);
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
@@ -697,11 +697,11 @@
 .templates-import-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 .templates-import-table td {
-  padding: 6px 10px 6px 0;
+  padding: var(--space-1-5) var(--space-2-5) var(--space-1-5) 0;
   border-top: 1px solid var(--border);
   vertical-align: middle;
 }
@@ -717,35 +717,35 @@
 .templates-warnings {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  font-size: 12px;
+  gap: var(--space-0-5);
+  font-size: var(--text-meta);
 }
 
 /* Recommended-binding chips (import wizard step 2). */
 .templates-recs-toggle {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: var(--space-1);
 }
 
 .templates-recs-toggle-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
+  gap: var(--space-2);
+  font-size: var(--text-dense);
   font-weight: 500;
   cursor: pointer;
 }
 
 .templates-recs-subline {
-  font-size: 12px;
+  font-size: var(--text-meta);
 }
 
 /* The strip visually belongs to the manifest row above it: dashed separator
    instead of the table's solid row border. */
 .templates-import-table tr.templates-rec-strip td {
   border-top: 1px dashed var(--border);
-  padding: 5px 0 8px;
+  padding: var(--space-1-5) 0 var(--space-2);
 }
 
 .templates-rec-strip.inert .templates-rec-row,
@@ -756,12 +756,12 @@
 .templates-rec-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-1-5);
   align-items: center;
 }
 
 .templates-rec-label {
-  font-size: 11px;
+  font-size: var(--text-caption);
   color: var(--fg-muted);
 }
 
@@ -771,12 +771,12 @@
 .templates-rec-chip {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1-5);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
-  padding: 2px 9px;
+  font-size: var(--text-caption);
+  padding: var(--space-0-5) var(--space-2-5);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: none;
   color: var(--fg-muted);
   align-self: auto;
@@ -813,7 +813,7 @@
 .templates-rec-badge {
   display: inline-block;
   font-family: system-ui, sans-serif;
-  font-size: 9px;
+  font-size: var(--text-micro);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   white-space: nowrap;
@@ -829,11 +829,11 @@
 
 .deploy-body .templates-rec-add-input {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: var(--text-caption);
   width: 90px;
-  padding: 2px 9px;
+  padding: var(--space-0-5) var(--space-2-5);
   border: 1px solid var(--accent);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-alt);
   color: var(--fg);
 }
@@ -847,22 +847,22 @@
 }
 
 .templates-rec-warn {
-  margin-top: 5px;
-  font-size: 11px;
+  margin-top: var(--space-1-5);
+  font-size: var(--text-caption);
   color: var(--warning-soft);
 }
 
 .templates-result-bindings {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
+  font-size: var(--text-meta);
   color: var(--fg-muted);
 }
 
 .templates-result {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  font-size: 13px;
+  gap: var(--space-1);
+  font-size: var(--text-dense);
 }
 
 .templates-result-line {
@@ -874,9 +874,9 @@
    their intended looks at higher specificity. */
 .deploy-body .templates-picker-cell {
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-control);
   background: none;
-  padding: 6px 8px;
+  padding: var(--space-1-5) var(--space-2);
   width: 100%;
 }
 
@@ -888,8 +888,8 @@
 .deploy-body .templates-chip-x {
   border: none;
   background: none;
-  padding: 0 0 0 2px;
-  font-size: 10px;
+  padding: 0 0 0 var(--space-0-5);
+  font-size: var(--text-micro);
   color: var(--fg-muted);
 }
 
@@ -900,9 +900,9 @@
 }
 
 .deploy-body .templates-seg-btn {
-  padding: 6px 11px;
+  padding: var(--space-1-5) var(--space-3);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: none;
   color: var(--fg-muted);
 }
@@ -927,7 +927,7 @@
 
 .templates-inv-icon {
   display: inline-flex;
-  margin-right: 8px;
+  margin-right: var(--space-2);
   color: var(--fg-muted);
   vertical-align: middle;
 }

--- a/tests/design_scale_allowlist.txt
+++ b/tests/design_scale_allowlist.txt
@@ -3,3 +3,5 @@
 styles/explorer.css::padding-right: …96px   # listing row reserves the size column width (geometry, not rhythm)
 styles/explorer.css::padding-right: …116px  # listing row reserves size + mtime columns
 styles/explorer.css::padding-right: …210px  # listing row reserves size + mtime + wide mtime
+lan/App.tsx::text-[44px]  # fallback tile initial sized to fill the app-icon tile, not a type-scale label
+platform/ui/playground/ProgressBar.tsx::duration-[.4s]  # eases to match the ~1s poll cadence that moves the bar, not UI rhythm

--- a/tests/design_scale_allowlist.txt
+++ b/tests/design_scale_allowlist.txt
@@ -1,0 +1,5 @@
+# Rhythm literals the scale does not cover, one per line: path::literal  # why
+# Keep this short. A pattern that recurs belongs in scale.css as a step.
+styles/explorer.css::padding-right: …96px   # listing row reserves the size column width (geometry, not rhythm)
+styles/explorer.css::padding-right: …116px  # listing row reserves size + mtime columns
+styles/explorer.css::padding-right: …210px  # listing row reserves size + mtime + wide mtime

--- a/tests/test_design_scale.py
+++ b/tests/test_design_scale.py
@@ -26,7 +26,7 @@ ALLOWLIST_PATH = os.path.join(REPO_ROOT, "tests", "design_scale_allowlist.txt")
 # Files that MAY carry literals: the scale itself, the shadcn bridge/theme
 # mapping, and the vendored shadcn primitives (installed, not authored).
 CSS_EXEMPT = {"scale.css", "tailwind.css"}
-TSX_EXEMPT_DIRS = (os.path.join("platform", "shadcn") + os.sep,)
+TSX_EXEMPT_DIRS = ("platform/shadcn/",)
 
 # Properties whose px values must come from the scale. `1px` is a hairline
 # (borders, dividers) and stays a literal; `0` is not a size.
@@ -94,12 +94,14 @@ def _css_files() -> list[str]:
 def _tsx_files() -> list[str]:
     out: list[str] = []
     for root, _dirs, files in os.walk(SRC_DIR):
-        rel_root = os.path.relpath(root, SRC_DIR)
-        if any(rel_root.startswith(d.rstrip(os.sep)) for d in TSX_EXEMPT_DIRS):
+        # Forward slashes on every platform: the allowlist and the exempt
+        # prefixes are written that way, and Windows walks with backslashes.
+        rel_root = os.path.relpath(root, SRC_DIR).replace(os.sep, "/")
+        if any(rel_root.startswith(d) for d in TSX_EXEMPT_DIRS):
             continue
         for f in files:
             if f.endswith((".tsx", ".ts")) and not f.endswith((".test.tsx", ".test.ts")):
-                out.append(os.path.join(rel_root, f))
+                out.append(f"{rel_root}/{f}" if rel_root != "." else f)
     return sorted(out)
 
 

--- a/tests/test_design_scale.py
+++ b/tests/test_design_scale.py
@@ -1,0 +1,179 @@
+"""The design scale is the only source of type, spacing, radius and motion.
+
+`frontend/src/styles/scale.css` declares the steps; hand-written CSS says
+`var(--text-dense)` / `var(--space-3)` / `var(--radius-card)` /
+`var(--dur-fast)`, and composites say `text-dense` / `p-3` / `rounded-card`.
+A px literal for one of those properties anywhere else is a second source of
+truth, and the two drift. This test refuses it.
+
+Exceptions are real (a 14px SVG ring, a 1px optical nudge) and go in
+`tests/design_scale_allowlist.txt` as `path::literal  # why`, one per line.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+
+from _theme_sources import REPO_ROOT, read_repo_file  # noqa: F401
+
+STYLES_DIR = os.path.join(REPO_ROOT, "frontend", "src", "styles")
+SRC_DIR = os.path.join(REPO_ROOT, "frontend", "src")
+ALLOWLIST_PATH = os.path.join(REPO_ROOT, "tests", "design_scale_allowlist.txt")
+
+# Files that MAY carry literals: the scale itself, the shadcn bridge/theme
+# mapping, and the vendored shadcn primitives (installed, not authored).
+CSS_EXEMPT = {"scale.css", "tailwind.css"}
+TSX_EXEMPT_DIRS = (os.path.join("platform", "shadcn") + os.sep,)
+
+# Properties whose px values must come from the scale. `1px` is a hairline
+# (borders, dividers) and stays a literal; `0` is not a size.
+RHYTHM_PROPS = (
+    "font-size",
+    "border-radius",
+    "border-top-left-radius",
+    "border-top-right-radius",
+    "border-bottom-left-radius",
+    "border-bottom-right-radius",
+    "padding",
+    "padding-top",
+    "padding-right",
+    "padding-bottom",
+    "padding-left",
+    "padding-inline",
+    "padding-block",
+    "margin",
+    "margin-top",
+    "margin-right",
+    "margin-bottom",
+    "margin-left",
+    "margin-inline",
+    "margin-block",
+    "gap",
+    "row-gap",
+    "column-gap",
+)
+DURATION_PROPS = ("transition", "transition-duration", "animation", "animation-duration")
+
+_DECL = re.compile(r"(?P<prop>[a-z-]+)\s*:\s*(?P<value>[^;{}]+);", re.I)
+_PX = re.compile(r"(?<![\w.-])(\d*\.?\d+)px\b")
+_DUR = re.compile(r"(?<![\w.-])(\d*\.?\d+)(ms|s)\b")
+_COMMENT = re.compile(r"/\*.*?\*/", re.S)
+
+# Tailwind arbitrary values that restate a rhythm literal.
+_TW_ARBITRARY = re.compile(
+    r"(?<![\w-])(?:-?)(?:text|leading|p|px|py|pt|pb|pl|pr|ps|pe|m|mx|my|mt|mb|ml|mr|"
+    r"gap|gap-x|gap-y|space-x|space-y|inset|top|right|bottom|left|"
+    r"rounded(?:-[trbl]{1,2}|-[se]{1,2}|-ss|-se|-ee|-es)?|duration|delay)"
+    r"-\[(\d*\.?\d+)(px|ms|s)\]"
+)
+
+
+def _allowlist() -> set[tuple[str, str]]:
+    if not os.path.exists(ALLOWLIST_PATH):
+        return set()
+    out: set[tuple[str, str]] = set()
+    for raw in open(ALLOWLIST_PATH, encoding="utf-8"):
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        assert "::" in line, f"allowlist line needs path::literal — {raw!r}"
+        path, literal = line.split("::", 1)
+        out.add((path.strip(), literal.strip()))
+    return out
+
+
+def _css_files() -> list[str]:
+    return sorted(
+        n for n in os.listdir(STYLES_DIR) if n.endswith(".css") and n not in CSS_EXEMPT
+    )
+
+
+def _tsx_files() -> list[str]:
+    out: list[str] = []
+    for root, _dirs, files in os.walk(SRC_DIR):
+        rel_root = os.path.relpath(root, SRC_DIR)
+        if any(rel_root.startswith(d.rstrip(os.sep)) for d in TSX_EXEMPT_DIRS):
+            continue
+        for f in files:
+            if f.endswith((".tsx", ".ts")) and not f.endswith((".test.tsx", ".test.ts")):
+                out.append(os.path.join(rel_root, f))
+    return sorted(out)
+
+
+def _css_offenders(name: str, source: str) -> list[str]:
+    body = _COMMENT.sub("", source)
+    found: list[str] = []
+    for m in _DECL.finditer(body):
+        prop = m.group("prop").lower()
+        value = m.group("value")
+        if prop in RHYTHM_PROPS:
+            for px in _PX.findall(value):
+                if px in ("0", "1", "0.5"):
+                    continue
+                found.append(f"{prop}: …{px}px")
+        elif prop in DURATION_PROPS:
+            for num, unit in _DUR.findall(value):
+                if num in ("0", "0.01") or (unit == "ms" and num == "1"):
+                    continue
+                ms = float(num) * (1000 if unit == "s" else 1)
+                if ms >= 500:
+                    continue  # ambient loops (spinners, shimmer) are not UI motion
+                found.append(f"{prop}: …{num}{unit}")
+    return found
+
+
+def _tsx_offenders(source: str) -> list[str]:
+    return [f"{m.group(0)}" for m in _TW_ARBITRARY.finditer(source)]
+
+
+@pytest.mark.parametrize("name", _css_files())
+def test_stylesheet_takes_rhythm_from_the_scale(name):
+    allow = _allowlist()
+    source = read_repo_file(f"frontend/src/styles/{name}")
+    offenders = [
+        o for o in _css_offenders(name, source) if (f"styles/{name}", o) not in allow
+    ]
+    assert not offenders, (
+        f"styles/{name}: px/duration literals for rhythm properties — use "
+        f"var(--text-*), var(--space-*), var(--radius-*), var(--dur-*) from "
+        f"scale.css, or allowlist with a reason: {sorted(set(offenders))}"
+    )
+
+
+def test_components_take_rhythm_from_the_scale():
+    allow = _allowlist()
+    bad: dict[str, list[str]] = {}
+    for rel in _tsx_files():
+        source = read_repo_file(f"frontend/src/{rel}")
+        offenders = [o for o in _tsx_offenders(source) if (rel, o) not in allow]
+        if offenders:
+            bad[rel] = sorted(set(offenders))
+    assert not bad, (
+        "arbitrary rhythm values in components — use text-<role>, the numeric "
+        "spacing scale, rounded-<name>, duration-(--dur-*), or allowlist with a "
+        f"reason: {bad}"
+    )
+
+
+def test_scale_declares_every_role_tailwind_maps():
+    scale = read_repo_file("frontend/src/styles/scale.css")
+    tailwind = read_repo_file("frontend/src/styles/tailwind.css")
+    declared = set(re.findall(r"^\s*(--[a-z0-9-]+):", scale, re.M))
+    mapped = set(re.findall(r"^\s*(--[a-z0-9-]+):\s*var\((--[a-z0-9-]+)\)", tailwind, re.M))
+    for _name, target in mapped:
+        if target.startswith(("--text-", "--radius-", "--font-", "--ease-glide")):
+            assert target in declared, f"tailwind.css maps {target}, scale.css never declares it"
+
+
+def test_allowlist_entries_are_still_needed():
+    """An allowlist line whose literal no longer exists is debt; delete it."""
+    for path, literal in sorted(_allowlist()):
+        source = read_repo_file(f"frontend/src/{path}")
+        if path.startswith("styles/"):
+            present = literal in _css_offenders(os.path.basename(path), source)
+        else:
+            present = literal in _tsx_offenders(source)
+        assert present, f"allowlist entry no longer matches anything: {path}::{literal}"

--- a/tests/test_new_task_css.py
+++ b/tests/test_new_task_css.py
@@ -40,6 +40,8 @@ Four invariants, all from the same run of reviews (Akshil, 2026-08-17):
 import os
 import re
 
+from _theme_sources import read_repo_file
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _CSS = os.path.join(REPO_ROOT, "frontend", "src", "styles", "new-task.css")
 
@@ -97,10 +99,22 @@ def _fills(css: str) -> list[tuple[str, str]]:
 _SURFACE = ("new-task-field", "new-task-title", "new-task-ask")
 
 
+def _scale() -> dict[str, str]:
+    """The design scale's steps, so a `var(--text-dense)` resolves to its px."""
+    text = read_repo_file("frontend/src/styles/scale.css")
+    return dict(re.findall(r"^\s*(--[a-z0-9-]+):\s*([^;]+);", text, re.M))
+
+
 def _px(value: str) -> int:
     """A length in px. A bare `0` is a length too — CSS drops the unit on zero,
-    and `padding: 6px 0` is exactly how "no horizontal padding" is written."""
-    found = re.fullmatch(r"(\d+)(?:px)?", value.strip())
+    and `padding: 6px 0` is exactly how "no horizontal padding" is written.
+    A scale token (`var(--space-3)`, `var(--text-dense)`) is read through
+    styles/scale.css — the sheet says the step, the scale says the number."""
+    value = value.strip()
+    var = re.fullmatch(r"var\((--[a-z0-9-]+)\)", value)
+    if var:
+        value = _scale()[var.group(1)].strip()
+    found = re.fullmatch(r"(\d+)(?:px)?", value)
     assert found, f"not a px length: {value!r}"
     return int(found.group(1))
 

--- a/tests/test_schedule_css.py
+++ b/tests/test_schedule_css.py
@@ -24,6 +24,7 @@ import pytest
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _CSS = os.path.join(REPO_ROOT, "frontend", "src", "styles", "schedule.css")
+_SCALE = os.path.join(REPO_ROOT, "frontend", "src", "styles", "scale.css")
 _PAGE = os.path.join(REPO_ROOT, "frontend", "src", "shell", "Scheduled.tsx")
 _PREFS_CSS = os.path.join(REPO_ROOT, "frontend", "src", "styles", "preferences.css")
 
@@ -124,10 +125,19 @@ def test_the_popover_title_outranks_the_facts_under_it():
     are one muted `.schedule-pop-meta` line now (repeat · folder), not a stack
     of icon-led rows, but the step in size is the same invariant."""
     css = _read(_CSS)
+    # Sizes are scale steps now (styles/scale.css): the title wears the heading
+    # face, the facts the meta face — read the numbers through the scale.
+    scale = dict(re.findall(r"^\s*(--[a-z0-9-]+):\s*([^;]+);", _read(_SCALE), re.M))
+
+    def px(value: str) -> int:
+        var = re.fullmatch(r"var\((--[a-z0-9-]+)\)", value.strip())
+        raw = scale[var.group(1)] if var else value
+        return int(re.match(r"(\d+)px", raw.strip()).group(1))
+
     size = _decl(css, ".schedule-pop-write .schedule-pop-title", "font-size")
-    assert size and int(re.match(r"(\d+)px", size).group(1)) >= 16
+    assert size and px(size) >= 16
     meta = _decl(css, ".schedule-pop-meta", "font-size")
-    assert meta == "12px"
+    assert meta and px(meta) == 12
     assert _decl(css, ".schedule-pop-desc", "color") == "var(--fg-muted)"
 
 


### PR DESCRIPTION
Stacked on #986 (retarget to `main` once that merges).

## What

The app gets a **design scale** next to its colour tokens, and both worlds read it: hand-written `styles/*.css` through `var(--…)`, composites through Tailwind names. A guard test keeps literals out.

- `styles/scale.css` — nine type roles (size / line-height / weight), the 4 px spacing scale with halves, a named radius ladder, control heights, four durations, two easings, the two font stacks. Theme-agnostic, outside the palette blocks.
- `tailwind.css` maps them: `text-dense`, `text-meta`, `rounded-card`, `rounded-pill`, `ease-glide`, `font-mono`… Spacing is Tailwind's own numeric scale, which is the scale.
- **Legacy CSS sweep**: 2004 rhythm declarations across 27 sheets rewritten to scale vars (`font-size: 13px` → `var(--text-dense)`, `padding: 8px 12px` → `var(--space-2) var(--space-3)`, `transition … .12s` → `var(--dur-fast)`). 330 values snapped onto the scale by ≤ 2 px (11.5→12, 12.5→13, 13.5→14, 5→6, 7→8, 22→24 …). Ambient loop durations (≥ 500 ms spinners/shimmer) left alone. Three explorer column reservations allowlisted.
- **Composites**: 138 arbitrary class values (`text-[13px]`, `rounded-[10px]`, `duration-[.12s]`) → scale names. `tailwind-merge` config extended so the scale's `text-*`/`rounded-*` names conflict correctly with shadcn's own classes (a composite's class must beat the primitive's).
- **Guard** `tests/test_design_scale.py`: no px/duration literals for rhythm properties in `styles/*.css`, no `*-[Npx]` in `.tsx`; allowlist with reasons; stale allowlist entries fail.
- **Docs**: `docs/DESIGN_SYSTEM.md` (tokens, roles, scale, shape, motion, controls, components, do/don't, guards); playbook updated.

## Behaviour

Unchanged. Handlers, hooks, timers, aria, tooltips, keyboard paths untouched — only class strings and CSS values moved. UI shifts are the intended snaps (rows a pixel or two taller where 15 px padding became 16, 13.5 px labels became 14).

## Verification

- `bun test` 3056 / 3056 (12 assertions that pinned px in CSS text now assert the var) · `tsc` clean · boundaries OK · `test_theme.py` 133 · `test_design_scale.py` 32.
- Screenshot matrix at 1440×900, base (#986) vs this branch: home, explorer, tasks, claude-config, preferences, templates, mounts, apps, playground ×3. Diffs 0–5 %, all attributable to snaps or per-server data; no layout breaks, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly styling tokens, docs, and test expectations; no auth, data, or API logic changes, with sub‑2px visual snaps as the main user-visible effect.
> 
> **Overview**
> Introduces a **design scale** (`scale.css`, wired through `shell.css` and Tailwind `@theme`) so legacy CSS and React composites share one rhythm vocabulary—`var(--text-dense)` vs `text-dense`, `rounded-panel`, `duration-(--dur-fast)`, and the numeric spacing scale.
> 
> **Documentation and enforcement:** adds `docs/DESIGN_SYSTEM.md` and extends the shadcn migration playbook; `tests/test_design_scale.py` blocks stray px/ms literals (with an allowlist). Pinned CSS tests in explorer, sidebar, and tasks now expect scale tokens where sheets were rewritten.
> 
> **UI code:** replaces hundreds of arbitrary Tailwind sizes (`text-[13px]`, `rounded-[12px]`, etc.) across playground composites, LAN Apps, shell API/onboarding, and related surfaces. **`cn()` / tailwind-merge** is extended so custom `text-*` and `rounded-*` utilities win over shadcn defaults when both appear.
> 
> Behaviour is intentionally unchanged aside from small snap deltas (e.g. 13.5px → 14px) where values land on the 4px scale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86cb7626c323f03a19bf524a35f547a453d0fc70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->