### PR TITLE
App Doctor replaces the Migrate button on both surfaces

### DIFF
--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -8,7 +8,6 @@ import { createPortal } from "react-dom";
 import {
   addCurrentApp,
   getAppEntry,
-  migrateApp,
   setAppPreview,
   getAppFileCloneTarget,
   cloneAppFile,
@@ -25,8 +24,8 @@ import {
 } from "@platform/lib/api";
 import type { StatResult, TemplateEntry, RegistryEntryForPath } from "@platform/lib/api";
 import { captureAppPreview, cropRect, exportAppFile } from "@platform/lib/appShot";
-import { appLandingUrl } from "@platform/lib/appLanding";
-import { announceCurrentAppsChanged, announceTasksChanged } from "@platform/lib/tasksChanged";
+import { AppDoctorModal } from "@platform/ui/AppDoctorModal";
+import { announceCurrentAppsChanged } from "@platform/lib/tasksChanged";
 import { navigate, navigateUrl, urlForFsPath, viewUrlForFsPath, replaceSearch, encodeFsPathSegments, IS_EMBED, IS_FOREIGN_EMBED, IS_PREVIEW } from "@platform/lib/router";
 import { formatSize, formatMtimeFull, basename } from "@platform/lib/format";
 import {
@@ -254,35 +253,31 @@ export function CloneAppFileButton({ fsPath, toView }: { fsPath: string; toView?
   );
 }
 
-// The app page's Migrate button, on the explorer topbar: shown only when the
-// previewed page IS its folder's app entry AND declares a fused API version
-// behind the runtime's (both facts from the same /api/apps/entry answer). One
-// click creates the migration task on this page (POST /api/apps/migrate) and
-// lands in the Claude pane on its run; while a task is live — the server says
-// so, across reloads — the button reads "in progress" and opens the app page's
-// Tasks tab instead. Same gate as ExportAppButton beside it, same reason:
-// the server owns the entry rule, the filename says nothing.
-function MigrateAppButton({ fsPath }: { fsPath: string }) {
-  const [info, setInfo] = useState<{
-    behind: boolean;
-    to: number;
-    from: number;
-    live: boolean;
-  } | null>(null);
-  const [busy, setBusy] = useState(false);
+// The App Doctor button, on the explorer topbar: shown whenever the previewed
+// page IS its folder's app entry (the server's own entry rule, asked of
+// /api/apps/entry — same gate as ExportAppButton beside it, same reason: the
+// filename says nothing). One click opens the checklist dialog, which runs the
+// deterministic checks and offers the one task that explains and fixes them
+// (platform/ui/AppDoctorModal).
+//
+// It REPLACES the "Migrate to new version" button that stood here: a stale
+// `fused-api-version` tag is one row of that checklist now, alongside the
+// things it never covered — a leaked key, a device path, stray generated
+// files, an uncommitted tree. That is also why the gate widened: migrate had
+// nothing to say about an app that was already current, and the doctor does.
+function AppDoctorButton({ fsPath }: { fsPath: string }) {
+  const [isEntry, setIsEntry] = useState(false);
+  const [open, setOpen] = useState(false);
   const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
   const dir = fsPath.slice(0, fsPath.lastIndexOf("/")) || "/";
   useEffect(() => {
     let alive = true;
-    setInfo(null);
+    setIsEntry(false);
+    setOpen(false);
     getAppEntry(dir)
       .then((r) => {
         if (!alive) return;
-        if (r.entry == null || canon(r.entry) !== fsPath) return;
-        const from = r.api_version ?? null;
-        const to = r.current_api_version ?? null;
-        if (from == null || to == null) return;
-        setInfo({ behind: from < to, to, from, live: !!r.migration_task });
+        setIsEntry(r.entry != null && canon(r.entry) === fsPath);
       })
       .catch(() => {
         /* indeterminate reads as "not an entry" — no button for nothing */
@@ -291,59 +286,23 @@ function MigrateAppButton({ fsPath }: { fsPath: string }) {
       alive = false;
     };
   }, [fsPath, dir]);
-  if (!info || !info.behind) return null;
-  const name = basename(dir);
-  const doMigrate = async () => {
-    if (busy) return;
-    setBusy(true);
-    try {
-      const res = await migrateApp(dir);
-      if (res.task) announceTasksChanged();
-      if (res.task_error) throw new Error(res.task_error);
-      // Live now, whatever happens next: a second click must not create a
-      // second task while this one is being sent.
-      setInfo({ ...info, live: true });
-      if (res.task?.run_id) navigateUrl(appLandingUrl(res.entry_html, res.task.run_id));
-    } catch (e) {
-      pushToast({
-        msg: "Could not create the migration task for " + name + ": " + (e as Error).message,
-        tone: "error",
-      });
-    } finally {
-      setBusy(false);
-    }
-  };
-  if (info.live) {
-    return (
+  if (!isEntry) return null;
+  return (
+    <>
       <button
         type="button"
         className="bar-ctl bar-ctl-bordered"
-        title={"A migration task for " + name + " is still running — listed under the app's Tasks tab"}
-        // The app page's Tasks tab (`/apps/<folder>?_tab=tasks`, the address
-        // current-apps-lib.appPageUrl builds; spelled here because an app may
-        // not import the shell).
-        onClick={() =>
-          navigateUrl("/apps/" + encodeFsPathSegments(dir) + "?_tab=tasks")
+        title={
+          "Check " + basename(dir) +
+          " before you share it: leaked credentials, paths tied to this machine, " +
+          "stray generated files, uncommitted work, a stale fused API version"
         }
+        onClick={() => setOpen(true)}
       >
-        Migration in progress
+        App Doctor
       </button>
-    );
-  }
-  return (
-    <button
-      type="button"
-      className="bar-ctl bar-ctl-bordered"
-      title={
-        name + " declares fused API version " + info.from + "; the runtime is on " + info.to +
-        ". Creates a task that updates the code and the tag."
-      }
-      onClick={doMigrate}
-      disabled={busy}
-    >
-      {busy && <span className="mode-icon-spinner" />}
-      {busy ? "Creating task…" : "Migrate to new version"}
-    </button>
+      {open && <AppDoctorModal dir={dir} onClose={() => setOpen(false)} />}
+    </>
   );
 }
 
@@ -1811,7 +1770,7 @@ function TemplatePreview({
           when this page is its folder's app entry (the component asks the
           server). Embed mode hides the whole header/topbar, so an opened
           .fused app never shows it. */}
-      {!stat.is_dir && <MigrateAppButton fsPath={fsPath} />}
+      {!stat.is_dir && <AppDoctorButton fsPath={fsPath} />}
       {!stat.is_dir && <ExportAppButton fsPath={fsPath} />}
       {/* The folder view's "Open in project", offered on the app's entry page
           too (same server-side entry gate), wearing the same bordered look as

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2318,13 +2318,14 @@ export interface AppEntryInfo {
   // The fused page API version the entry declares via
   // `<meta name="fused-api-version">` — 0 when undeclared (every app authored
   // before the tag existed), null when there is no entry. Beside the version
-  // the runtime speaks now; the app page offers "Migrate" when it is behind.
-  // Both optional so an older server (entry only) still types.
+  // the runtime speaks now. No button hangs off these any more: the gap is a
+  // ROW of the App Doctor checklist (`getAppDoctor`), which is what replaced
+  // the standalone Migrate button. Both optional so an older server (entry
+  // only) still types.
   api_version?: number | null;
   current_api_version?: number;
   // A migration task on this entry that has not finished (pending, sending,
-  // or running with no verdict yet) — the button reads "in progress" instead
-  // of offering a second one. Null / absent when none.
+  // or running with no verdict yet). Null / absent when none.
   migration_task?: { id: string; state: string; run_id: string | null } | null;
 }
 
@@ -2338,6 +2339,11 @@ export function getAppEntry(path: string): Promise<AppEntryInfo> {
 // shape /api/apps/new creates, its prompt invoking the fused-render-api-migration
 // skill for the jump from the declared version to the current one. 409 when the
 // app is already current, 404 when the folder has no entry.
+//
+// No UI calls this any longer — the App Doctor button took the place of the
+// Migrate button on both surfaces, and its fix session routes a stale version
+// through the migration skill itself. The endpoint stays as the narrow,
+// single-purpose way to ask for exactly that one task.
 export interface MigrateAppResult extends NewAppResult {
   from_version: number;
   to_version: number;
@@ -2349,6 +2355,60 @@ export function migrateApp(
   effort: SessionEffort = "",
 ): Promise<MigrateAppResult> {
   return postJson<MigrateAppResult>("/api/apps/migrate", { path, model, effort });
+}
+
+// ---- App Doctor (fused_render/app_doctor.py) --------------------------------
+//
+// The share-readiness checklist for one app folder: deterministic checks only —
+// a row is `pass`, `fail`, or `skip` (the check could not run: no entry to read,
+// no git repo, an optional file that isn't there), never a judgment. The
+// judgment is the fix TASK's, which is a Claude session running the
+// fused-render-app-doctor skill (`runAppDoctor` below).
+
+export type AppCheckState = "pass" | "fail" | "skip";
+
+export interface AppCheckFinding {
+  rule: string;
+  path: string;
+  /** 0 for a finding about the folder rather than a line. */
+  line: number;
+  /** Already masked server-side when it came off a secret — safe to render. */
+  excerpt: string;
+}
+
+export interface AppCheck {
+  id: string;
+  label: string;
+  state: AppCheckState;
+  detail: string;
+  findings: AppCheckFinding[];
+}
+
+export interface AppDoctorReport {
+  path: string;
+  entry: string | null;
+  /** Nothing failed. A skipped check is not a pass, but it is not a problem. */
+  ok: boolean;
+  checks: AppCheck[];
+  /** A fix task on the entry that has not finished yet, or null. */
+  task?: { id: string; state: string; run_id: string | null } | null;
+}
+
+export function getAppDoctor(path: string): Promise<AppDoctorReport> {
+  return getJson<AppDoctorReport>(
+    `/api/apps/doctor?path=${encodeURIComponent(path)}`,
+  );
+}
+
+// Create the App Doctor FIX task on the app's entry page — one session for the
+// whole report, its prompt invoking the fused-render-app-doctor skill. 409 when
+// one is already running, 404 when the folder has no entry page.
+export function runAppDoctor(
+  path: string,
+  model: DefaultModel = "",
+  effort: SessionEffort = "",
+): Promise<NewAppResult> {
+  return postJson<NewAppResult>("/api/apps/doctor", { path, model, effort });
 }
 
 // ---- Current apps (the sidebar's desk, fused_render/current_apps.py) --------

--- a/frontend/src/platform/ui/AppDoctorModal.tsx
+++ b/frontend/src/platform/ui/AppDoctorModal.tsx
@@ -1,0 +1,244 @@
+// App Doctor: the share-readiness checklist for one app folder, and the one
+// button that hands the whole report to a Claude session.
+//
+// It stands where the "Migrate to new version" button used to (the app page's
+// header, the explorer's entry-page topbar) and it subsumes it: the stale
+// `fused-api-version` tag is now ONE ROW of the checklist rather than a button
+// of its own, because it was never the only thing wrong with an app about to
+// be shared — a pasted key, a path that only resolves on the author's machine,
+// a `__pycache__` swept along and an uncommitted working tree are all invisible
+// from the outside and all worth knowing before you send someone a folder.
+//
+// EVERY ROW IS DETERMINISTIC (fused_render/app_doctor.py, which is the
+// authority on what each check means): a row passed, failed, or could not run.
+// Nothing in this dialog decides whether a finding matters. That judgment
+// belongs to the `fused-render-app-doctor` skill, and "Explain and fix" is how
+// you get it — one task on the app's entry page, whose session runs the skill
+// end to end and lands in the Claude pane. One task for the whole report, not
+// one per row: the findings are about the same folder and often the same file,
+// and two sessions rewriting one app at once is a merge nobody asked for.
+//
+// Shared by the shell and the explorer, so it spells its own routes rather than
+// importing either app's helpers (an app may not import the shell — the same
+// reason Preview.tsx spells `/apps/<folder>?_tab=tasks` by hand).
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getAppDoctor,
+  runAppDoctor,
+  type AppCheck,
+  type AppCheckState,
+  type AppDoctorReport,
+} from "@platform/lib/api";
+import {
+  findingWhere,
+  splitFindings,
+  STATE_LABEL,
+  summaryLine,
+  tasksTabUrl,
+} from "./appdoctor-lib";
+import { Modal } from "@platform/ui/modal/Modal";
+import { ErrorBanner } from "@platform/ui/ErrorBanner";
+import { SkeletonLines } from "@platform/ui/Skeleton";
+import { appLandingUrl } from "@platform/lib/appLanding";
+import { navigateUrl } from "@platform/lib/router";
+import { announceTasksChanged } from "@platform/lib/tasksChanged";
+import { basename } from "@platform/lib/format";
+
+// Inline rather than lucide: this dialog is rendered inside the explorer too,
+// which draws its own icons and imports no icon library.
+function StateIcon({ state }: { state: AppCheckState }) {
+  const common = {
+    width: 16,
+    height: 16,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    "aria-hidden": true,
+  };
+  if (state === "pass")
+    return (
+      <svg {...common}>
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+    );
+  if (state === "fail")
+    return (
+      <svg {...common}>
+        <circle cx="12" cy="12" r="9" />
+        <path d="M12 8v4M12 16h.01" />
+      </svg>
+    );
+  return (
+    <svg {...common}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M8 12h8" />
+    </svg>
+  );
+}
+
+function CheckRow({ check }: { check: AppCheck }) {
+  const { shown, hidden } = splitFindings(check.findings);
+  return (
+    <li className={"appdoc-row appdoc-" + check.state}>
+      <span
+        className="appdoc-state"
+        role="img"
+        aria-label={STATE_LABEL[check.state]}
+        title={STATE_LABEL[check.state]}
+      >
+        <StateIcon state={check.state} />
+      </span>
+      <div className="appdoc-text">
+        <span className="appdoc-label">{check.label}</span>
+        <span className="appdoc-detail">{check.detail}</span>
+        {shown.length > 0 && (
+          <ul className="appdoc-findings">
+            {shown.map((f, i) => (
+              <li key={f.rule + f.path + f.line + i}>
+                <code>{findingWhere(f)}</code>
+                {/* Already masked server-side when it came off a secret
+                    (app_check.py's `_mask`), so this is safe to draw. */}
+                <span className="appdoc-excerpt">{f.excerpt}</span>
+              </li>
+            ))}
+            {hidden > 0 && (
+              <li className="appdoc-more">
+                and {hidden} more — the fix task sees all of them
+              </li>
+            )}
+          </ul>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export function AppDoctorModal({
+  dir,
+  onClose,
+}: {
+  /** The app FOLDER (canonical forward-slash), not its entry page. */
+  dir: string;
+  onClose: () => void;
+}) {
+  const [report, setReport] = useState<AppDoctorReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const alive = useRef(true);
+  useEffect(() => () => {
+    alive.current = false;
+  }, []);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const r = await getAppDoctor(dir);
+      if (alive.current) setReport(r);
+    } catch (e) {
+      if (alive.current) setError((e as Error).message);
+    }
+  }, [dir]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const live = report?.task ?? null;
+
+  const fix = async () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await runAppDoctor(dir);
+      if (res.task) announceTasksChanged();
+      if (res.task_error) throw new Error(res.task_error);
+      // The Claude pane can only attach to a run it has the id of; without one
+      // the task is stored but not yet running, and the Tasks tab lists it.
+      navigateUrl(
+        res.task?.run_id
+          ? appLandingUrl(res.entry_html, res.task.run_id)
+          : tasksTabUrl(dir),
+      );
+      onClose();
+    } catch (e) {
+      if (alive.current) {
+        setError((e as Error).message);
+        setBusy(false);
+      }
+    }
+  };
+
+  return (
+    <Modal
+      title={"App Doctor — " + (basename(dir) || dir)}
+      onClose={onClose}
+      // The fix task keeps running server-side whether or not this dialog is
+      // open, so closing mid-create abandons nothing.
+      busy={false}
+      dialogClassName="appdoc-modal"
+      width={620}
+      footer={
+        <>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => {
+              setReport(null);
+              void load();
+            }}
+            disabled={busy || report === null}
+          >
+            Re-run
+          </button>
+          {live ? (
+            <button
+              type="button"
+              className="btn btn-primary"
+              title="An App Doctor task for this app is still running — listed under the app's Tasks tab"
+              onClick={() => {
+                navigateUrl(tasksTabUrl(dir));
+                onClose();
+              }}
+            >
+              Fix in progress
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={fix}
+              disabled={busy || report === null || !report.entry}
+              title={
+                report && !report.entry
+                  ? "A task has to land on a page, and this folder has no entry page yet"
+                  : "Creates one task on the app's entry page: a session that runs the App Doctor skill, explains every finding and fixes what is safe to fix"
+              }
+            >
+              {busy ? "Creating task…" : "Explain and fix"}
+            </button>
+          )}
+        </>
+      }
+    >
+      <ErrorBanner>{error}</ErrorBanner>
+      {report === null ? (
+        <SkeletonLines rows={6} />
+      ) : (
+        <>
+          <p className="appdoc-summary">{summaryLine(report.checks)}</p>
+          <ul className="appdoc-list">
+            {report.checks.map((c) => (
+              <CheckRow key={c.id} check={c} />
+            ))}
+          </ul>
+        </>
+      )}
+    </Modal>
+  );
+}
+
+export default AppDoctorModal;

--- a/frontend/src/platform/ui/AppDoctorModal.tsx
+++ b/frontend/src/platform/ui/AppDoctorModal.tsx
@@ -128,8 +128,15 @@ export function AppDoctorModal({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const alive = useRef(true);
-  useEffect(() => () => {
-    alive.current = false;
+  useEffect(() => {
+    // Re-arm on every mount: a remount (or React's dev double-invoke under
+    // StrictMode) would otherwise leave this false forever, and every
+    // setReport/setError below would be skipped — the dialog stuck on
+    // SkeletonLines with no error shown.
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
   }, []);
 
   const load = useCallback(async () => {

--- a/frontend/src/platform/ui/appdoctor-lib.test.ts
+++ b/frontend/src/platform/ui/appdoctor-lib.test.ts
@@ -1,0 +1,106 @@
+// The App Doctor dialog's pure decisions (appdoctor-lib.ts). The dialog itself
+// mounts through the modal chassis' portal, which react-test-renderer cannot
+// render — same split, and same reason, as modal/dirty-guard.test.ts.
+import { expect, test } from "bun:test";
+import type { AppCheck, AppCheckFinding } from "@platform/lib/api";
+
+// `tasksTabUrl` encodes through lib/router, which reads `location` and
+// `history` at module init (its legacy-URL rewrite). A minimal stand-in
+// installed before the dynamic import is enough, and is preferred over
+// `mock.module("…/router")` — bun's module mocks are process-wide, so stubbing
+// a module this widely imported would reach unrelated files.
+//
+// The globals are PUT BACK the moment the import resolves, for the same
+// reason: `bun test` runs every file in one process, and a leaked `location`
+// breaks whoever else reads it (appEntry.test.ts does). Router has already
+// read them by then and never looks again.
+const before = {
+  location: Reflect.getOwnPropertyDescriptor(globalThis, "location"),
+  history: Reflect.getOwnPropertyDescriptor(globalThis, "history"),
+};
+Object.assign(globalThis, {
+  location: { pathname: "/", search: "", href: "http://localhost/" },
+  history: { state: null, replaceState() {} },
+});
+const lib = await import("./appdoctor-lib");
+for (const key of ["location", "history"] as const) {
+  const desc = before[key];
+  if (desc) Reflect.defineProperty(globalThis, key, desc);
+  else Reflect.deleteProperty(globalThis, key);
+}
+
+const {
+  findingWhere,
+  MAX_FINDINGS_SHOWN,
+  splitFindings,
+  STATE_LABEL,
+  summaryLine,
+  tasksTabUrl,
+} = lib;
+
+const check = (id: string, state: AppCheck["state"]): AppCheck => ({
+  id,
+  label: id,
+  state,
+  detail: "",
+  findings: [],
+});
+
+const finding = (path: string, line = 0): AppCheckFinding => ({
+  rule: "r",
+  path,
+  line,
+  excerpt: "x",
+});
+
+test("a clean report does not claim to have checked what it skipped", () => {
+  expect(summaryLine([check("a", "pass"), check("b", "pass")])).toBe(
+    "Every check this app can answer passed.",
+  );
+  // The whole point of the wording: two passes and a skip is NOT "all clear".
+  expect(summaryLine([check("a", "pass"), check("b", "skip")])).toBe(
+    "Every check this app can answer passed. 1 could not be checked.",
+  );
+});
+
+test("a failing report counts the failures against every row", () => {
+  const checks = [check("a", "fail"), check("b", "pass"), check("c", "fail")];
+  expect(summaryLine(checks)).toBe("2 of 3 checks failed.");
+});
+
+test("failures and skips are counted separately", () => {
+  const checks = [check("a", "fail"), check("b", "skip"), check("c", "skip")];
+  expect(summaryLine(checks)).toBe("1 of 3 checks failed. 2 could not be checked.");
+});
+
+test("a long finding list is capped and the rest counted", () => {
+  const many = Array.from({ length: MAX_FINDINGS_SHOWN + 5 }, (_, i) =>
+    finding(`f${i}.py`, i + 1),
+  );
+  const { shown, hidden } = splitFindings(many);
+  expect(shown).toHaveLength(MAX_FINDINGS_SHOWN);
+  expect(hidden).toBe(5);
+  // A list that fits is drawn whole, with nothing to count.
+  expect(splitFindings(many.slice(0, 3))).toEqual({
+    shown: many.slice(0, 3),
+    hidden: 0,
+  });
+});
+
+test("a finding about the folder shows no line number", () => {
+  // The server sends line 0 for a finding about the folder itself; `path:0`
+  // would read as a real location and jump nowhere.
+  expect(findingWhere(finding("__pycache__/"))).toBe("__pycache__/");
+  expect(findingWhere(finding("app.py", 12))).toBe("app.py:12");
+});
+
+test("the tasks tab is the app page's own address, path-encoded", () => {
+  expect(tasksTabUrl("/Users/me/Fused/local/my app")).toBe(
+    "/apps/Users/me/Fused/local/my%20app?_tab=tasks",
+  );
+});
+
+test("every state has a label, so no row renders a bare icon", () => {
+  expect(Object.keys(STATE_LABEL).sort()).toEqual(["fail", "pass", "skip"]);
+  expect(Object.values(STATE_LABEL).every((v) => v.length > 0)).toBe(true);
+});

--- a/frontend/src/platform/ui/appdoctor-lib.ts
+++ b/frontend/src/platform/ui/appdoctor-lib.ts
@@ -1,0 +1,55 @@
+// The pure half of the App Doctor dialog (AppDoctorModal.tsx): what the
+// summary line says, how many findings a row draws, and the address of the
+// app's Tasks tab. Split out for the same reason modal/dirty-guard.ts is —
+// the chassis renders through a portal, which react-test-renderer cannot
+// mount, so the decisions worth pinning live where a test can call them.
+import { encodeFsPathSegments } from "@platform/lib/router";
+import type { AppCheck, AppCheckFinding, AppCheckState } from "@platform/lib/api";
+
+// A long finding list is a report, not a UI: past this many the rest are
+// counted rather than drawn, and the fix task sees all of them regardless.
+export const MAX_FINDINGS_SHOWN = 12;
+
+export const STATE_LABEL: Record<AppCheckState, string> = {
+  pass: "Passed",
+  fail: "Failed",
+  skip: "Not checked",
+};
+
+/** The app's Tasks tab. Spelled here, not imported from the shell's
+ *  current-apps-lib: this dialog renders inside the explorer too, and an app
+ *  may not import the shell. */
+export function tasksTabUrl(dir: string): string {
+  return "/apps/" + encodeFsPathSegments(dir) + "?_tab=tasks";
+}
+
+export function splitFindings(findings: AppCheckFinding[]): {
+  shown: AppCheckFinding[];
+  hidden: number;
+} {
+  const shown = findings.slice(0, MAX_FINDINGS_SHOWN);
+  return { shown, hidden: findings.length - shown.length };
+}
+
+/** `path:line` for a finding, or just the path when it is about the folder
+ *  rather than a line (the server sends line 0 for those). */
+export function findingWhere(f: AppCheckFinding): string {
+  return f.line ? `${f.path}:${f.line}` : f.path;
+}
+
+/** The sentence above the checklist.
+ *
+ *  "Every check this app can answer passed" rather than "all checks passed":
+ *  a skipped row is not a pass, and a summary that counted it as one would
+ *  claim the doctor looked at something it could not see. */
+export function summaryLine(checks: AppCheck[]): string {
+  const failed = checks.filter((c) => c.state === "fail").length;
+  const skipped = checks.filter((c) => c.state === "skip").length;
+  const head =
+    failed === 0
+      ? "Every check this app can answer passed."
+      : `${failed} of ${checks.length} checks failed.`;
+  return skipped > 0
+    ? `${head} ${skipped} could not be checked.`
+    : head;
+}

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -58,6 +58,10 @@
 /* After the whole tasks family: the app page (/apps/<slug>, D488) hosts the
    Tasks page inside its Tasks tab and adds only the header and frame around it. */
 @import "./styles/app-page.css";
+/* After app-page.css: the App Doctor dialog is opened from that header (and
+   from the explorer's entry-page topbar) and layers only its checklist over
+   the shared modal chrome imported far above. */
+@import "./styles/app-doctor.css";
 @import "./styles/setup-modal.css";
 @import "./styles/templates.css";
 @import "./styles/home.css";

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -53,7 +53,6 @@ import {
   appIconUrl,
   getAppEntry,
   getAppIcon,
-  migrateApp,
   resolveConditions,
   statPath,
   type Config,
@@ -77,11 +76,8 @@ import { AppStar } from "@platform/ui/AppStar";
 import IconPicker, { type IconPick } from "@platform/ui/IconPicker";
 import { applyIconPick } from "@platform/lib/app-icon";
 import { pushToast } from "@platform/lib/toast";
-import {
-  announceTasksChanged,
-  CURRENT_APPS_CHANGED_EVENT,
-} from "@platform/lib/tasksChanged";
-import { appLandingUrl } from "@platform/lib/appLanding";
+import { CURRENT_APPS_CHANGED_EVENT } from "@platform/lib/tasksChanged";
+import { AppDoctorModal } from "@platform/ui/AppDoctorModal";
 import { Button } from "@platform/shadcn/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@platform/shadcn/ui/tabs";
 import { SkeletonLines } from "@platform/ui/Skeleton";
@@ -203,14 +199,6 @@ type Resolved =
   | {
       kind: "app";
       entry: string | null;
-      // The fused API version the entry declares (0 = undeclared, predates
-      // the tag) and the one the runtime speaks; "Migrate" shows when behind.
-      // Null from an older server that does not report versions.
-      apiVersion: number | null;
-      currentApiVersion: number | null;
-      // A migration task on the entry that has not finished yet (the server's
-      // own verdict), so a reload does not offer a second one.
-      migrationTask: { id: string; state: string; run_id: string | null } | null;
     };
 
 export default function AppPage({
@@ -344,14 +332,7 @@ export default function AppPage({
         // question every other surface asks, so this page can never disagree
         // with the card that pictures the app.
         const info = await getAppEntry(dir);
-        if (live)
-          setResolved({
-            kind: "app",
-            entry: info.entry,
-            apiVersion: info.api_version ?? null,
-            currentApiVersion: info.current_api_version ?? null,
-            migrationTask: info.migration_task ?? null,
-          });
+        if (live) setResolved({ kind: "app", entry: info.entry });
       } catch (e) {
         if (live) setResolved({ kind: "error", message: (e as Error).message });
       }
@@ -437,59 +418,18 @@ export default function AppPage({
   const home = config.home.replace(/\\/g, "/");
   const entry = resolved?.kind === "app" ? resolved.entry : null;
 
-  // The fused-API migration: offered only when the entry declares a version
-  // behind the runtime's (an undeclared page is 0, so every pre-tag app
-  // qualifies — the task's prompt tells the session to verify the code
-  // before touching it). One click creates the task on the entry page (the
-  // /api/apps/new shape) and lands in the Claude pane on its run; an app that
-  // could not even get its task stores the reason here, not silently.
-  const behind =
-    resolved?.kind === "app" &&
-    !!entry &&
-    resolved.apiVersion != null &&
-    resolved.currentApiVersion != null &&
-    resolved.apiVersion < resolved.currentApiVersion;
-  // A migration already underway (server-side fact, survives a reload): the
-  // button shows it instead of offering another. Clicking it opens the Tasks
-  // tab, where the task is listed.
-  const inProgress = resolved?.kind === "app" && !!resolved.migrationTask;
-  // `created` is sticky for this page: the entry still declares the OLD
-  // version until the session writes the tag, so `behind` stays true and the
-  // button would otherwise come straight back, inviting a second task that
-  // rewrites the same files. Reset when `dir` changes (below), and by a fresh
-  // page load — at which point the tag says whether the migration landed.
-  const [migrateState, setMigrateState] = useState<"idle" | "creating" | "created">(
-    "idle",
-  );
-  const [migrateError, setMigrateError] = useState<string | null>(null);
+  // App Doctor: the share-readiness checklist for this folder, opened from the
+  // header beside "Open app". It stands where the fused-API "Migrate" button
+  // stood, and subsumes it — a stale `fused-api-version` tag is one row of the
+  // checklist now, beside the things migrate never covered (a leaked key, a
+  // path tied to one machine, stray generated files, an uncommitted tree). The
+  // dialog owns the whole flow: it runs the checks, and its "Explain and fix"
+  // creates the one task that hands the report to a session
+  // (platform/ui/AppDoctorModal).
+  const [doctorOpen, setDoctorOpen] = useState(false);
   useEffect(() => {
-    setMigrateState("idle");
-    setMigrateError(null);
+    setDoctorOpen(false);
   }, [dir]);
-  const startMigration = async () => {
-    if (migrateState !== "idle") return;
-    setMigrateState("creating");
-    setMigrateError(null);
-    try {
-      const res = await migrateApp(dir);
-      if (res.task) announceTasksChanged();
-      if (res.task_error) {
-        setMigrateError(res.task_error);
-        setMigrateState("idle");
-        return;
-      }
-      setMigrateState("created");
-      if (res.task?.run_id) {
-        navigateUrl(appLandingUrl(res.entry_html, res.task.run_id));
-      } else {
-        // Stored but not yet running: the Tasks tab lists it.
-        navigateUrl(appPageUrl(dir, "tasks", location.search));
-      }
-    } catch (e) {
-      setMigrateError((e as Error).message);
-      setMigrateState("idle");
-    }
-  };
 
   return (
     <div className="app-page">
@@ -533,37 +473,17 @@ export default function AppPage({
         </div>
         {entry && (
           <div className="app-page-actions">
-            {behind && resolved?.kind === "app" && (
-              /* The app is on an older fused API than the runtime: one click
-                 creates the migration task on its entry page, carrying the
-                 changelog for every version being crossed. */
-              <Button
-                size="sm"
-                className="app-page-migrate"
-                variant="outline"
-                disabled={!inProgress && migrateState !== "idle"}
-                title={
-                  inProgress
-                    ? "A migration task for this app is still running; it is listed under Tasks. The button returns once it finishes."
-                    : migrateState === "created"
-                      ? "A migration task was created for this app; it is listed under Tasks."
-                      : `This app declares fused API version ${resolved.apiVersion}; the runtime is on ${resolved.currentApiVersion}. Creates a task that updates the code and the tag.`
-                }
-                onClick={
-                  inProgress
-                    ? () => navigateUrl(appPageUrl(dir, "tasks", location.search))
-                    : startMigration
-                }
-              >
-                {inProgress
-                  ? "Migration in progress"
-                  : migrateState === "creating"
-                    ? "Creating task…"
-                    : migrateState === "created"
-                      ? "Migration task created"
-                      : "Migrate to new version"}
-              </Button>
-            )}
+            {/* Every app gets this, current or not: what an app about to be
+                shared needs checked is never only its API version. */}
+            <Button
+              size="sm"
+              className="app-page-doctor"
+              variant="outline"
+              title="Check this app before you share it: leaked credentials, paths tied to this machine, stray generated files, uncommitted work, a stale fused API version"
+              onClick={() => setDoctorOpen(true)}
+            >
+              App Doctor
+            </Button>
             {/* The app full-size AS AN APP — its entry page in embed mode,
                 chrome-free — in a new tab so this page and its live frame stay
                 put. The top-level embed's strip (EmbedStrip) is the way back
@@ -590,8 +510,11 @@ export default function AppPage({
           onClose={() => setIconAnchor(null)}
         />
       )}
-      {migrateError && (
-        <ErrorBanner>Could not create the migration task: {migrateError}</ErrorBanner>
+      {/* The checklist, and the task that fixes it. It reports its own errors
+          inside the dialog — a failure to create the fix task is about the
+          dialog you are standing in, not about this page. */}
+      {doctorOpen && (
+        <AppDoctorModal dir={dir} onClose={() => setDoctorOpen(false)} />
       )}
 
       <div className="app-page-body">

--- a/frontend/src/styles/app-doctor.css
+++ b/frontend/src/styles/app-doctor.css
@@ -1,0 +1,116 @@
+/* App Doctor's dialog (platform/ui/AppDoctorModal.tsx). The chassis, the head
+ * and the footer buttons are the shared modal's (deploy.css / buttons-modal.css);
+ * everything here is the checklist inside it.
+ *
+ * The three states are told by COLOUR AND SHAPE together — a ✓, a (!) and a (–)
+ * — never by colour alone, so the list survives a monochrome or colour-blind
+ * reading. Colours are the palette's own semantic tokens (tokens.css), so both
+ * themes come for free. */
+
+.appdoc-summary {
+  margin: 0 0 12px;
+  color: var(--fg-muted);
+}
+
+.appdoc-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.appdoc-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 8px 10px;
+  border-radius: 6px;
+}
+
+/* Only a failure gets a ground of its own: a list where every row is tinted is
+ * a list with no signal in it. */
+.appdoc-row.appdoc-fail {
+  background: rgba(var(--error-rgb), 0.08);
+}
+
+.appdoc-state {
+  display: flex;
+  flex: none;
+  align-items: center;
+  height: 20px; /* the label's line box, so the mark sits on its first line */
+}
+
+.appdoc-pass .appdoc-state {
+  color: var(--success);
+}
+
+.appdoc-fail .appdoc-state {
+  color: var(--error);
+}
+
+.appdoc-skip .appdoc-state {
+  color: var(--fg-muted);
+}
+
+.appdoc-text {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.appdoc-label {
+  font-weight: 500;
+  line-height: 20px;
+}
+
+.appdoc-skip .appdoc-label {
+  color: var(--fg-muted);
+}
+
+.appdoc-detail {
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+/* The lines a finding sits on. Scrollable in its own box rather than widening
+ * the dialog: a device path or a masked key is long, and a report must never
+ * make the page scroll sideways. */
+.appdoc-findings {
+  display: flex;
+  max-height: 160px;
+  flex-direction: column;
+  gap: 2px;
+  overflow: auto;
+  margin: 4px 0 0;
+  padding: 0;
+  list-style: none;
+  font-size: 12px;
+}
+
+.appdoc-findings li {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  white-space: nowrap;
+}
+
+.appdoc-findings code {
+  flex: none;
+  color: var(--fg-muted);
+  font-size: 11px;
+}
+
+.appdoc-excerpt {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.appdoc-more {
+  color: var(--fg-muted);
+  font-style: italic;
+}

--- a/fused_render/app_doctor.py
+++ b/fused_render/app_doctor.py
@@ -1,0 +1,404 @@
+"""The App Doctor report, and the task that explains and fixes it.
+
+Sharing an app is the moment its folder stops being private: a key pasted
+into a `.py` while wiring something up, a path that only resolves on the
+machine it was written on, a `__pycache__` swept along, an entry page still
+declaring a fused API version the runtime stopped speaking. None of that is
+visible from the outside, and all of it is deterministic to check — so the
+app page and the explorer's entry-page header offer one button that runs the
+checks and shows them as a checklist.
+
+THE JUDGMENT IS A SKILL. `skills/fused-render-app-doctor/` owns the review a
+person actually wants — is this hit a real credential or a placeholder, is
+this absolute path load-bearing or prose — and its `ci/app_check.py` is the
+deterministic FLOOR of that review: the secret shapes, the device-path roots,
+the structural gaps, each already tested (tests/test_app_doctor.py). This
+module is not a second copy of either. It LOADS that script (by path — it is
+stdlib-only and lives under a skill directory, so it is not importable as
+part of the package; see `tests/_app_check_module.py`, which loads it the
+same way for the same reason) and groups its findings into the checklist the
+modal draws, adding only the rows the CI floor deliberately leaves out
+because they need the runtime's own knowledge:
+
+* the ENTRY rule (a page carrying `<meta name="fused-app">`, D301 — the CI
+  script asks for `index.html` because a repo checkout has no runtime to ask,
+  and filenames are all it has),
+* the declared fused API version against the one the runtime speaks
+  (`fused_api_version`),
+* generated state loose in the tree instead of under `.fused/`,
+* `pyproject.toml` and `icon.svg` parsing, when either is there at all, and
+* whether the folder's own git repo has everything committed.
+
+EVERY CHECK IS DETERMINISTIC. Nothing here forms an opinion — a check either
+found a shape or it did not, and a "fail" is a fact plus the lines it sits on.
+The opinion is the fix task's, and the fix task is a Claude session running
+the skill: `doctor_prompt` is one line that invokes it, the same seam the
+migration task uses (`fused_api_version.migration_prompt`).
+
+Never raises. A doctor that crashes on the app it was asked to examine is
+worse than no doctor, so every check that touches the filesystem or a
+subprocess degrades to `skip` with the reason in `detail`.
+"""
+import importlib.util
+import os
+
+from fused_render import app_listing, fused_api_version
+from fused_render.skill_sources import skill_sources
+
+SKILL = "fused-render-app-doctor"
+SKILL_QUALIFIED = f"fused-render:{SKILL}"
+
+# The floor engine, inside the skill that owns it.
+_SCRIPT_REL = os.path.join("ci", "app_check.py")
+
+# One check as the modal draws it: an id it keys off, the label it reads, a
+# state, a one-line detail, and the lines the state came from.
+PASS = "pass"
+FAIL = "fail"
+SKIP = "skip"
+
+
+def _check(cid: str, label: str, state: str, detail: str,
+           findings: list | None = None) -> dict:
+    return {
+        "id": cid,
+        "label": label,
+        "state": state,
+        "detail": detail,
+        "findings": findings or [],
+    }
+
+
+_engine = None
+_engine_error: str | None = None
+
+
+def engine():
+    """The loaded `app_check` module, or None when the skill is not resolvable
+    (a checkout or wheel with no skills at all). Loaded once — the script is
+    stdlib-only and has no state, so a second exec would buy nothing."""
+    global _engine, _engine_error
+    if _engine is not None or _engine_error is not None:
+        return _engine
+    src = skill_sources().get(SKILL)
+    if not src:
+        _engine_error = f"the {SKILL} skill is not installed"
+        return None
+    path = os.path.join(src, _SCRIPT_REL)
+    if not os.path.isfile(path):
+        _engine_error = f"{_SCRIPT_REL} is missing from the {SKILL} skill"
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("fused_render_app_check", path)
+        if spec is None or spec.loader is None:
+            raise ImportError("no loader for the script")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception as exc:  # noqa: BLE001 — an unloadable floor is "skip", never a 500
+        _engine_error = f"could not load {_SCRIPT_REL}: {exc}"
+        return None
+    _engine = module
+    return _engine
+
+
+def engine_error() -> str | None:
+    """Why `engine()` came back None, for the `skip` rows' detail."""
+    engine()
+    return _engine_error
+
+
+# ------------------------------------------------------------ generated state
+
+# An app's own machine-local state belongs under `.fused/` (D548). These are
+# the shapes that mean "generated" wherever else they turn up: caches by
+# directory name, artifacts by suffix.
+_GENERATED_DIRS = ("__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache")
+_GENERATED_SUFFIXES = (".pyc", ".pyo", ".log", ".db", ".sqlite", ".sqlite3")
+
+# Never walked as app content: `.fused/` is exactly where this state is
+# SUPPOSED to live, `.git`/`.venv`/`node_modules` are bookkeeping whose
+# contents are nobody's finding.
+_SKIP_DIRS = frozenset({".fused", ".git", ".venv", "node_modules"})
+
+# A bounded walk, for the same reason the floor engine bounds its own: a
+# review of a huge half-abandoned folder must report rather than hang.
+_MAX_ENTRIES = 20_000
+
+
+def _generated_paths(app_dir: str) -> list[str]:
+    """App-relative paths that look generated and sit outside `.fused/`,
+    a cache directory reported as itself rather than by its contents."""
+    out: list[str] = []
+    seen = 0
+
+    def recurse(dir_abs: str, dir_rel: str) -> bool:
+        nonlocal seen
+        try:
+            entries = sorted(os.scandir(dir_abs), key=lambda e: e.name)
+        except OSError:
+            return True
+        for entry in entries:
+            seen += 1
+            if seen > _MAX_ENTRIES:
+                return False
+            rel = f"{dir_rel}/{entry.name}" if dir_rel else entry.name
+            try:
+                is_dir = entry.is_dir(follow_symlinks=False)
+            except OSError:
+                continue
+            if is_dir:
+                if entry.name in _GENERATED_DIRS:
+                    out.append(rel + "/")
+                    continue
+                if entry.name in _SKIP_DIRS:
+                    continue
+                if not recurse(entry.path, rel):
+                    return False
+            elif entry.name.endswith(_GENERATED_SUFFIXES):
+                out.append(rel)
+        return True
+
+    recurse(app_dir, "")
+    return out
+
+
+# ------------------------------------------------------------------ git state
+
+
+def _git_pending(app_dir: str) -> tuple[str, list[str]]:
+    """`(state, paths)` for the folder's version control: FAIL with the
+    uncommitted paths, PASS when the folder is clean, SKIP when git cannot
+    answer (not a repo, git missing, a repo that will not read).
+
+    Status is scoped to the app folder itself — sibling apps share one `local`
+    repo (D626), and a neighbour's work in progress is not this app's finding.
+    Read-only, so unlike `app_git`'s writes there is no need to establish that
+    the repo is one we own: asking git about a user's own repository is the
+    same question their own `git status` answers.
+    """
+    from fused_render import app_git
+
+    try:
+        r = app_git._git(app_dir, "status", "--porcelain", "--", ".")
+    except Exception:  # noqa: BLE001 — includes a hung git past _GIT_TIMEOUT
+        return SKIP, []
+    if r.returncode != 0:
+        return SKIP, []
+    lines = [ln for ln in (r.stdout or "").splitlines() if ln.strip()]
+    if not lines:
+        return PASS, []
+    # `git status` reports paths relative to the REPO root, which for an app in
+    # the shared repo is one level up from the folder being reviewed. Strip that
+    # prefix so a row reads like every other finding's path — app-relative.
+    prefix = os.path.basename(app_dir.rstrip("/\\")) + "/"
+    out = []
+    for ln in lines:
+        code, _, rest = ln[:2], ln[2:3], ln[3:]
+        rest = rest.strip().strip('"')
+        if rest.startswith(prefix):
+            rest = rest[len(prefix):]
+        out.append(f"{code.strip() or '??'} {rest}")
+    return FAIL, out
+
+
+# --------------------------------------------------------------- file parsing
+
+
+def _parses(path: str, kind: str) -> tuple[bool, str]:
+    """`(ok, reason)` for a file whose whole check is "does it parse". Absence
+    is the caller's business — both files this is used for are optional."""
+    try:
+        with open(path, "rb") as fh:
+            raw = fh.read()
+    except OSError as exc:
+        return False, exc.strerror or str(exc)
+    try:
+        if kind == "toml":
+            import tomllib
+
+            tomllib.loads(raw.decode("utf-8"))
+        else:
+            from xml.etree import ElementTree
+
+            ElementTree.fromstring(raw)
+    except Exception as exc:  # noqa: BLE001 — any parse failure is the finding
+        return False, str(exc).splitlines()[0] if str(exc) else "does not parse"
+    return True, ""
+
+
+# --------------------------------------------------------------------- report
+
+_FAMILY_CHECKS = (
+    ("secrets", "No leaked credentials", "secrets:",
+     "nothing shaped like a live credential"),
+    ("device-paths", "No paths tied to one machine", "device-path:",
+     "no absolute path that only resolves on one machine"),
+)
+
+
+def report(app_dir: str) -> dict:
+    """The whole checklist for one app folder.
+
+    `{"path", "entry", "ok", "checks": [...]}`. `ok` is "nothing failed" —
+    a skipped check is not a pass, but it is not a problem to report either.
+    """
+    app_dir = os.path.abspath(app_dir)
+    checks: list[dict] = []
+
+    try:
+        entry = app_listing.app_entry(app_dir)
+    except OSError:
+        entry = None
+    checks.append(_check(
+        "entry", "Has an app entry page", PASS if entry else FAIL,
+        f"{os.path.basename(entry)} carries the fused-app marker" if entry
+        else 'no page in this folder carries <meta name="fused-app"> — '
+             "without one there is nothing for whoever you share it with to open",
+    ))
+
+    # The declared API version. Only askable of an entry, and only meaningful
+    # when the runtime knows its own version (no migration docs = version 0,
+    # and nothing is behind 0).
+    current = fused_api_version.current_version()
+    if entry is None:
+        checks.append(_check("api-version", "Declares the current fused API version",
+                             SKIP, "no entry page to read the version tag off"))
+    elif current <= 0:
+        checks.append(_check("api-version", "Declares the current fused API version",
+                             SKIP, "this runtime does not report a fused API version"))
+    else:
+        declared = fused_api_version.api_version(entry)
+        behind = declared < current
+        checks.append(_check(
+            "api-version", "Declares the current fused API version",
+            FAIL if behind else PASS,
+            f"declares version {declared}; the runtime is on {current} — "
+            f"the `fused` calls in this app may have moved since"
+            if behind else f"version {current}, the one the runtime speaks",
+        ))
+
+    # The floor engine's two content families.
+    eng = engine()
+    if eng is None:
+        why = engine_error() or "the check engine is unavailable"
+        for cid, label, _prefix, _clean in _FAMILY_CHECKS:
+            checks.append(_check(cid, label, SKIP, why))
+    else:
+        why = ""
+        try:
+            findings = eng.check(app_dir)
+        except Exception as exc:  # noqa: BLE001 — `check` promises not to raise; trust nothing
+            findings = None
+            why = f"the check engine failed: {exc}"
+        for cid, label, prefix, clean in _FAMILY_CHECKS:
+            if findings is None:
+                checks.append(_check(cid, label, SKIP, why))
+                continue
+            hits = [f for f in findings if str(f.get("rule", "")).startswith(prefix)]
+            hits.sort(key=lambda f: (f.get("path", ""), f.get("line", 0), f.get("rule", "")))
+            checks.append(_check(
+                cid, label, FAIL if hits else PASS,
+                f"{len(hits)} line{'' if len(hits) == 1 else 's'} to look at"
+                if hits else clean,
+                hits,
+            ))
+
+    # Generated state loose in the tree.
+    stray = _generated_paths(app_dir)
+    checks.append(_check(
+        "generated", "No generated files outside .fused/",
+        FAIL if stray else PASS,
+        f"{len(stray)} generated path{'' if len(stray) == 1 else 's'} in the app "
+        "tree — delete them, move them under .fused/, or gitignore them"
+        if stray else "no caches or build artifacts loose in the folder",
+        [{"rule": "generated:stray", "path": p, "line": 0, "excerpt": p} for p in stray],
+    ))
+
+    # Structure: the two files that make a share recognizable.
+    try:
+        names = os.listdir(app_dir)
+    except OSError:
+        names = []
+    has_readme = any(n.lower().startswith("readme")
+                     and os.path.isfile(os.path.join(app_dir, n)) for n in names)
+    checks.append(_check(
+        "readme", "Has a README", PASS if has_readme else FAIL,
+        "a README says what this is" if has_readme
+        else "no README — say what this app does for whoever you share it with",
+    ))
+
+    preview = os.path.join(app_dir, app_listing.PREVIEW_IMAGE_NAME)
+    try:
+        has_preview = os.path.isfile(preview) and os.path.getsize(preview) > 0
+    except OSError:
+        has_preview = False
+    checks.append(_check(
+        "preview", "Has a preview.png thumbnail", PASS if has_preview else FAIL,
+        "preview.png is what a card shows" if has_preview
+        else f"no {app_listing.PREVIEW_IMAGE_NAME} (or it is empty) — this is how "
+             "the app is recognized in a grid of others",
+    ))
+
+    # Two optional files, whose whole check is that they parse. Absent is not
+    # a finding: an app is not obliged to have either.
+    for cid, name, kind, label in (
+        ("pyproject", "pyproject.toml", "toml", "pyproject.toml parses"),
+        ("icon", app_listing.ICON_NAME, "xml", "icon.svg parses"),
+    ):
+        path = os.path.join(app_dir, name)
+        if not os.path.isfile(path):
+            checks.append(_check(cid, label, SKIP, f"no {name} in this folder"))
+            continue
+        ok, reason = _parses(path, kind)
+        checks.append(_check(cid, label, PASS if ok else FAIL,
+                             f"{name} parses" if ok else f"{name}: {reason}"))
+
+    # Version control.
+    state, pending = _git_pending(app_dir)
+    checks.append(_check(
+        "git", "Everything committed", state,
+        "this folder is not in a git repository this server can read" if state == SKIP
+        else f"{len(pending)} uncommitted path{'' if len(pending) == 1 else 's'} — "
+             "commit them so what you share is what you tested" if state == FAIL
+        else "the working tree is clean",
+        [{"rule": "git:uncommitted", "path": p, "line": 0, "excerpt": p}
+         for p in pending],
+    ))
+
+    return {
+        "path": app_dir,
+        "entry": entry,
+        "ok": not any(c["state"] == FAIL for c in checks),
+        "checks": checks,
+    }
+
+
+# ------------------------------------------------------------------- the task
+
+# The first words of every App Doctor task's prompt — how a stored task is
+# recognised as one (`server/routers/apps.py`) without a second field on the
+# schedule entry, the same trick the migration task uses.
+DOCTOR_PROMPT_PREFIX = "Run App Doctor on this fused-render app"
+
+
+def is_doctor_prompt(message: str) -> bool:
+    return str(message or "").startswith(DOCTOR_PROMPT_PREFIX)
+
+
+def doctor_prompt(entry_html: str) -> str:
+    """The fix task's text: invoke the skill, name the entry page. The skill
+    carries the checks, the judgment about which hits are real, and where each
+    kind of fix belongs — repeating any of that here would be the second copy
+    the skill exists to prevent."""
+    entry_name = os.path.basename(entry_html)
+    return (
+        f"{DOCTOR_PROMPT_PREFIX} (`{entry_name}` is its entry page). Invoke the "
+        f"`{SKILL_QUALIFIED}` skill and follow it end to end. Then, for each "
+        f"finding: say in one line what it is and why it matters, and fix the "
+        f"ones that are safe to fix here — a hardcoded path, stray generated "
+        f"files, a missing README or a stale `fused-api-version` tag (route that "
+        f"last one through the skill it names). For a leaked credential, say "
+        f"where it is and that it needs rotating; do not move the value "
+        f"somewhere else and call it fixed. Leave everything the skill does not "
+        f"ask about alone."
+    )

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -60,6 +60,7 @@ import time
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Body, File, Form, Header, UploadFile
+from fastapi.responses import JSONResponse
 
 from fused_render import app_listing, fused_api_version, schedule
 from fused_render.server.common import _error, _require_fused
@@ -453,8 +454,9 @@ def api_app_entry(path: str):
         # The fused page API version the entry declares (`<meta
         # name="fused-api-version">`, 0 when undeclared — every app authored
         # before the tag existed) beside the version the runtime speaks now.
-        # The app page's "Migrate" button is `api_version < current_api_version`.
-        # Null when there is no entry to read it off.
+        # `api_version < current_api_version` is "behind", which is now one ROW
+        # of the App Doctor checklist (`app_doctor.report`) rather than a button
+        # of its own. Null when there is no entry to read it off.
         "api_version": fused_api_version.api_version(entry) if entry else None,
         "current_api_version": fused_api_version.current_version(),
         # A migration task on this entry that has not finished — the button
@@ -463,15 +465,19 @@ def api_app_entry(path: str):
     }
 
 
-def _live_migration_task(entry_html: str) -> dict | None:
-    """The stored migration task on `entry_html` that is still LIVE — pending,
-    sending, or sent with no `turn` verdict yet — as `{id, state, run_id}`, or
-    None. A migration is recognised by its prompt's fixed first words
-    (`fused_api_version.is_migration_prompt`); "finished" is the schedule's own
+def _live_app_task(entry_html: str, is_ours) -> dict | None:
+    """The stored task on `entry_html` that is still LIVE — pending, sending,
+    or sent with no `turn` verdict yet — and whose prompt `is_ours` claims, as
+    `{id, state, run_id}`, or None.
+
+    A task family is recognised by its prompt's fixed first words rather than
+    by a field of its own on the schedule entry: the entries are the New task
+    form's own shape, and a feature-specific column on them would be a second
+    schema for every consumer to know about. "Finished" is the schedule's own
     verdict (`turn` is stamped ok/failed/cancelled when the run closes), so a
-    session that died without writing the tag frees the button again rather
-    than pinning it forever. The tag on disk stays the one truth about whether
-    the migration LANDED — this only says whether one is underway."""
+    session that died halfway frees the button again rather than pinning it
+    forever — what LANDED is always read off the folder itself, never off the
+    task."""
     want = os.path.realpath(entry_html)
     try:
         entries = schedule.list_entries()
@@ -482,7 +488,7 @@ def _live_migration_task(entry_html: str) -> dict | None:
             continue
         if e.get("turn"):
             continue
-        if not fused_api_version.is_migration_prompt(e.get("message")):
+        if not is_ours(e.get("message")):
             continue
         target = str(e.get("target") or "")
         if not target or os.path.realpath(target) != want:
@@ -493,6 +499,13 @@ def _live_migration_task(entry_html: str) -> dict | None:
             "run_id": e.get("run_id") or None,
         }
     return None
+
+
+def _live_migration_task(entry_html: str) -> dict | None:
+    """The live fused-API migration task on `entry_html`, or None. The tag on
+    disk stays the one truth about whether the migration LANDED — this only
+    says whether one is underway."""
+    return _live_app_task(entry_html, fused_api_version.is_migration_prompt)
 
 
 @router.post("/api/apps/migrate")
@@ -506,7 +519,13 @@ def api_migrate_app(body: dict = Body(...), x_fused: str | None = Header(default
     the same shape and the same seam as the scaffolding task `/api/apps/new`
     creates, so the app's Tasks tab lists it and the Claude pane can attach to
     its run. The version tag itself is the session's to write: stamping it
-    here would declare a migration done before the code moved."""
+    here would declare a migration done before the code moved.
+
+    NO UI CALLS THIS ANY MORE. The Migrate button on the app page and on the
+    explorer's entry-page topbar became the App Doctor button, and a stale
+    version tag is one ROW of that checklist (`app_doctor.report`) — its fix
+    session routes that row through this same migration skill itself. This
+    endpoint stays as the narrow way to ask for exactly that one task."""
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
@@ -551,6 +570,102 @@ def api_migrate_app(body: dict = Body(...), x_fused: str | None = Header(default
         "entry_html": entry_html,
         "from_version": from_version,
         "to_version": to_version,
+        # Same two keys as /api/apps/new, same meaning: the stored entry with
+        # its `run_id` once the send resolved, and why no entry was stored.
+        "task": task,
+        "task_error": task_error,
+    }
+
+
+def _doctor_folder(path) -> tuple[str, JSONResponse | None]:
+    """`(folder, error)` for a doctor request's `path` — the shared preflight
+    both verbs run. A folder is enough: unlike migrate, the report says for
+    itself whether there is an entry page (it is the first row of the
+    checklist), so a folder with none is a REPORT, not a 404."""
+    from fused_render.index.ignore import MountGuard
+
+    if not isinstance(path, str) or not os.path.isabs(path):
+        return "", _error("'path' must be an absolute folder path")
+    if MountGuard().blocks(path) or not os.path.isdir(path):
+        return "", _error("no such app folder", status=404)
+    return os.path.abspath(path), None
+
+
+@router.get("/api/apps/doctor")
+def api_app_doctor(path: str):
+    """The App Doctor report for one folder: the deterministic checklist the
+    modal draws (`app_doctor.report` — what it checks and why lives there),
+    beside the live fix task if one is already running.
+
+    Read-only and cheap enough for a button press: a bounded walk of the
+    folder plus one `git status`. Nothing here forms a judgment about a
+    finding — that is the fix task's job, and the fix task is a Claude session
+    running the skill (POST, below)."""
+    from fused_render import app_doctor
+
+    folder, err = _doctor_folder(path)
+    if err is not None:
+        return err
+    report = app_doctor.report(folder)
+    entry = report.get("entry")
+    # The same key shape /api/apps/entry uses for its migration task, and for
+    # the same reason: the button reads "in progress" instead of offering a
+    # second session over the same files.
+    report["task"] = (_live_app_task(entry, app_doctor.is_doctor_prompt)
+                      if entry else None)
+    return report
+
+
+@router.post("/api/apps/doctor")
+def api_app_doctor_fix(body: dict = Body(...),
+                       x_fused: str | None = Header(default=None)):
+    """Create the FIX task: one session that explains every App Doctor finding
+    and fixes what is safe to fix. The prompt is one line invoking the
+    `fused-render-app-doctor` skill (`app_doctor.doctor_prompt`) — the skill
+    owns the checks, the judgment about which hits are real, and where each
+    kind of fix belongs.
+
+    One task for the whole report, not one per finding: the findings are about
+    the same folder and often the same file, and two sessions rewriting one
+    app at once is a merge nobody asked for. Same shape and same seam as the
+    scaffolding task `/api/apps/new` creates, so the app's Tasks tab lists it
+    and the Claude pane can attach to its run."""
+    from fused_render import app_doctor
+
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+
+    folder, err = _doctor_folder(body.get("path"))
+    if err is not None:
+        return err
+    model = body.get("model", "")
+    effort = body.get("effort", "")
+    for field, value, allowed in (("model", model, VALID_DEFAULT_MODELS),
+                                  ("effort", effort, _VALID_SESSION_EFFORTS)):
+        cerr = _session_choice_error(field, value, allowed)
+        if cerr is not None:
+            return _error(cerr)
+
+    try:
+        entry_html = app_listing.app_entry(folder)
+    except OSError:
+        entry_html = None
+    if not entry_html:
+        # A task has to land ON a page (that is what lets "open this task"
+        # reach the app rather than the folder), so the one finding the doctor
+        # cannot hand to a session is the missing entry itself.
+        return _error('this folder has no app entry page (no <meta name="fused-app">)',
+                      status=404)
+    if _live_app_task(entry_html, app_doctor.is_doctor_prompt) is not None:
+        return _error("an App Doctor task for this app is already in progress",
+                      status=409)
+
+    prompt = app_doctor.doctor_prompt(entry_html)
+    task, task_error = _create_app_task(entry_html, prompt, model, effort)
+    return {
+        "path": folder,
+        "entry_html": entry_html,
         # Same two keys as /api/apps/new, same meaning: the stored entry with
         # its `run_id` once the send resolved, and why no entry was stored.
         "task": task,

--- a/tests/test_app_doctor_report.py
+++ b/tests/test_app_doctor_report.py
@@ -1,0 +1,355 @@
+"""App Doctor as the app page and the explorer see it: the checklist
+(`fused_render/app_doctor.py`) and the two endpoints that serve it
+(`GET`/`POST /api/apps/doctor`).
+
+The deterministic FLOOR — which secret shapes and device-path roots count — is
+tested where it lives, against the script itself (test_app_doctor.py,
+test_app_doctor_housekeeping.py). What is tested here is everything the report
+adds on top: the rows the CI floor deliberately omits (the entry rule, the
+declared fused API version, stray generated state, an optional file that does
+not parse, an uncommitted working tree), the grouping of the floor's findings
+into rows, and the fix task's one-per-app rule.
+
+The spawn is stubbed at the same module seam the scaffolding tests use
+(`apps_mod._create_app_task`) — no test here launches a real claude.
+"""
+import os
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render import app_doctor
+from fused_render.server import create_app
+from fused_render.server.routers import apps as apps_mod
+
+HDRS = {"X-Fused": "1"}
+
+PAGE = ('<html><head><meta name="fused-app" />'
+        '<meta name="fused-api-version" content="{v}" /></head><body>hi</body></html>')
+
+
+@pytest.fixture()
+def workspace(tmp_path, monkeypatch):
+    fdir = tmp_path / "Fused"
+    fdir.mkdir()
+    monkeypatch.setenv("FUSED_RENDER_DIR", str(fdir))
+    return fdir
+
+
+@pytest.fixture()
+def client(tmp_path, workspace):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def _app(workspace, name="demo", *, version=None, readme=True, preview=True):
+    """An app folder that passes every check by default, so each test can break
+    exactly one thing and read the row it broke."""
+    d = workspace / "local" / name
+    d.mkdir(parents=True)
+    current = app_doctor.fused_api_version.current_version()
+    (d / "index.html").write_text(PAGE.format(
+        v=current if version is None else version))
+    if readme:
+        (d / "README.md").write_text("what this is\n")
+    if preview:
+        (d / "preview.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 8)
+    return d
+
+
+def _rows(report):
+    return {c["id"]: c for c in report["checks"]}
+
+
+def _state(report, cid):
+    return _rows(report)[cid]["state"]
+
+
+# ------------------------------------------------------------------ the report
+
+def test_a_clean_app_passes_every_check_it_can_answer(workspace):
+    d = _app(workspace)
+    report = app_doctor.report(str(d))
+    rows = _rows(report)
+    assert report["ok"] is True
+    assert report["entry"] == str(d / "index.html")
+    # Every row is one of the three states, and none of them failed.
+    assert {c["state"] for c in report["checks"]} <= {"pass", "fail", "skip"}
+    assert [c["id"] for c in report["checks"] if c["state"] == "fail"] == []
+    # The two optional files are absent, which is not a finding.
+    assert rows["pyproject"]["state"] == "skip"
+    assert rows["icon"]["state"] == "skip"
+
+
+def test_no_tagged_page_fails_the_entry_row(workspace):
+    d = workspace / "local" / "pageless"
+    d.mkdir(parents=True)
+    (d / "index.html").write_text("<html><body>no marker</body></html>")
+    report = app_doctor.report(str(d))
+    assert report["entry"] is None
+    assert _state(report, "entry") == "fail"
+    assert report["ok"] is False
+    # The version row cannot be answered without an entry to read it off —
+    # "skip", not a failure invented out of a missing file.
+    assert _state(report, "api-version") == "skip"
+
+
+def test_a_stale_api_version_fails_and_names_both_numbers(workspace):
+    current = app_doctor.fused_api_version.current_version()
+    if current <= 0:
+        pytest.skip("no migration docs resolve, so nothing is behind")
+    d = _app(workspace, version=0)
+    report = app_doctor.report(str(d))
+    row = _rows(report)["api-version"]
+    assert row["state"] == "fail"
+    assert "0" in row["detail"] and str(current) in row["detail"]
+
+
+def test_a_leaked_key_and_a_device_path_land_in_their_own_rows(workspace):
+    d = _app(workspace)
+    (d / "app.py").write_text(
+        'KEY = "AKIAIOSFODNN7EXAMPLE"\n'
+        'DATA = "/Users/someone/private/data.csv"\n'
+    )
+    rows = _rows(app_doctor.report(str(d)))
+    assert rows["secrets"]["state"] == "fail"
+    assert rows["device-paths"]["state"] == "fail"
+    # Grouped by family, not merged: a credential and a path are different
+    # problems with different fixes.
+    assert all(f["rule"].startswith("secrets:") for f in rows["secrets"]["findings"])
+    assert all(f["rule"].startswith("device-path:")
+               for f in rows["device-paths"]["findings"])
+    # The excerpt is masked at the source (app_check.py's `_mask`) — the whole
+    # secret must never reach a modal, a log, or a chat transcript.
+    assert not any("AKIAIOSFODNN7EXAMPLE" in f["excerpt"]
+                   for f in rows["secrets"]["findings"])
+    assert rows["device-paths"]["findings"][0]["line"] == 2
+
+
+def test_generated_state_outside_dot_fused_is_a_finding_and_inside_it_is_not(workspace):
+    d = _app(workspace)
+    (d / "__pycache__").mkdir()
+    (d / "__pycache__" / "app.cpython-312.pyc").write_bytes(b"\x00")
+    (d / "notes.log").write_text("run 1\n")
+    # The app's OWN state folder is exactly where this belongs (D548).
+    (d / ".fused" / "cache").mkdir(parents=True)
+    (d / ".fused" / "cache" / "tiles.db").write_bytes(b"\x00")
+
+    row = _rows(app_doctor.report(str(d)))["generated"]
+    assert row["state"] == "fail"
+    found = {f["path"] for f in row["findings"]}
+    # The cache dir is reported as ITSELF, not once per file inside it.
+    assert found == {"__pycache__/", "notes.log"}
+
+
+def test_missing_readme_and_thumbnail_each_fail_their_own_row(workspace):
+    d = _app(workspace, readme=False, preview=False)
+    rows = _rows(app_doctor.report(str(d)))
+    assert rows["readme"]["state"] == "fail"
+    assert rows["preview"]["state"] == "fail"
+
+
+def test_an_empty_thumbnail_reads_as_no_thumbnail(workspace):
+    d = _app(workspace)
+    (d / "preview.png").write_bytes(b"")
+    assert _state(app_doctor.report(str(d)), "preview") == "fail"
+
+
+@pytest.mark.parametrize("name,body,cid", [
+    ("pyproject.toml", "[project\nname = 'x'\n", "pyproject"),
+    ("icon.svg", "<svg><path d=", "icon"),
+])
+def test_an_optional_file_that_does_not_parse_fails_its_row(workspace, name, body, cid):
+    d = _app(workspace)
+    (d / name).write_text(body)
+    row = _rows(app_doctor.report(str(d)))[cid]
+    assert row["state"] == "fail"
+    assert name in row["detail"]
+
+
+@pytest.mark.parametrize("name,body,cid", [
+    ("pyproject.toml", '[project]\nname = "x"\n', "pyproject"),
+    ("icon.svg", '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>', "icon"),
+])
+def test_an_optional_file_that_parses_passes_its_row(workspace, name, body, cid):
+    d = _app(workspace)
+    (d / name).write_text(body)
+    assert _state(app_doctor.report(str(d)), cid) == "pass"
+
+
+def test_a_folder_that_is_not_a_repo_skips_the_git_row(workspace):
+    d = _app(workspace)
+    row = _rows(app_doctor.report(str(d)))["git"]
+    assert row["state"] == "skip"
+    # A skip is not a pass, but it is not a problem either.
+    assert app_doctor.report(str(d))["ok"] is True
+
+
+def _git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, close_fds=False)
+
+
+@pytest.mark.skipif(not __import__("shutil").which("git"), reason="git not on PATH")
+def test_uncommitted_work_fails_the_git_row_and_a_clean_tree_passes(workspace):
+    """The check the owner asked for: everything in the app is committed.
+
+    Staged in the SHARED `local` repo (D626) rather than a repo per app, which
+    is the layout real apps have — and the reason the row's paths are stripped
+    back to app-relative: `git status` reports them from the repo root, one
+    level above the folder being reviewed.
+    """
+    d = _app(workspace)
+    repo = workspace / "local"
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "in")
+
+    row = _rows(app_doctor.report(str(d)))["git"]
+    assert row["state"] == "pass"
+
+    (d / "app.py").write_text("print('new')\n")
+    row = _rows(app_doctor.report(str(d)))["git"]
+    assert row["state"] == "fail"
+    assert [f["path"] for f in row["findings"]] == ["?? app.py"]
+
+
+@pytest.mark.skipif(not __import__("shutil").which("git"), reason="git not on PATH")
+def test_a_sibling_apps_uncommitted_work_is_not_this_apps_finding(workspace):
+    """Sibling apps share one repo, so the status has to be scoped to the
+    folder under review or every app in the workspace reads as dirty at once."""
+    mine = _app(workspace, "mine")
+    theirs = _app(workspace, "theirs")
+    repo = workspace / "local"
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "in")
+    (theirs / "wip.py").write_text("half a thought\n")
+
+    assert _state(app_doctor.report(str(mine)), "git") == "pass"
+    assert _state(app_doctor.report(str(theirs)), "git") == "fail"
+
+
+def test_a_missing_folder_reports_rather_than_raising(tmp_path):
+    """A doctor that crashes on the app it was asked to examine is worse than
+    no doctor: every check degrades, none raises."""
+    report = app_doctor.report(str(tmp_path / "nope"))
+    assert report["ok"] is False
+    assert _state(report, "entry") == "fail"
+    assert {c["id"] for c in report["checks"]}  # a full checklist, not a stub
+
+
+def test_an_unresolvable_check_engine_skips_its_rows_instead_of_failing(
+    workspace, monkeypatch,
+):
+    d = _app(workspace)
+    monkeypatch.setattr(app_doctor, "engine", lambda: None)
+    monkeypatch.setattr(app_doctor, "engine_error", lambda: "no skill here")
+    rows = _rows(app_doctor.report(str(d)))
+    assert rows["secrets"]["state"] == "skip"
+    assert rows["device-paths"]["state"] == "skip"
+    assert rows["secrets"]["detail"] == "no skill here"
+    # The rows that do not need the engine still answer.
+    assert rows["readme"]["state"] == "pass"
+
+
+# --------------------------------------------------------------- the endpoints
+
+def test_get_serves_the_checklist_for_a_folder(client, workspace):
+    d = _app(workspace)
+    r = client.get("/api/apps/doctor", params={"path": str(d)})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["task"] is None
+    assert [c["id"] for c in body["checks"]] == [
+        c["id"] for c in app_doctor.report(str(d))["checks"]
+    ]
+
+
+def test_get_needs_an_absolute_path_and_a_real_folder(client, workspace):
+    assert client.get("/api/apps/doctor", params={"path": "relative"}).status_code == 400
+    r = client.get("/api/apps/doctor", params={"path": str(workspace / "gone")})
+    assert r.status_code == 404
+
+
+def test_get_reports_a_page_less_folder_instead_of_404ing(client, workspace):
+    """A folder with no entry is the FIRST ROW of the report, not an error:
+    "this is not shareable yet" is exactly what the dialog exists to say."""
+    d = workspace / "local" / "pageless"
+    d.mkdir(parents=True)
+    r = client.get("/api/apps/doctor", params={"path": str(d)})
+    assert r.status_code == 200
+    assert r.json()["entry"] is None
+
+
+def test_post_requires_the_fused_header(client, workspace):
+    d = _app(workspace)
+    assert client.post("/api/apps/doctor", json={"path": str(d)}).status_code == 403
+
+
+def test_post_creates_one_task_on_the_entry_page_invoking_the_skill(
+    client, workspace, monkeypatch,
+):
+    d = _app(workspace)
+    seen = []
+    monkeypatch.setattr(apps_mod, "_create_app_task",
+                        lambda entry, prompt, *rest:
+                        seen.append((entry, prompt)) or ({"id": "t1", "run_id": "r1"}, None))
+    r = client.post("/api/apps/doctor", json={"path": str(d)}, headers=HDRS)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["entry_html"] == str(d / "index.html")
+    assert body["task"] == {"id": "t1", "run_id": "r1"}
+    assert body["task_error"] is None
+    # The task lands on the FILE (that is what lets "open this task" reach the
+    # page rather than the folder), and its prompt invokes the skill by name.
+    (entry, prompt), = seen
+    assert entry == str(d / "index.html")
+    assert app_doctor.is_doctor_prompt(prompt)
+    assert app_doctor.SKILL_QUALIFIED in prompt
+    assert "index.html" in prompt
+
+
+def test_post_reports_a_task_that_could_not_be_stored(client, workspace, monkeypatch):
+    d = _app(workspace)
+    monkeypatch.setattr(apps_mod, "_create_app_task",
+                        lambda *a, **k: (None, "store is read-only"))
+    body = client.post("/api/apps/doctor", json={"path": str(d)},
+                       headers=HDRS).json()
+    assert body["task"] is None
+    assert body["task_error"] == "store is read-only"
+
+
+def test_post_refuses_a_folder_with_no_entry_page(client, workspace):
+    d = workspace / "local" / "pageless"
+    d.mkdir(parents=True)
+    r = client.post("/api/apps/doctor", json={"path": str(d)}, headers=HDRS)
+    assert r.status_code == 404
+    assert "entry page" in r.json()["error"]
+
+
+def test_post_refuses_a_second_task_while_one_is_live(client, workspace, monkeypatch):
+    """One session per app: two rewriting the same folder at once is a merge
+    nobody asked for. The GET says so too, so a reload shows "in progress"
+    rather than offering another."""
+    d = _app(workspace)
+    entry = str(d / "index.html")
+    live = {"id": "t1", "state": "sent", "run_id": "r1"}
+    monkeypatch.setattr(apps_mod, "_live_app_task",
+                        lambda e, matcher: live if matcher("Run App Doctor on this "
+                                                           "fused-render app x") else None)
+    r = client.post("/api/apps/doctor", json={"path": str(d)}, headers=HDRS)
+    assert r.status_code == 409
+    assert client.get("/api/apps/doctor",
+                      params={"path": str(d)}).json()["task"] == live
+    assert os.path.isfile(entry)
+
+
+def test_post_rejects_an_unknown_model_or_effort(client, workspace):
+    d = _app(workspace)
+    for field in ("model", "effort"):
+        r = client.post("/api/apps/doctor",
+                        json={"path": str(d), field: "nonesuch"}, headers=HDRS)
+        assert r.status_code == 400, field
+        assert field in r.json()["error"]


### PR DESCRIPTION
## Summary

- **The "Migrate to new version" button is gone from both places it appeared** — the app page's header and the explorer's entry-page topbar — replaced by **App Doctor**, shown on every app entry rather than only on an app behind the runtime's fused API version. A stale `fused-api-version` tag was never the only thing wrong with an app about to be shared, and it said nothing at all about an app already current.
- **The button opens a deterministic checklist**: an entry page carrying the `fused-app` marker, the declared API version against the runtime's, leaked credentials, paths tied to one machine, generated state loose outside `.fused/`, a README, a `preview.png`, `pyproject.toml` and `icon.svg` parsing when either is present, and **whether everything in the folder is committed**. Each row is `pass` / `fail` / `skip` plus the lines it came from — no judgment, no guessing.
- **"Explain and fix" hands the whole report to one Claude session** running the `fused-render-app-doctor` skill, landing in the Claude pane on its run. One task per app, not one per finding; while a task is live the button reads "Fix in progress" and opens the app's Tasks tab.
- **The secret and device-path detection is not reimplemented.** `fused_render/app_doctor.py` loads the skill's own already-tested `ci/app_check.py` and groups its findings into rows, adding only the rows a repo checkout cannot know without a runtime.
- `POST /api/apps/migrate` stays as the narrow way to ask for just the migration task — no UI calls it now, and the fix session routes a stale version row through the migration skill itself.

## Visuals

```mermaid
flowchart TD
    E[App entry page] --> B[App Doctor button]
    B --> G["GET /api/apps/doctor"]
    G --> R[app_doctor.report]
    R --> F["ci/app_check.py<br/>secrets, device paths"]
    R --> O[Runtime-only rows]
    O --> M[Checklist modal]
    F --> M
    M --> P["POST /api/apps/doctor"]
    P --> T[One task on the entry page]
```

The runtime-only rows are the ones the CI floor deliberately omits: the `fused-app` entry rule, the declared API version, generated state outside `.fused/`, `pyproject.toml` / `icon.svg` parsing, and `git status` scoped to the app folder.

## Usage

In the app (`/apps/<folder>`, or an app's entry page in the explorer), press **App Doctor** in the header. The dialog lists every check with its findings; **Re-run** re-reads the folder, **Explain and fix** creates the session that explains and fixes it.

Directly:

```bash
curl "localhost:PORT/api/apps/doctor?path=/Users/me/Fused/local/demo"
curl -X POST localhost:PORT/api/apps/doctor -H 'X-Fused: 1' \
     -H 'Content-Type: application/json' -d '{"path":"/Users/me/Fused/local/demo"}'
```

Or from Python: `fused_render.app_doctor.report("/path/to/app")`.

## Test Plan

- [x] `tests/test_app_doctor_report.py` — 25 new tests: every row's pass/fail/skip, secrets masked in the excerpt, a cache dir reported as itself, the shared-repo git scoping (a sibling app's WIP is not this app's finding), a missing folder reporting instead of raising, an unresolvable check engine skipping rather than failing, and the endpoints (400/404/403/409, task prompt invoking the skill by name, one task per app).
- [x] `frontend/src/platform/ui/appdoctor-lib.test.ts` — 7 new tests on the dialog's pure decisions (summary wording never counts a skip as a pass, finding cap, `path:0` drawn without a line, tasks-tab URL).
- [x] `bun test` full frontend suite green (3064 pass), `bun run build` green (boundaries + `tsc --noEmit` + vite).
- [x] `pytest tests/test_apps_api.py tests/test_app_doctor*.py tests/test_theme.py` green apart from one **pre-existing** failure unrelated to this branch: `test_theme.py::test_shell_css_has_no_colour_literals_outside_the_palettes` flags two literals in `frontend/src/styles/preferences.css`, which this branch does not touch.
- [ ] **The full local pytest suite has not been run on this branch** — deliberately deferred; CI is the first full run.
- [ ] Manual: open an app's entry page in the explorer and the app page, confirm the button appears on both and the Migrate button is gone; paste `KEY = "AKIAIOSFODNN7EXAMPLE"` and a `"/Users/…"` path into a `.py` in the folder, leave the file uncommitted, re-run and confirm three rows fail with the key masked; press **Explain and fix** and confirm it lands in the Claude pane; reopen and confirm the button reads "Fix in progress".
