### PR TITLE
Playground: no sentence for an Apple tier this Mac will never have

### DIFF
--- a/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
+++ b/frontend/src/apps/ai_models/playground/PlaygroundTab.tsx
@@ -275,16 +275,17 @@ export default function PlaygroundTab() {
   // sidebar is the only list of what is on the disk that this tab shows, and a
   // model that silently is not in it reads as a download that failed.
   const unsupported = catalog.status === "ok" ? catalog.unsupported : [];
-  // The apple tier's own state, for the one sentence the rail says when its
-  // ids are NOT merged in: on a Mac that could run them (`relevant`) but has
-  // Apple Intelligence off or the model still downloading. Quiet elsewhere —
-  // "needs macOS" is not advice a Linux user can take.
+  // The apple tier's own state, for the one sentence the rail says while its
+  // ids are STILL COMING: the model is downloading and its rows land when it
+  // does. **An unavailable tier says nothing at all** — the reason line it
+  // used to draw ("Apple Silicon is required", "Apple Intelligence is off")
+  // named a machine the reader cannot change from here, so it was a permanent
+  // sentence in a menu of things you can do. Absence is the honest rendering
+  // of a tier this Mac will never have.
   const apple = catalog.status === "ok" ? catalog.apple : null;
   const appleNote =
-    apple && apple.relevant && !apple.available
-      ? apple.state === "loading"
-        ? "Apple's on-device model is still downloading — its rows appear when it lands."
-        : `Apple on-device model: ${apple.reason || "unavailable"}`
+    apple && apple.relevant && !apple.available && apple.state === "loading"
+      ? "Apple's on-device model is still downloading — its rows appear when it lands."
       : null;
 
   // The RAIL's reading order — text generation leads now (2026-08-24): it is


### PR DESCRIPTION
The Playground sidebar drew a reason line where the Apple on-device rows would be, whenever the tier was relevant but unavailable. On an Intel Mac that read

> Apple on-device model: this Mac cannot run Apple's on-device model (Apple Silicon is required)

permanently, in a menu of things you can actually do. It is a fact about the machine, not an action, so an unavailable tier now says nothing at all.

The one case the note survives is the one where the rows are still coming: the model is downloading, and the sentence tells the reader to wait rather than to change hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UX change in the Playground sidebar; no API, auth, or data-handling impact.
> 
> **Overview**
> The Playground sidebar **no longer shows a permanent “Apple on-device model: …” line** when the Apple tier is relevant but unavailable (e.g. Intel Mac, Apple Intelligence off). Those messages named hardware or settings the user cannot fix from this menu, so an unavailable tier is now rendered with **no note at all**.
> 
> The **only remaining Apple rail message** is while the on-device model is still **downloading** (`apple.state === "loading"`), telling the user that rows will appear when the download finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f90d1ef0b3cd36490860dc4e50ec4c662849bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->