### PR TITLE
Onboarding: per-stage progress meter in the sidebar and status-driven step pills

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -198,6 +198,10 @@ export function dismissFdaNudge(): Promise<{ ok: boolean }> {
 export interface OnboardingState {
   completed_at: number | null;
   dismissed_at: number | null;
+  // When the wizard was first on screen (stamped by the first step write).
+  // Third leg of the auto-show rule (shell/onboarding/state): a wizard that
+  // has been opened is never auto-shown again. Optional: older server.
+  opened_at?: number | null;
   // The step id the user last had open — the resume point after a server
   // restart or a dismiss. Optional: an older server does not send it.
   step?: string | null;

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -202,9 +202,6 @@ export interface OnboardingState {
   // Third leg of the auto-show rule (shell/onboarding/state): a wizard that
   // has been opened is never auto-shown again. Optional: older server.
   opened_at?: number | null;
-  // The step id the user last had open — the resume point after a server
-  // restart or a dismiss. Optional: an older server does not send it.
-  step?: string | null;
   // Per-step progress (the meter): what each step last reported about itself,
   // overruled server-side where the truth is cheap to see. Optional: an older
   // server does not send it. Rules live in shell/onboarding/progress.ts.
@@ -235,8 +232,10 @@ export function dismissOnboarding(): Promise<OnboardingState> {
   return postJson<OnboardingState>("/api/onboarding/dismiss", {});
 }
 
-export function setOnboardingStep(step: string): Promise<OnboardingState> {
-  return postJson<OnboardingState>("/api/onboarding/step", { step });
+/** The wizard is on screen — stamps `opened_at` (the auto-show's third leg)
+    without saying anything else. */
+export function openedOnboarding(): Promise<OnboardingState> {
+  return postJson<OnboardingState>("/api/onboarding/opened", {});
 }
 
 export function setOnboardingStage(

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -201,7 +201,22 @@ export interface OnboardingState {
   // The step id the user last had open — the resume point after a server
   // restart or a dismiss. Optional: an older server does not send it.
   step?: string | null;
+  // Per-step progress (the meter): what each step last reported about itself,
+  // overruled server-side where the truth is cheap to see. Optional: an older
+  // server does not send it. Rules live in shell/onboarding/progress.ts.
+  stages?: Record<string, OnboardingStage>;
   version: number;
+}
+
+/** `n/a` = this machine has no such step; it leaves the denominator. */
+export type OnboardingStageStatus = "pending" | "partial" | "complete" | "n/a";
+
+export interface OnboardingStage {
+  status: OnboardingStageStatus;
+  /** Free-form notes the step left for reference (version found, account,
+      model ids started). Merged on write; never read by a rule. */
+  meta: Record<string, unknown>;
+  updated_at: number | null;
 }
 
 export function getOnboarding(): Promise<OnboardingState> {
@@ -218,6 +233,14 @@ export function dismissOnboarding(): Promise<OnboardingState> {
 
 export function setOnboardingStep(step: string): Promise<OnboardingState> {
   return postJson<OnboardingState>("/api/onboarding/step", { step });
+}
+
+export function setOnboardingStage(
+  stage: string,
+  status: OnboardingStageStatus,
+  meta?: Record<string, unknown>,
+): Promise<OnboardingState> {
+  return postJson<OnboardingState>("/api/onboarding/stage", { stage, status, meta: meta ?? {} });
 }
 
 // -- Is Claude Code usable (fused_render/claude_health.py) -------------------

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -52,7 +52,8 @@ import GlobalSidebar from "@shell/GlobalSidebar";
 import { appPathFromPath } from "@shell/current-apps-lib";
 import NotificationHost from "@platform/ui/NotificationHost";
 import OnboardingWizard from "@shell/onboarding/OnboardingWizard";
-import { ONBOARDING_PATH, onboardingUrl, shouldAutoShow } from "@shell/onboarding/state";
+import { ONBOARDING_PATH, shouldAutoShow } from "@shell/onboarding/state";
+import { onboardingUrl } from "@shell/onboarding/progress";
 import StatusBar from "@platform/ui/StatusBar";
 import ModelsDock from "@shell/ModelsDock";
 import ActivityDock from "@shell/ActivityDock";
@@ -657,7 +658,7 @@ export default function App({ config }: { config: Config }) {
     location.pathname === "/home" &&
     shouldAutoShow(config)
   ) {
-    history.replaceState(null, "", onboardingUrl(config));
+    history.replaceState(null, "", onboardingUrl(config.onboarding?.stages));
   }
   autoShowDecided = true;
   // Legacy: the CLAUDE.md explorer ("MD Files") was deleted from the Config

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -20,6 +20,7 @@ import { navigateUrl } from "@platform/lib/router";
 import { isBrowserHandledClick } from "@platform/lib/appEntry";
 import { TOURS, startTour } from "@platform/lib/tours";
 import { ONBOARDING_PATH } from "@shell/onboarding/state";
+import { SetupProgressRing, SetupProgressRow, useSetupMeter } from "@shell/onboarding/SetupProgress";
 import { useUrlVersion } from "@platform/lib/hooks";
 import { useClaudeConfigAvailable } from "@apps/claude_config/available";
 import { useCanvasesLoggedIn } from "@apps/canvases/logged-in";
@@ -676,6 +677,11 @@ export default function GlobalSidebar({ config }: { config: Config }) {
     setPrefsPos({ left: r.left, bottom: window.innerHeight - r.top + 4 });
   };
 
+  // THE SETUP METER (shell/onboarding/progress): how far first-run setup has
+  // got, as a row above Settings and a ring on the rail, both leading back into
+  // the wizard. Null = nothing to show (never started, or finished).
+  const setupMeter = useSetupMeter(config);
+
   const rail: SidebarRailItem[] = [
     { key: "home", label: "Home", icon: HOME_ICON, href: "/home", active: homeActive },
     {
@@ -707,12 +713,26 @@ export default function GlobalSidebar({ config }: { config: Config }) {
       active: aiModelsActive,
       badge: residentDot,
     },
+    // Same gate and same place as the expanded row: the rail is the whole
+    // sidebar when collapsed, and a meter that vanished on collapse would read
+    // as setup being done.
+    ...(setupMeter
+      ? [
+          {
+            key: "setup",
+            label: setupMeter.title,
+            icon: <SetupProgressRing percent={setupMeter.percent} />,
+            href: ONBOARDING_PATH,
+            pinBottom: true,
+          },
+        ]
+      : []),
     {
       key: "preferences",
       label: "Preferences",
       icon: PREFERENCES_ICON,
       href: "/preferences",
-      pinBottom: true,
+      pinBottom: !setupMeter,
       active: prefsActive,
       // Same Settings popover as the expanded row, not a straight nav — the
       // collapsed rail otherwise has no way to reach Templates/Mounts/etc.
@@ -773,6 +793,8 @@ export default function GlobalSidebar({ config }: { config: Config }) {
         <BookmarksSection />
         <div className="sidebar-section sidebar-settings">
           <UpdateBadge />
+          {/* Setup progress, above Settings: "Setup · 60%", back into the wizard. */}
+          {setupMeter && <SetupProgressRow meter={setupMeter} />}
           {/* The version rides the Settings row's trailing edge rather than the
               brand row it used to sit in. Two reasons it moved: the brand row is
               one click target for Home, so a version glued to the title read as

--- a/frontend/src/shell/onboarding/ClaudeStep.tsx
+++ b/frontend/src/shell/onboarding/ClaudeStep.tsx
@@ -18,6 +18,7 @@ import { Button } from "@platform/shadcn/ui/button";
 import { Skeleton } from "@platform/shadcn/ui/skeleton";
 import { IssueRow } from "@platform/ui/ClaudeHealthStrip";
 
+import { reportStage, type StageStatus } from "./progress";
 import { StepHeader } from "./StepHeader";
 
 type RowState = "done" | "open" | "unknown";
@@ -133,6 +134,22 @@ export function ClaudeStep({
     (r) => r.state === "open" && issues.some((i) => r.issueIds.includes(i.id)),
   );
   useEffect(() => onWork(anyActionable === true), [onWork, anyActionable]);
+  // THE STAGE (progress.ts): complete when every required row is done;
+  // partial when the CLI runs but a required row is open or unknown (an
+  // unknown is never a green check — same rule the PATH row states);
+  // pending when it does not run at all. Nothing until health has answered.
+  const runnable = health ? health.found && !health.broken : false;
+  const stage: StageStatus | null = !health ? null : allDone ? "complete" : runnable ? "partial" : "pending";
+  useEffect(() => {
+    if (!health || !stage) return;
+    reportStage("claude", stage, {
+      version: health.version,
+      outdated: health.outdated,
+      signed_in: health.signed_in,
+      account: health.account?.email ?? health.account?.method ?? null,
+      on_shell_path: health.on_shell_path,
+    });
+  }, [stage, health]);
 
   return (
     <div className="flex flex-col gap-6">

--- a/frontend/src/shell/onboarding/FdaStep.tsx
+++ b/frontend/src/shell/onboarding/FdaStep.tsx
@@ -28,6 +28,7 @@ import { openFdaSettings, type Config } from "@platform/lib/api";
 import { FDA_COPY, RELAUNCH_HREF, pokeFda, seedFda, useFda } from "@platform/lib/fda";
 import { Button } from "@platform/shadcn/ui/button";
 
+import { reportStage } from "./progress";
 import { StepHeader } from "./StepHeader";
 
 export function FdaStep({
@@ -55,6 +56,15 @@ export function FdaStep({
   // Open Settings / Relaunch is the yellow button until the grant is in;
   // then Next takes the colour. A dev server (nothing offered) has no button.
   useEffect(() => onWork(offered && !granted), [onWork, offered, granted]);
+  // THE STAGE (progress.ts): granted = complete; granted-but-relaunch-pending
+  // = partial; otherwise pending — including a dev server, where nothing is
+  // offered but this IS a Mac with the pane. The server overrules this from
+  // its own probe on every read, so the two never disagree for long.
+  useEffect(() => {
+    if (live === undefined && config.fda === undefined) return; // first paint, no answer yet
+    const status = granted ? "complete" : pending ? "partial" : "pending";
+    reportStage("fda", status, { granted, pending_relaunch: pending, offered, opened_settings: opened });
+  }, [granted, pending, offered, opened, live, config.fda]);
 
   const open = () => {
     setError(null);

--- a/frontend/src/shell/onboarding/FirstAppStep.tsx
+++ b/frontend/src/shell/onboarding/FirstAppStep.tsx
@@ -12,11 +12,12 @@ import type { ReactNode } from "react";
 // The showcase clone is fire-and-forget at startup and may not have landed
 // yet — the same catalog→refresh dance Apps.tsx does forces it, with a
 // skeleton row meanwhile.
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AlertTriangle } from "lucide-react";
 
 import { HeroComposer } from "@apps/builder/HomeHero";
 import { getApps, type AppInfo, type ClaudeHealth } from "@platform/lib/api";
+import { hrefFor } from "@platform/lib/appEntry";
 import { runCommunity } from "@platform/lib/community";
 import { Skeleton } from "@platform/shadcn/ui/skeleton";
 import { AppPreviewCard } from "@platform/ui/AppPreviewCard";
@@ -68,14 +69,34 @@ export function FirstAppStep({
   health,
   eyebrow,
   onComplete,
+  onShowcaseOpened,
 }: {
   health: ClaudeHealth | null;
   eyebrow: ReactNode;
   /** The composer created a folder — real progress, flag it. Showcase cards
-      need no hook: the navigation they perform is what the wizard reads. */
+      need no click hook: the navigation they perform is what the wizard reads. */
   onComplete: () => void;
+  /** A showcase card was OPENED: the step unmounted onto one of their pages.
+      Checked against the cards' own hrefs, not "any unmount from here" —
+      browser Back leaves the wizard from this step too, and built nothing. */
+  onShowcaseOpened: () => void;
 }) {
   const { apps: showcase, error: showcaseError } = useLocalAiShowcase();
+  const showcaseRef = useRef(showcase);
+  showcaseRef.current = showcase;
+  const openedRef = useRef(onShowcaseOpened);
+  openedRef.current = onShowcaseOpened;
+  useEffect(
+    () => () => {
+      const here = location.pathname + location.search;
+      const landed = (showcaseRef.current ?? []).find((app) => {
+        const u = new URL(hrefFor(app), location.origin);
+        return u.pathname + u.search === here;
+      });
+      if (landed) openedRef.current();
+    },
+    [],
+  );
   const claudeReady = health ? health.found && !health.broken && health.signed_in !== false : true;
 
   return (

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -45,6 +45,7 @@ import { Checkbox } from "@platform/shadcn/ui/checkbox";
 import { Skeleton } from "@platform/shadcn/ui/skeleton";
 
 import { comfortableIds, modelPicks, selectedTotal, type ModelPick } from "./modelPicks";
+import { reportStage } from "./progress";
 import { StepHeader } from "./StepHeader";
 
 /** `null` while the catalog is still answering — the wizard reads that as
@@ -289,6 +290,22 @@ export function ModelsStep({
   // Download is the yellow button while something is selected and not yet
   // fetched; once started (or nothing to do) Next takes the colour.
   useEffect(() => onWork(pending.length > 0), [onWork, pending.length]);
+  // THE STAGE (progress.ts): every offered model here = complete; some here
+  // or any download in flight = partial; nothing = pending. Nothing until the
+  // catalog has answered (an empty catalog is the wizard's `n/a`, not ours).
+  // Keyed on the counts, so the jobs poll does not re-send the same verdict.
+  const hereCount = rows.filter((r) => r.here).length;
+  const rowCount = rows.length;
+  useEffect(() => {
+    if (picks === null || rowCount === 0) return;
+    const status = hereCount === rowCount ? "complete" : hereCount > 0 || busyCount > 0 ? "partial" : "pending";
+    reportStage("models", status, {
+      offered: rows.map((r) => r.pick.model.id),
+      here: rows.filter((r) => r.here).map((r) => r.pick.model.id),
+      downloading: rows.filter((r) => r.busy).map((r) => r.pick.model.id),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `rows` is a per-render array; the counts are its signal
+  }, [picks, rowCount, hereCount, busyCount]);
 
   // Driven by the checkbox's own reported value, not by flipping what this
   // render happened to see: the primitive owns the state transition.

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -9,10 +9,10 @@
 //   4 Models       — local models that fit this machine, downloaded in the background
 //   5 First app    — the Home composer, or a showcase local-AI app
 //
-// Steps 1–3 write nothing but the resume step (which step is open, so a
-// restart or a reopen lands back on it) and their own STAGE STATUS for the
-// progress meter (progress.ts — the sidebar's "Setup N%" row and the pills in
-// the bar above). Step 4 starts model downloads, which
+// Steps 1–3 write nothing but their own STAGE STATUS for the progress meter
+// (progress.ts — the sidebar's "Setup N%" row and the pills in the bar above;
+// a reopen lands on the first step still to do). Step 4 starts model
+// downloads, which
 // are server-owned jobs that outlive the wizard and block nothing in it — a
 // head start, since a model is fetched on first use anyway. Step 5's create
 // (or a showcase open) is the only other durable action and doubles as
@@ -26,7 +26,7 @@ import { ArrowLeft, ArrowRight, Check, X } from "lucide-react";
 import {
   completeOnboarding,
   dismissOnboarding,
-  setOnboardingStep,
+  openedOnboarding,
   type Config,
 } from "@platform/lib/api";
 import { useClaudeSetup } from "@platform/lib/claude-setup";
@@ -35,8 +35,15 @@ import { Button } from "@platform/shadcn/ui/button";
 import { cn } from "@platform/lib/utils";
 import { FusedMark } from "@platform/ui/FusedMark";
 
-import { recallStep, rememberStep } from "./state";
-import { reportStage, seedProgress, stageStatus, useOnboardingState } from "./progress";
+import {
+  firstOpenStage,
+  getProgress,
+  reportStage,
+  seedProgress,
+  setProgress,
+  stageStatus,
+  useOnboardingState,
+} from "./progress";
 import { AboutStep } from "./AboutStep";
 import { ClaudeStep } from "./ClaudeStep";
 import { FdaStep } from "./FdaStep";
@@ -80,23 +87,25 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // shift the page under the user. Mirrored with replaceState: steps are not
   // history entries, Back leaves the wizard.
   //
-  // Without a step in the URL (Help › Setup wizard is a plain link, a restart
-  // relaunches on /home) the wizard RESUMES: this page load's memory, then the
-  // server's stored step (shell/onboarding/state), then the first step. Every
-  // step change is written back, fire-and-forget — the write is a courtesy to
-  // the next open, and a failed one must not hold this page. Not once the
-  // wizard has settled (complete / dismiss): a completed wizard's resume point
-  // is cleared, and a step change made while it is still mounted afterwards
-  // (Back after a composer `task_error`, a step pill) must not restore one.
-  const [stepId, setStepId] = useState<StepId>(
-    () => stepFromUrl() ?? asStepId(recallStep(config)) ?? "about",
-  );
+  // Without a step in the URL (Help › Setup wizard is a plain link) the wizard
+  // opens on the FIRST STEP STILL TO DO, read off the stage statuses
+  // (progress.ts firstOpenStage) — the same answer the sidebar meter and the
+  // boot auto-show link to. This replaced a stored "last open step": what is
+  // left to do is a better place to land than wherever the user last was.
+  const [stepId, setStepId] = useState<StepId>(() => {
+    seedProgress(config); // before the first read, and before any subscriber
+    return stepFromUrl() ?? asStepId(firstOpenStage(getProgress()?.stages)) ?? "about";
+  });
   const settled = useRef(false);
+  // Being on screen is the one fact the server needs from a visit: it is the
+  // auto-show's "never opened" leg (shell/onboarding/state). Once per mount.
   useEffect(() => {
-    if (!settled.current) {
-      rememberStep(stepId);
-      setOnboardingStep(stepId).catch(() => undefined);
-    }
+    openedOnboarding().then(
+      (s) => setProgress(s),
+      () => undefined,
+    );
+  }, []);
+  useEffect(() => {
     const url = new URL(location.href);
     if (url.searchParams.get(STEP_PARAM) === stepId) return;
     url.searchParams.set(STEP_PARAM, stepId);
@@ -114,7 +123,6 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // PROGRESS (progress.ts): seeded from the config we hold, then live. The
   // pills read a step's STATUS from it, not its position — a skipped Claude
   // step is not a green tick because the user walked past it.
-  useState(() => seedProgress(config)); // once, before the first subscriber
   const progress = useOnboardingState();
   const stages = progress?.stages;
   // Stages this machine does not have leave the meter: `n/a` once the answer
@@ -174,10 +182,7 @@ export function OnboardingWizard({ config }: { config: Config }) {
     if (via) reportStage("app", "complete", { via });
     if (settled.current) return;
     settled.current = true;
-    // The server clears its resume step on complete; mirror that in this
-    // page load's memory so a reopen starts at the top, not at the last step.
-    rememberStep(null);
-    // Same reason, for the Models step's own across-mount memory: a wizard
+    // The Models step's own across-mount memory: a wizard
     // reopened in this page load should offer a fresh selection, not rows
     // still reporting a download that has since finished.
     forgetModelsStep();

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -34,6 +34,7 @@ import { cn } from "@platform/lib/utils";
 import { FusedMark } from "@platform/ui/FusedMark";
 
 import { recallStep, rememberStep } from "./state";
+import { reportStage, seedProgress, stageStatus, useOnboardingState } from "./progress";
 import { AboutStep } from "./AboutStep";
 import { ClaudeStep } from "./ClaudeStep";
 import { FdaStep } from "./FdaStep";
@@ -108,6 +109,20 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // whether it exists at all come from it (a machine no local engine serves has
   // nothing to offer, so it gets no step).
   const picks = useModelPicks();
+  // PROGRESS (progress.ts): seeded from the config we hold, then live. The
+  // pills read a step's STATUS from it, not its position — a skipped Claude
+  // step is not a green tick because the user walked past it.
+  seedProgress(config);
+  const progress = useOnboardingState();
+  const stages = progress?.stages;
+  // Stages this machine does not have leave the meter: `n/a` once the answer
+  // is KNOWN (health said the platform; the catalog said "nothing to offer").
+  useEffect(() => {
+    if (health?.platform && health.platform !== "darwin") reportStage("fda", "n/a", { platform: health.platform });
+  }, [health?.platform]);
+  useEffect(() => {
+    if (picks !== null && picks.length === 0) reportStage("models", "n/a", { offered: 0 });
+  }, [picks]);
   const steps = STEPS.filter((s) => {
     if (s.id === "fda") return isMac(health?.platform);
     // Kept while the answer is UNKNOWN (`null`), unlike the FDA step's
@@ -126,6 +141,10 @@ export function OnboardingWizard({ config }: { config: Config }) {
   const step = steps[index];
   const last = index >= steps.length - 1;
   const setIndex = (i: number) => setStepId(steps[Math.max(0, Math.min(i, steps.length - 1))].id);
+  // About has nothing to check: opening it is completing it.
+  useEffect(() => {
+    if (step.id === "about") reportStage("about", "complete", { viewed_at: Date.now() / 1000 });
+  }, [step.id]);
   // Counted over the steps this machine actually has (no FDA off macOS).
   const eyebrowText = `Step ${index + 1} of ${steps.length}`;
   // One yellow button per screen. A step with its own work to do (install,
@@ -145,7 +164,12 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // to the NEXT launch, and a failed write must not hold the page over the
   // app the user is trying to reach. (`settled` is declared above, by the
   // step effect that reads it.)
-  const markComplete = useCallback(() => {
+  // `via` names the ACTION that finished it — the composer made an app, or a
+  // showcase card was opened — and is what marks the First-app STAGE
+  // complete. "I'll explore on my own" passes none: it ends the wizard but
+  // builds nothing, and the meter must say so.
+  const markComplete = useCallback((via?: "composer" | "showcase") => {
+    if (via) reportStage("app", "complete", { via });
     if (settled.current) return;
     settled.current = true;
     // The server clears its resume step on complete; mirror that in this
@@ -182,7 +206,9 @@ export function OnboardingWizard({ config }: { config: Config }) {
   lastRef.current = last;
   useEffect(
     () => () => {
-      if (lastRef.current) markComplete();
+      // Not already settled: a dismiss or "explore on my own" from the last
+      // step settled first, so what is left here is a card's navigation.
+      if (lastRef.current && !settled.current) markComplete("showcase");
     },
     [markComplete],
   );
@@ -273,15 +299,22 @@ export function OnboardingWizard({ config }: { config: Config }) {
           className="my-0 hidden list-none items-center gap-0.5 rounded-lg bg-muted/60 p-0.5 sm:flex"
           aria-label="Setup steps"
         >
+          {/* The mark is the stage's STATUS (progress.ts), not its position:
+              green check = complete, half-filled amber = partial, the number
+              = pending. Walking past a step earns it nothing. */}
           {steps.map((s, i) => {
-            const done = i < index;
+            const status = stageStatus(stages, s.id);
+            const done = status === "complete";
+            const partial = status === "partial";
             const current = i === index;
+            const statusWord = done ? "complete" : partial ? "partly done" : "not done";
             return (
               <li key={s.id} className="flex items-center">
                 <button
                   type="button"
                   onClick={() => setStepId(s.id)}
                   aria-current={current ? "step" : undefined}
+                  title={`${s.label} — ${statusWord}`}
                   className={cn(
                     "flex cursor-pointer appearance-none items-center gap-1.5 rounded-md border-0 bg-transparent px-3 py-1.5 text-xs leading-none [font-family:inherit] transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring",
                     current
@@ -292,13 +325,20 @@ export function OnboardingWizard({ config }: { config: Config }) {
                   <span
                     className={cn(
                       "grid size-4 place-items-center rounded-full text-[10px] font-semibold tabular-nums",
-                      current && "bg-foreground text-background",
                       done && "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
-                      !current && !done && "bg-muted-foreground/15 text-muted-foreground",
+                      partial && "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+                      !done && !partial && current && "bg-foreground text-background",
+                      !done && !partial && !current && "bg-muted-foreground/15 text-muted-foreground",
                     )}
                     aria-hidden
                   >
-                    {done ? <Check className="size-2.5" strokeWidth={3} /> : i + 1}
+                    {done ? (
+                      <Check className="size-2.5" strokeWidth={3} />
+                    ) : partial ? (
+                      <span className="size-2 rounded-full border-[1.5px] border-current [background:linear-gradient(90deg,currentColor_50%,transparent_50%)]" />
+                    ) : (
+                      i + 1
+                    )}
                   </span>
                   {s.label}
                 </button>
@@ -325,7 +365,9 @@ export function OnboardingWizard({ config }: { config: Config }) {
           {step.id === "claude" && <ClaudeStep setup={setup} eyebrow={eyebrow} onWork={onWork} />}
           {step.id === "fda" && <FdaStep config={config} eyebrow={eyebrow} onWork={onWork} />}
           {step.id === "models" && <ModelsStep picks={picks} eyebrow={eyebrow} onWork={onWork} />}
-          {step.id === "app" && <FirstAppStep health={health} eyebrow={eyebrow} onComplete={markComplete} />}
+          {step.id === "app" && (
+            <FirstAppStep health={health} eyebrow={eyebrow} onComplete={() => markComplete("composer")} />
+          )}
         </div>
       </div>
 

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -10,7 +10,9 @@
 //   5 First app    — the Home composer, or a showcase local-AI app
 //
 // Steps 1–3 write nothing but the resume step (which step is open, so a
-// restart or a reopen lands back on it). Step 4 starts model downloads, which
+// restart or a reopen lands back on it) and their own STAGE STATUS for the
+// progress meter (progress.ts — the sidebar's "Setup N%" row and the pills in
+// the bar above). Step 4 starts model downloads, which
 // are server-owned jobs that outlive the wizard and block nothing in it — a
 // head start, since a model is fetched on first use anyway. Step 5's create
 // (or a showcase open) is the only other durable action and doubles as
@@ -112,7 +114,7 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // PROGRESS (progress.ts): seeded from the config we hold, then live. The
   // pills read a step's STATUS from it, not its position — a skipped Claude
   // step is not a green tick because the user walked past it.
-  seedProgress(config);
+  useState(() => seedProgress(config)); // once, before the first subscriber
   const progress = useOnboardingState();
   const stages = progress?.stages;
   // Stages this machine does not have leave the meter: `n/a` once the answer
@@ -204,11 +206,12 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // The unmount is that navigation.
   const lastRef = useRef(last);
   lastRef.current = last;
+  // The FLAG only: this unmount also fires on browser Back from the last
+  // step, where nothing was built. The First-app STAGE is claimed by the step
+  // itself, which checks the page it landed on (FirstAppStep onShowcaseOpened).
   useEffect(
     () => () => {
-      // Not already settled: a dismiss or "explore on my own" from the last
-      // step settled first, so what is left here is a card's navigation.
-      if (lastRef.current && !settled.current) markComplete("showcase");
+      if (lastRef.current) markComplete();
     },
     [markComplete],
   );
@@ -366,7 +369,12 @@ export function OnboardingWizard({ config }: { config: Config }) {
           {step.id === "fda" && <FdaStep config={config} eyebrow={eyebrow} onWork={onWork} />}
           {step.id === "models" && <ModelsStep picks={picks} eyebrow={eyebrow} onWork={onWork} />}
           {step.id === "app" && (
-            <FirstAppStep health={health} eyebrow={eyebrow} onComplete={() => markComplete("composer")} />
+            <FirstAppStep
+              health={health}
+              eyebrow={eyebrow}
+              onComplete={() => markComplete("composer")}
+              onShowcaseOpened={() => markComplete("showcase")}
+            />
           )}
         </div>
       </div>

--- a/frontend/src/shell/onboarding/SetupProgress.tsx
+++ b/frontend/src/shell/onboarding/SetupProgress.tsx
@@ -1,0 +1,83 @@
+// The sidebar's setup meter: a row above Settings that says how far first-run
+// setup has got ("Setup · 60%") and takes the reader back into the wizard, and
+// the ring the collapsed rail shows in its place. Reads progress.ts; draws.
+//
+// Shown only while there is something to show (progress.meterVisible): after
+// the wizard has written at least one stage, and until the meter reads 100.
+// An install upgrading into this build never sees it, and a finished setup
+// gives the row back to the Settings block — the wizard stays one click away
+// under Help › Setup wizard.
+import { navigateUrl } from "@platform/lib/router";
+import type { Config } from "@platform/lib/api";
+
+import { ONBOARDING_PATH } from "./state";
+import { meterVisible, progressPercent, seedProgress, useOnboardingState } from "./progress";
+
+export interface SetupMeter {
+  percent: number;
+  /** "3 of 5 done" — the tooltip's sentence. */
+  title: string;
+}
+
+/** The meter for the sidebar, or null when the row should not exist. */
+export function useSetupMeter(config: Config): SetupMeter | null {
+  seedProgress(config);
+  const state = useOnboardingState();
+  if (!meterVisible(state)) return null;
+  const p = progressPercent(state?.stages);
+  const half = p.partial > 0 ? `, ${p.partial} partly` : "";
+  return {
+    percent: p.percent,
+    title: `Setup ${p.percent}% — ${p.complete} of ${p.counted} steps done${half}. Open the setup wizard.`,
+  };
+}
+
+/** A ring that fills clockwise with `percent`. 16px, like every rail glyph. */
+export function SetupProgressRing({ percent }: { percent: number }) {
+  const r = 6.5;
+  const c = 2 * Math.PI * r;
+  const dash = (Math.max(0, Math.min(100, percent)) / 100) * c;
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="setup-ring">
+      <circle cx="8" cy="8" r={r} stroke="currentColor" strokeWidth="2" opacity="0.22" />
+      <circle
+        cx="8"
+        cy="8"
+        r={r}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeDasharray={`${dash} ${c - dash}`}
+        transform="rotate(-90 8 8)"
+        className="setup-ring-fill"
+      />
+    </svg>
+  );
+}
+
+/** The expanded-sidebar row: ring, "Setup", a thin bar and the number. */
+export function SetupProgressRow({ meter }: { meter: SetupMeter }) {
+  return (
+    <a
+      href={ONBOARDING_PATH}
+      id="setup-progress-link"
+      className="sidebar-item setup-progress"
+      title={meter.title}
+      onClick={(e) => {
+        e.preventDefault();
+        navigateUrl(ONBOARDING_PATH);
+      }}
+    >
+      <span className="icon">
+        <SetupProgressRing percent={meter.percent} />
+      </span>{" "}
+      Setup
+      <span className="sidebar-item-trail">
+        <span className="setup-progress-bar" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={meter.percent}>
+          <span className="setup-progress-fill" style={{ width: `${meter.percent}%` }} />
+        </span>
+        <span className="setup-progress-pct">{meter.percent}%</span>
+      </span>
+    </a>
+  );
+}

--- a/frontend/src/shell/onboarding/SetupProgress.tsx
+++ b/frontend/src/shell/onboarding/SetupProgress.tsx
@@ -12,13 +12,15 @@ import { useState } from "react";
 import { navigateUrl } from "@platform/lib/router";
 import type { Config } from "@platform/lib/api";
 
-import { ONBOARDING_PATH } from "./state";
-import { meterVisible, progressPercent, seedProgress, useOnboardingState } from "./progress";
+import { meterVisible, onboardingUrl, progressPercent, seedProgress, useOnboardingState } from "./progress";
 
 export interface SetupMeter {
   percent: number;
   /** "3 of 5 done" — the tooltip's sentence. */
   title: string;
+  /** Where a click lands: the wizard, open on the FIRST step still to do —
+      not the resume point, which is wherever the user last happened to be. */
+  href: string;
 }
 
 /** The meter for the sidebar, or null when the row should not exist. */
@@ -31,6 +33,7 @@ export function useSetupMeter(config: Config): SetupMeter | null {
   return {
     percent: p.percent,
     title: `Setup ${p.percent}% — ${p.complete} of ${p.counted} steps done${half}. Open the setup wizard.`,
+    href: onboardingUrl(state?.stages),
   };
 }
 
@@ -61,13 +64,13 @@ export function SetupProgressRing({ percent }: { percent: number }) {
 export function SetupProgressRow({ meter }: { meter: SetupMeter }) {
   return (
     <a
-      href={ONBOARDING_PATH}
+      href={meter.href}
       id="setup-progress-link"
       className="sidebar-item setup-progress"
       title={meter.title}
       onClick={(e) => {
         e.preventDefault();
-        navigateUrl(ONBOARDING_PATH);
+        navigateUrl(meter.href);
       }}
     >
       <span className="icon">

--- a/frontend/src/shell/onboarding/SetupProgress.tsx
+++ b/frontend/src/shell/onboarding/SetupProgress.tsx
@@ -7,6 +7,8 @@
 // An install upgrading into this build never sees it, and a finished setup
 // gives the row back to the Settings block — the wizard stays one click away
 // under Help › Setup wizard.
+import { useState } from "react";
+
 import { navigateUrl } from "@platform/lib/router";
 import type { Config } from "@platform/lib/api";
 
@@ -21,7 +23,7 @@ export interface SetupMeter {
 
 /** The meter for the sidebar, or null when the row should not exist. */
 export function useSetupMeter(config: Config): SetupMeter | null {
-  seedProgress(config);
+  useState(() => seedProgress(config)); // once, before the first subscriber
   const state = useOnboardingState();
   if (!meterVisible(state)) return null;
   const p = progressPercent(state?.stages);

--- a/frontend/src/shell/onboarding/progress.ts
+++ b/frontend/src/shell/onboarding/progress.ts
@@ -1,0 +1,182 @@
+// Onboarding PROGRESS — one store for every surface that says how far setup
+// has got: the sidebar's "Setup 60%" row, the wizard's top-bar pills, and the
+// steps themselves, which are the writers.
+//
+// THE MODEL. Every wizard step is a STAGE with a status the step decides for
+// itself, from the facts it already checks to draw its own rows:
+//
+//   stage    pending                partial                      complete
+//   about    not yet opened         —                            opened once
+//   claude   not installed/unknown  runs, but outdated/signed    installed, new
+//                                   out/unknown                  enough, signed in
+//   fda      not granted            granted, relaunch pending    granted
+//   models   none fetched           some here or downloading     every offered
+//                                                                model is here
+//   app      nothing built          —                            composer made an
+//                                                                app, or a showcase
+//                                                                app was opened
+//
+// plus `n/a` for a stage this machine does not have (Disk Access off macOS,
+// Models when no engine can serve anything) — it leaves the denominator, so
+// a Linux user is not stuck at 80% over a pane they cannot open.
+//
+// The status is written to the server (shell/onboarding.py `stages`) with a
+// free-form `meta` note for reference, and read back from `config.onboarding`
+// like the flags. Server-side, not localStorage: every port is a new origin
+// (the server module's docstring). The server OVERRULES the stored status for
+// the stages it can see cheaply (FDA, first app, Claude from its health cache),
+// so a grant made from the Home strip moves the meter too.
+//
+// THE PERCENTAGE: over the stages that count (not `n/a`), complete is 1,
+// partial is ½, pending is 0, rounded. A stage nobody has written yet is
+// pending — a fresh install starts at 0%.
+//
+// Why a store and not the boot config: `config` is fetched ONCE (main.tsx),
+// and the sidebar is unmounted while the wizard is up — so the row would come
+// back showing whatever boot said. Every stage write replaces the snapshot
+// with the server's reply, and a subscriber mounting re-reads once. Same
+// `useSyncExternalStore` shape as platform/lib/fda.ts.
+import { useSyncExternalStore } from "react";
+
+import {
+  getOnboarding,
+  setOnboardingStage,
+  type Config,
+  type OnboardingStage,
+  type OnboardingStageStatus,
+  type OnboardingState,
+} from "@platform/lib/api";
+
+export type StageStatus = OnboardingStageStatus;
+export type Stages = Record<string, OnboardingStage>;
+
+/** The stage ids, in wizard order — the server's closed set (STEPS). */
+export const STAGE_IDS = ["about", "claude", "fda", "models", "app"] as const;
+export type StageId = (typeof STAGE_IDS)[number];
+
+let snapshot: OnboardingState | null = null;
+const listeners = new Set<() => void>();
+let inflight: Promise<void> | null = null;
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+function set(next: OnboardingState | null) {
+  if (next === snapshot) return;
+  snapshot = next;
+  emit();
+}
+
+/** Seed from the boot config, once — a first paint that does not wait. */
+export function seedProgress(config: Config): void {
+  if (snapshot === null && config.onboarding) set(config.onboarding);
+}
+
+/** Re-read the server. A failed fetch keeps what we have. */
+export function refreshProgress(): Promise<void> {
+  if (inflight) return inflight;
+  inflight = getOnboarding()
+    .then((s) => set(s))
+    .catch(() => undefined)
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+export function getProgress(): OnboardingState | null {
+  return snapshot;
+}
+
+export function subscribeProgress(cb: () => void): () => void {
+  listeners.add(cb);
+  if (listeners.size === 1) void refreshProgress();
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+export function useOnboardingState(): OnboardingState | null {
+  return useSyncExternalStore(subscribeProgress, getProgress, getProgress);
+}
+
+// What each stage last wrote — so a step reporting the same status on every
+// poll (Models, every few seconds) writes once, not on every tick. Keyed by
+// stage; the meta is not compared (a note may change without a status change,
+// and re-sending it is harmless but is not what this dedupes).
+const lastWritten = new Map<string, StageStatus>();
+
+/** A step reports its status. Fire-and-forget; the server's reply is the new
+ *  snapshot. `force` re-sends even when the status has not changed (a step
+ *  with a NEW note to leave). */
+export function reportStage(
+  stage: StageId,
+  status: StageStatus,
+  meta?: Record<string, unknown>,
+  force = false,
+): void {
+  if (!force && lastWritten.get(stage) === status && snapshot?.stages?.[stage]?.status === status) return;
+  lastWritten.set(stage, status);
+  // Optimistic: the pills should move as the step does, not a round trip later.
+  if (snapshot) {
+    const prev = snapshot.stages?.[stage];
+    set({
+      ...snapshot,
+      stages: {
+        ...(snapshot.stages ?? {}),
+        [stage]: { status, meta: { ...(prev?.meta ?? {}), ...(meta ?? {}) }, updated_at: Date.now() / 1000 },
+      },
+    });
+  }
+  setOnboardingStage(stage, status, meta).then(
+    (s) => set(s),
+    () => undefined,
+  );
+}
+
+export function stageStatus(stages: Stages | undefined, id: string): StageStatus {
+  return stages?.[id]?.status ?? "pending";
+}
+
+const WEIGHT: Record<StageStatus, number> = { pending: 0, partial: 0.5, complete: 1, "n/a": 0 };
+
+/** The meter. `counted` is the denominator (stages that are not `n/a`);
+ *  `percent` is rounded 0..100, and 100 only when every counted stage is
+ *  complete. `ids` limits the count to the stages a caller has (the wizard's
+ *  visible steps); default is every stage. */
+export function progressPercent(
+  stages: Stages | undefined,
+  ids: readonly string[] = STAGE_IDS,
+): { percent: number; counted: number; complete: number; partial: number } {
+  let counted = 0;
+  let sum = 0;
+  let complete = 0;
+  let partial = 0;
+  for (const id of ids) {
+    const s = stageStatus(stages, id);
+    if (s === "n/a") continue;
+    counted += 1;
+    sum += WEIGHT[s];
+    if (s === "complete") complete += 1;
+    if (s === "partial") partial += 1;
+  }
+  if (counted === 0) return { percent: 0, counted, complete, partial };
+  const raw = (sum / counted) * 100;
+  // Never round up to 100 over a stage that is only half done.
+  const percent = complete === counted ? 100 : Math.min(99, Math.round(raw));
+  return { percent, counted, complete, partial };
+}
+
+/** Whether the sidebar shows the meter at all. Not before anything has been
+ *  written (an install upgrading into this build was seeded `completed` with
+ *  no stages — it must not wake to "Setup 0%"), and not once it reads 100
+ *  (the wizard stays one click away under Help › Setup wizard). */
+export function meterVisible(state: OnboardingState | null): boolean {
+  if (!state?.stages) return false;
+  // `updated_at` is stamped by a WIZARD write only; the server's own
+  // observations leave it null (shell/onboarding.py `_observe`).
+  const written = Object.values(state.stages).some((s) => s.updated_at != null);
+  if (!written) return false;
+  return progressPercent(state.stages).percent < 100;
+}

--- a/frontend/src/shell/onboarding/progress.ts
+++ b/frontend/src/shell/onboarding/progress.ts
@@ -47,6 +47,8 @@ import {
   type OnboardingState,
 } from "@platform/lib/api";
 
+import { ONBOARDING_PATH } from "./state";
+
 export type StageStatus = OnboardingStageStatus;
 export type Stages = Record<string, OnboardingStage>;
 
@@ -66,6 +68,12 @@ function set(next: OnboardingState | null) {
   if (next === snapshot) return;
   snapshot = next;
   emit();
+}
+
+/** Adopt a snapshot some other call brought back (the wizard's `opened`
+ *  write, complete, dismiss) — every reply is the whole state. */
+export function setProgress(next: OnboardingState): void {
+  set(next);
 }
 
 /** Seed from the boot config, once — a first paint that does not wait. */
@@ -166,6 +174,27 @@ export function progressPercent(
   // Never round up to 100 over a stage that is only half done.
   const percent = complete === counted ? 100 : Math.min(99, Math.round(raw));
   return { percent, counted, complete, partial };
+}
+
+/** The first stage that still needs doing (not complete, not `n/a`), in
+ *  wizard order — where a click on the meter should land. Null when nothing
+ *  is left. */
+export function firstOpenStage(stages: Stages | undefined): StageId | null {
+  for (const id of STAGE_IDS) {
+    const s = stageStatus(stages, id);
+    if (s !== "complete" && s !== "n/a") return id;
+  }
+  return null;
+}
+
+/** The wizard's URL, open on the first step still to do — what the sidebar
+ *  meter, Help › Setup wizard and the boot auto-show all land on. This
+ *  REPLACED the stored "last open step" resume point: where the user last
+ *  happened to be is a worse answer than what is left to do, and the stages
+ *  already know that. Nothing left (or nothing known) opens at the top. */
+export function onboardingUrl(stages: Stages | undefined): string {
+  const open = firstOpenStage(stages);
+  return open && open !== STAGE_IDS[0] ? `${ONBOARDING_PATH}?step=${encodeURIComponent(open)}` : ONBOARDING_PATH;
 }
 
 /** Whether the sidebar shows the meter at all. Not before anything has been

--- a/frontend/src/shell/onboarding/progress.ts
+++ b/frontend/src/shell/onboarding/progress.ts
@@ -70,10 +70,41 @@ function set(next: OnboardingState | null) {
   emit();
 }
 
+// EVERY REPLY IS THE WHOLE STATE, AND REPLIES DO NOT ARRIVE IN ORDER. Two
+// stage POSTs in one tick, or the sidebar's mount-time GET racing the last
+// write the wizard made on its way out — whichever lands LAST would win, and a
+// stale one would put a stage back to what it was (bugbot: a showcase open is
+// the sharp case, since the server cannot observe it and nothing would ever
+// correct the loss). So a reply is MERGED, not adopted:
+//   * flags (completed/dismissed/opened) only ever gain a value — a stamp the
+//     server has made cannot be un-made by an older reply;
+//   * each stage keeps whichever record is NEWER by `updated_at`. An optimistic
+//     local write stamps `now`; the server's own stamp for that write is later
+//     still, so the reply replaces it, while a reply from BEFORE the write
+//     (older stamp, or no stage at all) leaves the local record standing.
+//     A server observation carries the stored record's stamp (or null), which
+//     is exactly "not newer than anything the wizard has written since".
+function merge(reply: OnboardingState): void {
+  const cur = snapshot;
+  if (!cur) return set(reply);
+  const stages: Stages = { ...(reply.stages ?? {}) };
+  for (const [id, mine] of Object.entries(cur.stages ?? {})) {
+    const theirs = stages[id];
+    if (!theirs || (mine.updated_at ?? -1) > (theirs.updated_at ?? -1)) stages[id] = mine;
+  }
+  set({
+    ...reply,
+    completed_at: reply.completed_at ?? cur.completed_at,
+    dismissed_at: reply.dismissed_at ?? cur.dismissed_at,
+    opened_at: reply.opened_at ?? cur.opened_at,
+    stages,
+  });
+}
+
 /** Adopt a snapshot some other call brought back (the wizard's `opened`
- *  write, complete, dismiss) — every reply is the whole state. */
+ *  write, complete, dismiss). Merged, like every reply (see `merge`). */
 export function setProgress(next: OnboardingState): void {
-  set(next);
+  merge(next);
 }
 
 /** Seed from the boot config, once — a first paint that does not wait. */
@@ -85,7 +116,7 @@ export function seedProgress(config: Config): void {
 export function refreshProgress(): Promise<void> {
   if (inflight) return inflight;
   inflight = getOnboarding()
-    .then((s) => set(s))
+    .then((s) => merge(s))
     .catch(() => undefined)
     .finally(() => {
       inflight = null;
@@ -138,7 +169,7 @@ export function reportStage(
     });
   }
   setOnboardingStage(stage, status, meta).then(
-    (s) => set(s),
+    (s) => merge(s),
     () => undefined,
   );
 }

--- a/frontend/src/shell/onboarding/state.ts
+++ b/frontend/src/shell/onboarding/state.ts
@@ -7,12 +7,15 @@ import type { Config } from "@platform/lib/api";
 
 export const ONBOARDING_PATH = "/onboarding";
 
-/** The auto-show rule, from the server's flag: never completed AND never
-    dismissed. A backend without the field (older server) shows nothing. */
+/** The auto-show rule, from the server's flags: never completed, never
+    dismissed AND NEVER OPENED. The wizard is for a first run; once it has been
+    on screen, however the user left it (Back, a refresh, the sidebar meter),
+    /home is /home again and the meter row is the way back in. A backend without
+    the field (older server) shows nothing. */
 export function shouldAutoShow(config: Config): boolean {
   const s = config.onboarding;
   if (!s) return false;
-  return s.completed_at == null && s.dismissed_at == null;
+  return s.completed_at == null && s.dismissed_at == null && s.opened_at == null;
 }
 
 // The resume point. The server keeps the last open step (shell/onboarding.py

--- a/frontend/src/shell/onboarding/state.ts
+++ b/frontend/src/shell/onboarding/state.ts
@@ -2,7 +2,12 @@
 // renders it alone (no sidebar, no status bar) on that path, the server
 // answers a refresh on it (server/routers/shell.py), and Help › Setup wizard
 // is an ordinary link. Opening and closing are navigations — nothing here
-// needs a store. What is left is the boot-time rule, and the resume point.
+// needs a store. What is left is the boot-time rule.
+//
+// There is no "resume at the last open step" any more (it was stored
+// server-side as `step`): where the wizard opens is the FIRST STEP STILL TO DO,
+// read off the stage statuses — progress.ts `onboardingUrl`. What is left is a
+// better answer than where the user last happened to be.
 import type { Config } from "@platform/lib/api";
 
 export const ONBOARDING_PATH = "/onboarding";
@@ -16,34 +21,4 @@ export function shouldAutoShow(config: Config): boolean {
   const s = config.onboarding;
   if (!s) return false;
   return s.completed_at == null && s.dismissed_at == null && s.opened_at == null;
-}
-
-// The resume point. The server keeps the last open step (shell/onboarding.py
-// `step`) so a restart lands on it; but `config` is fetched ONCE at boot
-// (main.tsx), so within a page load the wizard's own writes would be invisible
-// to a reopen — dismiss on step 3, Help › Setup wizard, and the prop still
-// says whatever boot said. This module-level memory is the same-page-load
-// half; the server is the across-restart half. Not localStorage: every port
-// is a new origin (see the server module's docstring).
-//
-// `undefined` = this page load has not touched the wizard (defer to boot);
-// `null` = it completed the wizard (start over, as the server also says now).
-let rememberedStep: string | null | undefined = undefined;
-
-export function rememberStep(step: string | null): void {
-  rememberedStep = step;
-}
-
-/** Where a reopen should land, most recent source first: this page load's
-    memory, then the boot snapshot. Null when neither knows. */
-export function recallStep(config: Config): string | null {
-  if (rememberedStep !== undefined) return rememberedStep;
-  return config.onboarding?.step ?? null;
-}
-
-/** The wizard's URL for the boot auto-show: names the resume step when the
-    server has one, so a restart mid-wizard reopens the same page. */
-export function onboardingUrl(config: Config): string {
-  const step = recallStep(config);
-  return step ? `${ONBOARDING_PATH}?step=${encodeURIComponent(step)}` : ONBOARDING_PATH;
 }

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -1190,3 +1190,45 @@ a.bookmark-name::after {
 .current-apps-compose .home-composer-wrap {
   margin-bottom: 0;
 }
+
+/* -- The setup meter (shell/onboarding/SetupProgress) --------------------------
+   A `.sidebar-item` row above Settings: ring glyph, "Setup", then a thin bar
+   and the number in the trailing slot. The fill is the accent — this is the
+   one row in the sidebar that is an invitation rather than a destination, and
+   the wizard's own yellow says so. The rail shows the ring alone. */
+.setup-progress-bar {
+  position: relative;
+  width: 44px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(var(--tint), 0.1);
+  overflow: hidden;
+}
+
+.setup-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 400ms ease;
+}
+
+.setup-progress-pct {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+  min-width: 3ch;
+  text-align: right;
+}
+
+.setup-ring-fill {
+  color: var(--accent);
+  transition: stroke-dasharray 400ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .setup-progress-fill,
+  .setup-ring-fill {
+    transition: none;
+  }
+}

--- a/fused_render/claude_health.py
+++ b/fused_render/claude_health.py
@@ -1200,6 +1200,16 @@ def _read_cache() -> Optional[dict]:
     return data if isinstance(data, dict) else None
 
 
+def cached() -> Optional[dict]:
+    """The cached snapshot if it is still trustworthy (same binary, not too
+    old), else None — and NEVER a measure. For readers on hot paths that may
+    say nothing rather than spawn (shell/onboarding's progress observer)."""
+    c = _read_cache()
+    if c and c.get("fingerprint") == _fingerprint(c.get("path")) and not _too_old(c):
+        return dict(c)
+    return None
+
+
 def snapshot(refresh: bool = False) -> dict:
     """The health snapshot: cached when still valid, re-measured when not.
 

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -22,6 +22,24 @@ after a dismiss (Help › Setup wizard reopens where the user left). `complete`
 clears it, so a finished user who reopens the wizard starts from the top;
 `dismiss` keeps it. Server-side for the same reason as the flags.
 
+`stages` is the fourth field, and the one behind the PROGRESS METER (the
+sidebar's "Setup 60%" row and the wizard's top-bar pills): one record per
+wizard step, `{status, meta, updated_at}`, `status` one of
+`pending | partial | complete | n/a`. Each step of the wizard decides its own
+status from the facts it already checks (shell/onboarding/progress.ts holds
+the table) and POSTs it here whenever it changes; `meta` is whatever the step
+wants to remember about how it got there (the version it found, the account,
+the model ids it started) — free-form, for reference, never read back by a
+rule. `n/a` is a step this machine does not have (Disk Access off macOS, Models
+with nothing to offer) — it leaves the denominator.
+
+The stored status is what the wizard last SAW. For the stages the server can
+check cheaply it is overruled on every read by what is true now (`_observe`):
+Full Disk Access from fda.py's TTL-cached probe, "first app" from the
+workspace's local/ folder, Claude Code from claude_health's disk cache (never a
+spawn). So a grant made from the Home strip, or an app built without the
+wizard, moves the meter without the wizard being reopened.
+
 `seed_for_existing_users` is the upgrade edge: "first time they open the app"
 means a NEW user, and an existing install upgrading into this build has no
 flag either. A workspace that already holds apps under <fused_dir>/local is
@@ -31,8 +49,10 @@ ever asks.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import sys
 import time
 
 from fastapi import APIRouter, Header
@@ -56,6 +76,13 @@ _KEY = "onboarding"
 #: rather than stored.
 STEPS = ("about", "claude", "fda", "models", "app")
 
+#: Stage statuses. `n/a` = the machine has no such step; it is not counted.
+STATUSES = ("pending", "partial", "complete", "n/a")
+
+#: Largest `meta` a stage write may carry, in JSON bytes — prefs.json is
+#: shared state and a stage note is a note, not a log.
+META_MAX_BYTES = 4096
+
 #: `FUSED_RENDER_ONBOARDING=1` forces the auto-show (state reads as fresh) so a
 #: dev server can render the wizard without deleting prefs.json; `=0` forces
 #: it off. Read per request: flipping it needs no restart.
@@ -78,17 +105,115 @@ def _write(patch: dict) -> dict:
     return state
 
 
+def _stages(state: dict) -> dict:
+    """The stored stage records, validated (an unknown id or a malformed record
+    is dropped, not served), then overruled by what the server can see now."""
+    raw = state.get("stages")
+    out: dict = {}
+    if isinstance(raw, dict):
+        for sid, rec in raw.items():
+            if sid not in STEPS or not isinstance(rec, dict):
+                continue
+            if rec.get("status") not in STATUSES:
+                continue
+            meta = rec.get("meta")
+            out[sid] = {
+                "status": rec["status"],
+                "meta": meta if isinstance(meta, dict) else {},
+                "updated_at": rec.get("updated_at"),
+            }
+    _observe(out)
+    return out
+
+
+def _observe(stages: dict) -> None:
+    """Overrule the stored status with the truth where it is cheap to know.
+    Mutates `stages` in place; a stage the server cannot see is left as the
+    wizard wrote it. Never raises — a meter must not take /api/config down."""
+
+    def put(sid: str, status: str, **meta: object) -> None:
+        rec = stages.get(sid) or {"status": "pending", "meta": {}, "updated_at": None}
+        if rec["status"] == status and all(rec["meta"].get(k) == v for k, v in meta.items()):
+            stages.setdefault(sid, rec)
+            return
+        stages[sid] = {
+            "status": status,
+            "meta": {**rec["meta"], **meta, "observed": True},
+            "updated_at": rec.get("updated_at"),
+        }
+
+    # Full Disk Access: fda.snapshot() is the strip's own verdict, TTL-cached.
+    try:
+        from fused_render.shell import fda as shell_fda
+
+        fda = shell_fda.snapshot()
+        if fda is not None:
+            if fda.get("granted"):
+                put("fda", "complete", granted=True)
+            elif fda.get("pending_relaunch"):
+                put("fda", "partial", pending_relaunch=True)
+            elif stages.get("fda", {}).get("status") == "complete":
+                # A grant this process no longer has (revoked) — back to pending.
+                put("fda", "pending", granted=False)
+        elif sys.platform != "darwin":
+            put("fda", "n/a")
+    except Exception:  # noqa: BLE001
+        log.debug("onboarding: fda observe failed", exc_info=True)
+
+    # First app: any folder under <fused_dir>/local IS an app the user has.
+    try:
+        from fused_render.shell.seed import fused_dir
+
+        local = os.path.join(fused_dir(), "local")
+        if os.path.isdir(local):
+            with os.scandir(local) as it:
+                count = sum(1 for e in it if e.is_dir() and not e.name.startswith("."))
+            if count:
+                put("app", "complete", app_count=count)
+    except Exception:  # noqa: BLE001
+        log.debug("onboarding: app observe failed", exc_info=True)
+
+    # Claude Code: the health module's DISK CACHE only — a fresh measure spawns
+    # processes, and /api/config is read on every page load. No cache, no say.
+    try:
+        from fused_render import claude_health
+
+        h = claude_health.cached()
+        if h is not None:
+            runnable = bool(h.get("found")) and not h.get("broken")
+            ok = (
+                runnable
+                and h.get("version") is not None
+                and not h.get("outdated")
+                and h.get("signed_in") is True
+            )
+            status = "complete" if ok else "partial" if runnable else "pending"
+            acct = h.get("account") or {}
+            put(
+                "claude",
+                status,
+                version=h.get("version"),
+                signed_in=h.get("signed_in"),
+                account=acct.get("email") or acct.get("method"),
+                on_shell_path=h.get("on_shell_path"),
+            )
+    except Exception:  # noqa: BLE001
+        log.debug("onboarding: claude observe failed", exc_info=True)
+
+
 def snapshot() -> dict:
     """The `onboarding` field of /api/config: `{completed_at, dismissed_at,
-    step, version}` — each timestamp epoch seconds or None, `step` the last
-    open step id or None. The shell auto-shows when BOTH timestamps are None."""
+    step, stages, version}` — each timestamp epoch seconds or None, `step` the
+    last open step id or None, `stages` the per-step progress records (module
+    docstring). The shell auto-shows when BOTH timestamps are None."""
     force = os.environ.get(FORCE_ENV)
     state = _read()
     step = state.get("step") if state.get("step") in STEPS else None
+    stages = _stages(state)
     if force == "1":
         # The override fakes the FLAGS, not the step: a dev server forced into
         # the wizard still resumes where it was, which is how this is smoked.
-        return {"completed_at": None, "dismissed_at": None, "step": step, "version": VERSION}
+        return {"completed_at": None, "dismissed_at": None, "step": step, "stages": stages, "version": VERSION}
     if force == "0" and state.get("dismissed_at") is None:
         # Reads as dismissed without writing anything: the override is for
         # this process, not a decision the user made.
@@ -97,6 +222,7 @@ def snapshot() -> dict:
         "completed_at": state.get("completed_at"),
         "dismissed_at": state.get("dismissed_at"),
         "step": step,
+        "stages": stages,
         "version": VERSION,
     }
 
@@ -166,4 +292,38 @@ def api_onboarding_step(body: dict, x_fused: str | None = Header(default=None)):
     if step not in STEPS:
         return JSONResponse({"error": f"unknown step {step!r}"}, status_code=400)
     _write({"step": step})
+    return snapshot()
+
+
+@router.post("/api/onboarding/stage")
+def api_onboarding_stage(body: dict, x_fused: str | None = Header(default=None)):
+    """A step reports its status — `{stage, status, meta?}`. The status is
+    replaced; `meta` is MERGED over what the stage stored before (a step notes
+    one more fact without restating the rest). Refuses ids and statuses it
+    does not know, and a note over `META_MAX_BYTES`."""
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    if not isinstance(body, dict):
+        return JSONResponse({"error": "body must be an object"}, status_code=400)
+    stage = body.get("stage")
+    status = body.get("status")
+    meta = body.get("meta") or {}
+    if stage not in STEPS:
+        return JSONResponse({"error": f"unknown stage {stage!r}"}, status_code=400)
+    if status not in STATUSES:
+        return JSONResponse({"error": f"unknown status {status!r}"}, status_code=400)
+    if not isinstance(meta, dict):
+        return JSONResponse({"error": "meta must be an object"}, status_code=400)
+    try:
+        if len(json.dumps(meta)) > META_MAX_BYTES:
+            return JSONResponse({"error": f"meta over {META_MAX_BYTES} bytes"}, status_code=400)
+    except (TypeError, ValueError):
+        return JSONResponse({"error": "meta must be JSON"}, status_code=400)
+    state = _read()
+    stages = dict(state["stages"]) if isinstance(state.get("stages"), dict) else {}
+    prev = stages.get(stage) if isinstance(stages.get(stage), dict) else {}
+    prev_meta = prev.get("meta") if isinstance(prev.get("meta"), dict) else {}
+    stages[stage] = {"status": status, "meta": {**prev_meta, **meta}, "updated_at": time.time()}
+    _write({"stages": stages})
     return snapshot()

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -15,12 +15,14 @@ what lets a later "Setup" entry in the sidebar's Help menu reopen the wizard
 without either write being touched, and what a future version bump could key
 a re-show on (a dismissed user is a different audience from a completed one).
 
-`step` is the third field: the id of the wizard step the user last had open,
-written by the shell on every step change. It is what lets the wizard RESUME —
-after a server restart (the auto-show lands on that step, not the first) and
-after a dismiss (Help › Setup wizard reopens where the user left). `complete`
-clears it, so a finished user who reopens the wizard starts from the top;
-`dismiss` keeps it. Server-side for the same reason as the flags.
+`opened_at` is the third: when the wizard was first on screen, stamped by the
+first write of any kind (a stage report, ✕, the end, or the bare `opened`
+POST the wizard makes on mount). It is the auto-show's third leg — the wizard
+is shown to someone who has NEVER seen it, and however they leave (Back, a
+refresh, the sidebar meter) it is not shown again unasked. (A `step` field, the
+last open step for a resume, was stored by earlier builds; it is gone — the
+wizard now opens on the first step still to do, read off `stages` — and a
+stored one only counts as evidence of an open.)
 
 `stages` is the fourth field, and the one behind the PROGRESS METER (the
 sidebar's "Setup 60%" row and the wizard's top-bar pills): one record per
@@ -220,21 +222,19 @@ def _observe(stages: dict) -> None:
 
 def snapshot() -> dict:
     """The `onboarding` field of /api/config: `{completed_at, dismissed_at,
-    step, stages, version}` — each timestamp epoch seconds or None, `step` the
-    last open step id or None, `stages` the per-step progress records (module
-    docstring). The shell auto-shows when BOTH timestamps are None."""
+    opened_at, stages, version}` — each timestamp epoch seconds or None,
+    `stages` the per-step progress records (module docstring). The shell
+    auto-shows while all three timestamps are None."""
     force = os.environ.get(FORCE_ENV)
     state = _read()
-    step = state.get("step") if state.get("step") in STEPS else None
     stages = _stages(state)
     if force == "1":
-        # The override fakes the FLAGS, not the step: a dev server forced into
-        # the wizard still resumes where it was, which is how this is smoked.
+        # The override fakes the FLAGS, not the stages: a dev server forced into
+        # the wizard still opens on its first open step, which is how this is smoked.
         return {
             "completed_at": None,
             "dismissed_at": None,
             "opened_at": None,
-            "step": step,
             "stages": stages,
             "version": VERSION,
         }
@@ -245,15 +245,14 @@ def snapshot() -> dict:
     return {
         "completed_at": state.get("completed_at"),
         "dismissed_at": state.get("dismissed_at"),
-        # First time the wizard was ever on screen (stamped by the first step
+        # First time the wizard was ever on screen (stamped by any wizard
         # write). The auto-show is for a wizard NEVER seen: once opened, every
         # way out — Back, a refresh, the sidebar meter — is a way out, and the
         # meter row is how one gets back in. Before this, only complete/dismiss
         # stopped the bounce, and a /home reload after Back re-entered forever.
-        # A stored step from a build before this field IS evidence of an open;
-        # 0 = "opened, when unknown", so the upgrade does not bounce once more.
-        "opened_at": state.get("opened_at") if state.get("opened_at") is not None else (0 if step else None),
-        "step": step,
+        # A `step` left by a build that stored the last open step IS evidence
+        # of an open; 0 = "opened, when unknown", so an upgrade does not bounce.
+        "opened_at": state.get("opened_at") if state.get("opened_at") is not None else (0 if state.get("step") else None),
         "stages": stages,
         "version": VERSION,
     }
@@ -298,9 +297,7 @@ def api_onboarding_complete(x_fused: str | None = Header(default=None)):
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
-    # Completion resets the resume point: reopening a FINISHED wizard from
-    # Help starts at the top, a dismissed one resumes (see module docstring).
-    _write({"completed_at": time.time(), "step": None})
+    _write({"completed_at": time.time()})
     return snapshot()
 
 
@@ -313,17 +310,15 @@ def api_onboarding_dismiss(x_fused: str | None = Header(default=None)):
     return snapshot()
 
 
-@router.post("/api/onboarding/step")
-def api_onboarding_step(body: dict, x_fused: str | None = Header(default=None)):
-    """Remember the step the user has open, so a restart or a reopen resumes
-    there. Fire-and-forget from the shell; refuses ids it does not know."""
+@router.post("/api/onboarding/opened")
+def api_onboarding_opened(x_fused: str | None = Header(default=None)):
+    """The wizard is on screen. Writes nothing but the `opened_at` stamp every
+    write makes (`_write`) — the auto-show's "never opened" leg, from a visit
+    that may otherwise leave no other mark (opened, looked, pressed Back)."""
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
-    step = body.get("step") if isinstance(body, dict) else None
-    if step not in STEPS:
-        return JSONResponse({"error": f"unknown step {step!r}"}, status_code=400)
-    _write({"step": step})
+    _write({})
     return snapshot()
 
 

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -103,11 +103,18 @@ def _read() -> dict:
 _LOCK = threading.RLock()
 
 
-def _write(patch: dict) -> dict:
+def _write(patch: dict, *, opened: bool = True) -> dict:
+    """Merge `patch` into the stored state. Every write the WIZARD makes (a
+    step, a stage, ✕, the end) is proof it was on screen, so `opened_at` is
+    stamped on the first of them whichever it is — a user who opens the wizard
+    and crosses it straight off has opened it. `opened=False` is for the
+    startup seed, which is not the user doing anything."""
     with _LOCK:
         all_prefs = prefs.read_prefs()
         current = all_prefs.get(_KEY)
         state = dict(current) if isinstance(current, dict) else {}
+        if opened and state.get("opened_at") is None:
+            state["opened_at"] = time.time()
         state.update(patch)
         state["version"] = VERSION
         all_prefs[_KEY] = state
@@ -267,7 +274,7 @@ def seed_for_existing_users(fused_ws: str) -> None:
         with os.scandir(local) as it:
             has_app = any(e.is_dir() and not e.name.startswith(".") for e in it)
         if has_app:
-            _write({"completed_at": time.time(), "seeded": True})
+            _write({"completed_at": time.time(), "seeded": True}, opened=False)
             log.info("onboarding: existing workspace found, wizard marked completed")
     except Exception:  # noqa: BLE001 — startup chore, never fatal
         log.exception("onboarding: seed check failed (continuing)")
@@ -316,11 +323,7 @@ def api_onboarding_step(body: dict, x_fused: str | None = Header(default=None)):
     step = body.get("step") if isinstance(body, dict) else None
     if step not in STEPS:
         return JSONResponse({"error": f"unknown step {step!r}"}, status_code=400)
-    with _LOCK:
-        patch: dict = {"step": step}
-        if _read().get("opened_at") is None:
-            patch["opened_at"] = time.time()
-        _write(patch)
+    _write({"step": step})
     return snapshot()
 
 

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -53,6 +53,7 @@ import json
 import logging
 import os
 import sys
+import threading
 import time
 
 from fastapi import APIRouter, Header
@@ -94,15 +95,24 @@ def _read() -> dict:
     return data if isinstance(data, dict) else {}
 
 
+#: Every write is a read-modify-write of the whole prefs file, and the routes
+#: are sync `def`s FastAPI runs on a threadpool — so two stage reports landing
+#: in the same tick (the wizard's `step` and `about`, health's `claude` and
+#: `fda: n/a`) would each read the old `stages` and the loser's vanish from
+#: disk. One lock; reentrant so a route can read-then-write under it.
+_LOCK = threading.RLock()
+
+
 def _write(patch: dict) -> dict:
-    all_prefs = prefs.read_prefs()
-    current = all_prefs.get(_KEY)
-    state = dict(current) if isinstance(current, dict) else {}
-    state.update(patch)
-    state["version"] = VERSION
-    all_prefs[_KEY] = state
-    storage.write_json(prefs._path(), all_prefs)
-    return state
+    with _LOCK:
+        all_prefs = prefs.read_prefs()
+        current = all_prefs.get(_KEY)
+        state = dict(current) if isinstance(current, dict) else {}
+        state.update(patch)
+        state["version"] = VERSION
+        all_prefs[_KEY] = state
+        storage.write_json(prefs._path(), all_prefs)
+        return state
 
 
 def _stages(state: dict) -> dict:
@@ -320,10 +330,11 @@ def api_onboarding_stage(body: dict, x_fused: str | None = Header(default=None))
             return JSONResponse({"error": f"meta over {META_MAX_BYTES} bytes"}, status_code=400)
     except (TypeError, ValueError):
         return JSONResponse({"error": "meta must be JSON"}, status_code=400)
-    state = _read()
-    stages = dict(state["stages"]) if isinstance(state.get("stages"), dict) else {}
-    prev = stages.get(stage) if isinstance(stages.get(stage), dict) else {}
-    prev_meta = prev.get("meta") if isinstance(prev.get("meta"), dict) else {}
-    stages[stage] = {"status": status, "meta": {**prev_meta, **meta}, "updated_at": time.time()}
-    _write({"stages": stages})
+    with _LOCK:
+        state = _read()
+        stages = dict(state["stages"]) if isinstance(state.get("stages"), dict) else {}
+        prev = stages.get(stage) if isinstance(stages.get(stage), dict) else {}
+        prev_meta = prev.get("meta") if isinstance(prev.get("meta"), dict) else {}
+        stages[stage] = {"status": status, "meta": {**prev_meta, **meta}, "updated_at": time.time()}
+        _write({"stages": stages})
     return snapshot()

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -223,7 +223,14 @@ def snapshot() -> dict:
     if force == "1":
         # The override fakes the FLAGS, not the step: a dev server forced into
         # the wizard still resumes where it was, which is how this is smoked.
-        return {"completed_at": None, "dismissed_at": None, "step": step, "stages": stages, "version": VERSION}
+        return {
+            "completed_at": None,
+            "dismissed_at": None,
+            "opened_at": None,
+            "step": step,
+            "stages": stages,
+            "version": VERSION,
+        }
     if force == "0" and state.get("dismissed_at") is None:
         # Reads as dismissed without writing anything: the override is for
         # this process, not a decision the user made.
@@ -231,6 +238,14 @@ def snapshot() -> dict:
     return {
         "completed_at": state.get("completed_at"),
         "dismissed_at": state.get("dismissed_at"),
+        # First time the wizard was ever on screen (stamped by the first step
+        # write). The auto-show is for a wizard NEVER seen: once opened, every
+        # way out — Back, a refresh, the sidebar meter — is a way out, and the
+        # meter row is how one gets back in. Before this, only complete/dismiss
+        # stopped the bounce, and a /home reload after Back re-entered forever.
+        # A stored step from a build before this field IS evidence of an open;
+        # 0 = "opened, when unknown", so the upgrade does not bounce once more.
+        "opened_at": state.get("opened_at") if state.get("opened_at") is not None else (0 if step else None),
         "step": step,
         "stages": stages,
         "version": VERSION,
@@ -301,7 +316,11 @@ def api_onboarding_step(body: dict, x_fused: str | None = Header(default=None)):
     step = body.get("step") if isinstance(body, dict) else None
     if step not in STEPS:
         return JSONResponse({"error": f"unknown step {step!r}"}, status_code=400)
-    _write({"step": step})
+    with _LOCK:
+        patch: dict = {"step": step}
+        if _read().get("opened_at") is None:
+            patch["opened_at"] = time.time()
+        _write(patch)
     return snapshot()
 
 


### PR DESCRIPTION
## Summary

- Every wizard step is now a **stage** with a status it decides for itself — `pending`, `partial`, `complete`, or `n/a` for a step this machine does not have — plus a free-form `meta` note for reference. Written via `POST /api/onboarding/stage`, stored in prefs.json under `onboarding.stages`, read back on `config.onboarding.stages`.
- The server **overrules** the stored status where the truth is cheap on every read: Full Disk Access from `fda.snapshot()`, First app from the `local/` folder, Claude Code from `claude_health`'s disk cache (new `cached()` reader, never a spawn).
- **Sidebar**: a "Setup · N%" row above Settings (ring glyph on the collapsed rail) that reopens the wizard. Shown after the wizard writes its first stage, hidden at 100%.
- **Wizard top bar**: pills draw the stage status, not the position — green check = complete, amber half-dot = partial, number = pending. Skipping Claude no longer earns a tick.

## Stage conditions

| stage | pending | partial | complete | n/a |
|---|---|---|---|---|
| About | not opened | — | opened | — |
| Claude Code | not installed / unknown | runs, but outdated / signed out / unknown | installed, new enough, signed in (PATH row is optional) | — |
| Disk Access | not granted | granted, relaunch pending | granted | off macOS |
| Models | none fetched | some here or downloading | every offered model here | no engine can serve anything |
| First app | nothing built | — | composer created an app, or a showcase card opened | — |

Percentage: over counted stages, complete = 1, partial = ½, rounded; 100 only when all complete.

## Judgment calls

- "I'll explore on my own" ends the wizard but does NOT complete the First-app stage.
- Meter is hidden for installs upgrading into this build (seeded complete, no stages) and again once it reads 100 — Help › Setup wizard remains the re-entry.
- Prefs writes now go through a module lock: stage reports from several steps can land in the same tick.

## Test plan

- [ ] `FUSED_RENDER_ONBOARDING=1`: walk the wizard, skip Claude — its pill stays a number, sidebar row appears on leaving, percentage matches.
- [ ] Grant FDA from the Home strip later — meter moves without reopening the wizard.
- [ ] Collapsed sidebar shows the ring above Settings; click opens the wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted prefs, boot auto-show behavior, and concurrent stage writes; server observation can diverge briefly from wizard-reported stages but is designed to converge on read.
> 
> **Overview**
> First-run setup now tracks **per-step stage status** (`pending` / `partial` / `complete` / `n/a`) instead of a stored “last open step.” Steps report via `POST /api/onboarding/stage`; the shell persists `onboarding.stages` and re-reads them through a new **`progress.ts`** client store (optimistic writes, merge by `updated_at`).
> 
> **UX:** A **Setup · N%** row (and collapsed-rail ring) in the sidebar links back into the wizard; wizard pills reflect **real progress** (not walk-past position). Re-entry and boot auto-show land on the **first step still to do** (`onboardingUrl` / `firstOpenStage`). Auto-show also requires **`opened_at` still unset** (`POST /api/onboarding/opened` on mount); once seen, `/home` stops bouncing users in.
> 
> **Backend:** `onboarding.py` adds stage validation, a prefs **write lock**, `opened_at` stamping, and **`_observe`** to override stored stages from FDA probe, `local/` apps, and **`claude_health.cached()`** (no spawn on config reads). Legacy `step` in prefs counts as “already opened” for upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223fdd40160ccd2ba3aa209ef69fb4214b28306e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->