### PR TITLE
LAN sharing: pair over https, follow the network, survive sleep

### DIFF
--- a/frontend/src/shell/Preferences.tsx
+++ b/frontend/src/shell/Preferences.tsx
@@ -220,7 +220,12 @@ function CanvasesSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Pref
 // listener is up it shows the QR code a phone scans to pair (the ONLY way in —
 // no PIN, no approval dialog), and the devices that have, with revoke.
 function LanSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) => void }) {
-  const [busy, setBusy] = useState(false);
+  // What the click asked for, held until the PUT answers. Turning sharing on
+  // binds the listener, issues a certificate and announces two mDNS names
+  // before the response comes back — a couple of seconds in which the old
+  // code left the checkbox sitting unchecked, which read as a dead page.
+  const [pending, setPending] = useState<boolean | null>(null);
+  const busy = pending !== null;
   const [error, setError] = useState<string | null>(null);
   const lan = prefs.lan;
   const enabled = lan?.enabled ?? false;
@@ -232,16 +237,17 @@ function LanSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) =>
 
   const toggle = async () => {
     if (busy) return;
-    setBusy(true);
+    const want = !enabled;
+    setPending(want);
     setError(null);
     try {
-      const next = await putLanEnabled(!enabled);
+      const next = await putLanEnabled(want);
       onChange(next);
       setDevices(next.lan?.devices ?? []);
     } catch (e) {
       setError((e as Error).message);
     } finally {
-      setBusy(false);
+      setPending(null);
     }
   };
 
@@ -286,12 +292,28 @@ function LanSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) =>
         computer is reachable. Plain http: on iPhone the live microphone and clipboard paste stay off,
         and on an open (password-less) network the pairing cookie travels in the clear.
       </p>
+      {/* The box follows the click, not the round trip — `pending` is what was
+          asked for and the line below says the work is still going. */}
       <label className="prefs-radio">
-        <input type="checkbox" checked={enabled} disabled={busy} onChange={toggle} />
+        <input
+          type="checkbox"
+          checked={pending ?? enabled}
+          disabled={busy}
+          aria-busy={busy}
+          onChange={toggle}
+        />
         <span>
           <b>Share my apps</b> on this network.
         </span>
       </label>
+      {busy && (
+        <p className="lan-working" role="status">
+          <span className="lan-spinner" aria-hidden="true" />
+          {pending
+            ? "Starting the listener and announcing this computer on the Wi-Fi…"
+            : "Stopping and taking this computer off the Wi-Fi…"}
+        </p>
+      )}
       {/* A code as long as SOMETHING is listening: with the http listener down
           but https up, a browser cannot get in but the iPhone app still pairs
           (the code names https then — /api/lan/pair-token decides). */}
@@ -330,6 +352,10 @@ function LanSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) =>
 function LanPairing({ url, deviceCount }: { url: string; deviceCount: number }) {
   const [svg, setSvg] = useState<string | null>(null);
   const [ipUrl, setIpUrl] = useState<string | null>(null);
+  // Why there is no code, when there is none. An empty paper square said the
+  // same thing as one still being minted — and the mint can now answer 503
+  // (nothing is listening), which is worth reading.
+  const [problem, setProblem] = useState<string | null>(null);
   const [nonce, setNonce] = useState(0);
 
   useEffect(() => {
@@ -339,6 +365,7 @@ function LanPairing({ url, deviceCount }: { url: string; deviceCount: number }) 
   useEffect(() => {
     let alive = true;
     let timer: number | null = null;
+    setProblem(null);
     getLanPairToken()
       .then((t) => {
         if (!alive) return;
@@ -350,7 +377,11 @@ function LanPairing({ url, deviceCount }: { url: string; deviceCount: number }) 
         // Rotate just before the server forgets this one.
         timer = window.setTimeout(() => alive && setNonce((n) => n + 1), Math.max(5, t.ttl_s - 5) * 1000);
       })
-      .catch(() => alive && setSvg(null));
+      .catch((e) => {
+        if (!alive) return;
+        setSvg(null);
+        setProblem((e as Error).message || "No pairing code — the listener did not answer.");
+      });
     return () => {
       alive = false;
       if (timer !== null) window.clearTimeout(timer);
@@ -359,12 +390,15 @@ function LanPairing({ url, deviceCount }: { url: string; deviceCount: number }) 
 
   return (
     <div className="lan-pair">
-      <div
-        className="lan-pair-qr"
-        aria-label="Pairing QR code"
-        dangerouslySetInnerHTML={{ __html: svg ?? "" }}
-      />
+      <div className="lan-pair-qr" aria-label="Pairing QR code" aria-busy={!svg && !problem}>
+        {svg ? (
+          <span dangerouslySetInnerHTML={{ __html: svg }} />
+        ) : problem ? null : (
+          <span className="lan-spinner lan-spinner-qr" aria-hidden="true" />
+        )}
+      </div>
       <div className="lan-pair-text">
+        {problem && <ErrorBanner>{problem}</ErrorBanner>}
         <p>
           <b>Scan from the Fused Render app</b> (or the iPhone's Camera app — not the Control Center
           scanner, whose in-app browser can't pair Safari). Each code pairs one device; a new code

--- a/frontend/src/shell/Preferences.tsx
+++ b/frontend/src/shell/Preferences.tsx
@@ -225,6 +225,9 @@ function LanSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) =>
   const lan = prefs.lan;
   const enabled = lan?.enabled ?? false;
   const running = enabled && !!lan?.running;
+  // Enough of the listener is up to pair a device: the http one (browsers and
+  // the app) or, on its own, the https one (the app alone).
+  const pairable = enabled && ((running && !!lan?.url) || !!lan?.https_url);
   const [devices, setDevices] = useState<LanDevice[]>(lan?.devices ?? []);
 
   const toggle = async () => {
@@ -245,7 +248,7 @@ function LanSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) =>
   // While the QR is on screen, watch for the phone to pair: the list grows,
   // and the spent code is replaced with a fresh one (tokens are single-use).
   useEffect(() => {
-    if (!running) return;
+    if (!pairable) return;
     let alive = true;
     const tick = async () => {
       try {
@@ -261,7 +264,7 @@ function LanSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) =>
       alive = false;
       window.clearInterval(id);
     };
-  }, [running]);
+  }, [pairable]);
 
   const revoke = async (id: string | null) => {
     setError(null);
@@ -289,13 +292,22 @@ function LanSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) =>
           <b>Share my apps</b> on this network.
         </span>
       </label>
-      {running && lan.url && (
-        <LanPairing url={lan.url} deviceCount={devices.length} />
+      {/* A code as long as SOMETHING is listening: with the http listener down
+          but https up, a browser cannot get in but the iPhone app still pairs
+          (the code names https then — /api/lan/pair-token decides). */}
+      {pairable && (
+        <LanPairing url={lan!.url ?? lan!.https_url!} deviceCount={devices.length} />
       )}
-      {running && (
+      {pairable && (
         <LanDevices devices={devices} onRevoke={revoke} />
       )}
-      {enabled && !lan?.running && (
+      {enabled && !lan?.running && lan?.https_url && (
+        <ErrorBanner>
+          {`Browsers can't reach this computer${lan.error ? `: ${lan.error}` : " (the http listener is down)"}. ` +
+            "The iPhone app can still pair with the code above."}
+        </ErrorBanner>
+      )}
+      {enabled && !lan?.running && !lan?.https_url && (
         <ErrorBanner>{lan?.error ? `Not sharing: ${lan.error}` : "Starting…"}</ErrorBanner>
       )}
       {/* The listener can be up while a piece of it failed — zeroconf missing

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -1511,11 +1511,62 @@
   background: var(--qr-paper); /* a QR is read by a camera: always dark-on-white */
   border-radius: 10px;
   transition: opacity 160ms ease;
+  /* Centres the spinner shown while the code is being minted; the code itself
+     is the span below, which fills the square. */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.lan-pair-qr > span:not(.lan-spinner) {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 .lan-pair-qr svg {
   display: block;
   width: 100%;
   height: 100%;
+}
+
+/* Turning sharing on binds the listener, issues a certificate and announces
+   two mDNS names — seconds, during which the checkbox alone said nothing. */
+.lan-working {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  /* Lines up with the label's text: the box (~14px) plus .prefs-radio's 9px gap. */
+  margin: 8px 0 0 23px;
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+.lan-spinner {
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--border);
+  border-top-color: var(--fg-muted);
+  border-radius: 50%;
+  animation: lan-spin 0.7s linear infinite;
+}
+.lan-spinner-qr {
+  /* On the QR's paper, which is white in both themes. */
+  width: 22px;
+  height: 22px;
+  border-width: 2px;
+  border-color: rgb(0 0 0 / 12%);
+  border-top-color: rgb(0 0 0 / 45%);
+}
+
+@keyframes lan-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lan-spinner {
+    animation: none;
+  }
 }
 .lan-pair-text {
   flex: 1;

--- a/fused_render/lan.py
+++ b/fused_render/lan.py
@@ -1006,11 +1006,14 @@ class _Controller:
 
         from fused_render import lan_tls
 
-        # Already listening for this address — a restart of the http half
-        # (status()) must not start a second one, which would find 443 taken
-        # by us, land on 8443, and leave the first thread orphaned.
-        if self.tls_running and ip == self._tls_ip:
-            return
+        # Already listening — a restart of the http half (status()) must not
+        # start a second one, which would find 443 taken by us, land on 8443,
+        # and leave the first thread orphaned. For a different address the
+        # certificate has to be reissued, so that one stops first.
+        if self.tls_running:
+            if ip == self._tls_ip:
+                return
+            self._stop_tls()
         self.tls_error = None
         try:
             cert, key = lan_tls.ensure_server_cert([HOSTNAME, ALIAS_HOSTNAME], [ip] if ip else [])

--- a/fused_render/lan.py
+++ b/fused_render/lan.py
@@ -866,6 +866,8 @@ class _Controller:
         self._ip: str | None = None
         self.port: int | None = None
         self.error: str | None = None
+        # The stored preference as last applied — see apply().
+        self._want = False
         # The https listener (lan_tls.py) beside the http one.
         self._tls_server = None
         self._tls_thread: threading.Thread | None = None
@@ -902,9 +904,9 @@ class _Controller:
         # ahead of it). `apply()` only runs when the preference changes, so
         # this read is the one place that notices, and a stale `port` here is
         # what let a pairing code advertise a dead listener.
-        if self._thread is not None and not self._thread.is_alive():
+        if self._want and self._thread is not None and not self._thread.is_alive():
             with self._lock:
-                if self._thread is not None and not self._thread.is_alive():
+                if self._want and self._thread is not None and not self._thread.is_alive():
                     logger.warning("lan: http listener stopped on its own; restarting")
                     self._server = self._thread = None
                     self.port = None
@@ -954,10 +956,22 @@ class _Controller:
     # -- start/stop
     def apply(self, enabled: bool) -> None:
         with self._lock:
+            # What the preference asks for, so status()'s restart of a dead
+            # listener cannot resurrect sharing the user switched off.
+            self._want = enabled
             if enabled and not self.running:
                 self._start()
-            elif not enabled and self.running:
+            elif not enabled and self._anything_up:
                 self._stop()
+
+    @property
+    def _anything_up(self) -> bool:
+        """Some piece of sharing is still live. NOT `running`: with the http
+        thread dead, that reads False while the https listener and the mDNS
+        records are still up, and switching sharing off has to take those
+        down too."""
+        return (self._thread is not None or self._tls_thread is not None
+                or self._zeroconf is not None)
 
     def _start(self) -> None:
         import uvicorn
@@ -1008,10 +1022,13 @@ class _Controller:
 
         # Already listening — a restart of the http half (status()) must not
         # start a second one, which would find 443 taken by us, land on 8443,
-        # and leave the first thread orphaned. For a different address the
-        # certificate has to be reissued, so that one stops first.
+        # and leave the first thread orphaned. For a DIFFERENT address the
+        # certificate has to be reissued, so that one stops first; for no
+        # address at all the live listener and its certificate are still the
+        # best we have, and tearing them down to reissue a certificate naming
+        # nothing would only lose the address it does name.
         if self.tls_running:
-            if ip == self._tls_ip:
+            if ip is None or ip == self._tls_ip:
                 return
             self._stop_tls()
         self.tls_error = None

--- a/fused_render/lan.py
+++ b/fused_render/lan.py
@@ -1097,7 +1097,7 @@ class _Controller:
                 # with the interface, and zeroconf does not announce again by
                 # itself. (A flap shorter than one interval at an unchanged
                 # address, with the process running, is the gap this leaves.)
-                moved = bool(ips) and (ips != self._ips or self._last_seen is None or slept)
+                moved = bool(ips) and (ips != self._ips or not self._last_seen or slept)
                 self._last_seen = ips
                 if not moved and not (self._want and self._thread is not None
                                       and not self._thread.is_alive()):

--- a/fused_render/lan.py
+++ b/fused_render/lan.py
@@ -71,6 +71,9 @@ PORT_CANDIDATES = (80, 8080, 1888)
 #: first so the app's URL carries no port.
 TLS_PORT_CANDIDATES = (443, 8443, 1889)
 
+# How often the watcher looks at the network address (see _Controller._watch).
+WATCH_INTERVAL_S = 5.0
+
 _STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static", "lan")
 
 
@@ -874,6 +877,11 @@ class _Controller:
         self._tls_ip: str | None = None
         self.tls_port: int | None = None
         self.tls_error: str | None = None
+        # The watcher that follows the network (see _watch). `_last_seen` is
+        # what the last poll OBSERVED; `_ip` above is what is advertised.
+        self._watch_thread: threading.Thread | None = None
+        self._watch_stop = threading.Event()
+        self._last_seen: str | None = None
 
     # -- wiring
     def attach(self, inner) -> None:
@@ -1011,7 +1019,64 @@ class _Controller:
             self._advertise(ip)
         else:
             self.error = "no network address found"
+        self._last_seen = ip
+        self._start_watch()
         logger.info("lan: sharing at %s / %s (%s)", self.url(), self.https_url(), ip)
+
+    def _start_watch(self) -> None:
+        if self._watch_thread is not None and self._watch_thread.is_alive():
+            return
+        self._watch_stop.clear()
+        self._watch_thread = threading.Thread(target=self._watch, daemon=True, name="fused-lan-watch")
+        self._watch_thread.start()
+
+    def _watch(self) -> None:
+        """Follow the network. Joining a different Wi-Fi, or leaving one and
+        coming back, leaves the mDNS records pointing at an address that is
+        gone — and the records themselves gone with the interface they were
+        announced on, even when the address comes back the same. Nothing on
+        the phone can repair that, and until this existed nothing here
+        noticed either: the check lived in status(), which only runs when
+        something reads the preferences.
+        """
+        while not self._watch_stop.wait(WATCH_INTERVAL_S):
+            # Only the current watcher works. A stop while this one waited on
+            # the lock (`_stop` holds it) hands the job to whichever thread
+            # `_start_watch` made next, and this one retires.
+            if self._watch_thread is not threading.current_thread():
+                return
+            try:
+                ip = lan_ip()
+                # A DOWN → UP transition re-announces even at the same
+                # address: the sockets those records were announced on went
+                # with the interface, and zeroconf does not announce again by
+                # itself. (A flap shorter than one interval at an unchanged
+                # address is the gap this leaves.)
+                moved = ip is not None and (ip != self._ip or self._last_seen is None)
+                self._last_seen = ip
+                if not moved and not (self._want and self._thread is not None
+                                      and not self._thread.is_alive()):
+                    continue
+                with self._lock:
+                    if self._watch_thread is not threading.current_thread():
+                        return  # stopped (or replaced) while this waited for the lock
+                    if self._want and self._thread is not None and not self._thread.is_alive():
+                        logger.warning("lan: http listener stopped on its own; restarting")
+                        self._server = self._thread = None
+                        self.port = None
+                        self._start()
+                        continue  # _start advertised and reissued for `ip` itself
+                    if moved and self.running:
+                        logger.info("lan: network changed (%s -> %s); re-advertising", self._ip, ip)
+                        # `_advertise` closes the old zeroconf and opens a new
+                        # one — bounded (goodbye packets, python-zeroconf
+                        # 0.151), and on this thread rather than a request's.
+                        self._advertise(ip)
+                        if ip != self._tls_ip:
+                            self._stop_tls()
+                            self._start_tls(ip)
+            except Exception:  # noqa: BLE001 — a watcher that dies stops watching
+                logger.warning("lan: network watch failed", exc_info=True)
 
     def _start_tls(self, ip: str | None) -> None:
         """The https listener for the native shell (lan_tls.py). Best-effort:
@@ -1066,6 +1131,13 @@ class _Controller:
         self._tls_server, self._tls_thread = server, thread
 
     def _stop(self) -> None:
+        # The watcher first: it restarts a listener that stopped, so leaving it
+        # running through a shutdown would bring sharing back. NOT joined —
+        # this runs holding the lock the watcher takes, so waiting for it here
+        # would wait out its own timeout every time. Dropping the reference is
+        # the signal: a watcher that is no longer `_watch_thread` retires.
+        self._watch_stop.set()
+        self._watch_thread = None
         self._unadvertise()
         server, thread = self._server, self._thread
         tls_server, tls_thread = self._tls_server, self._tls_thread

--- a/fused_render/lan.py
+++ b/fused_render/lan.py
@@ -47,6 +47,7 @@ import logging
 import os
 import socket
 import threading
+import time
 from urllib.parse import parse_qs, urlencode
 
 from starlette.requests import Request
@@ -73,6 +74,9 @@ TLS_PORT_CANDIDATES = (443, 8443, 1889)
 
 # How often the watcher looks at the network address (see _Controller._watch).
 WATCH_INTERVAL_S = 5.0
+# A watcher tick that took this much longer than WATCH_INTERVAL_S on the wall
+# clock was slept through (see _Controller._watch).
+SLEEP_GAP_S = 30.0
 
 _STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static", "lan")
 
@@ -476,8 +480,7 @@ def _host_ok(scope) -> bool:
         return False
     if host in (HOSTNAME, ALIAS_HOSTNAME):
         return True
-    ip = _controller._ip or lan_ip()
-    return bool(ip) and host == ip
+    return host in (_controller._ips or lan_ips())
 
 
 _PAIR_PAGE = """<!doctype html><meta charset="utf-8">
@@ -858,6 +861,33 @@ def lan_ip() -> str | None:
     return None if ip.startswith("127.") else ip
 
 
+def lan_ips() -> list[str]:
+    """Every IPv4 address a device on some local network could reach us on,
+    the default-route one (lan_ip) first. Advertising and naming all of them
+    is what keeps a phone on Wi-Fi reaching the computer when a dock's
+    ethernet comes and goes: with only the default-route address advertised,
+    every such flap moved the records to the other interface and rebuilt the
+    certificate, and the phone lost the name for a while each time.
+    Loopback and link-local (169.254) are not addresses anyone dials."""
+    primary = lan_ip()
+    found: list[str] = []
+    try:
+        import ifaddr  # a zeroconf dependency
+
+        for adapter in ifaddr.get_adapters():
+            for entry in adapter.ips:
+                ip = entry.ip
+                if not isinstance(ip, str) or ip.startswith(("127.", "169.254.")):
+                    continue
+                if ip not in found:
+                    found.append(ip)
+    except Exception:  # noqa: BLE001 — the default-route address alone still works
+        logger.debug("lan: interface enumeration failed", exc_info=True)
+    if primary:
+        found = [primary] + [ip for ip in found if ip != primary]
+    return found
+
+
 class _Controller:
     def __init__(self):
         self._lock = threading.Lock()
@@ -866,6 +896,9 @@ class _Controller:
         self._thread: threading.Thread | None = None
         self._zeroconf = None
         self._infos: list = []
+        # Advertised addresses (lan_ips order: default-route first). `_ip` is
+        # the first — the one QR codes and `_host_ok` name.
+        self._ips: list[str] = []
         self._ip: str | None = None
         self.port: int | None = None
         self.error: str | None = None
@@ -874,14 +907,14 @@ class _Controller:
         # The https listener (lan_tls.py) beside the http one.
         self._tls_server = None
         self._tls_thread: threading.Thread | None = None
-        self._tls_ip: str | None = None
+        self._tls_ips: list[str] = []
         self.tls_port: int | None = None
         self.tls_error: str | None = None
         # The watcher that follows the network (see _watch). `_last_seen` is
-        # what the last poll OBSERVED; `_ip` above is what is advertised.
+        # what the last poll OBSERVED; `_ips` above is what is advertised.
         self._watch_thread: threading.Thread | None = None
         self._watch_stop = threading.Event()
-        self._last_seen: str | None = None
+        self._last_seen: list[str] | None = None
 
     # -- wiring
     def attach(self, inner) -> None:
@@ -906,7 +939,8 @@ class _Controller:
         return f"https://{HOSTNAME}/" if self.tls_port == 443 else f"https://{HOSTNAME}:{self.tls_port}/"
 
     def status(self) -> dict:
-        ip = lan_ip()
+        ips = lan_ips()
+        ip = ips[0] if ips else None
         # The http listener's thread is gone but the preference is still on
         # (INCIDENT 2026-09-07 — why it died is not known; nothing in the log
         # ahead of it). `apply()` only runs when the preference changes, so
@@ -919,18 +953,16 @@ class _Controller:
                     self._server = self._thread = None
                     self.port = None
                     self._start()
-        if self.running and ip and ip != self._ip:
-            # Wi-Fi changed under us: re-advertise the new address, and reissue
-            # the certificate (it names the address) on a fresh https listener.
-            # Under the controller lock: this runs on whatever thread asks for
-            # prefs, and must not race apply()'s start/stop of the same
-            # zeroconf and tls state.
+        if self.running and ips and ips != self._ips:
+            # Wi-Fi changed under us: re-advertise the new addresses, and
+            # reissue the certificate (it names them) on a fresh https
+            # listener. Under the controller lock: this runs on whatever
+            # thread asks for prefs, and must not race apply()'s start/stop of
+            # the same zeroconf and tls state.
             with self._lock:
-                if self.running and ip != self._ip:
-                    self._advertise(ip)
-                    if ip != self._tls_ip:
-                        self._stop_tls()
-                        self._start_tls(ip)
+                if self.running and ips != self._ips:
+                    self._advertise(ips)
+                    self._start_tls(ips)
         from fused_render import lan_tls
 
         try:
@@ -1012,16 +1044,16 @@ class _Controller:
                                   daemon=True, name="fused-lan")
         thread.start()
         self._server, self._thread = server, thread
-        ip = lan_ip()
+        ips = lan_ips()
         # https first: the mDNS record names its port.
-        self._start_tls(ip)
-        if ip:
-            self._advertise(ip)
+        self._start_tls(ips)
+        if ips:
+            self._advertise(ips)
         else:
             self.error = "no network address found"
-        self._last_seen = ip
+        self._last_seen = ips
         self._start_watch()
-        logger.info("lan: sharing at %s / %s (%s)", self.url(), self.https_url(), ip)
+        logger.info("lan: sharing at %s / %s (%s)", self.url(), self.https_url(), ", ".join(ips))
 
     def _start_watch(self) -> None:
         if self._watch_thread is not None and self._watch_thread.is_alive():
@@ -1039,6 +1071,7 @@ class _Controller:
         noticed either: the check lived in status(), which only runs when
         something reads the preferences.
         """
+        last_tick = time.time()
         while not self._watch_stop.wait(WATCH_INTERVAL_S):
             # Only the current watcher works. A stop while this one waited on
             # the lock (`_stop` holds it) hands the job to whichever thread
@@ -1046,14 +1079,26 @@ class _Controller:
             if self._watch_thread is not threading.current_thread():
                 return
             try:
-                ip = lan_ip()
+                # Sleep. The laptop closing takes the interface down and
+                # brings it back with (usually) the same address, and no poll
+                # runs in between to see the gap — to this loop it looks like
+                # nothing happened, while zeroconf's sockets went with the
+                # interface and the phone can no longer resolve the name.
+                # The only trace a suspended process keeps is the clock: a
+                # wait for WATCH_INTERVAL_S that took far longer on the wall
+                # clock was one we slept through. Wall clock on purpose —
+                # time.monotonic() stands still during sleep on macOS.
+                now = time.time()
+                slept = now - last_tick > SLEEP_GAP_S
+                last_tick = now
+                ips = lan_ips()
                 # A DOWN → UP transition re-announces even at the same
                 # address: the sockets those records were announced on went
                 # with the interface, and zeroconf does not announce again by
                 # itself. (A flap shorter than one interval at an unchanged
-                # address is the gap this leaves.)
-                moved = ip is not None and (ip != self._ip or self._last_seen is None)
-                self._last_seen = ip
+                # address, with the process running, is the gap this leaves.)
+                moved = bool(ips) and (ips != self._ips or self._last_seen is None or slept)
+                self._last_seen = ips
                 if not moved and not (self._want and self._thread is not None
                                       and not self._thread.is_alive()):
                     continue
@@ -1067,18 +1112,18 @@ class _Controller:
                         self._start()
                         continue  # _start advertised and reissued for `ip` itself
                     if moved and self.running:
-                        logger.info("lan: network changed (%s -> %s); re-advertising", self._ip, ip)
+                        logger.info("lan: %s (%s -> %s); re-advertising",
+                                    "woke from sleep" if slept else "network changed",
+                                    ", ".join(self._ips) or "-", ", ".join(ips))
                         # `_advertise` closes the old zeroconf and opens a new
                         # one — bounded (goodbye packets, python-zeroconf
                         # 0.151), and on this thread rather than a request's.
-                        self._advertise(ip)
-                        if ip != self._tls_ip:
-                            self._stop_tls()
-                            self._start_tls(ip)
+                        self._advertise(ips)
+                        self._start_tls(ips)
             except Exception:  # noqa: BLE001 — a watcher that dies stops watching
                 logger.warning("lan: network watch failed", exc_info=True)
 
-    def _start_tls(self, ip: str | None) -> None:
+    def _start_tls(self, ips: list[str]) -> None:
         """The https listener for the native shell (lan_tls.py). Best-effort:
         a failure here leaves http working and is reported in `tls_error`."""
         import uvicorn
@@ -1087,19 +1132,20 @@ class _Controller:
 
         # Already listening — a restart of the http half (status()) must not
         # start a second one, which would find 443 taken by us, land on 8443,
-        # and leave the first thread orphaned. For a DIFFERENT address the
-        # certificate has to be reissued, so that one stops first; for no
-        # address at all the live listener and its certificate are still the
-        # best we have, and tearing them down to reissue a certificate naming
-        # nothing would only lose the address it does name.
+        # and leave the first thread orphaned. An address the certificate
+        # does not name means reissuing it, so that one stops first. An
+        # address that merely went away (a dock unplugged) does not: a
+        # certificate naming one address too many is harmless, and tearing
+        # the listener down for it would cut every phone on the surviving
+        # address. No address at all: the live listener is the best we have.
         if self.tls_running:
-            if ip is None or ip == self._tls_ip:
+            if not ips or set(ips) <= set(self._tls_ips):
                 return
             self._stop_tls()
         self.tls_error = None
         try:
-            cert, key = lan_tls.ensure_server_cert([HOSTNAME, ALIAS_HOSTNAME], [ip] if ip else [])
-            self._tls_ip = ip
+            cert, key = lan_tls.ensure_server_cert([HOSTNAME, ALIAS_HOSTNAME], ips)
+            self._tls_ips = list(ips)
         except Exception as e:  # noqa: BLE001
             self.tls_error = f"certificate: {e}"
             logger.warning("lan: tls certificate failed: %s", e)
@@ -1152,7 +1198,7 @@ class _Controller:
         logger.info("lan: sharing stopped")
 
     # -- mDNS
-    def _advertise(self, ip: str) -> None:
+    def _advertise(self, ips: list[str]) -> None:
         try:
             from zeroconf import ServiceInfo, Zeroconf
         except ImportError:
@@ -1166,7 +1212,7 @@ class _Controller:
                 info = ServiceInfo(
                     "_http._tcp.local.",
                     f"Fused Render ({host})._http._tcp.local.",
-                    addresses=[socket.inet_aton(ip)],
+                    addresses=[socket.inet_aton(ip) for ip in ips],
                     port=self.port or 80,
                     server=host + ".",
                     # `https`: the port the native shell should prefer.
@@ -1174,7 +1220,7 @@ class _Controller:
                 )
                 zc.register_service(info)
                 infos.append(info)
-            self._zeroconf, self._infos, self._ip = zc, infos, ip
+            self._zeroconf, self._infos, self._ips, self._ip = zc, infos, list(ips), ips[0]
             # Advertising is the only thing that sets `error` while the
             # listener runs ("no network address found", a failed attempt) —
             # a later success, e.g. status() re-advertising once Wi-Fi is
@@ -1186,7 +1232,7 @@ class _Controller:
 
     def _unadvertise(self) -> None:
         zc, infos = self._zeroconf, self._infos
-        self._zeroconf, self._infos, self._ip = None, [], None
+        self._zeroconf, self._infos, self._ips, self._ip = None, [], [], None
         if zc is None:
             return
         try:

--- a/fused_render/lan.py
+++ b/fused_render/lan.py
@@ -897,6 +897,18 @@ class _Controller:
 
     def status(self) -> dict:
         ip = lan_ip()
+        # The http listener's thread is gone but the preference is still on
+        # (INCIDENT 2026-09-07 — why it died is not known; nothing in the log
+        # ahead of it). `apply()` only runs when the preference changes, so
+        # this read is the one place that notices, and a stale `port` here is
+        # what let a pairing code advertise a dead listener.
+        if self._thread is not None and not self._thread.is_alive():
+            with self._lock:
+                if self._thread is not None and not self._thread.is_alive():
+                    logger.warning("lan: http listener stopped on its own; restarting")
+                    self._server = self._thread = None
+                    self.port = None
+                    self._start()
         if self.running and ip and ip != self._ip:
             # Wi-Fi changed under us: re-advertise the new address, and reissue
             # the certificate (it names the address) on a fresh https listener.
@@ -994,6 +1006,11 @@ class _Controller:
 
         from fused_render import lan_tls
 
+        # Already listening for this address — a restart of the http half
+        # (status()) must not start a second one, which would find 443 taken
+        # by us, land on 8443, and leave the first thread orphaned.
+        if self.tls_running and ip == self._tls_ip:
+            return
         self.tls_error = None
         try:
             cert, key = lan_tls.ensure_server_cert([HOSTNAME, ALIAS_HOSTNAME], [ip] if ip else [])
@@ -1123,8 +1140,19 @@ def api_lan_pair_token():
     """Mint a one-time pairing token and the URL to put in the QR code."""
     from fused_render import lan_tls
 
+    # NEVER a made-up base. A code naming `http://<host>/` while the http
+    # listener is down (INCIDENT 2026-09-07: the listener's thread had gone,
+    # `port` still said 80) points the phone at a port nothing answers on, and
+    # the app could only report it as a certificate that did not match. When
+    # http is down but https is up the app can still pair — it fetches the CA
+    # over https and the fingerprint below is what vouches for it — so the
+    # https base is the honest code; with neither, there is no code to give.
+    http_base, https_base = _controller.url(), _controller.https_url()
+    if not http_base and not https_base:
+        return JSONResponse(
+            {"error": _controller.error or "local-network sharing is not running"},
+            status_code=503)
     token = mint_pair_token()
-    base = _controller.url()
     # The QR is an http URL so a browser can use it as-is. Two extra params
     # ride along for the native shell: `ca`, the private CA's fingerprint, and
     # `s`, the https port — it fetches /lan/ca.pem, checks the fingerprint, pins
@@ -1136,12 +1164,17 @@ def api_lan_pair_token():
             params["s"] = str(_controller.tls_port)
         except Exception:  # noqa: BLE001 — https stays optional
             pass
-    url = (base or f"http://{HOSTNAME}/") + "pair?" + urlencode(params)
+    # http while it is up, so a phone browser can use the same code; https only
+    # as the fallback that keeps the native app pairing without it.
+    over_http = bool(http_base)
+    base = http_base if over_http else https_base
+    url = base + "pair?" + urlencode(params)
     ip = _controller._ip or lan_ip()
-    port = _controller.port
     ip_url = None
     if ip:
-        ip_url = f"http://{ip}{'' if port in (None, 80) else ':' + str(port)}/pair?" + urlencode(params)
+        scheme, port, default = ("http", _controller.port, 80) if over_http else ("https", _controller.tls_port, 443)
+        host = f"{ip}{'' if port in (None, default) else ':' + str(port)}"
+        ip_url = f"{scheme}://{host}/pair?" + urlencode(params)
     return {"url": url, "ip_url": ip_url, "ttl_s": PAIR_TOKEN_TTL_S,
             "https_url": _controller.https_url(), "ca_fingerprint": params.get("ca")}
 

--- a/fused_render/lan_tls.py
+++ b/fused_render/lan_tls.py
@@ -20,11 +20,16 @@ import hashlib
 import ipaddress
 import logging
 import os
+import threading
 
 logger = logging.getLogger("fused_render.lan_tls")
 
 CA_DAYS = 3650
 LEAF_DAYS = 365
+
+# The one CA this process uses, per state folder (see _ensure_ca).
+_ca_by_dir: dict = {}
+_ca_lock = threading.Lock()
 
 
 def _dir() -> str:
@@ -49,7 +54,24 @@ def _write_private(path: str, data: bytes) -> None:
 
 
 def _ensure_ca():
-    """Load or create the CA. Returns (cert, key)."""
+    """Load or create the CA. Returns (cert, key).
+
+    Memoised for the life of the process, and that is load-bearing, not a
+    speed-up: a pairing QR carries ``ca_fingerprint()`` and the phone then
+    fetches the bytes ``ca_pem()`` reads. If those two calls ever disagreed
+    — a half-present folder (a cert whose key is gone) makes this function
+    generate a fresh CA and overwrite ca.pem on EVERY call — no code could
+    pair, and the app could only report it as a certificate that did not
+    match. One CA per process, whatever the folder looks like.
+    """
+    folder = _dir()
+    with _ca_lock:
+        if folder not in _ca_by_dir:
+            _ca_by_dir[folder] = _load_or_create_ca()
+        return _ca_by_dir[folder]
+
+
+def _load_or_create_ca():
     from cryptography import x509
     from cryptography.hazmat.primitives import hashes, serialization
     from cryptography.hazmat.primitives.asymmetric import ec
@@ -63,6 +85,12 @@ def _ensure_ca():
             key = serialization.load_pem_private_key(f.read(), password=None)
         if cert.not_valid_after_utc > _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(days=30):
             return cert, key
+        logger.warning("lan_tls: local CA expires within 30 days - issuing a new one; phones must pair again")
+    elif os.path.exists(cert_path) or os.path.exists(key_path):
+        # Half a CA is no CA: every device paired against the old one is about
+        # to stop trusting this computer, so say so rather than churn quietly.
+        logger.warning("lan_tls: local CA is incomplete (cert %s, key %s) - issuing a new one; "
+                       "phones must pair again", os.path.exists(cert_path), os.path.exists(key_path))
     key = ec.generate_private_key(ec.SECP256R1())
     name = x509.Name([
         x509.NameAttribute(NameOID.COMMON_NAME, "Fused Render local CA"),
@@ -167,6 +195,10 @@ def ca_fingerprint() -> str:
 
 
 def ca_pem() -> bytes:
-    _ensure_ca()
-    with open(ca_pem_path(), "rb") as f:
-        return f.read()
+    """The CA the QR's fingerprint was taken from — the certificate in hand,
+    not a re-read of the file, so the bytes a phone fetches and the fingerprint
+    it checks them against cannot come from two different CAs."""
+    from cryptography.hazmat.primitives import serialization
+
+    cert, _ = _ensure_ca()
+    return cert.public_bytes(serialization.Encoding.PEM)

--- a/ios/FusedRender/AppModel.swift
+++ b/ios/FusedRender/AppModel.swift
@@ -124,7 +124,8 @@ final class AppModel: ObservableObject {
 
     /// The QR code (or a pasted URL) names `http://<host>[:port]/pair?t=…`,
     /// plus `ca` (the CA fingerprint) and `s` (the https port) from a server
-    /// that has https. With those, the CA is fetched over http, checked against
+    /// that has https. With those, the CA is fetched (https first, http as a
+    /// fallback — TLSTrust.fetchCA), checked against
     /// the fingerprint from the QR — the one channel an attacker on the Wi-Fi
     /// cannot touch — pinned, and the pairing happens over https, so the cookie
     /// lives on the https origin. A fingerprint that does not check out ends
@@ -149,11 +150,24 @@ final class AppModel: ObservableObject {
         pairProblem = nil
         var server = Server(name: discovered.first(where: { $0.host == host })?.name ?? host, host: host, port: httpPort)
         if let fingerprint, let httpsPort {
-            guard let ca = await TLSTrust.fetchCA(host: host, httpPort: httpPort, expected: fingerprint) else {
-                pairProblem = "The computer's certificate did not match this code. Try a fresh code from Preferences → Render local network."
+            switch await TLSTrust.fetchCA(host: host, httpPort: httpPort, httpsPort: httpsPort,
+                                          expected: fingerprint) {
+            case .success(let ca):
+                server = Server(name: server.name, host: host, port: httpsPort, scheme: "https", caDER: ca)
+            // Three different things go wrong here and they need three
+            // different sentences: a fresh code fixes none of the first two,
+            // and telling someone whose phone never reached the computer that
+            // a certificate did not match sends them nowhere.
+            case .failure(.unreachable):
+                pairProblem = "Could not reach \(host). Check that this phone and the computer are on the same Wi-Fi, and that Fused Render is allowed under Settings → Privacy & Security → Local Network."
+                return false
+            case .failure(.badResponse):
+                pairProblem = "\(host) answered, but not with the computer's certificate. Check that Render local network is still on in Preferences, then try a fresh code."
+                return false
+            case .failure(.mismatch):
+                pairProblem = "The computer's certificate did not match this code — another computer on this Wi-Fi may answer to \(host). Try a fresh code from Preferences → Render local network."
                 return false
             }
-            server = Server(name: server.name, host: host, port: httpsPort, scheme: "https", caDER: ca)
         }
         // Cancelled while the CA was being fetched (the sheet's Cancel): do
         // not connect behind the user's back. The token is only spent when

--- a/ios/FusedRender/TLSTrust.swift
+++ b/ios/FusedRender/TLSTrust.swift
@@ -1,6 +1,7 @@
 // Trusting the computer's private CA (fused_render/lan_tls.py) with zero user
 // steps. The pairing QR carries the CA's SHA-256 fingerprint; the app fetches
-// /lan/ca.pem over http, checks it against that fingerprint, and from then on
+// /lan/ca.pem (https, unvalidated — the fingerprint is the trust, not the
+// transport — falling back to http), checks it against that fingerprint, and
 // evaluates the https listener's chain against THAT certificate only — no
 // profile install, no Settings trip. The QR is the ONLY channel that pins a
 // CA — no trust-on-first-use from Bonjour, so nothing on the Wi-Fi can slip
@@ -30,27 +31,78 @@ enum TLSTrust {
         SHA256.hash(data: der).map { String(format: "%02x", $0) }.joined()
     }
 
-    /// Fetch the CA over plain http and verify it against `expected` (hex
-    /// SHA-256 of the DER). Returns the DER when it matches.
-    static func fetchCA(host: String, httpPort: Int, expected: String) async -> Data? {
+    /// Why fetching the CA failed. The three are worth telling apart: only
+    /// `mismatch` means a certificate that is not the one the pairing code
+    /// named — the other two are "we never got a certificate at all", and
+    /// reporting those as a mismatch sent people hunting for a fresh code that
+    /// could not help.
+    enum CAProblem: Error {
+        /// Nothing answered on either port — the phone is on another network,
+        /// Local Network access is denied, or the listener is down.
+        case unreachable
+        /// Something answered, but not with a certificate.
+        case badResponse
+        /// A certificate that is not the one the pairing code named.
+        case mismatch
+    }
+
+    /// Fetch the CA and verify it against `expected` (hex SHA-256 of the DER).
+    ///
+    /// https FIRST, over a session that accepts whatever certificate answers:
+    /// the transport is not the trust here — the fingerprint the QR carried is,
+    /// and it is checked against the bytes that come back — so an unvalidated
+    /// fetch plus that check is exactly as strong as the plain-http fetch this
+    /// replaces. It also keeps pairing working when the computer's http
+    /// listener is down, which the https one the pairing itself runs over does
+    /// not depend on. http stays as the fallback.
+    static func fetchCA(host: String, httpPort: Int, httpsPort: Int?,
+                        expected: String) async -> Result<Data, CAProblem> {
+        var problem = CAProblem.unreachable
+        var attempts: [(String, Int)] = []
+        if let httpsPort { attempts.append(("https", httpsPort)) }
+        attempts.append(("http", httpPort))
+        for (scheme, port) in attempts {
+            switch await fetchCA(scheme: scheme, host: host, port: port, expected: expected) {
+            case .success(let der):
+                return .success(der)
+            case .failure(let kind):
+                // A mismatch is the answer: a computer answering to this name
+                // holds a CA that is not the one in the code, and the other
+                // port will not change that. Otherwise keep the most specific
+                // problem seen so far.
+                if kind == .mismatch { return .failure(.mismatch) }
+                if kind == .badResponse { problem = .badResponse }
+            }
+        }
+        return .failure(problem)
+    }
+
+    private static func fetchCA(scheme: String, host: String, port: Int,
+                                expected: String) async -> Result<Data, CAProblem> {
         var c = URLComponents()
-        c.scheme = "http"
+        c.scheme = scheme
         c.host = host
-        c.port = httpPort == 80 ? nil : httpPort
+        c.port = port == (scheme == "https" ? 443 : 80) ? nil : port
         c.path = "/lan/ca.pem"
-        guard let url = c.url else { return nil }
+        guard let url = c.url else { return .failure(.unreachable) }
         var req = URLRequest(url: url)
         req.cachePolicy = .reloadIgnoringLocalCacheData
         req.timeoutInterval = 5
-        guard let (data, response) = try? await URLSession.shared.data(for: req),
-              (response as? HTTPURLResponse)?.statusCode == 200,
-              let der = derFromPEM(data) else { return nil }
+        let session = PinnedSession(caDER: nil, acceptAnyCertificate: scheme == "https")
+        guard let (data, response) = try? await session.data(for: req) else {
+            log.info("tls: CA fetch over \(scheme, privacy: .public) did not answer for \(host, privacy: .public)")
+            return .failure(.unreachable)
+        }
+        guard (response as? HTTPURLResponse)?.statusCode == 200, let der = derFromPEM(data) else {
+            log.error("tls: CA fetch over \(scheme, privacy: .public) answered without a certificate for \(host, privacy: .public)")
+            return .failure(.badResponse)
+        }
         let got = fingerprint(der)
         guard got == expected.lowercased() else {
             log.error("tls: CA fingerprint mismatch for \(host, privacy: .public): got \(got, privacy: .public)")
-            return nil
+            return .failure(.mismatch)
         }
-        return der
+        return .success(der)
     }
 
     static func derFromPEM(_ pem: Data) -> Data? {
@@ -72,10 +124,16 @@ enum TLSTrust {
 final class PinnedSession {
     private let session: URLSession
 
-    init(caDER: Data?) {
+    /// `acceptAnyCertificate` is for the ONE request that has no anchor yet —
+    /// fetching the CA a pairing code named, where the code's fingerprint is
+    /// the trust and is checked on the bytes that come back (`fetchCA`).
+    /// Everything else passes the pinned CA and nothing else is trusted.
+    init(caDER: Data?, acceptAnyCertificate: Bool = false) {
         let config = URLSessionConfiguration.ephemeral
         config.waitsForConnectivity = false
-        session = URLSession(configuration: config, delegate: PinDelegate(caDER: caDER), delegateQueue: nil)
+        session = URLSession(configuration: config,
+                             delegate: PinDelegate(caDER: caDER, acceptAny: acceptAnyCertificate),
+                             delegateQueue: nil)
     }
 
     deinit {
@@ -89,8 +147,12 @@ final class PinnedSession {
 
 private final class PinDelegate: NSObject, URLSessionDelegate {
     private let caDER: Data?
+    private let acceptAny: Bool
 
-    init(caDER: Data?) { self.caDER = caDER }
+    init(caDER: Data?, acceptAny: Bool = false) {
+        self.caDER = caDER
+        self.acceptAny = acceptAny
+    }
 
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
                     completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
@@ -99,7 +161,9 @@ private final class PinDelegate: NSObject, URLSessionDelegate {
             completionHandler(.performDefaultHandling, nil)
             return
         }
-        if let ca = caDER, TLSTrust.accepts(trust, caDER: ca, host: challenge.protectionSpace.host) {
+        if acceptAny {
+            completionHandler(.useCredential, URLCredential(trust: trust))
+        } else if let ca = caDER, TLSTrust.accepts(trust, caDER: ca, host: challenge.protectionSpace.host) {
             completionHandler(.useCredential, URLCredential(trust: trust))
         } else {
             completionHandler(.cancelAuthenticationChallenge, nil)

--- a/ios/FusedRender/WebView.swift
+++ b/ios/FusedRender/WebView.swift
@@ -11,6 +11,7 @@
 // navigation delegate accepts exactly that CA for exactly this host
 // (TLSTrust.swift) — which is what gives pages a secure context, and with it
 // the microphone and clipboard the same pages lack on plain http.
+import Network
 import SwiftUI
 import WebKit
 import os
@@ -126,11 +127,40 @@ struct WebView: UIViewRepresentable {
         let onGridLoaded: (String) -> Void
         let bridge = CaptureBridge()
 
+        /// Set when a navigation failed, cleared when one lands. What makes
+        /// the network watch below reload exactly once after a failure rather
+        /// than on every Wi-Fi ⇄ cellular handoff of a page that is fine.
+        private var navigationFailed = false
+        private let network = NWPathMonitor()
+
         init(server: Server, controller: WebController, onGridLoaded: @escaping (String) -> Void) {
             self.server = server
             self.baseURL = server.baseURL
             self.controller = controller
             self.onGridLoaded = onGridLoaded
+            super.init()
+            // Coming back onto a network reloads a page that died on the way
+            // out. Leaving one Wi-Fi for another takes the computer's address
+            // with it — the desktop re-announces itself (lan.py's watcher),
+            // and this is the phone's half: without it the webview sits on
+            // WebKit's error page until someone pulls to refresh.
+            network.pathUpdateHandler = { [weak self] path in
+                guard path.status == .satisfied else { return }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { self?.retryAfterNetworkChange() }
+            }
+            network.start(queue: .main)
+        }
+
+        deinit { network.cancel() }
+
+        @MainActor
+        private func retryAfterNetworkChange() {
+            guard navigationFailed, let web = webView else { return }
+            webLog.info("network back; reloading \(web.url?.absoluteString ?? self.baseURL.absoluteString, privacy: .public)")
+            // `reload()` on an error page re-requests the URL that failed;
+            // with no URL at all (the very first load never landed) there is
+            // nothing to reload, so go to the base.
+            if web.url != nil { web.reload() } else { web.load(URLRequest(url: baseURL)) }
         }
 
         @objc func pulled(_ sender: UIRefreshControl) {
@@ -162,14 +192,17 @@ struct WebView: UIViewRepresentable {
 
         func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
             webView.scrollView.refreshControl?.endRefreshing()
+            navigationFailed = true
         }
 
         func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
             webView.scrollView.refreshControl?.endRefreshing()
+            navigationFailed = true
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             webView.scrollView.refreshControl?.endRefreshing()
+            navigationFailed = false
             webLog.info("finished \(webView.url?.absoluteString ?? "-", privacy: .public)")
             controller.location = webView.url
             controller.canGoBack = webView.canGoBack

--- a/ios/FusedRender/WebView.swift
+++ b/ios/FusedRender/WebView.swift
@@ -131,6 +131,12 @@ struct WebView: UIViewRepresentable {
         /// the network watch below reload exactly once after a failure rather
         /// than on every Wi-Fi ⇄ cellular handoff of a page that is fine.
         private var navigationFailed = false
+        /// The main-frame URL the last navigation asked for. What a retry
+        /// reloads when the failed load never committed (`webView.url` is nil
+        /// then): during pairing that is `/pair?t=…`, and falling back to the
+        /// base URL instead would land on the how-to-pair page, which
+        /// didFinish would then take for a pairing that succeeded.
+        private var requestedURL: URL?
         private let network = NWPathMonitor()
 
         init(server: Server, controller: WebController, onGridLoaded: @escaping (String) -> Void) {
@@ -159,8 +165,26 @@ struct WebView: UIViewRepresentable {
             webLog.info("network back; reloading \(web.url?.absoluteString ?? self.baseURL.absoluteString, privacy: .public)")
             // `reload()` on an error page re-requests the URL that failed;
             // with no URL at all (the very first load never landed) there is
-            // nothing to reload, so go to the base.
-            if web.url != nil { web.reload() } else { web.load(URLRequest(url: baseURL)) }
+            // nothing to reload, so ask again for what was requested.
+            if web.url != nil { web.reload() } else { web.load(URLRequest(url: requestedURL ?? baseURL)) }
+        }
+
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            if navigationAction.targetFrame?.isMainFrame ?? true, let url = navigationAction.request.url {
+                requestedURL = url
+            }
+            decisionHandler(.allow)
+        }
+
+        /// A navigation WebKit gave up on because another replaced it, or the
+        /// page itself stopped it, is not a page that died on the network —
+        /// reloading for it would interrupt the navigation that replaced it.
+        private static func isRealFailure(_ error: Error) -> Bool {
+            let e = error as NSError
+            if e.domain == NSURLErrorDomain && e.code == NSURLErrorCancelled { return false }
+            if e.domain == "WebKitErrorDomain" && e.code == 102 { return false }  // frame load interrupted
+            return true
         }
 
         @objc func pulled(_ sender: UIRefreshControl) {
@@ -192,12 +216,12 @@ struct WebView: UIViewRepresentable {
 
         func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
             webView.scrollView.refreshControl?.endRefreshing()
-            navigationFailed = true
+            if Self.isRealFailure(error) { navigationFailed = true }
         }
 
         func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
             webView.scrollView.refreshControl?.endRefreshing()
-            navigationFailed = true
+            if Self.isRealFailure(error) { navigationFailed = true }
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -17,8 +17,8 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.10"
-    MARKETING_VERSION: "0.1.1"
-    CURRENT_PROJECT_VERSION: "2"
+    MARKETING_VERSION: "0.1.2"
+    CURRENT_PROJECT_VERSION: "3"
     # The Fused developer team (Apple Development identity in the keychain):
     # signs simulator and device builds alike; the App Group entitlement the
     # widget needs is provisioned against it.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -17,8 +17,8 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.10"
-    MARKETING_VERSION: "0.1.0"
-    CURRENT_PROJECT_VERSION: "1"
+    MARKETING_VERSION: "0.1.1"
+    CURRENT_PROJECT_VERSION: "2"
     # The Fused developer team (Apple Development identity in the keychain):
     # signs simulator and device builds alike; the App Group entitlement the
     # widget needs is provisioned against it.


### PR DESCRIPTION
LAN sharing that a phone can rely on. Started from one report — **"The computer's certificate did not match this code"** on every fresh code — and grew into every way the pairing and the connection went stale: a dead listener nobody noticed, a CA that changed under the QR, a laptop that slept, a Wi‑Fi that moved, a dock that flapped. Server (`lan.py`, `lan_tls.py`), iOS app, and Preferences.

## Pairing

**The CA comes over https** (`TLSTrust.fetchCA`), https first through a session that accepts any certificate, http as the fallback. The trust has always been the fingerprint carried by the QR, checked against the bytes fetched, never the transport, so this is exactly as strong as the plain-http fetch it replaces, and pairing no longer depends on the http listener at all.

**Three failures, three sentences.** `.unreachable` (same Wi‑Fi, Local Network permission), `.badResponse` (answered, but not with the computer's certificate), `.mismatch` (another computer may answer to that name). A fresh code helps with the last one only, and the copy says so.

**No code for a listener that is not there.** `pair-token` uses the http base while it is up, https when only that is, and 503s with the reason when neither is. `ip_url` had the same lie. A dead http thread is restarted while the preference is on (`_want`), and `apply(False)` tears down whatever is still up rather than checking `running`.

**One CA per process.** A half-present `lan_tls/` folder made `_ensure_ca` mint a new CA on every call, so the QR fingerprint and the fetched bytes came from two different CAs. Memoised per state folder; `/lan/ca.pem` serves the certificate in hand.

## Staying reachable

**A watcher follows the network** (`fused-lan-watch`, 5s). Until now the address check lived in `status()`, which only ran when someone opened Preferences. The watcher re-advertises on a changed address, on a down → up transition at the same address (the records went with the interface; zeroconf does not announce again by itself), and restarts a listener thread that died.

**Waking from sleep counts as a network change.** A closed laptop takes the interface down and brings it back with the same address, and no poll runs in between to see the gap. The clock is the trace a suspended process keeps: a tick that took more than 30s of wall clock (not `time.monotonic()`, which stands still through sleep on macOS) re-advertises. This is the "disable and enable it again after sleep" bug.

**Every address is advertised** (`lan_ips()`, ifaddr, default-route address first). With only the default-route address in the records and the certificate, a dock's ethernet coming and going moved both on every flap. The tls listener now restarts only for an address the certificate does not name; an address that merely went away is left alone. The Host allowlist accepts any advertised address.

**The phone's half.** The webview reloads once when the network comes back under a navigation that really failed (`NWPathMonitor`, gated so a Wi‑Fi/cellular handoff does not reload a page that is fine, and cancelled or interrupted loads do not count). The retry re-requests the main-frame URL it asked for, so a pairing interrupted by the network re-requests `/pair?t=…` rather than landing on the how-to-pair page and being taken for a successful pairing.

## Preferences

The share checkbox follows the click (`pending`), shows start/stop progress, treats https-only as pairable with a browser warning, and shows pair-token errors in the QR area instead of a blank square.

iOS app version 0.1.1 (2).

## Verification

iOS simulator build succeeds. Python: syntax + a stubbed watcher run (steady state no calls; a clock jump re-advertises; a new address re-advertises and reissues). Still needs a device: pair with the http listener stopped, close the lid for a minute and confirm the phone resolves the name on wake without toggling sharing.

Open: why the http thread died in the original report. Nothing was logged ahead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LAN listener lifecycle, mDNS/TLS certificate reissuance, and pairing trust paths across Python and iOS; fixes are reliability-focused but touch security-sensitive local pairing behavior.
> 
> **Overview**
> Hardens **local-network sharing** so phones can pair and stay connected when listeners flap, Wi‑Fi changes, or the laptop sleeps—addressing dead http threads still advertising QR codes and CA fingerprints that no longer matched fetched certs.
> 
> **Server (`lan.py`, `lan_tls.py`):** Adds **`lan_ips()`** and advertises **all reachable IPv4s** in mDNS/TLS (default-route first) so dock/Wi‑Fi flaps do not constantly reissue certs. A **`fused-lan-watch`** thread re-advertises on address changes, after **sleep gaps** (wall-clock >30s), and on interface down→up; it also **restarts a dead http listener** when sharing is still wanted (`_want`). **`/api/lan/pair-token`** returns **503** when nothing is listening and builds QR/`ip_url` from **https when http is down** (no fake `http://` bases). Shutdown uses **`_anything_up`** so https/mDNS tear down even if http `running` is false. **`lan_tls`** memoizes **one CA per process** and serves **`ca_pem`** from the same in-memory cert as **`ca_fingerprint`**.
> 
> **iOS:** **`TLSTrust.fetchCA`** tries **https first** (accept-any for that hop), falls back to http, and returns **unreachable / badResponse / mismatch** for clearer copy in **`AppModel.pair`**. **`WebView`** uses **`NWPathMonitor`** to **reload once** after a real navigation failure when connectivity returns (preserving `/pair?t=…`).
> 
> **Preferences:** Share checkbox uses **`pending`** optimistic state, start/stop status + spinners, **`pairable`** (https-only still shows QR with a browser warning), and surfaces **pair-token errors** in the QR area. App version **0.1.2 (3)** in **`project.yml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0543096a3c9f660acb27cc29364f0f6b4b8bcc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->