### PR TITLE
Claude chat: open approval card always sits last, above the status line

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -14234,20 +14234,35 @@ function showPermissionCard(card, working) {
   scrollBottom();
 }
 
-// An OPEN card is the one thing the run is blocked on, so it is always the LAST
-// thing before the working line — whatever else got mounted after it. Anything
-// that inserts before `working.el` after the card did (the reply bubble on a
-// re-attach, a follow-up's fresh bubble) would otherwise sit between the two
-// and, with a long enough reply, push the card above the fold while the status
-// line below says "Waiting for your approval". Idempotent: a card already in
-// place is left alone, so the 400 ms poll does not reflow anything.
-function pinOpenCard(card, working) {
-  const el = card && card.el;
-  const anchor = working && working.el;
-  if (!el || !el.isConnected || !anchor || !anchor.isConnected) return;
-  if (el.parentNode !== anchor.parentNode || el.nextElementSibling === anchor) return;
-  anchor.parentNode.insertBefore(el, anchor);
-  scrollBottom();
+// OPEN cards are the things the run is blocked on, so together they are the
+// LAST thing before the working line — whatever else got mounted after them.
+// Anything that inserts before `working.el` after a card did (the reply bubble
+// on a re-attach, a follow-up's fresh bubble, a note) would otherwise sit
+// between the two and, with a long enough reply, push the card above the fold
+// while the status line below says "Waiting for your approval".
+//
+// Takes the WHOLE set of open cards, in request order, and pins them as one
+// contiguous block ending at the working line: card[n-1] directly before the
+// working line, card[n-2] directly before card[n-1], and so on. Checking each
+// card against its own successor (not all of them against the working line) is
+// what makes this idempotent with two or more cards pending — a sub-agent's
+// card beside the main one — so the 400 ms poll never reorders anything
+// already in place, and scrolls only when a card actually moved.
+function pinOpenCards(cards, working) {
+  const anchorEl = working && working.el;
+  if (!anchorEl || !anchorEl.isConnected) return;
+  let anchor = anchorEl;
+  let moved = false;
+  for (let i = cards.length - 1; i >= 0; i--) {
+    const el = cards[i].el;
+    if (!el || !el.isConnected || el.parentNode !== anchor.parentNode) continue;
+    if (el.nextElementSibling !== anchor) {
+      anchor.parentNode.insertBefore(el, anchor);
+      moved = true;
+    }
+    anchor = el;
+  }
+  if (moved) scrollBottom();
 }
 
 // An ANSWERED card belongs where it was answered. While a card is open it lives
@@ -14298,6 +14313,7 @@ function parkResolvedCard(card) {
 // Reconcile the poll's request list with what is on screen. Idempotent — poll
 // replays the whole list every 400 ms.
 function syncPermissions(list, run_id, working, liveMode) {
+  const open = [];   // still-unanswered cards, in request order — see pinOpenCards
   for (const p of list || []) {
     if (!p || !p.id) continue;
     let card = permCards.get(p.id);
@@ -14307,9 +14323,8 @@ function syncPermissions(list, run_id, working, liveMode) {
     }
     if (!card.el.isConnected) {
       showPermissionCard(card, working);
-    } else if (!p.decision) {
-      pinOpenCard(card, working);
     }
+    if (!p.decision) open.push(card);
     // `answers` is only ever set on a question card, and it is why poll carries
     // it: a frame that re-attaches after the click has to be able to show what
     // was chosen, not just that something was.
@@ -14322,6 +14337,7 @@ function syncPermissions(list, run_id, working, liveMode) {
       parkResolvedCard(card);
     }
   }
+  pinOpenCards(open, working);
 }
 
 // What a LIVE api_retry says on the status line. The status code picks the
@@ -15862,8 +15878,8 @@ async function pollLoop(run_id, gen = logGen) {
       // re-attach (open from Tasks, reload, follow-up reset) delivers the
       // card and the reply in the same poll, and the order they are mounted
       // in is the order the reader sees. syncPermissions also re-pins an
-      // unanswered card right above the working line every poll, so no later
-      // mount can bury it either.
+      // unanswered cards right above the working line every poll, so no later
+      // mount can bury them either.
       syncPermissions(data.permissions, run_id, w, data.mode);
       if (data.done) {
         // OWNERSHIP-GUARDED, same as the `finally` block below: a respawn

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -14234,6 +14234,22 @@ function showPermissionCard(card, working) {
   scrollBottom();
 }
 
+// An OPEN card is the one thing the run is blocked on, so it is always the LAST
+// thing before the working line — whatever else got mounted after it. Anything
+// that inserts before `working.el` after the card did (the reply bubble on a
+// re-attach, a follow-up's fresh bubble) would otherwise sit between the two
+// and, with a long enough reply, push the card above the fold while the status
+// line below says "Waiting for your approval". Idempotent: a card already in
+// place is left alone, so the 400 ms poll does not reflow anything.
+function pinOpenCard(card, working) {
+  const el = card && card.el;
+  const anchor = working && working.el;
+  if (!el || !el.isConnected || !anchor || !anchor.isConnected) return;
+  if (el.parentNode !== anchor.parentNode || el.nextElementSibling === anchor) return;
+  anchor.parentNode.insertBefore(el, anchor);
+  scrollBottom();
+}
+
 // An ANSWERED card belongs where it was answered. While a card is open it lives
 // at the bottom of the log, right above the working line, because that is where
 // a control the run is blocked on has to be — but the turn's prose and tool
@@ -14291,6 +14307,8 @@ function syncPermissions(list, run_id, working, liveMode) {
     }
     if (!card.el.isConnected) {
       showPermissionCard(card, working);
+    } else if (!p.decision) {
+      pinOpenCard(card, working);
     }
     // `answers` is only ever set on a question card, and it is why poll carries
     // it: a frame that re-attaches after the click has to be able to show what
@@ -15773,7 +15791,11 @@ async function pollLoop(run_id, gen = logGen) {
       // usage arrives only at message end; estimate from streamed text meanwhile
       const tokens = Math.max(data.tokens || 0, Math.round((data.text || "").length / 4));
       w.setStats(tokens, data.phase || "thinking", data.retry, data.activity);
-      syncPermissions(data.permissions, run_id, w, data.mode);
+      // syncPermissions runs AFTER the segment render below, not here — see the
+      // call site past it. A card mounted before the reply bubble existed ended
+      // up ABOVE the bubble once `addAssistant` slid in under the working line,
+      // and a long reply then scrolled the one control the run was blocked on
+      // out of view.
       noteSkills(data.skills, w);
       // Not awaited: a snapshot must never hold up the streaming reply, and the
       // answered-set makes a second poll arriving mid-answer a no-op.
@@ -15835,6 +15857,14 @@ async function pollLoop(run_id, gen = logGen) {
           tailText = renderSegments(segBody, segs, { typer });
         } else if (!data.done) typer.update(flatText);
       }
+      // After the reply bubble is guaranteed to exist for anything this poll
+      // carried, so an open card lands BELOW the prose it interrupts — a
+      // re-attach (open from Tasks, reload, follow-up reset) delivers the
+      // card and the reply in the same poll, and the order they are mounted
+      // in is the order the reader sees. syncPermissions also re-pins an
+      // unanswered card right above the working line every poll, so no later
+      // mount can bury it either.
+      syncPermissions(data.permissions, run_id, w, data.mode);
       if (data.done) {
         // OWNERSHIP-GUARDED, same as the `finally` block below: a respawn
         // (sendFollowUp's attachment/effort-change path) kills this run and


### PR DESCRIPTION
## Problem

"Waiting for your approval…" showed on the status line, but the Allow/Deny (or AskUserQuestion / plan) card was nowhere on screen.

The card was in the DOM, above the reply bubble. On a re-attach — opening a running chat from Tasks, Cards view or the task popup, a reload, or a mid-turn follow-up — the first poll carries the card and the reply together. `syncPermissions` ran before the reply bubble was created; both insert before the working line, so the reply landed under the card. A long reply plus scroll-to-bottom hid the one control the run was blocked on.

## Fix (`fused_render/templates/claude/template.html`)

- `syncPermissions` now runs after the segment render in `pollLoop`.
- New `pinOpenCard`: every poll, an unanswered card is moved directly above the working line if anything got between them (reply bubble, follow-up bubble, note). Idempotent, no reflow on the steady poll. Answered cards are untouched and keep their transcript position via `parkResolvedCard` as before.

Applies to permission, AskUserQuestion and plan cards (same handle).

## Verified

- Live on a parked run: re-attach order is `user → assistant → perm → working`, 4 buttons present. Injected a late bubble before the working line: card slid back under it within one poll.
- 357 permission-bridge / scroll-follow / narrow / segment tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side DOM ordering and scroll behavior in the Claude chat template only; no server auth or persistence changes.
> 
> **Overview**
> Fixes a layout bug where **“Waiting for your approval…”** could show on the status line while the Allow/Deny (and related) card was scrolled off-screen above a long assistant reply.
> 
> **`pollLoop`** now calls **`syncPermissions`** *after* segment/reply rendering so a re-attach poll that delivers permissions and streaming text together mounts the reply bubble first; open cards no longer end up above prose that grows underneath them.
> 
> Adds **`pinOpenCards`**, which every poll reorders still-unanswered cards into one contiguous block directly above the working line (idempotent per card vs its successor). **`syncPermissions`** tracks open cards and invokes pinning after reconcile; resolved cards still **`parkResolvedCard`** into the transcript as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4675789b27560b2a135da54c70e334695a683e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->