### PR TITLE
Projects: green dot is the app's own unread state, cleared by opening the app

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2362,10 +2362,13 @@ export interface CurrentAppEntry {
   icon?: string | null;
   icon_mtime?: number | null;
   added_at: number | null;
-  /** Epoch (server clock) of the last `openCurrentApp` — the stamp the
-   *  sidebar's green dot is judged against. Null: never opened since the
-   *  stamp shipped. */
+  /** Epoch (server clock) of the last `openCurrentApp`; 0 for a row a task
+   *  put on the desk that has never been opened. */
   opened_at?: number | null;
+  /** A task under the app finished since `opened_at` — the sidebar's green
+   *  dot. The server's flag (current_apps.observe), cleared by `openCurrentApp`
+   *  and by nothing done to the tasks. */
+  unread?: boolean;
 }
 
 export function getCurrentApps(): Promise<{ apps: CurrentAppEntry[] }> {

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2721,6 +2721,12 @@ export interface Task {
   // server, which reads the same way.
   started?: number;
   last_active: number;
+  // WHEN SOMETHING LAST ACTUALLY HAPPENED — a run finishing, a transcript
+  // growing — and 0 when nothing has. Unlike `last_active` it never carries a
+  // scheduled due time or a creation stamp (tasks.py `_row`). The desk's
+  // unread flag is judged against it server-side, and the sidebar refetches the
+  // projects table when it moves. Absent on an older server.
+  happened_at?: number;
   message_count: number;
   // WHEN THIS NEXT RUNS, and WHICH schedule entry that run is: `min(at)` over
   // every PENDING entry the task has, epoch seconds, decided by the server
@@ -2768,6 +2774,7 @@ export type TaskPulseTask = Pick<
   | "status"
   | "unread"
   | "last_active"
+  | "happened_at"
   | "project"
   | "task_id"
   | "title"

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2375,15 +2375,18 @@ export function getCurrentApps(): Promise<{ apps: CurrentAppEntry[] }> {
   return getJson<{ apps: CurrentAppEntry[] }>("/api/current-apps");
 }
 
-/** The user opened the app: stamp its row `opened_at` (server clock). Clears
- *  the sidebar's green dot; touches no task. */
-export function openCurrentApp(
-  path: string,
-): Promise<{ ok: boolean; opened: boolean; opened_at: number }> {
-  return postJson<{ ok: boolean; opened: boolean; opened_at: number }>(
-    "/api/current-apps/open",
-    { path },
-  );
+/** The user opened the app: stamp its row `opened_at` (server clock) and clear
+ *  its `unread`. Touches no task. Answers with the whole table as it stands
+ *  after the stamp, so the caller can adopt it without a second read. */
+export interface OpenCurrentAppResult {
+  ok: boolean;
+  opened: boolean;
+  opened_at: number;
+  apps: CurrentAppEntry[];
+}
+
+export function openCurrentApp(path: string): Promise<OpenCurrentAppResult> {
+  return postJson<OpenCurrentAppResult>("/api/current-apps/open", { path });
 }
 
 /** The optional `icon.svg` of the app that owns `fsPath` (the folder itself

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2362,10 +2362,25 @@ export interface CurrentAppEntry {
   icon?: string | null;
   icon_mtime?: number | null;
   added_at: number | null;
+  /** Epoch (server clock) of the last `openCurrentApp` — the stamp the
+   *  sidebar's green dot is judged against. Null: never opened since the
+   *  stamp shipped. */
+  opened_at?: number | null;
 }
 
 export function getCurrentApps(): Promise<{ apps: CurrentAppEntry[] }> {
   return getJson<{ apps: CurrentAppEntry[] }>("/api/current-apps");
+}
+
+/** The user opened the app: stamp its row `opened_at` (server clock). Clears
+ *  the sidebar's green dot; touches no task. */
+export function openCurrentApp(
+  path: string,
+): Promise<{ ok: boolean; opened: boolean; opened_at: number }> {
+  return postJson<{ ok: boolean; opened: boolean; opened_at: number }>(
+    "/api/current-apps/open",
+    { path },
+  );
 }
 
 /** The optional `icon.svg` of the app that owns `fsPath` (the folder itself

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -65,6 +65,11 @@ import {
 // and is folder paths now, and a slug-shaped order would match nothing.
 export const ORDER_KEY = "fused-render:current-apps-order:v2";
 
+// A cross-window nudge, not a store: set to the stamp after POST
+// /api/current-apps/open lands, so the other windows' sections refetch the
+// desk (the server row is the truth; this only says "look again").
+export const DESK_CHANGED_KEY = "fused-render:current-apps-changed";
+
 /** The picked emoji as a standalone icon.svg document — square viewBox, no
  *  fixed size, transparent ground (a colour emoji carries its own colours, so
  *  it reads on both themes; see skills/fused-render-app-icon). The same file
@@ -418,7 +423,20 @@ export default function CurrentAppsSection() {
     const guess = Date.now() / 1000;
     setOpenedLocal((m) => new Map(m).set(path, guess));
     openCurrentApp(path).then(
-      (r) => setOpenedLocal((m) => new Map(m).set(path, r.opened_at)),
+      (r) => {
+        setOpenedLocal((m) => new Map(m).set(path, r.opened_at));
+        // Tell the OTHER windows the desk changed: `storage` fires only in
+        // other documents (the ORDER_KEY wiring above, the chat's activity
+        // stamp), and their sections refetch on it. Without this a second
+        // window keeps the dot until something else makes it refetch (Bugbot,
+        // 2026-09-07). Value is the stamp so two opens in one second still
+        // differ; a blocked store just means no cross-window nudge.
+        try {
+          localStorage.setItem(DESK_CHANGED_KEY, String(r.opened_at));
+        } catch {
+          /* no store: this window is up to date, the others catch up on their own */
+        }
+      },
       () => {
         // A failed stamp leaves the guess: the dot stays out for this page,
         // and comes back on the next launch if the server never heard.
@@ -509,9 +527,18 @@ export default function CurrentAppsSection() {
   // /api/current-apps/add) and announces it over the window — apps cannot
   // import this section — so the new row lands on top as its page opens,
   // rather than on the next task pulse (platform/lib/tasksChanged).
+  // The same nudge from ANOTHER window (DESK_CHANGED_KEY): an open there
+  // stamped a row on the server, and this window's dot has to follow.
   useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === DESK_CHANGED_KEY) refetch();
+    };
     window.addEventListener(CURRENT_APPS_CHANGED_EVENT, refetch);
-    return () => window.removeEventListener(CURRENT_APPS_CHANGED_EVENT, refetch);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(CURRENT_APPS_CHANGED_EVENT, refetch);
+      window.removeEventListener("storage", onStorage);
+    };
   }, [refetch]);
 
   // ---- the icon picker -------------------------------------------------------

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -41,7 +41,7 @@ import ContextMenu, { type MenuEntry } from "@platform/ui/ContextMenu";
 import { MenuIcons } from "@platform/ui/MenuIcons";
 import { Modal } from "@platform/ui/modal/Modal";
 import { HeroComposer } from "@apps/builder/HomeHero";
-import { inFlight, isDoneUnread, opensElsewhere, statusColumn } from "@shell/tasks-lib";
+import { inFlight, opensElsewhere, statusColumn } from "@shell/tasks-lib";
 import { pokeTasks, useTasksPulseRows } from "@shell/tasksPulse";
 import { CURRENT_APPS_CHANGED_EVENT } from "@platform/lib/tasksChanged";
 import {
@@ -53,15 +53,58 @@ import {
   currentApps,
   moveSlug,
   orderedSlugs,
+  parseProjectsSeen,
   parseSavedOrder,
   reorderTo,
+  seenAfterOpen,
   type AppOrder,
   type CurrentApp,
+  type DoneStamp,
+  type ProjectsSeen,
 } from "@shell/current-apps-lib";
 
 // Bumped from `current-apps-order` with the redesign: the saved list was slugs
 // and is folder paths now, and a slug-shaped order would match nothing.
 export const ORDER_KEY = "fused-render:current-apps-order:v2";
+
+// The per-app unread stamps (current-apps-lib.ProjectsSeen): app path -> the
+// newest completion under it the user has opened the app for. Same store shape
+// and wiring as `appOrder` below — hydrated at import, written by ONE gesture
+// (opening an app), heard cross-tab through `storage`.
+export const PROJECTS_SEEN_KEY = "fused-render:current-apps-seen:v1";
+
+let projectsSeen: ProjectsSeen = {};
+
+function readProjectsSeen(): ProjectsSeen {
+  try {
+    return parseProjectsSeen(localStorage.getItem(PROJECTS_SEEN_KEY));
+  } catch {
+    return {};
+  }
+}
+
+function saveProjectsSeen(next: ProjectsSeen): void {
+  projectsSeen = next;
+  try {
+    localStorage.setItem(PROJECTS_SEEN_KEY, JSON.stringify(next));
+  } catch {
+    // A blocked store just means the dot's memory lasts as long as the page.
+  }
+}
+
+// Mounted sections, so an open in another tab clears the dot in this one.
+const seenListeners = new Set<() => void>();
+
+try {
+  projectsSeen = readProjectsSeen();
+  window.addEventListener("storage", (e: StorageEvent) => {
+    if (e.key !== PROJECTS_SEEN_KEY) return;
+    projectsSeen = parseProjectsSeen(e.newValue);
+    for (const listener of seenListeners) listener();
+  });
+} catch {
+  // No store and no window: the stamps live and die with this page.
+}
 
 /** The picked emoji as a standalone icon.svg document — square viewBox, no
  *  fixed size, transparent ground (a colour emoji carries its own colours, so
@@ -201,6 +244,7 @@ function CurrentAppRow({
   onRemoved,
   onGlyphClick,
   onMenu,
+  onSeen,
 }: {
   app: CurrentApp;
   active: boolean;
@@ -208,6 +252,8 @@ function CurrentAppRow({
   onRemoved: () => void;
   onGlyphClick: (e: React.MouseEvent<HTMLSpanElement>, path: string) => void;
   onMenu: (e: React.MouseEvent, app: CurrentApp) => void;
+  /** The user opened this app — stamp its completions seen (clears the dot). */
+  onSeen: (path: string) => void;
 }) {
   const [busy, setBusy] = useState(false);
   // The destination keeps the TAB the user is on (owner, 2026-08-26): switching
@@ -219,10 +265,17 @@ function CurrentAppRow({
   const onAppPage = appPathFromPath(location.pathname) !== null;
   const tab = onAppPage ? appPageTabFromSearch(location.search) : undefined;
   const href = appPageUrl(app.path, tab);
+  // The dot clears on the OPEN gesture, whatever the tasks under the app say
+  // (owner, 2026-09-07) — and on the row already active, since a completion
+  // landing while the user is on the app's page is one they are looking at.
+  useEffect(() => {
+    if (active && app.unread) onSeen(app.path);
+  }, [active, app.unread, app.path, onSeen]);
   const onOpen = (e: React.MouseEvent<HTMLAnchorElement>) => {
     // Middle/modified clicks keep the browser's own new-tab gesture on the href.
     if (opensElsewhere(e)) return;
     e.preventDefault();
+    onSeen(app.path);
     // The row for the page already on screen, on the tab it already shows, is
     // a no-op; the tab's own params would be the only thing the click cleared.
     if (!active) navigateUrl(href);
@@ -321,12 +374,12 @@ function CurrentAppRow({
           aria-hidden="true"
         />
       )}
-      {/* The unread dot: a task under this app finished and has not been read —
-          the Tasks row's green, worn per app, in the running dot's own slot
-          after the name (owner, 2026-08-31). Yellow outranks green (one dot per
-          row, the Tasks rule), so it hides while anything runs; it clears when
-          the task is read, since it draws the raw doneUnread state, not a
-          visit-stamped one. */}
+      {/* The unread dot: a task under this app finished since the user last
+          opened it — the Tasks row's green, worn per app, in the running dot's
+          own slot after the name (owner, 2026-08-31). Yellow outranks green
+          (one dot per row, the Tasks rule), so it hides while anything runs.
+          It clears when the APP is opened, not when the task is read — the
+          app's own state (owner, 2026-09-07; current-apps-lib.projectUnread). */}
       {app.unread && !app.running && (
         <span
           className="sidebar-rail-dot is-unread current-app-unread"
@@ -365,27 +418,49 @@ export default function CurrentAppsSection() {
     () => rows.filter((r) => inFlight(statusColumn(r.status))).map((r) => r.project || ""),
     [rows],
   );
-  // The projects with a finished-and-unread task — the raw doneUnread state
-  // the Tasks row's count chip reads, not the visit-stamped `unseen`: a dot
-  // per app clears by the task being READ, not by glancing at some page.
-  const unreadProjects = useMemo(
-    () => rows.filter(isDoneUnread).map((r) => r.project || ""),
+  // The Done-lane rows — the completions the per-app dot is judged against
+  // (current-apps-lib.projectUnread): a completion newer than the app's stamp
+  // lights it; opening the app, and only that, stamps it.
+  const doneRows = useMemo<DoneStamp[]>(
+    () =>
+      rows
+        .filter((r) => statusColumn(r.status) === "done")
+        .map((r) => ({ project: r.project, last_active: r.last_active, unread: r.unread })),
     [rows],
   );
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const entries = useCurrentApps(keySignal, refreshEpoch);
   // A drop mutates `appOrder`, which React cannot see; this counter is what
-  // turns that mutation into a render.
+  // turns that mutation into a render. `seenEpoch` is the same for the stamps.
   const [orderEpoch, setOrderEpoch] = useState(0);
+  const [seenEpoch, setSeenEpoch] = useState(0);
   const apps = useMemo(() => {
-    const found = currentApps(entries, runningProjects, unreadProjects);
+    const found = currentApps(entries, runningProjects, doneRows, projectsSeen);
     // Assigning during render is safe because it is idempotent: an app that
     // already has a sequence keeps it, so a double-invoked render (StrictMode)
     // or a re-run on the same rows cannot renumber anything.
     assignSequences(appOrder, found);
     return bySequence(found, appOrder);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- orderEpoch is the drag signal
-  }, [entries, runningProjects, unreadProjects, orderEpoch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- orderEpoch is the drag signal, seenEpoch the stamp signal
+  }, [entries, runningProjects, doneRows, orderEpoch, seenEpoch]);
+  // The one writer of the stamps: the user opened `path`. Pruned to the apps on
+  // the desk, so a removed app's stamp goes with it.
+  const onSeen = useCallback(
+    (path: string) => {
+      saveProjectsSeen(
+        seenAfterOpen(projectsSeen, path, doneRows, entries.map((e) => e.path)),
+      );
+      setSeenEpoch((n) => n + 1);
+    },
+    [doneRows, entries],
+  );
+  useEffect(() => {
+    const bump = () => setSeenEpoch((n) => n + 1);
+    seenListeners.add(bump);
+    return () => {
+      seenListeners.delete(bump);
+    };
+  }, []);
   // NOTHING is saved here. A new app, a removed one, a fetch landing — all of
   // those move rows on screen and write nothing to the store; the saved order is
   // an arrangement the user made, and only they can change it.
@@ -638,10 +713,11 @@ export default function CurrentAppsSection() {
         onRemoved={refetch}
         onGlyphClick={onGlyphClick}
         onMenu={onRowMenu}
+        onSeen={onSeen}
       />
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dragProps closes over `apps`
-    [onPath, apps, refetch, onGlyphClick, onRowMenu],
+    [onPath, apps, refetch, onGlyphClick, onRowMenu, onSeen],
   );
   // The "+ New app" row at the foot of the list opens the /apps composer in a
   // modal (D489). The section ALWAYS renders: a door to "make one" is exactly

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -176,31 +176,33 @@ try {
 function useCurrentApps(
   signal: string,
   refreshEpoch: number,
-): { entries: CurrentAppEntry[]; reload: () => Promise<void> } {
+): { entries: CurrentAppEntry[]; adopt: (apps: CurrentAppEntry[]) => void } {
   const [apps, setApps] = useState<CurrentAppEntry[]>(knownApps);
+  // Every table this hook shows is SEQUENCED: a read applies only if nothing
+  // newer was issued while it was in flight. Without this a slow fetch started
+  // before an open could land after the open's answer and put the pre-stamp
+  // row — dot and all — back on screen (Bugbot, 2026-09-07). Latest issued
+  // wins; a stale answer is dropped, not merged.
+  const seq = useRef(0);
   useEffect(() => {
-    let live = true;
+    const mine = ++seq.current;
     getCurrentApps().then(
       (r) => {
-        if (!live) return;
+        if (mine !== seq.current) return;
         knownApps = r.apps ?? [];
         setApps(knownApps);
       },
       () => {},
     );
-    return () => {
-      live = false;
-    };
   }, [signal, refreshEpoch]);
-  // A fetch the caller can WAIT for — the open gesture needs to know when the
-  // table on screen is one read after its POST, which a counter bump cannot
-  // say. Rejects on a failed read; the caller decides what that means.
-  const reload = useCallback(async () => {
-    const r = await getCurrentApps();
-    knownApps = r.apps ?? [];
-    setApps(knownApps);
+  // A table handed in from elsewhere — the open's answer carries one — takes
+  // the newest sequence, so any read still in flight is stale by definition.
+  const adopt = useCallback((next: CurrentAppEntry[]) => {
+    seq.current++;
+    knownApps = next;
+    setApps(next);
   }, []);
-  return { entries: apps, reload };
+  return { entries: apps, adopt };
 }
 
 interface RowDragProps {
@@ -401,16 +403,17 @@ export default function CurrentAppsSection() {
     [rows],
   );
   const [refreshEpoch, setRefreshEpoch] = useState(0);
-  const { entries, reload } = useCurrentApps(pulseSignal, refreshEpoch);
+  const { entries, adopt } = useCurrentApps(pulseSignal, refreshEpoch);
   // A drop mutates `appOrder`, which React cannot see; this counter is what
   // turns that mutation into a render.
   const [orderEpoch, setOrderEpoch] = useState(0);
   // The rows the user opened in THIS window whose open the server has not yet
   // answered — so the dot dies on the click rather than on the refetch. A path
-  // leaves the set once the read AFTER its POST has landed (`onSeen`), whatever
-  // that read says: from then on the server's flag is drawn as is, so a
-  // completion after the stamp — or an `observe` that raced the open — shows
-  // rather than being masked for the page's lifetime (Bugbot, 2026-09-07).
+  // leaves the set the moment the POST's answer (which carries the stamped
+  // table) is adopted (`onSeen`): from then on the server's flag is drawn as
+  // is, so a completion after the stamp — or an `observe` that raced the open
+  // — shows rather than being masked for the page's lifetime (Bugbot,
+  // 2026-09-07).
   const [clearedHere, setClearedHere] = useState<ReadonlySet<string>>(() => new Set());
   const uncover = useCallback(
     (path: string) =>
@@ -451,16 +454,11 @@ export default function CurrentAppsSection() {
           } catch {
             /* no store: this window is up to date, the others catch up on their own */
           }
-          // Awaited, not a counter bump: the cover comes off only once a read
-          // that started AFTER the server stamped the row is on screen. A read
-          // already in flight when the POST landed could still say unread.
-          try {
-            await reload();
-          } catch {
-            // The read failed: ask again through the counter. The cover still
-            // comes off — a cover that outlives its POST is the masking bug.
-            refetch();
-          }
+          // The answer carries the table after the stamp: adopt it and lift the
+          // cover in the same tick. No second read to race, and `adopt` takes
+          // the newest sequence so a fetch still in flight from before the POST
+          // is dropped rather than putting the pre-stamp row back.
+          adopt(r.apps ?? []);
           uncover(path);
         },
         () => {
@@ -472,7 +470,7 @@ export default function CurrentAppsSection() {
         },
       );
     },
-    [reload, refetch, uncover],
+    [adopt, uncover],
   );
   // NOTHING is saved here. A new app, a removed one, a fetch landing — all of
   // those move rows on screen and write nothing to the store; the saved order is

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -27,6 +27,7 @@ import React, {
 import {
   archiveCurrentAppTasks,
   getCurrentApps,
+  openCurrentApp,
   readCurrentAppTasks,
   removeAppIcon,
   removeCurrentApp,
@@ -53,58 +54,16 @@ import {
   currentApps,
   moveSlug,
   orderedSlugs,
-  parseProjectsSeen,
   parseSavedOrder,
   reorderTo,
-  seenAfterOpen,
   type AppOrder,
   type CurrentApp,
   type DoneStamp,
-  type ProjectsSeen,
 } from "@shell/current-apps-lib";
 
 // Bumped from `current-apps-order` with the redesign: the saved list was slugs
 // and is folder paths now, and a slug-shaped order would match nothing.
 export const ORDER_KEY = "fused-render:current-apps-order:v2";
-
-// The per-app unread stamps (current-apps-lib.ProjectsSeen): app path -> the
-// newest completion under it the user has opened the app for. Same store shape
-// and wiring as `appOrder` below — hydrated at import, written by ONE gesture
-// (opening an app), heard cross-tab through `storage`.
-export const PROJECTS_SEEN_KEY = "fused-render:current-apps-seen:v1";
-
-let projectsSeen: ProjectsSeen = {};
-
-function readProjectsSeen(): ProjectsSeen {
-  try {
-    return parseProjectsSeen(localStorage.getItem(PROJECTS_SEEN_KEY));
-  } catch {
-    return {};
-  }
-}
-
-function saveProjectsSeen(next: ProjectsSeen): void {
-  projectsSeen = next;
-  try {
-    localStorage.setItem(PROJECTS_SEEN_KEY, JSON.stringify(next));
-  } catch {
-    // A blocked store just means the dot's memory lasts as long as the page.
-  }
-}
-
-// Mounted sections, so an open in another tab clears the dot in this one.
-const seenListeners = new Set<() => void>();
-
-try {
-  projectsSeen = readProjectsSeen();
-  window.addEventListener("storage", (e: StorageEvent) => {
-    if (e.key !== PROJECTS_SEEN_KEY) return;
-    projectsSeen = parseProjectsSeen(e.newValue);
-    for (const listener of seenListeners) listener();
-  });
-} catch {
-  // No store and no window: the stamps live and die with this page.
-}
 
 /** The picked emoji as a standalone icon.svg document — square viewBox, no
  *  fixed size, transparent ground (a colour emoji carries its own colours, so
@@ -431,35 +390,40 @@ export default function CurrentAppsSection() {
   const [refreshEpoch, setRefreshEpoch] = useState(0);
   const entries = useCurrentApps(keySignal, refreshEpoch);
   // A drop mutates `appOrder`, which React cannot see; this counter is what
-  // turns that mutation into a render. `seenEpoch` is the same for the stamps.
+  // turns that mutation into a render.
   const [orderEpoch, setOrderEpoch] = useState(0);
-  const [seenEpoch, setSeenEpoch] = useState(0);
+  // The stamp lives on the server row (`opened_at`); this is the client's
+  // optimistic copy for the row just opened, so the dot goes out on the click
+  // and not on the refetch. Held per path, never dropped: the server's stamp
+  // overtakes it on the next fetch (current-apps-lib.latestOpen), and a stale
+  // override cannot re-light anything since it only ever raises the stamp.
+  const [openedLocal, setOpenedLocal] = useState<ReadonlyMap<string, number>>(
+    () => new Map(),
+  );
   const apps = useMemo(() => {
-    const found = currentApps(entries, runningProjects, doneRows, projectsSeen);
+    const found = currentApps(entries, runningProjects, doneRows, openedLocal);
     // Assigning during render is safe because it is idempotent: an app that
     // already has a sequence keeps it, so a double-invoked render (StrictMode)
     // or a re-run on the same rows cannot renumber anything.
     assignSequences(appOrder, found);
     return bySequence(found, appOrder);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- orderEpoch is the drag signal, seenEpoch the stamp signal
-  }, [entries, runningProjects, doneRows, orderEpoch, seenEpoch]);
-  // The one writer of the stamps: the user opened `path`. Pruned to the apps on
-  // the desk, so a removed app's stamp goes with it.
-  const onSeen = useCallback(
-    (path: string) => {
-      saveProjectsSeen(
-        seenAfterOpen(projectsSeen, path, doneRows, entries.map((e) => e.path)),
-      );
-      setSeenEpoch((n) => n + 1);
-    },
-    [doneRows, entries],
-  );
-  useEffect(() => {
-    const bump = () => setSeenEpoch((n) => n + 1);
-    seenListeners.add(bump);
-    return () => {
-      seenListeners.delete(bump);
-    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- orderEpoch is the drag signal
+  }, [entries, runningProjects, doneRows, openedLocal, orderEpoch]);
+  // The user opened `path`: stamp the row on the server (POST
+  // /api/current-apps/open) and, ahead of the answer, locally with the client
+  // clock. The server's stamp replaces the guess when the answer lands — the
+  // two clocks are the same machine, and the answer's `opened_at` is the truth
+  // the tasks' `last_active` is measured on.
+  const onSeen = useCallback((path: string) => {
+    const guess = Date.now() / 1000;
+    setOpenedLocal((m) => new Map(m).set(path, guess));
+    openCurrentApp(path).then(
+      (r) => setOpenedLocal((m) => new Map(m).set(path, r.opened_at)),
+      () => {
+        // A failed stamp leaves the guess: the dot stays out for this page,
+        // and comes back on the next launch if the server never heard.
+      },
+    );
   }, []);
   // NOTHING is saved here. A new app, a removed one, a fetch landing — all of
   // those move rows on screen and write nothing to the store; the saved order is

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -58,7 +58,6 @@ import {
   reorderTo,
   type AppOrder,
   type CurrentApp,
-  type DoneStamp,
 } from "@shell/current-apps-lib";
 
 // Bumped from `current-apps-order` with the redesign: the saved list was slugs
@@ -171,9 +170,9 @@ try {
 }
 
 /** The desk's table, fetched on mount and again whenever `signal` changes —
- *  the caller passes the pulse's set of task keys, since a task this document
- *  has not seen is the one thing that can add a row. Errors keep the last
- *  answer: a failed read is not an empty desk. */
+ *  the caller passes a digest of the task pulse (`pulseSignal`), since a task
+ *  appearing adds a row and a task finishing flips a row's `unread`, both on
+ *  the server. Errors keep the last answer: a failed read is not an empty desk. */
 function useCurrentApps(signal: string, refreshEpoch: number): CurrentAppEntry[] {
   const [apps, setApps] = useState<CurrentAppEntry[]>(knownApps);
   useEffect(() => {
@@ -232,6 +231,8 @@ function CurrentAppRow({
   // The dot clears on the OPEN gesture, whatever the tasks under the app say
   // (owner, 2026-09-07) — and on the row already active, since a completion
   // landing while the user is on the app's page is one they are looking at.
+  // Safe to key on `app.unread`: onSeen hides the dot at once and a failed
+  // POST leaves it hidden (see onSeen), so this cannot re-fire into a retry loop.
   useEffect(() => {
     if (active && app.unread) onSeen(app.path);
   }, [active, app.unread, app.path, onSeen]);
@@ -367,13 +368,17 @@ function CurrentAppRow({
 
 export default function CurrentAppsSection() {
   const rows = useTasksPulseRows();
-  // The set of task keys, as one string: it changes exactly when a task
-  // appears or leaves, and a new task is the only thing that can add an app.
-  // Order-independent (sorted) so a re-sorted pulse does not refetch.
-  const keySignal = useMemo(
+  // When to refetch the desk: a digest of the pulse — per task its key, lane,
+  // read state and activity — so the table reloads when a task appears or
+  // leaves (the one thing that adds a row) AND when one changes lane or speaks
+  // (the things that flip a row's `unread` on the server, which is computed
+  // inside the same listing the pulse reads). `last_active` is a fine CHANGE
+  // DETECTOR — it moves whenever the task does — it was only ever wrong as a
+  // threshold. Sorted, so a re-ordered pulse does not refetch.
+  const pulseSignal = useMemo(
     () =>
       rows
-        .map((r) => r.key)
+        .map((r) => `${r.key} ${r.status} ${r.unread} ${r.last_active}`)
         .sort()
         .join("\n"),
     [rows],
@@ -382,67 +387,67 @@ export default function CurrentAppsSection() {
     () => rows.filter((r) => inFlight(statusColumn(r.status))).map((r) => r.project || ""),
     [rows],
   );
-  // The Done-lane rows — the completions the per-app dot is judged against
-  // (current-apps-lib.projectUnread): a completion newer than the app's stamp
-  // lights it; opening the app, and only that, stamps it.
-  const doneRows = useMemo<DoneStamp[]>(
-    () =>
-      rows
-        .filter((r) => statusColumn(r.status) === "done")
-        .map((r) => ({ project: r.project, last_active: r.last_active, unread: r.unread })),
-    [rows],
-  );
   const [refreshEpoch, setRefreshEpoch] = useState(0);
-  const entries = useCurrentApps(keySignal, refreshEpoch);
+  const entries = useCurrentApps(pulseSignal, refreshEpoch);
   // A drop mutates `appOrder`, which React cannot see; this counter is what
   // turns that mutation into a render.
   const [orderEpoch, setOrderEpoch] = useState(0);
-  // The stamp lives on the server row (`opened_at`); this is the client's
-  // optimistic copy for the row just opened, so the dot goes out on the click
-  // and not on the refetch. Held per path, never dropped: the server's stamp
-  // overtakes it on the next fetch (current-apps-lib.latestOpen), and a stale
-  // override cannot re-light anything since it only ever raises the stamp.
-  const [openedLocal, setOpenedLocal] = useState<ReadonlyMap<string, number>>(
-    () => new Map(),
-  );
+  // The rows the user opened in THIS window and the server has not yet answered
+  // for, so the dot dies on the click rather than on the refetch. A path leaves
+  // the set the moment a fetch shows the server agreeing (`unread: false`) — so
+  // a LATER completion, which sets the flag again, is not masked by a stale
+  // entry from this session.
+  const [clearedHere, setClearedHere] = useState<ReadonlySet<string>>(() => new Set());
+  useEffect(() => {
+    setClearedHere((prev) => {
+      if (!prev.size) return prev;
+      const next = new Set(prev);
+      for (const e of entries) if (!e.unread) next.delete(e.path);
+      return next.size === prev.size ? prev : next;
+    });
+  }, [entries]);
   const apps = useMemo(() => {
-    const found = currentApps(entries, runningProjects, doneRows, openedLocal);
+    const found = currentApps(entries, runningProjects, clearedHere);
     // Assigning during render is safe because it is idempotent: an app that
     // already has a sequence keeps it, so a double-invoked render (StrictMode)
     // or a re-run on the same rows cannot renumber anything.
     assignSequences(appOrder, found);
     return bySequence(found, appOrder);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- orderEpoch is the drag signal
-  }, [entries, runningProjects, doneRows, openedLocal, orderEpoch]);
-  // The user opened `path`: stamp the row on the server (POST
-  // /api/current-apps/open) and, ahead of the answer, locally with the client
-  // clock. The server's stamp replaces the guess when the answer lands — the
-  // two clocks are the same machine, and the answer's `opened_at` is the truth
-  // the tasks' `last_active` is measured on.
-  const onSeen = useCallback((path: string) => {
-    const guess = Date.now() / 1000;
-    setOpenedLocal((m) => new Map(m).set(path, guess));
-    openCurrentApp(path).then(
-      (r) => {
-        setOpenedLocal((m) => new Map(m).set(path, r.opened_at));
-        // Tell the OTHER windows the desk changed: `storage` fires only in
-        // other documents (the ORDER_KEY wiring above, the chat's activity
-        // stamp), and their sections refetch on it. Without this a second
-        // window keeps the dot until something else makes it refetch (Bugbot,
-        // 2026-09-07). Value is the stamp so two opens in one second still
-        // differ; a blocked store just means no cross-window nudge.
-        try {
-          localStorage.setItem(DESK_CHANGED_KEY, String(r.opened_at));
-        } catch {
-          /* no store: this window is up to date, the others catch up on their own */
-        }
-      },
-      () => {
-        // A failed stamp leaves the guess: the dot stays out for this page,
-        // and comes back on the next launch if the server never heard.
-      },
-    );
-  }, []);
+  }, [entries, runningProjects, clearedHere, orderEpoch]);
+  // The user opened `path`: clear the dot here at once, and tell the server
+  // (POST /api/current-apps/open — the row's `opened_at` and `unread` are its
+  // to keep). The refetch on the answer brings the row back agreeing.
+  const refetch = useCallback(() => setRefreshEpoch((n) => n + 1), []);
+  const onSeen = useCallback(
+    (path: string) => {
+      setClearedHere((s) => new Set(s).add(path));
+      openCurrentApp(path).then(
+        (r) => {
+          refetch();
+          // Tell the OTHER windows the desk changed: `storage` fires only in
+          // other documents (the ORDER_KEY wiring above, the chat's activity
+          // stamp), and their sections refetch on it. Without this a second
+          // window keeps the dot until something else makes it refetch (Bugbot,
+          // 2026-09-07). Value is the stamp so two opens in one second still
+          // differ; a blocked store just means no cross-window nudge.
+          try {
+            localStorage.setItem(DESK_CHANGED_KEY, String(r.opened_at));
+          } catch {
+            /* no store: this window is up to date, the others catch up on their own */
+          }
+        },
+        () => {
+          // The server never heard. The dot stays hidden for this page — it
+          // comes back on the next load, since the server still says unread.
+          // Deliberately NOT restored: the active-row effect above keys on
+          // `app.unread`, and a restore would re-fire it into a retry loop at
+          // network-error cadence.
+        },
+      );
+    },
+    [refetch],
+  );
   // NOTHING is saved here. A new app, a removed one, a fetch landing — all of
   // those move rows on screen and write nothing to the store; the saved order is
   // an arrangement the user made, and only they can change it.
@@ -520,8 +525,6 @@ export default function CurrentAppsSection() {
       clearDrag();
     },
   });
-
-  const refetch = useCallback(() => setRefreshEpoch((n) => n + 1), []);
 
   // The explorer's "Open in project" button adds a row (POST
   // /api/current-apps/add) and announces it over the window — apps cannot

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -173,7 +173,10 @@ try {
  *  the caller passes a digest of the task pulse (`pulseSignal`), since a task
  *  appearing adds a row and a task finishing flips a row's `unread`, both on
  *  the server. Errors keep the last answer: a failed read is not an empty desk. */
-function useCurrentApps(signal: string, refreshEpoch: number): CurrentAppEntry[] {
+function useCurrentApps(
+  signal: string,
+  refreshEpoch: number,
+): { entries: CurrentAppEntry[]; reload: () => Promise<void> } {
   const [apps, setApps] = useState<CurrentAppEntry[]>(knownApps);
   useEffect(() => {
     let live = true;
@@ -189,7 +192,15 @@ function useCurrentApps(signal: string, refreshEpoch: number): CurrentAppEntry[]
       live = false;
     };
   }, [signal, refreshEpoch]);
-  return apps;
+  // A fetch the caller can WAIT for — the open gesture needs to know when the
+  // table on screen is one read after its POST, which a counter bump cannot
+  // say. Rejects on a failed read; the caller decides what that means.
+  const reload = useCallback(async () => {
+    const r = await getCurrentApps();
+    knownApps = r.apps ?? [];
+    setApps(knownApps);
+  }, []);
+  return { entries: apps, reload };
 }
 
 interface RowDragProps {
@@ -372,13 +383,15 @@ export default function CurrentAppsSection() {
   // read state and activity — so the table reloads when a task appears or
   // leaves (the one thing that adds a row) AND when one changes lane or speaks
   // (the things that flip a row's `unread` on the server, which is computed
-  // inside the same listing the pulse reads). `last_active` is a fine CHANGE
-  // DETECTOR — it moves whenever the task does — it was only ever wrong as a
-  // threshold. Sorted, so a re-ordered pulse does not refetch.
+  // inside the same listing the pulse reads). The activity term is
+  // `happened_at`, the clock `observe` itself compares — NOT `last_active`,
+  // which keeps a scheduled due time and so does not move when a recurring
+  // run finishes early (Bugbot, 2026-09-07). Sorted, so a re-ordered pulse
+  // does not refetch.
   const pulseSignal = useMemo(
     () =>
       rows
-        .map((r) => `${r.key} ${r.status} ${r.unread} ${r.last_active}`)
+        .map((r) => `${r.key} ${r.status} ${r.happened_at ?? 0}`)
         .sort()
         .join("\n"),
     [rows],
@@ -388,24 +401,27 @@ export default function CurrentAppsSection() {
     [rows],
   );
   const [refreshEpoch, setRefreshEpoch] = useState(0);
-  const entries = useCurrentApps(pulseSignal, refreshEpoch);
+  const { entries, reload } = useCurrentApps(pulseSignal, refreshEpoch);
   // A drop mutates `appOrder`, which React cannot see; this counter is what
   // turns that mutation into a render.
   const [orderEpoch, setOrderEpoch] = useState(0);
-  // The rows the user opened in THIS window and the server has not yet answered
-  // for, so the dot dies on the click rather than on the refetch. A path leaves
-  // the set the moment a fetch shows the server agreeing (`unread: false`) — so
-  // a LATER completion, which sets the flag again, is not masked by a stale
-  // entry from this session.
+  // The rows the user opened in THIS window whose open the server has not yet
+  // answered — so the dot dies on the click rather than on the refetch. A path
+  // leaves the set once the read AFTER its POST has landed (`onSeen`), whatever
+  // that read says: from then on the server's flag is drawn as is, so a
+  // completion after the stamp — or an `observe` that raced the open — shows
+  // rather than being masked for the page's lifetime (Bugbot, 2026-09-07).
   const [clearedHere, setClearedHere] = useState<ReadonlySet<string>>(() => new Set());
-  useEffect(() => {
-    setClearedHere((prev) => {
-      if (!prev.size) return prev;
-      const next = new Set(prev);
-      for (const e of entries) if (!e.unread) next.delete(e.path);
-      return next.size === prev.size ? prev : next;
-    });
-  }, [entries]);
+  const uncover = useCallback(
+    (path: string) =>
+      setClearedHere((s) => {
+        if (!s.has(path)) return s;
+        const next = new Set(s);
+        next.delete(path);
+        return next;
+      }),
+    [],
+  );
   const apps = useMemo(() => {
     const found = currentApps(entries, runningProjects, clearedHere);
     // Assigning during render is safe because it is idempotent: an app that
@@ -415,16 +431,15 @@ export default function CurrentAppsSection() {
     return bySequence(found, appOrder);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- orderEpoch is the drag signal
   }, [entries, runningProjects, clearedHere, orderEpoch]);
-  // The user opened `path`: clear the dot here at once, and tell the server
-  // (POST /api/current-apps/open — the row's `opened_at` and `unread` are its
-  // to keep). The refetch on the answer brings the row back agreeing.
+  // The user opened `path`: clear the dot here at once, tell the server (POST
+  // /api/current-apps/open — the row's `opened_at` and `unread` are its to
+  // keep), then read the table back and hand the row to the server's flag.
   const refetch = useCallback(() => setRefreshEpoch((n) => n + 1), []);
   const onSeen = useCallback(
     (path: string) => {
       setClearedHere((s) => new Set(s).add(path));
       openCurrentApp(path).then(
-        (r) => {
-          refetch();
+        async (r) => {
           // Tell the OTHER windows the desk changed: `storage` fires only in
           // other documents (the ORDER_KEY wiring above, the chat's activity
           // stamp), and their sections refetch on it. Without this a second
@@ -436,6 +451,17 @@ export default function CurrentAppsSection() {
           } catch {
             /* no store: this window is up to date, the others catch up on their own */
           }
+          // Awaited, not a counter bump: the cover comes off only once a read
+          // that started AFTER the server stamped the row is on screen. A read
+          // already in flight when the POST landed could still say unread.
+          try {
+            await reload();
+          } catch {
+            // The read failed: ask again through the counter. The cover still
+            // comes off — a cover that outlives its POST is the masking bug.
+            refetch();
+          }
+          uncover(path);
         },
         () => {
           // The server never heard. The dot stays hidden for this page — it
@@ -446,7 +472,7 @@ export default function CurrentAppsSection() {
         },
       );
     },
-    [refetch],
+    [reload, refetch, uncover],
   );
   // NOTHING is saved here. A new app, a removed one, a fetch landing — all of
   // those move rows on screen and write nothing to the store; the saved order is

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -13,7 +13,7 @@
 // the drag-ordered sequence layer.
 //
 // EVERY app is rendered — the list is not capped (owner, 2026-08-26).
-import type { CurrentAppEntry, TaskPulseTask } from "@platform/lib/api";
+import type { CurrentAppEntry } from "@platform/lib/api";
 
 // The explorer's fs-path codec (router.ts encodeFsPathSegments / rootedFsPath),
 // restated here rather than imported: router.ts rewrites `location` at import
@@ -53,8 +53,8 @@ export interface CurrentApp {
   running: boolean;
   /** A task under it finished since the user last opened this app — the row
    *  wears the green dot (unless running: yellow outranks green, the Tasks
-   *  row's own rule). The app's OWN unread state (see `projectUnread`), not the
-   *  task's: reading the task elsewhere does not clear it, opening the app does. */
+   *  row's own rule). The server's flag (the unread section below), the app's
+   *  OWN state: reading the task elsewhere does not clear it, opening the app does. */
   unread: boolean;
   /** The app's optional `icon.svg`, as a drawable URL (api.appIconUrl), or
    *  null — the glyph slot falls back to the generic mark. */
@@ -76,61 +76,26 @@ export function isUnderDir(project: string, dir: string): boolean {
 // trigger — a completion under the app lights the dot — but the app clears it
 // on its own gesture, opening the app, and nothing done to the task clears it.
 //
-// So the app row itself carries the stamp — `opened_at` in the desk's own
-// store (current_apps.json, written by POST /api/current-apps/open with the
-// server's clock). A done task under the app whose `last_active` (the same
-// server clock) is later than the stamp is a completion the user has not opened
-// the app for since, and the dot is on. `last_active` moves with every message,
-// so a task that speaks again after the open lights the dot again — the same
-// reasoning as tasks-lib.TasksSeen, per app instead of per task. The desk
-// store rather than localStorage because the stamp is a fact about the desk,
-// like the row's addedAt: it belongs beside the row and follows the user to
-// every window on this machine (owner, 2026-09-07).
-//
-// A row with NO stamp has never been opened since this shipped. For it the old
-// rule holds — a done task with unread output — so the upgrade changes nothing
-// on screen: apps whose tasks were read stay quiet rather than every old
-// completion lighting at once. The first open stamps it and it is on the new
-// rule from then on.
-
-/** The done tasks' fields the rule reads. */
-export type DoneStamp = Pick<TaskPulseTask, "project" | "last_active" | "unread">;
-
-/** Does the app at `path`, opened at `openedAt` (null: never), have a completion
- *  the user has not opened it for? `done` is the pulse's Done-lane rows (any
- *  project — the containment test is here). */
-export function projectUnread(
-  path: string,
-  openedAt: number | null | undefined,
-  done: Iterable<DoneStamp>,
-): boolean {
-  for (const t of done) {
-    if (!isUnderDir(t.project || "", path)) continue;
-    if (openedAt == null ? t.unread > 0 : t.last_active > openedAt) return true;
-  }
-  return false;
-}
-
-/** The later of the server's stamp and the client's optimistic one; null when
- *  neither exists (never opened). */
-function latestOpen(server: number | null | undefined, local: number | undefined): number | null {
-  if (server == null) return local ?? null;
-  return local === undefined ? server : Math.max(server, local);
-}
+// The flag is the SERVER's (fused_render/current_apps.py, the unread section):
+// the desk row carries `unread`, recomputed on every tasks listing from each
+// task's `happened_at` against the row's `opened_at`, and cleared by POST
+// /api/current-apps/open. This file does not compute it — it draws it. Two
+// client-side cuts that derived it here from the pulse's `last_active` both
+// broke on the same fact: `last_active` keeps a scheduled message's DUE time
+// for sorting, so it is not a clock an open can be compared against (Bugbot
+// ×2, 2026-09-07). The only client-side input is `clearedHere`: the rows the
+// user opened in THIS window ahead of the refetch, so the dot dies on the click.
 
 /** The store's rows as sidebar rows, in the store's ADDED order (oldest
  *  first), with the running dot read off the projects of the tasks currently
- *  in progress and the unread dot off `projectUnread` (the Done-lane rows
- *  against each row's `opened_at`). `openedOverride` is the client's optimistic
- *  stamp for a row it just opened, ahead of the refetch. */
+ *  in progress and the unread dot the server's flag, minus the rows opened here
+ *  since the last fetch. */
 export function currentApps(
   entries: CurrentAppEntry[],
   runningProjects: Iterable<string>,
-  done: Iterable<DoneStamp> = [],
-  openedOverride: ReadonlyMap<string, number> = new Map(),
+  clearedHere: ReadonlySet<string> = new Set(),
 ): CurrentApp[] {
   const live = [...runningProjects];
-  const finished = [...done];
   return entries.map((e) => ({
     path: e.path,
     name: e.name,
@@ -138,7 +103,7 @@ export function currentApps(
     kind: e.kind,
     exists: e.exists,
     running: live.some((p) => isUnderDir(p, e.path)),
-    unread: projectUnread(e.path, latestOpen(e.opened_at, openedOverride.get(e.path)), finished),
+    unread: Boolean(e.unread) && !clearedHere.has(e.path),
     iconUrl: e.icon ? iconUrlFor(e.icon, e.icon_mtime) : null,
   }));
 }

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -76,94 +76,58 @@ export function isUnderDir(project: string, dir: string): boolean {
 // trigger — a completion under the app lights the dot — but the app clears it
 // on its own gesture, opening the app, and nothing done to the task clears it.
 //
-// So each app carries a stamp of its own: the highest `last_active` among the
-// done tasks under it AS OF the last time the user opened it. A done task with a
-// later stamp is a completion the user has not opened the app for since, and
-// the dot is on. `last_active` moves with every message, so a task that speaks
-// again after being seen lights the dot again — the same reasoning as
-// tasks-lib.TasksSeen, per app instead of per task.
+// So the app row itself carries the stamp — `opened_at` in the desk's own
+// store (current_apps.json, written by POST /api/current-apps/open with the
+// server's clock). A done task under the app whose `last_active` (the same
+// server clock) is later than the stamp is a completion the user has not opened
+// the app for since, and the dot is on. `last_active` moves with every message,
+// so a task that speaks again after the open lights the dot again — the same
+// reasoning as tasks-lib.TasksSeen, per app instead of per task. The desk
+// store rather than localStorage because the stamp is a fact about the desk,
+// like the row's addedAt: it belongs beside the row and follows the user to
+// every window on this machine (owner, 2026-09-07).
 //
-// An app with NO stamp has never been opened since this shipped. For it the
-// old rule holds — a done task with unread output — so the upgrade changes
-// nothing on screen: apps whose tasks were read stay quiet rather than every
-// old completion lighting at once. The first open stamps it and it is on the
-// new rule from then on.
-//
-// The store is localStorage, for the reasons `appOrder` gives below, written
-// only by the open gesture (one writer, no poll race).
-
-/** app path -> `last_active` of the newest completion seen under it. */
-export type ProjectsSeen = Record<string, number>;
+// A row with NO stamp has never been opened since this shipped. For it the old
+// rule holds — a done task with unread output — so the upgrade changes nothing
+// on screen: apps whose tasks were read stay quiet rather than every old
+// completion lighting at once. The first open stamps it and it is on the new
+// rule from then on.
 
 /** The done tasks' fields the rule reads. */
 export type DoneStamp = Pick<TaskPulseTask, "project" | "last_active" | "unread">;
 
-/** Does `app` have a completion the user has not opened it for? `done` is the
- *  pulse's Done-lane rows (any project — the containment test is here). */
+/** Does the app at `path`, opened at `openedAt` (null: never), have a completion
+ *  the user has not opened it for? `done` is the pulse's Done-lane rows (any
+ *  project — the containment test is here). */
 export function projectUnread(
-  app: string,
+  path: string,
+  openedAt: number | null | undefined,
   done: Iterable<DoneStamp>,
-  seen: ProjectsSeen,
 ): boolean {
-  const stamp = seen[app];
   for (const t of done) {
-    if (!isUnderDir(t.project || "", app)) continue;
-    if (stamp === undefined ? t.unread > 0 : t.last_active > stamp) return true;
+    if (!isUnderDir(t.project || "", path)) continue;
+    if (openedAt == null ? t.unread > 0 : t.last_active > openedAt) return true;
   }
   return false;
 }
 
-/** `seen` after the user opened `app`: stamped with the newest completion under
- *  it (0 when none — the stamp still records that the app was opened, so the
- *  fallback rule no longer applies). Pruned to `live` (the apps on the desk), so
- *  the store cannot grow past the list it describes; guarded on a non-empty
- *  list so an unloaded list cannot wipe it. */
-export function seenAfterOpen(
-  seen: ProjectsSeen,
-  app: string,
-  done: Iterable<DoneStamp>,
-  live: Iterable<string>,
-): ProjectsSeen {
-  const keep = new Set(live);
-  const next: ProjectsSeen = {};
-  for (const [k, v] of Object.entries(seen)) {
-    if (!keep.size || keep.has(k)) next[k] = v;
-  }
-  let at = 0;
-  for (const t of done) {
-    if (isUnderDir(t.project || "", app)) at = Math.max(at, t.last_active);
-  }
-  next[app] = at;
-  return next;
-}
-
-/** What came out of localStorage is a string written by SOMEONE ELSE (an older
- *  build, a hand-edited devtools row): anything unreadable degrades to "no app
- *  opened yet" — the fallback rule — rather than throwing inside a render. */
-export function parseProjectsSeen(raw: string | null): ProjectsSeen {
-  if (!raw) return {};
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return {};
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-  const out: ProjectsSeen = {};
-  for (const [key, at] of Object.entries(parsed as Record<string, unknown>)) {
-    if (typeof at === "number" && Number.isFinite(at)) out[key] = at;
-  }
-  return out;
+/** The later of the server's stamp and the client's optimistic one; null when
+ *  neither exists (never opened). */
+function latestOpen(server: number | null | undefined, local: number | undefined): number | null {
+  if (server == null) return local ?? null;
+  return local === undefined ? server : Math.max(server, local);
 }
 
 /** The store's rows as sidebar rows, in the store's ADDED order (oldest
  *  first), with the running dot read off the projects of the tasks currently
- *  in progress and the unread dot off `projectUnread` (done rows + stamps). */
+ *  in progress and the unread dot off `projectUnread` (the Done-lane rows
+ *  against each row's `opened_at`). `openedOverride` is the client's optimistic
+ *  stamp for a row it just opened, ahead of the refetch. */
 export function currentApps(
   entries: CurrentAppEntry[],
   runningProjects: Iterable<string>,
   done: Iterable<DoneStamp> = [],
-  seen: ProjectsSeen = {},
+  openedOverride: ReadonlyMap<string, number> = new Map(),
 ): CurrentApp[] {
   const live = [...runningProjects];
   const finished = [...done];
@@ -174,7 +138,7 @@ export function currentApps(
     kind: e.kind,
     exists: e.exists,
     running: live.some((p) => isUnderDir(p, e.path)),
-    unread: projectUnread(e.path, finished, seen),
+    unread: projectUnread(e.path, latestOpen(e.opened_at, openedOverride.get(e.path)), finished),
     iconUrl: e.icon ? iconUrlFor(e.icon, e.icon_mtime) : null,
   }));
 }

--- a/frontend/src/shell/current-apps-lib.ts
+++ b/frontend/src/shell/current-apps-lib.ts
@@ -13,7 +13,7 @@
 // the drag-ordered sequence layer.
 //
 // EVERY app is rendered — the list is not capped (owner, 2026-08-26).
-import type { CurrentAppEntry } from "@platform/lib/api";
+import type { CurrentAppEntry, TaskPulseTask } from "@platform/lib/api";
 
 // The explorer's fs-path codec (router.ts encodeFsPathSegments / rootedFsPath),
 // restated here rather than imported: router.ts rewrites `location` at import
@@ -51,8 +51,10 @@ export interface CurrentApp {
   /** Something is running under it right now — the row wears the running dot.
    *  Read from the task pulse, which the sidebar already subscribes to. */
   running: boolean;
-  /** A task under it finished with something unread — the row wears the green
-   *  dot (unless running: yellow outranks green, the Tasks row's own rule). */
+  /** A task under it finished since the user last opened this app — the row
+   *  wears the green dot (unless running: yellow outranks green, the Tasks
+   *  row's own rule). The app's OWN unread state (see `projectUnread`), not the
+   *  task's: reading the task elsewhere does not clear it, opening the app does. */
   unread: boolean;
   /** The app's optional `icon.svg`, as a drawable URL (api.appIconUrl), or
    *  null — the glyph slot falls back to the generic mark. */
@@ -66,16 +68,105 @@ export function isUnderDir(project: string, dir: string): boolean {
   return project === dir || project.startsWith(dir + "/");
 }
 
+// ---- the per-app unread dot -------------------------------------------------
+//
+// The dot used to be the tasks' own unread state worn per app: it lit when a
+// task under the app finished with unread output and went out when THAT TASK
+// was read. The owner decoupled the two (2026-09-07): the task is still the
+// trigger — a completion under the app lights the dot — but the app clears it
+// on its own gesture, opening the app, and nothing done to the task clears it.
+//
+// So each app carries a stamp of its own: the highest `last_active` among the
+// done tasks under it AS OF the last time the user opened it. A done task with a
+// later stamp is a completion the user has not opened the app for since, and
+// the dot is on. `last_active` moves with every message, so a task that speaks
+// again after being seen lights the dot again — the same reasoning as
+// tasks-lib.TasksSeen, per app instead of per task.
+//
+// An app with NO stamp has never been opened since this shipped. For it the
+// old rule holds — a done task with unread output — so the upgrade changes
+// nothing on screen: apps whose tasks were read stay quiet rather than every
+// old completion lighting at once. The first open stamps it and it is on the
+// new rule from then on.
+//
+// The store is localStorage, for the reasons `appOrder` gives below, written
+// only by the open gesture (one writer, no poll race).
+
+/** app path -> `last_active` of the newest completion seen under it. */
+export type ProjectsSeen = Record<string, number>;
+
+/** The done tasks' fields the rule reads. */
+export type DoneStamp = Pick<TaskPulseTask, "project" | "last_active" | "unread">;
+
+/** Does `app` have a completion the user has not opened it for? `done` is the
+ *  pulse's Done-lane rows (any project — the containment test is here). */
+export function projectUnread(
+  app: string,
+  done: Iterable<DoneStamp>,
+  seen: ProjectsSeen,
+): boolean {
+  const stamp = seen[app];
+  for (const t of done) {
+    if (!isUnderDir(t.project || "", app)) continue;
+    if (stamp === undefined ? t.unread > 0 : t.last_active > stamp) return true;
+  }
+  return false;
+}
+
+/** `seen` after the user opened `app`: stamped with the newest completion under
+ *  it (0 when none — the stamp still records that the app was opened, so the
+ *  fallback rule no longer applies). Pruned to `live` (the apps on the desk), so
+ *  the store cannot grow past the list it describes; guarded on a non-empty
+ *  list so an unloaded list cannot wipe it. */
+export function seenAfterOpen(
+  seen: ProjectsSeen,
+  app: string,
+  done: Iterable<DoneStamp>,
+  live: Iterable<string>,
+): ProjectsSeen {
+  const keep = new Set(live);
+  const next: ProjectsSeen = {};
+  for (const [k, v] of Object.entries(seen)) {
+    if (!keep.size || keep.has(k)) next[k] = v;
+  }
+  let at = 0;
+  for (const t of done) {
+    if (isUnderDir(t.project || "", app)) at = Math.max(at, t.last_active);
+  }
+  next[app] = at;
+  return next;
+}
+
+/** What came out of localStorage is a string written by SOMEONE ELSE (an older
+ *  build, a hand-edited devtools row): anything unreadable degrades to "no app
+ *  opened yet" — the fallback rule — rather than throwing inside a render. */
+export function parseProjectsSeen(raw: string | null): ProjectsSeen {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  const out: ProjectsSeen = {};
+  for (const [key, at] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof at === "number" && Number.isFinite(at)) out[key] = at;
+  }
+  return out;
+}
+
 /** The store's rows as sidebar rows, in the store's ADDED order (oldest
  *  first), with the running dot read off the projects of the tasks currently
- *  in progress. */
+ *  in progress and the unread dot off `projectUnread` (done rows + stamps). */
 export function currentApps(
   entries: CurrentAppEntry[],
   runningProjects: Iterable<string>,
-  unreadProjects: Iterable<string> = [],
+  done: Iterable<DoneStamp> = [],
+  seen: ProjectsSeen = {},
 ): CurrentApp[] {
   const live = [...runningProjects];
-  const fresh = [...unreadProjects];
+  const finished = [...done];
   return entries.map((e) => ({
     path: e.path,
     name: e.name,
@@ -83,7 +174,7 @@ export function currentApps(
     kind: e.kind,
     exists: e.exists,
     running: live.some((p) => isUnderDir(p, e.path)),
-    unread: fresh.some((p) => isUnderDir(p, e.path)),
+    unread: projectUnread(e.path, finished, seen),
     iconUrl: e.icon ? iconUrlFor(e.icon, e.icon_mtime) : null,
   }));
 }

--- a/fused_render/current_apps.py
+++ b/fused_render/current_apps.py
@@ -2,7 +2,8 @@
 
 ``~/.fused-render/current_apps.json``::
 
-    {"apps": [{"path": "/Users/me/Fused/local/foo", "addedAt": "<iso>"}],
+    {"apps": [{"path": "/Users/me/Fused/local/foo", "addedAt": "<iso>",
+               "openedAt": <epoch, optional — see mark_opened>}],
      "seen": ["<task key>", ...]}
 
 The sidebar's "Current apps" section (D487) used to DERIVE this list from the
@@ -201,6 +202,26 @@ def remove(path: str) -> bool:
     return True
 
 
+def mark_opened(path: str, at: float) -> bool:
+    """Stamp `path` as OPENED at `at` (epoch seconds, the server's clock) — the
+    row's ``openedAt``. The sidebar's green dot is the app's own unread state
+    (owner, 2026-09-07): a task finishing under the app lights it, and only
+    opening the app clears it — whatever is done to the task. The client
+    judges a done task's ``last_active`` (the same server clock) against this
+    stamp, so it lives in this table beside the app, not in the browser: it
+    is a fact about the desk, and it should follow the user across windows.
+    True when the row exists and was stamped; False for a path not on the desk
+    (nothing to clear on)."""
+    folder = canonical_fs_path(os.path.abspath(path)).rstrip("/")
+    state = read_state()
+    for a in state["apps"]:
+        if a["path"] == folder:
+            a["openedAt"] = float(at)
+            write_state(state)
+            return True
+    return False
+
+
 def _added_epoch(ts) -> float | None:
     if not isinstance(ts, str):
         return None
@@ -231,8 +252,10 @@ def list_apps() -> list[dict]:
     (folder name), ``kind`` (``linked`` for a registry folder, ``workspace``
     otherwise), ``entry`` (the page to run, or None), ``exists``, ``icon`` /
     ``icon_mtime`` (the optional ``icon.svg``, see `app_icon`), ``added_at``
-    (epoch). A folder that is gone or unreadable still lists — the row is the
-    user's to remove — with ``exists`` false and no entry."""
+    (epoch), ``opened_at`` (epoch of the last `mark_opened`, or None for a row
+    never opened since the stamp shipped). A folder that is gone or unreadable
+    still lists — the row is the user's to remove — with ``exists`` false and
+    no entry."""
     linked = {
         canonical_fs_path(os.path.abspath(e["path"])).rstrip("/")
         for e in registered_apps.read_entries()
@@ -261,5 +284,7 @@ def list_apps() -> list[dict]:
             "icon": icon["icon"] if icon else None,
             "icon_mtime": icon["mtime"] if icon else None,
             "added_at": _added_epoch(a.get("addedAt")),
+            "opened_at": (a["openedAt"] if isinstance(a.get("openedAt"), (int, float))
+                          else None),
         })
     return out

--- a/fused_render/current_apps.py
+++ b/fused_render/current_apps.py
@@ -3,7 +3,7 @@
 ``~/.fused-render/current_apps.json``::
 
     {"apps": [{"path": "/Users/me/Fused/local/foo", "addedAt": "<iso>",
-               "openedAt": <epoch, optional — see mark_opened>}],
+               "openedAt": <epoch>, "unread": <bool>}],
      "seen": ["<task key>", ...]}
 
 The sidebar's "Current apps" section (D487) used to DERIVE this list from the
@@ -132,9 +132,57 @@ def app_dir_for(project: str) -> str | None:
     return None
 
 
+# ---- the unread dot ----------------------------------------------------------
+#
+# Each desk row carries its OWN unread state (owner, 2026-09-07): ``unread`` is
+# true when a task under the folder FINISHED since the user last opened the app,
+# and opening the app — nothing else — clears it. It is decoupled from the
+# tasks' per-message read state on purpose: reading the task in the Tasks page,
+# the chat, anywhere, leaves the app's dot alone, and opening the app leaves the
+# task's messages unread.
+#
+# Two facts per row, both here, both the server's:
+#
+# * ``openedAt`` — epoch of the last open (`mark_opened`, POST
+#   /api/current-apps/open). 0.0 for a row a task put on the desk (`observe`):
+#   never opened, so the completion that put it there lights it. `add` (the
+#   explorer's "Open in project", which navigates there at once) stamps now.
+# * ``unread`` — RECOMPUTED on every `observe` pass, never incremented: any task
+#   row under the folder that is not running or archived and whose
+#   ``happened_at`` (tasks._row: the newest thing that actually ran or was
+#   written, never a due time or a creation stamp) is later than ``openedAt``.
+#   A recomputation rather than a transition detector because `observe` sees
+#   snapshots per poll: a rerun that starts and ends between two polls shows no
+#   transition, and a recurring task goes in_progress → upcoming without ever
+#   touching Done. Comparing clocks catches both, and is idempotent — a missed
+#   poll costs nothing, the next one gets the same answer.
+#
+# Running rows are left out so the flag means "finished", not "active": while a
+# run is in flight the row wears the running dot (yellow outranks green, the
+# Tasks rule), and the moment it ends the next pass lights the green.
+
+# The lanes whose rows do NOT count as finished work. Every other status —
+# `done`, `blocked` (a failed run has happened), `upcoming` (a recurring task
+# whose last run finished and whose next is on the books) — does.
+_NOT_FINISHED = frozenset({"in_progress", "needs_attention", "archived"})
+
+
+def _unread(folder: str, opened_at: float, rows: list[dict]) -> bool:
+    for row in rows:
+        if row.get("status") in _NOT_FINISHED:
+            continue
+        project = str(row.get("project") or "")
+        if not project or not is_under(project, folder):
+            continue
+        if float(row.get("happened_at") or 0.0) > opened_at:
+            return True
+    return False
+
+
 def observe(rows: list[dict]) -> None:
     """Look at every task row once: a key not seen before is a new task, and a
-    new task that is not archived adds its app. Called from the tasks listing,
+    new task that is not archived adds its app. Then recompute every row's
+    ``unread`` (see the section comment above). Called from the tasks listing,
     so the listing's own response already reflects the add. Writes only when
     something changed — an idle poll must not rewrite the file."""
     state = read_state()
@@ -143,6 +191,14 @@ def observe(rows: list[dict]) -> None:
     changed = False
     now = None
     live_keys: set[str] = set()
+    # Rows from before the stamp shipped have no ``openedAt``. Stamp them NOW,
+    # once: the quiet upgrade — nothing already on the desk lights until a task
+    # finishes under it from here on (the alternative, 0.0, would light every
+    # app with any finished task, which is most of them).
+    for a in state["apps"]:
+        if not isinstance(a.get("openedAt"), (int, float)):
+            a["openedAt"] = _now_epoch()
+            changed = True
     # OLDEST activity first: `_task_rows` sorts newest first, and the table is
     # added-order (the sidebar numbers the first entry lowest, so the last
     # added lands on top). Walking the listing as given would seed a first-run
@@ -163,12 +219,22 @@ def observe(rows: list[dict]) -> None:
         if folder is None or folder in known:
             continue
         now = now or datetime.now(timezone.utc).isoformat()
-        state["apps"].append({"path": folder, "addedAt": now})
+        # Never opened: the task that put it here lights it once it finishes.
+        state["apps"].append({"path": folder, "addedAt": now, "openedAt": 0.0})
         known.add(folder)
+    for a in state["apps"]:
+        flag = _unread(a["path"], float(a["openedAt"]), rows)
+        if a.get("unread") is not flag:
+            a["unread"] = flag
+            changed = True
     pruned = seen & live_keys
     if changed or pruned != set(state["seen"]):
         state["seen"] = sorted(pruned)
         write_state(state)
+
+
+def _now_epoch() -> float:
+    return datetime.now(timezone.utc).timestamp()
 
 
 def add(path: str) -> bool:
@@ -184,6 +250,9 @@ def add(path: str) -> bool:
     state["apps"].append({
         "path": folder,
         "addedAt": datetime.now(timezone.utc).isoformat(),
+        # The button navigates to the app at once: it IS an open.
+        "openedAt": _now_epoch(),
+        "unread": False,
     })
     write_state(state)
     return True
@@ -203,20 +272,18 @@ def remove(path: str) -> bool:
 
 
 def mark_opened(path: str, at: float) -> bool:
-    """Stamp `path` as OPENED at `at` (epoch seconds, the server's clock) — the
-    row's ``openedAt``. The sidebar's green dot is the app's own unread state
-    (owner, 2026-09-07): a task finishing under the app lights it, and only
-    opening the app clears it — whatever is done to the task. The client
-    judges a done task's ``last_active`` (the same server clock) against this
-    stamp, so it lives in this table beside the app, not in the browser: it
-    is a fact about the desk, and it should follow the user across windows.
-    True when the row exists and was stamped; False for a path not on the desk
-    (nothing to clear on)."""
+    """The user opened the app: stamp the row's ``openedAt`` with `at` (epoch,
+    the server's clock) and clear its ``unread`` — the one gesture that clears
+    the dot (see the unread section above). The next `observe` pass recomputes
+    the flag against the new stamp, so only a task that finishes AFTER this
+    lights it again. True when the row exists; False for a path not on the
+    desk (nothing to clear on)."""
     folder = canonical_fs_path(os.path.abspath(path)).rstrip("/")
     state = read_state()
     for a in state["apps"]:
         if a["path"] == folder:
             a["openedAt"] = float(at)
+            a["unread"] = False
             write_state(state)
             return True
     return False
@@ -252,10 +319,11 @@ def list_apps() -> list[dict]:
     (folder name), ``kind`` (``linked`` for a registry folder, ``workspace``
     otherwise), ``entry`` (the page to run, or None), ``exists``, ``icon`` /
     ``icon_mtime`` (the optional ``icon.svg``, see `app_icon`), ``added_at``
-    (epoch), ``opened_at`` (epoch of the last `mark_opened`, or None for a row
-    never opened since the stamp shipped). A folder that is gone or unreadable
-    still lists — the row is the user's to remove — with ``exists`` false and
-    no entry."""
+    (epoch), ``opened_at`` (epoch of the last `mark_opened`; 0 for a row a task
+    put here that has never been opened), ``unread`` (a task finished under it
+    since that open — the sidebar's green dot, see the unread section). A
+    folder that is gone or unreadable still lists — the row is the user's to
+    remove — with ``exists`` false and no entry."""
     linked = {
         canonical_fs_path(os.path.abspath(e["path"])).rstrip("/")
         for e in registered_apps.read_entries()
@@ -286,5 +354,6 @@ def list_apps() -> list[dict]:
             "added_at": _added_epoch(a.get("addedAt")),
             "opened_at": (a["openedAt"] if isinstance(a.get("openedAt"), (int, float))
                           else None),
+            "unread": bool(a.get("unread")),
         })
     return out

--- a/fused_render/server/routers/current_apps.py
+++ b/fused_render/server/routers/current_apps.py
@@ -18,6 +18,8 @@ The row's right-click menu adds three more verbs, all folder-scoped:
   folder read, in one pass.
 * ``POST /api/current-apps/archive`` — the DELETE's task half without its desk
   half: archive every task under the folder, keep the row.
+* ``POST /api/current-apps/open`` — stamp the row opened (its ``openedAt``):
+  the sidebar's green dot clears on this, not on reading the tasks.
 
 Two ways onto the desk: the tasks listing (`current_apps.observe`, run inside
 `tasks._task_rows`) adds the app of every new task, and
@@ -107,6 +109,19 @@ def api_current_apps_add(patch: FolderPatch):
     if not os.path.isdir(folder):
         raise HTTPException(status_code=404, detail="no such folder")
     return {"ok": True, "added": current_apps.add(folder), "path": folder}
+
+
+@router.post("/api/current-apps/open")
+def api_current_apps_open(patch: FolderPatch):
+    """The user opened the app: stamp the row's ``openedAt`` with the server
+    clock (`current_apps.mark_opened`). This is what clears the sidebar's green
+    dot — the app's own unread state, judged against its tasks' `last_active`
+    on the same clock — and it touches no task: reading is the tasks' verb
+    (``/read`` above), opening is the desk's. A path not on the desk answers
+    ``opened: false`` rather than an error; there is no dot to clear."""
+    folder = _require_folder(patch.path)
+    at = time.time()
+    return {"ok": True, "opened": current_apps.mark_opened(folder, at), "opened_at": at}
 
 
 @router.post("/api/current-apps/archive")

--- a/fused_render/server/routers/current_apps.py
+++ b/fused_render/server/routers/current_apps.py
@@ -128,7 +128,11 @@ def api_current_apps_open(patch: FolderPatch):
     reads it."""
     folder = _require_folder(patch.path)
     at = time.time()
-    return {"ok": True, "opened": current_apps.mark_opened(folder, at), "opened_at": at}
+    opened = current_apps.mark_opened(folder, at)
+    # The table as it stands after the stamp rides along, so the client can
+    # adopt it in the same tick it lifts its optimistic cover — no second read
+    # that a fetch already in flight could overtake (Bugbot, 2026-09-07).
+    return {"ok": True, "opened": opened, "opened_at": at, "apps": current_apps.list_apps()}
 
 
 @router.post("/api/current-apps/archive")

--- a/fused_render/server/routers/current_apps.py
+++ b/fused_render/server/routers/current_apps.py
@@ -118,10 +118,31 @@ def api_current_apps_open(patch: FolderPatch):
     dot — the app's own unread state, judged against its tasks' `last_active`
     on the same clock — and it touches no task: reading is the tasks' verb
     (``/read`` above), opening is the desk's. A path not on the desk answers
-    ``opened: false`` rather than an error; there is no dot to clear."""
+    ``opened: false`` rather than an error; there is no dot to clear.
+
+    The stamp is the LATER of now and the newest `last_active` among the Done
+    rows under the folder, not the wall clock alone. `last_active` keeps a
+    scheduled message's DUE time even after the message was run early (see
+    `tasks._row`: the listing sorts a message due tomorrow near the top), so a
+    finished run can carry a `last_active` in the future — against a wall-clock
+    stamp its dot would survive every open until the due time passed (Bugbot,
+    2026-09-07). Taking the max clears what is done right now and still lights
+    on the next completion, whose `last_active` climbs past this one."""
     folder = _require_folder(patch.path)
     at = time.time()
+    for row in tasks_router._task_rows():
+        if row.get("status") in _NOT_DONE:
+            continue
+        project = canonical_fs_path(str(row.get("project") or ""))
+        if project and current_apps.is_under(project, folder):
+            at = max(at, float(row.get("last_active") or 0.0))
     return {"ok": True, "opened": current_apps.mark_opened(folder, at), "opened_at": at}
+
+
+# The lanes that are NOT Done — the client's `statusColumn` reads every status
+# it does not know as Done, so the complement is the list to keep, not a list
+# of Done words that a new status would silently fall out of.
+_NOT_DONE = frozenset({"upcoming", "in_progress", "needs_attention", "blocked", "archived"})
 
 
 @router.post("/api/current-apps/archive")

--- a/fused_render/server/routers/current_apps.py
+++ b/fused_render/server/routers/current_apps.py
@@ -120,29 +120,15 @@ def api_current_apps_open(patch: FolderPatch):
     (``/read`` above), opening is the desk's. A path not on the desk answers
     ``opened: false`` rather than an error; there is no dot to clear.
 
-    The stamp is the LATER of now and the newest `last_active` among the Done
-    rows under the folder, not the wall clock alone. `last_active` keeps a
-    scheduled message's DUE time even after the message was run early (see
-    `tasks._row`: the listing sorts a message due tomorrow near the top), so a
-    finished run can carry a `last_active` in the future — against a wall-clock
-    stamp its dot would survive every open until the due time passed (Bugbot,
-    2026-09-07). Taking the max clears what is done right now and still lights
-    on the next completion, whose `last_active` climbs past this one."""
+    Plain wall clock, and nothing read off the tasks: the flag is recomputed
+    by `current_apps.observe` on the next listing against each task's
+    ``happened_at`` (tasks._row), which is when something actually ran — the
+    one clock that is comparable with an open. The listing's `last_active` is
+    NOT that clock (it keeps a due time for sorting), which is why nothing here
+    reads it."""
     folder = _require_folder(patch.path)
     at = time.time()
-    for row in tasks_router._task_rows():
-        if row.get("status") in _NOT_DONE:
-            continue
-        project = canonical_fs_path(str(row.get("project") or ""))
-        if project and current_apps.is_under(project, folder):
-            at = max(at, float(row.get("last_active") or 0.0))
     return {"ok": True, "opened": current_apps.mark_opened(folder, at), "opened_at": at}
-
-
-# The lanes that are NOT Done — the client's `statusColumn` reads every status
-# it does not know as Done, so the complement is the list to keep, not a list
-# of Done words that a new status would silently fall out of.
-_NOT_DONE = frozenset({"upcoming", "in_progress", "needs_attention", "blocked", "archived"})
 
 
 @router.post("/api/current-apps/archive")

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -1678,6 +1678,17 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     # (see `_entry_at`).
     if newest is not None:
         active = max(active, newest["ran_at"] or 0.0)
+    # The row's `happened_at`: `active` as it stands HERE — the newest thing
+    # that actually ran or was written, 0.0 when nothing has — before the two
+    # fallbacks below let a due time or a creation stamp stand in for it. The
+    # desk (current_apps.observe) reads this and only this to decide whether a
+    # task finished under an app since the app was last opened: a message due
+    # tomorrow has not happened, and a task merely asked for has not either.
+    # `last_active` cannot serve — it keeps the due time so the List sorts a
+    # future message near the top — and two attempts to lean on it anyway (a
+    # wall-clock stamp, then a max over it) each broke on exactly that (Bugbot
+    # ×2, 2026-09-07).
+    happened = active
     if not active and task["entries"]:
         # Nothing has run and there is no transcript to date: what happened is
         # that the message was ASKED for, and `created` is when. Deliberately
@@ -1750,6 +1761,7 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # way every other absent time on this row reads.
         "started": task.get("started") or 0.0,
         "last_active": surfaced,
+        "happened_at": happened,
         "message_count": total,
         # The next run, and the entry it belongs to — `min(at)` over every
         # pending entry, not over the window below. 0.0 / "" when the task has

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -1992,6 +1992,12 @@ def api_tasks_changes(since: int = Query(-1), wait: float = Query(tasks_watch.MA
 _PULSE_FIELDS = (
     "key", "status", "unread", "last_active", "project",
     "task_id", "title", "target", "session_id",
+    # The desk's change detector (shell/CurrentAppsSection `pulseSignal`): the
+    # sidebar refetches the projects table when a task's `happened_at` moves,
+    # since that is exactly when `current_apps.observe` can have flipped a
+    # row's unread. `last_active` cannot stand in — a recurring task whose run
+    # finished early keeps its due time there and the digest would not move.
+    "happened_at",
 )
 
 

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -355,9 +355,12 @@ def test_sidebar_pulse_is_the_compact_projection_of_the_task_rows(
     # needs-attention rows (2026-09-03), which have to NAME the waiting task and
     # then open its conversation. Four short strings on a row that is being built
     # anyway; the alternative was a second /api/tasks poll from the status bar.
+    # `happened_at` (2026-09-07) is the Projects section's change detector: the
+    # desk refetches when a task actually ran, which `last_active` cannot say
+    # (it keeps a scheduled due time for sorting).
     pulse_fields = (
         "key", "status", "unread", "last_active", "project",
-        "task_id", "title", "target", "session_id",
+        "task_id", "title", "target", "session_id", "happened_at",
     )
     assert pulse == [
         {field: row[field] for field in pulse_fields}


### PR DESCRIPTION
## What

The sidebar's per-project green dot is the project's own unread state. A task finishing under the project lights it. Opening the project clears it. Nothing done to the tasks (reading them in Tasks, in the chat, anywhere) touches it, and opening the project leaves the tasks' own unread state alone.

## Design

The **server owns the flag**. Each desk row in `current_apps.json` carries two fields:

- `openedAt` — epoch of the last open, written by `POST /api/current-apps/open` (wall clock).
- `unread` — recomputed by `current_apps.observe` on every tasks listing: any task under the folder, not running or archived, whose `happened_at` is later than `openedAt`.

`happened_at` is a new field on the task row (`tasks._row`): the newest thing that actually ran or was written, 0 when nothing has. It is `active` before the two fallbacks that let a scheduled due time or a creation stamp stand in — which is why `last_active` could never serve here (it keeps the due time for sorting; both earlier cuts broke on that).

Recomputation rather than transition detection, on purpose: `observe` sees snapshots per poll. A rerun that starts and ends between two polls shows no transition, and a recurring task goes in_progress → upcoming without ever touching Done. Comparing clocks catches both and is idempotent.

Running rows are excluded so the flag means "finished": the row wears the running dot meanwhile (yellow outranks green), and the pass after the run ends lights the green. `blocked` (a failed run has happened) and `upcoming` (a recurring task whose last run finished) both count.

## Seeds (owner's to flip)

- A row a **task** puts on the desk gets `openedAt = 0`: never opened, so the completion that put it there lights it.
- Rows from **before this shipped** are stamped `now` once on the first listing: quiet upgrade, nothing lights until a task finishes from here on.
- The explorer's **"Open in project"** stamps `now`: it navigates there at once, so it is an open.
- The **active row** also clears: a completion landing while the user is on that project's page is stamped without a click. The ask was "when user clicks"; this reads the open page as the same gesture. Consequence to weigh: a chat session on the project's page is itself a task under the project, so every chat turn that finishes there sets the flag. With this on, that is one `POST /open` per turn and the active row never lights. With it vetoed, the project you are working in lights after every turn.

## Client

Draws the flag, computes nothing. Kept: a per-window cover over rows opened ahead of the refetch so the dot dies on the click (lifted once the read after the POST lands, whatever it says), a desk refetch keyed on a digest of the pulse (key, lane, `happened_at` — the same clock the server compares, now on the pulse projection), and a `storage` nudge so other windows refetch after an open.

## Notes for review

- **Rename** (`app_state_move._rewrite_current_apps`) mutates the row's `path` in place, so `openedAt` and `unread` ride along. The earlier "rename drops the stamp" finding was about the deleted localStorage store.
- **Concurrent writes.** `observe` and `mark_opened` are read-modify-write on the same JSON with no lock. Pre-existing shape (`add` vs `observe` always was), and `observe` writes only when something changed, so the window is one changed poll coinciding with a click. Worst case a click's clear is overwritten and the next click clears it.
- `happened_at` is on the full task row and on the pulse projection (`_PULSE_FIELDS`): one extra float per compact row.

No DECISIONS row: D487 does not state the clearing clause, and the owner's rule is no row for ordinary features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desk persistence, tasks row shaping, and multi-window sidebar sync; wrong clocks or RMW races on `current_apps.json` could mis-set dots, though behavior is mostly recomputed on poll.
> 
> **Overview**
> **Per-project green dots** are now **app-level unread state**, not a rollup of task message unread. A completion under the project lights the dot; **opening the project** (click, or the already-active row) clears it via **`POST /api/current-apps/open`**, which stamps `openedAt` and returns the full desk table for the client to adopt. Reading tasks elsewhere does not affect the dot.
> 
> On the server, **`current_apps.json`** rows gain **`openedAt`** and **`unread`**. **`observe`** recomputes `unread` on each tasks listing by comparing each non-running task’s new **`happened_at`** (actual work time, before `last_active`’s due-time fallbacks) to `openedAt`. Manual “Open in project” counts as an open; task-added rows start at `openedAt = 0`; legacy rows get a one-time `now` stamp so nothing lights until new finishes.
> 
> The sidebar **draws the server flag** (with optimistic hide + sequenced refetch so stale GETs cannot restore the dot), refetches the desk when the pulse digest includes **`happened_at`**, and **nudges other windows** through **`localStorage`** after a successful open. Types/API surface **`openCurrentApp`**, **`CurrentAppEntry.opened_at` / `.unread`**, and pulse **`happened_at`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8afcc1a0092f73212730c2465483fb9678cfd2f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


