### PR TITLE
Claude chat: Esc in Comment mode discards the round's unsent notes

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -15496,7 +15496,14 @@ function onEscape(e) {
   e.preventDefault();
   if (act === "close-viewer") shotViewClose();
   else if (act === "close-composer") annCloseComposer();
-  else annSetMode(false);
+  // Esc in a typed Comment mode is CANCEL (Akshil, 2026-09-06: "I press
+  // escape, it doesn't discard it") — this round's unsent notes go, not just
+  // the mode; the bar's trash and this key are the same exit. A live
+  // walkthrough keeps its own Esc (stop and keep — annSetMode's branch), and
+  // through Stopping…/Transcribing… the marks are the recording's to settle,
+  // so those two still only leave the mode.
+  else if (annRecOn || annCta.classList.contains("busy")) annSetMode(false);
+  else annNotesDiscard();
 }
 
 // Bound on BOTH documents. Annotate mode is driven with the pointer over the

--- a/tests/test_claude_annotation_modes.py
+++ b/tests/test_claude_annotation_modes.py
@@ -988,6 +988,16 @@ def test_the_bar_folds_by_measure_not_breakpoint(html):
     assert "@container" not in html
 
 
+def test_escape_in_comment_mode_discards_the_round(html):
+    """Esc in a typed Comment mode is cancel (Akshil, 2026-09-06): the round's
+    unsent notes die with the mode, same as the bar's trash. A live recording
+    keeps Esc = stop-and-keep, and a settling one only leaves the mode."""
+    esc = _block(html, "function onEscape(e) {", "\n}\n")
+    assert 'else if (annRecOn || annCta.classList.contains("busy")) annSetMode(false);' in esc
+    assert "else annNotesDiscard();" in esc
+    assert esc.index("annCloseComposer();") < esc.index("annNotesDiscard();")
+
+
 def test_discard_covers_the_typed_round_too(html):
     """The bar keeps BOTH exits in both modes (Akshil, 2026-09-04; onto the
     bar 2026-09-06): the trash beside ✓ Done throws this round's unsent notes


### PR DESCRIPTION
## What

Follow-up to #1022 (this commit landed on that branch after it merged).

**Esc in a typed Comment mode is now cancel**: this round's unsent notes and their pins go with the mode — the same exit as the bar's 🗑. Before, Esc only left the mode and the notes stayed pending as chips, so a cancelled round still rode the next message.

Unchanged: Esc while a walkthrough records = stop and keep; Esc during Stopping…/Transcribing… only leaves the mode (the marks are the recording's to settle). Notes from an earlier round still survive (round rule).

## Verified
- cmux browser: arm → click element → type → Enter (chip shown) → Esc → 0 pending, chips gone, mode off.
- `pytest tests/test_claude*.py tests/test_theme.py` green (7 pre-existing `test_claude_health` failures aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small keyboard-handler change in annotation UX with a matching test; no auth, data, or send-path logic beyond discarding unsent local notes.
> 
> **Overview**
> **Escape in typed Comment mode now cancels the round**, not just exits the mode. Unsent notes and their pins for the current arm are dropped via `annNotesDiscard()` — the same path as the bar's trash — so a cancelled review no longer leaves pending chips on the next send.
> 
> **Recording behavior is unchanged:** Escape while a walkthrough is live or during Stopping…/Transcribing… still only disarms (`annSetMode(false)`), preserving stop-and-keep and settling marks.
> 
> A regression test locks the `onEscape` branches and ordering relative to closing the composer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da79c19820f16057ee6e8ed7c3260ad6c87c3cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->