### PR TITLE
Tasks: toolbar controls on the design system (leaf-only)

### DIFF
--- a/frontend/src/platform/shadcn/ui/dropdown-menu.tsx
+++ b/frontend/src/platform/shadcn/ui/dropdown-menu.tsx
@@ -1,0 +1,267 @@
+import * as React from "react"
+"use client"
+
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+import { cn } from "@platform/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/frontend/src/platform/shadcn/ui/popover.tsx
+++ b/frontend/src/platform/shadcn/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+import { cn } from "@platform/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+}

--- a/frontend/src/platform/ui/list/FilterCount.tsx
+++ b/frontend/src/platform/ui/list/FilterCount.tsx
@@ -1,0 +1,19 @@
+// The little count on a filter trigger ("Status 2"): an accent-tinted pill at
+// micro size, 16px tall, centred. Was `.schedule-tv-filter-count`.
+import type { ComponentProps } from "react";
+
+import { cn } from "@platform/lib/utils";
+import { Badge } from "@platform/shadcn/ui/badge";
+
+export function FilterCount({ className, ...props }: ComponentProps<typeof Badge>) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "schedule-tv-filter-count h-4 min-w-4 justify-center rounded-pill border-0 bg-[rgba(var(--accent-rgb),0.16)] px-1.5 py-0 text-micro font-semibold leading-4 text-[var(--accent-soft)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/platform/ui/list/README.md
+++ b/frontend/src/platform/ui/list/README.md
@@ -1,0 +1,20 @@
+# List kit
+
+Leaf controls for list-shaped pages (Tasks today). Rows, lanes, cards, scrollers
+and drag targets are NOT here on purpose: they keep their DOM and their CSS
+(already on the design scale) — hover, `:has()`, scroll and drag behaviour is
+functionality, and a kit that re-implements it in React is how the first Tasks
+attempt broke. Only elements that render one control with the same handlers
+and attributes get a component.
+
+| Old | Component | Notes |
+|---|---|---|
+| `.schedule-form-seg` (view switch only) | `SegmentedControl` | the calendar's and the New-task form's segs stay on CSS |
+| `.btn.btn-secondary.schedule-view-btn` | `SegmentButton` | `schedule-view-btn` + `is-active` stay as the glyph-colour hook |
+| `.schedule-tv-filter-count` | `FilterCount` | shadcn Badge |
+| `.btn.btn-primary.schedule-new` | shadcn `Button` | in Scheduled.tsx |
+| `.tasks-outcome-pill` | shadcn `Badge variant="outline"` | class kept; the only pill on the page |
+
+Deliberately left on CSS: `.schedule-tv-filter-btn` / `.is-split` / `.schedule-tv-filter-x`
+(a coupled split control whose group-hover paints both halves), folder chip / id
+tag (row hit-zone math), everything inside rows, lanes and cards.

--- a/frontend/src/platform/ui/list/SegmentedControl.tsx
+++ b/frontend/src/platform/ui/list/SegmentedControl.tsx
@@ -1,0 +1,46 @@
+// The List / Board / Cards / Calendar switch: one bordered box, its halves laid
+// out by their text, the selected half carrying a fill and nothing else — no
+// weight change, because bolding re-measures every half and the toggle jitters
+// (audit 2026-08-16). Callers keep their own <button> attributes: `aria-pressed`
+// is the state, `data-view`/`onClick` are theirs, and the `schedule-view-btn`
+// class stays as the hook the glyph rules in schedule.css hang off.
+//
+// No Tailwind preflight in this app: the button reset (UA plate, border,
+// margin) is stated here once rather than in a page sheet.
+import type { ComponentProps } from "react";
+
+import { cn } from "@platform/lib/utils";
+
+export function SegmentedControl({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "inline-flex overflow-hidden rounded-control border border-solid border-border",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SegmentButton({ className, ...props }: ComponentProps<"button">) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        // reset (no preflight)
+        "m-0 cursor-pointer appearance-none bg-transparent font-[inherit] text-foreground",
+        // the .btn chassis, minus its own border and radius (the box has them)
+        "inline-flex h-8 items-center gap-1.5 border-0 border-solid border-border px-3.5 text-dense leading-[normal]",
+        // halves meet on a hairline
+        "[&+&]:border-l",
+        // hover = a wash between --bg-alt and --bg; active = --bg-alt (the fill IS the state)
+        "hover:bg-[color-mix(in_srgb,var(--bg-alt)_60%,var(--bg))] aria-pressed:bg-[var(--bg-alt)]",
+        // overflow:hidden on the box clips an outside ring; draw it inside
+        "focus-visible:outline-2 focus-visible:outline-[var(--accent)] focus-visible:-outline-offset-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/platform/ui/list/index.ts
+++ b/frontend/src/platform/ui/list/index.ts
@@ -1,0 +1,2 @@
+export * from "./SegmentedControl";
+export * from "./FilterCount";

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -44,9 +44,11 @@ import {
 } from "@platform/lib/api";
 import type { Task, TaskMessage } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
+import { Badge } from "@platform/shadcn/ui/badge";
 import { useMarginWheel } from "./useMarginWheel";
 import { BOARD_COLUMNS, BOARD_LANES, columnLabel, laneOf } from "./schedule-lib";
 import type { BoardColumn, BoardLane } from "./schedule-lib";
+import { FilterCount } from "@platform/ui/list";
 import {
   EMPTY_FILTERS,
   EMPTY_LIST_MEMORY,
@@ -539,10 +541,16 @@ function IdChip({ id, kind }: { id: string; kind: "task" | "message" }) {
    own words, and the foot is for the run's circumstances — the folder it ran in,
    the run ahead. This is a fact about the task, so it goes with the id. */
 function OutcomePill({ outcome }: { outcome: OutcomeTag }) {
+  // Badge for the semantic/kit wrapper; the visual geometry (14px height,
+  // hairline border in the text's own colour, radius-pill, text-micro) stays
+  // exactly `.tasks-outcome-pill` (tasks.css:1680) — Badge's own utility
+  // classes for those same properties are unlayered-losers against it by
+  // design (see SHADCN_MIGRATION_PLAYBOOK.md's cascade note), so keeping the
+  // class is what guarantees pixel parity rather than approximating it.
   return (
-    <span className="tasks-outcome-pill" title={outcome.title}>
+    <Badge variant="outline" className="tasks-outcome-pill" title={outcome.title}>
       {outcome.text}
-    </span>
+    </Badge>
   );
 }
 
@@ -694,7 +702,7 @@ function FilterMenu({
           onClick={() => setOpen((v) => !v)}
         >
           {glyph ?? ICON_CIRCLE_DOT} {label}
-          {count > 0 && <span className="schedule-tv-filter-count">{count}</span>}
+          {count > 0 && <FilterCount>{count}</FilterCount>}
         </button>
         {splittable && (
           <button

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -65,6 +65,7 @@ import type {
 import { useRefreshOnReturn } from "@platform/lib/hooks";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
+import { Button } from "@platform/shadcn/ui/button";
 import ScheduleCalendar, {
   ICON_VIEW_BOARD,
   ICON_VIEW_CALENDAR,
@@ -87,6 +88,7 @@ import { TASK_VIEWS, mergeTaskChanges, viewFromSearch, viewUrl } from "./tasks-l
 import type { TaskView } from "./tasks-lib";
 import { TaskCards } from "./TaskCards";
 import { isUnderDir } from "./current-apps-lib";
+import { SegmentedControl, SegmentButton } from "@platform/ui/list";
 
 /** The app page's Tasks tab (shell/AppPage.tsx, D488) mounts this SAME page
  *  narrowed to one folder: every task whose project is `project` or sits inside
@@ -534,44 +536,44 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
                 controls in the app wear `.schedule-form-seg` (the calendar's
                 range, the modal's Ends), so the shared class cannot name this
                 one. Styling still hangs off `.schedule-form-seg`. */}
-            <div className="schedule-form-seg schedule-view-seg" role="radiogroup" aria-label="View">
-              <button type="button"
+            <SegmentedControl className="schedule-view-seg" role="radiogroup" aria-label="View">
+              <SegmentButton
                       data-view="list"
-                      className={"btn btn-secondary schedule-view-btn" + (view === "list" ? " is-active" : "")}
+                      className={"schedule-view-btn" + (view === "list" ? " is-active" : "")}
                       aria-pressed={view === "list"}
                       onClick={() => pickView("list")}>
                 {ICON_VIEW_LIST}
                 List
-              </button>
-              <button type="button"
+              </SegmentButton>
+              <SegmentButton
                       data-view="board"
-                      className={"btn btn-secondary schedule-view-btn" + (view === "board" ? " is-active" : "")}
+                      className={"schedule-view-btn" + (view === "board" ? " is-active" : "")}
                       aria-pressed={view === "board"}
                       onClick={() => pickView("board")}>
                 {ICON_VIEW_BOARD}
                 Board
-              </button>
+              </SegmentButton>
               {/* Before the calendar (Akshil, 2026-09-03): the first three
                   answer "what is there" and "what is happening right now",
                   and the calendar is the drill-down for the scheduled subset —
                   the same argument that made List the default. */}
-              <button type="button"
+              <SegmentButton
                       data-view="cards"
-                      className={"btn btn-secondary schedule-view-btn" + (view === "cards" ? " is-active" : "")}
+                      className={"schedule-view-btn" + (view === "cards" ? " is-active" : "")}
                       aria-pressed={view === "cards"}
                       onClick={() => pickView("cards")}>
                 {ICON_VIEW_CARDS}
                 Cards
-              </button>
-              <button type="button"
+              </SegmentButton>
+              <SegmentButton
                       data-view="calendar"
-                      className={"btn btn-secondary schedule-view-btn" + (view === "calendar" ? " is-active" : "")}
+                      className={"schedule-view-btn" + (view === "calendar" ? " is-active" : "")}
                       aria-pressed={view === "calendar"}
                       onClick={() => pickView("calendar")}>
                 {ICON_VIEW_CALENDAR}
                 Calendar
-              </button>
-            </div>
+              </SegmentButton>
+            </SegmentedControl>
             {/* Search, Status and Project, on ALL THREE views (2026-08-18). They
                 used to be hidden on the calendar, on the argument that it
                 answers "when" and a week with tasks filtered out of it is a week
@@ -593,10 +595,13 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               onChange={setFilters}
               hideArchiveStatus={view === "calendar"}
             />
-            <button type="button" className="btn btn-primary schedule-new"
-                    onClick={() => openForm("blank", null)}>
+            <Button
+              type="button"
+              className="schedule-new h-8 gap-2 rounded-[var(--radius-control)] px-3.5 py-0 text-dense font-semibold hover:bg-[var(--on-fg)]"
+              onClick={() => openForm("blank", null)}
+            >
               + New task
-            </button>
+            </Button>
           </div>
 
           {/* No chip row under the toolbar: each filter menu already carries its

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2941,17 +2941,6 @@ input.schedule-when-field {
   color: var(--fg-muted);
 }
 
-.schedule-tv-filter-count {
-  min-width: 16px;
-  padding: 0 var(--space-1-5);
-  border-radius: var(--radius-pill);
-  background: rgba(var(--accent-rgb), 0.16);
-  color: var(--accent-soft);
-  font-size: var(--text-micro);
-  font-weight: 600;
-  line-height: 16px;
-  text-align: center;
-}
 
 /* Absolute, and nothing between it and the page clips: the toolbar is a plain
    flex row with no overflow of its own. */


### PR DESCRIPTION
Stacked on #1029 (Preferences + form kit) → #1027 (design scale) → #986 (Playground).

## What (and what deliberately not)

The Tasks page's **single controls** move onto shared components. Everything with behaviour stays exactly as it is — same DOM, same CSS, same handlers:

| Changed (leaf) | Component |
|---|---|
| `+ New task` | shadcn `Button` (primary) |
| List / Board / Cards / Calendar switch | `SegmentedControl` + `SegmentButton` — same four `<button>`s, same `aria-pressed`, same `data-view`/`onClick`; `schedule-view-btn`/`is-active` kept for the glyph rules |
| Filter count | `Badge` (`FilterCount`) |
| Outcome pill ("Stopped") | `Badge variant="outline"` — still the only pill |

| Untouched on purpose | Why |
|---|---|
| Task rows, message rows, caret, ring, folder/id chips, archive slot | hover / `:has()` / hit-zone behaviour lives in CSS; re-implementing it is a behaviour change |
| List scroller, Board lanes, cards, rail, drag targets | scroll and drag are functionality |
| Filter trigger + ✕ split control | group-hover paints both halves; coupled |
| Calendar, Cards wall, New-task modal | separate PRs |

A first attempt that rebuilt rows/lanes/scrollers as components was rejected (layout drift, wrong scroll target, drag broken) and discarded; `platform/ui/list/README.md` records the rule so it does not happen again.

## Verification (cmux frontmost, 1440×900, base = #1029 branch)

- View switch: 344×34 box; buttons 70/85/85/103 × 32, 14 px padding, 13 px, active fill — identical on both.
- Task row 36 px on both; list scroller `overflow-y: auto` on both.
- Hover a task title → instant hint tooltip with the title (verified live).
- Screenshots List / expanded / Board: identical apart from data.
- tsc · boundaries · `bun test` 3056/3056 · CSS-contract + theme + scale tests 192 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Leaf-level UI swaps with preserved CSS classes and no API or auth changes; main risk is subtle visual regression on the toolbar if cascade/order drifts.
> 
> **Overview**
> Moves **only** the Tasks page toolbar’s single-purpose controls onto shared components while keeping the same handlers, ARIA, and CSS hooks (`schedule-view-btn`, `tasks-outcome-pill`, etc.) so layout and behaviour stay unchanged.
> 
> The **List / Board / Cards / Calendar** switch uses new `SegmentedControl` and `SegmentButton` wrappers instead of a raw `schedule-form-seg` box plus `.btn.btn-secondary` buttons; **+ New task** uses shadcn `Button` with existing `schedule-new` sizing classes. Filter triggers render counts via `FilterCount` (shadcn `Badge`), and outcome tags use `Badge variant="outline"` while retaining `.tasks-outcome-pill` for pixel parity. Duplicate `.schedule-tv-filter-count` rules are removed from `schedule.css` in favour of the component styles.
> 
> Adds a small **`platform/ui/list`** kit and README that document the “leaf only” rule (no row/lane/scroller rewrites). Also introduces shadcn **`dropdown-menu`** and **`popover`** primitives on Base UI; they are not wired into Tasks in this diff.
> 
> Filter popovers, split clear controls, rows, board lanes, and drag/scroll behaviour are intentionally untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b4413352ca5ed637525580f8faa87133ce0e92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->