### PR TITLE
Explorer: fullscreen button opens the same page as an embed

### DIFF
--- a/frontend/src/apps/explorer/EmbedStrip.tsx
+++ b/frontend/src/apps/explorer/EmbedStrip.tsx
@@ -47,11 +47,19 @@ export default function EmbedStrip({ fsPath, isDir }: { fsPath: string; isDir: b
   const isFused = isDir === false && fsPath.toLowerCase().endsWith(".fused");
   const name = fsPath.split("/").filter(Boolean).pop() || fsPath;
   // Full page load, not `navigate`: the prefix (embed vs view) is read once
-  // at module init, so switching it IS a new document. A folder resolves to
-  // its entry page first; an entry-less or unreadable folder opens as itself.
+  // at module init, so switching it IS a new document. The query rides along
+  // so the explorer opens the SAME page: `_mode`, `_side`, a grid selection —
+  // whatever this embed was showing. Preview's fullscreen button is the main
+  // producer (it stamps the view's query onto the embed URL), and this is its
+  // way back. A folder resolves to its entry page first — the CLI/link case,
+  // where the user was looking at the app — UNLESS the query names a `_mode`:
+  // then the folder was being viewed AS something (its listing, a graph), and
+  // that view is what comes back. An entry-less or unreadable folder opens
+  // as itself.
   const openInExplorer = async () => {
     let target = fsPath;
-    if (isDir) {
+    const search = location.search;
+    if (isDir && !new URLSearchParams(search).has("_mode")) {
       try {
         const info = await getAppEntry(fsPath);
         if (info.entry) target = info.entry;
@@ -59,7 +67,7 @@ export default function EmbedStrip({ fsPath, isDir }: { fsPath: string; isDir: b
         /* no entry answer — the folder itself is still the right place */
       }
     }
-    location.assign(viewUrlForFsPath(target));
+    location.assign(viewUrlForFsPath(target, target === fsPath ? search : ""));
   };
   return (
     <div className="embed-strip" role="toolbar" aria-label="Embedded view">

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -1867,9 +1867,15 @@ function TemplatePreview({
         title="Open fullscreen, without the sidebar and toolbar"
         aria-label="Open fullscreen, without the sidebar and toolbar"
         onClick={() => {
-          const q = new URLSearchParams(location.search);
-          q.set("_mode", entry.mode);
-          location.assign(embedUrlForFsPath(fsPath, "?" + q.toString()));
+          // The existing query goes across BYTE FOR BYTE — no URLSearchParams
+          // round trip, which would re-encode every value on the way. Only the
+          // `_mode` stamp is appended, and only when the URL omits it (the
+          // default mode; setMode deletes the param for clean URLs).
+          const search = location.search;
+          const stamped = new URLSearchParams(search).has("_mode")
+            ? search
+            : (search ? search + "&" : "?") + "_mode=" + encodeURIComponent(entry.mode);
+          location.assign(embedUrlForFsPath(fsPath, stamped));
         }}
       >
         <span className="mode-menu-icon">{MenuIcons.fullscreen}</span>

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -1853,17 +1853,24 @@ function TemplatePreview({
         />
       )}
       {/* Fullscreen: this same page under the chrome-free embed prefix — no
-          sidebar, no crumb, no header — with the current query carried over so
-          `_mode` survives the hop. A FULL page load rather than `navigate`:
+          sidebar, no crumb, no header — with the current query carried over,
+          and `_mode` stamped explicitly even when the view is on its default
+          (the URL omits it then). A FULL page load rather than `navigate`:
           the view/embed prefix is read once at module init (router.ts), so
           switching it is a new document. The way back is EmbedStrip's "Open
-          in explorer", which the top-level embed shows. */}
+          in explorer", which the top-level embed shows: it carries the query
+          back, and reads the `_mode` stamp as "return to THIS page" rather
+          than hopping a folder to its app entry. */}
       <button
         type="button"
         className="bar-ctl bar-ctl-icon"
         title="Open fullscreen, without the sidebar and toolbar"
         aria-label="Open fullscreen, without the sidebar and toolbar"
-        onClick={() => location.assign(embedUrlForFsPath(fsPath, location.search))}
+        onClick={() => {
+          const q = new URLSearchParams(location.search);
+          q.set("_mode", entry.mode);
+          location.assign(embedUrlForFsPath(fsPath, "?" + q.toString()));
+        }}
       >
         <span className="mode-menu-icon">{MenuIcons.fullscreen}</span>
       </button>

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -26,7 +26,7 @@ import type { StatResult, TemplateEntry, RegistryEntryForPath } from "@platform/
 import { captureAppPreview, cropRect, exportAppFile } from "@platform/lib/appShot";
 import { AppDoctorModal } from "@platform/ui/AppDoctorModal";
 import { announceCurrentAppsChanged } from "@platform/lib/tasksChanged";
-import { navigate, navigateUrl, urlForFsPath, viewUrlForFsPath, replaceSearch, encodeFsPathSegments, IS_EMBED, IS_FOREIGN_EMBED, IS_PREVIEW } from "@platform/lib/router";
+import { navigate, navigateUrl, urlForFsPath, viewUrlForFsPath, embedUrlForFsPath, replaceSearch, encodeFsPathSegments, IS_EMBED, IS_FOREIGN_EMBED, IS_PREVIEW } from "@platform/lib/router";
 import { formatSize, formatMtimeFull, basename } from "@platform/lib/format";
 import {
   dirname,
@@ -1852,6 +1852,21 @@ function TemplatePreview({
           onClick={toggleSide}
         />
       )}
+      {/* Fullscreen: this same page under the chrome-free embed prefix — no
+          sidebar, no crumb, no header — with the current query carried over so
+          `_mode` survives the hop. A FULL page load rather than `navigate`:
+          the view/embed prefix is read once at module init (router.ts), so
+          switching it is a new document. The way back is EmbedStrip's "Open
+          in explorer", which the top-level embed shows. */}
+      <button
+        type="button"
+        className="bar-ctl bar-ctl-icon"
+        title="Open fullscreen, without the sidebar and toolbar"
+        aria-label="Open fullscreen, without the sidebar and toolbar"
+        onClick={() => location.assign(embedUrlForFsPath(fsPath, location.search))}
+      >
+        <span className="mode-menu-icon">{MenuIcons.fullscreen}</span>
+      </button>
       {/* The app view's overflow lived here — one "Open in explorer" entry,
           jumping from the app's own route back to the folder. The route went
           with D262 and the app view itself with D264. */}

--- a/frontend/src/platform/ui/MenuIcons.tsx
+++ b/frontend/src/platform/ui/MenuIcons.tsx
@@ -299,4 +299,12 @@ export const MenuIcons: Record<string, ReactNode> = {
       <path d="M12 8h.01" />
     </svg>
   ),
+  fullscreen: (
+    <svg {...svgProps}>
+      <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+      <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+      <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+      <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+    </svg>
+  ),
 };

--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -61,12 +61,11 @@ import {
 import { useFavicon, useUrlVersion } from "@platform/lib/hooks";
 import { useThemedIconSrc } from "@platform/lib/app-icon-src";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
-import { embedUrlForFsPath, navigateUrl, urlForFsPath } from "@platform/lib/router";
+import { navigateUrl, urlForFsPath } from "@platform/lib/router";
 import {
   AppWindow,
   Files,
   GitBranch,
-  ExternalLink,
   ListTodo,
   Webhook,
   type LucideIcon,
@@ -419,7 +418,7 @@ export default function AppPage({
   const entry = resolved?.kind === "app" ? resolved.entry : null;
 
   // App Doctor: the share-readiness checklist for this folder, opened from the
-  // header beside "Open app". It stands where the fused-API "Migrate" button
+  // header beside "Open in explorer". It stands where the fused-API "Migrate" button
   // stood, and subsumes it — a stale `fused-api-version` tag is one row of the
   // checklist now, beside the things migrate never covered (a leaked key, a
   // path tied to one machine, stray generated files, an uncommitted tree). The
@@ -465,7 +464,8 @@ export default function AppPage({
           <div className="app-page-name">
             <h1>{slug}</h1>
             {/* Reads as the folder and IS the folder: opens its listing in the
-                explorer. The app itself is the "Open app" button opposite. */}
+                explorer. The app's entry page is the "Open in explorer"
+                button opposite. */}
             <a className="app-page-folder" href={folderHref} title={dir}>
               {tildePath(dir, home)}
             </a>
@@ -484,19 +484,19 @@ export default function AppPage({
             >
               App Doctor
             </Button>
-            {/* The app full-size AS AN APP — its entry page in embed mode,
-                chrome-free — in a new tab so this page and its live frame stay
-                put. The top-level embed's strip (EmbedStrip) is the way back
-                into the explorer from there; the folder link opposite is the
-                explorer route from here. */}
+            {/* The app's entry page in the EXPLORER — sidebar, crumb, header
+                and all. This button used to open the chrome-free embed in a
+                new tab; the explorer's own header now carries a fullscreen
+                control that does that hop, so this page offers one route (the
+                explorer) and the explorer offers the next (the embed). The
+                folder link opposite is the same route one level up. */}
             <Button
               size="sm"
               variant="outline"
               className="app-page-open"
-              onClick={() => window.open(embedUrlForFsPath(entry), "_blank", "noopener")}
+              onClick={() => navigateUrl(urlForFsPath(entry), { isDir: false })}
             >
-              Open app
-              <ExternalLink data-icon="inline-end" />
+              Open in explorer
             </Button>
           </div>
         )}


### PR DESCRIPTION
## Summary
- New glyph-only **fullscreen** button in the explorer preview header (files and folders), right after the mode control.
- Click loads `/explorer/embed/<same path>` with the current query preserved and `_mode` stamped explicitly, so the page keeps its mode while the sidebar, crumb and header go away.
- Full page load rather than `navigate()`: the view/embed prefix is read once at module init (router.ts), so switching prefix is a new document.
- **EmbedStrip** ("Open in explorer", PR #1033) now carries the query back, and reads a `_mode` stamp as "return to this page" rather than hopping a folder to its app entry. CLI/link folder embeds (no stamp) still resolve to the entry page.
- **App page**: "Open app" (embed in a new tab) becomes **"Open in explorer"**, navigating in place to the entry page under the view prefix. The explorer's fullscreen control is the route to the embed from there.
- Adds `MenuIcons.fullscreen` (four corner brackets, same 16px stroke recipe).

## Test plan
- [ ] Open any file in the explorer, click the fullscreen glyph: chrome-free reload at the embed URL, same mode.
- [ ] Same on a folder listing; "Open in explorer" on the strip returns to the listing, not the app entry.
- [ ] Switch a file to a non-default mode, fullscreen, come back: mode preserved both ways.
- [ ] `/apps/<path>`: "Open in explorer" lands on the entry page with full chrome.
- [ ] Button not visible inside a panel pane or tab (header is CSS-hidden in embed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and URL/query handling only; no auth, data, or API contract changes.
> 
> **Overview**
> Adds a **fullscreen** control in the explorer preview header that full-page loads the same path under the embed prefix, copying the current query verbatim and stamping `_mode` when the URL omits it (default mode). That pairs with **EmbedStrip** “Open in explorer”, which now forwards the query back to the view URL and only jumps a folder to its app entry when there is no `_mode` (CLI/link embeds unchanged).
> 
> On **`/apps/...`**, **Open app** (new-tab embed) becomes **Open in explorer**—in-place navigation to the entry page with full chrome; fullscreen from the explorer is the path to chrome-free embed. Adds `MenuIcons.fullscreen`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b671c3d802642e8fb00d1ca0bfab78582121fb99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->