### PR TITLE
Claude setup: PATH is optional, so it never takes the accent

### DIFF
--- a/frontend/src/platform/lib/claude-health.ts
+++ b/frontend/src/platform/lib/claude-health.ts
@@ -30,6 +30,13 @@ export interface ClaudeIssue {
   helpKind: TroubleKind;
   /** A terminal command that fixes it, when one does. */
   command?: string;
+  /** Nothing in the APP is worse off while this is unfixed — it is a
+      convenience the user may take or leave. Set on `not-on-path` and nothing
+      else, and it costs the row the accent fill everywhere it renders: an
+      always-optional extra must never look like the thing standing between the
+      user and a working app, and must never be the one yellow button on a
+      screen (see the wizard's Next). */
+  optional?: boolean;
   /** What the APP can do about it, when it can do anything.
    *
    *  This is the field that turns the strip from a notice into a repair. It is
@@ -228,6 +235,9 @@ export function claudeIssues(health: ClaudeHealth | null): ClaudeIssue[] {
       action: health.path_fix_command
         ? { kind: "link-path", label: "Add to PATH for me" }
         : undefined,
+      // The app already works. Typing `claude` in a terminal yourself is the
+      // only thing this buys, so it never takes the accent and never gates.
+      optional: true,
     });
   }
 

--- a/frontend/src/platform/ui/ClaudeHealthStrip.tsx
+++ b/frontend/src/platform/ui/ClaudeHealthStrip.tsx
@@ -150,7 +150,16 @@ export function IssueRow({
         <div className="claude-health-actions">
           <button
             type="button"
-            className="claude-health-action"
+            // An OPTIONAL issue's button is quiet, for the same reason Cancel
+            // is: the accent is the app's "this is the next thing to do", and
+            // a row that changes nothing about whether the app works is never
+            // that. On the wizard's Claude step it would also be the one
+            // yellow button on the screen, out-shouting Next.
+            className={
+              issue.optional
+                ? "claude-health-action claude-health-action-quiet"
+                : "claude-health-action"
+            }
             onClick={() => onAct(issue)}
             disabled={busy || running || signingIn}
           >

--- a/frontend/src/shell/onboarding/ClaudeStep.tsx
+++ b/frontend/src/shell/onboarding/ClaudeStep.tsx
@@ -117,10 +117,21 @@ export function ClaudeStep({
   const { health, loaded, busy, load } = setup;
   const issues = claudeIssues(health);
   const rows = health ? rowsFor(health) : null;
-  const allDone = rows?.every((r) => r.state === "done" || (r.optional && r.state !== "open"));
-  const anyActionable = rows?.some((r) => r.state === "open" && issues.some((i) => r.issueIds.includes(i.id)));
+  // OPTIONAL ROWS ARE NOT WORK. PATH is a convenience — the app is finished
+  // with Claude Code without it — so "done" here means every REQUIRED row is
+  // done, whatever the optional one says. Counting it made the step look
+  // unfinished forever on the many machines whose shell rc we never edit.
+  const required = rows?.filter((r) => !r.optional);
+  const allDone = required?.every((r) => r.state === "done");
+  const optionalOpen = rows?.some((r) => r.optional && r.state === "open");
   // Tell the wizard whether this step still has a button of its own to press:
   // while it does (the strip's yellow actions), Next is not the yellow one.
+  // Only a REQUIRED row can claim the accent — the optional row's button is
+  // quiet (lib/claude-health `optional`), so Next stays the one yellow button
+  // once the three that matter are green.
+  const anyActionable = required?.some(
+    (r) => r.state === "open" && issues.some((i) => r.issueIds.includes(i.id)),
+  );
   useEffect(() => onWork(anyActionable === true), [onWork, anyActionable]);
 
   return (
@@ -143,10 +154,12 @@ export function ClaudeStep({
         <p className="text-sm text-muted-foreground" role="status">
           {!loaded
             ? "Checking this machine…"
-            : allDone
-              ? "Everything is in place."
-              : anyActionable
-                ? "A few things still need doing — the open rows have buttons."
+            : anyActionable
+              ? "A few things still need doing — the open rows have buttons."
+              : allDone
+                ? optionalOpen
+                  ? "Claude Code is ready. The last row is optional."
+                  : "Everything is in place."
                 : "Nothing here will block you — carry on."}
         </p>
         <Button variant="outline" size="sm" onClick={() => load(true)} disabled={busy}>


### PR DESCRIPTION
Adding `claude` to the shell PATH changes nothing about whether Fused Render works — it exists so the user can type `claude` in their own terminal. It was styled and counted as if it were the last thing standing between the user and a working setup: its **Add to PATH for me** button took the accent fill (on the onboarding step it was the *one* yellow button on the screen, out-shouting Next), and its open row kept the Claude step reporting work-to-do forever, so Next stayed outlined with installed / version / signed-in all green.

**What changed**

- `ClaudeIssue` carries `optional`, set on `not-on-path` and nothing else.
- `IssueRow` renders an optional issue's button quiet — the treatment Cancel already had — everywhere it renders, the Home health strip included.
- The wizard's Claude step counts only the **required** rows towards `onWork`, so once those three are done Next is the primary action. Status line says so: "Claude Code is ready. The last row is optional."

**Smoke**

`FUSED_RENDER_ONBOARDING=1`, step 2 on a machine whose rc file has no `~/.local/bin`: three green checks, a grey PATH button, a yellow Next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UX and wizard gating; no auth, API, or data-path changes.
> 
> **Overview**
> PATH fixes for typing `claude` in the terminal no longer behave like required setup. **`ClaudeIssue`** gains **`optional`**, set only on **`not-on-path`**, so the product can distinguish “app works” from “terminal convenience.”
> 
> **`IssueRow`** in the health strip (and onboarding) applies **`claude-health-action-quiet`** to optional issue buttons instead of the accent style, matching Cancel and avoiding a yellow **Add to PATH for me** that competes with **Next**.
> 
> On the onboarding **Claude** step, **`allDone`**, **`anyActionable`**, and **`onWork`** count **required** rows only; an open PATH row no longer blocks the step or keeps **Next** secondary. Status copy now says **Claude Code is ready. The last row is optional.** when only PATH remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f54cef5753e490595e25348a275893295ab8b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->