### PR TITLE
Icon picker: theme-following colours for lucide picks

### DIFF
--- a/frontend/src/platform/lib/app-icon-src.ts
+++ b/frontend/src/platform/lib/app-icon-src.ts
@@ -1,0 +1,66 @@
+// The `src` to draw an app's icon.svg from, recoloured for the live theme.
+//
+// Every surface that shows an app icon — the sidebar's Projects row, the app
+// page's header mark, the /apps card, the tab favicon — draws the file through
+// an `<img>` or a `<link rel="icon">`, where the shell's CSS cannot reach. A
+// picked lucide glyph (IconPicker.glyphIconSvg) therefore names its colour
+// instead of baking it (`data-fused-color`, icon-color.ts), and this hook
+// fetches the file once, swaps `currentColor` for the theme's hex, and hands
+// back a data: URL. Files without the marker — emoji glyphs, hand-authored
+// icons — come back as the raw URL they always were: drawn as is, the owner's
+// standing rule (2026-08-27).
+//
+// Until the fetch lands (and for anything without a marker) the answer is the
+// raw URL itself, never null: null would flash the AppStar fallback, and the
+// raw file's own `prefers-color-scheme` fallback already paints the right
+// colour whenever the app follows the OS, so the swap is usually invisible.
+import { useEffect, useState } from "react";
+
+import { readIconColor, svgDataUrl, themeIconSvg } from "@platform/lib/icon-color";
+import { useResolvedTheme, type Theme } from "@platform/lib/theme";
+
+// One fetch per URL: the URL carries the file's mtime as a cache key
+// (appIconUrl / current-apps-lib.iconUrlFor), so a changed file is a new key
+// and an unchanged one is answered from here across every row and remount.
+// `null` = fetched, no marker (or unreadable): use the raw URL.
+const texts = new Map<string, Promise<string | null>>();
+
+function iconText(url: string): Promise<string | null> {
+  let p = texts.get(url);
+  if (!p) {
+    p = fetch(url)
+      .then((r) => (r.ok ? r.text() : null))
+      .then((svg) => (svg && readIconColor(svg) ? svg : null))
+      .catch(() => null);
+    texts.set(url, p);
+  }
+  return p;
+}
+
+/** The recoloured src for `url` under `theme` — a data: URL for a marked svg,
+ *  the raw URL otherwise. Pure once the text is known. */
+export function themedIconSrc(url: string, svg: string | null, theme: Theme): string {
+  return svg ? svgDataUrl(themeIconSvg(svg, theme)) : url;
+}
+
+/** `url` is the raw icon URL (or null for an app without an icon, passed
+ *  through). The result re-resolves when the theme changes. */
+export function useThemedIconSrc(url: string | null): string | null {
+  const theme = useResolvedTheme();
+  const [svg, setSvg] = useState<{ url: string; text: string | null } | null>(null);
+  useEffect(() => {
+    if (!url) return;
+    let live = true;
+    iconText(url).then((text) => {
+      if (live) setSvg({ url, text });
+    });
+    return () => {
+      live = false;
+    };
+  }, [url]);
+  if (!url) return null;
+  // A stale answer (the URL changed under us) must not recolour the NEW file
+  // with the OLD file's text — fall back to the raw URL until its own lands.
+  const text = svg && svg.url === url ? svg.text : null;
+  return themedIconSrc(url, text, theme);
+}

--- a/frontend/src/platform/lib/app-icon.ts
+++ b/frontend/src/platform/lib/app-icon.ts
@@ -25,7 +25,7 @@ export function emojiIconSvg(emoji: string): string {
 
 /** Apply an icon picker's answer to the app folder at `path`: `null` removes
  *  the file (back to the generic mark), an icon pick is stored as the finished
- *  branded svg it arrives as, and an emoji gets the standalone wrapper above.
+ *  grey-glyph svg it arrives as, and an emoji gets the standalone wrapper above.
  *
  *  Announces the desk change on success, and that is the reason this is shared
  *  rather than two call sites: the sidebar's Projects row for this app is on

--- a/frontend/src/platform/lib/hooks.ts
+++ b/frontend/src/platform/lib/hooks.ts
@@ -160,6 +160,10 @@ let defaultHref: string | null = null;
 // server ignores the query, so the bytes are the same file under a new key.
 let faviconSeq = 0;
 function bust(url: string): string {
+  // A data: URL has no query — anything appended lands INSIDE the svg text
+  // (`</svg>?r=1`) and the icon fails to parse. Its content is its identity
+  // (app-icon-src.ts recolours per theme), so it needs no key anyway.
+  if (url.startsWith("data:")) return url;
   const sep = url.includes("?") ? "&" : "?";
   return `${url}${sep}r=${++faviconSeq}`;
 }

--- a/frontend/src/platform/lib/icon-color.ts
+++ b/frontend/src/platform/lib/icon-color.ts
@@ -1,0 +1,92 @@
+// The app-icon palette: Notion's ten icon colours, each a light/dark pair, so
+// a picked lucide glyph follows the shell's theme the way the generic AppStar
+// (on currentColor) already does.
+//
+// The problem this solves: `icon.svg` is a static file drawn through `<img>`
+// and `<link rel="icon">`, and neither crosses into the shell's CSS — no
+// `currentColor`, no `--fg-muted`, no `data-theme`. So the picker writes the
+// COLOUR'S NAME into the file (`data-fused-color="red"`) and strokes the glyph
+// in `currentColor`, and the shell substitutes the hex for the live theme
+// before the browser ever sees it (app-icon-src.ts). The file also carries a
+// `prefers-color-scheme` fallback so it reads right standalone — Finder,
+// GitHub, a bare tab — where only the OS theme is knowable.
+//
+// DOM-free on purpose (no fetch, no document): current-apps-lib.ts and the bun
+// tests can import it.
+import type { Theme } from "@platform/lib/theme";
+
+export const ICON_COLORS = [
+  "default",
+  "gray",
+  "brown",
+  "yellow",
+  "orange",
+  "green",
+  "blue",
+  "purple",
+  "pink",
+  "red",
+] as const;
+
+export type IconColor = (typeof ICON_COLORS)[number];
+
+/** Hex per theme. `default` is the `--fg-muted` pair (tokens.css) — the tint
+ *  the generic AppStar fallback wears, so an uncoloured pick and no pick at
+ *  all sit in the same register. The rest are Notion's icon palette. The
+ *  same values live in tokens.css as `--app-icon-<name>` for the picker's
+ *  swatches; the svg needs them as literals. */
+export const ICON_COLOR_HEX: Record<IconColor, { light: string; dark: string }> = {
+  default: { light: "#61656c", dark: "#9aa0a6" },
+  gray: { light: "#787774", dark: "#9b9b9b" },
+  brown: { light: "#9f6b53", dark: "#ba856f" },
+  yellow: { light: "#cb912f", dark: "#ca9849" },
+  orange: { light: "#d9730d", dark: "#c77d48" },
+  green: { light: "#448361", dark: "#529e72" },
+  blue: { light: "#337ea9", dark: "#5e87c9" },
+  purple: { light: "#9065b0", dark: "#9d68d3" },
+  pink: { light: "#c14c8a", dark: "#d15796" },
+  red: { light: "#d44c47", dark: "#df5452" },
+};
+
+export const ICON_COLOR_LABEL: Record<IconColor, string> = {
+  default: "Default",
+  gray: "Gray",
+  brown: "Brown",
+  yellow: "Yellow",
+  orange: "Orange",
+  green: "Green",
+  blue: "Blue",
+  purple: "Purple",
+  pink: "Pink",
+  red: "Red",
+};
+
+export function isIconColor(v: unknown): v is IconColor {
+  return typeof v === "string" && (ICON_COLORS as readonly string[]).includes(v);
+}
+
+/** The colour name an icon.svg declares on its root, or null for a file with
+ *  none (an emoji glyph, a hand-authored icon) — those are drawn as they are.
+ *  Only the root's attribute counts, and only a known name: the file is
+ *  author-controlled, so an unknown value is "no marker", not an error. */
+export function readIconColor(svg: string): IconColor | null {
+  const root = svg.match(/<svg\b[^>]*>/);
+  if (!root) return null;
+  const m = root[0].match(/\sdata-fused-color="([a-z]+)"/);
+  return m && isIconColor(m[1]) ? m[1] : null;
+}
+
+/** The svg with its `currentColor` strokes resolved to the theme's hex —
+ *  what the shell actually hands the `<img>` / favicon. A file without a
+ *  marker comes back untouched. */
+export function themeIconSvg(svg: string, theme: Theme): string {
+  const color = readIconColor(svg);
+  if (!color) return svg;
+  return svg.replace(/currentColor/g, ICON_COLOR_HEX[color][theme]);
+}
+
+/** A data: URL for an svg document. encodeURIComponent, not base64: the
+ *  result is readable in devtools and about a third smaller for this text. */
+export function svgDataUrl(svg: string): string {
+  return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svg);
+}

--- a/frontend/src/platform/lib/theme.ts
+++ b/frontend/src/platform/lib/theme.ts
@@ -172,6 +172,20 @@ export function useThemePref(): [ThemePref, (pref: ThemePref) => void] {
   return [pref, setThemePref];
 }
 
+// The theme actually painted, live: the preference resolved, re-resolved on
+// every signal subscribeThemePref knows (own menu, another window, an OS flip
+// under System). For the few places that need the answer as a VALUE rather
+// than through CSS — an `<img>` cannot read a token, so the app-icon
+// recolouring (app-icon-src.ts) picks the hex for this theme itself.
+export function useResolvedTheme(): Theme {
+  const [theme, setTheme] = useState<Theme>(() => resolveTheme(loadThemePref()));
+  useEffect(
+    () => subscribeThemePref(() => setTheme(resolveTheme(loadThemePref()))),
+    []
+  );
+  return theme;
+}
+
 // Keep `data-theme` on <html> in step with the preference for the lifetime of
 // the app. The FIRST application already happened in index.html's inline
 // bootstrap (before paint) — this only handles later changes, so mounting it

--- a/frontend/src/platform/ui/AppPreviewCard.tsx
+++ b/frontend/src/platform/ui/AppPreviewCard.tsx
@@ -35,6 +35,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { AppInfo } from "@platform/lib/api";
 import { appIconUrl, appfilePreviewUrl, rawUrl } from "@platform/lib/api";
+import { useThemedIconSrc } from "@platform/lib/app-icon-src";
 import { exportAppFile } from "@platform/lib/appShot";
 import { pushToast } from "@platform/lib/toast";
 import { AppStar } from "@platform/ui/AppStar";
@@ -85,6 +86,11 @@ export function AppPreviewCard({
   // the browser gestures use the same href, so the two still can't disagree.
   href?: string;
 }) {
+  // The icon.svg recoloured for the live theme when it names a colour
+  // (picker-written), the raw file otherwise.
+  const iconSrc = useThemedIconSrc(
+    app.icon ? appIconUrl(app.icon, app.icon_mtime) : null,
+  );
   const title = app.title || app.name;
   // The same timestamp the grid SORTS by (last opened, modified standing in) —
   // a card ranked first for being opened just now must not label itself with a
@@ -237,10 +243,10 @@ export function AppPreviewCard({
             `draggable={false}` for the reason the still's shield exists — an
             <img> carries the browser's native drag-the-image gesture, which
             starts a drag instead of the click that opens the card. */}
-        {app.icon ? (
+        {iconSrc ? (
           <img
             className="app-pcard-icon"
-            src={appIconUrl(app.icon, app.icon_mtime)}
+            src={iconSrc}
             alt=""
             draggable={false}
           />

--- a/frontend/src/platform/ui/IconPicker.tsx
+++ b/frontend/src/platform/ui/IconPicker.tsx
@@ -1,6 +1,6 @@
 // Notion-style icon picker popover: an Emoji tab (the whole Unicode set, from
-// emojibase), an Icons tab (the whole lucide set, branded on pick as a black
-// rounded square with the glyph in fused yellow), a filter box, a shuffle
+// emojibase), an Icons tab (the whole lucide set, written on pick as the bare
+// glyph in grey, like the generic fallback mark), a filter box, a shuffle
 // button that picks at random from the active tab, a Recent row per tab, and
 // a Remove action that restores the caller's default glyph.
 //
@@ -31,7 +31,7 @@ import { Tabs, TabsList, TabsTrigger } from "@platform/shadcn/ui/tabs";
 
 export type IconPickerTab = "emoji" | "icon";
 
-/** What a pick hands back. An icon pick carries the finished branded svg so a
+/** What a pick hands back. An icon pick carries the finished svg document so a
  *  caller that stores files (the Projects rows' icon.svg) writes it as is. */
 export type IconPick =
   | { kind: "emoji"; emoji: string }
@@ -57,13 +57,13 @@ interface IconPickerProps {
   tabs?: IconPickerTab[];
 }
 
-// ---- brand -----------------------------------------------------------------
+// ---- icon svg--------------------------------------------------------------
 
-/** fused yellow, baked in: icon.svg is a static file with no theme context, and
- *  the light theme's `--accent` is a darker olive (tokens.css) that would read
- *  wrong on the black plate anyway. */
-const BRAND_YELLOW = "#E5FF44";
-const BRAND_BLACK = "#000000";
+/** The glyph's grey, baked in: icon.svg is a static file with no theme
+ *  context, so it cannot read `--fg-muted` — the tint the generic AppStar
+ *  fallback wears. This sits between that token's two values (#9aa0a6 dark,
+ *  #61656c light) so the file reads as the same quiet mark in either theme. */
+const GLYPH_GREY = "#7e838a";
 
 type IconNode = [tag: string, attrs: Record<string, string | number>][];
 
@@ -71,10 +71,10 @@ function escapeAttr(v: string | number): string {
   return String(v).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
 }
 
-/** A lucide icon on the brand plate as a standalone icon.svg document: a
- *  64-unit square, black rounded rect, the 24-unit glyph scaled 1.75× and
- *  centred with 11 units of margin, stroked in fused yellow. */
-export function brandedIconSvg(node: IconNode): string {
+/** A lucide icon as a standalone icon.svg document: a 64-unit square with no
+ *  plate — the bare glyph in grey, like the generic AppStar fallback — the
+ *  24-unit glyph scaled 1.75× and centred with 11 units of margin. */
+export function glyphIconSvg(node: IconNode): string {
   const inner = node
     .map(([tag, attrs]) => {
       const a = Object.entries(attrs)
@@ -86,14 +86,12 @@ export function brandedIconSvg(node: IconNode): string {
     .join("");
   return (
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">' +
-    `<rect width="64" height="64" rx="14" fill="${BRAND_BLACK}"/>` +
-    // 1.75: a 42-unit glyph with 11 of margin — at favicon size the plate
-    // vanishes into a dark tab strip and only the glyph shows, so it has to
-    // carry the icon on its own.
+    // 1.75: a 42-unit glyph with 11 of margin — the glyph carries the icon
+    // on its own, at favicon size as much as in the row.
     '<g transform="translate(11 11) scale(1.75)" fill="none" ' +
     // 2.5 not lucide's 2: the row draws the file at 14px, where a 2-unit
     // stroke lands under a pixel and reads faint beside the emoji rows.
-    `stroke="${BRAND_YELLOW}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">` +
+    `stroke="${GLYPH_GREY}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">` +
     inner +
     "</g></svg>"
   );
@@ -387,7 +385,7 @@ export default function IconPicker({
   const pick = useCallback(
     (cell: Cell) => {
       pushRecent(tab, cell.id);
-      if (cell.node) onPick({ kind: "icon", name: cell.id, svg: brandedIconSvg(cell.node) });
+      if (cell.node) onPick({ kind: "icon", name: cell.id, svg: glyphIconSvg(cell.node) });
       else onPick({ kind: "emoji", emoji: cell.id });
     },
     [tab, onPick],

--- a/frontend/src/platform/ui/IconPicker.tsx
+++ b/frontend/src/platform/ui/IconPicker.tsx
@@ -604,7 +604,10 @@ export default function IconPicker({
                 role="listbox"
                 aria-label="Icon colour"
                 data-slot="icon-picker-colors"
-                className="absolute top-full right-0 z-10 mt-1 grid grid-cols-5 gap-1.5 rounded-lg border border-border bg-popover p-2 shadow-md"
+                // Fixed tracks, not grid-cols-5: an absolutely positioned box
+                // shrinks to fit, and 1fr tracks contribute no intrinsic width,
+                // so the five swatches piled onto one another.
+                className="absolute top-full right-0 z-10 mt-1 grid w-max grid-cols-[repeat(5,1.75rem)] gap-1.5 rounded-lg border border-border bg-popover p-2 shadow-md"
               >
                 {ICON_COLORS.map((c) => (
                   <button

--- a/frontend/src/platform/ui/IconPicker.tsx
+++ b/frontend/src/platform/ui/IconPicker.tsx
@@ -1,6 +1,8 @@
 // Notion-style icon picker popover: an Emoji tab (the whole Unicode set, from
 // emojibase), an Icons tab (the whole lucide set, written on pick as the bare
-// glyph in grey, like the generic fallback mark), a filter box, a shuffle
+// glyph in one of ten theme-following colours — icon-color.ts; the Notion
+// swatch popover beside the shuffle button chooses, and the choice sticks
+// across picks rather than being asked each time), a filter box, a shuffle
 // button that picks at random from the active tab, a Recent row per tab, and
 // a Remove action that restores the caller's default glyph.
 //
@@ -24,6 +26,13 @@ import React, {
 } from "react";
 import { Search, Shuffle } from "lucide-react";
 
+import {
+  ICON_COLORS,
+  ICON_COLOR_HEX,
+  ICON_COLOR_LABEL,
+  isIconColor,
+  type IconColor,
+} from "@platform/lib/icon-color";
 import { cn } from "@platform/lib/utils";
 import { Button } from "@platform/shadcn/ui/button";
 import { Input } from "@platform/shadcn/ui/input";
@@ -57,13 +66,7 @@ interface IconPickerProps {
   tabs?: IconPickerTab[];
 }
 
-// ---- icon svg--------------------------------------------------------------
-
-/** The glyph's grey, baked in: icon.svg is a static file with no theme
- *  context, so it cannot read `--fg-muted` — the tint the generic AppStar
- *  fallback wears. This sits between that token's two values (#9aa0a6 dark,
- *  #61656c light) so the file reads as the same quiet mark in either theme. */
-const GLYPH_GREY = "#7e838a";
+// ---- icon svg --------------------------------------------------------------
 
 type IconNode = [tag: string, attrs: Record<string, string | number>][];
 
@@ -71,10 +74,18 @@ function escapeAttr(v: string | number): string {
   return String(v).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
 }
 
-/** A lucide icon as a standalone icon.svg document: a 64-unit square with no
- *  plate, no margin — the bare glyph in grey, like the generic AppStar
- *  fallback, filling lucide's own 24-unit viewBox edge to edge. */
-export function glyphIconSvg(node: IconNode): string {
+/** A lucide icon as a standalone icon.svg document: no plate, no margin — the
+ *  bare glyph filling lucide's own 24-unit viewBox edge to edge, in the
+ *  named colour.
+ *
+ *  The colour is written TWICE, for two readers. The root's `data-fused-color`
+ *  plus `stroke="currentColor"` is the shell's contract (icon-color.ts): it
+ *  swaps the hex for the live theme before the `<img>` sees the file, so the
+ *  icon follows a pinned Light/Dark exactly as the AppStar fallback does. The
+ *  `<style>` block is for everyone else — Finder, GitHub, a bare tab — where
+ *  only the OS theme is knowable: it sets `color` (which currentColor reads)
+ *  for light and flips it under prefers-color-scheme: dark. */
+export function glyphIconSvg(node: IconNode, color: IconColor = "default"): string {
   const inner = node
     .map(([tag, attrs]) => {
       const a = Object.entries(attrs)
@@ -84,14 +95,16 @@ export function glyphIconSvg(node: IconNode): string {
       return `<${tag}${a}/>`;
     })
     .join("");
+  const hex = ICON_COLOR_HEX[color];
   return (
     // Lucide's own viewBox, untransformed: the glyph fills the tile with no
     // margin, so it draws as large as the host's box allows.
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">' +
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" data-fused-color="${color}">` +
+    `<style>svg{color:${hex.light}}@media(prefers-color-scheme:dark){svg{color:${hex.dark}}}</style>` +
     '<g fill="none" ' +
     // 2.5 not lucide's 2: the row draws the file at 14px, where a 2-unit
     // stroke lands under a pixel and reads faint beside the emoji rows.
-    `stroke="${GLYPH_GREY}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">` +
+    'stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">' +
     inner +
     "</g></svg>"
   );
@@ -249,6 +262,32 @@ function pushRecent(tab: IconPickerTab, id: string) {
   }
 }
 
+// ---- colour ----------------------------------------------------------------
+// The Icons tab's colour is a setting, not a per-pick question: it sticks
+// (localStorage) until the swatch popover changes it — Notion's "Ask every
+// time" is off here by design.
+
+const COLOR_KEY = "fused-render:icon-picker-color";
+
+function readColor(): IconColor {
+  try {
+    const v = localStorage.getItem(COLOR_KEY);
+    return isIconColor(v) ? v : "default";
+  } catch {
+    return "default";
+  }
+}
+
+function saveColor(color: IconColor) {
+  try {
+    localStorage.setItem(COLOR_KEY, color);
+  } catch {
+    // Storage blocked: the colour still applies for this open picker.
+  }
+}
+
+const colorVar = (color: IconColor) => `var(--app-icon-${color})`;
+
 // ---- component -------------------------------------------------------------
 
 const GRID_COLS = 8;
@@ -290,6 +329,8 @@ export default function IconPicker({
   const [tab, setTab] = useState<IconPickerTab>(tabs[0] ?? "emoji");
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
+  const [color, setColor] = useState<IconColor>(readColor);
+  const [colorOpen, setColorOpen] = useState(false);
   const baseId = useId();
   const rootRef = useRef<HTMLDivElement | null>(null);
   // The shadcn Input is a plain function component (no forwardRef under React
@@ -385,11 +426,18 @@ export default function IconPicker({
   const pick = useCallback(
     (cell: Cell) => {
       pushRecent(tab, cell.id);
-      if (cell.node) onPick({ kind: "icon", name: cell.id, svg: glyphIconSvg(cell.node) });
+      if (cell.node) onPick({ kind: "icon", name: cell.id, svg: glyphIconSvg(cell.node, color) });
       else onPick({ kind: "emoji", emoji: cell.id });
     },
-    [tab, onPick],
+    [tab, color, onPick],
   );
+
+  const chooseColor = (next: IconColor) => {
+    setColor(next);
+    saveColor(next);
+    setColorOpen(false);
+    searchInput()?.focus();
+  };
 
   // Choosing from the grid is the deliberate pick: apply it and close.
   const pickAndClose = useCallback(
@@ -450,6 +498,7 @@ export default function IconPicker({
     setTab(next);
     setQuery("");
     setActive(0);
+    setColorOpen(false);
     searchInput()?.focus();
   };
 
@@ -529,6 +578,59 @@ export default function IconPicker({
         >
           <Shuffle />
         </Button>
+        {tab === "icon" && (
+          // The colour every icon pick is written in — a dot in that colour,
+          // and under it Notion's two rows of five swatches. Inside the
+          // picker's root, so the document-level outside-click closer treats
+          // it as the picker's own.
+          <div className="relative">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              title={`Icon colour: ${ICON_COLOR_LABEL[color]}`}
+              aria-label={`Icon colour: ${ICON_COLOR_LABEL[color]}`}
+              aria-haspopup="listbox"
+              aria-expanded={colorOpen}
+              onClick={() => setColorOpen((v) => !v)}
+            >
+              <span
+                className="block size-3 rounded-full"
+                style={{ background: colorVar(color) }}
+                aria-hidden="true"
+              />
+            </Button>
+            {colorOpen && (
+              <div
+                role="listbox"
+                aria-label="Icon colour"
+                data-slot="icon-picker-colors"
+                className="absolute top-full right-0 z-10 mt-1 grid grid-cols-5 gap-1.5 rounded-lg border border-border bg-popover p-2 shadow-md"
+              >
+                {ICON_COLORS.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    role="option"
+                    aria-selected={c === color}
+                    title={ICON_COLOR_LABEL[c]}
+                    aria-label={ICON_COLOR_LABEL[c]}
+                    onClick={() => chooseColor(c)}
+                    className={cn(
+                      "flex size-7 cursor-pointer items-center justify-center rounded-full border-0 bg-transparent p-0 hover:bg-muted",
+                      c === color && "ring-2 ring-ring",
+                    )}
+                  >
+                    <span
+                      className="block size-4 rounded-full"
+                      style={{ background: colorVar(c) }}
+                      aria-hidden="true"
+                    />
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       <div
@@ -536,6 +638,9 @@ export default function IconPicker({
         role="listbox"
         aria-label={TAB_LABEL[tab]}
         className="max-h-[288px] overflow-y-auto"
+        // The Icons grid previews in the chosen colour (its glyphs draw on
+        // currentColor), so the swatch is seen before it is committed.
+        style={tab === "icon" ? { color: colorVar(color) } : undefined}
       >
         {!loaded && <div className="px-1 py-3 text-xs text-muted-foreground">Loading…</div>}
         {loaded && visible.length === 0 && (
@@ -573,7 +678,10 @@ export default function IconPicker({
                     title={cell.title}
                     onClick={() => pickAndClose(cell)}
                     className={cn(
-                      "flex size-8 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-[19px] leading-none text-foreground hover:bg-muted",
+                      "flex size-8 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-[19px] leading-none hover:bg-muted",
+                      // Emoji carry their own colours; a lucide cell inherits
+                      // the grid's tint (the chosen icon colour, above).
+                      cell.node ? "text-inherit" : "text-foreground",
                       isActive && "bg-muted ring-2 ring-ring ring-inset",
                     )}
                   >

--- a/frontend/src/platform/ui/IconPicker.tsx
+++ b/frontend/src/platform/ui/IconPicker.tsx
@@ -72,8 +72,8 @@ function escapeAttr(v: string | number): string {
 }
 
 /** A lucide icon as a standalone icon.svg document: a 64-unit square with no
- *  plate — the bare glyph in grey, like the generic AppStar fallback — the
- *  24-unit glyph scaled 1.75× and centred with 11 units of margin. */
+ *  plate, no margin — the bare glyph in grey, like the generic AppStar
+ *  fallback, filling lucide's own 24-unit viewBox edge to edge. */
 export function glyphIconSvg(node: IconNode): string {
   const inner = node
     .map(([tag, attrs]) => {
@@ -85,10 +85,10 @@ export function glyphIconSvg(node: IconNode): string {
     })
     .join("");
   return (
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">' +
-    // 1.75: a 42-unit glyph with 11 of margin — the glyph carries the icon
-    // on its own, at favicon size as much as in the row.
-    '<g transform="translate(11 11) scale(1.75)" fill="none" ' +
+    // Lucide's own viewBox, untransformed: the glyph fills the tile with no
+    // margin, so it draws as large as the host's box allows.
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">' +
+    '<g fill="none" ' +
     // 2.5 not lucide's 2: the row draws the file at 14px, where a 2-unit
     // stroke lands under a pixel and reads faint beside the emoji rows.
     `stroke="${GLYPH_GREY}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">` +

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -16,6 +16,7 @@
 // on each route() call (fresh iframes, fresh fetches, dropped local state).
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import type { Job } from "@platform/lib/jobs";
+import { useThemedIconSrc } from "@platform/lib/app-icon-src";
 import {
   IS_EMBED,
   IS_PREVIEW,
@@ -387,7 +388,9 @@ function StatView({
       live = false;
     };
   }, [fsPath]);
-  useFavicon(iconHref);
+  // Theme-resolved: a picker-written icon.svg names its colour and the
+  // favicon cannot read a token itself (app-icon-src.ts).
+  useFavicon(useThemedIconSrc(iconHref));
   // Recents: the explorer's own store, gated on a confirmed FILE, so a
   // directory never lands there. The app
   // builder's parallel (tag, name) store went with its route — nothing displays

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -60,6 +60,7 @@ import {
   type TemplateEntry,
 } from "@platform/lib/api";
 import { useFavicon, useUrlVersion } from "@platform/lib/hooks";
+import { useThemedIconSrc } from "@platform/lib/app-icon-src";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import { embedUrlForFsPath, navigateUrl, urlForFsPath } from "@platform/lib/router";
 import {
@@ -274,7 +275,11 @@ export default function AppPage({
     window.addEventListener(CURRENT_APPS_CHANGED_EVENT, loadIcon);
     return () => window.removeEventListener(CURRENT_APPS_CHANGED_EVENT, loadIcon);
   }, [loadIcon]);
-  useFavicon(iconHref);
+  // Both the header mark and the favicon draw the theme-resolved src: a
+  // picker-written glyph names its colour, and neither an <img> nor a
+  // <link rel="icon"> can read a token on its own (app-icon-src.ts).
+  const iconSrc = useThemedIconSrc(iconHref);
+  useFavicon(iconSrc);
 
   // ---- the header mark's icon picker -----------------------------------------
   // The same picker the sidebar's Projects row opens from its glyph (the emoji
@@ -507,8 +512,8 @@ export default function AppPage({
               );
             }}
           >
-            {iconHref ? (
-              <img src={iconHref} alt="" draggable={false} />
+            {iconSrc ? (
+              <img src={iconSrc} alt="" draggable={false} />
             ) : (
               <AppStar />
             )}

--- a/frontend/src/shell/CurrentAppsSection.tsx
+++ b/frontend/src/shell/CurrentAppsSection.tsx
@@ -45,6 +45,7 @@ import { HeroComposer } from "@apps/builder/HomeHero";
 import { inFlight, opensElsewhere, statusColumn } from "@shell/tasks-lib";
 import { pokeTasks, useTasksPulseRows } from "@shell/tasksPulse";
 import { CURRENT_APPS_CHANGED_EVENT } from "@platform/lib/tasksChanged";
+import { useThemedIconSrc } from "@platform/lib/app-icon-src";
 import {
   appPageTabFromSearch,
   appPageUrl,
@@ -216,6 +217,7 @@ function CurrentAppRow({
   onSeen: (path: string) => void;
 }) {
   const [busy, setBusy] = useState(false);
+  const iconSrc = useThemedIconSrc(app.iconUrl);
   // The destination keeps the TAB the user is on (owner, 2026-08-26): switching
   // apps from the Files tab lands on the next app's Files tab, so the sidebar
   // reads as "same view, other app". Only `_tab` rides along — a tab's own
@@ -291,14 +293,16 @@ function CurrentAppRow({
         title="Change icon"
         onClick={(e) => onGlyphClick(e, app.path)}
       >
-        {app.iconUrl ? (
+        {iconSrc ? (
           // The app's own icon.svg in the generic mark's slot, drawn as is —
-          // the author's colours, no mask or tint (owner, 2026-08-27). Not
-          // draggable: an <img> drags natively, and the glyph is the natural
-          // handle for the row reorder (same as the name's draggable={false}).
+          // the author's colours, no mask or tint (owner, 2026-08-27); a
+          // picker-written glyph names its colour and useThemedIconSrc
+          // resolves it for the live theme. Not draggable: an <img> drags
+          // natively, and the glyph is the natural handle for the row reorder
+          // (same as the name's draggable={false}).
           <img
             className="current-app-icon"
-            src={app.iconUrl}
+            src={iconSrc}
             alt=""
             draggable={false}
           />

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -247,6 +247,21 @@
   --icon-db: #82abbf;
   --icon-file: #868c93;
 
+  /* App-icon palette — the icon picker's ten colours (Notion's set), the
+     swatches and the tinted grid. icon-color.ts carries the SAME hex as
+     literals for the icon.svg file itself, which cannot read a token: keep
+     the two in step. `default` is the --fg-muted pair. */
+  --app-icon-default: #9aa0a6;
+  --app-icon-gray: #9b9b9b;
+  --app-icon-brown: #ba856f;
+  --app-icon-yellow: #ca9849;
+  --app-icon-orange: #c77d48;
+  --app-icon-green: #529e72;
+  --app-icon-blue: #5e87c9;
+  --app-icon-purple: #9d68d3;
+  --app-icon-pink: #d15796;
+  --app-icon-red: #df5452;
+
   /* Task chip hues — the Calendar's per-PROJECT colour (shell/ScheduleCalendar.tsx,
      indexed by schedule-lib.taskColour, which hashes the task's folder). Eight,
      hand-picked and evenly spread around the wheel, because the calendar's whole
@@ -421,6 +436,17 @@
   --icon-archive: #806341;
   --icon-db: #3d7b93;
   --icon-file: #6b7178;
+
+  --app-icon-default: #61656c;
+  --app-icon-gray: #787774;
+  --app-icon-brown: #9f6b53;
+  --app-icon-yellow: #cb912f;
+  --app-icon-orange: #d9730d;
+  --app-icon-green: #448361;
+  --app-icon-blue: #337ea9;
+  --app-icon-purple: #9065b0;
+  --app-icon-pink: #c14c8a;
+  --app-icon-red: #d44c47;
 
   --task-c0: #2563eb;
   --task-c1: #0d9488;

--- a/skills/fused-render-app-icon/SKILL.md
+++ b/skills/fused-render-app-icon/SKILL.md
@@ -15,14 +15,3 @@ Rules:
 - **Plain standalone file**: everything inline — no external images/fonts/CSS imports (favicon fetched standalone), no scripts/animation. Few KB; `svgo` if tool-exported.
 
 Serviceable default: dark rounded `<rect rx>` + one bright glyph (path, or centred `<text>` monogram); swap glyph + colours for app's own.
-
-## Theme-following colour (optional)
-
-Shell cannot tint an `<img>`; so a file may NAME its colour and let the shell resolve it per theme (`frontend/src/platform/lib/icon-color.ts`):
-
-- Root: `data-fused-color="<name>"`, name ∈ `default gray brown yellow orange green blue purple pink red`.
-- Paint with `currentColor` (`stroke`/`fill`). Shell swaps it for that name's light/dark hex before the `<img>`/favicon loads.
-- Add `<style>svg{color:LIGHT}@media(prefers-color-scheme:dark){svg{color:DARK}}</style>` so standalone viewers (Finder, GitHub) still get a colour — OS theme only there.
-- No marker → drawn as is (hand-authored, emoji). Unknown name → treated as no marker.
-
-Icon picker (sidebar glyph / app-page mark, Icons tab) writes exactly this shape.

--- a/skills/fused-render-app-icon/SKILL.md
+++ b/skills/fused-render-app-icon/SKILL.md
@@ -15,3 +15,14 @@ Rules:
 - **Plain standalone file**: everything inline — no external images/fonts/CSS imports (favicon fetched standalone), no scripts/animation. Few KB; `svgo` if tool-exported.
 
 Serviceable default: dark rounded `<rect rx>` + one bright glyph (path, or centred `<text>` monogram); swap glyph + colours for app's own.
+
+## Theme-following colour (optional)
+
+Shell cannot tint an `<img>`; so a file may NAME its colour and let the shell resolve it per theme (`frontend/src/platform/lib/icon-color.ts`):
+
+- Root: `data-fused-color="<name>"`, name ∈ `default gray brown yellow orange green blue purple pink red`.
+- Paint with `currentColor` (`stroke`/`fill`). Shell swaps it for that name's light/dark hex before the `<img>`/favicon loads.
+- Add `<style>svg{color:LIGHT}@media(prefers-color-scheme:dark){svg{color:DARK}}</style>` so standalone viewers (Finder, GitHub) still get a colour — OS theme only there.
+- No marker → drawn as is (hand-authored, emoji). Unknown name → treated as no marker.
+
+Icon picker (sidebar glyph / app-page mark, Icons tab) writes exactly this shape.


### PR DESCRIPTION
## Summary
- Icons-tab picks no longer bake a black plate + fused-yellow stroke. The svg now names its colour (`data-fused-color`) and strokes in `currentColor`; the shell resolves the hex for the live theme before `<img>`/favicon load it (`useThemedIconSrc`, `icon-color.ts`). Follows a pinned Light/Dark, not just the OS.
- Ten colours (Notion's set: default + gray, brown, yellow, orange, green, blue, purple, pink, red), each a light/dark pair. `default` = the `--fg-muted` pair, matching the AppStar fallback.
- Picker: colour dot beside shuffle, 2×5 swatch popover, choice persists across picks (no "ask every time"), Icons grid previews in the chosen colour.
- Glyph fills lucide's own 24-unit viewBox, no margin.
- Emoji and hand-authored icons untouched (drawn as is). `bust()` skips `data:` hrefs.
- SKILL.md documents the marker contract.

## Smoke
- `tsc --noEmit` clean. Pick a coloured icon from the sidebar or app-page picker; flip Appearance and check row, header, /apps card and favicon recolour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad UI change across icon rendering and favicon handling with async fetch/recolour logic; no auth or data paths, but regressions could affect tab icons or stale/wrong colours on theme switches.
> 
> **Overview**
> Lucide icon picks **no longer use the black plate and fused-yellow stroke**. Picks are written as bare glyphs with `data-fused-color` and `stroke="currentColor"`, plus an embedded `prefers-color-scheme` fallback for standalone file views.
> 
> New **`icon-color.ts`** and **`useThemedIconSrc`** fetch marked `icon.svg` files, substitute the palette hex for the **resolved** light/dark theme (via **`useResolvedTheme`**), and expose a **data:** URL to every `<img>` and favicon surface (sidebar Projects row, app page header, `/apps` cards, embed shell). Emoji and unmarked icons stay raw URLs.
> 
> The **Icons tab** gains a persistent colour setting (10 Notion-style swatches beside shuffle, stored in localStorage) and previews the grid in the chosen tint. **`tokens.css`** adds matching `--app-icon-*` variables for swatches. **Favicon cache-busting** skips query params on `data:` hrefs so SVG parsing does not break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c409d459c7c3ce02de6e859da68f74867298f2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->