### PR TITLE
Preferences > Indexing: Full Disk Access card instead of the bare 409 error

### DIFF
--- a/frontend/src/apps/explorer/IndexFdaCta.tsx
+++ b/frontend/src/apps/explorer/IndexFdaCta.tsx
@@ -12,12 +12,33 @@
 // (`pending_relaunch`); granted (which this process can only see after that
 // relaunch, so in practice the callout is gone by then — the startup scan has
 // begun and the gap reads `scanning`).
+//
+// Also the card Preferences > Indexing shows for the same gate: there the
+// server answers a Re-index with 409 "indexing needs Full Disk Access on
+// macOS", which named the wall and offered no door. Same callout, indexing
+// wording (`copy`), same one action.
 import { useState } from "react";
 
 import { openFdaSettings } from "@platform/lib/api";
 import { FDA_COPY, RELAUNCH_HREF, pokeFda, useFda } from "@platform/lib/fda";
 
-export function IndexFdaCta() {
+export const SEARCH_FDA_COPY = {
+  blocked:
+    "Search needs Full Disk Access to index your files — nothing is scanned until you grant it.",
+  pending: "Full Disk Access is granted — relaunch FusedRender to start indexing your files.",
+} as const;
+
+export const INDEXING_FDA_COPY = {
+  blocked:
+    "Indexing needs Full Disk Access on macOS — no scan can start until you grant it. Search still works by walking folders live.",
+  pending: "Full Disk Access is granted — relaunch FusedRender and the startup scan will build the index.",
+} as const;
+
+export function IndexFdaCta({
+  copy = SEARCH_FDA_COPY,
+}: {
+  copy?: { blocked: string; pending: string };
+} = {}) {
   const fda = useFda();
   const [opened, setOpened] = useState(false);
   const pending = fda?.pending_relaunch === true;
@@ -30,9 +51,7 @@ export function IndexFdaCta() {
   return (
     <div className="fh-index-cta" data-testid="fh-index-fda">
       <span className="fh-index-cta-text">
-        {pending
-          ? "Full Disk Access is granted — relaunch FusedRender to start indexing your files."
-          : "Search needs Full Disk Access to index your files — nothing is scanned until you grant it."}
+        {pending ? copy.pending : copy.blocked}
       </span>
       {pending ? (
         <a className="btn btn-secondary fh-index-cta-btn" href={RELAUNCH_HREF}>

--- a/frontend/src/shell/Indexing.tsx
+++ b/frontend/src/shell/Indexing.tsx
@@ -18,6 +18,8 @@ import {
 import type { IndexConfig, Prefs } from "@platform/lib/api";
 import type { IndexQueryOutcome } from "@platform/lib/index-query";
 import { useIndexStatus } from "@platform/lib/index-status";
+import { useFda } from "@platform/lib/fda";
+import { INDEXING_FDA_COPY, IndexFdaCta } from "@apps/explorer/IndexFdaCta";
 import { formatMtimeFull } from "@platform/lib/format";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
@@ -89,6 +91,14 @@ export function IndexingPanel({
   const [nonce, setNonce] = useState(0);
   const status = useIndexStatus(true, nonce);
   const scanning = !!status?.scanning;
+  // The server's other reason to refuse a scan (shell/index_gate.py): the
+  // packaged mac app without Full Disk Access. Mirrors that gate — offered
+  // (the `fda` field exists) and not granted to THIS process — so the card
+  // is up before the user presses anything, not only after the 409 comes
+  // back. `pending_relaunch` is still "not granted here": the card's
+  // Relaunch face handles it.
+  const fda = useFda();
+  const fdaBlocked = !!fda && !fda.granted;
 
   useEffect(() => {
     let alive = true;
@@ -147,6 +157,14 @@ export function IndexingPanel({
   const dirty = config !== null && text !== patternsToText(config.ignore);
   const stale = config !== null ? missingDefaults(config.ignore, config.defaults) : [];
   const indexingOff = !prefs.indexing.enabled;
+  // Scan buttons have nothing to do while either gate is shut; the sentence
+  // under them says which. FDA outranks "off": with no access, flipping the
+  // toggle on does not get a scan either.
+  const scanBlockedTitle = indexingOff
+    ? "Indexing is off — turn it back on above to scan"
+    : fdaBlocked
+      ? "Indexing needs Full Disk Access — grant it below first"
+      : null;
 
   return (
     <>
@@ -201,11 +219,10 @@ export function IndexingPanel({
         <div className="prefs-actions">
           <button
             type="button"
-            disabled={busy || scanning || indexingOff}
+            disabled={busy || scanning || indexingOff || fdaBlocked}
             title={
-              indexingOff
-                ? "Indexing is off — turn it back on above to scan"
-                : "Check for changes since the last scan (fast — unchanged folders are skipped)"
+              scanBlockedTitle ??
+              "Check for changes since the last scan (fast — unchanged folders are skipped)"
             }
             onClick={() =>
               act(async () => {
@@ -218,11 +235,10 @@ export function IndexingPanel({
           </button>
           <button
             type="button"
-            disabled={busy || scanning || indexingOff}
+            disabled={busy || scanning || indexingOff || fdaBlocked}
             title={
-              indexingOff
-                ? "Indexing is off — turn it back on above to scan"
-                : "Rebuild from scratch, ignoring what the last scan recorded — use this if results look wrong"
+              scanBlockedTitle ??
+              "Rebuild from scratch, ignoring what the last scan recorded — use this if results look wrong"
             }
             onClick={() =>
               act(async () => {
@@ -254,8 +270,15 @@ export function IndexingPanel({
             above first.
           </p>
         )}
+        {/* No Full Disk Access: the fix, not the refusal. The 409 the scan
+            route answers ("indexing needs Full Disk Access on macOS") used to
+            land in the error banner below — a wall with no door. The card is
+            the same one the home search shows for this gate (explorer/
+            IndexFdaCta): open Settings, or Relaunch once the grant landed.
+            While it is up, a scan error is a restatement, so the card wins. */}
+        {fdaBlocked && !indexingOff && <IndexFdaCta copy={INDEXING_FDA_COPY} />}
         {note && <p className="deploy-muted">{note}</p>}
-        {error && <ErrorBanner>{error}</ErrorBanner>}
+        {error && !fdaBlocked && <ErrorBanner>{error}</ErrorBanner>}
       </section>
 
       <section className="prefs-section">

--- a/frontend/src/shell/Indexing.tsx
+++ b/frontend/src/shell/Indexing.tsx
@@ -24,6 +24,7 @@ import { formatMtimeFull } from "@platform/lib/format";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
 import {
+  isFdaRefusal,
   missingDefaults,
   patternsToText,
   scanErrorLine,
@@ -280,10 +281,12 @@ export function IndexingPanel({
             land in the error banner below — a wall with no door. The card is
             the same one the home search shows for this gate (explorer/
             IndexFdaCta): open Settings, or Relaunch once the grant landed.
-            While it is up, a scan error is a restatement, so the card wins. */}
+            Only THAT refusal is kept out of the banner — matched by its text,
+            not by the gate — so a Save or Delete that fails for its own
+            reason while the card is up still says so. */}
         {fdaBlocked && !indexingOff && <IndexFdaCta copy={INDEXING_FDA_COPY} />}
         {note && <p className="deploy-muted">{note}</p>}
-        {error && !fdaBlocked && <ErrorBanner>{error}</ErrorBanner>}
+        {error && !(fdaBlocked && isFdaRefusal(error)) && <ErrorBanner>{error}</ErrorBanner>}
       </section>
 
       <section className="prefs-section">

--- a/frontend/src/shell/Indexing.tsx
+++ b/frontend/src/shell/Indexing.tsx
@@ -140,6 +140,11 @@ export function IndexingPanel({
       // rebuilds. The server starts that scan on save; say so, because the
       // alternative is a user wondering why an excluded folder is still
       // showing up in search.
+      // The server tries to start that rescan and swallows the refusal
+      // (logs it), so `needs_rescan` alone would promise a rebuild that never
+      // starts while the FDA gate is shut. Say what actually happens.
+      if (saved.needs_rescan && fdaBlocked)
+        return "Saved. The index rebuilds once Full Disk Access is granted and FusedRender relaunches.";
       return saved.needs_rescan
         ? "Saved. Rebuilding the index so the new rules apply."
         : "Saved.";

--- a/frontend/src/shell/indexing-lib.ts
+++ b/frontend/src/shell/indexing-lib.ts
@@ -65,3 +65,12 @@ export function scanErrorLine(error: string): string {
   const lines = error.split("\n").filter((l) => l.trim() !== "");
   return lines.length === 0 ? "" : lines[lines.length - 1].trim();
 }
+
+// The scan route's 409 body when the packaged mac app has no Full Disk Access
+// (shell/index_gate.py FDA_MESSAGE), and the runner's ValueError for the same
+// gate — the one error the Indexing panel's FDA card already explains, so the
+// banner should not repeat it. Every OTHER error (Save, Delete, config load)
+// still shows: the gate being shut says nothing about those.
+export function isFdaRefusal(error: string | null | undefined): boolean {
+  return (error ?? "").toLowerCase().includes("needs full disk access");
+}


### PR DESCRIPTION
## Summary
- Preferences > Indexing on a packaged mac app without Full Disk Access showed only the server's 409 text ("indexing needs Full Disk Access on macOS") in the red error banner, with no way to resolve it.
- The panel now reads the shared FDA store (`platform/lib/fda.ts`), mirrors the server gate (`fda` field present and not granted), and renders the same callout the home search uses for this case (`IndexFdaCta`) with indexing wording: **Open System Settings**, or **Relaunch FusedRender** once the grant landed (`pending_relaunch`).
- Re-index / Full scan are disabled while the gate is shut, with a tooltip saying why. The scan error banner is hidden while the card is up, since it only restates it.
- `IndexFdaCta` gained an optional `copy` prop; the search copy stays the default.

## Test plan
- [ ] Packaged mac build without FDA: open Preferences > Indexing, card shows before pressing anything; Re-index/Full scan disabled; Delete index still works.
- [ ] Grant FDA in System Settings: card flips to the Relaunch face; after relaunch the card is gone and buttons enable.
- [ ] Home search FDA callout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> macOS preferences UX around indexing and FDA gating only; no changes to auth, data handling, or server gate logic.
> 
> **Overview**
> **Preferences > Indexing** on macOS without Full Disk Access now shows the same actionable FDA callout as home search (`IndexFdaCta`), with indexing-specific copy, instead of only surfacing the server’s 409 text in the error banner.
> 
> The panel reads `useFda()` and treats “offered but not granted” (including `pending_relaunch`) as blocked **before** the user hits Re-index: scan buttons are disabled with an FDA tooltip, the card offers **Open System Settings** or **Relaunch**, and duplicate FDA refusal messages are suppressed via `isFdaRefusal` while other errors still show. Saving skip rules when FDA blocks a rebuild gets an honest note that the index will rebuild after grant + relaunch.
> 
> `IndexFdaCta` accepts an optional `copy` prop (`SEARCH_FDA_COPY` remains the default for explorer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f37282eccc10ceff7d76fb5119027c6dbdc73d2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->