### PR TITLE
Icon picker: Icons tab first, five colours

### DIFF
--- a/frontend/src/apps/builder/Apps.tsx
+++ b/frontend/src/apps/builder/Apps.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getApps, getBackgroundAppsRunning, getHomeApps } from "@platform/lib/api";
 import type { AppInfo, Config } from "@platform/lib/api";
+import { useCurrentAppsChanged } from "@platform/lib/tasksChanged";
 import { appCardMenu } from "@platform/lib/appCardMenu";
 import { sortApps } from "@platform/lib/appEntry";
 import { runCommunity } from "@platform/lib/community";
@@ -177,8 +178,12 @@ export default function Apps({ config }: { config: Config }) {
     if (tag !== null) setMode("repo");
     else if (category !== null) setMode("category");
   }, [tag, category]);
-  // Bumped when the panel creates an app: refetches the grid without clearing it.
+  // Bumped when the panel creates an app, and on the desk-changed announcement
+  // (an icon picked from the sidebar's Projects row while the grid is on
+  // screen): refetches the grid without clearing it, so the card's mark
+  // follows the new icon.svg.
   const [nonce, setNonce] = useState(0);
+  useCurrentAppsChanged(() => setNonce((n) => n + 1));
   // One context-menu portal for the whole grid, at the cursor coords — same
   // shape as the explorer listing's (Listing.tsx openRowMenu).
   const [menu, setMenu] = useState<{ x: number; y: number; items: MenuEntry[] } | null>(null);

--- a/frontend/src/platform/lib/icon-color.ts
+++ b/frontend/src/platform/lib/icon-color.ts
@@ -1,6 +1,6 @@
-// The app-icon palette: Notion's ten icon colours, each a light/dark pair, so
-// a picked lucide glyph follows the shell's theme the way the generic AppStar
-// (on currentColor) already does.
+// The app-icon palette: five picks (default grey, fused yellow, then blue /
+// green / red), each a light/dark pair, so a picked lucide glyph follows the
+// shell's theme the way the generic AppStar (on currentColor) already does.
 //
 // The problem this solves: `icon.svg` is a static file drawn through `<img>`
 // and `<link rel="icon">`, and neither crosses into the shell's CSS — no
@@ -15,31 +15,28 @@
 // tests can import it.
 import type { Theme } from "@platform/lib/theme";
 
-export const ICON_COLORS = [
-  "default",
-  "gray",
-  "brown",
-  "yellow",
-  "orange",
-  "green",
-  "blue",
-  "purple",
-  "pink",
-  "red",
-] as const;
+/** What the picker offers, in swatch order. */
+export const ICON_COLORS = ["default", "yellow", "blue", "green", "red"] as const;
 
-export type IconColor = (typeof ICON_COLORS)[number];
+/** Names an existing icon.svg may still declare: the five above plus the
+ *  Notion colours the picker used to offer. Kept so those files keep
+ *  following the theme instead of falling back to their baked-in hex. */
+const LEGACY_ICON_COLORS = ["gray", "brown", "orange", "purple", "pink"] as const;
+const ALL_ICON_COLORS: readonly string[] = [...ICON_COLORS, ...LEGACY_ICON_COLORS];
+
+export type IconColor = (typeof ICON_COLORS)[number] | (typeof LEGACY_ICON_COLORS)[number];
 
 /** Hex per theme. `default` is the `--fg-muted` pair (tokens.css) — the tint
  *  the generic AppStar fallback wears, so an uncoloured pick and no pick at
- *  all sit in the same register. The rest are Notion's icon palette. The
+ *  all sit in the same register. `yellow` is the fused accent (`--accent`),
+ *  the rest are Notion's icon palette. The
  *  same values live in tokens.css as `--app-icon-<name>` for the picker's
  *  swatches; the svg needs them as literals. */
 export const ICON_COLOR_HEX: Record<IconColor, { light: string; dark: string }> = {
   default: { light: "#61656c", dark: "#9aa0a6" },
   gray: { light: "#787774", dark: "#9b9b9b" },
   brown: { light: "#9f6b53", dark: "#ba856f" },
-  yellow: { light: "#cb912f", dark: "#ca9849" },
+  yellow: { light: "#5f7300", dark: "#E5FF44" },
   orange: { light: "#d9730d", dark: "#c77d48" },
   green: { light: "#448361", dark: "#529e72" },
   blue: { light: "#337ea9", dark: "#5e87c9" },
@@ -62,7 +59,7 @@ export const ICON_COLOR_LABEL: Record<IconColor, string> = {
 };
 
 export function isIconColor(v: unknown): v is IconColor {
-  return typeof v === "string" && (ICON_COLORS as readonly string[]).includes(v);
+  return typeof v === "string" && ALL_ICON_COLORS.includes(v);
 }
 
 /** The colour name an icon.svg declares on its root, or null for a file with

--- a/frontend/src/platform/lib/tasksChanged.ts
+++ b/frontend/src/platform/lib/tasksChanged.ts
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 // "A task just changed" — the platform half of a poke at the shell's shared
 // tasks store (shell/tasksPulse.ts). An APP that creates a task (the Home
 // hero's new-app composer: its prompt becomes a task on the new folder's
@@ -25,4 +27,16 @@ export const CURRENT_APPS_CHANGED_EVENT = "fused-render:current-apps-changed";
 
 export function announceCurrentAppsChanged(): void {
   window.dispatchEvent(new Event(CURRENT_APPS_CHANGED_EVENT));
+}
+
+/** Subscribe for the component's lifetime. `cb` is read through a ref so a
+ *  fresh closure each render does not churn the listener. */
+export function useCurrentAppsChanged(cb: () => void): void {
+  const ref = useRef(cb);
+  ref.current = cb;
+  useEffect(() => {
+    const fire = () => ref.current();
+    window.addEventListener(CURRENT_APPS_CHANGED_EVENT, fire);
+    return () => window.removeEventListener(CURRENT_APPS_CHANGED_EVENT, fire);
+  }, []);
 }

--- a/frontend/src/platform/ui/AppPreviewCard.tsx
+++ b/frontend/src/platform/ui/AppPreviewCard.tsx
@@ -264,8 +264,14 @@ export function AppPreviewCard({
         <span className="app-pcard-lines">
           <span className="app-pcard-title">{title}</span>
           <span className="app-pcard-meta">
-            <span className="app-pcard-tag">{app.tag}</span>
-            {title !== app.name && <span className="app-pcard-name">{app.name}</span>}
+            {/* Where the app lives, as one path — `local/short-builder` — in
+                place of a bordered tag chip beside the folder name (owner:
+                the chip was visual noise). Always the full path, even when the
+                title is the folder name: the tag alone is only half an
+                address. */}
+            <span className="app-pcard-name">
+              {app.tag}/{app.name}
+            </span>
             {badge && <span className="app-pcard-name">{badge}</span>}
             {ago && <span className="app-pcard-ago">{ago}</span>}
           </span>

--- a/frontend/src/platform/ui/IconPicker.tsx
+++ b/frontend/src/platform/ui/IconPicker.tsx
@@ -329,7 +329,12 @@ export default function IconPicker({
 }: IconPickerProps) {
   const [tab, setTab] = useState<IconPickerTab>(tabs[0] ?? "icon");
   const [query, setQuery] = useState("");
-  const [active, setActive] = useState(0);
+  // The keyboard highlight. null until an arrow key moves it: the picker
+  // opens with NO cell marked — a ring on the first cell read as "this is the
+  // current icon", which it never was (the picker doesn't know the current
+  // icon). Typing or switching tabs drops back to null; Enter with nothing
+  // highlighted takes the first match, so type-and-Enter still works.
+  const [active, setActive] = useState<number | null>(null);
   const [color, setColor] = useState<IconColor>(readColor);
   const [colorOpen, setColorOpen] = useState(false);
   const baseId = useId();
@@ -421,7 +426,8 @@ export default function IconPicker({
   // cell via aria-activedescendant. Sections start each grid row fresh, but a
   // single flat ±GRID_COLS Up/Down is predictable enough across them.
   const flat = useMemo(() => visible.flatMap((s) => s.cells), [visible]);
-  const activeIdx = Math.min(active, Math.max(0, flat.length - 1));
+  const activeIdx =
+    active === null || flat.length === 0 ? null : Math.min(active, flat.length - 1);
   const cellId = (i: number) => `${baseId}-cell-${i}`;
 
   const pick = useCallback(
@@ -464,7 +470,10 @@ export default function IconPicker({
 
   const moveActive = (delta: number) => {
     if (flat.length === 0) return;
-    const next = Math.max(0, Math.min(flat.length - 1, activeIdx + delta));
+    // First arrow press lands on the first cell (Right/Down) or stays put
+    // (Left/Up) rather than jumping a row from a phantom origin.
+    const next =
+      activeIdx === null ? 0 : Math.max(0, Math.min(flat.length - 1, activeIdx + delta));
     setActive(next);
     document.getElementById(cellId(next))?.scrollIntoView({ block: "nearest" });
   };
@@ -489,7 +498,10 @@ export default function IconPicker({
         break;
       case "Enter":
         e.preventDefault();
-        if (flat[activeIdx]) pickAndClose(flat[activeIdx]);
+        {
+          const cell = flat[activeIdx ?? 0];
+          if (cell) pickAndClose(cell);
+        }
         break;
       // Escape is handled by the document-level listener (closes the popover).
     }
@@ -498,7 +510,7 @@ export default function IconPicker({
   const switchTab = (next: IconPickerTab) => {
     setTab(next);
     setQuery("");
-    setActive(0);
+    setActive(null);
     setColorOpen(false);
     searchInput()?.focus();
   };
@@ -560,11 +572,11 @@ export default function IconPicker({
             role="combobox"
             aria-expanded="true"
             aria-controls={`${baseId}-grid`}
-            aria-activedescendant={flat.length > 0 ? cellId(activeIdx) : undefined}
+            aria-activedescendant={activeIdx !== null ? cellId(activeIdx) : undefined}
             value={query}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               setQuery(e.target.value);
-              setActive(0);
+              setActive(null);
             }}
             onKeyDown={onSearchKeyDown}
           />

--- a/frontend/src/platform/ui/IconPicker.tsx
+++ b/frontend/src/platform/ui/IconPicker.tsx
@@ -1,6 +1,6 @@
-// Notion-style icon picker popover: an Emoji tab (the whole Unicode set, from
-// emojibase), an Icons tab (the whole lucide set, written on pick as the bare
-// glyph in one of ten theme-following colours — icon-color.ts; the Notion
+// Notion-style icon picker popover: an Icons tab first (the whole lucide set,
+// written on pick as the bare glyph in one of five theme-following colours —
+// icon-color.ts), then an Emoji tab (the whole Unicode set, from emojibase); the Notion
 // swatch popover beside the shuffle button chooses, and the choice sticks
 // across picks rather than being asked each time), a filter box, a shuffle
 // button that picks at random from the active tab, a Recent row per tab, and
@@ -272,7 +272,8 @@ const COLOR_KEY = "fused-render:icon-picker-color";
 function readColor(): IconColor {
   try {
     const v = localStorage.getItem(COLOR_KEY);
-    return isIconColor(v) ? v : "default";
+    // A colour saved before the palette shrank falls back to default.
+    return isIconColor(v) && (ICON_COLORS as readonly string[]).includes(v) ? v : "default";
   } catch {
     return "default";
   }
@@ -324,9 +325,9 @@ export default function IconPicker({
   onRemove,
   onClose,
   toggleSelector = ".bookmark-glyph:not(.folder-glyph):not(.current-app-glyph)",
-  tabs = ["emoji", "icon"],
+  tabs = ["icon", "emoji"],
 }: IconPickerProps) {
-  const [tab, setTab] = useState<IconPickerTab>(tabs[0] ?? "emoji");
+  const [tab, setTab] = useState<IconPickerTab>(tabs[0] ?? "icon");
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const [color, setColor] = useState<IconColor>(readColor);
@@ -606,7 +607,7 @@ export default function IconPicker({
                 data-slot="icon-picker-colors"
                 // Fixed tracks, not grid-cols-5: an absolutely positioned box
                 // shrinks to fit, and 1fr tracks contribute no intrinsic width,
-                // so the five swatches piled onto one another.
+                // so the swatches piled onto one another.
                 className="absolute top-full right-0 z-10 mt-1 grid w-max grid-cols-[repeat(5,1.75rem)] gap-1.5 rounded-lg border border-border bg-popover p-2 shadow-md"
               >
                 {ICON_COLORS.map((c) => (

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -186,8 +186,7 @@ function SkeletonCard({ variant }: { variant: "app" | "folder" }) {
           <span className="app-pcard-lines">
             <span className="skel-bar" style={{ width: "58%" }} />
             <span className="app-pcard-meta">
-              <span className="skel-bar" style={{ width: "46px" }} />
-              <span className="skel-bar" style={{ width: "64px" }} />
+              <span className="skel-bar" style={{ width: "110px" }} />
             </span>
           </span>
         </span>

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -19,6 +19,7 @@ import {
 import { useIndexStatus } from "@platform/lib/index-status";
 import { runCommunity } from "@platform/lib/community";
 import { loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
+import { useCurrentAppsChanged } from "@platform/lib/tasksChanged";
 import { FilesSearch } from "@apps/explorer/FilesHome";
 import { FolderPreviewCard, RecentPreviewCard } from "@apps/explorer/BookmarkCards";
 import { AppPreviewCard } from "@platform/ui/AppPreviewCard";
@@ -370,6 +371,13 @@ export default function Home({ config }: { config: Config }) {
   // showcase fallback without charging returning visits for an exhaustive walk.
   const [apps, setApps] = useState<AppInfo[] | null>(null);
   const [appsError, setAppsError] = useState<string | null>(null);
+  // Bumped on the desk-changed announcement (an icon picked from the sidebar
+  // while this row is on screen) so the cards redraw with the new icon.svg —
+  // the row's AppInfo carries the icon path + mtime, and nothing else here
+  // would ever refresh it. Refetch in place: `apps` is not cleared, so the
+  // row never flashes back to skeletons.
+  const [appsNonce, setAppsNonce] = useState(0);
+  useCurrentAppsChanged(() => setAppsNonce((n) => n + 1));
   useEffect(() => {
     if (limit === null) return;
     let alive = true;
@@ -426,7 +434,7 @@ export default function Home({ config }: { config: Config }) {
     return () => {
       alive = false;
     };
-  }, [limit]);
+  }, [limit, appsNonce]);
 
   // Claude session folders — Home's endpoint orders transcript mtimes first,
   // then opens only enough newest JSONL files to fill this one row.

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -403,15 +403,6 @@ body[data-capture-shooting] .app-pcard-export {
   color: var(--fg-muted);
 }
 
-.app-pcard-tag {
-  flex: 0 0 auto;
-  padding: 1px 8px;
-  font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 10.5px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-}
-
 .app-pcard-name {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -259,7 +259,7 @@
   --app-icon-default: #9aa0a6;
   --app-icon-gray: #9b9b9b;
   --app-icon-brown: #ba856f;
-  --app-icon-yellow: #ca9849;
+  --app-icon-yellow: #E5FF44;
   --app-icon-orange: #c77d48;
   --app-icon-green: #529e72;
   --app-icon-blue: #5e87c9;
@@ -447,7 +447,7 @@
   --app-icon-default: #61656c;
   --app-icon-gray: #787774;
   --app-icon-brown: #9f6b53;
-  --app-icon-yellow: #cb912f;
+  --app-icon-yellow: #5f7300;
   --app-icon-orange: #d9730d;
   --app-icon-green: #448361;
   --app-icon-blue: #337ea9;


### PR DESCRIPTION
For the Projects sidebar and app page icon picker:

1. Icons tab is the default and comes first; Emoji second. Bookmarks (emoji-only) unchanged.
2. Colour options reduced from ten to five.
3. Order: default grey, fused yellow (`--accent`: #5f7300 light / #E5FF44 dark), then blue, green, red.

Legacy colour names (gray/brown/orange/purple/pink) are still recognised when reading an existing `icon.svg`, so already-picked icons keep following the theme. A legacy colour saved in localStorage falls back to default in the picker.

No tests run per owner preference; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, palette, and client-side refetch wiring; legacy icon colour parsing preserves existing icons.
> 
> **Overview**
> **Icon picker** defaults to the **Icons** tab (Emoji second), offers **five** swatches (default grey, fused-accent yellow, blue, green, red), and maps yellow to `--accent` in `tokens.css` / `icon-color.ts`. Removed Notion colours are still honored when **reading** existing `icon.svg`; stale picker colours in localStorage reset to default. Opening the picker no longer highlights the first cell until arrow keys move focus.
> 
> **App preview cards** show one muted **`tag/name`** path instead of a bordered tag chip plus folder name; related skeleton/CSS for `.app-pcard-tag` is removed.
> 
> **Home** and the **/apps** grid subscribe to `useCurrentAppsChanged` so picking an icon from the Projects sidebar refetches app data in place (icons update without skeleton flash), alongside the existing nonce bump when creating an app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b09e4f8d3999fb63bf6ffd8448242f3a7890f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->