### PR TITLE
Folder rename carries the Claude chats along, so the pane lists them at once

### DIFF
--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -1,5 +1,6 @@
 import ctypes
 import datetime
+import logging
 import errno
 import json
 import os
@@ -27,6 +28,8 @@ from fused_render.server.gitignore import _is_repo_root
 from fused_render.server.index_touch import note_index_mutation
 from fused_render.server.mount import _invalidate_stat_cache, _is_under_snapshot_root, _mount_probe, _mount_stat_payload, _mutation_result_payload, _probe_path, _stat_payload, _writable
 from fused_render.server.walk import _mount_list_error_response
+
+logger = logging.getLogger(__name__)
 
 
 # An ABSOLUTE git path is required to reach posix_spawn, not merely tidy: CPython
@@ -1345,6 +1348,33 @@ def _fs_rename(body: dict, x_fused: str | None):
         shutil.move(src, dst)
     except OSError as e:
         return _error(f"cannot rename {src} -> {dst}: {e}")
+    # A FOLDER moved: carry its Claude chats and app state along NOW (Akshil,
+    # 2026-09-07 — "rename a folder, go into it, recent chats don't show up;
+    # reload and they do"). The settle used to ride the next /render of the
+    # app's entry page (app_fused_dir.ensure via record_app_open), a request
+    # unordered against the chat pane's one read of the session list — and one
+    # that never fires while the companion pane is what opened the folder
+    # (`_noopen`). Same two doors /api/current-apps/rename uses: the witness
+    # (`.fused/meta.json` naming the old path) settles through `ensure`'s full
+    # machinery; a folder with no witness settles best-effort by hand.
+    if os.path.isdir(dst) and not os.path.islink(dst):
+        try:
+            from fused_render import (app_fused_dir, app_state_move,
+                                      claude_session_move)
+
+            s0, d0 = os.path.abspath(src), os.path.abspath(dst)
+            recorded = app_fused_dir.recorded_app_dir(d0)
+            if recorded and (os.path.normcase(os.path.abspath(recorded))
+                             == os.path.normcase(s0)):
+                app_fused_dir.ensure(d0)
+            else:
+                app_state_move.rewrite_stores(s0, d0)
+                claude_session_move.relocate(s0, d0)
+        except Exception:
+            # The rename itself is done and must answer OK; the chats not
+            # following is worth a line in the log, not a failed move.
+            logger.warning("rename %s -> %s: chat/app-state settle failed",
+                           src, dst, exc_info=True)
     # A WHOLE app folder moved: record both sides in the shared repo, or the
     # old name's deletion sits uncommitted forever (see _record_app_removal).
     # The dst-only case is the RESTORE path — undo-from-trash comes back as a

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -1199,7 +1199,12 @@ def _fs_trash_move(body: dict, x_fused: str | None):
     info_out = _xdg_trash_entry_info(src)   # leaving the trash → drop its sidecar
     info_in = _xdg_trash_entry_info(dst)    # entering the trash → write one
 
-    result = _fs_rename({"src": src, "dst": dst, "overwrite": False}, x_fused)
+    # `settle=False`: a trip into or out of the bin is not a move the chats
+    # follow (Bugbot, PR #1048) — rehoming them under a trash path would leave
+    # them pointing at nothing after an OS-level restore. The sessions stay
+    # keyed to the folder's real path and are there again when it comes back.
+    result = _fs_rename({"src": src, "dst": dst, "overwrite": False}, x_fused,
+                        settle=False)
     # Any refusal comes back verbatim and the sidecars are left exactly as they
     # were: nothing moved, so nothing about the bin's bookkeeping has changed.
     if isinstance(result, JSONResponse):
@@ -1245,7 +1250,7 @@ def _fs_trash_move(body: dict, x_fused: str | None):
     return result
 
 
-def _fs_rename(body: dict, x_fused: str | None):
+def _fs_rename(body: dict, x_fused: str | None, *, settle: bool = True):
     # Move/rename src -> dst. dst must be absolute and its parent writable
     # (same "outside"/readonly guards as elsewhere). An existing dst is a 409
     # unless overwrite=true; a missing src is a 404. shutil.move handles the
@@ -1357,7 +1362,7 @@ def _fs_rename(body: dict, x_fused: str | None):
     # (`_noopen`). Same two doors /api/current-apps/rename uses: the witness
     # (`.fused/meta.json` naming the old path) settles through `ensure`'s full
     # machinery; a folder with no witness settles best-effort by hand.
-    if os.path.isdir(dst) and not os.path.islink(dst):
+    if settle and os.path.isdir(dst) and not os.path.islink(dst):
         try:
             from fused_render import (app_fused_dir, app_state_move,
                                       claude_session_move)

--- a/tests/test_server_fs_mutate.py
+++ b/tests/test_server_fs_mutate.py
@@ -1020,6 +1020,16 @@ def test_rename_dir_settles_the_claude_chats_now(tmp_path, monkeypatch):
     src2.mkdir()
     out = _data(RENAME({"src": str(src2), "dst": str(dst2)}, x_fused="1"))
     assert out["is_dir"] is True and dst2.is_dir()
+    # a trip through the bin is not a move the chats follow (Bugbot, PR #1048)
+    calls.clear()
+    monkeypatch.setattr(claude_session_move, "relocate",
+                        lambda a, b: calls.append(("relocate", a, b)))
+    src3 = tmp_path / "t1"
+    src3.mkdir()
+    trash = tmp_path / "Trash" / "files"
+    trash.mkdir(parents=True)
+    _data(TRASH_MOVE({"from": str(src3), "to": str(trash / "t1")}, x_fused="1"))
+    assert calls == []
     # a FILE rename has no chats to carry
     calls.clear()
     f = tmp_path / "a.txt"

--- a/tests/test_server_fs_mutate.py
+++ b/tests/test_server_fs_mutate.py
@@ -994,6 +994,40 @@ def test_rename_dir(tmp_path):
     assert out["is_dir"] is True
 
 
+def test_rename_dir_settles_the_claude_chats_now(tmp_path, monkeypatch):
+    """Akshil, 2026-09-07: rename a folder, open it, "Recent chats" is empty
+    until a reload. The migration rode the NEXT /render of the app entry — a
+    request unordered against the chat pane's read (and one the companion pane
+    never issues). The rename itself now relocates the chats and app state."""
+    from fused_render import app_state_move, claude_session_move
+
+    calls = []
+    monkeypatch.setattr(claude_session_move, "relocate",
+                        lambda a, b: calls.append(("relocate", a, b)))
+    monkeypatch.setattr(app_state_move, "rewrite_stores",
+                        lambda a, b: calls.append(("stores", a, b)))
+    src = tmp_path / "d1"
+    src.mkdir()
+    (src / "c").write_text("x")
+    dst = tmp_path / "d2"
+    _data(RENAME({"src": str(src), "dst": str(dst)}, x_fused="1"))
+    assert ("stores", str(src), str(dst)) in calls
+    assert ("relocate", str(src), str(dst)) in calls
+    # a settle that blows up is logged, and the rename still answers OK
+    monkeypatch.setattr(claude_session_move, "relocate",
+                        lambda a, b: (_ for _ in ()).throw(RuntimeError("boom")))
+    src2, dst2 = tmp_path / "e1", tmp_path / "e2"
+    src2.mkdir()
+    out = _data(RENAME({"src": str(src2), "dst": str(dst2)}, x_fused="1"))
+    assert out["is_dir"] is True and dst2.is_dir()
+    # a FILE rename has no chats to carry
+    calls.clear()
+    f = tmp_path / "a.txt"
+    f.write_text("y")
+    _data(RENAME({"src": str(f), "dst": str(tmp_path / "b.txt")}, x_fused="1"))
+    assert calls == []
+
+
 def test_rename_missing_src_404(tmp_path):
     resp = RENAME({"src": str(tmp_path / "ghost"), "dst": str(tmp_path / "x")}, x_fused="1")
     assert _status(resp) == 404


### PR DESCRIPTION
## Summary
Rename or move a folder in Fused Render → open it → Claude pane showed no recent chats until a reload.

**Root cause**: `POST /api/fs/rename` moved the files but never migrated the Claude sessions. The only migration trigger was the *app open* one (`/render` of the app entry → `record_app_open → app_fused_dir.ensure`), which (a) races the chat pane's single session-list read and (b) never fires when the Claude companion pane is what opened the folder (`_noopen`). A reload happened to land after that render.

**Change — new triggers, app trigger kept as is**:
- The app-open trigger (`record_app_open → ensure`) is untouched.
- `POST /api/fs/rename` — every Fused Render folder **rename** and **move** (Explorer rename, drag-and-drop move, cut/paste, Preview rename, undo of those) — now settles the chats itself: `app_fused_dir.ensure` when `.fused/meta.json` witnesses the old path, else `app_state_move.rewrite_stores` + `claude_session_move.relocate`. Directories only; a failed settle is logged, the rename still answers OK.
- Trash moves (`/api/fs/trash-move`: delete, undo/redo of delete) deliberately do **not** settle — chats stay keyed to the folder's real path so an OS-level restore still finds them (Bugbot).

## Tests
- `tests/test_server_fs_mutate.py`: dir rename → `rewrite_stores` + `relocate(src, dst)`; file rename → nothing; trash move → nothing; a raising settle still returns the moved entry.
- Verified e2e via HTTP: after the rename call, `~/.claude/projects/<new munge>/` exists and the transcript `cwd` is rewritten.

## How to test
1. Folder with ≥1 Claude chat → Explorer → rename it → enter → open Claude pane: recent chats listed immediately, no reload.
2. Same with drag-and-drop move of the folder into another folder, and with cut/paste.
3. `ls ~/.claude/projects | grep <new-name>` shows the bucket right after the move.
4. Delete the folder (trash) → restore: chats still listed (bucket never moved).
5. Rename a plain file: no side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)