### PR TITLE
Projects menu: "Mark all tasks as read" gets the unread ring icon

### DIFF
--- a/frontend/src/platform/ui/MenuIcons.tsx
+++ b/frontend/src/platform/ui/MenuIcons.tsx
@@ -77,6 +77,17 @@ export const MenuIcons: Record<string, ReactNode> = {
       <path d="M10 11v6M14 11v6" />
     </svg>
   ),
+  // Unread — the task views' status ring with its centre filled
+  // (`.schedule-ring--unread`, schedule.css: a 16px ring with an 8px disc in
+  // it), redrawn on this table's 24-grid so "Mark all tasks as read" carries
+  // the very mark it clears. The disc is filled with currentColor, as the
+  // ring's `::after` is, so it tints with the row like every other glyph here.
+  unread: (
+    <svg {...svgProps}>
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="12" cy="12" r="3.5" fill="currentColor" stroke="none" />
+    </svg>
+  ),
   // Rename — pencil.
   rename: (
     <svg {...svgProps}>

--- a/frontend/src/platform/ui/MenuIcons.tsx
+++ b/frontend/src/platform/ui/MenuIcons.tsx
@@ -84,8 +84,8 @@ export const MenuIcons: Record<string, ReactNode> = {
   // ring's `::after` is, so it tints with the row like every other glyph here.
   unread: (
     <svg {...svgProps}>
-      <circle cx="12" cy="12" r="9" />
-      <circle cx="12" cy="12" r="3.5" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="8.5" strokeWidth="2.25" />
+      <circle cx="12" cy="12" r="4.5" fill="currentColor" stroke="none" />
     </svg>
   ),
   // Rename — pencil.

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -692,6 +692,7 @@ export default function CurrentAppsSection() {
     "separator",
     {
       label: "Mark all tasks as read",
+      icon: MenuIcons.unread,
       onClick: () => {
         readCurrentAppTasks(app.path)
           .catch(() => {})


### PR DESCRIPTION
The right-click menu on a Projects row had one icon-less entry. It now carries the task views' unread status ring (outline ring, filled centre) as a new `MenuIcons.unread` glyph, drawn in currentColor like the rest of the menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI: a new menu icon and one `icon` prop; no changes to read/archive logic or APIs.
> 
> **Overview**
> Adds **`MenuIcons.unread`**, a ring-with-filled-center glyph aligned with the task views’ unread status mark, and assigns it to **Mark all tasks as read** on the Projects row context menu so that action matches the other icon-backed entries.
> 
> Behavior is unchanged: the item still calls `readCurrentAppTasks` and refreshes tasks via `pokeTasks()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 027b1c87f9e229544ee0c8dd91ad4c6a2811f118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->