### PR TITLE
The app page's header carries the app's mark, and picks it

### DIFF
--- a/frontend/src/platform/lib/app-icon.ts
+++ b/frontend/src/platform/lib/app-icon.ts
@@ -1,0 +1,44 @@
+// Writing an app's `icon.svg` from an icon-picker pick — the one place the
+// pick → disk rule lives, because two surfaces now offer it: the sidebar's
+// Projects row (its glyph is the picker's toggle) and the app page's header
+// mark. The READ side needs no sharing; every surface already draws the file
+// through `appIconUrl`.
+import type { IconPick } from "@platform/ui/IconPicker";
+import { removeAppIcon, setAppIcon } from "@platform/lib/api";
+import { announceCurrentAppsChanged } from "@platform/lib/tasksChanged";
+
+/** The picked emoji as a standalone icon.svg document — square viewBox, no
+ *  fixed size, transparent ground (a colour emoji carries its own colours, so
+ *  it reads on both themes; see skills/fused-render-app-icon). The same file
+ *  a hand-authored icon.svg would be, just generated. */
+export function emojiIconSvg(emoji: string): string {
+  const safe = emoji
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">' +
+    '<text x="32" y="32" text-anchor="middle" dominant-baseline="central" ' +
+    `font-size="52">${safe}</text></svg>`
+  );
+}
+
+/** Apply an icon picker's answer to the app folder at `path`: `null` removes
+ *  the file (back to the generic mark), an icon pick is stored as the finished
+ *  branded svg it arrives as, and an emoji gets the standalone wrapper above.
+ *
+ *  Announces the desk change on success, and that is the reason this is shared
+ *  rather than two call sites: the sidebar's Projects row for this app is on
+ *  screen while the app page's own mark is picked, and it only refetches on
+ *  that event — without it the row keeps yesterday's glyph until something
+ *  else pokes it. Throws whatever the write threw; the caller reports it (a
+ *  failed write leaves the old icon, and a refetch shows the truth). */
+export async function applyIconPick(
+  path: string,
+  pick: IconPick | null,
+): Promise<void> {
+  if (pick === null) await removeAppIcon(path);
+  else if (pick.kind === "icon") await setAppIcon(path, pick.svg);
+  else await setAppIcon(path, emojiIconSvg(pick.emoji));
+  announceCurrentAppsChanged();
+}

--- a/frontend/src/platform/ui/AppPreviewCard.tsx
+++ b/frontend/src/platform/ui/AppPreviewCard.tsx
@@ -37,6 +37,7 @@ import type { AppInfo } from "@platform/lib/api";
 import { appIconUrl, appfilePreviewUrl, rawUrl } from "@platform/lib/api";
 import { exportAppFile } from "@platform/lib/appShot";
 import { pushToast } from "@platform/lib/toast";
+import { AppStar } from "@platform/ui/AppStar";
 import { MenuIcons } from "@platform/ui/MenuIcons";
 import { thumbFrame } from "@platform/lib/thumb-frame";
 import { embedUrlForFsPath, navigateUrl } from "@platform/lib/router";
@@ -244,18 +245,10 @@ export function AppPreviewCard({
             draggable={false}
           />
         ) : (
-          // The generic mark, one drawing shared with the sidebar
-          // (CurrentAppsSection's `current-app-star`): the app icon's own
-          // sparkle, on currentColor so it takes the card's muted tone
-          // rather than competing with the name beside it.
-          <svg
-            className="app-pcard-star"
-            viewBox="0 0 64 64"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <path d="M32 2 C36.5 20.5 43.5 27.5 62 32 C43.5 36.5 36.5 43.5 32 62 C27.5 43.5 20.5 36.5 2 32 C20.5 27.5 27.5 20.5 32 2 Z" />
-          </svg>
+          // The generic mark (AppStar — the same drawing the sidebar row and
+          // the app page's header show), on currentColor so it takes the
+          // card's muted tone rather than competing with the name beside it.
+          <AppStar className="app-pcard-star" />
         )}
         {/* The two text lines, stacked beside the icon rather than under it —
             the icon is a column of the head, spanning both (owner). Their own

--- a/frontend/src/platform/ui/AppStar.tsx
+++ b/frontend/src/platform/ui/AppStar.tsx
@@ -1,0 +1,16 @@
+// The generic app mark: the brand's four-point star (the app icon's own
+// sparkle), drawn on `currentColor` so each host tints it with its own tokens.
+// What an app WITHOUT an `icon.svg` shows — the sidebar's Projects row, the
+// /apps and /home cards, the app page's header. Three hosts, one path, since
+// the third copy of a 200-character bezier is where it stops being a coincidence.
+//
+// Sizing and colour stay with the host (its own class): the row's is 12px and
+// follows the row state (muted at rest, accent when active), the card's and
+// the page's are a whole slot beside the name.
+export function AppStar(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 64 64" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M32 2 C36.5 20.5 43.5 27.5 62 32 C43.5 36.5 36.5 43.5 32 62 C27.5 43.5 20.5 36.5 2 32 C20.5 27.5 27.5 20.5 32 2 Z" />
+    </svg>
+  );
+}

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -76,7 +76,10 @@ import { AppStar } from "@platform/ui/AppStar";
 import IconPicker, { type IconPick } from "@platform/ui/IconPicker";
 import { applyIconPick } from "@platform/lib/app-icon";
 import { pushToast } from "@platform/lib/toast";
-import { announceTasksChanged } from "@platform/lib/tasksChanged";
+import {
+  announceTasksChanged,
+  CURRENT_APPS_CHANGED_EVENT,
+} from "@platform/lib/tasksChanged";
 import { appLandingUrl } from "@platform/lib/appLanding";
 import { Button } from "@platform/shadcn/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@platform/shadcn/ui/tabs";
@@ -260,6 +263,16 @@ export default function AppPage({
   useEffect(() => {
     setIconHref(null);
     loadIcon();
+  }, [loadIcon]);
+  // The icon can also be changed from the OTHER end of the same app — the
+  // sidebar's Projects glyph, whose picker writes the same file while this
+  // page is the one on screen. It pokes the desk on a successful write
+  // (applyIconPick), so the poke is the signal to re-read: without this the
+  // header's mark and the tab favicon both kept the old glyph until the next
+  // navigation, and only a pick made HERE ever looked refreshed.
+  useEffect(() => {
+    window.addEventListener(CURRENT_APPS_CHANGED_EVENT, loadIcon);
+    return () => window.removeEventListener(CURRENT_APPS_CHANGED_EVENT, loadIcon);
   }, [loadIcon]);
   useFavicon(iconHref);
 

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -41,6 +41,7 @@
 // must not reload it. The frame stays mounted behind the Tasks tab for the
 // same reason (display:none, not unmount).
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -71,6 +72,10 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
+import { AppStar } from "@platform/ui/AppStar";
+import IconPicker, { type IconPick } from "@platform/ui/IconPicker";
+import { applyIconPick } from "@platform/lib/app-icon";
+import { pushToast } from "@platform/lib/toast";
 import { announceTasksChanged } from "@platform/lib/tasksChanged";
 import { appLandingUrl } from "@platform/lib/appLanding";
 import { Button } from "@platform/shadcn/ui/button";
@@ -226,24 +231,63 @@ export default function AppPage({
   useUrlVersion();
   const tab = appPageTabFromSearch(location.search);
 
-  // The tab favicon is the app's optional icon.svg while its page is open
-  // (`/api/apps/icon`; the same file the Projects row draws). Guarded by
-  // `live` like the resolve below, so a fast switch between two apps cannot
-  // paint the first one's icon over the second.
+  // The app's optional icon.svg (`/api/apps/icon`; the same file the Projects
+  // row draws) — the header's mark AND, through useFavicon, the tab icon while
+  // this page is open. One state for both, and one refetch after a pick: the
+  // POST answers `{path, replaced}` with no mtime, and the mtime is exactly
+  // what busts the browser's image and (far more stubborn) favicon caches, so
+  // an optimistic set would show the old glyph under a new URL-less src.
   const [iconHref, setIconHref] = useState<string | null>(null);
-  useEffect(() => {
-    let live = true;
-    setIconHref(null);
+  // The generation token stands in for the effect's usual `live` flag: a pick
+  // reloads outside any effect, and a bare boolean captured per-effect cannot
+  // cancel THAT read when the folder changes under it. A stale response is one
+  // whose token is no longer current, whoever asked for it — which is also
+  // what keeps a fast switch between two apps from painting the first one's
+  // icon over the second.
+  const iconGenRef = useRef(0);
+  const loadIcon = useCallback(() => {
+    const gen = ++iconGenRef.current;
     getAppIcon(dir)
       .then((r) => {
-        if (live) setIconHref(r.icon ? appIconUrl(r.icon, r.mtime) : null);
+        if (iconGenRef.current === gen) {
+          setIconHref(r.icon ? appIconUrl(r.icon, r.mtime) : null);
+        }
       })
-      .catch(() => live && setIconHref(null));
-    return () => {
-      live = false;
-    };
+      .catch(() => {
+        if (iconGenRef.current === gen) setIconHref(null);
+      });
   }, [dir]);
+  useEffect(() => {
+    setIconHref(null);
+    loadIcon();
+  }, [loadIcon]);
   useFavicon(iconHref);
+
+  // ---- the header mark's icon picker -----------------------------------------
+  // The same picker the sidebar's Projects row opens from its glyph (the emoji
+  // + branded-lucide IconPicker), anchored to the mark that opened it, writing
+  // the same `icon.svg` through the same shared rule (applyIconPick, which also
+  // pokes the sidebar so that row's glyph changes with this one). Its own
+  // toggle selector: both glyphs are on screen together, and a loose selector
+  // means each leaves the other's picker open (IconPicker's own note).
+  const [iconAnchor, setIconAnchor] = useState<{ top: number; left: number } | null>(
+    null,
+  );
+  const onPickIcon = async (pick: IconPick | null) => {
+    setIconAnchor(null);
+    try {
+      await applyIconPick(dir, pick);
+    } catch (e) {
+      // Louder than the sidebar's silent swallow: this mark is a deliberate
+      // click on a page-level action, and a header that simply doesn't change
+      // reads as the page being broken rather than the write having failed.
+      pushToast({
+        msg: "Could not change the icon: " + (e as Error).message,
+        tone: "error",
+      });
+    }
+    loadIcon();
+  };
 
   useEffect(() => {
     let live = true;
@@ -432,12 +476,41 @@ export default function AppPage({
     <div className="app-page">
       <header className="app-page-head">
         <div className="app-page-title">
-          <h1>{slug}</h1>
-          {/* Reads as the folder and IS the folder: opens its listing in the
-              explorer. The app itself is the "Open app" button opposite. */}
-          <a className="app-page-folder" href={folderHref} title={dir}>
-            {tildePath(dir, home)}
-          </a>
+          {/* The app's mark, and the way to change it: a click opens the same
+              icon picker the sidebar's Projects row does (below). The app's
+              own icon.svg drawn as is — the author's colours, no tint — or
+              the generic star when it has none, which is also the affordance
+              for an app that has never had an icon. */}
+          <button
+            type="button"
+            className="app-page-icon app-page-icon-toggle"
+            title="Change icon"
+            aria-label="Change icon"
+            onClick={(e) => {
+              const rect = e.currentTarget.getBoundingClientRect();
+              setIconAnchor((cur) =>
+                cur ? null : { top: rect.top, left: rect.left },
+              );
+            }}
+          >
+            {iconHref ? (
+              <img src={iconHref} alt="" draggable={false} />
+            ) : (
+              <AppStar />
+            )}
+          </button>
+          {/* The name and the folder keep their own baseline row: the mark is
+              a column beside the PAIR (it centers against both), and a
+              baseline-aligned box in the same row would drop the text off
+              center against it. */}
+          <div className="app-page-name">
+            <h1>{slug}</h1>
+            {/* Reads as the folder and IS the folder: opens its listing in the
+                explorer. The app itself is the "Open app" button opposite. */}
+            <a className="app-page-folder" href={folderHref} title={dir}>
+              {tildePath(dir, home)}
+            </a>
+          </div>
         </div>
         {entry && (
           <div className="app-page-actions">
@@ -489,6 +562,15 @@ export default function AppPage({
           </div>
         )}
       </header>
+      {iconAnchor && (
+        <IconPicker
+          anchor={iconAnchor}
+          toggleSelector=".app-page-icon-toggle"
+          onPick={(pick) => onPickIcon(pick)}
+          onRemove={() => onPickIcon(null)}
+          onClose={() => setIconAnchor(null)}
+        />
+      )}
       {migrateError && (
         <ErrorBanner>Could not create the migration task: {migrateError}</ErrorBanner>
       )}

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -29,12 +29,12 @@ import {
   getCurrentApps,
   openCurrentApp,
   readCurrentAppTasks,
-  removeAppIcon,
   removeCurrentApp,
   renameCurrentApp,
-  setAppIcon,
   type CurrentAppEntry,
 } from "@platform/lib/api";
+import { applyIconPick } from "@platform/lib/app-icon";
+import { AppStar } from "@platform/ui/AppStar";
 import IconPicker, { type IconPick } from "@platform/ui/IconPicker";
 import { embedUrlForFsPath, navigateUrl } from "@platform/lib/router";
 import { pushToast } from "@platform/lib/toast";
@@ -68,22 +68,6 @@ export const ORDER_KEY = "fused-render:current-apps-order:v2";
 // /api/current-apps/open lands, so the other windows' sections refetch the
 // desk (the server row is the truth; this only says "look again").
 export const DESK_CHANGED_KEY = "fused-render:current-apps-changed";
-
-/** The picked emoji as a standalone icon.svg document — square viewBox, no
- *  fixed size, transparent ground (a colour emoji carries its own colours, so
- *  it reads on both themes; see skills/fused-render-app-icon). The same file
- *  a hand-authored icon.svg would be, just generated. */
-function emojiIconSvg(emoji: string): string {
-  const safe = emoji
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-  return (
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">' +
-    '<text x="32" y="32" text-anchor="middle" dominant-baseline="central" ' +
-    `font-size="52">${safe}</text></svg>`
-  );
-}
 
 // The section fold, "1" when hidden — the Bookmarks section's own key pattern.
 export const COLLAPSED_KEY = "fused-render:current-apps-collapsed";
@@ -319,20 +303,12 @@ function CurrentAppRow({
             draggable={false}
           />
         ) : (
-          // The brand's four-point star (the app icon's sparkle) as the
-          // generic mark, on currentColor so it follows the glyph's tokens
+          // The brand's four-point star (AppStar — the app icon's sparkle, the
+          // same drawing the /apps cards and the app page's header show) as
+          // the generic mark, on currentColor so it follows the glyph's tokens
           // (muted at rest, accent on the active row) — the SidebarFrame
           // cube's own posture.
-          <svg
-            className="current-app-star"
-            width="12"
-            height="12"
-            viewBox="0 0 64 64"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <path d="M32 2 C36.5 20.5 43.5 27.5 62 32 C43.5 36.5 36.5 43.5 32 62 C27.5 43.5 20.5 36.5 2 32 C20.5 27.5 27.5 20.5 32 2 Z" />
-          </svg>
+          <AppStar className="current-app-star" width={12} height={12} />
         )}
       </span>
       <a
@@ -596,11 +572,10 @@ export default function CurrentAppsSection() {
     setIconPicker(null);
     if (!target) return;
     try {
-      if (pick === null) await removeAppIcon(target.path);
-      // An icon pick arrives as the finished branded svg; an emoji gets the
-      // same standalone wrapper a hand-authored icon.svg would have.
-      else if (pick.kind === "icon") await setAppIcon(target.path, pick.svg);
-      else await setAppIcon(target.path, emojiIconSvg(pick.emoji));
+      // The pick → disk rule is shared with the app page's header mark
+      // (platform/lib/app-icon): remove, or store the svg an icon pick
+      // arrives as, or wrap an emoji in one.
+      await applyIconPick(target.path, pick);
     } catch {
       // A failed write leaves the old glyph; the refetch shows the truth.
     }

--- a/frontend/src/styles/app-page.css
+++ b/frontend/src/styles/app-page.css
@@ -27,11 +27,61 @@
   padding: 14px 0 10px;
 }
 
+/* Mark, then the name/folder pair. CENTER, not baseline: the mark is a square
+   beside both lines of text, and a baseline-aligned box in the same row would
+   sit on the name's baseline and drag the pair off center against it. The
+   baseline row the header always had is `.app-page-name` inside this. */
 .app-page-title {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.app-page-name {
   min-width: 0;
   display: flex;
   align-items: baseline;
   gap: 12px;
+}
+
+/* The app's mark and the icon picker's toggle in one: a plain button, since
+   nothing here wraps it in a link (the sidebar's glyph is a span for exactly
+   that reason). 26px against the 18px name — the same posture as the card's
+   mark, sized to the text beside it rather than the other way round. */
+.app-page-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+
+.app-page-icon:hover {
+  background: var(--bg-alt);
+  color: var(--fg);
+}
+
+.app-page-icon img {
+  width: 100%;
+  height: 100%;
+  /* An author's svg can declare any intrinsic size; contain keeps a wide or
+     tall one inside the square instead of stretching it. */
+  object-fit: contain;
+}
+
+/* The generic star (AppStar) is a bare sparkle where an authored icon is a
+   whole tile of artwork — inset, so it does not shout louder than the name. */
+.app-page-icon svg {
+  width: 16px;
+  height: 16px;
 }
 
 .app-page-title h1 {


### PR DESCRIPTION
Follows #1044 (the card mark), now merged; rebased onto main.

`/apps/<path>` named the app in text alone while its own tab favicon was already drawing its `icon.svg`. The header now shows that mark left of the name, and clicking it opens the SAME picker the sidebar's Projects row opens — so the one place an app is examined is also a place its icon can be set.

**The fetch it already had.** The page resolved the icon for the favicon; that became a `loadIcon` the pick calls again. Nothing is set optimistically: `POST /api/apps/icon` answers `{path, replaced}` with no mtime, and the mtime is what busts the browser's image and (far more stubborn) favicon caches — so the refetch IS the update, one state feeding the header mark and the tab icon both. Its staleness guard moved from a per-effect `live` flag to a generation token: a pick reloads outside any effect, and a captured boolean cannot cancel that read when the folder changes under it.

**Two extractions, each for a second caller rather than on principle.**
- `platform/lib/app-icon` — `emojiIconSvg` + `applyIconPick` (remove / store the branded svg / wrap an emoji). It also pokes the desk, which is the point of sharing it: the sidebar row for this same app is on screen while the header's mark is picked, and it only refetches on that event, so without the poke that row keeps the old glyph.
- `platform/ui/AppStar` — the generic mark's path, now that the sidebar row, the cards and this header all draw it. Size and colour stay with each host (12px following the row's state; a slot beside the name on the card and the page).

**Layout.** `.app-page-title` was `align-items: baseline`; a square in that row would sit on the name's baseline and drag the text off center against it, so the name and its folder caption keep their own baseline row (`.app-page-name`) and the mark centers against the pair. 26px against the 18px name, with a hover plate so it reads clickable.

A failed write toasts here rather than being swallowed the way the sidebar's tiny glyph can afford: a page-level action whose header simply doesn't change reads as the page being broken.

**Also here:** picking an icon from the sidebar's Projects glyph while that app's page was open left the header mark and the tab favicon on the old glyph — only a pick made on the page called `loadIcon`. The write already pokes the desk, so the page listens for that poke and re-reads: same signal both directions.

Still stale after a sidebar pick, deliberately: the `/apps` and `/home` grid cards, whose data is the whole catalog listing — refetching that on every desk poke is heavier than the fix deserves.

## Test plan

- `/apps/<path>` for an app with an `icon.svg`: mark left of the name, matching the tab favicon; for one without: the generic star.
- Click the mark → picker opens anchored to it; pick an emoji, then a lucide icon → header updates, tab favicon updates, and the sidebar's Projects row for the same app changes with it.
- Remove → back to the star, in both places.
- The sidebar's own glyph picker still opens and closes independently (separate toggle selectors).
- A long app name still ellipsises; the header's height is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes around app icon display and client-side writes to existing icon APIs, with no auth or backend contract changes.
> 
> **Overview**
> The app page header now shows the app’s **`icon.svg`** (or the generic star) beside the name, and **clicking it opens the same `IconPicker`** the sidebar Projects row uses. Picks persist via new shared **`applyIconPick`** in `platform/lib/app-icon` (remove / branded SVG / emoji-wrapped SVG) and **`announceCurrentAppsChanged`** so the sidebar row and header stay in sync when either surface changes the icon.
> 
> Icon loading is refactored to a **`loadIcon` callback** with a **generation token** (instead of a per-effect `live` flag) so post-pick refetches and folder switches don’t race; the page **listens for `CURRENT_APPS_CHANGED_EVENT`** to refresh the header mark and tab favicon without optimistic updates (mtime busts image/favicon cache). Failed writes on the app page **toast**; sidebar behavior is unchanged aside from calling the shared helper.
> 
> **`AppStar`** centralizes the default four-point star SVG for the sidebar row, app cards, and app page header. **`app-page.css`** lays out the clickable 26px mark centered against the name/folder pair in **`.app-page-name`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccbbef9b2ce0740ed5e3ef15f60eae7fe0a9a9ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
