### PR TITLE
App cards draw the app's icon beside its name

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2196,6 +2196,13 @@ export interface AppInfo {
   // repo's per-app metadata shape), or null when absent/invalid. Undefined on
   // older backends. Apps without one only appear under the "All" filter.
   category?: string | null;
+  // The app's optional `icon.svg` at the folder's root (absolute path) and its
+  // mtime — the mark a card draws to the left of its name, the same file the
+  // sidebar's Projects row and the app's tab favicon draw. Null for an app
+  // without one (and for an exported `.fused`, which has no folder root),
+  // undefined on backends that predate the keys; draw it through appIconUrl.
+  icon?: string | null;
+  icon_mtime?: number | null;
   title: string | null;
   // Last-modified time, epoch seconds. Optional/null for servers that don't
   // report it (older backends) — those sort last in the Home grid.

--- a/frontend/src/platform/ui/AppPreviewCard.tsx
+++ b/frontend/src/platform/ui/AppPreviewCard.tsx
@@ -34,7 +34,7 @@
 // live preview (D365).
 import { useEffect, useRef, useState } from "react";
 import type { AppInfo } from "@platform/lib/api";
-import { appfilePreviewUrl, rawUrl } from "@platform/lib/api";
+import { appIconUrl, appfilePreviewUrl, rawUrl } from "@platform/lib/api";
 import { exportAppFile } from "@platform/lib/appShot";
 import { pushToast } from "@platform/lib/toast";
 import { MenuIcons } from "@platform/ui/MenuIcons";
@@ -225,7 +225,29 @@ export function AppPreviewCard({
       title={openTargetFor(app).path}
     >
       <span className="app-pcard-body">
-        <span className="app-pcard-title">{title}</span>
+        {/* The app's own `icon.svg` to the left of its name — the same mark
+            the sidebar's Projects row and the app's tab favicon draw, so an
+            app reads as itself wherever it is listed. Drawn AS IS: the
+            author's colours, no mask or tint (owner, 2026-08-27).
+            Absent when the app has no icon.svg, with no generic mark in its
+            place: the monogram the card used to fall back to is exactly what
+            D365 deleted from this card, and a stand-in star would put it
+            back. The sidebar keeps a slot because its glyph is the icon
+            picker's toggle; a card has nothing to toggle.
+            `draggable={false}` for the reason the still's shield exists — an
+            <img> carries the browser's native drag-the-image gesture, which
+            starts a drag instead of the click that opens the card. */}
+        <span className="app-pcard-head">
+          {app.icon && (
+            <img
+              className="app-pcard-icon"
+              src={appIconUrl(app.icon, app.icon_mtime)}
+              alt=""
+              draggable={false}
+            />
+          )}
+          <span className="app-pcard-title">{title}</span>
+        </span>
         <span className="app-pcard-meta">
           <span className="app-pcard-tag">{app.tag}</span>
           {title !== app.name && <span className="app-pcard-name">{app.name}</span>}

--- a/frontend/src/platform/ui/AppPreviewCard.tsx
+++ b/frontend/src/platform/ui/AppPreviewCard.tsx
@@ -225,34 +225,51 @@ export function AppPreviewCard({
       title={openTargetFor(app).path}
     >
       <span className="app-pcard-body">
-        {/* The app's own `icon.svg` to the left of its name — the same mark
+        {/* The app's own `icon.svg` to the left of its two text lines, tall
+            enough to span both — the same mark
             the sidebar's Projects row and the app's tab favicon draw, so an
             app reads as itself wherever it is listed. Drawn AS IS: the
             author's colours, no mask or tint (owner, 2026-08-27).
-            Absent when the app has no icon.svg, with no generic mark in its
-            place: the monogram the card used to fall back to is exactly what
-            D365 deleted from this card, and a stand-in star would put it
-            back. The sidebar keeps a slot because its glyph is the icon
-            picker's toggle; a card has nothing to toggle.
+            An app with no icon.svg gets the same generic mark the sidebar row
+            falls back to — the brand's four-point star — so the slot is there
+            on every card and a name never shifts left for the want of a file.
             `draggable={false}` for the reason the still's shield exists — an
             <img> carries the browser's native drag-the-image gesture, which
             starts a drag instead of the click that opens the card. */}
-        <span className="app-pcard-head">
-          {app.icon && (
-            <img
-              className="app-pcard-icon"
-              src={appIconUrl(app.icon, app.icon_mtime)}
-              alt=""
-              draggable={false}
-            />
-          )}
+        {app.icon ? (
+          <img
+            className="app-pcard-icon"
+            src={appIconUrl(app.icon, app.icon_mtime)}
+            alt=""
+            draggable={false}
+          />
+        ) : (
+          // The generic mark, one drawing shared with the sidebar
+          // (CurrentAppsSection's `current-app-star`): the app icon's own
+          // sparkle, on currentColor so it takes the card's muted tone
+          // rather than competing with the name beside it.
+          <svg
+            className="app-pcard-star"
+            viewBox="0 0 64 64"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M32 2 C36.5 20.5 43.5 27.5 62 32 C43.5 36.5 36.5 43.5 32 62 C27.5 43.5 20.5 36.5 2 32 C20.5 27.5 27.5 20.5 32 2 Z" />
+          </svg>
+        )}
+        {/* The two text lines, stacked beside the icon rather than under it —
+            the icon is a column of the head, spanning both (owner). Their own
+            element because the icon has to be a SIBLING of the pair for that:
+            with the icon inside the first line it could only ever be as tall
+            as the name. */}
+        <span className="app-pcard-lines">
           <span className="app-pcard-title">{title}</span>
-        </span>
-        <span className="app-pcard-meta">
-          <span className="app-pcard-tag">{app.tag}</span>
-          {title !== app.name && <span className="app-pcard-name">{app.name}</span>}
-          {badge && <span className="app-pcard-name">{badge}</span>}
-          {ago && <span className="app-pcard-ago">{ago}</span>}
+          <span className="app-pcard-meta">
+            <span className="app-pcard-tag">{app.tag}</span>
+            {title !== app.name && <span className="app-pcard-name">{app.name}</span>}
+            {badge && <span className="app-pcard-name">{badge}</span>}
+            {ago && <span className="app-pcard-ago">{ago}</span>}
+          </span>
         </span>
       </span>
       {/* `data-capture-ready` marks the thumb as a picture of the APP — the

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -151,10 +151,11 @@ function Section({
 // because Home's two async strips draw two DIFFERENT real cards and a single
 // shared shape would be wrong for one of them:
 //   - "app"    mirrors AppPreviewCard/`.app-pcard` (apps.css) — title + a meta
-//     row (tag pill, timestamp) OVER a full-bleed thumb. No icon: the real
-//     card draws one only for an app that HAS an `icon.svg`, which is a fact
-//     of the fetch that hasn't landed — a slot here would claim an icon is
-//     coming for the apps that will never show one.
+//     row (tag pill, timestamp) OVER a full-bleed thumb. The real card's head
+//     DOES carry an icon now (the app's `icon.svg`, or the generic star), but
+//     it's the folder variant's case below: WHICH mark it is comes with the
+//     fetch, so shimmering the slot — or standing the star in it — would
+//     claim something is loading that isn't.
 //   - "folder" mirrors FolderPreviewCard/`.fhb-card` (preferences.css) — a
 //     head row over an inset thumb well. The real card's head DOES carry an
 //     icon, but it's a static decorative folder glyph, identical on every
@@ -175,10 +176,15 @@ function SkeletonCard({ variant }: { variant: "app" | "folder" }) {
     return (
       <span className="app-pcard home-skel-card" aria-hidden="true">
         <span className="app-pcard-body">
-          <span className="skel-bar" style={{ width: "58%" }} />
-          <span className="app-pcard-meta">
-            <span className="skel-bar" style={{ width: "46px" }} />
-            <span className="skel-bar" style={{ width: "64px" }} />
+          {/* The lines wrapper, not bars straight in the body: the body is a
+              ROW since the icon column landed beside them (apps.css), so bars
+              placed directly in it would sit side by side. */}
+          <span className="app-pcard-lines">
+            <span className="skel-bar" style={{ width: "58%" }} />
+            <span className="app-pcard-meta">
+              <span className="skel-bar" style={{ width: "46px" }} />
+              <span className="skel-bar" style={{ width: "64px" }} />
+            </span>
           </span>
         </span>
         <span className="app-pcard-thumb home-skel-body" />

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -152,7 +152,9 @@ function Section({
 // shared shape would be wrong for one of them:
 //   - "app"    mirrors AppPreviewCard/`.app-pcard` (apps.css) — title + a meta
 //     row (tag pill, timestamp) OVER a full-bleed thumb. No icon: the real
-//     card has none.
+//     card draws one only for an app that HAS an `icon.svg`, which is a fact
+//     of the fetch that hasn't landed — a slot here would claim an icon is
+//     coming for the apps that will never show one.
 //   - "folder" mirrors FolderPreviewCard/`.fhb-card` (preferences.css) — a
 //     head row over an inset thumb well. The real card's head DOES carry an
 //     icon, but it's a static decorative folder glyph, identical on every

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -151,11 +151,13 @@ function Section({
 // because Home's two async strips draw two DIFFERENT real cards and a single
 // shared shape would be wrong for one of them:
 //   - "app"    mirrors AppPreviewCard/`.app-pcard` (apps.css) — title + a meta
-//     row (tag pill, timestamp) OVER a full-bleed thumb. The real card's head
-//     DOES carry an icon now (the app's `icon.svg`, or the generic star), but
-//     it's the folder variant's case below: WHICH mark it is comes with the
-//     fetch, so shimmering the slot — or standing the star in it — would
-//     claim something is loading that isn't.
+//     row (tag pill, timestamp) OVER a full-bleed thumb, with a 32px mark in
+//     the head's icon column. This variant DOES shimmer that square, unlike
+//     the folder one below: which mark the real card draws (the app's own
+//     `icon.svg`, or the generic star) arrives with the fetch, so a shimmer
+//     there claims exactly what is true — and without it the skeleton's text
+//     would start 42px left of where the real card's does and jump sideways
+//     on the swap.
 //   - "folder" mirrors FolderPreviewCard/`.fhb-card` (preferences.css) — a
 //     head row over an inset thumb well. The real card's head DOES carry an
 //     icon, but it's a static decorative folder glyph, identical on every
@@ -176,6 +178,7 @@ function SkeletonCard({ variant }: { variant: "app" | "folder" }) {
     return (
       <span className="app-pcard home-skel-card" aria-hidden="true">
         <span className="app-pcard-body">
+          <span className="skel-bar app-pcard-icon-skel" />
           {/* The lines wrapper, not bars straight in the body: the body is a
               ROW since the icon column landed beside them (apps.css), so bars
               placed directly in it would sit side by side. */}

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -332,12 +332,36 @@ body[data-capture-shooting] .app-pcard-export {
   min-width: 0;
 }
 
+/* The name row: the app's icon.svg (when it has one) then the name. The icon
+   is capped BELOW the title's own line box, so a card with an icon is exactly
+   as tall as one without — Home's skeleton card reuses these classes and its
+   promise is that its height tracks the real card's (Home.tsx SkeletonCard). */
+.app-pcard-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.app-pcard-icon {
+  flex: 0 0 auto;
+  width: 15px;
+  height: 15px;
+  /* An author's svg can declare any intrinsic size; contain keeps a wide or
+     tall one inside the square instead of stretching it. */
+  object-fit: contain;
+}
+
 .app-pcard-title {
   font-size: 13.5px;
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* A flex child's min-width is auto, which refuses to shrink below its text
+     — without this the ellipsis never engages and a long name pushes the
+     icon out of the card. */
+  min-width: 0;
 }
 
 .app-pcard-meta {

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -332,8 +332,8 @@ body[data-capture-shooting] .app-pcard-export {
 .app-pcard-body {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 11px 14px 12px;
+  gap: 9px;
+  padding: 8px 11px 9px;
   min-width: 0;
 }
 
@@ -341,15 +341,33 @@ body[data-capture-shooting] .app-pcard-export {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  /* The load-bearing one: a flex item's automatic minimum size is its content,
+     so without this a long app name refuses to shrink and pushes the mark out
+     of the card instead of ellipsising (the title's own overflow rules only
+     get to act once this box can be narrower than its text). */
   min-width: 0;
   flex: 1 1 auto;
 }
 
+/* 32px, deliberately under the two lines it spans: the name's line box is
+   ~16px (13.5px at the default `normal` line-height) and the meta row's about
+   the same, plus the 4px gap — ~36px, so the mark is the head's tallest thing
+   in neither theme nor font. That's what keeps a card the height it was before
+   icons, and Home's skeleton (which reuses these classes to track that height)
+   honest. */
 .app-pcard-icon,
-.app-pcard-star {
+.app-pcard-star,
+.app-pcard-body .app-pcard-icon-skel {
   flex: 0 0 auto;
-  width: 34px;
-  height: 34px;
+  width: 32px;
+  height: 32px;
+}
+
+/* Home's skeleton square, in the mark's slot (Home.tsx SkeletonCard). Selector
+   compounded with the body so it beats `.skel-bar`'s own 10px height whatever
+   order the two stylesheets land in. */
+.app-pcard-body .app-pcard-icon-skel {
+  border-radius: 8px;
 }
 
 /* An author's svg can declare any intrinsic size; contain keeps a wide or
@@ -361,7 +379,7 @@ body[data-capture-shooting] .app-pcard-export {
 /* The generic mark for an app with no icon.svg: muted, so it reads as the
    slot being filled rather than as a badge on the name, and inset inside that
    slot — an authored icon is a whole tile of artwork, a bare sparkle drawn to
-   the same 34px would shout louder than the name next to it. */
+   the same 32px would shout louder than the name next to it. */
 .app-pcard-star {
   box-sizing: border-box;
   padding: 7px;
@@ -374,10 +392,6 @@ body[data-capture-shooting] .app-pcard-export {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  /* A flex child's min-width is auto, which refuses to shrink below its text
-     — without this the ellipsis never engages and a long name pushes the
-     icon out of the card. */
-  min-width: 0;
 }
 
 .app-pcard-meta {

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -324,32 +324,48 @@ body[data-capture-shooting] .app-pcard-export {
   transition: none;
 }
 
+/* A ROW: the app's mark as a column of its own, then the two text lines
+   stacked beside it (`.app-pcard-lines`). The head's height is still the
+   lines' — the icon is sized to span them, never to set the height — so a
+   card is as tall as it was before icons and Home's skeleton, which reuses
+   these classes to track that height, stays honest (Home.tsx SkeletonCard). */
 .app-pcard-body {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  align-items: center;
+  gap: 10px;
   padding: 11px 14px 12px;
   min-width: 0;
 }
 
-/* The name row: the app's icon.svg (when it has one) then the name. The icon
-   is capped BELOW the title's own line box, so a card with an icon is exactly
-   as tall as one without — Home's skeleton card reuses these classes and its
-   promise is that its height tracks the real card's (Home.tsx SkeletonCard). */
-.app-pcard-head {
+.app-pcard-lines {
   display: flex;
-  align-items: center;
-  gap: 6px;
+  flex-direction: column;
+  gap: 4px;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
-.app-pcard-icon {
+.app-pcard-icon,
+.app-pcard-star {
   flex: 0 0 auto;
-  width: 15px;
-  height: 15px;
-  /* An author's svg can declare any intrinsic size; contain keeps a wide or
-     tall one inside the square instead of stretching it. */
+  width: 34px;
+  height: 34px;
+}
+
+/* An author's svg can declare any intrinsic size; contain keeps a wide or
+   tall one inside the square instead of stretching it. */
+.app-pcard-icon {
   object-fit: contain;
+}
+
+/* The generic mark for an app with no icon.svg: muted, so it reads as the
+   slot being filled rather than as a badge on the name, and inset inside that
+   slot — an authored icon is a whole tile of artwork, a bare sparkle drawn to
+   the same 34px would shout louder than the name next to it. */
+.app-pcard-star {
+  box-sizing: border-box;
+  padding: 7px;
+  color: var(--fg-muted);
 }
 
 .app-pcard-title {

--- a/fused_render/app_listing.py
+++ b/fused_render/app_listing.py
@@ -149,6 +149,38 @@ def app_preview_image(dir_path: str) -> str | None:
     return os.path.abspath(p) if stat.S_ISREG(st.st_mode) and st.st_size > 0 else None
 
 
+# The one app icon name — `icon.svg` at the app folder's root. The same file
+# the sidebar's Projects row draws as its glyph and an app's pages serve as
+# their tab favicon (`current_apps.app_icon` delegates here), so an author who
+# drops one in gets the app's mark on every surface that lists the app rather
+# than on one at a time.
+ICON_NAME = "icon.svg"
+
+
+def app_icon(dir_path: str) -> dict | None:
+    """The app's optional icon: ``{"icon": <abs path>, "mtime": <epoch>}`` for
+    an `icon.svg` sitting directly in the folder, else None.
+
+    The mtime rides along because every reader turns this into a URL, and both
+    the browser's image cache and (far more stubbornly) its favicon cache will
+    keep serving yesterday's glyph — callers stamp it on as a cache key.
+
+    A stat, not the listdir `app_preview_image` pays for: this name is WRITTEN
+    by us (POST /api/apps/icon) rather than dropped in by hand, so there is no
+    `Icon.svg` for two filesystems to disagree about.
+
+    Never raises, like the two resolvers above it: an unreadable or vanished
+    folder is "no icon", which is exactly what a card then draws.
+    """
+    p = os.path.join(dir_path, ICON_NAME)
+    try:
+        if not os.path.isfile(p):
+            return None
+        return {"icon": os.path.abspath(p), "mtime": os.stat(p).st_mtime}
+    except OSError:
+        return None
+
+
 def app_category(dir_path: str) -> str | None:
     """The app's authored category: the `category` field of a `metadata.json`
     at the folder's root — the same per-app metadata shape the showcase repo
@@ -180,6 +212,7 @@ def app_dict(path: str, name: str, tag: str, entry_html: str | None, *,
     such ambiguity to hand back (see `app_preview_image`), so resolving it once
     in the shared shape keeps callers from having to remember it separately.
     """
+    icon = app_icon(path)
     return {
         "name": name,
         "tag": tag,
@@ -206,6 +239,12 @@ def app_dict(path: str, name: str, tag: str, entry_html: str | None, *,
         # The authored category from `metadata.json`, or None. Drives the apps
         # page's category filter; None means "All only".
         "category": app_category(path),
+        # The app's own `icon.svg` and its mtime, or None twice — the mark a
+        # card draws to the left of its name, the same file the sidebar row
+        # and the tab favicon draw. Resolved here for `preview_image`'s
+        # reason: one shape, one place, no caller left to remember it.
+        "icon": icon["icon"] if icon else None,
+        "icon_mtime": icon["mtime"] if icon else None,
         "title": entry_title(entry_html) if entry_html else None,
         # A recent-first caller already has `opened_at`, which outranks this
         # fallback timestamp. It may skip the direct-child stat sweep; the

--- a/fused_render/current_apps.py
+++ b/fused_render/current_apps.py
@@ -298,20 +298,20 @@ def _added_epoch(ts) -> float | None:
         return None
 
 
-ICON_NAME = "icon.svg"
+ICON_NAME = app_listing.ICON_NAME
 
 
 def app_icon(folder: str) -> dict | None:
     """The app's optional ``icon.svg`` — ``{"icon": <canonical path>, "mtime":
-    <epoch>}`` when the file sits directly in the app folder, else None. One
-    fixed name, no lookup table: the sidebar's Projects row and the tab favicon
-    both read it, and the mtime rides along so the client can bust the
-    browser's (aggressive) favicon cache when the author edits the file.
-    Raises OSError like the isdir it sits next to — callers already catch."""
-    p = os.path.join(folder, ICON_NAME)
-    if not os.path.isfile(p):
+    <epoch>}`` when the file sits directly in the app folder, else None. The
+    resolution itself lives in `app_listing.app_icon` (which the /apps listing
+    reads through `app_dict`, so a card carries the same mark this row does);
+    this wrapper only restates the path in the shell's canonical (forward-slash)
+    form, which every other field of a desk row is already in."""
+    found = app_listing.app_icon(folder)
+    if found is None:
         return None
-    return {"icon": canonical_fs_path(p), "mtime": os.stat(p).st_mtime}
+    return {"icon": canonical_fs_path(found["icon"]), "mtime": found["mtime"]}
 
 
 def list_apps() -> list[dict]:

--- a/fused_render/exported_apps.py
+++ b/fused_render/exported_apps.py
@@ -215,6 +215,12 @@ def _row(path: str, mtime: float | None, opened: float | None) -> dict:
         "entry_html": None,
         "preview_image": None,
         "category": None,
+        # No icon either: an `icon.svg` inside the payload would have to be
+        # streamed out of the zip (the preview's own endpoint shape), and a
+        # `.fused` is a FILE — there is no folder root to read one from. The
+        # card draws its name with no mark, which is what it did before icons.
+        "icon": None,
+        "icon_mtime": None,
         "title": None,
         "updated_at": mtime,
         "opened_at": opened,


### PR DESCRIPTION
An app's `icon.svg` was its identity in two places — the sidebar's Projects row and its own tab favicon — and nowhere on the card that lists it. Same app: itself in the sidebar, a bare name on /home and /apps.

**Server.** `app_listing.app_icon` resolves `icon.svg` at the folder root, next to `app_preview_image`, and `app_dict` reports `icon` / `icon_mtime`. One place, so the exhaustive `/api/apps` walk, registered (linked) apps and `/api/apps/home`'s recents strip all carry it. `current_apps.app_icon` keeps its canonical-path contract but delegates the resolution instead of restating the rule (direction matters — `current_apps` already imports `app_listing`). An exported `.fused` (`exported_apps._row`) reports `null`: it is a file, with no folder root to read an icon from.

**Card.** `AppPreviewCard` is the single card `/home`, `/apps` and the onboarding first-app step all render, so the mark lands on all three at once. It sits left of the name, drawn as is — the author's colours, no mask or tint (the sidebar's rule) — and is a COLUMN of the card's head, 32px, spanning the name and the meta row beneath it: the body is a flex row now, with the two text lines in `.app-pcard-lines`. The head tightened around it (8px/11px/9px, 9px gap), and 32px is deliberately under the two lines it spans (~16px name + 4px gap + ~16px meta), so the mark never drives the card's height. `draggable={false}` for the reason the still's shield exists: an `<img>` carries the browser's native drag gesture, which would start a drag instead of the click that opens the card.

**Fallback.** An app with no `icon.svg` gets the same generic mark the sidebar row falls back to, the brand's four-point star — muted and inset in its slot, since a bare sparkle at a full icon tile's size shouts louder than the name beside it. Every card carries a mark, so no name shifts left for the want of a file.

Two things fell out of the row layout: `min-width: 0` moved off `.app-pcard-title` onto `.app-pcard-lines` (in a column flex the automatic minimum size is main-axis only, so the title's copy was dead — the guard that lets a long name ellipsise rather than push the mark out is the box beside the mark), and Home's `SkeletonCard` grew the same `.app-pcard-lines` wrapper plus a shimmer square in the mark's slot. Unlike the folder variant's static glyph, WHICH mark the real card draws arrives with the fetch, so that shimmer claims something true — and without it the skeleton's text started 42px left of the real card's and jumped sideways on the swap.

## Test plan

- `/apps` and `/home`: an app with an `icon.svg` shows it left of its name, spanning the name and the tag/time row; one without shows the star. Owner-verified live.
- Pick a new icon from the sidebar row, then reload `/apps` — the card shows the new glyph (mtime cache key).
- A long app name still ellipsises without pushing the mark out; card heights match the loading skeletons.
- A `.fused` card (Fused-App tag) shows the star.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
