### PR TITLE
Onboarding: Back/Next on the step-counter row, one yellow button per step

### DIFF
--- a/frontend/src/apps/builder/HomeHero.tsx
+++ b/frontend/src/apps/builder/HomeHero.tsx
@@ -247,7 +247,14 @@ function ComposerPick<T extends string>({
 // + button (shell/CurrentAppsSection.tsx, D489), which opens THIS composer in a
 // modal: same naming, same scaffold, same landing in the new app's chat. One
 // create path, three doors.
-export function HeroComposer({ onCreated }: { onCreated: () => void }) {
+export function HeroComposer({
+  onCreated,
+  autoFocus = false,
+}: {
+  onCreated: () => void;
+  /** Focus the prompt on mount (onboarding: the focus ring IS the step's cue). */
+  autoFocus?: boolean;
+}) {
   const [prompt, setPrompt] = useState("");
   // The chip above the box — set by the Playground's "Build an app with this
   // AI" button (?annot=). null means no model is annotated; the composer
@@ -304,6 +311,10 @@ export function HeroComposer({ onCreated }: { onCreated: () => void }) {
     replaceSearch(location.pathname + (search ? "?" + search : ""));
     requestAnimationFrame(() => inputRef.current?.focus());
   }, []);
+
+  useEffect(() => {
+    if (autoFocus) requestAnimationFrame(() => inputRef.current?.focus());
+  }, [autoFocus]);
 
   const busy = phase !== "idle";
   const canSubmit = prompt.trim().length > 0 && !busy;

--- a/frontend/src/platform/shadcn/ui/button.tsx
+++ b/frontend/src/platform/shadcn/ui/button.tsx
@@ -9,6 +9,10 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/80",
+        // The fused yellow: the ONE next action on a screen (onboarding's
+        // forward step). Same fill as .claude-health-action, so a screen never
+        // shows two shades of "do this".
+        accent: "bg-[var(--accent)] text-[var(--on-accent)] hover:brightness-[1.06]",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/frontend/src/shell/onboarding/AboutStep.tsx
+++ b/frontend/src/shell/onboarding/AboutStep.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 // Step 1 — what this is. Copy and video come from the download page
 // (scripts/download_page/index.html), which is what the user just came from;
 // the video streams from the same origin that page ships from rather than
@@ -29,7 +30,7 @@ const FEATURES = [
   },
 ];
 
-export function AboutStep({ eyebrow }: { eyebrow: string }) {
+export function AboutStep({ eyebrow }: { eyebrow: ReactNode }) {
   const [videoOk, setVideoOk] = useState(true);
   return (
     <div className="flex flex-col gap-6">

--- a/frontend/src/shell/onboarding/ClaudeStep.tsx
+++ b/frontend/src/shell/onboarding/ClaudeStep.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 // Step 2 — Claude Code. A CHECKLIST, not the strip: the strip renders only
 // what is wrong and nothing when all is well, which is right for a page
 // header and wrong for a setup step, where "installed ✓, signed in ✓" is the
@@ -104,7 +105,7 @@ function StateIcon({ state, optional }: { state: RowState; optional?: boolean })
 
 // `setup` is the wizard's single machine (OnboardingWizard owns it, so what
 // gets fixed here is what step 4 reads).
-export function ClaudeStep({ setup, eyebrow }: { setup: ClaudeSetup; eyebrow: string }) {
+export function ClaudeStep({ setup, eyebrow }: { setup: ClaudeSetup; eyebrow: ReactNode }) {
   const { health, loaded, busy, load } = setup;
   const issues = claudeIssues(health);
   const rows = health ? rowsFor(health) : null;

--- a/frontend/src/shell/onboarding/ClaudeStep.tsx
+++ b/frontend/src/shell/onboarding/ClaudeStep.tsx
@@ -138,7 +138,7 @@ export function ClaudeStep({ setup, eyebrow }: { setup: ClaudeSetup; eyebrow: Re
                 ? "A few things still need doing — the open rows have buttons."
                 : "Nothing here will block you — carry on."}
         </p>
-        <Button variant="ghost" size="sm" onClick={() => load(true)} disabled={busy}>
+        <Button variant="outline" size="sm" onClick={() => load(true)} disabled={busy}>
           <RefreshCw data-icon="inline-start" className={busy ? "animate-spin" : undefined} />
           {busy ? "Checking…" : "Check again"}
         </Button>

--- a/frontend/src/shell/onboarding/ClaudeStep.tsx
+++ b/frontend/src/shell/onboarding/ClaudeStep.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 // Step 2 — Claude Code. A CHECKLIST, not the strip: the strip renders only
 // what is wrong and nothing when all is well, which is right for a page
 // header and wrong for a setup step, where "installed ✓, signed in ✓" is the
@@ -105,12 +105,23 @@ function StateIcon({ state, optional }: { state: RowState; optional?: boolean })
 
 // `setup` is the wizard's single machine (OnboardingWizard owns it, so what
 // gets fixed here is what step 4 reads).
-export function ClaudeStep({ setup, eyebrow }: { setup: ClaudeSetup; eyebrow: ReactNode }) {
+export function ClaudeStep({
+  setup,
+  eyebrow,
+  onWork,
+}: {
+  setup: ClaudeSetup;
+  eyebrow: ReactNode;
+  onWork: (busy: boolean) => void;
+}) {
   const { health, loaded, busy, load } = setup;
   const issues = claudeIssues(health);
   const rows = health ? rowsFor(health) : null;
   const allDone = rows?.every((r) => r.state === "done" || (r.optional && r.state !== "open"));
   const anyActionable = rows?.some((r) => r.state === "open" && issues.some((i) => r.issueIds.includes(i.id)));
+  // Tell the wizard whether this step still has a button of its own to press:
+  // while it does (the strip's yellow actions), Next is not the yellow one.
+  useEffect(() => onWork(anyActionable === true), [onWork, anyActionable]);
 
   return (
     <div className="flex flex-col gap-6">

--- a/frontend/src/shell/onboarding/FdaStep.tsx
+++ b/frontend/src/shell/onboarding/FdaStep.tsx
@@ -30,7 +30,15 @@ import { Button } from "@platform/shadcn/ui/button";
 
 import { StepHeader } from "./StepHeader";
 
-export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: ReactNode }) {
+export function FdaStep({
+  config,
+  eyebrow,
+  onWork,
+}: {
+  config: Config;
+  eyebrow: ReactNode;
+  onWork: (busy: boolean) => void;
+}) {
   // The wizard already holds a config: seed so the first paint is right,
   // then the shared store takes over.
   useEffect(() => seedFda(config.fda), [config.fda]);
@@ -44,6 +52,9 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: ReactNod
   const offered = fda != null;
   const granted = fda?.granted === true;
   const pending = fda?.pending_relaunch === true;
+  // Open Settings / Relaunch is the yellow button until the grant is in;
+  // then Next takes the colour. A dev server (nothing offered) has no button.
+  useEffect(() => onWork(offered && !granted), [onWork, offered, granted]);
 
   const open = () => {
     setError(null);
@@ -124,7 +135,7 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: ReactNod
             {/* A plain link, like the update-restart banner: the OS hands the
                 deep link to the running app, which quits and respawns. This
                 tab keeps polling and flips to "Already granted" on its own. */}
-            <Button render={<a href={RELAUNCH_HREF} />}>
+            <Button variant="accent" render={<a href={RELAUNCH_HREF} />}>
               <RotateCw data-icon="inline-start" />
               {FDA_COPY.relaunch}
             </Button>
@@ -140,7 +151,7 @@ export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: ReactNod
               ))}
             </ol>
             <div className="flex flex-wrap items-center gap-3">
-              <Button onClick={open} disabled={!offered} title={offered ? undefined : "Available in the installed FusedRender app"}>
+              <Button variant="accent" onClick={open} disabled={!offered} title={offered ? undefined : "Available in the installed FusedRender app"}>
                 <ExternalLink data-icon="inline-start" />
                 {opened ? FDA_COPY.reopen : FDA_COPY.open}
               </Button>

--- a/frontend/src/shell/onboarding/FdaStep.tsx
+++ b/frontend/src/shell/onboarding/FdaStep.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 // Step 3 — Full Disk Access (macOS).
 //
 // This deliberately REVERSES FdaStrip's "not at launch" rule (FdaStrip.tsx):
@@ -29,7 +30,7 @@ import { Button } from "@platform/shadcn/ui/button";
 
 import { StepHeader } from "./StepHeader";
 
-export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: string }) {
+export function FdaStep({ config, eyebrow }: { config: Config; eyebrow: ReactNode }) {
   // The wizard already holds a config: seed so the first paint is right,
   // then the shared store takes over.
   useEffect(() => seedFda(config.fda), [config.fda]);

--- a/frontend/src/shell/onboarding/FirstAppStep.tsx
+++ b/frontend/src/shell/onboarding/FirstAppStep.tsx
@@ -97,7 +97,7 @@ export function FirstAppStep({
       )}
 
       <div className="onboarding-composer">
-        <HeroComposer onCreated={onComplete} />
+        <HeroComposer onCreated={onComplete} autoFocus />
       </div>
 
       <section className="flex flex-col gap-3">

--- a/frontend/src/shell/onboarding/FirstAppStep.tsx
+++ b/frontend/src/shell/onboarding/FirstAppStep.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 // Step 4 — the first app. The Home composer as-is (it names, scaffolds, starts
 // the Claude run and navigates), or one of the showcase's local-AI apps.
 // Either path is the wizard's "complete": this is the only step whose action
@@ -69,7 +70,7 @@ export function FirstAppStep({
   onComplete,
 }: {
   health: ClaudeHealth | null;
-  eyebrow: string;
+  eyebrow: ReactNode;
   /** The composer created a folder — real progress, flag it. Showcase cards
       need no hook: the navigation they perform is what the wizard reads. */
   onComplete: () => void;

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -204,7 +204,15 @@ function useJobs(): { jobs: Job[]; refresh: () => void } {
   return { jobs, refresh: () => refresh.current() };
 }
 
-export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: ReactNode }) {
+export function ModelsStep({
+  picks,
+  eyebrow,
+  onWork,
+}: {
+  picks: ModelPicks;
+  eyebrow: ReactNode;
+  onWork: (busy: boolean) => void;
+}) {
   // Each of the three is React state for THIS mount and module memory across
   // mounts — the setters below write both, so a remount seeds from what the
   // last one left rather than from scratch.
@@ -278,6 +286,9 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: Rea
   });
   const pending = rows.filter((r) => r.pending);
   const busyCount = rows.filter((r) => r.busy).length;
+  // Download is the yellow button while something is selected and not yet
+  // fetched; once started (or nothing to do) Next takes the colour.
+  useEffect(() => onWork(pending.length > 0), [onWork, pending.length]);
 
   // Driven by the checkbox's own reported value, not by flipping what this
   // render happened to see: the primitive owns the state transition.
@@ -373,7 +384,7 @@ export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: Rea
       )}
 
       <div className="flex flex-wrap items-center gap-3">
-        <Button onClick={start} disabled={pending.length === 0}>
+        <Button variant={pending.length > 0 ? "accent" : "outline"} onClick={start} disabled={pending.length === 0}>
           {pending.length > 0
             ? startLabel
             : busyCount > 0

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 // Step 4 — local models, and a head start on downloading them.
 //
 // The step exists because of a timing problem, not a capability one: a model
@@ -203,7 +204,7 @@ function useJobs(): { jobs: Job[]; refresh: () => void } {
   return { jobs, refresh: () => refresh.current() };
 }
 
-export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: string }) {
+export function ModelsStep({ picks, eyebrow }: { picks: ModelPicks; eyebrow: ReactNode }) {
   // Each of the three is React state for THIS mount and module memory across
   // mounts — the setters below write both, so a remount seeds from what the
   // last one left rather than from scratch.

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -127,7 +127,7 @@ export function OnboardingWizard({ config }: { config: Config }) {
   const last = index >= steps.length - 1;
   const setIndex = (i: number) => setStepId(steps[Math.max(0, Math.min(i, steps.length - 1))].id);
   // Counted over the steps this machine actually has (no FDA off macOS).
-  const eyebrow = `Step ${index + 1} of ${steps.length}`;
+  const eyebrowText = `Step ${index + 1} of ${steps.length}`;
 
   // Fire-and-forget, and at most one flag per visit: the flag is a courtesy
   // to the NEXT launch, and a failed write must not hold the page over the
@@ -198,6 +198,30 @@ export function OnboardingWizard({ config }: { config: Config }) {
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `next` is a per-render closure over index
   }, [finish, last, index, steps.length]);
+
+  // Step counter on the left, Back/Next hugging the right edge of the content
+  // column: the pair reads as one control, so they sit together.
+  const eyebrow = (
+    <>
+      <span>{eyebrowText}</span>
+      <div className="flex items-center gap-2 normal-case tracking-normal">
+        <Button variant="ghost" size="sm" onClick={back} disabled={index === 0}>
+          <ArrowLeft data-icon="inline-start" />
+          Back
+        </Button>
+        {last ? (
+          <Button key="explore" variant="outline" size="sm" onClick={() => finish("complete")}>
+            I'll explore on my own
+          </Button>
+        ) : (
+          <Button key="next" size="sm" onClick={next} title="⌘/Ctrl + Enter">
+            Next
+            <ArrowRight data-icon="inline-end" />
+          </Button>
+        )}
+      </div>
+    </>
+  );
 
   return (
     <div
@@ -287,26 +311,6 @@ export function OnboardingWizard({ config }: { config: Config }) {
         </div>
       </div>
 
-      {/* Footer */}
-      <div className="flex items-center justify-between border-t border-border px-5 py-3">
-        <Button variant="ghost" size="sm" onClick={back} disabled={index === 0}>
-          <ArrowLeft data-icon="inline-start" />
-          Back
-        </Button>
-        <div className="text-xs text-muted-foreground sm:hidden">
-          {index + 1} / {steps.length}
-        </div>
-        {last ? (
-          <Button key="explore" variant="outline" size="sm" onClick={() => finish("complete")}>
-            I'll explore on my own
-          </Button>
-        ) : (
-          <Button key="next" size="sm" onClick={next} title="⌘/Ctrl + Enter">
-            Next
-            <ArrowRight data-icon="inline-end" />
-          </Button>
-        )}
-      </div>
     </div>
   );
 }

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -128,6 +128,14 @@ export function OnboardingWizard({ config }: { config: Config }) {
   const setIndex = (i: number) => setStepId(steps[Math.max(0, Math.min(i, steps.length - 1))].id);
   // Counted over the steps this machine actually has (no FDA off macOS).
   const eyebrowText = `Step ${index + 1} of ${steps.length}`;
+  // One yellow button per screen. A step with its own work to do (install,
+  // grant, download) owns the colour while that work is open and Next goes
+  // quiet; the moment it is done — or on a step with nothing to do — Next
+  // is the yellow one. Steps report through `onWork`; a step change resets
+  // to "nothing open" so a fresh step never inherits the last one's verdict.
+  const [stepHasWork, setStepHasWork] = useState(false);
+  useEffect(() => setStepHasWork(false), [step.id]);
+  const onWork = useCallback((busy: boolean) => setStepHasWork(busy), []);
 
   // Fire-and-forget, and at most one flag per visit: the flag is a courtesy
   // to the NEXT launch, and a failed write must not hold the page over the
@@ -214,7 +222,13 @@ export function OnboardingWizard({ config }: { config: Config }) {
             I'll explore on my own
           </Button>
         ) : (
-          <Button key="next" size="sm" onClick={next} title="⌘/Ctrl + Enter">
+          <Button
+            key="next"
+            variant={stepHasWork ? "outline" : "accent"}
+            size="sm"
+            onClick={next}
+            title="⌘/Ctrl + Enter"
+          >
             Next
             <ArrowRight data-icon="inline-end" />
           </Button>
@@ -304,9 +318,9 @@ export function OnboardingWizard({ config }: { config: Config }) {
       <div className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-4xl px-6 py-10">
           {step.id === "about" && <AboutStep eyebrow={eyebrow} />}
-          {step.id === "claude" && <ClaudeStep setup={setup} eyebrow={eyebrow} />}
-          {step.id === "fda" && <FdaStep config={config} eyebrow={eyebrow} />}
-          {step.id === "models" && <ModelsStep picks={picks} eyebrow={eyebrow} />}
+          {step.id === "claude" && <ClaudeStep setup={setup} eyebrow={eyebrow} onWork={onWork} />}
+          {step.id === "fda" && <FdaStep config={config} eyebrow={eyebrow} onWork={onWork} />}
+          {step.id === "models" && <ModelsStep picks={picks} eyebrow={eyebrow} onWork={onWork} />}
           {step.id === "app" && <FirstAppStep health={health} eyebrow={eyebrow} onComplete={markComplete} />}
         </div>
       </div>

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -205,7 +205,7 @@ export function OnboardingWizard({ config }: { config: Config }) {
     <>
       <span>{eyebrowText}</span>
       <div className="flex items-center gap-2 normal-case tracking-normal">
-        <Button variant="ghost" size="sm" onClick={back} disabled={index === 0}>
+        <Button variant="outline" size="sm" onClick={back} disabled={index === 0}>
           <ArrowLeft data-icon="inline-start" />
           Back
         </Button>

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -131,11 +131,15 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // One yellow button per screen. A step with its own work to do (install,
   // grant, download) owns the colour while that work is open and Next goes
   // quiet; the moment it is done — or on a step with nothing to do — Next
-  // is the yellow one. Steps report through `onWork`; a step change resets
-  // to "nothing open" so a fresh step never inherits the last one's verdict.
-  const [stepHasWork, setStepHasWork] = useState(false);
-  useEffect(() => setStepHasWork(false), [step.id]);
-  const onWork = useCallback((busy: boolean) => setStepHasWork(busy), []);
+  // is the yellow one. Steps report through `onWork`, and the report is
+  // TAGGED with the step it came from: a fresh step never inherits the last
+  // one's verdict, and no reset effect is needed. (A reset effect was tried
+  // and lost the race — a child's effect runs before its parent's, so the new
+  // step's `onWork(true)` landed first and the reset then wiped it, leaving
+  // Download AND Next both yellow.)
+  const [work, setWork] = useState<{ id: string; busy: boolean } | null>(null);
+  const stepHasWork = work?.id === step.id && work.busy;
+  const onWork = useCallback((busy: boolean) => setWork({ id: step.id, busy }), [step.id]);
 
   // Fire-and-forget, and at most one flag per visit: the flag is a courtesy
   // to the NEXT launch, and a failed write must not hold the page over the

--- a/frontend/src/shell/onboarding/StepHeader.tsx
+++ b/frontend/src/shell/onboarding/StepHeader.tsx
@@ -5,13 +5,15 @@ export function StepHeader({
   title,
   lead,
 }: {
-  eyebrow: string;
+  eyebrow: ReactNode;
   title: string;
   lead?: ReactNode;
 }) {
   return (
     <header className="flex flex-col gap-2">
-      <div className="text-xs font-medium tracking-wide text-muted-foreground uppercase">{eyebrow}</div>
+      <div className="flex min-h-8 items-center justify-between gap-4 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        {eyebrow}
+      </div>
       <h2 className="text-2xl font-semibold tracking-tight">{title}</h2>
       {lead && <p className="max-w-prose text-sm leading-relaxed text-muted-foreground">{lead}</p>}
     </header>


### PR DESCRIPTION
## Nav moves up
The wizard footer is gone. Back and Next (or "I'll explore on my own" on the last step) sit side by side at the right edge of the content column, on the "Step N of M" line. `StepHeader`'s `eyebrow` prop is now a `ReactNode` so the wizard hands it counter + buttons together. Back and the Claude step's "Check again" are `outline`, matching their neighbours.

## One yellow button per step
New `accent` Button variant (fused `--accent` / `--on-accent`, same fill as the Claude health strip's actions). Rule: a step with its own work to do owns the colour while that work is open and Next is outline; once the work is done, or on a step with nothing to do, Next is yellow. Never two yellows on one screen.

| Step | Yellow while… | then |
|---|---|---|
| About | — | Next |
| Claude | strip actions (install / sign in / PATH) while any issue is actionable | Next |
| FDA (mac) | Open System Settings / Relaunch until granted | Next |
| Models | Download while picks are pending | Next |
| First app | nothing — composer prompt is auto-focused, its focus ring is the cue | — |

Steps report through an `onWork(busy)` prop. The report is tagged with the step id and read only for the current step: a reset-on-step-change effect was tried and lost the race (child effects run before the parent's), which left Download and Next both yellow.

## Smoke
`FUSED_RENDER_ONBOARDING=1`, walk all five steps back and forth; Next should flip yellow when FDA grants or Download starts, never alongside another yellow.

CI: the `fused-engine` failure is `tests/test_env_install.py::test_a_retry_inside_the_poll_window_leaves_one_live_mirror_thread`, a Python thread-timing test unrelated to this frontend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)