### PR TITLE
Icon picker: shuffle applies without closing the popover

### DIFF
--- a/frontend/src/apps/explorer/sidebar/BookmarksSection.tsx
+++ b/frontend/src/apps/explorer/sidebar/BookmarksSection.tsx
@@ -506,7 +506,6 @@ export default function BookmarksSection() {
   // nowhere to live here.
   const onPickIcon = async (pick: IconPick | null) => {
     const target = iconPicker;
-    setIconPicker(null);
     if (target) {
       await setBookmarkIcon(target.id, pick && pick.kind === "emoji" ? pick.emoji : null);
       notifyBookmarksChanged();

--- a/frontend/src/platform/ui/IconPicker.tsx
+++ b/frontend/src/platform/ui/IconPicker.tsx
@@ -4,6 +4,10 @@
 // button that picks at random from the active tab, a Recent row per tab, and
 // a Remove action that restores the caller's default glyph.
 //
+// The picker owns when it closes, not the caller: a pick from the grid (or
+// Enter, or Remove) applies and closes, while the shuffle button applies and
+// stays open — a random draw is meant to be redrawn until one lands.
+//
 // Pure presentation — the caller owns positioning (anchor rect) and persists
 // the pick. Both data sets load lazily on first open: `emojibase-data` and the
 // vanilla `lucide` package are imported by nothing else in the shell, so they
@@ -36,6 +40,9 @@ export type IconPick =
 interface IconPickerProps {
   /** Viewport rect of the glyph that opened the picker. */
   anchor: { top: number; left: number };
+  /** Called for every applied pick — a grid choice, Enter, or a shuffle. The
+   *  picker calls `onClose` itself for the first two, so a host must NOT close
+   *  from here: shuffle applies without closing. */
   onPick: (pick: IconPick) => void;
   onRemove: () => void;
   onClose: () => void;
@@ -386,11 +393,26 @@ export default function IconPicker({
     [tab, onPick],
   );
 
+  // Choosing from the grid is the deliberate pick: apply it and close.
+  const pickAndClose = useCallback(
+    (cell: Cell) => {
+      pick(cell);
+      onClose();
+    },
+    [pick, onClose],
+  );
+
   // Random draws from the whole tab, not the filtered view: "surprise me"
-  // shouldn't depend on what happens to be typed in the box.
+  // shouldn't depend on what happens to be typed in the box. It applies the
+  // draw and leaves the popover open so it can be pressed again — the one
+  // action here that doesn't close. The Recent row deliberately doesn't grow
+  // under the cursor mid-shuffle (it is re-read on a tab or query change).
   const random = () => {
     if (all.length === 0) return;
     pick(all[Math.floor(Math.random() * all.length)]);
+    // A mouse click puts focus on the button; hand it back to the filter box
+    // so arrow-key navigation and typing keep working after a shuffle.
+    searchInput()?.focus();
   };
 
   const moveActive = (delta: number) => {
@@ -420,7 +442,7 @@ export default function IconPicker({
         break;
       case "Enter":
         e.preventDefault();
-        if (flat[activeIdx]) pick(flat[activeIdx]);
+        if (flat[activeIdx]) pickAndClose(flat[activeIdx]);
         break;
       // Escape is handled by the document-level listener (closes the popover).
     }
@@ -467,7 +489,10 @@ export default function IconPicker({
           size="sm"
           className="text-muted-foreground"
           title="Reset to the default glyph"
-          onClick={onRemove}
+          onClick={() => {
+            onRemove();
+            onClose();
+          }}
         >
           Remove
         </Button>
@@ -548,7 +573,7 @@ export default function IconPicker({
                     tabIndex={-1}
                     data-slot="icon-picker-cell"
                     title={cell.title}
-                    onClick={() => pick(cell)}
+                    onClick={() => pickAndClose(cell)}
                     className={cn(
                       "flex size-8 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-[19px] leading-none text-foreground hover:bg-muted",
                       isActive && "bg-muted ring-2 ring-ring ring-inset",

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -286,8 +286,9 @@ export default function AppPage({
   const [iconAnchor, setIconAnchor] = useState<{ top: number; left: number } | null>(
     null,
   );
+  // The picker decides when it closes (a shuffle leaves it open), so this only
+  // writes.
   const onPickIcon = async (pick: IconPick | null) => {
-    setIconAnchor(null);
     try {
       await applyIconPick(dir, pick);
     } catch (e) {

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -567,9 +567,10 @@ export default function CurrentAppsSection() {
     },
     [],
   );
+  // Closing is the picker's own call (it stays open on a shuffle), so this
+  // only writes.
   const onPickIcon = async (pick: IconPick | null) => {
     const target = iconPicker;
-    setIconPicker(null);
     if (!target) return;
     try {
       // The pick → disk rule is shared with the app page's header mark


### PR DESCRIPTION
The shuffle button in the icon picker applied a random glyph **and closed the popover**, so a draw you did not like meant reopening the picker to draw again. Now shuffle applies and stays open — press it until one lands. Picking from the grid (or Enter, or Remove) still closes, as before.

### The change

Closing moved out of the three hosts and into `IconPicker` — the only place that knows which action a pick came from:

- `pickAndClose` (grid click / Enter) and Remove call `onClose()`; `random()` deliberately doesn't.
- `onPickIcon` in `CurrentAppsSection`, `AppPage` and `BookmarksSection` now only writes; each dropped its `setIconPicker(null)` / `setIconAnchor(null)`.
- Shuffle re-focuses the filter box afterwards — a mouse click had taken focus to the button, which killed arrow-key navigation and typing now that the popover survives the click.

The Recent row does not grow under the cursor mid-shuffle (it is re-read on a tab or query change) — deliberate, so the grid does not reflow while you press.

### Surfaces

All three hosts of the shared component: the Projects sidebar rows' glyph, the app page header mark (both surfaces the ask named), and the explorer's bookmarks — leaving bookmarks on the old behavior would make the same button act differently per surface.

### Smoke

Owner-verified live. Worth checking: the popover survives the write's refetch (`refetch()` / `loadIcon()` re-render the anchor glyph, and the picker closes on any outside scroll event) on both the sidebar row and the app page header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI interaction change in the icon picker and its three call sites; no auth, data, or API contract changes.
> 
> **Overview**
> **Shuffle** in the shared `IconPicker` now applies a random glyph **without** closing the popover, so users can redraw until they like one. **Grid click**, **Enter**, and **Remove** still apply and close via new `pickAndClose` / explicit `onClose()` inside the picker.
> 
> Closing responsibility moved **into** `IconPicker` instead of each host clearing anchor state in `onPick`: `BookmarksSection`, `CurrentAppsSection`, and `AppPage` only persist picks now. Docs on `onPick` warn hosts not to close on shuffle.
> 
> After shuffle, focus returns to the filter field so keyboard navigation keeps working while the popover stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d1224727f950dba11a50c8c46e9f9391fab701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->