### PR TITLE
Native Claude chat (PR2/4): attachments and screenshots

### DIFF
--- a/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
@@ -37,6 +37,8 @@ interface RunCall {
 const runs: RunCall[] = [];
 /** The `start` reply: an `{error}` is the road that hands the pictures back. */
 let startError = "";
+/** Held so a test can be INSIDE a send — the window `inFlight` exists for. */
+let holdStart = false;
 
 const realFetch = globalThis.fetch;
 
@@ -70,6 +72,7 @@ function stubFetch(): void {
       const action = String(body.params?.action ?? "");
       runs.push({ action, params: body.params ?? {} });
       if (action === "start") {
+        if (holdStart) return new Promise<Response>(() => {});
         return jsonRes({ ok: true, result: startError ? { error: startError } : { run_id: "r1" } });
       }
       if (action === "poll") {
@@ -126,6 +129,7 @@ let asFound: Record<string, unknown> = {};
 beforeEach(() => {
   runs.length = 0;
   startError = "";
+  holdStart = false;
   pathIds = 0;
   asFound = { ...API };
   resetAgentDirCacheForTests();
@@ -473,4 +477,108 @@ test("a send that never launched hands the very pictures it took back", async ()
   // what the returned chip shows (T:16693-16720).
   expect(chips(r)).toHaveLength(1);
   expect(chipText(chips(r)[0]!)).toContain("shot.png");
+});
+
+// ---- Bugbot: the camera's window is part of the send gate ------------------
+
+/**
+ * A HOST'S CONTENT FRAME, which is what gives this chat-only mount a camera at
+ * all (`annotateTarget`; ClaudeChat's `appFrame`). Only the two properties
+ * `frameIsCrossOrigin` and the capture path read off it.
+ */
+function hostFrame(): () => HTMLIFrameElement | null {
+  const frame = {
+    isConnected: true,
+    contentDocument: {},
+    contentWindow: { document: {}, location: { href: "http://localhost/render" } },
+  } as unknown as HTMLIFrameElement;
+  return () => frame;
+}
+
+test("a send fired DURING the camera's window waits for the picture", async () => {
+  // `capture()` plants NOTHING in the tray until the bytes are in hand — the
+  // seat swap is the whole of its commit — so `attachPending`, which read the
+  // chips, could not see the camera's window at all. The flash had already
+  // fired, so the picture looked taken; an Enter in that window went out
+  // WITHOUT it and it then landed in the tray for the NEXT message.
+  let release = () => {};
+  const landed = new Promise<void>((done) => {
+    release = done;
+  });
+  patchApi({
+    attachPane: async () => {
+      await landed;
+      return { id: "pane1", kind: "pane", seat: "pane", view: "/shots/v.png" } as Attachment;
+    },
+  });
+  const r = await mountChat({ annotateTarget: hostFrame() });
+  const box = r.root.findByType("textarea");
+  const send = () => r.root.findByProps({ className: "c-send" });
+  // Words, so the send would otherwise be perfectly sendable on its own.
+  await act(async () => box.props.onChange({ currentTarget: { value: "what is this" } }));
+  await settle();
+  expect(send().props.disabled).toBe(false);
+
+  // The shutter opens…
+  await act(async () => r.root.findByProps({ className: "c-viewshot" }).props.onClick());
+  await settle();
+  // …and no chip exists yet, which is exactly why the gate could not see it.
+  expect(chips(r)).toHaveLength(0);
+  expect(send().props.disabled).toBe(true);
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+  expect(started()).toHaveLength(0);
+
+  // The bytes land ⇒ the chip appears, the door opens, and the picture rides
+  // the message it was taken for.
+  release();
+  await settle(20);
+  expect(chips(r)).toHaveLength(1);
+  expect(send().props.disabled).toBe(false);
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+  expect(started()).toHaveLength(1);
+  expect(started()[0]!.params.message).toContain("<" + PANE_SHOT_TAG + ">");
+});
+
+// ---- Bugbot: the blobs a send is still carrying ---------------------------
+
+test("closing a chat mid-send revokes the pictures that send is carrying", async () => {
+  // `take()` moves them OUT of the tray and into `inFlight`, so the tray's own
+  // unmount revoke (which walks its live list) cannot see them — and
+  // `attachBack`'s cleanup nulls `giveBack`, so the hand-back cannot reach them
+  // either. Nothing was left holding a full-pane Blob's only handle.
+  const revoked: string[] = [];
+  patchApi({
+    revoke: (att: Attachment | null | undefined) => {
+      if (att) revoked.push(att.id);
+    },
+  });
+  holdStart = true;
+  const r = await mountChat();
+  const box = r.root.findByType("textarea");
+  await act(async () => {
+    box.props.onPaste({ clipboardData: {}, preventDefault: () => {} });
+  });
+  await settle();
+  expect(chips(r)).toHaveLength(1);
+
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+  // Out of the tray and into the send, which is parked: this is the window.
+  expect(chips(r)).toHaveLength(0);
+  expect(inFlightSizeForTests()).toBe(1);
+  expect(revoked).toEqual([]);
+
+  await act(() => {
+    r.unmount();
+  });
+  expect(revoked).toEqual(["f1"]);
+  expect(inFlightSizeForTests()).toBe(0);
 });

--- a/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
@@ -1,0 +1,423 @@
+// THE WIRING THE TRAY'S OWN SUITE CANNOT SEE (inventory 03 §C/§D).
+//
+// `ui/attach.test.tsx` proves the tray's rules with the pipeline replaced, and
+// it does it by re-implementing the four gesture handlers — so the handlers
+// ClaudeChat actually installs were the one part of PR2 with no coverage at all,
+// and three of the review's MAJORs lived in exactly that gap: the blocks spread,
+// `onDiscardShot`'s identity match and the dragleave counter. Two of QA round
+// 1's unresolved anomalies were there too — a paste that looked like it made two
+// chips, and a `.dropping` ring that never appeared.
+//
+// So this file mounts the REAL component over a stubbed `fetch` and a patched
+// `ATTACH_API`, and drives the props it hands out. Everything is asserted
+// through what reaches `/api/run` or what the chip row renders, because that is
+// where getting any of it wrong actually lands.
+import { installDomShim } from "@platform/lib/testDomShim";
+installDomShim();
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { act, create } from "react-test-renderer";
+
+const { ClaudeChat } = await import("./ClaudeChat");
+const { ShotViewer } = await import("./ui/ShotViewer");
+const { ATTACH_API } = await import("./ui/attachApi");
+const { createMemoryParamsStore } = await import("./params/store");
+const { resetAgentDirCacheForTests } = await import("./protocol/agent");
+const { PANE_SHOT_TAG } = await import("./protocol/wire");
+const { inFlightSizeForTests } = await import("./ClaudeChat");
+type Attachment = import("./shots/types").Attachment;
+type AttachApi = import("./ui/attachApi").AttachApi;
+type Viewable = import("./ui/attachApi").Viewable;
+
+// ---- the server, cut down to the three endpoints a booting chat touches -----
+
+interface RunCall {
+  action: string;
+  params: Record<string, string>;
+}
+const runs: RunCall[] = [];
+/** The `start` reply: an `{error}` is the road that hands the pictures back. */
+let startError = "";
+
+const realFetch = globalThis.fetch;
+
+function jsonRes(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function stubFetch(): void {
+  (globalThis as { fetch: unknown }).fetch = async (
+    input: unknown,
+    init?: { body?: unknown },
+  ): Promise<Response> => {
+    const url = String(typeof input === "string" ? input : (input as { url: string }).url);
+    if (url.startsWith("/api/fs/stat")) {
+      return jsonRes({
+        path: "/w/p",
+        is_dir: true,
+        templates: [{ mode: "claude", path: "/w/p/.claude/template.html" }],
+      });
+    }
+    if (url === "/api/prefs") return jsonRes({});
+    // The landing's Recent list long-polls this forever; answering it instantly
+    // spins the loop inside `act` and the test never returns. Held open, which
+    // is what the real endpoint does.
+    if (url.startsWith("/api/tasks/changes")) return new Promise<Response>(() => {});
+    if (url === "/api/run") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        py: string;
+        params: Record<string, string>;
+      };
+      const action = String(body.params?.action ?? "");
+      runs.push({ action, params: body.params ?? {} });
+      if (action === "start") {
+        return jsonRes({ ok: true, result: startError ? { error: startError } : { run_id: "r1" } });
+      }
+      if (action === "poll") {
+        return jsonRes({ ok: true, result: { done: true, session_id: "s1", text: "ok" } });
+      }
+      return jsonRes({ ok: true, result: {} });
+    }
+    return jsonRes({});
+  };
+}
+
+// ---- the pipeline, patched IN PLACE ---------------------------------------
+// `ATTACH_API` is the single object both `ClaudeChat` and `useAttachments` reach
+// through at call time, so patching its members is what stands in for injecting
+// a whole fake — and the members are put back after every test, because `bun
+// test` shares one process.
+
+/** Every path handed to `addPaths`, so a test can watch the drop road. */
+let pathIds = 0;
+
+const API = ATTACH_API as unknown as Record<string, unknown>;
+
+/**
+ * PATCHED PER TEST, AND PUT BACK PER TEST. Not from a snapshot taken at module
+ * load: `bun test` shares one process, so at that moment `ATTACH_API` is
+ * whatever the file that ran before this one left behind — `ui/attach.test.tsx`
+ * injects a whole fake and never touches the singleton, but nothing makes that
+ * permanent. And `Object.assign(ATTACH_API, REAL)` could not have removed a key
+ * the patch ADDED, only overwrite the ones it already had.
+ *
+ * So each key is snapshotted the first time it is patched, WITH whether it was
+ * there at all, and the restore deletes the ones that were not.
+ */
+const patched = new Map<string, { had: boolean; was: unknown }>();
+
+function patchApi(over: Partial<AttachApi>): void {
+  for (const [k, v] of Object.entries(over)) {
+    if (!patched.has(k)) patched.set(k, { had: k in API, was: API[k] });
+    API[k] = v;
+  }
+}
+
+function restoreApi(): void {
+  for (const [k, snap] of patched) {
+    if (snap.had) API[k] = snap.was;
+    else delete API[k];
+  }
+  patched.clear();
+}
+
+/** The singleton as this test found it, asserted intact in `afterEach`. */
+let asFound: Record<string, unknown> = {};
+
+beforeEach(() => {
+  runs.length = 0;
+  startError = "";
+  pathIds = 0;
+  asFound = { ...API };
+  resetAgentDirCacheForTests();
+  stubFetch();
+  patchApi({
+    flash: () => () => {},
+    // One pasted picture per paste, and it lands with a real path so the chip is
+    // an ordinary attached image rather than a refusal.
+    filesFromPaste: (ev) =>
+      (ev as { clipboardData?: unknown }).clipboardData ? [{ name: "shot.png" } as File] : [],
+    attachFiles: async function* (_dir, files) {
+      for (const f of files) {
+        yield {
+          id: "f" + ++pathIds,
+          kind: "image",
+          view: "/shots/" + (f.name || "x"),
+          name: f.name,
+        } satisfies Attachment;
+      }
+    },
+    // THE SAME PATH, TWICE, with different ids — the reachable shape of the
+    // identity bug: a real-path drag repeated has nothing but the id to tell the
+    // two chips apart.
+    attachPaths: () => [
+      {
+        id: "p" + ++pathIds,
+        kind: "file",
+        view: "/x/README.md",
+        name: pathIds === 1 ? "first" : "second",
+        brought: true,
+      } satisfies Attachment,
+    ],
+    attachPane: async () => ({ id: "pane1", kind: "pane", seat: "pane", view: "/shots/v.png" }),
+    readDirs: () => ["/shots"],
+    readDirsFor: () => ["/shots"],
+    revoke: () => {},
+    // A drag carries an attachment when it has a DataTransfer at all — the shape
+    // of the real reader, and the shape the dragleave guard used to fail on.
+    dragHasAttachment: (dt) => !!dt,
+    pathsFromDrop: () => ["/x/README.md"],
+  });
+});
+
+const mounted: Array<ReturnType<typeof create>> = [];
+afterEach(() => {
+  for (const r of mounted.splice(0)) act(() => r.unmount());
+  (globalThis as { fetch: unknown }).fetch = realFetch;
+  restoreApi();
+  // THE RESTORE IS ASSERTED, not assumed: a patch left behind is a failure in
+  // whichever suite runs next, which is the hardest kind of test failure to read.
+  expect(Object.keys(API).sort()).toEqual(Object.keys(asFound).sort());
+  for (const k of Object.keys(asFound)) expect(API[k]).toBe(asFound[k]);
+});
+
+const baseProps = {
+  file: "/w/p",
+  // The sidebar surface: no pane, which is where QA exercised paste and drop and
+  // where the tray has to work with no camera at all.
+  chatOnly: true,
+  compact: false,
+  peek: false,
+  autoFocus: false,
+} as const;
+
+async function settle(ms = 0): Promise<void> {
+  await act(async () => {
+    await new Promise((done) => setTimeout(done, ms));
+  });
+}
+
+async function mountChat(extra: Record<string, unknown> = {}) {
+  const params = createMemoryParamsStore();
+  let r!: ReturnType<typeof create>;
+  await act(async () => {
+    r = create(<ClaudeChat {...baseProps} params={params} {...extra} />);
+  });
+  mounted.push(r);
+  await settle();
+  return r;
+}
+
+type Chat = Awaited<ReturnType<typeof mountChat>>;
+
+/** Every attachment chip on screen, in row order. */
+function chips(r: Chat) {
+  return r.root.findAll(
+    (n) =>
+      typeof n.type === "string" &&
+      String((n.props as { className?: string }).className ?? "").includes("c-shotchip"),
+  );
+}
+
+/** What one chip says it is (`.c-txt`). */
+function chipText(chip: ReturnType<typeof chips>[number]): string {
+  const txt = chip.findAll(
+    (n) =>
+      typeof n.type === "string" &&
+      String((n.props as { className?: string }).className ?? "") === "c-txt",
+  )[0];
+  return String((txt?.props as { children?: unknown })?.children ?? "");
+}
+
+/** The chat COLUMN — the element the four drag listeners are on (T:11745). */
+function column(r: Chat) {
+  return r.root.findAll(
+    (n) =>
+      typeof n.type === "string" &&
+      String((n.props as { className?: string }).className ?? "").startsWith("c-chat"),
+  )[0]!;
+}
+
+function dragEv(withData = true) {
+  return {
+    dataTransfer: withData
+      ? ({ types: ["Files"], files: [], dropEffect: "" } as unknown as DataTransfer)
+      : undefined,
+    preventDefault: () => {},
+  } as unknown as React.DragEvent;
+}
+
+const started = () => runs.filter((c) => c.action === "start");
+
+// ---- QA anomaly 4: one paste, one chip ------------------------------------
+
+test("ONE paste makes ONE chip, and only a clipboard with files is taken", async () => {
+  // QA round 1 saw a single dispatched `paste` produce two chips and could not
+  // reproduce it. There is exactly one listener to find — the textarea's — and
+  // this is what pins that: a second handler anywhere (the column, the root)
+  // would show up here as a second chip.
+  const r = await mountChat();
+  const box = r.root.findByType("textarea");
+  let prevented = 0;
+  await act(async () => {
+    box.props.onPaste({ clipboardData: {}, preventDefault: () => (prevented += 1) });
+  });
+  await settle();
+  expect(chips(r)).toHaveLength(1);
+  expect(prevented).toBe(1);
+
+  // And an ordinary paste of WORDS is not stolen from the box it lands in
+  // (T:11719-11728): no chip, and no `preventDefault`.
+  await act(async () => {
+    box.props.onPaste({ clipboardData: null, preventDefault: () => (prevented += 1) });
+  });
+  await settle();
+  expect(chips(r)).toHaveLength(1);
+  expect(prevented).toBe(1);
+});
+
+// ---- QA anomaly 5 / review MAJOR: the .dropping ring's depth counter -------
+
+test("the .dropping ring follows a DEPTH counter, and a bare dragleave still counts", async () => {
+  const r = await mountChat();
+  const cls = () => String((column(r).props as { className: string }).className);
+  expect(cls()).not.toContain("dropping");
+
+  // dragenter/dragleave fire for every child the pointer crosses, so the class
+  // is driven by a counter rather than toggled — a plain toggle flickers the
+  // ring off the moment the cursor moves over a chip (T:11745-11751).
+  await act(async () => column(r).props.onDragEnter(dragEv()));
+  expect(cls()).toContain("dropping");
+  await act(async () => column(r).props.onDragEnter(dragEv()));
+
+  // THE REGRESSION THIS PINS: several engines expose no `types` at all on
+  // `dragleave`, and the handler used to early-return on that — so the depth
+  // never came back down and the ring stuck until the next drop. Both leaves
+  // here carry no DataTransfer whatsoever.
+  await act(async () => column(r).props.onDragLeave(dragEv(false)));
+  expect(cls()).toContain("dropping");
+  await act(async () => column(r).props.onDragLeave(dragEv(false)));
+  expect(cls()).not.toContain("dropping");
+
+  // The counter floors at zero: a stray leave cannot put the ring into a state
+  // the next enter has to dig out of.
+  await act(async () => column(r).props.onDragLeave(dragEv(false)));
+  await act(async () => column(r).props.onDragEnter(dragEv()));
+  expect(cls()).toContain("dropping");
+
+  // A drop RESETS it, because a drop delivers no leave for the enters before it.
+  await act(async () => column(r).props.onDrop(dragEv()));
+  await settle();
+  expect(cls()).not.toContain("dropping");
+});
+
+// ---- review MAJOR: Discard matches by id ----------------------------------
+
+test("Discard removes the chip it was opened from, not its twin", async () => {
+  const r = await mountChat();
+  // The same real path dragged in twice: same kind, same `view`, and every
+  // refusal in the tray has `view: null` too — so the old `view === shot.view &&
+  // kind === shot.kind` match could not tell two chips apart at all.
+  await act(async () => column(r).props.onDrop(dragEv()));
+  await settle();
+  await act(async () => column(r).props.onDrop(dragEv()));
+  await settle();
+  expect(chips(r).map(chipText)).toEqual(["first", "second"]);
+
+  // `onDiscardShot` is the viewer's, and the viewer is a portalled dialog no
+  // `react-test-renderer` tree can enter — so it is driven through the prop the
+  // chat hands it, which is the very function under test.
+  const viewer = r.root.findByType(ShotViewer);
+  const second: Viewable = { id: "p2", kind: "file", view: "/x/README.md", pending: true };
+  await act(async () => viewer.props.onDiscard?.(second));
+  await settle();
+  expect(chips(r).map(chipText)).toEqual(["first"]);
+
+  // And a shot the tray no longer holds removes nothing, rather than the first
+  // thing that happens to share its kind.
+  await act(async () =>
+    viewer.props.onDiscard?.({ id: "gone", kind: "file", view: "/x/README.md", pending: true }),
+  );
+  await settle();
+  expect(chips(r).map(chipText)).toEqual(["first"]);
+});
+
+// ---- review MAJOR: the send seam ------------------------------------------
+
+test("a send carries the tray's block and its Read rules, and empties the tray", async () => {
+  const r = await mountChat();
+  const box = r.root.findByType("textarea");
+  await act(async () => {
+    box.props.onPaste({ clipboardData: {}, preventDefault: () => {} });
+  });
+  await settle();
+  expect(chips(r)).toHaveLength(1);
+
+  // The form's submit is the real send road; `hasAttachments` is what lets a
+  // picture go out with no words at all (T:17903).
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+
+  expect(started()).toHaveLength(1);
+  expect(started()[0]!.params.message).toContain("<" + PANE_SHOT_TAG + ">");
+  expect(started()[0]!.params.message).toContain("/shots/shot.png");
+  // Granted for the SESSION, not the turn (T:16657-16668).
+  expect(JSON.parse(started()[0]!.params.read_dirs)).toEqual(["/shots"]);
+  // Emptied by the same call that read it, so a second Enter cannot send the
+  // same picture twice (T:16532).
+  expect(chips(r)).toHaveLength(0);
+});
+
+test("a send that LANDED lets go of its pictures", async () => {
+  // The other half of the `inFlight` map, and the half with no symptom: the
+  // entry is keyed by the `Receipt[]` the controller was handed, and on the road
+  // that landed nothing ever comes looking for it — `onSendReturned` only fires
+  // when the send did NOT launch. Never deleted, the map keeps every receipt row
+  // and every Attachment (with its blob URL) the page has ever sent alive for as
+  // long as the chat is open.
+  const r = await mountChat();
+  const box = r.root.findByType("textarea");
+  await act(async () => {
+    box.props.onPaste({ clipboardData: {}, preventDefault: () => {} });
+  });
+  await settle();
+  expect(chips(r)).toHaveLength(1);
+  expect(inFlightSizeForTests()).toBe(0);
+
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+
+  // It went out, the tray is empty — and so is the bookkeeping.
+  expect(started()).toHaveLength(1);
+  expect(started()[0]!.params.message).toContain("<" + PANE_SHOT_TAG + ">");
+  expect(chips(r)).toHaveLength(0);
+  expect(inFlightSizeForTests()).toBe(0);
+});
+
+test("a send that never launched hands the very pictures it took back", async () => {
+  // The `inFlight` map is keyed by the `Receipt[]` the controller is handed, and
+  // the merge now BUILDS that array (it may hold two owners' rows) — so if the
+  // key and the array ever drift, `onSendReturned` finds nothing and the user's
+  // picture is gone for good. This is that key's test.
+  startError = "no session";
+  const r = await mountChat();
+  const box = r.root.findByType("textarea");
+  await act(async () => {
+    box.props.onPaste({ clipboardData: {}, preventDefault: () => {} });
+  });
+  await settle();
+
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+
+  expect(started()).toHaveLength(1);
+  // Back in the tray, and never revoked on this road — those very thumbnails are
+  // what the returned chip shows (T:16693-16720).
+  expect(chips(r)).toHaveLength(1);
+  expect(chipText(chips(r)[0]!)).toContain("shot.png");
+});

--- a/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
@@ -222,6 +222,15 @@ function chips(r: Chat) {
   );
 }
 
+/** Every `<img>` a thumbnail button is showing — the chips' while a message is
+ *  being composed, the receipt rows' once it has been sent (ShotThumb). */
+function thumbSrcs(r: Chat): string[] {
+  return r.root
+    .findAllByType("img")
+    .map((n) => String((n.props as { src?: string }).src ?? ""))
+    .filter(Boolean);
+}
+
 /** What one chip says it is (`.c-txt`). */
 function chipText(chip: ReturnType<typeof chips>[number]): string {
   const txt = chip.findAll(
@@ -546,6 +555,105 @@ test("a send fired DURING the camera's window waits for the picture", async () =
 });
 
 // ---- Bugbot: the blobs a send is still carrying ---------------------------
+
+test("a send that LANDED re-points its receipts at the copy on disk and drops the blobs", async () => {
+  // The half of the same leak with no symptom at all. `done()` used to just
+  // DELETE the entry, and the receipts under the sent bubble were drawn with the
+  // attachment's own object URL — so the bubble held the only handle to a
+  // full-pane Blob, and `newChat`, a file change or a later unmount threw those
+  // turns away with the blobs still pinned for the life of the document.
+  //
+  // The bytes are on disk at `view` by then, so the rows move to `rawUrl(view)`
+  // — the very URL a RESTORED turn is drawn with — and only then is the handle
+  // released. Both halves are asserted: a revoke with the row left on `blob:`
+  // would be a broken picture, and a rewrite with no revoke would be the leak.
+  const revoked: string[] = [];
+  patchApi({
+    revoke: (att: Attachment | null | undefined) => {
+      if (att) revoked.push(att.id);
+    },
+    // A PASTED PICTURE WITH PIXELS: `attachFile`'s drawable road mints an object
+    // URL for the thumbnail and saves the bytes under `view` (shots/attach.ts).
+    attachFiles: async function* (_dir, files) {
+      for (const f of files) {
+        yield {
+          id: "f" + ++pathIds,
+          kind: "image",
+          view: "/shots/" + (f.name || "x"),
+          name: f.name,
+          thumb: "blob:fused/shot-" + pathIds,
+        } satisfies Attachment;
+      }
+    },
+  });
+  const r = await mountChat();
+  const box = r.root.findByType("textarea");
+  await act(async () => {
+    box.props.onPaste({ clipboardData: {}, preventDefault: () => {} });
+  });
+  await settle();
+  expect(chips(r)).toHaveLength(1);
+  // The chip is showing the blob, which is what makes the handle worth keeping
+  // until the send is over.
+  expect(thumbSrcs(r)).toEqual(["blob:fused/shot-1"]);
+
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+
+  expect(started()).toHaveLength(1);
+  expect(chips(r)).toHaveLength(0);
+  expect(inFlightSizeForTests()).toBe(0);
+  // THE RECEIPT ROW under the sent bubble, on the restored turn's own road.
+  expect(thumbSrcs(r)).toEqual(["/api/fs/raw?path=" + encodeURIComponent("/shots/shot.png")]);
+  expect(revoked).toEqual(["f1"]);
+  // …and nothing is left to revoke twice when the chat closes.
+  revoked.length = 0;
+  await act(() => {
+    r.unmount();
+  });
+  expect(revoked).toEqual([]);
+});
+
+test("a send that never launched keeps its blob thumbnails alive", async () => {
+  // The settle is gated on the entry STILL BEING THERE, because that is what
+  // says the send went out. `onSendReturned` removed it first on this road and
+  // the chips the user is looking at are those very thumbnails, so a settle here
+  // would revoke the picture out from under the tray.
+  startError = "no session";
+  const revoked: string[] = [];
+  patchApi({
+    revoke: (att: Attachment | null | undefined) => {
+      if (att) revoked.push(att.id);
+    },
+    attachFiles: async function* (_dir, files) {
+      for (const f of files) {
+        yield {
+          id: "f" + ++pathIds,
+          kind: "image",
+          view: "/shots/" + (f.name || "x"),
+          name: f.name,
+          thumb: "blob:fused/shot-" + pathIds,
+        } satisfies Attachment;
+      }
+    },
+  });
+  const r = await mountChat();
+  const box = r.root.findByType("textarea");
+  await act(async () => {
+    box.props.onPaste({ clipboardData: {}, preventDefault: () => {} });
+  });
+  await settle();
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+
+  expect(chips(r)).toHaveLength(1);
+  expect(thumbSrcs(r)).toEqual(["blob:fused/shot-1"]);
+  expect(revoked).toEqual([]);
+});
 
 test("closing a chat mid-send revokes the pictures that send is carrying", async () => {
   // `take()` moves them OUT of the tray and into `inFlight`, so the tray's own

--- a/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
@@ -567,10 +567,21 @@ test("a send that LANDED re-points its receipts at the copy on disk and drops th
   // — the very URL a RESTORED turn is drawn with — and only then is the handle
   // released. Both halves are asserted: a revoke with the row left on `blob:`
   // would be a broken picture, and a rewrite with no revoke would be the leak.
+  //
+  // AND THE ORDER IS THE WHOLE FIX. `settleAttachments` is a store write, not a
+  // render: the first cut revoked in that same tick, so the <img> under the
+  // bubble was still showing the object URL when it stopped resolving — the img
+  // errored and `ShotRow` read that as the pruner having deleted the file, so
+  // every successful send of a pasted picture ended in "screenshot no longer on
+  // disk" (Bugbot, PR #1064). `srcsAtRevoke` is what the rows were ACTUALLY
+  // drawn with at the moment the handle went.
   const revoked: string[] = [];
+  const srcsAtRevoke: string[][] = [];
+  let chat: Chat | null = null;
   patchApi({
     revoke: (att: Attachment | null | undefined) => {
       if (att) revoked.push(att.id);
+      if (chat) srcsAtRevoke.push(thumbSrcs(chat));
     },
     // A PASTED PICTURE WITH PIXELS: `attachFile`'s drawable road mints an object
     // URL for the thumbnail and saves the bytes under `view` (shots/attach.ts).
@@ -587,6 +598,7 @@ test("a send that LANDED re-points its receipts at the copy on disk and drops th
     },
   });
   const r = await mountChat();
+  chat = r;
   const box = r.root.findByType("textarea");
   await act(async () => {
     box.props.onPaste({ clipboardData: {}, preventDefault: () => {} });
@@ -606,8 +618,13 @@ test("a send that LANDED re-points its receipts at the copy on disk and drops th
   expect(chips(r)).toHaveLength(0);
   expect(inFlightSizeForTests()).toBe(0);
   // THE RECEIPT ROW under the sent bubble, on the restored turn's own road.
-  expect(thumbSrcs(r)).toEqual(["/api/fs/raw?path=" + encodeURIComponent("/shots/shot.png")]);
+  const onDisk = "/api/fs/raw?path=" + encodeURIComponent("/shots/shot.png");
+  expect(thumbSrcs(r)).toEqual([onDisk]);
   expect(revoked).toEqual(["f1"]);
+  // …and the row was already SHOWING it when the handle was released, which is
+  // the difference between a receipt that keeps its picture and one that says
+  // the screenshot is gone.
+  expect(srcsAtRevoke).toEqual([[onDisk]]);
   // …and nothing is left to revoke twice when the chat closes.
   revoked.length = 0;
   await act(() => {

--- a/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.attach.test.tsx
@@ -369,6 +369,59 @@ test("a send carries the tray's block and its Read rules, and empties the tray",
   expect(chips(r)).toHaveLength(0);
 });
 
+test("nothing is sent while a chip is still attaching", async () => {
+  // `hasAttachments` counts the in-flight placeholder but `take()` leaves it in
+  // the tray, so this submit used to launch an EMPTY send — the words (if any)
+  // going out without the files they were written about (Bugbot, PR #1064).
+  let release = (): void => {};
+  const landed = new Promise<void>((done) => {
+    release = done;
+  });
+  patchApi({
+    attachFiles: async function* (_dir, files) {
+      await landed;
+      for (const f of files) {
+        yield {
+          id: "f" + ++pathIds,
+          kind: "image",
+          view: "/shots/" + (f.name || "x"),
+          name: f.name,
+        } satisfies Attachment;
+      }
+    },
+  });
+  const r = await mountChat();
+  const box = r.root.findByType("textarea");
+  const send = () => r.root.findByProps({ className: "c-send" });
+  await act(async () => {
+    box.props.onPaste({ clipboardData: {}, preventDefault: () => {} });
+  });
+  await settle();
+  // A chip the user can see, and a Send they cannot press.
+  expect(chips(r)).toHaveLength(1);
+  expect(send().props.disabled).toBe(true);
+
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+  expect(started()).toHaveLength(0);
+  // Still in the tray, waiting for the message it belongs to.
+  expect(chips(r)).toHaveLength(1);
+
+  // The bytes land ⇒ the door opens, and the picture rides the send.
+  release();
+  await settle(20);
+  expect(send().props.disabled).toBe(false);
+  await act(async () => {
+    r.root.findByType("form").props.onSubmit({ preventDefault: () => {} });
+  });
+  await settle(20);
+  expect(started()).toHaveLength(1);
+  expect(started()[0]!.params.message).toContain("<" + PANE_SHOT_TAG + ">");
+  expect(chips(r)).toHaveLength(0);
+});
+
 test("a send that LANDED lets go of its pictures", async () => {
   // The other half of the `inFlight` map, and the half with no symptom: the
   // entry is keyed by the `Receipt[]` the controller was handed, and on the road

--- a/frontend/src/apps/claude/ClaudeChat.boot.test.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.boot.test.tsx
@@ -58,6 +58,13 @@ function stubFetch(): void {
         templates: [{ mode: "claude", path: "/w/p/.claude/template.html" }],
       });
     }
+    // THE LANDING'S LONG POLL, and it has to be a LONG poll here. `sessions.ts`
+    // re-arms `/api/tasks/changes` the moment one returns, so a stub that
+    // answers it immediately is an infinite re-arm inside `act` — which flushes
+    // until the queue is empty and therefore never returns at all. A promise
+    // that never settles is what the real endpoint does (it holds the request
+    // open until something changes), so the landing view can be mounted.
+    if (url.startsWith("/api/tasks/changes")) return new Promise<Response>(() => {});
     if (url === "/api/prefs") {
       if (holdPrefs) return new Promise<Response>(() => {});
       return jsonRes({});
@@ -325,4 +332,57 @@ test("a host that DROPS initialAsk mid-wait still sends the ask once (Fix with A
   await settle(1700);
   expect(started().length).toBe(1);
   expect(started()[0].params.message).toContain("fix it");
+});
+
+// ── THE ANNOTATION STRIP FOLLOWS THE TARGET, NOT THE LAYOUT ─────────────────
+//
+// T's `annPollTarget` sets `hidden` on Screenshot/Comment/Annotate off ONE fact
+// — is there an `annFrame` — and `annFrame` is the pane iframe in the split
+// layout or, in CHAT_ONLY, the host's marked frame (`annMarkedFrame`, T:6113).
+// So the only state that hides the group is "nothing to act on". Measured on
+// `:1777` for `?_side=claude` on a file: `#anncta` 312x26, all three buttons
+// `hidden:false`; on a FOLDER listing in the same layout, all three `hidden`
+// and the group collapsed. These pin both ends of that.
+
+/** Every element carrying `cls`, by className, wherever it is in the tree. */
+function byClass(r: ReturnType<typeof create>, cls: string) {
+  return r.root.findAll(
+    (n) => typeof n.type === "string" && String(n.props.className ?? "").split(/\s+/).includes(cls),
+    { deep: true },
+  );
+}
+
+test("a HOSTED chat shows the strip — landing included — because the host has a target", async () => {
+  // The bug: `stripShown` read `!chatOnly`, a question about OUR layout, so the
+  // sidebar lost the whole row on both views while the app sat on screen in the
+  // middle column with its mark on it.
+  const { r } = await mountChat({ annotateTarget: hostFrameStub() });
+  await settle(20);
+  // The landing, not the transcript: nothing has been sent.
+  expect(byClass(r, "c-home").length).toBe(1);
+  expect(byClass(r, "c-anntools").length).toBe(1);
+  expect(byClass(r, "c-anncta").length).toBe(1);
+  const seats = byClass(r, "c-anncta")[0].findAllByType("button");
+  expect(seats.length).toBe(3);
+  // Screenshot is PR2's and live; the other two are PR3's and are disabled
+  // SEATS rather than absences — the row must not grow two buttons under the
+  // reader's hand when they come alive.
+  expect(seats[0].props.disabled).toBe(false);
+  expect(seats[1].props.disabled).toBe(true);
+  expect(seats[2].props.disabled).toBe(true);
+});
+
+test("a hosted chat whose host has marked NOTHING hides the strip, like the folder listing on :1777", async () => {
+  const { r } = await mountChat({ annotateTarget: () => null });
+  await settle(20);
+  expect(byClass(r, "c-anntools").length).toBe(0);
+  expect(byClass(r, "c-anncta").length).toBe(0);
+});
+
+test("a chat-only mount with no host getter at all hides the strip", async () => {
+  // A cards tile and the peek modal pass none: there is genuinely nothing to
+  // photograph, and "absent beats dead" (T:238-241).
+  const { r } = await mountChat();
+  await settle(20);
+  expect(byClass(r, "c-anntools").length).toBe(0);
 });

--- a/frontend/src/apps/claude/ClaudeChat.boot.test.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.boot.test.tsx
@@ -352,7 +352,7 @@ function byClass(r: ReturnType<typeof create>, cls: string) {
   );
 }
 
-test("a HOSTED chat shows the strip — landing included — because the host has a target", async () => {
+test("a HOSTED chat shows the seats — landing included — because the host has a target", async () => {
   // The bug: `stripShown` read `!chatOnly`, a question about OUR layout, so the
   // sidebar lost the whole row on both views while the app sat on screen in the
   // middle column with its mark on it.
@@ -363,26 +363,42 @@ test("a HOSTED chat shows the strip — landing included — because the host ha
   expect(byClass(r, "c-anntools").length).toBe(1);
   expect(byClass(r, "c-anncta").length).toBe(1);
   const seats = byClass(r, "c-anncta")[0].findAllByType("button");
-  expect(seats.length).toBe(3);
-  // Screenshot is PR2's and live; the other two are PR3's and are disabled
-  // SEATS rather than absences — the row must not grow two buttons under the
-  // reader's hand when they come alive.
+  // ONE SEAT IN PR2 (P2-2). Comment and Annotate shipped here disabled and the
+  // owner's rule is that neither is ever drawn dead — T greys one only while the
+  // OTHER mode is armed (T:320-322) — so PR2 draws Screenshot alone and PR3
+  // turns the other two on through `AnnStrip`'s `modes`.
+  expect(seats.length).toBe(1);
   expect(seats[0].props.disabled).toBe(false);
-  expect(seats[1].props.disabled).toBe(true);
-  expect(seats[2].props.disabled).toBe(true);
+  expect(String(seats[0].props.className)).toContain("c-viewshot");
 });
 
-test("a hosted chat whose host has marked NOTHING hides the strip, like the folder listing on :1777", async () => {
+test("the strip ROW stands even with nothing to photograph — it carries the ⋮", async () => {
+  // T's `#anntools` is static markup and holds `← Chats` and `#kebab` as well as
+  // the three seats, so a folder listing keeps the row and loses only the
+  // buttons (T:526 `body.nopane #kebab { margin-left: auto }` is that state).
+  // Native used to drop the whole row, which took the menu with it (P2-1).
   const { r } = await mountChat({ annotateTarget: () => null });
   await settle(20);
-  expect(byClass(r, "c-anntools").length).toBe(0);
+  expect(byClass(r, "c-anntools").length).toBe(1);
   expect(byClass(r, "c-anncta").length).toBe(0);
+  expect(byClass(r, "c-kebab").length).toBe(1);
 });
 
-test("a chat-only mount with no host getter at all hides the strip", async () => {
+test("the seats are absent on a chat-only mount with no host getter at all", async () => {
   // A cards tile and the peek modal pass none: there is genuinely nothing to
   // photograph, and "absent beats dead" (T:238-241).
   const { r } = await mountChat();
   await settle(20);
-  expect(byClass(r, "c-anntools").length).toBe(0);
+  expect(byClass(r, "c-anncta").length).toBe(0);
+});
+
+// THE MENU AND THE WAY OUT RIDE THE SAME ONE ROW (P2-1).
+test("the ⋮ is in the strip on the landing, and `← Chats` joins it in a chat", async () => {
+  const { r } = await mountChat({ annotateTarget: hostFrameStub() });
+  await settle(20);
+  const strip = () => byClass(r, "c-anntools")[0];
+  // The landing has no chat to leave, so no back button — and the menu is the
+  // landing's own one item ("New session in terminal", T:13415).
+  expect(strip().findAll((n) => String(n.props.className ?? "") === "c-back").length).toBe(0);
+  expect(strip().findAll((n) => String(n.props.className ?? "").split(/\s+/).includes("c-kebab")).length).toBe(1);
 });

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -61,6 +61,7 @@ import {
 import {
   AnnStrip,
   AttachTray,
+  Kebab,
   CardPolicyProvider,
   Composer,
   createCardPolicy,
@@ -1208,15 +1209,6 @@ function ChatBody(props: ChatBodyProps) {
     [controller],
   );
 
-  /** The raw wire of the newest user turn, for the kebab's "what was sent". */
-  const lastRaw = useMemo(() => {
-    for (let i = state.turns.length - 1; i >= 0; i--) {
-      const t = state.turns[i];
-      if (t.role === "user" && t.raw) return t.raw;
-    }
-    return undefined;
-  }, [state.turns]);
-
   const name = file ? file.split(/[\\/]/).filter(Boolean).pop() || file : "Claude";
   const running =
     state.status === "running" || state.status === "starting" || state.status === "stopping";
@@ -1246,18 +1238,22 @@ function ChatBody(props: ChatBodyProps) {
   // `hostPane` is the polled answer to the second half and already lives above
   // (HOST_PANE_POLL_MS, T's tick), so this is the same OR that `hasPane` makes.
   const annTarget = paneShown || hostPane;
-  // THE STRIP IS NOT THE NARROW LAYOUT'S ALONE any more. In T `#anntools` is a
-  // row the landing and the transcript both keep in EVERY layout (T:3842) — it
-  // is where the three preview controls live — and PR1 rendered it only below
-  // the breakpoint, because until now its only contents were the narrow view's
-  // own two controls. The camera moved into it on 2026-08-27, so the row now
-  // exists wherever there is a pane to photograph — OURS OR THE HOST'S; the
-  // view toggle and the picker stay narrow-only inside it (`pickerHost`).
-  const stripShown = annTarget;
+  // THE STRIP ITSELF IS NOT CONDITIONAL any more (P2-1): T's `#anntools` is
+  // static markup and it holds the way out and the ⋮ as well as the three
+  // preview seats, so the row stands in every layout and `annTarget` decides
+  // only whether `AnnStrip` draws anything inside it. The view toggle and the
+  // picker stay narrow-only in there (`pickerHost`).
   // T:7566 `annFitStrip` — the strip's words collapse to icons only when they
   // MEASURABLY do not fit (QA #2: at 1280px with a pane the chat column is
   // ~308px and the three full labels overflowed it by 8px).
   const stripRef = useFitStrip();
+  // Where focus goes when the erase confirm closes, whichever way it closed
+  // (T:13293, 13319-13321). It lived in the top bar with the menu; the menu is
+  // in the shared strip now, so its seat is too.
+  const kebabBtn = useRef<HTMLElement | null>(null);
+  // The page must not stay on a transcript that no longer exists
+  // (T:13348-13366); the menu has already dropped every cache keyed by it.
+  const onErased = useCallback(() => onBack(), [onBack]);
 
   // MEMOIZED, like the two callbacks below it: a fresh object per render defeats
   // every `React.memo` in the tree it is handed to, and this one is handed to
@@ -1468,12 +1464,40 @@ function ChatBody(props: ChatBodyProps) {
         onDragLeave={onDragLeave}
         onDrop={onDrop}
       >
-        {stripShown ? (
-          // A row ABOVE both views, never over either, and the ONE row the
-          // narrow rules never hide — it carries the way out of each view
-          // (T:3833-3843). PR3 arms the annotate switch and the recorder here;
-          // their seats are already in it.
+        {!compact && !peek ? (
+          // ONE HEADER ROW, WHICH IS WHAT T HAS (T:3934-4010, P2-1). `#anntools`
+          // is a real layout row above both views and it carries FIVE things:
+          // `← Chats` at its left end, then the picker, the three preview seats,
+          // the view toggle and `#kebab` riding the right-hand end — on the
+          // landing and in the transcript alike (`#chat.home #topbar` hides only
+          // the IDENTITY row below, T:1277). Native had split those across three
+          // rows — this strip, `.c-hdr-tools` in the top bar and
+          // `.c-home-tools` on the landing — so the seats sat on a left-aligned
+          // row of their own ABOVE the row that held the ⋮ (Akshil, 2026-09-09:
+          // "just follow the UI we had previously").
+          //
+          // THE ROW IS ALWAYS THERE, and only its CONTENTS answer to the target:
+          // T's markup is static and `annPollTarget` hides the three buttons, so
+          // a folder listing keeps the row with the way out and the menu in it
+          // (T:526 `body.nopane #kebab { margin-left: auto }` is that exact
+          // state). `AnnStrip` returns null for itself when there is nothing to
+          // photograph.
           <div className="c-anntools" ref={stripRef}>
+            {/* The way back, at the strip's left end (T:3941). Absent on the
+                landing: there is no chat to leave. */}
+            {inChat ? (
+              <button
+                type="button"
+                className="c-back"
+                aria-label="Back to chats"
+                onClick={onBack}
+              >
+                ← Chats
+              </button>
+            ) : null}
+            {/* ONE auto margin in the row: everything before it sits left, the
+                seats and the ⋮ ride the right-hand end together (T:255-262). */}
+            <span className="c-hdr-slack" />
             <AnnStrip
               paneNoun={pane.paneNoun}
               // The camera photographs whatever the annotate target is, so the
@@ -1494,6 +1518,19 @@ function ChatBody(props: ChatBodyProps) {
               />
             ) : null}
             {narrowView.narrow ? <ViewToggle narrowView={narrowView} /> : null}
+            {/* The menu rides the same seat in BOTH views (T's `#kebab` is on
+                the one strip they share), so it never appears out of nowhere on
+                entering a chat. On the landing it is the one item that can mean
+                anything without a session (T:13415). */}
+            <Kebab
+              agentDir={agentDir}
+              file={file}
+              sessionId={inChat ? (state.sessionId ?? "") : ""}
+              btnRef={kebabBtn}
+              running={running}
+              landing={!inChat}
+              onErased={onErased}
+            />
           </div>
         ) : null}
         {inChat ? (
@@ -1503,14 +1540,10 @@ function ChatBody(props: ChatBodyProps) {
                 (T:1412-1438). */}
             {!compact && !peek ? (
               <Topbar
-                agentDir={agentDir}
-                file={file}
                 sessionId={state.sessionId ?? ""}
                 subtitle={name}
                 {...(taskId ? { taskId } : {})}
                 running={running}
-                onBack={onBack}
-                {...(lastRaw ? { lastRaw } : {})}
               />
             ) : null}
             <Transcript

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -498,6 +498,26 @@ function ChatBody(props: ChatBodyProps) {
       if (inFlightForTests === inFlight.current) inFlightForTests = null;
     };
   }, []);
+  // …AND THE PICTURES ALREADY ON THEIR WAY, which nothing else can reach.
+  //
+  // `take()` moves a send's attachments OUT of the tray and into `inFlight`, so
+  // the tray's own unmount revoke — which walks its live list (useAttachments'
+  // `alive` effect) — cannot see them, and the hand-back that would have
+  // returned them is nulled by `attachBack`'s cleanup below. A chat closed while
+  // a send was in flight therefore pinned a full-pane Blob per picture for the
+  // life of the page (Bugbot, PR #1064).
+  //
+  // REVOKED, not handed back: there is no tray left to hand them to. Declared
+  // here so it is the FIRST of these three cleanups to run — React runs them in
+  // declaration order — and the map is cleared, so a StrictMode re-mount does
+  // not walk revoked handles again.
+  useEffect(() => {
+    const sends = inFlight.current;
+    return () => {
+      for (const items of sends.values()) for (const att of items) ATTACH_API.revoke(att);
+      sends.clear();
+    };
+  }, []);
   const attachBack = useRef<((items: readonly Attachment[]) => void) | null>(null);
   const [stranded, setStranded] = useState<{ text: string; seq: number } | null>(null);
   const strandSeq = useRef(0);
@@ -1342,7 +1362,7 @@ function ChatBody(props: ChatBodyProps) {
       // out without it, and it then landed in the tray for the NEXT message. T
       // holds the send for the in-flight shot for the same reason
       // (`shotBusy`/`shotAttachPane`); `capturing` is that flag.
-      attachPending: attach.items.some((a: Attachment) => a.pending),
+      attachPending: attach.capturing || attach.items.some((a: Attachment) => a.pending),
       chips: (
         <AttachTray
           items={attach.items}

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -36,6 +36,8 @@ import { createUrlParamsStore, type ParamsStore } from "./params/store";
 import { useChatParam } from "./params/useChatParams";
 import { resolveAgentDir } from "./protocol/agent";
 import type { SendOptions, UserTurn } from "./protocol/controller-api";
+import { watchStreamTeardown, watchTopOrigin } from "./shots";
+import type { Attachment, Receipt } from "./shots/types";
 import { enhanceCodeBlocks } from "./protocol/markdown";
 import { createChatController } from "./protocol/run-controller";
 import { finishedTailText, parseTailKey, streamingTailOf } from "./protocol/segments";
@@ -57,6 +59,8 @@ import {
   type PaneSrcFlags,
 } from "./pane";
 import {
+  AnnStrip,
+  AttachTray,
   CardPolicyProvider,
   Composer,
   createCardPolicy,
@@ -64,13 +68,19 @@ import {
   openCardIds,
   resetCardPolicy,
   SentPop,
+  ShotViewer,
   Topbar,
   Transcript,
   TroubleView,
+  ATTACH_API,
+  mergeSendOptions,
+  useAttachments,
+  useFitStrip,
   useComposerDefaults,
   useRecentSessions,
   useTaskId,
   type TranscriptTail,
+  type Viewable,
 } from "./ui";
 import "./styles/chat.css";
 import "./styles/hljs.css";
@@ -185,6 +195,23 @@ function rootClass(
   ]
     .filter(Boolean)
     .join(" ");
+}
+
+/**
+ * TEST-ONLY WINDOW ONTO THE SEND BOOKKEEPING (`inFlight` below).
+ *
+ * The delete-on-success is invisible from outside: nothing on screen changes
+ * either way, the map merely keeps every `Receipt[]` and every `Attachment` the
+ * page has ever sent — with their blob URLs — alive for as long as the chat is
+ * open. A leak with no symptom needs a seam or it has no test, so the most
+ * recently mounted chat parks its map here from an effect (`resetAgentDirCacheForTests`
+ * in protocol/agent.ts is the same idiom).
+ */
+let inFlightForTests: Map<Receipt[], Attachment[]> | null = null;
+
+/** How many sends are still holding their pictures. Tests only. */
+export function inFlightSizeForTests(): number {
+  return inFlightForTests ? inFlightForTests.size : 0;
 }
 
 /**
@@ -453,6 +480,25 @@ function ChatBody(props: ChatBodyProps) {
   // run loop.
   const liveModel = useRef("");
   const liveEffort = useRef("");
+  /**
+   * PR2's two send-time refs, declared HERE because the controller closes over
+   * them and is built before the tray below exists.
+   *
+   * `inFlight` maps the very `Receipt[]` handed to a send to the ATTACHMENTS it
+   * came from — the identity is the key, so a send whose bubble was dropped
+   * gives back its own pictures and not another send's. `attachBack` is the
+   * tray's own `giveBack`, filled once the tray is built.
+   */
+  const inFlight = useRef(new Map<Receipt[], Attachment[]>());
+  // The one seam the delete-on-success can be read through (see
+  // `inFlightSizeForTests` at the top of this file).
+  useEffect(() => {
+    inFlightForTests = inFlight.current;
+    return () => {
+      if (inFlightForTests === inFlight.current) inFlightForTests = null;
+    };
+  }, []);
+  const attachBack = useRef<((items: readonly Attachment[]) => void) | null>(null);
   const [stranded, setStranded] = useState<{ text: string; seq: number } | null>(null);
   const strandSeq = useRef(0);
 
@@ -498,6 +544,16 @@ function ChatBody(props: ChatBodyProps) {
         // (T:16229, 16321-16330); the ticks already run on T's clock.
         onArtifactsTick: () => {},
         onRunEnded: () => {},
+        // The agent saw none of it, so the pictures come back to the tray —
+        // never revoked on this road, because those very thumbnails are what the
+        // returned chips show (T:16693-16720).
+        onSendReturned: ({ attachments }) => {
+          if (!attachments) return;
+          const back = inFlight.current.get(attachments);
+          if (!back) return;
+          inFlight.current.delete(attachments);
+          attachBack.current?.(back);
+        },
       }),
     [agentDir, file, params],
   );
@@ -508,6 +564,59 @@ function ChatBody(props: ChatBodyProps) {
     controller.getState,
     controller.getState,
   );
+
+  // ── the attachments this message will carry (PR2, inventory 03) ────────────
+  //
+  // The tray lives HERE and not in the composer, for the reason T keeps
+  // `shotAttached` at module scope: the camera that fills it is in the control
+  // strip, the chips that show it are above the box, the receipts it becomes are
+  // in the transcript and the send that empties it is the controller's — four
+  // places, one list.
+  const attach = useAttachments({
+    agentDir,
+    // The pane's iframe, read at gesture time: a capture aimed at the element as
+    // it was when this callback was made would photograph a document that has
+    // since been replaced by a mode swap.
+    frame: () => paneFrame.current,
+    // What the shutter flashes over: the frame's own box, which is the offset
+    // parent the pins and the highlight also live in (T:11233).
+    flashHost: () => paneFrame.current?.parentElement ?? null,
+    paneNoun: pane.paneNoun,
+  });
+  /** The picture the viewer is showing, pending or sent (T:10681 `shotViewing`). */
+  const [viewing, setViewing] = useState<Viewable | null>(null);
+  // The tray's hand-back, reachable from the controller's callback above. In an
+  // EFFECT and not the render body: a render React throws away (a StrictMode
+  // double-invoke, a concurrent attempt that loses) must not leave its handle
+  // installed for the controller to call.
+  useEffect(() => {
+    attachBack.current = attach.giveBack;
+    return () => {
+      attachBack.current = null;
+    };
+  }, [attach.giveBack]);
+
+  /**
+   * THE TWO CAPTURE LISTENERS THE CHAT OWNS, registered from its own mount.
+   *
+   *   * `watchTopOrigin` learns the top window's viewport origin from the click
+   *     that PRECEDES a capture (T:9812). It used to be registered at module
+   *     load, which put a document-wide listener on every bundle that so much as
+   *     imports `shots/*` — the chat flag off included.
+   *   * `watchStreamTeardown` ends the kept tab share on `pagehide` and on this
+   *     unmount, which is what the xo-capture header promises: the browser's
+   *     "sharing this tab" indicator must not outlive the chat that raised it
+   *     (T:9731).
+   */
+  useEffect(() => {
+    const win = typeof window === "undefined" ? null : window;
+    const offOrigin = watchTopOrigin(win);
+    const offStream = watchStreamTeardown(win);
+    return () => {
+      offOrigin();
+      offStream();
+    };
+  }, []);
 
   // ── the three pills ────────────────────────────────────────────────────────
   const defaults = useComposerDefaults(agentDir, file, params);
@@ -902,6 +1011,55 @@ function ChatBody(props: ChatBodyProps) {
   // behind it should not run for one that is not showing them (T:18339).
   const recent = useRecentSessions(inChat ? null : agentDir, file);
 
+  /**
+   * WHAT THE TRAY PUTS ON THE WIRE, on both send roads: the `<pane-shot>` block,
+   * the Read rules for the directories real-path attachments live in — granted
+   * for the SESSION, not the turn (T:16657-16668) — and the receipts the turn
+   * will wear. The tray is emptied by the same call that reads it, so a second
+   * Enter cannot send the same pictures twice (T:16532).
+   */
+  const takeAttachments = useCallback((): { opts: SendOptions; items: Attachment[] } => {
+    const out = attach.take();
+    if (!out.items.length) return { opts: {}, items: [] };
+    return {
+      opts: { blocks: out.blocks, readDirs: out.readDirs, attachments: out.receipts },
+      items: out.items,
+    };
+  }, [attach]);
+
+  /**
+   * BOTH SEND ROADS GO THROUGH HERE, and they MERGE rather than spread: T's wire
+   * order is state, pane-shot, annotations, text, and `{ ...opts, ...mine }`
+   * fixed no order at all — it replaced `opts.blocks` outright, which would have
+   * silently dropped PR3's `<annotations>` and PR4's `<live-app-state>`
+   * (ui/sendMerge.ts, protocol/wire.ts `composeBlocks`).
+   *
+   * The hand-back is registered under the very `Receipt[]` the controller is
+   * handed, because that ARRAY IS THE KEY — a send whose bubble was dropped must
+   * give back its own pictures and not another send's — and the merge may have
+   * built a new array out of two owners' rows.
+   */
+  const beginSend = useCallback(
+    (opts: SendOptions): { merged: SendOptions; done: () => void } => {
+      const mine = takeAttachments();
+      const merged = mergeSendOptions(opts, mine.opts);
+      const key = mine.items.length ? merged.attachments : undefined;
+      if (key) inFlight.current.set(key, mine.items);
+      // DELETED ON EVERY ROAD, not only the failed one: `onSendReturned` fires
+      // inside the send, so by the time this runs the entry is either already
+      // gone (the pictures went back to the tray) or is a send that LANDED — and
+      // a map that only ever grows pins every attachment and blob URL the page
+      // has ever sent for as long as it is open.
+      return {
+        merged,
+        done: () => {
+          if (key) inFlight.current.delete(key);
+        },
+      };
+    },
+    [takeAttachments],
+  );
+
   const onSend = useCallback(
     (text: string, opts: SendOptions) => {
       // OPTIMISTIC, and synchronously BEFORE the dispatch — exactly where T puts
@@ -919,18 +1077,24 @@ function ChatBody(props: ChatBodyProps) {
       // the failure INTO the chat, where the reader stays to read it. Back is
       // the way out, the same as for a run that started and then failed.
       setEntered(true);
-      void controller.sendMessage(text, opts);
+      const { merged, done } = beginSend(opts);
+      // `then(done, done)` and not `finally`: the promise is deliberately
+      // discarded, and a `finally` chain would turn a rejected send into an
+      // unhandled rejection in the console.
+      void controller.sendMessage(text, merged).then(done, done);
     },
-    [controller],
+    [controller, beginSend],
   );
   const onFollowUp = useCallback(
-    (text: string) =>
-      void controller.sendFollowUp(text, {
+    (text: string) => {
+      const { merged, done } = beginSend({
         model: defaults.model,
         effort: defaults.effort,
         permission: defaults.permission,
-      }),
-    [controller, defaults.model, defaults.effort, defaults.permission],
+      });
+      void controller.sendFollowUp(text, merged).then(done, done);
+    },
+    [controller, defaults.model, defaults.effort, defaults.permission, beginSend],
   );
   const onStop = useCallback(() => void controller.stopRun(), [controller]);
   const onBack = useCallback(() => {
@@ -1014,7 +1178,18 @@ function ChatBody(props: ChatBodyProps) {
   // persistent left column to hang a bar on (`pickerHost`).
   const host = pickerHost(narrowView.narrow, pane.noPane, pane.decision?.leftModes.length ?? 0);
   const paneShown = !chatOnly && !pane.noPane;
-  const stripShown = paneShown && narrowView.narrow;
+  // THE STRIP IS NOT THE NARROW LAYOUT'S ALONE any more. In T `#anntools` is a
+  // row the landing and the transcript both keep in EVERY layout (T:3842) — it
+  // is where the three preview controls live — and PR1 rendered it only below
+  // the breakpoint, because until now its only contents were the narrow view's
+  // own two controls. The camera moved into it on 2026-08-27, so the row now
+  // exists wherever there is a pane to photograph; the view toggle and the
+  // picker stay narrow-only inside it (`pickerHost`).
+  const stripShown = paneShown;
+  // T:7566 `annFitStrip` — the strip's words collapse to icons only when they
+  // MEASURABLY do not fit (QA #2: at 1280px with a pane the chat column is
+  // ~308px and the three full labels overflowed it by 8px).
+  const stripRef = useFitStrip();
 
   // MEMOIZED, like the two callbacks below it: a fresh object per render defeats
   // every `React.memo` in the tree it is handed to, and this one is handed to
@@ -1024,6 +1199,91 @@ function ChatBody(props: ChatBodyProps) {
   // a `back` from an earlier URL.
   const [urlTick, setUrlTick] = useState(0);
   useEffect(() => params.onChange(() => setUrlTick((n) => n + 1)), [params]);
+  // ⌘V. `preventDefault` ONLY when a picture was actually found: this listener
+  // sits on a box the user types in all day, and stealing an ordinary paste
+  // would be a far worse bug than never having had the feature. A paste carrying
+  // both an image and its alt text attaches the picture and drops the words,
+  // which is the same rule (T:11719-11728).
+  const onPaste = useCallback(
+    (ev: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const picks = ATTACH_API.filesFromPaste(ev);
+      if (!picks.length) return;
+      ev.preventDefault();
+      void attach.addFiles(picks);
+    },
+    [attach],
+  );
+
+  /**
+   * DRAG AND DROP (T:11745-11790). Four listeners, and the class is driven by a
+   * COUNTER rather than toggled: dragenter/dragleave fire for every child
+   * element the pointer crosses, so a plain toggle flickers the highlight off
+   * the moment the cursor moves over a chip. The counter is RESET on drop,
+   * because a drop delivers no leave for the enters that preceded it.
+   *
+   * `dragover` MUST preventDefault or the drop event never fires — the default
+   * action is "refuse the drag" — and both it and `dragenter` answer only for a
+   * drag that actually carries an attachment, so dragging TEXT out of the log
+   * into the box keeps the browser's own insert behaviour.
+   */
+  const [dropping, setDropping] = useState(false);
+  const dragDepth = useRef(0);
+  const onDragEnter = useCallback((ev: React.DragEvent) => {
+    if (!ATTACH_API.dragHasAttachment(ev.dataTransfer)) return;
+    ev.preventDefault();
+    dragDepth.current += 1;
+    setDropping(true);
+  }, []);
+  const onDragOver = useCallback((ev: React.DragEvent) => {
+    if (!ATTACH_API.dragHasAttachment(ev.dataTransfer)) return;
+    ev.preventDefault();
+    // What makes the cursor say "copy" rather than show the forbidden sign.
+    ev.dataTransfer.dropEffect = "copy";
+  }, []);
+  // NO `dragHasAttachment` GUARD HERE, unlike its three neighbours (T:11770
+  // guards nothing either): several engines expose no `types` at all on
+  // `dragleave` — it is the one drag event whose DataTransfer is deliberately
+  // protected — so a guarded leave never fired, the depth never came back down,
+  // and the accent ring stayed on the column until the next drop. An extra
+  // decrement is free: the counter floors at zero and only an ENTER that carried
+  // an attachment ever raised it.
+  const onDragLeave = useCallback(() => {
+    dragDepth.current = Math.max(0, dragDepth.current - 1);
+    if (!dragDepth.current) setDropping(false);
+  }, []);
+  const onDrop = useCallback(
+    (ev: React.DragEvent) => {
+      if (!ATTACH_API.dragHasAttachment(ev.dataTransfer)) return;
+      ev.preventDefault();
+      dragDepth.current = 0;
+      setDropping(false);
+      // REAL PATHS FIRST. Both payloads can ride one drag (a source that sets
+      // the path type may set `files` too), and when they do they describe the
+      // same file — one by where it lives, one by a copy of its bytes. The path
+      // is the better answer for every reader downstream: no upload, no 12-hour
+      // expiry, and an edit the agent makes lands on the user's own file
+      // (T:11777-11787).
+      const paths = ATTACH_API.pathsFromDrop(ev.dataTransfer);
+      if (paths.length) void attach.addPaths(paths);
+      else void attach.addFiles(Array.from(ev.dataTransfer.files || []));
+    },
+    [attach],
+  );
+
+  /** The viewer's Discard: the one place the user can judge that this is the
+   *  wrong picture (T:10961). Only ever offered for a PENDING shot, so the tray
+   *  is where it is looked up. */
+  const onDiscardShot = useCallback(
+    (shot: Viewable) => {
+      // BY ID. Every refusal has `view: null`, so the old `view === shot.view &&
+      // kind === shot.kind` match could not tell two failed pictures apart:
+      // Discard on the second one removed the first (`Viewable.id`, PR2 review).
+      const att = attach.items.find((a: Attachment) => a.id === shot.id);
+      if (att) attach.remove(att);
+    },
+    [attach],
+  );
+
   const card = useMemo(
     () => ({
       file,
@@ -1039,6 +1299,22 @@ function ChatBody(props: ChatBodyProps) {
       back: currentUrl(),
       onNavigate,
       boxRef,
+      // Pictures alone are sendable, with no words at all (T:17903).
+      hasAttachments: attach.items.length > 0,
+      chips: (
+        <AttachTray
+          items={attach.items}
+          paneNoun={pane.paneNoun}
+          onOpen={setViewing}
+          onRemove={attach.remove}
+        />
+      ),
+      onPaste,
+      // The chip row is ABOVE the control row and changes the composer's height,
+      // never the row's width — but T re-measures on exactly this kind of change
+      // (its MutationObserver watches the rows' subtree), and the footnote's
+      // two-line budget is measured in the same pass (T:12455-12474).
+      fitRevision: attach.items.length,
       // ONLY INSIDE A CONVERSATION. `card` is spread into `Home`'s composer as
       // well as the chat's, and a hand-back is about the turn that was running
       // — the landing has none.
@@ -1059,6 +1335,10 @@ function ChatBody(props: ChatBodyProps) {
       stranded,
       entered,
       urlTick,
+      attach.items,
+      attach.remove,
+      onPaste,
+      pane.paneNoun,
     ],
   );
   const onAnchorSpent = useCallback(() => params.set({ msg: null }), [params]);
@@ -1096,12 +1376,33 @@ function ChatBody(props: ChatBodyProps) {
           <SplitDivider split={split} />
         </>
       ) : null}
-      <div className="c-chat" ref={columnRef}>
+      <div
+        className={"c-chat" + (dropping ? " dropping" : "")}
+        ref={columnRef}
+        // DRAG AND DROP ON THE WHOLE COLUMN rather than on the textarea: a
+        // target the size of a one-line input is a target people miss, and
+        // everything in this column is part of the same message (T:11745-11751).
+        onDragEnter={onDragEnter}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+      >
         {stripShown ? (
           // A row ABOVE both views, never over either, and the ONE row the
           // narrow rules never hide — it carries the way out of each view
-          // (T:3833-3843). PR3 puts the annotate switch and the recorder here.
-          <div className="c-anntools">
+          // (T:3833-3843). PR3 arms the annotate switch and the recorder here;
+          // their seats are already in it.
+          <div className="c-anntools" ref={stripRef}>
+            <AnnStrip
+              paneNoun={pane.paneNoun}
+              // The camera photographs the PANE, so it goes when the pane is not
+              // on screen: the narrow CHAT view parks the preview off screen
+              // (T:3823 `body.view-chat .viewshot`), and a chat-only mount never
+              // had one.
+              shown={paneShown && !(narrowView.narrow && narrowView.view === "chat")}
+              capturing={attach.capturing}
+              onScreenshot={() => void attach.capture()}
+            />
             {host === "anntools" ? (
               <LeftModePicker
                 modes={pane.decision?.leftModes ?? []}
@@ -1109,7 +1410,7 @@ function ChatBody(props: ChatBodyProps) {
                 leftMode={leftMode}
               />
             ) : null}
-            <ViewToggle narrowView={narrowView} />
+            {narrowView.narrow ? <ViewToggle narrowView={narrowView} /> : null}
           </div>
         ) : null}
         {inChat ? (
@@ -1138,6 +1439,8 @@ function ChatBody(props: ChatBodyProps) {
               msgAnchor={msgAnchor}
               onAnchorSpent={onAnchorSpent}
               onShowSent={setSent}
+              onOpenShot={setViewing}
+              paneNoun={pane.paneNoun}
               what={file ? "using the chat on " + file : "using the chat"}
             />
             {/* A card is READ, not typed into: compact is the one cut that takes
@@ -1157,7 +1460,21 @@ function ChatBody(props: ChatBodyProps) {
           />
         )}
       </div>
-      <SentPop open={!!sent} onClose={() => setSent(null)} outgoing={sent?.raw ?? ""} />
+      <SentPop
+        open={!!sent}
+        onClose={() => setSent(null)}
+        outgoing={sent?.raw ?? ""}
+        paneNoun={pane.paneNoun}
+        onOpenShot={setViewing}
+      />
+      {/* ABOVE the popup (z 90 against 80): a picture opened from inside it must
+          land ON TOP or the click looks dead (T:1147-1148). */}
+      <ShotViewer
+        shot={viewing}
+        paneNoun={pane.paneNoun}
+        onClose={() => setViewing(null)}
+        onDiscard={onDiscardShot}
+      />
     </div>
    </CardPolicyProvider>
   );

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -520,6 +520,31 @@ function ChatBody(props: ChatBodyProps) {
       sends.clear();
     };
   }, []);
+  /**
+   * THE HANDLES A LANDED SEND HAS FINISHED WITH, held until the swap they were
+   * replaced by is actually ON SCREEN.
+   *
+   * `settleAttachments` re-points the receipts at the copy on disk, but that is
+   * a STORE WRITE: React has not rendered, let alone committed, by the time the
+   * call returns, so the `<img>` under the bubble is still showing the object
+   * URL. Revoking in that same tick pulled the picture out from under it — the
+   * img errored, `ShotRow` read the error as "the pruner deleted it" and every
+   * successful send of a pasted or captured picture ended in "screenshot no
+   * longer on disk" (Bugbot, PR #1064).
+   *
+   * So the spent handles go in STATE and are released from an effect: a passive
+   * effect runs after React has mutated the tree, so by the time it fires every
+   * receipt is drawn with `rawUrl(view)` and nothing on screen is holding a
+   * `blob:` handle any more.
+   */
+  const [spentBlobs, setSpentBlobs] = useState<readonly Attachment[]>([]);
+  useEffect(() => {
+    if (!spentBlobs.length) return;
+    for (const att of spentBlobs) ATTACH_API.revoke(att);
+    // Emptied, so a later swap's queue is its own; `revoke` is idempotent, so a
+    // re-run before that lands (StrictMode) costs nothing.
+    setSpentBlobs((q) => (q === spentBlobs ? [] : q));
+  }, [spentBlobs]);
   const attachBack = useRef<((items: readonly Attachment[]) => void) | null>(null);
   const [stranded, setStranded] = useState<{ text: string; seq: number } | null>(null);
   const strandSeq = useRef(0);
@@ -1097,10 +1122,12 @@ function ChatBody(props: ChatBodyProps) {
           inFlight.current.delete(key);
           const settled = settleReceipts(key, landed);
           if (!settled.spent.length) return;
-          // THE STORE FIRST, the revoke second: the rows have to be showing the
-          // copy on disk before the handles they were showing stop resolving.
+          // THE STORE FIRST, the revoke A COMMIT LATER: the rows have to be
+          // SHOWING the copy on disk — not merely told to — before the handles
+          // they were showing stop resolving, and a store write is not a render
+          // (`spentBlobs` above).
           controller.settleAttachments(key, settled.receipts);
-          for (const att of settled.spent) ATTACH_API.revoke(att);
+          setSpentBlobs((q) => (q.length ? q.concat(settled.spent) : settled.spent));
         },
       };
     },

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -1301,6 +1301,10 @@ function ChatBody(props: ChatBodyProps) {
       boxRef,
       // Pictures alone are sendable, with no words at all (T:17903).
       hasAttachments: attach.items.length > 0,
+      // ... but not while one of them is still on its way: `take()` leaves a
+      // `pending` chip in the tray, so a send fired now would go out WITHOUT
+      // the files whose chips made it sendable (Bugbot, PR #1064).
+      attachPending: attach.items.some((a: Attachment) => a.pending),
       chips: (
         <AttachTray
           items={attach.items}

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -68,6 +68,7 @@ import {
   openCardIds,
   resetCardPolicy,
   SentPop,
+  settleReceipts,
   ShotViewer,
   Topbar,
   Transcript,
@@ -1077,14 +1078,32 @@ function ChatBody(props: ChatBodyProps) {
       // gone (the pictures went back to the tray) or is a send that LANDED — and
       // a map that only ever grows pins every attachment and blob URL the page
       // has ever sent for as long as it is open.
+      //
+      // STILL BEING THERE IS WHAT SAYS IT LANDED, which is why this reads before
+      // it deletes: a send handed back to the tray was already removed by
+      // `onSendReturned`, and its thumbnails are the chips the user is looking
+      // at. A send that went out owns nothing on screen any more — the receipts
+      // under its bubble are re-pointed at the copy on disk and the blob URLs go
+      // (`settleReceipts`), so `newChat` or a file change can drop those turns
+      // without pinning a full-pane Blob per picture for the life of the
+      // document (Bugbot, PR #1064).
       return {
         merged,
         done: () => {
-          if (key) inFlight.current.delete(key);
+          if (!key) return;
+          const landed = inFlight.current.get(key);
+          if (!landed) return;
+          inFlight.current.delete(key);
+          const settled = settleReceipts(key, landed);
+          if (!settled.spent.length) return;
+          // THE STORE FIRST, the revoke second: the rows have to be showing the
+          // copy on disk before the handles they were showing stop resolving.
+          controller.settleAttachments(key, settled.receipts);
+          for (const att of settled.spent) ATTACH_API.revoke(att);
         },
       };
     },
-    [takeAttachments],
+    [controller, takeAttachments],
   );
 
   const onSend = useCallback(

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -574,13 +574,20 @@ function ChatBody(props: ChatBodyProps) {
   // places, one list.
   const attach = useAttachments({
     agentDir,
-    // The pane's iframe, read at gesture time: a capture aimed at the element as
-    // it was when this callback was made would photograph a document that has
-    // since been replaced by a mode swap.
-    frame: () => paneFrame.current,
-    // What the shutter flashes over: the frame's own box, which is the offset
-    // parent the pins and the highlight also live in (T:11233).
-    flashHost: () => paneFrame.current?.parentElement ?? null,
+    // THE FRAME WHOSE DOCUMENT IS THE APP, read at gesture time: ours when we
+    // have a pane, the HOST's marked one when we do not (`appFrame`). A capture
+    // aimed at the element as it was when this callback was made would
+    // photograph a document that has since been replaced by a mode swap — and
+    // one aimed at `paneFrame` alone found nothing at all in the hosted
+    // `?_side=claude` layout, where the only app frame is the host's. T does not
+    // have this seam because `appWindow()` reads off `annFrame` whichever of the
+    // two it is (T:4865), and the camera reads `annFrame`.
+    frame: () => appFrame(),
+    // What the shutter flashes over: that frame's own box, which is the offset
+    // parent the pins and the highlight also live in (T:11233). The host's frame
+    // is a node in THIS document (Preview.tsx renders both columns), so its
+    // parent is a real box to flash over.
+    flashHost: () => appFrame()?.parentElement ?? null,
     paneNoun: pane.paneNoun,
   });
   /** The picture the viewer is showing, pending or sent (T:10681 `shotViewing`). */
@@ -1178,14 +1185,36 @@ function ChatBody(props: ChatBodyProps) {
   // persistent left column to hang a bar on (`pickerHost`).
   const host = pickerHost(narrowView.narrow, pane.noPane, pane.decision?.leftModes.length ?? 0);
   const paneShown = !chatOnly && !pane.noPane;
+  // IS THERE AN ANNOTATE TARGET — the one question the strip's visibility has
+  // ever asked, and it is NOT a question about our layout.
+  //
+  // T's `annPollTarget` (T:8449-8465) resolves `annFrame` to the pane iframe in
+  // the split layout OR, in CHAT_ONLY, to the host's marked frame
+  // (`annMarkedFrame`, T:6113) — polled, because the mark moves with the host's
+  // own mode switcher — and sets `hidden` on the three buttons off that one
+  // fact. `#anncta:not(:has(#annbtn:not([hidden])))` then collapses the group.
+  // So the ONLY state that hides them is "nothing to act on": a folder listing,
+  // or a standalone mount with no pane.
+  //
+  // Native read `!chatOnly` instead, which is a question about the LAYOUT, and
+  // so the hosted `?_side=claude` sidebar — where the app is on screen in the
+  // middle column and `annotateTarget` hands us its frame — lost the whole row,
+  // on the landing and in the transcript alike, while `:1777` kept all three
+  // buttons on the same URL (measured: legacy `#anncta` 312x26 with
+  // viewshot/annbtn/annrec all `hidden:false`; native rendered no `.c-anncta`
+  // at all).
+  //
+  // `hostPane` is the polled answer to the second half and already lives above
+  // (HOST_PANE_POLL_MS, T's tick), so this is the same OR that `hasPane` makes.
+  const annTarget = paneShown || hostPane;
   // THE STRIP IS NOT THE NARROW LAYOUT'S ALONE any more. In T `#anntools` is a
   // row the landing and the transcript both keep in EVERY layout (T:3842) — it
   // is where the three preview controls live — and PR1 rendered it only below
   // the breakpoint, because until now its only contents were the narrow view's
   // own two controls. The camera moved into it on 2026-08-27, so the row now
-  // exists wherever there is a pane to photograph; the view toggle and the
-  // picker stay narrow-only inside it (`pickerHost`).
-  const stripShown = paneShown;
+  // exists wherever there is a pane to photograph — OURS OR THE HOST'S; the
+  // view toggle and the picker stay narrow-only inside it (`pickerHost`).
+  const stripShown = annTarget;
   // T:7566 `annFitStrip` — the strip's words collapse to icons only when they
   // MEASURABLY do not fit (QA #2: at 1280px with a pane the chat column is
   // ~308px and the three full labels overflowed it by 8px).
@@ -1304,6 +1333,15 @@ function ChatBody(props: ChatBodyProps) {
       // ... but not while one of them is still on its way: `take()` leaves a
       // `pending` chip in the tray, so a send fired now would go out WITHOUT
       // the files whose chips made it sendable (Bugbot, PR #1064).
+      //
+      // AND THE CAMERA COUNTS, even though it plants no chip. `capture()` puts
+      // nothing in the tray until the bytes are in hand — the seat swap is the
+      // whole of its commit — so its window (up to the native path's several
+      // seconds on a large pane) was invisible to this gate: the flash had
+      // already fired, so the picture LOOKED taken, an Enter in that window went
+      // out without it, and it then landed in the tray for the NEXT message. T
+      // holds the send for the in-flight shot for the same reason
+      // (`shotBusy`/`shotAttachPane`); `capturing` is that flag.
       attachPending: attach.items.some((a: Attachment) => a.pending),
       chips: (
         <AttachTray
@@ -1399,11 +1437,13 @@ function ChatBody(props: ChatBodyProps) {
           <div className="c-anntools" ref={stripRef}>
             <AnnStrip
               paneNoun={pane.paneNoun}
-              // The camera photographs the PANE, so it goes when the pane is not
-              // on screen: the narrow CHAT view parks the preview off screen
-              // (T:3823 `body.view-chat .viewshot`), and a chat-only mount never
-              // had one.
-              shown={paneShown && !(narrowView.narrow && narrowView.view === "chat")}
+              // The camera photographs whatever the annotate target is, so the
+              // seats go only when there is nothing to photograph. The narrow
+              // CHAT view parks OUR preview off screen (T:3823
+              // `body.view-chat .viewshot`) and is the one layout answer left in
+              // here; a hosted mount's target is the host's own column, which
+              // that view does not move.
+              shown={annTarget && !(paneShown && narrowView.narrow && narrowView.view === "chat")}
               capturing={attach.capturing}
               onScreenshot={() => void attach.capture()}
             />

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -538,13 +538,26 @@ function ChatBody(props: ChatBodyProps) {
    * `blob:` handle any more.
    */
   const [spentBlobs, setSpentBlobs] = useState<readonly Attachment[]>([]);
+  /** The same queue, where an UNMOUNT can still reach it. A chat closed between
+   *  the store write and its commit would otherwise leave handles nothing has a
+   *  reference to any more — the tray gave them up and `inFlight` has already
+   *  deleted the send — pinned for the life of the document. */
+  const spentAlive = useRef<Attachment[]>([]);
   useEffect(() => {
     if (!spentBlobs.length) return;
     for (const att of spentBlobs) ATTACH_API.revoke(att);
+    spentAlive.current = [];
     // Emptied, so a later swap's queue is its own; `revoke` is idempotent, so a
     // re-run before that lands (StrictMode) costs nothing.
     setSpentBlobs((q) => (q === spentBlobs ? [] : q));
   }, [spentBlobs]);
+  useEffect(
+    () => () => {
+      for (const att of spentAlive.current) ATTACH_API.revoke(att);
+      spentAlive.current = [];
+    },
+    [],
+  );
   const attachBack = useRef<((items: readonly Attachment[]) => void) | null>(null);
   const [stranded, setStranded] = useState<{ text: string; seq: number } | null>(null);
   const strandSeq = useRef(0);
@@ -1127,6 +1140,7 @@ function ChatBody(props: ChatBodyProps) {
           // they were showing stop resolving, and a store write is not a render
           // (`spentBlobs` above).
           controller.settleAttachments(key, settled.receipts);
+          spentAlive.current = spentAlive.current.concat(settled.spent);
           setSpentBlobs((q) => (q.length ? q.concat(settled.spent) : settled.spent));
         },
       };

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -532,32 +532,36 @@ function ChatBody(props: ChatBodyProps) {
    * successful send of a pasted or captured picture ended in "screenshot no
    * longer on disk" (Bugbot, PR #1064).
    *
-   * So the spent handles go in STATE and are released from an effect: a passive
-   * effect runs after React has mutated the tree, so by the time it fires every
-   * receipt is drawn with `rawUrl(view)` and nothing on screen is holding a
-   * `blob:` handle any more.
+   * So the spent handles are released from an EFFECT: a passive effect runs
+   * after React has mutated the tree, so by the time it fires every receipt is
+   * drawn with `rawUrl(view)` and nothing on screen is holding a `blob:` handle
+   * any more.
+   *
+   * ONE QUEUE, in a ref, and the state is only the TRIGGER. A second copy in
+   * state was two bookkeepers for one list, and they diverged: the effect
+   * cleared the ref wholesale while state legitimately kept a NEWER send's
+   * handles, so those lost their unmount path and were pinned for the life of
+   * the document (Bugbot, PR #1064). The effect now drains whatever the ref
+   * holds at commit time — every entry in it has had its store write already —
+   * and anything queued after that gets its own tick, its own effect run, or the
+   * unmount below.
    */
-  const [spentBlobs, setSpentBlobs] = useState<readonly Attachment[]>([]);
-  /** The same queue, where an UNMOUNT can still reach it. A chat closed between
-   *  the store write and its commit would otherwise leave handles nothing has a
-   *  reference to any more — the tray gave them up and `inFlight` has already
-   *  deleted the send — pinned for the life of the document. */
   const spentAlive = useRef<Attachment[]>([]);
-  useEffect(() => {
-    if (!spentBlobs.length) return;
-    for (const att of spentBlobs) ATTACH_API.revoke(att);
+  const [spentTick, setSpentTick] = useState(0);
+  const dropSpent = useCallback(() => {
+    const go = spentAlive.current;
+    if (!go.length) return;
     spentAlive.current = [];
-    // Emptied, so a later swap's queue is its own; `revoke` is idempotent, so a
-    // re-run before that lands (StrictMode) costs nothing.
-    setSpentBlobs((q) => (q === spentBlobs ? [] : q));
-  }, [spentBlobs]);
-  useEffect(
-    () => () => {
-      for (const att of spentAlive.current) ATTACH_API.revoke(att);
-      spentAlive.current = [];
-    },
-    [],
-  );
+    for (const att of go) ATTACH_API.revoke(att);
+  }, []);
+  // `spentTick` is not read in the body: it IS the message ("a swap has been
+  // committed"), and the drain deliberately takes the whole queue rather than
+  // the one send that raised the tick.
+  useEffect(dropSpent, [dropSpent, spentTick]);
+  // AND AT UNMOUNT, when there is no screen left to keep them for: the tray gave
+  // these up and `inFlight` has already deleted the send, so nothing else has a
+  // reference to release.
+  useEffect(() => dropSpent, [dropSpent]);
   const attachBack = useRef<((items: readonly Attachment[]) => void) | null>(null);
   const [stranded, setStranded] = useState<{ text: string; seq: number } | null>(null);
   const strandSeq = useRef(0);
@@ -1141,7 +1145,7 @@ function ChatBody(props: ChatBodyProps) {
           // (`spentBlobs` above).
           controller.settleAttachments(key, settled.receipts);
           spentAlive.current = spentAlive.current.concat(settled.spent);
-          setSpentBlobs((q) => (q.length ? q.concat(settled.spent) : settled.spent));
+          setSpentTick((n) => n + 1);
         },
       };
     },

--- a/frontend/src/apps/claude/protocol/controller-api.ts
+++ b/frontend/src/apps/claude/protocol/controller-api.ts
@@ -21,6 +21,9 @@ import type {
   SwitchableMode,
   TranscriptStat,
 } from "./types";
+/** PR2: the attachment pipeline's own contract (`shots/types.ts`). Pure types —
+ *  the protocol layer never calls into it. */
+import type { Receipt } from "../shots/types";
 
 /** One transcript row. History turns and live turns share this shape. */
 export interface UserTurn {
@@ -40,6 +43,19 @@ export interface UserTurn {
    */
   appState?: true;
   uuid?: string;
+  /**
+   * ADDED (PR2): the receipt rows this turn wears — "screenshot attached",
+   * "file attached: notes.csv", or the refusal and its reason (T:10815
+   * `shotReceipt`).
+   *
+   * Set only on a turn THIS page sent, because only this page holds the blob
+   * URLs its thumbnails were drawn from. A turn read back off disk has none and
+   * its receipts are rebuilt from `raw`'s own `<pane-shot>` block instead
+   * (T:10903 `shotRestoreReceipt`, `ui/attachApi.restoreReceipts`) — so the two
+   * roads meet, and a picture visible while the session lasts is still there
+   * when the session is reopened.
+   */
+  attachments?: Receipt[];
 }
 
 export interface AssistantTurn {
@@ -200,6 +216,10 @@ export interface SendOptions {
    *  shots dir the spawn line always allows — one Read rule each, granted for
    *  the SESSION (Task 6, T:16657-16668). JSON-encoded onto the wire. */
   readDirs?: string[];
+  /** ADDED (PR2): the receipts the turn this send posts should wear. The
+   *  controller only carries them onto the bubble — the pipeline builds them,
+   *  and the same list goes back to the tray if the send never lands. */
+  attachments?: Receipt[];
 }
 
 /**
@@ -330,6 +350,21 @@ export interface ControllerDeps {
    * this is what goes out unasked with every message.
    */
   appStateBlock?: () => Promise<string>;
+  /**
+   * ADDED (PR2): a send whose BUBBLE WAS DROPPED — the run never launched, or a
+   * follow-up never reached a live one — so the agent saw none of it and the
+   * composer takes its attachments back (T:16091-16093, 16693-16720).
+   *
+   * The pictures are NOT revoked on this road and must not be: they are handed
+   * back as pending chips showing those very thumbnails. The user attached them
+   * deliberately — a capture of a moment that has passed, or a file they went
+   * and found — and a failed send is not a reason to make them do it again, nor
+   * could they, if what they photographed is gone.
+   *
+   * A DELIVERED follow-up stranded by a stop is not this: `onStranded` hands
+   * those words back, and their pictures are already in the agent's hands.
+   */
+  onSendReturned?: (info: { text: string; attachments?: Receipt[] }) => void;
 }
 
 export type { HistoryTurn };

--- a/frontend/src/apps/claude/protocol/controller-api.ts
+++ b/frontend/src/apps/claude/protocol/controller-api.ts
@@ -287,6 +287,15 @@ export interface ChatController {
   /** Back to home: clear transcript, drop session_id/run params (T:13031 enterChat/back). */
   newChat(): void;
 
+  /**
+   * ADDED (PR2): swap the receipts under the user turn that was sent with
+   * `receipts` for `next` — the rows re-pointed at the copy on disk once the
+   * send landed, so the blob URLs they were drawn with can be revoked
+   * (`shots/attach.settleReceipts`). The ARRAY IS THE ADDRESS, like the
+   * hand-back's; a send whose bubble is gone settles nothing.
+   */
+  settleAttachments(receipts: Receipt[], next: Receipt[]): void;
+
   /** Release timers/aborts. */
   dispose(): void;
 }

--- a/frontend/src/apps/claude/protocol/history.test.ts
+++ b/frontend/src/apps/claude/protocol/history.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 
 import { ago, historyToTurns, paneSlashes, rowPane, sessionTitle } from "./history";
 import type { HistoryResponse } from "./types";
-import { composeOutgoing, formatAnnotations, MARKER_VIEW, paneShotBlock } from "./wire";
+import {
+  composeOutgoing,
+  formatAnnotations,
+  MARKER_VIEW,
+  markerWord,
+  paneShotBlock,
+} from "./wire";
 
 const stat = { path: "/t.jsonl", mtime: 1, size: 2 };
 
@@ -103,7 +109,12 @@ describe("sessionTitle (T:18088)", () => {
     // What the store actually holds: the head of the wire, 80 chars, so the
     // `</pane-shot>` the strip matches on is not in the string at all.
     const preview = "<pane-shot>\nThe user attached a pi";
-    expect(sessionTitle({ id: "s1", preview })).toBe(MARKER_VIEW);
+    // A LABEL, so the marker arrives as its WORDS: the sigil that tells a
+    // marker apart from a typed "pane screenshot" is the bubble's detector, and
+    // a row title carrying an invisible format character is a title nothing
+    // else can match (Bugbot, PR #1064).
+    expect(sessionTitle({ id: "s1", preview })).toBe(markerWord(MARKER_VIEW));
+    expect(sessionTitle({ id: "s1", preview })).toBe("pane screenshot");
   });
 
   test("the annotation preamble is tag-less by construction and still cut", () => {

--- a/frontend/src/apps/claude/protocol/history.test.ts
+++ b/frontend/src/apps/claude/protocol/history.test.ts
@@ -108,7 +108,7 @@ describe("sessionTitle (T:18088)", () => {
 
   test("the annotation preamble is tag-less by construction and still cut", () => {
     expect(sessionTitle({ id: "s1", preview: "The user annotated 1 element in the l" })).toBe(
-      "📌 annotations",
+      "annotations",
     );
   });
 

--- a/frontend/src/apps/claude/protocol/history.ts
+++ b/frontend/src/apps/claude/protocol/history.ts
@@ -26,6 +26,7 @@ import {
   MARKER_JOIN,
   MARKER_VIEW,
   PANE_SHOT_TAG,
+  markerWords,
   stripBlocks,
 } from "./wire";
 
@@ -94,7 +95,12 @@ const BLOCK_OPENERS: [string, string][] = [
 
 /** T:18088 `sessionTitle` — what a session row (and a snapshot heading) is
  *  LABELLED with. Never blank: a row with no title is a row nobody can pick out
- *  of a list, so the markers, then the id, stand in. */
+ *  of a list, so the markers, then the id, stand in.
+ *
+ *  A LABEL, so the markers arrive as their words: the sigil that tells a marker
+ *  apart from a typed "files" belongs to the bubble's own detector, and a row
+ *  title carrying an invisible format character is a title nothing else — a
+ *  filter, a document title — can match (`markerWords`, wire.ts). */
 export function sessionTitle(s: Pick<SessionRow, "id" | "preview"> | null | undefined): string {
   const raw = (s && s.preview) || "";
   let text = stripBlocks(raw);
@@ -105,7 +111,7 @@ export function sessionTitle(s: Pick<SessionRow, "id" | "preview"> | null | unde
     text = text.slice(0, i).trim();
     if (marker) carried.push(marker);
   }
-  return text || carried.join(MARKER_JOIN) || (s && s.id) || "";
+  return markerWords(text || carried.join(MARKER_JOIN)) || (s && s.id) || "";
 }
 
 /** T:17945 `ago` — epoch SECONDS in, a relative phrase out. `now` is injectable

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1090,6 +1090,44 @@ describe("app state rides out with every message (T:16483)", () => {
     expect(posted.map((t) => t.appState)).toEqual([true, true]);
   });
 
+  test("the state leads the tray's pictures on BOTH send roads (§D order)", async () => {
+    // The wire is state → pane-shot → annotations → text. `[...blocks, live]`
+    // appended the controller's own block AFTER the tray's `<pane-shot>`, which
+    // is §D backwards and exactly what `composeBlocks` exists to decide
+    // (Bugbot, PR #1064).
+    const SHOTS = "<pane-shot>\n[]\n</pane-shot>";
+    let controller!: ChatController;
+    const made = makeController(
+      {
+        start: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        poll: async (_f, n) => {
+          if (n === 0) {
+            await controller.sendFollowUp("and this", { blocks: [SHOTS] });
+            return poll({ segments: [text("ok")] });
+          }
+          return poll({ done: true, segments: [text("ok")] });
+        },
+      },
+      createMemoryParamsStore(),
+      { appStateBlock: () => Promise.resolve(BLOCK) },
+    );
+    controller = made.controller;
+    await controller.sendMessage("look at my app", { blocks: [SHOTS] });
+
+    const roads: [string, string][] = [
+      [String(made.agent.of("start")[0]!.fields.message), "look at my app"],
+      [String(made.agent.of("send")[0]!.fields.message), "and this"],
+    ];
+    for (const [wire, typed] of roads) {
+      expect(wire).toContain(BLOCK);
+      expect(wire).toContain(SHOTS);
+      expect(wire.indexOf(BLOCK)).toBeLessThan(wire.indexOf(SHOTS));
+      // And the typed words stay LAST, after everything the page prepended.
+      expect(wire.indexOf(SHOTS)).toBeLessThan(wire.indexOf(typed));
+    }
+  });
+
   test("nothing to say ⇒ no block, no receipt, and the message is unchanged", async () => {
     // A chat with no pane, or a pane the watcher has learned nothing from:
     // `blockForSend` answers "" and this path must add neither markers nor a

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -95,6 +95,9 @@ function makeController(
   const agent = fakeAgent(handlers);
   const activity: number[] = [];
   const stranded: string[][] = [];
+  /** Every send that reported itself NOT SENT — the road the composer takes its
+   *  words and its pictures back on. */
+  const returned: { text: string; attachments?: unknown[] }[] = [];
   const controller = createChatController({
     ...over,
     file: "/proj/app.py",
@@ -108,8 +111,9 @@ function makeController(
     hasPane: () => true,
     onActivity: () => activity.push(1),
     onStranded: (t) => stranded.push(t),
+    onSendReturned: (info) => returned.push(info),
   });
-  return { controller, agent, params, activity, stranded };
+  return { controller, agent, params, activity, stranded, returned };
 }
 
 const assistants = (c: ChatController) =>
@@ -275,6 +279,51 @@ describe("start → poll → done", () => {
     expect(users(controller)[0].text).toBe("🖼 pane screenshot");
     expect(users(controller)[0].raw).toBe(block);
     expect(agent.of("start")[0].fields.read_dirs).toBe('["/tmp/shots"]');
+  });
+
+  // ---- every road out of a send says whether it went (Bugbot, PR #1064) -----
+  //
+  // `ClaudeChat.beginSend` empties the tray and parks the pictures under the
+  // `Receipt[]` it hands down here BEFORE the controller runs, and the only way
+  // they ever come back is `onSendReturned`. A road that returns silently is a
+  // picture the user attached deliberately — a capture of a moment that has
+  // passed — gone with no chip, no error and no way to retake it.
+
+  test("a send refused because one is already in flight hands its pictures back", async () => {
+    let release!: () => void;
+    const held = new Promise<void>((res) => (release = res));
+    const { controller, agent, returned } = makeController({
+      start: async () => {
+        await held;
+        return { run_id: "r1" };
+      },
+      poll: () => poll({ done: true }),
+    });
+    const first = controller.sendMessage("one");
+    const shots = [{ kind: "pane" as const, label: "attached", view: "/shots/v.png" }];
+    await controller.sendMessage("two", { attachments: shots });
+    // Refused, and refused OUT LOUD: the same array the caller handed down, so
+    // the map it parked the Attachments under can be unlocked by identity.
+    expect(returned).toEqual([{ text: "two", attachments: shots }]);
+    release();
+    await first;
+    expect(agent.of("start").length).toBe(1);
+    expect(users(controller).map((t) => t.text)).toEqual(["one"]);
+  });
+
+  test("a send into a DISPOSED controller hands its pictures back", async () => {
+    const { controller, agent, returned } = makeController({ start: () => ({ run_id: "r1" }) });
+    controller.dispose();
+    const shots = [{ kind: "image" as const, label: "attached", view: "/shots/a.png" }];
+    await controller.sendMessage("hi", { attachments: shots });
+    await controller.sendFollowUp("also this", { attachments: shots });
+    expect(agent.calls.length).toBe(0);
+    // Both roads, because both refuse before anything is attempted — and on an
+    // unmount the hand-back is what releases the blob URLs.
+    expect(returned).toEqual([
+      { text: "hi", attachments: shots },
+      { text: "also this", attachments: shots },
+    ]);
   });
 
   test("nothing to send at all is a no-op", async () => {

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1612,6 +1612,87 @@ describe("stop (T:15901)", () => {
     expect(assistants(controller).every((t) => !t.streaming)).toBe(true);
   });
 
+  // Bugbot, PR #1064. `stopRun` handed back the WORDS and dropped the bubble —
+  // and the pictures were parked in `ClaudeChat.beginSend`'s `inFlight` map
+  // under this send's own `Receipt[]`, reachable only through
+  // `onSendReturned`. So they vanished until the POST settled, and were lost
+  // outright when it answered `{sent: true}`.
+  test("a stop on an in-flight follow-up gives its PICTURES back too", async () => {
+    const shots = [{ kind: "image" as const, label: "attached", view: "/shots/a.png" }];
+    let controller!: ChatController;
+    let releaseSend: () => void = () => {};
+    const held = new Promise<void>((r) => {
+      releaseSend = r;
+    });
+    const made = makeController({
+      start: () => ({ run_id: "r1" }),
+      send: async () => {
+        await held;
+        // The worst case: the inbox DID take it, after the stop. The words are
+        // handed back on the honest "it did not land" reading, and the pictures
+        // ride with them rather than being lost to a map nobody reads.
+        return { sent: true as const };
+      },
+      cancel: () => ({ cancelled: "r1", still_queued: [] }),
+      poll: async (_f, n) => {
+        if (n === 0) return poll({ segments: [text("working")] });
+        if (n === 1) {
+          void controller.sendFollowUp("look at this", {
+            blocks: ["<pane-shot>\n/shots/a.png\n</pane-shot>"],
+            attachments: shots,
+          });
+          await Promise.resolve();
+          await Promise.resolve();
+          await controller.stopRun();
+          releaseSend();
+          // Let the parked `send` settle: `giveBack` must not hand the same
+          // pictures back a second time.
+          await Promise.resolve();
+          await Promise.resolve();
+          return poll({ segments: [text("working")] });
+        }
+        return poll({ done: true, error: "claude exited", segments: [text("working")] });
+      },
+    });
+    controller = made.controller;
+    await controller.sendMessage("go");
+    expect(made.stranded).toEqual([["look at this"]]);
+    // EXACTLY ONE hand-back, carrying the very array `beginSend` keyed by.
+    expect(made.returned).toEqual([{ text: "look at this", attachments: shots }]);
+    expect(made.returned[0].attachments).toBe(shots);
+    // The optimistic bubble went with the strand; only the opening turn stands.
+    expect(users(controller).map((t) => t.text)).toEqual(["go"]);
+  });
+
+  // The other half of the rule: a follow-up the CLI CONFIRMED and then named in
+  // `still_queued` owes only its words back — its bytes are already on disk in
+  // the agent's hands (`onSendReturned`'s own note).
+  test("a LANDED follow-up stranded by a stop hands back words, not pictures", async () => {
+    const shots = [{ kind: "image" as const, label: "attached", view: "/shots/a.png" }];
+    let controller!: ChatController;
+    const made = makeController({
+      start: () => ({ run_id: "r1" }),
+      send: () => ({ sent: true as const }),
+      cancel: () => ({
+        cancelled: "r1",
+        still_queued: [String(made.agent.of("send")[0]?.fields.message ?? "")],
+      }),
+      poll: async (_f, n) => {
+        if (n === 0) return poll({ segments: [text("working")] });
+        if (n === 1) {
+          await controller.sendFollowUp("look at this", { attachments: shots });
+          await controller.stopRun();
+          return poll({ segments: [text("working")] });
+        }
+        return poll({ done: true, error: "claude exited", segments: [text("working")] });
+      },
+    });
+    controller = made.controller;
+    await controller.sendMessage("go");
+    expect(made.stranded).toEqual([["look at this"]]);
+    expect(made.returned).toEqual([]);
+  });
+
   test("a still_queued the CLI DOES name hands back the typed text, not the wire form", async () => {
     let controller!: ChatController;
     const made = makeController({

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from "bun:test";
 const { PERM_CARD_MAX, createChatController, runEnding, stopAllowed, trimPermCards } =
   await import("./run-controller");
 const { createMemoryParamsStore } = await import("../params/store");
+const { MARKER_VIEW } = await import("./wire");
 
 import type { runAgent } from "./agent";
 import type { AssistantTurn, ChatController, NoteTurn, UserTurn } from "./controller-api";
@@ -276,7 +277,11 @@ describe("start → poll → done", () => {
     });
     const block = `<pane-shot>\ncaption\n[{"kind":"pane","view":"/p.png"}]\n</pane-shot>`;
     await controller.sendMessage("", { blocks: [block], readDirs: ["/tmp/shots"] });
-    expect(users(controller)[0].text).toBe("pane screenshot");
+    // The MARKER, sigil and all: the bubble's text IS the marker, and the sigil
+    // is the only thing telling it apart from a reader who typed those two
+    // words (Bugbot, PR #1064). `ui/AttachIcon` draws the word.
+    expect(users(controller)[0].text).toBe(MARKER_VIEW);
+    expect(users(controller)[0].text).not.toBe("pane screenshot");
     expect(users(controller)[0].raw).toBe(block);
     expect(agent.of("start")[0].fields.read_dirs).toBe('["/tmp/shots"]');
   });

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -276,7 +276,7 @@ describe("start → poll → done", () => {
     });
     const block = `<pane-shot>\ncaption\n[{"kind":"pane","view":"/p.png"}]\n</pane-shot>`;
     await controller.sendMessage("", { blocks: [block], readDirs: ["/tmp/shots"] });
-    expect(users(controller)[0].text).toBe("🖼 pane screenshot");
+    expect(users(controller)[0].text).toBe("pane screenshot");
     expect(users(controller)[0].raw).toBe(block);
     expect(agent.of("start")[0].fields.read_dirs).toBe('["/tmp/shots"]');
   });

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -72,7 +72,7 @@ import type {
   StartResponse,
   SwitchableMode,
 } from "./types";
-import { composeOutgoing, stripBlocks } from "./wire";
+import { composeBlocks, composeOutgoing, stripBlocks } from "./wire";
 /** PR2: the attachment pipeline's receipt row — carried, never built here. */
 import type { Receipt } from "../shots/types";
 
@@ -1256,7 +1256,12 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // is not consulted: the watcher answers "" for a pane it has learned
     // nothing from, which is the same non-answer a missing pane gives.
     const live = await appStateBlock();
-    const outgoing = composeOutgoing(text, live ? [...blocks, live] : blocks);
+    // THROUGH `composeBlocks`, never appended: the tray's `<pane-shot>` is
+    // already in `blocks`, and `[...blocks, live]` put the state AFTER the
+    // pictures — §D's reading order is state → pane-shot → annotations → text.
+    // `composeBlocks` ranks `<live-app-state>` first wherever it arrives from
+    // (Bugbot, PR #1064).
+    const outgoing = composeOutgoing(text, composeBlocks(blocks, live ? [live] : []));
     // The bubble shows what the user TYPED (or the markers for a wordless
     // send); the raw wire rides along for the "what was sent" popover.
     //
@@ -1383,7 +1388,12 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // three tool calls into a turn is describing a pane that has moved since
     // the opening one.
     const live = await appStateBlock();
-    const outgoing = composeOutgoing(text, live ? [...blocks, live] : blocks);
+    // THROUGH `composeBlocks`, never appended: the tray's `<pane-shot>` is
+    // already in `blocks`, and `[...blocks, live]` put the state AFTER the
+    // pictures — §D's reading order is state → pane-shot → annotations → text.
+    // `composeBlocks` ranks `<live-app-state>` first wherever it arrives from
+    // (Bugbot, PR #1064).
+    const outgoing = composeOutgoing(text, composeBlocks(blocks, live ? [live] : []));
     // The follow-up's bubble goes up immediately; the `followupSeq` bump that
     // tells a streaming pollLoop to start a NEW bubble after it happens only
     // once the INBOX has taken it. Bumping here left a failed send with a

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -73,6 +73,8 @@ import type {
   SwitchableMode,
 } from "./types";
 import { composeOutgoing, stripBlocks } from "./wire";
+/** PR2: the attachment pipeline's receipt row — carried, never built here. */
+import type { Receipt } from "../shots/types";
 
 
 // ---- constants (all with their T line) -------------------------------------
@@ -401,15 +403,25 @@ export function createChatController(deps: ControllerDeps): ChatController {
   /** T:13446 `addUser` — the bubble goes up BEFORE anything slow on the send
    *  path: the user's words appearing instantly is worth more than a receipt and
    *  a bubble arriving together (T:16490). */
-  const addUser = (text: string, raw?: string, appState = false): UserTurn => {
+  const addUser = (
+    text: string,
+    raw?: string,
+    attachments?: Receipt[],
+    appState = false,
+  ): UserTurn => {
     const turn: UserTurn = {
       role: "user",
       key: nextKey("u"),
       text,
       ...(raw ? { raw } : {}),
-      // The receipt legacy hangs under the bubble (T:16588-16596). Set from the
-      // block actually composed into `raw`, never from "is there a pane" — a
-      // pane that has told us nothing produces no block and owes no receipt.
+      // The receipt rides the bubble the send posted, so the row is under the
+      // words from the first paint rather than appended after the start
+      // round-trip (T:16560-16583 appends it to the last `.turn.user`).
+      ...(attachments && attachments.length ? { attachments } : {}),
+      // The push channel's own receipt legacy hangs under the bubble
+      // (T:16588-16596). Set from the block actually composed into `raw`, never
+      // from "is there a pane" — a pane that has told us nothing produces no
+      // block and owes no receipt.
       ...(appState ? { appState: true as const } : {}),
     };
     pushTurn(turn);
@@ -1225,7 +1237,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // `stripBlocks(outgoing)` for a wordless send is unaffected by the block
     // above — `wire.ts` strips every `<live-app-state>` — so a send that is
     // only pictures still reads as pictures.
-    const bubble = addUser(text || stripBlocks(outgoing), outgoing, !!live);
+    const bubble = addUser(text || stripBlocks(outgoing), outgoing, opts.attachments, !!live);
     let started = false;
     try {
       let runId = "";
@@ -1315,7 +1327,12 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // The run never launched, so the agent never saw any of it: drop the
       // bubble so the composer's own rollback (attachments, notes) matches
       // (T:16693-16720).
-      if (!started) dropTurn(bubble.key);
+      if (!started) {
+        dropTurn(bubble.key);
+        // ... and the attachments go back to the tray with the words, because
+        // the agent never saw either (T:16693-16720).
+        deps.onSendReturned?.({ text, ...(opts.attachments ? { attachments: opts.attachments } : {}) });
+      }
       reportTrouble(troubleFromError(err));
     } finally {
       if (sendSeq === seat) sending = false;
@@ -1340,7 +1357,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // once the INBOX has taken it. Bumping here left a failed send with a
     // counter pollLoop read as a landed follow-up, and the reply split around
     // the gap where the rolled-back row had been (Bugbot, PR #996).
-    const bubble = addUser(text || stripBlocks(outgoing), outgoing, !!live);
+    const bubble = addUser(text || stripBlocks(outgoing), outgoing, opts.attachments, !!live);
     // KEYED BY A SEQ, not by the text: two identical follow-ups ("again") used
     // to collapse into one entry, and the first ack cleared both — so the second
     // one's hint left the composer while the message was still in flight.
@@ -1364,6 +1381,10 @@ export function createChatController(deps: ControllerDeps): ChatController {
     const giveBack = () => {
       dropTurn(bubble.key);
       drop();
+      // The same road sendMessage takes for a run that never launched: the
+      // usual way a follow-up fails is the session having already ended, and
+      // the pictures the user attached deliberately are owed back (T:16080-16093).
+      deps.onSendReturned?.({ text, ...(opts.attachments ? { attachments: opts.attachments } : {}) });
     };
 
     // `activeRun` is set synchronously the moment pollLoop is entered, but

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -409,6 +409,31 @@ export function createChatController(deps: ControllerDeps): ChatController {
 
   const dropTurn = (key: string) => emit({ turns: state.turns.filter((t) => t.key !== key) });
 
+  /**
+   * PR2 — THE SENT BUBBLE LETS GO OF ITS BLOB URLS.
+   *
+   * `ClaudeChat.beginSend` parks a send's attachments under the very
+   * `Receipt[]` it hands down here, and on the road that LANDED it re-points
+   * those receipts at the copy the server now holds (`settleReceipts`) so the
+   * object URLs can be released. The rows are memoized on identity, so the
+   * replacement has to come through the store or the `<img>` would keep the URL
+   * that is about to be revoked (Bugbot, PR #1064).
+   *
+   * THE ARRAY IS THE ADDRESS, exactly as it is for the hand-back: a send whose
+   * bubble was dropped (a rollback, a `newChat`) finds no turn and settles
+   * nothing, rather than rewriting another send's receipts.
+   */
+  const settleAttachments = (receipts: Receipt[], next: Receipt[]): void => {
+    if (disposed) return;
+    let found = false;
+    const turns = state.turns.map((t) => {
+      if (t.role !== "user" || t.attachments !== receipts) return t;
+      found = true;
+      return { ...t, attachments: next };
+    });
+    if (found) emit({ turns });
+  };
+
   /** T:13446 `addUser` — the bubble goes up BEFORE anything slow on the send
    *  path: the user's words appearing instantly is worth more than a receipt and
    *  a bubble arriving together (T:16490). */
@@ -2144,6 +2169,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     resumeRun,
     adoptLiveRun,
     newChat,
+    settleAttachments,
     dispose() {
       disposed = true;
       logGen++;

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -316,6 +316,13 @@ export function createChatController(deps: ControllerDeps): ChatController {
    * It is what `stopRun` needs to tell "the CLI never got this" from "the CLI
    * got it and, on the measured behaviour of the held-open stdin, echoed it
    * straight away" (feedback #11 — see `stopRun`).
+   *
+   * `opts` IS THE SEND'S OWN OPTIONS, kept for exactly one reason: the pictures.
+   * `ClaudeChat.beginSend` parked them under `opts.attachments` before the send
+   * began, and a strand is a send that did not go — so whoever strands the entry
+   * owes them back through `returnSend`, not just the words through `onStranded`
+   * (Bugbot, PR #1064). `handedBack` keeps that from happening twice when the
+   * still-in-flight POST later settles into `giveBack`.
    */
   const queued: {
     seq: number;
@@ -323,6 +330,8 @@ export function createChatController(deps: ControllerDeps): ChatController {
     typed: string;
     bubble: string;
     landed: boolean;
+    opts: SendOptions;
+    handedBack: boolean;
   }[] = [];
   let queuedSeq = 0;
   const publishQueued = () => emit({ queued: queued.map((q) => q.typed || q.wire) });
@@ -1411,6 +1420,10 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // Flipped below, when the inbox confirms — see `queued`'s own note and
       // `stopRun`'s handback rule.
       landed: false,
+      // The pictures ride here so a STOP can give them back; `giveBack` reads
+      // the same `opts` off its closure.
+      opts,
+      handedBack: false,
     };
     queued.push(entry);
     publishQueued();
@@ -1426,6 +1439,14 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // The same road sendMessage takes for a run that never launched: the
       // usual way a follow-up fails is the session having already ended, and
       // the pictures the user attached deliberately are owed back (T:16080-16093).
+      //
+      // ONCE, THOUGH: a Stop landing on an unconfirmed send already handed these
+      // very pictures back, and this POST is only now settling behind it. A
+      // second hand-back would re-add the same chips (or, for a host that keys
+      // by the receipt array, be silently dropped) — either way the entry says
+      // it is done.
+      if (entry.handedBack) return;
+      entry.handedBack = true;
       returnSend(text, opts);
     };
 
@@ -1573,6 +1594,23 @@ export function createChatController(deps: ControllerDeps): ChatController {
         const back = at >= 0 || !entry.landed;
         if (!back) continue;
         stranded.push(entry.typed || entry.wire);
+        // AND ITS PICTURES, but only for a send the inbox never confirmed. The
+        // words go back through `onStranded`; the attachments are parked in
+        // `ClaudeChat`'s `inFlight` map under this send's own `Receipt[]` and
+        // come back only through `onSendReturned`, so a strand that returned
+        // text alone dropped the bubble holding the only visible trace of them
+        // and left the map holding the only handle — the picture disappearing
+        // until the POST settled, and lost outright if it answered `sent`
+        // (Bugbot, PR #1064).
+        //
+        // A LANDED follow-up the CLI named in `still_queued` is deliberately not
+        // this: its bytes are already on disk in the agent's hands and its
+        // receipts already rode a wire block, so only the words are owed back
+        // (`onSendReturned`'s own note).
+        if (!entry.landed && !entry.handedBack) {
+          entry.handedBack = true;
+          returnSend(entry.typed, entry.opts);
+        }
         // The optimistic bubble goes with it. A follow-up the interrupt
         // stranded was never answered, so leaving the row posted claims the
         // agent read it — and QA saw exactly that: the text committed as a

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -1199,6 +1199,23 @@ export function createChatController(deps: ControllerDeps): ChatController {
     }
   };
 
+  /**
+   * A SEND THAT NEVER HAPPENED owes the composer back what it was carrying.
+   *
+   * `ClaudeChat.beginSend` empties the tray and parks the pictures under the
+   * very `Receipt[]` it hands down here BEFORE this function runs, so every road
+   * out of a send has to say whether it went — including the two that refuse
+   * before anything is attempted (already sending; disposed). Returning silently
+   * from those left the tray empty and the map holding the only handle to the
+   * user's pictures, which is the picture disappearing (Bugbot, PR #1064).
+   */
+  const returnSend = (text: string, opts: SendOptions): void => {
+    deps.onSendReturned?.({
+      text,
+      ...(opts.attachments ? { attachments: opts.attachments } : {}),
+    });
+  };
+
   async function sendMessage(text: string, opts: SendOptions = {}): Promise<void> {
     // DISPOSED IS A CLOSED DOOR, not a race to lose. `dispose()` is the
     // unmount, and every entry point below it emits into a store nobody reads
@@ -1206,8 +1223,16 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // SPAWN a run. Callers hold the controller across awaits by construction
     // (ClaudeChat's boot walks it), so refusing here is the one place that can
     // be sure (Bugbot, PR #1061).
-    if (disposed) return;
-    if (sending) return;
+    if (disposed) {
+      returnSend(text, opts);
+      return;
+    }
+    // ONE TURN AT A TIME, and the refused one is refused OUT LOUD: its pictures
+    // are already out of the tray by now.
+    if (sending) {
+      returnSend(text, opts);
+      return;
+    }
     sending = true;
     const seat = ++sendSeq;
     // Sampled BEFORE anything is awaited: a Back landing mid-start outdates this
@@ -1217,6 +1242,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     const blocks = opts.blocks || [];
     if (!text && !blocks.length) {
       sending = false;
+      returnSend(text, opts);
       return;
     }
     clearTrouble();
@@ -1331,7 +1357,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
         dropTurn(bubble.key);
         // ... and the attachments go back to the tray with the words, because
         // the agent never saw either (T:16693-16720).
-        deps.onSendReturned?.({ text, ...(opts.attachments ? { attachments: opts.attachments } : {}) });
+        returnSend(text, opts);
       }
       reportTrouble(troubleFromError(err));
     } finally {
@@ -1342,10 +1368,16 @@ export function createChatController(deps: ControllerDeps): ChatController {
   // ---- follow-ups (T:16024-16185) ----------------------------------------
 
   async function sendFollowUp(text: string, opts: SendOptions = {}): Promise<void> {
-    if (disposed) return;
+    if (disposed) {
+      returnSend(text, opts);
+      return;
+    }
     const gen = logGen;
     const blocks = opts.blocks || [];
-    if (!text && !blocks.length) return;
+    if (!text && !blocks.length) {
+      returnSend(text, opts);
+      return;
+    }
     // Every send carries the app state, a follow-up included: T calls
     // `appStatePush()` from `sendFollowUp` too (T:16101), and a message typed
     // three tool calls into a turn is describing a pane that has moved since
@@ -1384,7 +1416,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // The same road sendMessage takes for a run that never launched: the
       // usual way a follow-up fails is the session having already ended, and
       // the pictures the user attached deliberately are owed back (T:16080-16093).
-      deps.onSendReturned?.({ text, ...(opts.attachments ? { attachments: opts.attachments } : {}) });
+      returnSend(text, opts);
     };
 
     // `activeRun` is set synchronously the moment pollLoop is entered, but

--- a/frontend/src/apps/claude/protocol/wire.test.ts
+++ b/frontend/src/apps/claude/protocol/wire.test.ts
@@ -15,6 +15,8 @@ import {
   MARKER_IMG,
   MARKER_JOIN,
   MARKER_VIEW,
+  markerWord,
+  markerWords,
   paneShotBlock,
   paneShotIn,
   parseInbound,
@@ -111,6 +113,26 @@ describe("markers name what a wordless send carried (T:10552)", () => {
     expect(isMarkerOnly(MARKER_FILE)).toBe(true);
     expect(isMarkerOnly("")).toBe(false);
     expect(isMarkerOnly("annotations and a word")).toBe(false);
+  });
+
+  test("the WORD is not the marker: a reader who types one is not a marker send", () => {
+    // The emoji T put in front of each marker also made it a string no reader
+    // could type. Without one, "files" — an ordinary thing to say to an agent —
+    // matched, and the bubble drew an attachment icon in front of the reader's
+    // own word (Bugbot, PR #1064). Marker-ness is the private sigil, never the
+    // visible word.
+    expect(isMarkerOnly("files")).toBe(false);
+    expect(isMarkerOnly("images")).toBe(false);
+    expect(isMarkerOnly("annotations")).toBe(false);
+    expect(isMarkerOnly("pane screenshot")).toBe(false);
+    expect(isMarkerOnly("files + images")).toBe(false);
+    // The sigil is invisible, so what a marker SAYS is still the word alone.
+    expect(markerWord(MARKER_FILE)).toBe("files");
+    expect(markerWords(MARKER_ANN + MARKER_JOIN + MARKER_VIEW)).toBe(
+      "annotations" + MARKER_JOIN + "pane screenshot",
+    );
+    // …and a string that never carried one comes back untouched.
+    expect(markerWords("files")).toBe("files");
   });
 });
 

--- a/frontend/src/apps/claude/protocol/wire.test.ts
+++ b/frontend/src/apps/claude/protocol/wire.test.ts
@@ -110,7 +110,7 @@ describe("markers name what a wordless send carried (T:10552)", () => {
     expect(isMarkerOnly(MARKER_ANN + MARKER_JOIN + MARKER_VIEW)).toBe(true);
     expect(isMarkerOnly(MARKER_FILE)).toBe(true);
     expect(isMarkerOnly("")).toBe(false);
-    expect(isMarkerOnly("📌 annotations and a word")).toBe(false);
+    expect(isMarkerOnly("annotations and a word")).toBe(false);
   });
 });
 

--- a/frontend/src/apps/claude/protocol/wire.ts
+++ b/frontend/src/apps/claude/protocol/wire.ts
@@ -33,10 +33,15 @@ export const PANE_SHOT_TAG = "pane-shot";
 // ONE definition, read by both the strip that produces them and the re-attach
 // probe, which must never match a prior turn on one.
 
-export const MARKER_ANN = "📌 annotations";
-export const MARKER_VIEW = "🖼 pane screenshot";
-export const MARKER_IMG = "🖼 images";
-export const MARKER_FILE = "📄 files";
+// NO EMOJI (Akshil, 2026-09-09, P2-7). T wrote these with 📌/🖼/📄 in front of
+// the word; the icon beside a wordless send's bubble is a lucide glyph now
+// (`ui/Turn`'s marker row), and the marker itself is the WORD alone — which is
+// also what it has to be, because this string is the bubble's own text and the
+// re-attach probe matches turns on it.
+export const MARKER_ANN = "annotations";
+export const MARKER_VIEW = "pane screenshot";
+export const MARKER_IMG = "images";
+export const MARKER_FILE = "files";
 export const MARKERS: string[] = [MARKER_ANN, MARKER_VIEW, MARKER_IMG, MARKER_FILE];
 export const MARKER_JOIN = " + ";
 

--- a/frontend/src/apps/claude/protocol/wire.ts
+++ b/frontend/src/apps/claude/protocol/wire.ts
@@ -307,6 +307,48 @@ export function annotationsIn(text: string | null | undefined): AnnotationWire[]
 
 // ---- compose / strip -------------------------------------------------------
 
+/**
+ * §D'S WIRE ORDER, IN ONE PLACE. `composeOutgoing` joins whatever list it is
+ * handed, so until now the order was whatever the caller's spread happened to
+ * produce — and `{ ...opts, ...takeAttachments() }` did not produce an order at
+ * all, it REPLACED `opts.blocks` wholesale. Latent while only one owner supplied
+ * blocks; the moment PR3's `<annotations>` and PR4's `<live-app-state>` arrive in
+ * `opts.blocks` they would have been silently dropped.
+ *
+ * So every owner's blocks come through here instead: state, pane-shot,
+ * annotations — the reading order T composes them in (T:10449) — and anything
+ * unrecognised keeps its arrival order at the END rather than being dropped or
+ * pushed in front of the three that have a stated place. The sort is STABLE, so
+ * two blocks of the same kind stay in the order their owner emitted them.
+ */
+export const BLOCK_ORDER: readonly string[] = [APP_STATE_TAG, PANE_SHOT_TAG, ANN_TAG];
+
+/** Which of `BLOCK_ORDER` a composed block opens with; `BLOCK_ORDER.length` for
+ *  anything else, which is what puts it last.
+ *
+ *  ATTRIBUTES ARE ALLOWED on the opening tag. Matching a bare `<tag>` meant the
+ *  first block to carry one — `<live-app-state v="2">`, which is PR4's tag to
+ *  write — would quietly stop recognising its own name and drop to the unranked
+ *  tail, with nothing to say so: the message still goes out, just with the state
+ *  after the pictures. `[^>]*` and not `.*`, so the sniff cannot run past the end
+ *  of the tag it is reading. */
+export function blockRank(block: string): number {
+  const tag = /^<([a-z][a-z0-9-]*)(?:\s[^>]*)?>/i.exec(block.trimStart());
+  const i = tag ? BLOCK_ORDER.indexOf(tag[1].toLowerCase()) : -1;
+  return i === -1 ? BLOCK_ORDER.length : i;
+}
+
+export function composeBlocks(
+  ...groups: (readonly (string | null | undefined)[] | null | undefined)[]
+): string[] {
+  const flat: string[] = [];
+  for (const g of groups) for (const b of g ?? []) if (b) flat.push(b);
+  return flat
+    .map((block, i) => ({ block, i, rank: blockRank(block) }))
+    .sort((a, b) => a.rank - b.rank || a.i - b.i)
+    .map((e) => e.block);
+}
+
 /** T:10449 `composeOutgoing`. The blocks are pre-composed by their owners
  *  (app-state, pictures, annotations — in that order) and joined `"\n\n"` with
  *  the typed message LAST. All three strips are position-independent, so the

--- a/frontend/src/apps/claude/protocol/wire.ts
+++ b/frontend/src/apps/claude/protocol/wire.ts
@@ -35,20 +35,48 @@ export const PANE_SHOT_TAG = "pane-shot";
 
 // NO EMOJI (Akshil, 2026-09-09, P2-7). T wrote these with 📌/🖼/📄 in front of
 // the word; the icon beside a wordless send's bubble is a lucide glyph now
-// (`ui/Turn`'s marker row), and the marker itself is the WORD alone — which is
-// also what it has to be, because this string is the bubble's own text and the
-// re-attach probe matches turns on it.
-export const MARKER_ANN = "annotations";
-export const MARKER_VIEW = "pane screenshot";
-export const MARKER_IMG = "images";
-export const MARKER_FILE = "files";
+// (`ui/Turn`'s marker row).
+//
+// THE EMOJI CARRIED MORE THAN A PICTURE. It also made the marker a string no
+// reader could plausibly type, and once it went, "files" — an ordinary thing to
+// say to an agent — was indistinguishable from the substitute text a wordless
+// send gets, so `isMarkerOnly` drew an attachment icon in front of the reader's
+// own word (Bugbot, PR #1064).
+//
+// So the marker is SIGILLED: every one of these strings opens with U+2063
+// INVISIBLE SEPARATOR, and marker-ness is THE SIGIL, never the visible word. It
+// is a private token of this page's display layer — stamped only on text
+// `stripBlocks` synthesises for a bubble that had no words, never composed onto
+// the wire (nothing `composeOutgoing` writes is built out of these), and peeled
+// back off by `markerWord` for everything a human reads.
+export const MARKER_SIGIL = "\u2063";
+export const MARKER_ANN = MARKER_SIGIL + "annotations";
+export const MARKER_VIEW = MARKER_SIGIL + "pane screenshot";
+export const MARKER_IMG = MARKER_SIGIL + "images";
+export const MARKER_FILE = MARKER_SIGIL + "files";
 export const MARKERS: string[] = [MARKER_ANN, MARKER_VIEW, MARKER_IMG, MARKER_FILE];
 export const MARKER_JOIN = " + ";
 
-/** T:10539 — every `" + "`-split part is one of MARKERS (and there is text). */
+/** One marker's visible word — what a bubble, a session row and every other
+ *  human-facing label show. A string with no sigil is already its own word. */
+export function markerWord(part: string): string {
+  return part.startsWith(MARKER_SIGIL) ? part.slice(MARKER_SIGIL.length) : part;
+}
+
+/** The same for a whole `" + "`-joined run of them — and for any other string,
+ *  which comes back untouched. What a label that is not drawn part-by-part (a
+ *  session row, a heading) shows. */
+export function markerWords(text: string): string {
+  return text.split(MARKER_SIGIL).join("");
+}
+
+/** T:10539 — every `" + "`-split part is one of MARKERS (and there is text).
+ *  A sigil-free string is the reader's own words, whatever they happen to say;
+ *  U+2063 is a format character and not whitespace, so `trim` cannot eat it. */
 export function isMarkerOnly(text: string | null | undefined): boolean {
   const t = (text || "").trim();
-  return !!t && t.split(MARKER_JOIN).every((part) => MARKERS.indexOf(part) !== -1);
+  if (!t || t.indexOf(MARKER_SIGIL) === -1) return false;
+  return t.split(MARKER_JOIN).every((part) => MARKERS.indexOf(part) !== -1);
 }
 
 // ---- the pictures block ----------------------------------------------------

--- a/frontend/src/apps/claude/shots/attach.test.ts
+++ b/frontend/src/apps/claude/shots/attach.test.ts
@@ -1,0 +1,556 @@
+// The attachment rules: what a thing IS, what it is called, what rides the wire,
+// what the receipt says, which directories the send has to grant — and the one
+// remaining refusal (T:11366-11750, 7067-7120, 16519, 10855, 10903).
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { installDomShim } from "@platform/lib/testDomShim";
+
+installDomShim();
+
+// `bun test` runs every file in ONE process and these globals are shared, so
+// whatever this suite stubbed is put back the moment it is done — a leaked
+// `fetch` or `URL.createObjectURL` breaks whoever runs next (the idiom
+// platform/ui/appdoctor-lib.test.ts sets out).
+const G = globalThis as Record<string, unknown>;
+const BEFORE = {
+  fetch: G.fetch,
+  createImageBitmap: G.createImageBitmap,
+  Image: G.Image,
+  createObjectURL: URL.createObjectURL,
+  revokeObjectURL: URL.revokeObjectURL,
+};
+afterAll(() => {
+  G.fetch = BEFORE.fetch;
+  G.createImageBitmap = BEFORE.createImageBitmap;
+  G.Image = BEFORE.Image;
+  Object.assign(URL, {
+    createObjectURL: BEFORE.createObjectURL,
+    revokeObjectURL: BEFORE.revokeObjectURL,
+  });
+});
+
+const {
+  attachFile,
+  attachPaths,
+  dragHasAttachment,
+  failLabel,
+  filesFromPaste,
+  formatLabel,
+  isImage,
+  kindFor,
+  pathsFromDrop,
+  probePruned,
+  prunedLabel,
+  readDirs,
+  receiptFor,
+  receiptsFromWire,
+  revoke,
+  saveExt,
+  shotAlt,
+  shotNoun,
+  sizeLabel,
+  toWire,
+} = await import("./attach");
+const { resetShotsDirForTests } = await import("./dir");
+const { resetWebpLatchForTests, setCanvasFactory } = await import("./encode");
+const { SHOT_ATTACH_MAX_BYTES, SHOT_PATH_TYPE } = await import("./types");
+type Attachment = import("./types").Attachment;
+
+// ── the fakes ───────────────────────────────────────────────────────────────
+
+let uploads: { path: string; bytes: number }[] = [];
+let runs: Record<string, unknown>[] = [];
+let convert: Record<string, unknown> | null = null;
+let heads: string[] = [];
+let headOk = true;
+let objectUrls = 0;
+let revoked: string[] = [];
+
+/** One `fetch` for every route this module reaches: the upload, `/api/run` and
+ *  the receipt's HEAD probe. */
+function installFetch(): void {
+  Object.assign(globalThis, {
+    fetch: (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href === "/api/fs/upload") {
+        const form = init?.body as FormData;
+        const path = String(form.get("path"));
+        const file = form.get("file") as Blob;
+        uploads.push({ path, bytes: file.size });
+        return json({ path, name: path, is_dir: false, size: file.size, mtime: 0 });
+      }
+      if (href === "/api/run") {
+        const body = JSON.parse(String(init?.body)) as { params: Record<string, unknown> };
+        runs.push(body.params);
+        if (body.params.action === "shots_dir") return json({ ok: true, result: { dir: "/shots" } });
+        if (body.params.action === "image_to_png") {
+          return json({ ok: true, result: convert ?? { error: "no" } });
+        }
+        return json({ ok: true, result: {} });
+      }
+      if (init?.method === "HEAD") {
+        heads.push(href);
+        return Promise.resolve({ ok: headOk, status: headOk ? 200 : 404 } as Response);
+      }
+      throw new Error("unexpected fetch: " + href);
+    },
+  });
+}
+
+function json(body: unknown): Promise<Response> {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+}
+
+/** A canvas that always answers a small PNG: the shrink path's ladder is
+ *  encode.test.ts's subject, so here it only has to SUCCEED. */
+function installCanvas(): void {
+  setCanvasFactory(
+    () =>
+      ({
+        width: 0,
+        height: 0,
+        getContext: () => ({ drawImage: () => {} }),
+        toBlob: (cb: (b: Blob | null) => void) =>
+          cb(new Blob([new Uint8Array(1024)], { type: "image/png" })),
+      }) as unknown as HTMLCanvasElement,
+  );
+}
+
+function installUrls(): void {
+  Object.assign(URL, {
+    createObjectURL: () => "blob:fake/" + ++objectUrls,
+    revokeObjectURL: (u: string) => revoked.push(u),
+  });
+}
+
+/** A decodable picture, whatever the bytes are. */
+function installBitmap(width = 4000, height = 3000): void {
+  Object.assign(globalThis, {
+    createImageBitmap: () => Promise.resolve({ width, height, close: () => {} }),
+  });
+}
+
+function undecodable(): void {
+  Object.assign(globalThis, {
+    createImageBitmap: () => Promise.reject(new Error("format")),
+    Image: undefined,
+  });
+}
+
+function fileOf(name: string, type: string, size: number): File {
+  // `size` is what the branch reads and a real allocation of 4 MiB per test is
+  // waste, so the length is faked over one byte of content.
+  const f = new File([new Uint8Array(1)], name, { type });
+  Object.defineProperty(f, "size", { value: size });
+  return f;
+}
+
+beforeEach(() => {
+  uploads = [];
+  runs = [];
+  heads = [];
+  revoked = [];
+  convert = null;
+  headOk = true;
+  objectUrls = 0;
+  resetShotsDirForTests();
+  resetWebpLatchForTests();
+  installFetch();
+  installCanvas();
+  installUrls();
+  installBitmap();
+});
+
+// ── kinds ───────────────────────────────────────────────────────────────────
+
+describe("kindFor / isImage", () => {
+  test("type first, extension as the fallback for a typeless drag (T:11392)", () => {
+    expect(kindFor({ name: "x.bin", type: "image/png" })).toBe("image");
+    expect(kindFor({ name: "shot.PNG", type: "" })).toBe("image");
+    expect(kindFor({ name: "IMG.jpeg", type: "" })).toBe("image");
+    expect(kindFor({ name: "notes.csv", type: "text/csv" })).toBe("file");
+    expect(kindFor({ name: "Makefile", type: "" })).toBe("file");
+    expect(isImage(null)).toBe(false);
+  });
+});
+
+describe("saveExt", () => {
+  test("a picture's name follows its bytes; a file keeps its own, or none (T:11403)", () => {
+    expect(saveExt({ name: "", type: "image/png" })).toBe(".png");
+    expect(saveExt({ name: "a.jpg", type: "image/jpeg" })).toBe(".jpg");
+    expect(saveExt({ name: "dump.PARQUET", type: "" })).toBe(".parquet");
+    expect(saveExt({ name: "Makefile", type: "" })).toBe("");
+  });
+});
+
+describe("formatLabel", () => {
+  test("the word a person says (T:11416)", () => {
+    expect(formatLabel("IMG_4031.HEIC")).toBe("HEIC");
+    expect(formatLabel("a.jpg")).toBe("JPEG");
+    expect(formatLabel("a.tif")).toBe("TIFF");
+    expect(formatLabel("a.zip")).toBe("ZIP");
+    expect(formatLabel("Makefile")).toBe("that format");
+  });
+});
+
+describe("sizeLabel", () => {
+  test("undefined is an answer, not a zero (T:7092)", () => {
+    expect(sizeLabel(undefined)).toBe("");
+    expect(sizeLabel(512)).toBe("512 B");
+    expect(sizeLabel(2048)).toBe("2 KB");
+    expect(sizeLabel(3 * 1024 * 1024)).toBe("3.0 MB");
+  });
+});
+
+// ── the wire ────────────────────────────────────────────────────────────────
+
+describe("toWire", () => {
+  test("a pane shot carries kind and view, and never a name (T:16519)", () => {
+    const att: Attachment = { id: "1", kind: "pane", view: "/shots/a-view.webp", name: "nope", thumb: "blob:x", seat: "pane" };
+    expect(toWire([att])).toEqual([{ kind: "pane", view: "/shots/a-view.webp" }]);
+  });
+
+  test("an image carries name, and size only when it has one (T:16532)", () => {
+    expect(toWire([{ id: "1", kind: "image", view: "/shots/a.png", name: "a.png", thumb: "blob:x" }])).toEqual([
+      { kind: "image", view: "/shots/a.png", name: "a.png" },
+    ]);
+    expect(toWire([{ id: "1", kind: "image", view: "/shots/a.heic", name: "a.heic", size: 99 }])).toEqual([
+      { kind: "image", view: "/shots/a.heic", name: "a.heic", size: 99 },
+    ]);
+  });
+
+  test("a file carries name and size; a brought-in path has no size (T:16539)", () => {
+    expect(toWire([{ id: "1", kind: "file", view: "/w/a.csv", name: "a.csv", brought: true }])).toEqual([
+      { kind: "file", view: "/w/a.csv", name: "a.csv" },
+    ]);
+  });
+
+  test("viewNote and why both ride, and a refusal keeps view null (T:16526)", () => {
+    expect(
+      toWire([{ id: "1", kind: "image", view: null, name: "a.png", viewNote: "not attached: …", why: "could not be saved" }]),
+    ).toEqual([{ kind: "image", view: null, viewNote: "not attached: …", why: "could not be saved", name: "a.png" }]);
+  });
+
+  test("the overview is unshifted FIRST — it is the picture to read (T:16545)", () => {
+    const wire = toWire([
+      { id: "1", kind: "image", view: "/shots/a.png", name: "a.png" },
+      { id: "2", kind: "overview", view: "/shots/o-overview.webp", viewNote: "…" },
+    ]);
+    expect(wire.map((w) => w.kind)).toEqual(["overview", "image"]);
+    expect(wire[0]).toEqual({ kind: "overview", view: "/shots/o-overview.webp", viewNote: "…" });
+  });
+});
+
+// ── receipts ────────────────────────────────────────────────────────────────
+
+describe("receiptFor / failLabel", () => {
+  test("the sent labels, verbatim (T:10849)", () => {
+    const r = (att: Partial<Attachment>) =>
+      receiptFor({ id: "1", kind: "pane", view: "/shots/a", ...att } as Attachment).label;
+    expect(r({})).toBe("screenshot attached");
+    expect(r({ kind: "overview" })).toBe("annotated overview attached");
+    expect(r({ kind: "image", name: "a.png" })).toBe("image attached: a.png");
+    expect(r({ kind: "image" })).toBe("image attached");
+    expect(r({ kind: "file", name: "a.csv" })).toBe("file attached: a.csv");
+  });
+
+  test("a refusal names its cause ON the row (T:7112)", () => {
+    expect(failLabel({ kind: "image", why: "could not be saved" })).toBe("no image — could not be saved");
+    expect(failLabel({ kind: "file" })).toBe("no file");
+    expect(failLabel({ kind: "overview" })).toBe("no overview screenshot");
+    expect(failLabel({ kind: "pane" })).toBe("no pane screenshot");
+    expect(receiptFor({ id: "1", kind: "pane", view: null, why: "x" } as Attachment).label).toBe(
+      "no pane screenshot — x",
+    );
+  });
+
+  test("a FILE never gets a src — an <img> at a .csv is a broken glyph (T:10820)", () => {
+    const r = receiptFor({ id: "1", kind: "file", view: "/w/a.csv", thumb: "blob:x" } as Attachment);
+    expect(r.src).toBeUndefined();
+    expect(r.thumb).toBeUndefined();
+  });
+});
+
+describe("receiptsFromWire", () => {
+  test("a drawable picture gets src; a bare one gets a probe (T:10903)", () => {
+    const [pane, file, undec] = receiptsFromWire([
+      { kind: "pane", view: "/shots/a-view.webp" },
+      { kind: "file", view: "/w/a.csv", name: "a.csv", size: 10 },
+      { kind: "image", view: "/shots/a.heic", name: "a.heic", size: 99 },
+    ]);
+    expect(pane.src).toBe("/api/fs/raw?path=%2Fshots%2Fa-view.webp");
+    expect(pane.probe).toBeUndefined();
+    expect(file.probe).toBe("/api/fs/raw?path=%2Fw%2Fa.csv");
+    expect(file.src).toBeUndefined();
+    // An image carrying a size has no pixels this browser can draw either.
+    expect(undec.probe).toBe("/api/fs/raw?path=%2Fshots%2Fa.heic");
+    expect(undec.src).toBeUndefined();
+  });
+
+  test("a refused entry probes nothing", () => {
+    const [r] = receiptsFromWire([{ kind: "image", view: null, why: "could not be saved" }]);
+    expect(r.probe).toBeUndefined();
+    expect(r.label).toBe("no image — could not be saved");
+  });
+});
+
+describe("probePruned", () => {
+  test("a 404 on the HEAD is the pruner (T:10875)", async () => {
+    const [r] = receiptsFromWire([{ kind: "file", view: "/w/a.csv", size: 1 }]);
+    headOk = false;
+    expect(await probePruned(r)).toBe(true);
+    expect(heads).toEqual(["/api/fs/raw?path=%2Fw%2Fa.csv"]);
+    headOk = true;
+    expect(await probePruned(r)).toBe(false);
+  });
+
+  test("no probe means no request", async () => {
+    expect(await probePruned({ kind: "pane", label: "x", view: "/a" })).toBe(false);
+    expect(heads).toEqual([]);
+  });
+
+  test("the words (T:10883)", () => {
+    expect(prunedLabel("image")).toBe(" — image pruned");
+    expect(prunedLabel("file")).toBe(" — file pruned");
+  });
+});
+
+// ── nouns ───────────────────────────────────────────────────────────────────
+
+describe("shotNoun / shotAlt", () => {
+  test("one source for the chip, the viewer and the alt text (T:7067)", () => {
+    expect(shotNoun({ kind: "pane" }, "app")).toBe("app screenshot");
+    expect(shotNoun({ kind: "overview" })).toBe("annotated overview");
+    expect(shotNoun({ kind: "image" })).toBe("pasted image");
+    expect(shotNoun({ kind: "file" })).toBe("attached file");
+    expect(shotNoun({ kind: "file", name: "a.csv" })).toBe("a.csv");
+    expect(shotAlt({ kind: "pane" }, "app")).toBe("screenshot of the whole app pane");
+    expect(shotAlt({ kind: "overview" }, "app")).toBe("overview of the app pane with a badge at each comment");
+    expect(shotAlt({ kind: "image", name: "a.png" })).toBe("image attached to this message: a.png");
+  });
+});
+
+// ── real-path drags ─────────────────────────────────────────────────────────
+
+describe("attachPaths", () => {
+  test("no upload, no size, an image still gets a rawUrl thumb (T:11680)", () => {
+    const out = attachPaths("/tpl", ["/w/a.png", "/w/b.csv"]);
+    expect(uploads).toEqual([]);
+    expect(out[0]).toMatchObject({
+      kind: "image",
+      view: "/w/a.png",
+      name: "a.png",
+      brought: true,
+      thumb: "/api/fs/raw?path=%2Fw%2Fa.png",
+    });
+    expect(out[0].size).toBeUndefined();
+    expect(out[1]).toMatchObject({ kind: "file", view: "/w/b.csv", brought: true });
+    expect(out[1].thumb).toBeUndefined();
+  });
+});
+
+describe("readDirs", () => {
+  test("deduped, and the shots dir is excluded — it is already granted (T:11698)", () => {
+    const atts = [
+      { view: "/shots/a-view.webp" },
+      { view: "/w/one/a.csv" },
+      { view: "/w/one/b.csv" },
+      { view: "/w/two/c.csv" },
+      { view: null },
+    ];
+    expect(readDirs(atts, "/shots")).toEqual(["/w/one", "/w/two"]);
+    // With no dir known yet, one redundant Read rule is the worst it costs.
+    expect(readDirs(atts, "")).toEqual(["/shots", "/w/one", "/w/two"]);
+  });
+});
+
+// ── DataTransfer reading ────────────────────────────────────────────────────
+
+describe("dragHasAttachment / pathsFromDrop / filesFromPaste", () => {
+  const dt = (types: string[], data?: string, throws = false): DataTransfer =>
+    ({
+      types,
+      getData: () => {
+        if (throws) throw new Error("no");
+        return data ?? "";
+      },
+      files: [],
+    }) as unknown as DataTransfer;
+
+  test("either payload answers yes (T:11742)", () => {
+    expect(dragHasAttachment(dt(["Files"]))).toBe(true);
+    expect(dragHasAttachment(dt([SHOT_PATH_TYPE]))).toBe(true);
+    expect(dragHasAttachment(dt(["text/plain"]))).toBe(false);
+    expect(dragHasAttachment(null)).toBe(false);
+  });
+
+  test("newline-joined, trimmed, blanks dropped (T:11665)", () => {
+    expect(pathsFromDrop(dt([SHOT_PATH_TYPE], "/w/a.csv\n  /w/b.csv  \n\n"))).toEqual([
+      "/w/a.csv",
+      "/w/b.csv",
+    ]);
+    expect(pathsFromDrop(dt(["Files"], "/w/a.csv"))).toEqual([]);
+    expect(pathsFromDrop(dt([SHOT_PATH_TYPE], "", true))).toEqual([]);
+  });
+
+  test("a paste of only words falls through untouched (T:11719)", () => {
+    expect(filesFromPaste({ clipboardData: dt(["text/plain"]) })).toEqual([]);
+    expect(filesFromPaste({})).toEqual([]);
+  });
+});
+
+// ── revoke ──────────────────────────────────────────────────────────────────
+
+describe("revoke", () => {
+  test("idempotent, and only ever an object URL (T:10645)", () => {
+    const att: Attachment = { id: "1", kind: "pane", view: "/a", thumb: "blob:one" };
+    revoke(att);
+    revoke(att);
+    revoke(null);
+    expect(revoked).toEqual(["blob:one"]);
+    expect(att.thumb).toBe("");
+    // A rawUrl thumb is not an object URL: the same call is safe and does nothing.
+    const brought: Attachment = { id: "2", kind: "image", view: "/w/a.png", thumb: "/api/fs/raw?path=x" };
+    revoke(brought);
+    expect(revoked).toEqual(["blob:one"]);
+  });
+});
+
+// ── the one refusal, and the downscale trigger ──────────────────────────────
+
+describe("attachFile", () => {
+  test("a small picture goes up whole, with a thumb and no size (T:11597)", async () => {
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", 1000));
+    expect(uploads.length).toBe(1);
+    expect(uploads[0].path).toMatch(/^\/shots\/\d{14}-[0-9a-f]{8}\.png$/);
+    expect(att.thumb).toBe("blob:fake/1");
+    expect(att.size).toBeUndefined();
+    expect(att.viewNote).toBeUndefined();
+  });
+
+  test("EXACTLY 4 MiB is not over: the trigger is strict (T:11355)", async () => {
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES));
+    expect(att.viewNote).toBeUndefined();
+    expect(uploads[0].bytes).toBe(1); // the original blob, not a re-encode
+  });
+
+  test("one byte over downscales, and says so verbatim (T:11573)", async () => {
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1));
+    expect(att.viewNote).toBe("downscaled from 4000×3000 to 1600×1200 for the agent's read (4.0 MB → 1 KB)");
+    // The extension follows the ENCODER's bytes once it was re-encoded.
+    expect(uploads[0].path).toMatch(/\.png$/);
+    expect(uploads[0].bytes).toBe(1024);
+  });
+
+  test("THE DECODE IS RELEASED EVEN WHEN THE SIZE LADDER THROWS", async () => {
+    // `shotPixels` hands back a full-size decode — a bitmap, or an `<img>` over
+    // an object URL — and `drawImage` on a tainted or zero-dimension canvas
+    // THROWS. Released in the branch's last statement rather than a `finally`,
+    // that throw pinned the whole decode for the life of the page, and the
+    // caller sees only the rejection.
+    let closed = 0;
+    Object.assign(globalThis, {
+      createImageBitmap: () =>
+        Promise.resolve({
+          width: 4000,
+          height: 3000,
+          close: () => {
+            closed++;
+          },
+        }),
+    });
+    setCanvasFactory(
+      () =>
+        ({
+          width: 0,
+          height: 0,
+          getContext: () => ({
+            drawImage: () => {
+              throw new Error("tainted");
+            },
+          }),
+        }) as unknown as HTMLCanvasElement,
+    );
+    await expect(
+      attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1)),
+    ).rejects.toThrow("tainted");
+    expect(closed).toBe(1);
+    // Nothing was written either: the throw is before the upload.
+    expect(uploads).toEqual([]);
+  });
+
+  test("and the <img> road's object URL goes with it", async () => {
+    // The other half of `shotPixels`: no `createImageBitmap`, so the decode is an
+    // `<img>` over an object URL and `free()` is a `revokeObjectURL`. Same
+    // `finally`, observable end.
+    Object.assign(globalThis, {
+      createImageBitmap: undefined,
+      Image: class {
+        naturalWidth = 4000;
+        naturalHeight = 3000;
+        src = "";
+        decode(): Promise<void> {
+          return Promise.resolve();
+        }
+      },
+    });
+    setCanvasFactory(
+      () =>
+        ({
+          width: 0,
+          height: 0,
+          getContext: () => ({
+            drawImage: () => {
+              throw new Error("tainted");
+            },
+          }),
+        }) as unknown as HTMLCanvasElement,
+    );
+    await expect(
+      attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1)),
+    ).rejects.toThrow("tainted");
+    expect(revoked).toEqual(["blob:fake/1"]);
+  });
+
+  test("an undecodable picture is converted server-side, and becomes drawable (T:11574)", async () => {
+    undecodable();
+    convert = { path: "/shots/a.png", width: 800, height: 600, source_w: 4032, source_h: 3024 };
+    const att = await attachFile("/tpl", fileOf("IMG.HEIC", "image/heic", 5000));
+    expect(runs.some((r) => r.action === "image_to_png")).toBe(true);
+    expect(att.view).toBe("/shots/a.png");
+    expect(att.thumb).toBe("/api/fs/raw?path=%2Fshots%2Fa.png");
+    expect(att.size).toBeUndefined();
+    expect(att.viewNote).toBe(
+      "converted from HEIC to PNG on the server (4032×3024 → 800×600) because neither the browser nor the agent can read that format",
+    );
+  });
+
+  test("a conversion that also fails says the true thing, with bytes and a size (T:11588)", async () => {
+    undecodable();
+    convert = null;
+    const att = await attachFile("/tpl", fileOf("IMG.HEIC", "image/heic", 5000));
+    expect(att.kind).toBe("image");
+    expect(att.size).toBe(5000);
+    expect(att.thumb).toBeUndefined();
+    expect(att.viewNote).toBe(
+      "attached as bytes: this browser cannot decode IMG.HEIC and the server could not convert it either, so the agent probably cannot read this format — say so rather than guessing at the pixels",
+    );
+  });
+
+  test("a file rides whole, with a size and no thumb, and no size refusal (D615)", async () => {
+    const att = await attachFile("/tpl", fileOf("dump.parquet", "", 40 * 1024 * 1024));
+    expect(att.kind).toBe("file");
+    expect(att.size).toBe(40 * 1024 * 1024);
+    expect(att.thumb).toBeUndefined();
+    expect(uploads[0].path).toMatch(/\.parquet$/);
+  });
+
+  test("THE ONE REFUSAL: an upload that failed (T:11611)", async () => {
+    Object.assign(globalThis, {
+      fetch: () => Promise.reject(new Error("readonly")),
+    });
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", 10));
+    expect(att.view).toBeNull();
+    expect(att.why).toBe("could not be saved");
+    expect(att.viewNote).toBe("not attached: it could not be saved (readonly)");
+  });
+});

--- a/frontend/src/apps/claude/shots/attach.test.ts
+++ b/frontend/src/apps/claude/shots/attach.test.ts
@@ -171,6 +171,20 @@ describe("kindFor / isImage", () => {
     expect(kindFor({ name: "Makefile", type: "" })).toBe("file");
     expect(isImage(null)).toBe(false);
   });
+
+  // Bugbot, PR #1064. Safari drops the MIME on a drag, and HEIC is the one
+  // format on this machine that NEEDS the server's converter — classified a
+  // `file` it never reached the decode that asks for it.
+  test("a typeless HEIC/HEIF/TIFF is a picture, not a file (Bugbot, PR #1064)", () => {
+    expect(kindFor({ name: "IMG_4031.HEIC", type: "" })).toBe("image");
+    expect(kindFor({ name: "IMG_4031.heic", type: "" })).toBe("image");
+    expect(kindFor({ name: "scan.heif", type: "" })).toBe("image");
+    expect(kindFor({ name: "scan.tif", type: "" })).toBe("image");
+    expect(kindFor({ name: "scan.TIFF", type: "" })).toBe("image");
+    // …and the neighbours a loose regex would swallow are still files.
+    expect(kindFor({ name: "notes.heicx", type: "" })).toBe("file");
+    expect(kindFor({ name: "a.tiffany", type: "" })).toBe("file");
+  });
 });
 
 describe("saveExt", () => {
@@ -554,6 +568,22 @@ describe("attachFile", () => {
     expect(att.view).toBe("/shots/a.png");
     expect(att.thumb).toBe("/api/fs/raw?path=%2Fshots%2Fa.png");
     expect(att.size).toBeUndefined();
+    expect(att.viewNote).toBe(
+      "converted from HEIC to PNG on the server (4032×3024 → 800×600) because neither the browser nor the agent can read that format",
+    );
+  });
+
+  test("a TYPELESS HEIC takes the same road — decode, fail, convert (Bugbot, PR #1064)", async () => {
+    // The Safari drag: no MIME at all, so only the extension says "picture".
+    undecodable();
+    convert = { path: "/shots/a.png", width: 800, height: 600, source_w: 4032, source_h: 3024 };
+    const att = await attachFile("/tpl", fileOf("IMG_4031.HEIC", "", 5000));
+    expect(att.kind).toBe("image");
+    // The copy on disk keeps the extension the bytes actually are…
+    expect(uploads[0].path).toMatch(/\.heic$/);
+    // …and the server was asked, which is the whole point.
+    expect(runs.some((r) => r.action === "image_to_png")).toBe(true);
+    expect(att.view).toBe("/shots/a.png");
     expect(att.viewNote).toBe(
       "converted from HEIC to PNG on the server (4032×3024 → 800×600) because neither the browser nor the agent can read that format",
     );

--- a/frontend/src/apps/claude/shots/attach.test.ts
+++ b/frontend/src/apps/claude/shots/attach.test.ts
@@ -52,7 +52,7 @@ const {
 } = await import("./attach");
 const { resetShotsDirForTests } = await import("./dir");
 const { resetWebpLatchForTests, setCanvasFactory } = await import("./encode");
-const { SHOT_ATTACH_MAX_BYTES, SHOT_PATH_TYPE } = await import("./types");
+const { SHOT_PATH_TYPE } = await import("./types");
 type Attachment = import("./types").Attachment;
 
 // ── the fakes ───────────────────────────────────────────────────────────────
@@ -429,7 +429,7 @@ describe("revoke", () => {
   });
 });
 
-// ── the one refusal, and the downscale trigger ──────────────────────────────
+// ── the one refusal, and NO CAP OF ANY KIND (P2-6) ─────────────────────────
 
 describe("attachFile", () => {
   test("a small picture goes up whole, with a thumb and no size (T:11597)", async () => {
@@ -441,31 +441,46 @@ describe("attachFile", () => {
     expect(att.viewNote).toBeUndefined();
   });
 
-  test("EXACTLY 4 MiB is not over: the trigger is strict (T:11355)", async () => {
-    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES));
-    expect(att.viewNote).toBeUndefined();
-    expect(uploads[0].bytes).toBe(1); // the original blob, not a re-encode
-  });
-
-  test("one byte over downscales, and says so verbatim (T:11573)", async () => {
-    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1));
-    expect(att.viewNote).toBe("downscaled from 4000×3000 to 1600×1200 for the agent's read (4.0 MB → 1 KB)");
-    // The extension follows the ENCODER's bytes once it was re-encoded.
+  test("A HUGE PICTURE GOES UP UNTOUCHED — no cap, no downscale (P2-6)", async () => {
+    // T re-encoded anything over 4 MiB before the upload (T:11355) on the
+    // argument that the number is about the agent's read of the pixels. Akshil,
+    // 2026-09-09: "any and every file, size and type must not matter" — so the
+    // bytes someone attached are the bytes that go up, whatever the size, and
+    // nothing claims to have changed them.
+    Object.assign(globalThis, {
+      createImageBitmap: () => Promise.resolve({ width: 8000, height: 6000, close: () => {} }),
+    });
+    const att = await attachFile("/tpl", fileOf("huge.png", "image/png", 80 * 1024 * 1024));
+    expect(uploads.length).toBe(1);
+    // The FILE'S own extension, because the file itself is what was copied.
     expect(uploads[0].path).toMatch(/\.png$/);
-    expect(uploads[0].bytes).toBe(1024);
+    expect(uploads[0].bytes).toBe(1);
+    expect(att.view).toBe(uploads[0].path);
+    expect(att.viewNote).toBeUndefined();
+    expect(att.why).toBeUndefined();
+    // Still drawable, so still a thumb and no size (T:11597).
+    expect(att.thumb).toBe("blob:fake/1");
+    expect(att.size).toBeUndefined();
   });
 
-  test("A DOWNSCALE THAT THROWS UPLOADS THE ORIGINAL BYTES, and releases the decode", async () => {
-    // `shotPixels` hands back a full-size decode — a bitmap, or an `<img>` over
-    // an object URL — and `drawImage` on a tainted or zero-dimension canvas
-    // THROWS. That throw used to escape `attachFile` outright: the tray then
-    // removed the placeholder with no chip in its place, and a picture the user
-    // dropped vanished with no answer (Bugbot, PR #1064).
-    //
-    // THE DOWNSCALE IS A TRIGGER, NOT A GATE (T:11518) — the 4 MiB number is
-    // about the agent's read of the pixels, never about whether the picture may
-    // be attached — so the original bytes go up instead. And the decode is still
-    // released, which is what the `finally` was put there for.
+  test("A 60 MB ZIP is attached like anything else — no type gate either (P2-6)", async () => {
+    const att = await attachFile("/tpl", fileOf("dump.zip", "application/zip", 60 * 1024 * 1024));
+    expect(att.kind).toBe("file");
+    expect(att.view).toBe(uploads[0].path);
+    expect(uploads[0].path).toMatch(/\.zip$/);
+    expect(att.why).toBeUndefined();
+    expect(att.viewNote).toBeUndefined();
+    // No pixels to look at, so the chip gets a size instead of a thumb.
+    expect(att.size).toBe(60 * 1024 * 1024);
+    expect(att.thumb).toBeUndefined();
+  });
+
+  test("THE DECODE IS STILL RELEASED — it happened only to learn `pic`", async () => {
+    // `shotPixels` hands back a full-size decode (a bitmap, or an `<img>` over an
+    // object URL) and the only question asked of it is whether a 22px view would
+    // show anything. Nothing is drawn from it any more, so there is nothing left
+    // that can throw — but the handle still has to be let go of, or a full-size
+    // decode is pinned for the life of the page.
     let closed = 0;
     Object.assign(globalThis, {
       createImageBitmap: () =>
@@ -477,59 +492,14 @@ describe("attachFile", () => {
           },
         }),
     });
-    setCanvasFactory(
-      () =>
-        ({
-          width: 0,
-          height: 0,
-          getContext: () => ({
-            drawImage: () => {
-              throw new Error("tainted");
-            },
-          }),
-        }) as unknown as HTMLCanvasElement,
-    );
-    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1));
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", 9 * 1024 * 1024));
     expect(closed).toBe(1);
-    // The file's own bytes, under the file's own extension — nothing was
-    // re-encoded, so there is no note claiming it was.
-    expect(uploads.length).toBe(1);
-    expect(uploads[0].path).toMatch(/\.png$/);
-    expect(uploads[0].bytes).toBe(1);
     expect(att.view).toBe(uploads[0].path);
-    expect(att.why).toBeUndefined();
-    expect(att.viewNote).toBeUndefined();
   });
 
-  test("...and if the upload of those bytes fails too, THEN it is the refusal chip", async () => {
-    // The one refusal left in this function, reached through the downscale road:
-    // never a throw, always a chip that says what happened.
-    Object.assign(globalThis, {
-      createImageBitmap: () => Promise.resolve({ width: 4000, height: 3000, close: () => {} }),
-    });
-    setCanvasFactory(
-      () =>
-        ({
-          width: 0,
-          height: 0,
-          getContext: () => ({
-            drawImage: () => {
-              throw new Error("tainted");
-            },
-          }),
-        }) as unknown as HTMLCanvasElement,
-    );
-    Object.assign(globalThis, { fetch: () => Promise.reject(new Error("readonly")) });
-    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1));
-    expect(att.view).toBeNull();
-    expect(att.why).toBe("could not be saved");
-    expect(att.viewNote).toBe("not attached: it could not be saved (readonly)");
-  });
-
-  test("and the <img> road's object URL goes with the same fallback", async () => {
+  test("and the <img> road's object URL is revoked the same way", async () => {
     // The other half of `shotPixels`: no `createImageBitmap`, so the decode is an
-    // `<img>` over an object URL and `free()` is a `revokeObjectURL`. Same
-    // `finally`, observable end.
+    // `<img>` over an object URL and `free()` is a `revokeObjectURL`.
     Object.assign(globalThis, {
       createImageBitmap: undefined,
       Image: class {
@@ -541,23 +511,18 @@ describe("attachFile", () => {
         }
       },
     });
-    setCanvasFactory(
-      () =>
-        ({
-          width: 0,
-          height: 0,
-          getContext: () => ({
-            drawImage: () => {
-              throw new Error("tainted");
-            },
-          }),
-        }) as unknown as HTMLCanvasElement,
-    );
-    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1));
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", 9 * 1024 * 1024));
     expect(revoked).toEqual(["blob:fake/1"]);
-    // Same fallback, and the picture is still attached.
     expect(att.view).toBe(uploads[0].path);
     expect(uploads[0].bytes).toBe(1);
+  });
+
+  test("an upload that FAILS is still the one refusal — a chip, never a throw", async () => {
+    Object.assign(globalThis, { fetch: () => Promise.reject(new Error("readonly")) });
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", 1000));
+    expect(att.view).toBeNull();
+    expect(att.why).toBe("could not be saved");
+    expect(att.viewNote).toBe("not attached: it could not be saved (readonly)");
   });
 
   test("an undecodable picture is converted server-side, and becomes drawable (T:11574)", async () => {

--- a/frontend/src/apps/claude/shots/attach.test.ts
+++ b/frontend/src/apps/claude/shots/attach.test.ts
@@ -441,12 +441,17 @@ describe("attachFile", () => {
     expect(uploads[0].bytes).toBe(1024);
   });
 
-  test("THE DECODE IS RELEASED EVEN WHEN THE SIZE LADDER THROWS", async () => {
+  test("A DOWNSCALE THAT THROWS UPLOADS THE ORIGINAL BYTES, and releases the decode", async () => {
     // `shotPixels` hands back a full-size decode — a bitmap, or an `<img>` over
     // an object URL — and `drawImage` on a tainted or zero-dimension canvas
-    // THROWS. Released in the branch's last statement rather than a `finally`,
-    // that throw pinned the whole decode for the life of the page, and the
-    // caller sees only the rejection.
+    // THROWS. That throw used to escape `attachFile` outright: the tray then
+    // removed the placeholder with no chip in its place, and a picture the user
+    // dropped vanished with no answer (Bugbot, PR #1064).
+    //
+    // THE DOWNSCALE IS A TRIGGER, NOT A GATE (T:11518) — the 4 MiB number is
+    // about the agent's read of the pixels, never about whether the picture may
+    // be attached — so the original bytes go up instead. And the decode is still
+    // released, which is what the `finally` was put there for.
     let closed = 0;
     Object.assign(globalThis, {
       createImageBitmap: () =>
@@ -470,15 +475,44 @@ describe("attachFile", () => {
           }),
         }) as unknown as HTMLCanvasElement,
     );
-    await expect(
-      attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1)),
-    ).rejects.toThrow("tainted");
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1));
     expect(closed).toBe(1);
-    // Nothing was written either: the throw is before the upload.
-    expect(uploads).toEqual([]);
+    // The file's own bytes, under the file's own extension — nothing was
+    // re-encoded, so there is no note claiming it was.
+    expect(uploads.length).toBe(1);
+    expect(uploads[0].path).toMatch(/\.png$/);
+    expect(uploads[0].bytes).toBe(1);
+    expect(att.view).toBe(uploads[0].path);
+    expect(att.why).toBeUndefined();
+    expect(att.viewNote).toBeUndefined();
   });
 
-  test("and the <img> road's object URL goes with it", async () => {
+  test("...and if the upload of those bytes fails too, THEN it is the refusal chip", async () => {
+    // The one refusal left in this function, reached through the downscale road:
+    // never a throw, always a chip that says what happened.
+    Object.assign(globalThis, {
+      createImageBitmap: () => Promise.resolve({ width: 4000, height: 3000, close: () => {} }),
+    });
+    setCanvasFactory(
+      () =>
+        ({
+          width: 0,
+          height: 0,
+          getContext: () => ({
+            drawImage: () => {
+              throw new Error("tainted");
+            },
+          }),
+        }) as unknown as HTMLCanvasElement,
+    );
+    Object.assign(globalThis, { fetch: () => Promise.reject(new Error("readonly")) });
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1));
+    expect(att.view).toBeNull();
+    expect(att.why).toBe("could not be saved");
+    expect(att.viewNote).toBe("not attached: it could not be saved (readonly)");
+  });
+
+  test("and the <img> road's object URL goes with the same fallback", async () => {
     // The other half of `shotPixels`: no `createImageBitmap`, so the decode is an
     // `<img>` over an object URL and `free()` is a `revokeObjectURL`. Same
     // `finally`, observable end.
@@ -505,10 +539,11 @@ describe("attachFile", () => {
           }),
         }) as unknown as HTMLCanvasElement,
     );
-    await expect(
-      attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1)),
-    ).rejects.toThrow("tainted");
+    const att = await attachFile("/tpl", fileOf("a.png", "image/png", SHOT_ATTACH_MAX_BYTES + 1));
     expect(revoked).toEqual(["blob:fake/1"]);
+    // Same fallback, and the picture is still attached.
+    expect(att.view).toBe(uploads[0].path);
+    expect(uploads[0].bytes).toBe(1);
   });
 
   test("an undecodable picture is converted server-side, and becomes drawable (T:11574)", async () => {

--- a/frontend/src/apps/claude/shots/attach.ts
+++ b/frontend/src/apps/claude/shots/attach.ts
@@ -1,0 +1,659 @@
+// FROM A GESTURE TO AN ATTACHMENT (T:11258-11750, 7067-7215, 10645, 10855,
+// 10903, 16519).
+//
+// Four gestures, one pipeline: the camera (`attachPane`), a paste or a drop of
+// BYTES (`attachFiles`), a drag from inside fused-render that carried a real
+// PATH (`attachPaths`), and the send-time badged overview (`attachOverview`).
+// All four land in the shots directory, wear a chip, open the same viewer, ride
+// the same `<pane-shot>` block and leave the same receipt — which is the whole
+// design: that directory is already the one path `--allowed-tools` pre-approves a
+// `Read` of, already pruned (12h/200 files), already served back through
+// `/api/fs/raw` for a restored turn.
+//
+// Nothing here throws for a reason the user could act on. Every refusal becomes
+// an attachment carrying its own `why`, so nothing the user gestured at
+// disappears without an answer — and since D615 exactly ONE thing still refuses:
+// an upload that failed.
+import { rawUrl, uploadFile } from "@platform/lib/api";
+import { runAgent } from "../protocol/agent";
+import type { PaneShotWire } from "../protocol/wire";
+import { capturePane, captureOverview, type CaptureOptions } from "./capture";
+import { viewNoteFrom } from "./dom-capture";
+import { shotExt, shotPixels, shrink } from "./encode";
+import {
+  SHOT_MIME_EXT,
+  SHOT_SUFFIX_OVERVIEW,
+  SHOT_SUFFIX_VIEW,
+  shotBase,
+  shotDirOf,
+  shotFileExt,
+  shotJoin,
+  shotStamp,
+  shotsDir,
+  shotsDirSeen,
+} from "./dir";
+import {
+  SHOT_ATTACH_MAX_BYTES,
+  SHOT_PATH_TYPE,
+  type Attachment,
+  type PaneShotEntry,
+  type Receipt,
+  type ShotBadge,
+  type ShotKind,
+} from "./types";
+
+// ── what it IS (T:11366-11430) ──────────────────────────────────────────────
+
+/** Anything with the two fields the kind rules read. A `File` is one; so is the
+ *  `{name, type:""}` a real-path drag synthesises (T:11683). */
+export interface NamedBlob {
+  name?: string;
+  type?: string;
+}
+
+/** Whether this file is a picture at all. `type` first because it is what the
+ *  clipboard supplies and what the browser sniffed; the extension is the fallback
+ *  for a drag whose source gave no type. It no longer decides whether the
+ *  attachment HAPPENS — every file type is accepted now (T:11392). */
+export function isImage(file: NamedBlob | null | undefined): boolean {
+  if (!file) return false;
+  if ((file.type || "").slice(0, 6) === "image/") return true;
+  return /\.(png|jpe?g|webp|gif|bmp|avif)$/i.test(file.name || "");
+}
+
+/** WHAT the attachment will be called on the wire (T:11366). */
+export function kindFor(file: NamedBlob): ShotKind {
+  return isImage(file) ? "image" : "file";
+}
+
+/** What to call the COPY on disk. A picture's name follows its BYTES, because a
+ *  clipboard image arrives with no filename and an agent Reading a `.png` that
+ *  holds JPEG bytes gets a file it cannot open. A file keeps its own extension
+ *  verbatim, and keeps NONE when it has none — the `.png` fallback that is right
+ *  for a nameless blob would be a lie about a Makefile (T:11403). */
+export function saveExt(file: NamedBlob): string {
+  if (isImage(file)) return shotFileExt(file.type, file.name);
+  const n = file.name || "";
+  const dot = n.lastIndexOf(".");
+  return dot > 0 ? n.slice(dot).toLowerCase() : "";
+}
+
+/** The FORMAT a name or path claims, spelled the way a person says it. Only ever
+ *  used in the sentence a converted attachment wears, and that sentence has to
+ *  name the format the user recognises: they dropped `IMG_4031.HEIC`, so
+ *  "converted from HEIC" is checkable against the chip next to it (T:11416). */
+export function formatLabel(name: string | null | undefined): string {
+  const s = String(name || "");
+  const dot = s.lastIndexOf(".");
+  const ext = dot > 0 ? s.slice(dot + 1).toLowerCase() : "";
+  const long: Record<string, string> = {
+    jpg: "JPEG",
+    jpeg: "JPEG",
+    tif: "TIFF",
+    tiff: "TIFF",
+    heic: "HEIC",
+    heif: "HEIF",
+  };
+  return long[ext] || (ext ? ext.toUpperCase() : "that format");
+}
+
+// ── the words (T:7067-7120) ─────────────────────────────────────────────────
+
+/** What one attachment IS, in the words the chip, the viewer and the alt text all
+ *  use. ONE place, because a pasted image called "preview screenshot" in the
+ *  receipt is a receipt that describes the wrong thing (T:7067). */
+export function shotNoun(att: Pick<Attachment, "kind" | "name"> | null, paneNoun = "preview"): string {
+  if (!att) return "picture";
+  if (att.kind === "image") return att.name || "pasted image";
+  if (att.kind === "file") return att.name || "attached file";
+  if (att.kind === "overview") return "annotated overview";
+  return paneNoun + " screenshot";
+}
+
+/** The alt text / aria label (T:7075). */
+export function shotAlt(att: Pick<Attachment, "kind" | "name"> | null, paneNoun = "preview"): string {
+  if (att && att.kind === "image") {
+    return "image attached to this message" + (att.name ? ": " + att.name : "");
+  }
+  if (att && att.kind === "file") {
+    return "file attached to this message" + (att.name ? ": " + att.name : "");
+  }
+  if (att && att.kind === "overview") {
+    return "overview of the " + paneNoun + " pane with a badge at each comment";
+  }
+  return "screenshot of the whole " + paneNoun + " pane";
+}
+
+/** How big it is, in the one unit a reader can act on — only ever shown for a
+ *  FILE. `undefined` is a real and ordinary answer: an attachment that came in as
+ *  a PATH has no size to report, and inventing "0 KB" for it would read as an
+ *  empty file (T:7092). */
+export function sizeLabel(bytes: number | undefined): string {
+  if (typeof bytes !== "number" || !isFinite(bytes) || bytes < 0) return "";
+  if (bytes < 1024) return bytes + " B";
+  if (bytes < 1024 * 1024) return Math.round(bytes / 1024) + " KB";
+  return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+}
+
+/** What a REFUSED attachment says, on the row, in both places one is drawn (the
+ *  pending chip and the sent receipt). ONE function because the two used to spell
+ *  it differently ("image failed" against "no image"), which made a receipt look
+ *  like a different event from the chip it replaced. `why` is ONE SHORT CLAUSE so
+ *  it fits on the row; the full sentence stays in the title and the viewer's note
+ *  line (T:7112). */
+export function failLabel(att: Pick<Attachment, "kind" | "why">): string {
+  const what =
+    att.kind === "image"
+      ? "no image"
+      : att.kind === "file"
+        ? "no file"
+        : att.kind === "overview"
+          ? "no overview screenshot"
+          : "no pane screenshot";
+  return att.why ? what + " — " + att.why : what;
+}
+
+// ── the camera and the overview (T:10088, 10127) ────────────────────────────
+
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+/** One picture of the whole visible pane, uploaded, as an Attachment — or one
+ *  with `view: null` naming what stopped it. The pane SEAT is unique (a second
+ *  click replaces the first, T:11309): that is the tray's swap to make, so this
+ *  only marks the seat (T:10088, 11258). */
+export async function attachPane(
+  agentDir: string,
+  frame: HTMLIFrameElement | null,
+  opts: CaptureOptions = {},
+): Promise<Attachment> {
+  const dir = beginShotsDir(agentDir);
+  const shot = await capturePane(frame, opts);
+  return uploadCapture(agentDir, shot, "pane", SHOT_SUFFIX_VIEW, dir);
+}
+
+/** T:10083 asks `shotDirPath()` BEFORE `shotPane()`, so an unresolvable shots
+ *  dir costs nothing. Here it is started ALONGSIDE the capture instead: the
+ *  round trip overlaps the style walk in the ordinary case, and the dead-dir
+ *  case still ends in the chip T's own upload failure ends in ("it could not be
+ *  saved"), rather than trading that sentence for a serialized request on every
+ *  capture. Rejections are parked here so the in-flight promise cannot become an
+ *  unhandled rejection while the capture is still running; `uploadCapture`
+ *  awaits it inside its own try. */
+function beginShotsDir(agentDir: string): Promise<string> {
+  const p = shotsDir(agentDir);
+  p.catch(() => {});
+  return p;
+}
+
+/**
+ * The send-time overview: ONE whole-pane screenshot with a red letter badge
+ * burned in at each note's spot (T:10127).
+ *
+ * EXPORTED BUT UNWIRED, AND DELIBERATELY PR3's. Nothing in PR2 has notes to
+ * badge, so there is no caller — and the seam it still needs belongs with the
+ * caller rather than here: T's failed-send path revokes the OVERVIEW while
+ * keeping the user's own pictures (T:16698-16708), because the overview is the
+ * page's own picture of a pane that has since moved on, where a picture the user
+ * attached may not be retakeable. `ClaudeChat`'s `onSendReturned` hands the
+ * whole tray back today, which is right for a tray that only ever holds the
+ * user's; the asymmetry arrives with the first overview and is PR3's to land
+ * with it.
+ */
+export async function attachOverview(
+  agentDir: string,
+  frame: HTMLIFrameElement | null,
+  badges: ShotBadge[],
+  opts: CaptureOptions = {},
+): Promise<Attachment> {
+  const dir = beginShotsDir(agentDir);
+  const shot = await captureOverview(frame, badges, opts);
+  return uploadCapture(agentDir, shot, "overview", SHOT_SUFFIX_OVERVIEW, dir);
+}
+
+async function uploadCapture(
+  agentDir: string,
+  shot: Awaited<ReturnType<typeof capturePane>>,
+  kind: ShotKind,
+  suffix: string,
+  dirp?: Promise<string>,
+): Promise<Attachment> {
+  const att: Attachment = { id: newId(), kind, view: null };
+  if (kind === "pane") att.seat = "pane";
+  if (!shot.blob) {
+    // A failed capture still becomes a chip, and still rides the message:
+    // degrading to "no image" is right, degrading to "no evidence anything was
+    // asked for" is the silent-failure shape (T:11305).
+    att.viewNote = shot.why;
+    return att;
+  }
+  try {
+    const dir = await (dirp ?? shotsDir(agentDir));
+    const path = shotJoin(dir, shotStamp() + suffix + shotExt(shot.blob));
+    await uploadFile(path, shot.blob, shotBase(path));
+    att.view = path;
+    if (shot.thumb) att.thumb = shot.thumb;
+    // Never suppressed for a blank canvas, only annotated: the caveat rides
+    // beside the real picture (T:10104).
+    const caveats = viewNoteFrom(shot.notes, shot.incomplete ?? false);
+    if (caveats) att.viewNote = caveats;
+    return att;
+  } catch (err) {
+    // The bytes never landed, so the thumbnail is a handle to a Blob nothing will
+    // ever show — released here, since no chip is going to hold it.
+    att.thumb = shot.thumb;
+    revoke(att);
+    att.thumb = undefined;
+    att.view = null;
+    att.why = "could not be saved";
+    att.viewNote = "not attached: it could not be saved (" + message(err) + ")";
+    return att;
+  }
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ── pasted and dropped BYTES (T:11530-11628) ────────────────────────────────
+
+/** Take one thing the user brought in. Never throws.
+ *
+ *  AN OVERSIZE PICTURE IS RESIZED, NOT REFUSED (D615): the 4 MiB number was
+ *  never about the disk, it is about the agent's read of the pixels, and a
+ *  picture too big for it is one downscale away from being exactly as useful.
+ *  There is no cap at all behind it for a file or an undecodable image (D612). */
+export async function attachFile(agentDir: string, file: File): Promise<Attachment> {
+  const kind = kindFor(file);
+  const name = file.name || (kind === "image" ? "pasted image" : "attached file");
+  // What actually gets written, what the chip says happened to it, and whether a
+  // 22px view of it would show anything. Decided in this order because each
+  // answer feeds the next (T:11549).
+  let blob: Blob = file;
+  let note = "";
+  let pic = kind === "image";
+  let undecodable = false;
+  if (kind === "image") {
+    const pix = await shotPixels(file);
+    if (!pix) {
+      // Still attached, and still called an image — but the note is NOT written
+      // here, because what it should say is not known yet: the server gets asked
+      // for a PNG after the upload (T:11554).
+      pic = false;
+      undecodable = true;
+    } else {
+      // `pix` holds an object URL the <img> road minted, and `shrink`/`encode`
+      // can THROW — `drawImage` on a tainted or zero-dimension canvas does — so
+      // the release is a finally and not the branch's last statement. A leak
+      // here pins the full-size decode for the life of the page.
+      try {
+        if (file.size > SHOT_ATTACH_MAX_BYTES) {
+          const small = await shrink(pix, SHOT_ATTACH_MAX_BYTES);
+          if (small) {
+            blob = small.blob;
+            note =
+              (small.width < pix.width
+                ? "downscaled from " +
+                  pix.width +
+                  "×" +
+                  pix.height +
+                  " to " +
+                  small.width +
+                  "×" +
+                  small.height
+                : "re-encoded") +
+              " for the agent's read (" +
+              sizeLabel(file.size) +
+              " → " +
+              sizeLabel(blob.size) +
+              ")";
+          }
+        }
+      } finally {
+        pix.free();
+      }
+    }
+  }
+  try {
+    const dir = await shotsDir(agentDir);
+    // The extension follows whichever bytes are going up: the file's own when the
+    // file itself is being copied, and the ENCODER'S when it was re-encoded — a
+    // path called `.jpg` holding webp bytes is the exact lie `shotExt` prevents
+    // (T:11567).
+    const ext = blob === file ? saveExt(file) : shotExt(blob);
+    const path = shotJoin(dir, shotStamp() + ext);
+    await uploadFile(path, blob, name);
+    // THE ONE THING THIS BROWSER CANNOT DO FOR ITSELF: the bytes are on disk now,
+    // inside the one directory the server will convert in, so a picture no engine
+    // here can decode gets one more chance from the side that has Pillow and (on
+    // a Mac) the OS's own decoders (T:11574).
+    let conv: { path: string; width: number; height: number; source_w: number; source_h: number } | null =
+      null;
+    if (undecodable) {
+      conv = await serverPng(agentDir, path);
+      note = conv
+        ? "converted from " +
+          formatLabel(name) +
+          " to " +
+          formatLabel(conv.path) +
+          " on the server (" +
+          conv.source_w +
+          "×" +
+          conv.source_h +
+          " → " +
+          conv.width +
+          "×" +
+          conv.height +
+          ") because neither the browser nor the agent can read that format"
+        : "attached as bytes: this browser cannot decode " +
+          name +
+          " and the " +
+          "server could not convert it either, so the agent probably cannot " +
+          "read this format — say so rather than guessing at the pixels";
+    }
+    // A thumbnail and a `size` are ALTERNATIVES, not a pair: whatever can be SEEN
+    // answers "which one did I just attach" by being looked at, and whatever
+    // cannot answers it by name and size. A CONVERTED picture is on the seen side
+    // of it, and carries no `size` for exactly the reason no other drawable
+    // picture does — which is what keeps the restore path's `bare` test true
+    // (T:11597).
+    const att: Attachment = { id: newId(), kind, view: conv ? conv.path : path, name };
+    if (note) att.viewNote = note;
+    if (conv) att.thumb = rawUrl(conv.path);
+    else if (pic) att.thumb = URL.createObjectURL(blob);
+    else att.size = file.size;
+    return att;
+  } catch (err) {
+    return {
+      id: newId(),
+      kind,
+      view: null,
+      name,
+      viewNote: "not attached: it could not be saved (" + message(err) + ")",
+      why: "could not be saved",
+    };
+  }
+}
+
+/** EVERYTHING in a paste or a drop, in order. Sequential rather than
+ *  `Promise.all`, and that is the one decision this function still makes: they
+ *  share one shots directory and one upload channel, and the chips appearing one
+ *  after another as they land IS the feedback for a drop big enough to take a
+ *  moment. A parallel fan-out would buy little and would land the chips in a
+ *  scrambled order (T:11618). No count cap (D617). */
+export async function* attachFiles(agentDir: string, files: File[]): AsyncIterable<Attachment> {
+  for (const f of (files || []).filter(Boolean)) {
+    yield await attachFile(agentDir, f);
+  }
+}
+
+/** `image_to_png`: never throws and never rejects — a failure here leaves the
+ *  attachment exactly as D613 left it (bytes, a glyph, a note), so the only thing
+ *  riding on this call is how GOOD the attachment is, never whether there is one
+ *  (T:11438). */
+async function serverPng(
+  agentDir: string,
+  path: string,
+): Promise<{ path: string; width: number; height: number; source_w: number; source_h: number } | null> {
+  try {
+    const out = await runAgent(agentDir, "image_to_png", { path }, { key: null });
+    return out && "path" in out && out.path ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── an attachment that is already a PATH (T:11634-11696) ────────────────────
+
+/** No upload, no bytes read, no size (the page never opened the file —
+ *  `undefined` is the honest answer). An image still gets a thumbnail, because
+ *  `/api/fs/raw` will serve it and a picture the user can see is the whole reason
+ *  the thumbnail exists. Copying would be the WRONG answer even though it would
+ *  work: the file is one the user already has, at a path they can name, and the
+ *  agent is about to be asked to Read it — likely to EDIT it next, which a copy
+ *  in a directory pruned in 12 hours cannot survive (T:11680). */
+export function attachPaths(_agentDir: string, paths: string[]): Attachment[] {
+  const out: Attachment[] = [];
+  for (const path of paths || []) {
+    const name = shotBase(path);
+    const kind = kindFor({ name, type: "" });
+    const att: Attachment = { id: newId(), kind, view: path, name, brought: true };
+    if (kind === "image") att.thumb = rawUrl(path);
+    out.push(att);
+  }
+  return out;
+}
+
+/** Every directory the agent has to be allowed to Read for THIS message, beyond
+ *  the shots dir it is always allowed. Only real-path attachments contribute:
+ *  everything that was copied lives under the shots dir, which the spawn line
+ *  pre-approves unconditionally, so filtering it out is what keeps the
+ *  `--allowed-tools` line from growing a duplicate rule on every turn.
+ *  Deduplicated, because dropping six rows out of one folder is one grant
+ *  (T:11698). */
+export function readDirs(
+  attachments: Pick<Attachment, "view">[] | null | undefined,
+  dir?: string,
+): string[] {
+  const skip = dir || "";
+  const dirs: string[] = [];
+  for (const s of attachments || []) {
+    if (!s || !s.view) continue;
+    const d = shotDirOf(s.view);
+    if (!d || d === skip) continue;
+    if (dirs.indexOf(d) === -1) dirs.push(d);
+  }
+  return dirs;
+}
+
+/** `readDirs` against whatever `shotsDir` has already answered for `agentDir` —
+ *  the synchronous read T's `shotDirSeen` exists for (T:9018). */
+export function readDirsFor(
+  agentDir: string,
+  attachments: Pick<Attachment, "view">[] | null | undefined,
+): string[] {
+  return readDirs(attachments, shotsDirSeen(agentDir));
+}
+
+// ── cleanup (T:10645) ───────────────────────────────────────────────────────
+
+/** Release an attachment's thumbnail and forget it. The blob URL is the only
+ *  handle to a Blob the size of a full-pane PNG, so an unrevoked one pins it for
+ *  the life of the page. Idempotent — the field is cleared — because both a drop
+ *  and an abandoned capture can reach it. A `rawUrl` thumb is not an object URL
+ *  and revoking it is a no-op, which is why the same call is safe for every
+ *  kind. */
+export function revoke(att: Attachment | null | undefined): void {
+  if (!att || !att.thumb) return;
+  if (att.thumb.startsWith("blob:")) {
+    try {
+      URL.revokeObjectURL(att.thumb);
+    } catch {
+      /* already gone */
+    }
+  }
+  att.thumb = "";
+}
+
+// ── the wire (T:16519) ──────────────────────────────────────────────────────
+
+/** Each picture goes on the wire as its path, its note, its kind, its name and
+ *  nothing else: `thumb` is a blob URL belonging to THIS page, a dead link
+ *  everywhere else and unreadable to the agent (T:16519).
+ *
+ *  The overview rides the same block, FIRST — it is the picture the annotations
+ *  block tells the model to read (T:16545). */
+export function toWire(attachments: Attachment[] | null | undefined): PaneShotEntry[] {
+  const out: PaneShotEntry[] = [];
+  for (const s of attachments || []) {
+    if (!s) continue;
+    const wire: PaneShotEntry = { kind: s.kind || "pane", view: s.view || null };
+    if (s.viewNote) wire.viewNote = s.viewNote;
+    // T:16546-16550 builds the overview entry out of kind/view/viewNote and
+    // NOTHING else: it is the page's own picture of the pane, so it has no name
+    // the user gave it, no size worth quoting, and its refusal is already the
+    // whole of `viewNote`. `why` is the receipt's short clause for an attachment
+    // the USER brought (see below), and an overview has no receipt of its own.
+    if (s.kind === "overview") {
+      out.unshift(wire);
+      continue;
+    }
+    // The short clause too, and for the SCREEN rather than for the model: a
+    // restored turn rebuilds its receipt out of this JSON alone, and without it a
+    // refusal that said why while the page was open goes back to saying "no
+    // image" and nothing else the moment the session is reopened.
+    if (s.why) wire.why = s.why;
+    // `name` rides for both kinds the user BROUGHT IN, and the block's own text
+    // leans on it — a capture of this pane has no such name (T:16532).
+    if (s.name && (s.kind === "image" || s.kind === "file")) wire.name = s.name;
+    // And how big, for a file only — plus an image the browser could not decode,
+    // for the same reason: there is no small picture of it to look at, so this is
+    // the only measurement of it there is. Absent when unknown (a real-path
+    // attachment was never opened) rather than sent as 0 (T:16539).
+    if ((s.kind === "file" || s.kind === "image") && typeof s.size === "number") {
+      wire.size = s.size;
+    }
+    out.push(wire);
+  }
+  return out;
+}
+
+// ── receipts (T:10815-10930) ────────────────────────────────────────────────
+
+/** The row under a sent user turn. ONE builder for the live send and for a
+ *  restored transcript: a screenshot visible while the session lasts and gone the
+ *  moment it is reopened is a screenshot the user cannot rely on having sent
+ *  (T:10815). */
+export function receiptFor(att: Attachment): Receipt {
+  const label = att.view
+    ? att.kind === "image"
+      ? "image attached" + (att.name ? ": " + att.name : "")
+      : att.kind === "file"
+        ? "file attached" + (att.name ? ": " + att.name : "")
+        : att.kind === "overview"
+          ? "annotated overview attached"
+          : "screenshot attached"
+    : failLabel(att);
+  const r: Receipt = { id: att.id, kind: att.kind, label, view: att.view };
+  // Never `src` for a file: an <img> pointed at a .csv is a broken-image glyph,
+  // which reads as a bug in the chat (T:10820).
+  if (att.kind !== "file" && att.thumb) {
+    r.thumb = att.thumb;
+    r.src = att.thumb;
+  }
+  if (att.viewNote) r.viewNote = att.viewNote;
+  if (att.name) r.name = att.name;
+  if (typeof att.size === "number") r.size = att.size;
+  if (att.why) r.why = att.why;
+  return r;
+}
+
+/** The receipts for a turn read back out of a session file. `src` is added here
+ *  because only the live page knows how to fetch a path.
+ *
+ *  A picture gets a `src` (it is drawn); a FILE gets a `probe` instead (there is
+ *  nothing to draw, and the only question left about it is whether the path it
+ *  names is still there). An IMAGE carrying a `size` is one the sending browser
+ *  could not decode — `attachFile` writes a thumbnail OR a size, never both — so
+ *  it has no pixels this browser can draw either, and it takes the file's
+ *  treatment rather than a broken `<img>` that would then blame the pruner for a
+ *  format (T:10903). */
+export function receiptsFromWire(entries: PaneShotWire[] | null | undefined): Receipt[] {
+  const out: Receipt[] = [];
+  for (const shot of entries || []) {
+    const kind = (shot.kind || "pane") as ShotKind;
+    const att: Attachment = {
+      id: newId(),
+      kind,
+      view: shot.view || null,
+      name: shot.name,
+      size: shot.size,
+      viewNote: shot.viewNote,
+      why: shot.why,
+    };
+    const r = receiptFor(att);
+    const bare = kind === "file" || (kind === "image" && typeof shot.size === "number");
+    if (shot.view) {
+      if (bare) r.probe = rawUrl(shot.view);
+      else {
+        r.src = rawUrl(shot.view);
+        r.thumb = r.src;
+      }
+    }
+    out.push(r);
+  }
+  return out;
+}
+
+/** A restored turn whose file the shots directory has pruned (12h/200 files).
+ *  Said in words rather than left as a broken-image glyph, which a reader takes
+ *  for a bug in the chat rather than for a temp file that expired (T:10875). */
+export async function probePruned(receipt: Receipt): Promise<boolean> {
+  if (!receipt.probe) return false;
+  try {
+    const res = await fetch(receipt.probe, { method: "HEAD" });
+    return !res.ok;
+  } catch {
+    // A DELIBERATE DIVERGENCE FROM T, and the one in this module. T:10869-10879
+    // is `.then(r => { if (!r.ok) throw }).catch(append)`, so one `catch` serves
+    // both a 404 and a rejected fetch — and a request that never left the
+    // machine therefore labels a file that is still on disk "— file pruned".
+    // A blip is not a verdict: only the SERVER can say the pruner has been
+    // through, so an unanswered question leaves the row saying what it said.
+    return false;
+  }
+}
+
+/** The words a pruned glyph row appends (T:10883). */
+export function prunedLabel(kind: ShotKind): string {
+  return " — " + (kind === "image" ? "image" : "file") + " pruned";
+}
+
+// ── the gestures' own reading of a DataTransfer (T:11644-11750) ─────────────
+
+/** TWO payloads answer yes, and the order they are TRIED in is the whole point:
+ *  a drag from inside fused-render carries the real path, and a copy of a file
+ *  the user already has is strictly worse than the file itself (T:11742). */
+export function dragHasAttachment(dt: DataTransfer | null | undefined): boolean {
+  if (!dt) return false;
+  const types = Array.from(dt.types || []);
+  return types.indexOf("Files") !== -1 || types.indexOf(SHOT_PATH_TYPE) !== -1;
+}
+
+/** Real paths a drop carried, one per line. Newline-joined because a multi-row
+ *  selection is one drag, and a newline is the one character a filesystem path
+ *  cannot contain on the platforms this ships to (T:11665). */
+export function pathsFromDrop(dt: DataTransfer | null | undefined): string[] {
+  if (!dt || Array.from(dt.types || []).indexOf(SHOT_PATH_TYPE) === -1) return [];
+  let raw = "";
+  try {
+    raw = dt.getData(SHOT_PATH_TYPE) || "";
+  } catch {
+    return [];
+  }
+  return raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** PASTE. `clipboardData.files` is empty for a clipboard that holds only text, so
+ *  a paste of words falls through untouched to the textarea — which is the
+ *  important half: this listener sits on a box a user types in all day, and
+ *  stealing an ordinary paste would be a far worse bug than never having had the
+ *  feature. The caller `preventDefault`s ONLY when this answers non-empty
+ *  (T:11719). */
+export function filesFromPaste(e: { clipboardData?: DataTransfer | null }): File[] {
+  const data = e.clipboardData;
+  if (!data) return [];
+  return Array.from(data.files || []);
+}
+
+/** Files a drop carried, when it carried no real path (T:11775). */
+export function filesFromDrop(dt: DataTransfer | null | undefined): File[] {
+  if (!dt) return [];
+  return Array.from(dt.files || []);
+}
+
+export { SHOT_MIME_EXT };

--- a/frontend/src/apps/claude/shots/attach.ts
+++ b/frontend/src/apps/claude/shots/attach.ts
@@ -19,7 +19,7 @@ import { runAgent } from "../protocol/agent";
 import type { PaneShotWire } from "../protocol/wire";
 import { capturePane, captureOverview, type CaptureOptions } from "./capture";
 import { viewNoteFrom } from "./dom-capture";
-import { shotExt, shotPixels, shrink } from "./encode";
+import { shotExt, shotPixels } from "./encode";
 import {
   SHOT_MIME_EXT,
   SHOT_SUFFIX_OVERVIEW,
@@ -33,7 +33,6 @@ import {
   shotsDirSeen,
 } from "./dir";
 import {
-  SHOT_ATTACH_MAX_BYTES,
   SHOT_PATH_TYPE,
   type Attachment,
   type PaneShotEntry,
@@ -284,10 +283,20 @@ async function pixelsOf(file: File): Promise<Awaited<ReturnType<typeof shotPixel
 
 /** Take one thing the user brought in. Never throws.
  *
- *  AN OVERSIZE PICTURE IS RESIZED, NOT REFUSED (D615): the 4 MiB number was
- *  never about the disk, it is about the agent's read of the pixels, and a
- *  picture too big for it is one downscale away from being exactly as useful.
- *  There is no cap at all behind it for a file or an undecodable image (D612). */
+ *  NO CAP OF ANY KIND, ON ANY FILE (Akshil, 2026-09-09, P2-6: "any and every
+ *  file, size and type must not matter"). There was never a size REFUSAL here
+ *  (D615) or a type gate (D612) — what there was is now gone too: a picture over
+ *  4 MiB used to be re-encoded down before the upload, on T's argument that the
+ *  number is about the agent's read of the pixels rather than about the disk
+ *  (T:11355, T:11518). It is still the bytes the agent reads, and the owner's
+ *  answer to that is the agent's problem: an attachment is handed over AS IT IS,
+ *  and a downscale the user did not ask for is this app quietly changing the
+ *  evidence someone attached. `SHOT_IMG_MAX_BYTES` stays where it belongs — on
+ *  the PANE SCREENSHOT this app takes ITSELF (`shots/dom-capture`), which is a
+ *  picture it composed and therefore gets to size.
+ *
+ *  The HEIC→PNG server transcode below stays: it is a conversion for a format
+ *  nothing here can read, not a refusal, and the chip says it happened. */
 export async function attachFile(agentDir: string, file: File): Promise<Attachment> {
   const kind = kindFor(file);
   const name = file.name || (kind === "image" ? "pasted image" : "attached file");
@@ -307,49 +316,15 @@ export async function attachFile(agentDir: string, file: File): Promise<Attachme
       pic = false;
       undecodable = true;
     } else {
-      // `pix` holds an object URL the <img> road minted, and `shrink`/`encode`
-      // can THROW — `drawImage` on a tainted or zero-dimension canvas does — so
-      // the release is a finally and not the branch's last statement. A leak
-      // here pins the full-size decode for the life of the page.
-      try {
-        if (file.size > SHOT_ATTACH_MAX_BYTES) {
-          const small = await shrink(pix, SHOT_ATTACH_MAX_BYTES);
-          if (small) {
-            blob = small.blob;
-            note =
-              (small.width < pix.width
-                ? "downscaled from " +
-                  pix.width +
-                  "×" +
-                  pix.height +
-                  " to " +
-                  small.width +
-                  "×" +
-                  small.height
-                : "re-encoded") +
-              " for the agent's read (" +
-              sizeLabel(file.size) +
-              " → " +
-              sizeLabel(blob.size) +
-              ")";
-          }
-        }
-      } catch {
-        // THE DOWNSCALE IS A TRIGGER, NOT A GATE (T:11518): the 4 MiB number is
-        // about the agent's read of the pixels, never about whether the picture
-        // may be attached at all. `drawImage` on a tainted or zero-dimension
-        // canvas throws, and that throw used to escape this function entirely —
-        // `addFiles` then removed the placeholder without a chip in its place,
-        // so a dropped picture vanished with no answer (Bugbot, PR #1064).
-        //
-        // So the original bytes go up instead, unresized and unannotated: a
-        // picture the agent has to downscale its own read of is worth
-        // immeasurably more than no picture.
-        blob = file;
-        note = "";
-      } finally {
-        pix.free();
-      }
+      // NOTHING IS DONE TO THE PIXELS (P2-6). The decode happened for one
+      // reason only — to learn whether a 22px view of this would show anything,
+      // which is what `pic` answers — so the object URL the <img> road minted is
+      // released and the FILE'S OWN BYTES are what goes up. There used to be a
+      // re-encode over 4 MiB here, and with it a `try`/`finally` guarding
+      // `drawImage`'s throw on a tainted or zero-dimension canvas (Bugbot, PR
+      // #1064); with the encode gone there is nothing left in this branch that
+      // can throw.
+      pix.free();
     }
   }
   try {

--- a/frontend/src/apps/claude/shots/attach.ts
+++ b/frontend/src/apps/claude/shots/attach.ts
@@ -513,6 +513,56 @@ export function revoke(att: Attachment | null | undefined): void {
   att.thumb = "";
 }
 
+/**
+ * A SEND THAT LANDED, as far as the blob URLs are concerned.
+ *
+ * The receipts under a sent bubble are drawn with the ATTACHMENT'S OWN `thumb`
+ * (`receiptFor`), which for a capture or a pasted picture is an object URL — so
+ * the BUBBLE, not the tray, is what keeps a full-pane Blob reachable. Nothing
+ * came looking for those once the send launched: the unmount revoke only walks
+ * sends still in flight, and `newChat`, a file change or a later unmount simply
+ * DROPS the turns, blobs and all (Bugbot, PR #1064).
+ *
+ * The bytes are on disk at `view` by then, so the receipts are re-pointed at the
+ * server copy — `rawUrl(view)`, which is EXACTLY what `receiptsFromWire` draws a
+ * restored turn with, so the thumbnail, the viewer and the popup all keep
+ * working on the road they already knew — and the object URLs become
+ * unreferenced.
+ *
+ * PURE, and it hands back BOTH halves: a fresh `Receipt[]` for the turn (the
+ * rows are memoized on identity, so a mutation in place would leave the `<img>`
+ * pointed at a URL that is about to be revoked) and the attachments whose thumbs
+ * are now nobody's, for the caller to `revoke` through its own seam.
+ *
+ * A blob with NO `view` behind it (an upload that failed) is left exactly as it
+ * is: the object URL is then the only copy of those pixels there is, and
+ * revoking it would trade a leak for a broken picture.
+ */
+export function settleReceipts(
+  receipts: Receipt[] | null | undefined,
+  items: Attachment[] | null | undefined,
+): { receipts: Receipt[]; spent: Attachment[] } {
+  // BY ID and not by kind+view: every refusal has `view: null`, so kind+view
+  // cannot tell two of them apart (PR2 review) — and a merged array may hold
+  // another owner's rows, which are not this send's to rewrite.
+  const server = new Map<string, string>();
+  const spent: Attachment[] = [];
+  for (const att of items || []) {
+    if (!att || !att.thumb || !att.thumb.startsWith("blob:")) continue;
+    if (!att.view) continue;
+    server.set(att.id, rawUrl(att.view));
+    spent.push(att);
+  }
+  const rows = (receipts || []).map((r) => {
+    const url = r && r.id ? server.get(r.id) : undefined;
+    // Only where there was one: a FILE receipt carries neither, and handing it a
+    // `src` would point an <img> at a .csv (T:10820).
+    if (!url || (!r.thumb && !r.src)) return r;
+    return { ...r, ...(r.thumb ? { thumb: url } : {}), ...(r.src ? { src: url } : {}) };
+  });
+  return { receipts: rows, spent };
+}
+
 // ── the wire (T:16519) ──────────────────────────────────────────────────────
 
 /** Each picture goes on the wire as its path, its note, its kind, its name and

--- a/frontend/src/apps/claude/shots/attach.ts
+++ b/frontend/src/apps/claude/shots/attach.ts
@@ -258,6 +258,18 @@ function message(err: unknown): string {
 
 // ── pasted and dropped BYTES (T:11530-11628) ────────────────────────────────
 
+/** `shotPixels`, which is a decode and can therefore reject (a codec that gives
+ *  up mid-frame, a browser that refuses the bytes). An undecodable picture is
+ *  not a refusal — it is the road that asks the server for a PNG — so a
+ *  rejection here answers exactly as `null` does. */
+async function pixelsOf(file: File): Promise<Awaited<ReturnType<typeof shotPixels>>> {
+  try {
+    return await shotPixels(file);
+  } catch {
+    return null;
+  }
+}
+
 /** Take one thing the user brought in. Never throws.
  *
  *  AN OVERSIZE PICTURE IS RESIZED, NOT REFUSED (D615): the 4 MiB number was
@@ -275,7 +287,7 @@ export async function attachFile(agentDir: string, file: File): Promise<Attachme
   let pic = kind === "image";
   let undecodable = false;
   if (kind === "image") {
-    const pix = await shotPixels(file);
+    const pix = await pixelsOf(file);
     if (!pix) {
       // Still attached, and still called an image — but the note is NOT written
       // here, because what it should say is not known yet: the server gets asked
@@ -310,6 +322,19 @@ export async function attachFile(agentDir: string, file: File): Promise<Attachme
               ")";
           }
         }
+      } catch {
+        // THE DOWNSCALE IS A TRIGGER, NOT A GATE (T:11518): the 4 MiB number is
+        // about the agent's read of the pixels, never about whether the picture
+        // may be attached at all. `drawImage` on a tainted or zero-dimension
+        // canvas throws, and that throw used to escape this function entirely —
+        // `addFiles` then removed the placeholder without a chip in its place,
+        // so a dropped picture vanished with no answer (Bugbot, PR #1064).
+        //
+        // So the original bytes go up instead, unresized and unannotated: a
+        // picture the agent has to downscale its own read of is worth
+        // immeasurably more than no picture.
+        blob = file;
+        note = "";
       } finally {
         pix.free();
       }

--- a/frontend/src/apps/claude/shots/attach.ts
+++ b/frontend/src/apps/claude/shots/attach.ts
@@ -54,11 +54,23 @@ export interface NamedBlob {
 /** Whether this file is a picture at all. `type` first because it is what the
  *  clipboard supplies and what the browser sniffed; the extension is the fallback
  *  for a drag whose source gave no type. It no longer decides whether the
- *  attachment HAPPENS — every file type is accepted now (T:11392). */
+ *  attachment HAPPENS — every file type is accepted now (T:11392).
+ *
+ *  THE FALLBACK LIST COVERS THE FORMATS NO BROWSER DECODES, and that is the
+ *  point of it: Safari drops the MIME on a drag of `IMG_4031.HEIC`, so the type
+ *  test says nothing and the extension is all there is. Called a `file`, such a
+ *  drop skipped the image road entirely — no decode attempt, so no
+ *  `image_to_png` ask and no undecodable note either: the one format on this
+ *  machine that NEEDS the server's Pillow was the one format never offered to
+ *  it (Bugbot, PR #1064). heic/heif and tif/tiff take the image road, fail the
+ *  browser decode, and come back converted.
+ *
+ *  T:11392 carried only the browser-decodable six; it is extended in the same
+ *  breath (`shotIsImage`), so the two lists still read as one rule. */
 export function isImage(file: NamedBlob | null | undefined): boolean {
   if (!file) return false;
   if ((file.type || "").slice(0, 6) === "image/") return true;
-  return /\.(png|jpe?g|webp|gif|bmp|avif)$/i.test(file.name || "");
+  return /\.(png|jpe?g|webp|gif|bmp|avif|heic|heif|tiff?)$/i.test(file.name || "");
 }
 
 /** WHAT the attachment will be called on the wire (T:11366). */

--- a/frontend/src/apps/claude/shots/capture.test.ts
+++ b/frontend/src/apps/claude/shots/capture.test.ts
@@ -1,0 +1,269 @@
+// The capture ORDER and the budget (T:9958, 10199, 11278). The three strategies
+// are injected: what is under test is which one is asked, in what order, and what
+// the caller gets when none of them answers in time — not the browser's pixels.
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { installDomShim } from "@platform/lib/testDomShim";
+
+installDomShim();
+
+// `bun test` runs every file in ONE process and these globals are shared, so
+// whatever this suite stubbed is put back the moment it is done — a leaked
+// `fetch` or `URL.createObjectURL` breaks whoever runs next (the idiom
+// platform/ui/appdoctor-lib.test.ts sets out).
+const G = globalThis as Record<string, unknown>;
+const BEFORE = {
+  fetch: G.fetch,
+  createImageBitmap: G.createImageBitmap,
+  Image: G.Image,
+  createObjectURL: URL.createObjectURL,
+  revokeObjectURL: URL.revokeObjectURL,
+};
+afterAll(() => {
+  G.fetch = BEFORE.fetch;
+  G.createImageBitmap = BEFORE.createImageBitmap;
+  G.Image = BEFORE.Image;
+  Object.assign(URL, {
+    createObjectURL: BEFORE.createObjectURL,
+    revokeObjectURL: BEFORE.revokeObjectURL,
+  });
+});
+
+const { capturePane, capturePaneBitmap, captureOverview } = await import("./capture");
+const { resetWebpLatchForTests, setCanvasFactory } = await import("./encode");
+const { APP_STATE_UNREADABLE } = await import("../pane/paneUrl");
+type PaneBitmap = import("./types").PaneBitmap;
+
+let revoked: string[] = [];
+let urls = 0;
+let encodes = 0;
+/** null = the encoder answers nothing, which is the over-budget path. */
+let encoded: Blob | null = new Blob([new Uint8Array(8)], { type: "image/png" });
+
+function installCanvas(): void {
+  setCanvasFactory(
+    () =>
+      ({
+        width: 0,
+        height: 0,
+        getContext: () => ({
+          drawImage: () => {},
+          save: () => {},
+          restore: () => {},
+          beginPath: () => {},
+          arc: () => {},
+          fill: () => {},
+          stroke: () => {},
+          fillText: () => {},
+          fillStyle: "",
+          strokeStyle: "",
+          lineWidth: 0,
+          font: "",
+          textAlign: "",
+          textBaseline: "",
+        }),
+        toBlob: (cb: (b: Blob | null) => void) => {
+          encodes++;
+          cb(encoded);
+        },
+      }) as unknown as HTMLCanvasElement,
+  );
+}
+
+function bitmap(over: Partial<PaneBitmap> = {}): PaneBitmap {
+  return {
+    canvas: {} as CanvasImageSource,
+    width: 800,
+    height: 600,
+    blanks: [],
+    styled: 0,
+    incomplete: false,
+    imagesMissing: 0,
+    ...over,
+  };
+}
+
+const frame = { isConnected: true } as HTMLIFrameElement;
+
+beforeEach(() => {
+  revoked = [];
+  urls = 0;
+  encodes = 0;
+  encoded = new Blob([new Uint8Array(8)], { type: "image/png" });
+  resetWebpLatchForTests();
+  installCanvas();
+  Object.assign(URL, {
+    createObjectURL: () => "blob:cap/" + ++urls,
+    revokeObjectURL: (u: string) => revoked.push(u),
+  });
+});
+
+describe("capturePaneBitmap order (T:9958)", () => {
+  test("native first, and nothing else is asked when it answers", async () => {
+    const asked: string[] = [];
+    const out = await capturePaneBitmap(frame, Date.now() + 1000, {
+      strategies: {
+        native: () => (asked.push("native"), Promise.resolve(bitmap())),
+        tab: () => (asked.push("tab"), Promise.resolve(bitmap())),
+        dom: () => (asked.push("dom"), Promise.resolve(bitmap())),
+      },
+      appWindow: () => ({}) as Window,
+    });
+    expect(asked).toEqual(["native"]);
+    expect(out.via).toBe("native");
+  });
+
+  test("a cross-origin target that native could not shoot takes the TAB share", async () => {
+    const asked: string[] = [];
+    const out = await capturePaneBitmap(frame, Date.now() + 1000, {
+      xo: true,
+      strategies: {
+        native: () => (asked.push("native"), Promise.resolve(null)),
+        tab: () => (asked.push("tab"), Promise.resolve(bitmap())),
+        dom: () => (asked.push("dom"), Promise.resolve(bitmap())),
+      },
+    });
+    expect(asked).toEqual(["native", "tab"]);
+    expect(out.via).toBe("tab");
+  });
+
+  test("a readable one takes the DOM clone, and never the tab share", async () => {
+    const asked: string[] = [];
+    const out = await capturePaneBitmap(frame, Date.now() + 1000, {
+      strategies: {
+        native: () => (asked.push("native"), Promise.resolve(null)),
+        tab: () => (asked.push("tab"), Promise.resolve(bitmap())),
+        dom: () => (asked.push("dom"), Promise.resolve(bitmap())),
+      },
+      appWindow: () => ({}) as Window,
+    });
+    expect(asked).toEqual(["native", "dom"]);
+    expect(out.via).toBe("dom");
+  });
+
+  test("no readable window and no share is 'none', not a throw", async () => {
+    const out = await capturePaneBitmap(frame, Date.now() + 1000, {
+      strategies: { native: () => Promise.resolve(null) },
+      appWindow: () => null,
+    });
+    expect(out).toEqual({ pane: null, via: "none" });
+  });
+});
+
+describe("capturePane", () => {
+  test("an unreadable pane answers the sentence, prefixed by the noun (T:10093)", async () => {
+    const out = await capturePane(frame, {
+      strategies: { native: () => Promise.resolve(null) },
+      appWindow: () => null,
+    });
+    expect(out.blob).toBeNull();
+    expect(out.why).toBe("no pane screenshot: " + APP_STATE_UNREADABLE);
+  });
+
+  test("over budget names the byte budget (T:10098)", async () => {
+    encoded = null;
+    const out = await capturePane(frame, {
+      strategies: { native: () => Promise.resolve(bitmap()) },
+    });
+    expect(out.why).toBe("no pane screenshot: it did not fit the 921600-byte budget");
+  });
+
+  test("a caveated capture carries its sentences and the trust line (T:10111)", async () => {
+    const out = await capturePane(frame, {
+      strategies: {
+        native: () => Promise.resolve(bitmap({ incomplete: "mutated", styled: 12, imagesMissing: 1 })),
+      },
+    });
+    expect(out.blob).not.toBeNull();
+    expect(out.thumb).toBe("blob:cap/1");
+    expect(out.notes.length).toBe(2);
+    expect(out.incomplete).toBe("mutated");
+  });
+
+  test("a THROWN capture is a sentence, never a rejection (T:11297)", async () => {
+    const out = await capturePane(frame, {
+      strategies: {
+        native: () => Promise.reject(new Error("boom")),
+      },
+    });
+    expect(out.why).toBe("no pane screenshot: the capture failed (boom)");
+  });
+
+  test("the timeout wins, and the late result's thumbnail is revoked (T:11288)", async () => {
+    const out = await capturePane(frame, {
+      timeoutMs: 5,
+      strategies: {
+        native: () =>
+          new Promise((res) => setTimeout(() => res(bitmap()), 30)),
+      },
+    });
+    expect(out.blob).toBeNull();
+    expect(out.why).toBe("no pane screenshot: the capture did not finish within 5ms and was abandoned");
+    // The abandoned capture is watched to the END: it still minted an object URL
+    // and the discarded result held the only handle to it.
+    await new Promise((res) => setTimeout(res, 60));
+    expect(revoked).toEqual(["blob:cap/1"]);
+  });
+
+  test("a late REJECTION is warned about, not left unhandled (T:11292)", async () => {
+    const warned: unknown[] = [];
+    const before = console.warn;
+    console.warn = (...args: unknown[]) => warned.push(args[0]);
+    try {
+      const out = await capturePane(frame, {
+        timeoutMs: 5,
+        strategies: {
+          native: () => new Promise((_res, rej) => setTimeout(() => rej(new Error("late")), 30)),
+        },
+      });
+      expect(out.blob).toBeNull();
+      await new Promise((res) => setTimeout(res, 60));
+      expect(warned).toContain("abandoned capture failed:");
+    } finally {
+      console.warn = before;
+    }
+  });
+});
+
+describe("captureOverview", () => {
+  test("the badged encode, and the overview's own noun (T:10176)", async () => {
+    const out = await captureOverview(frame, [{ x: 1, y: 2, label: "A" }], {
+      strategies: { native: () => Promise.resolve(bitmap()) },
+    });
+    expect(out.blob).not.toBeNull();
+    expect(encodes).toBeGreaterThan(0);
+    encoded = null;
+    const over = await captureOverview(frame, [{ x: 1, y: 2, label: "A" }], {
+      strategies: { native: () => Promise.resolve(bitmap()) },
+    });
+    expect(over.why).toBe("no overview screenshot: it did not fit the 921600-byte budget");
+  });
+
+  test("A THROW IS A CONSOLE LINE HERE, and the wire gets the abandoned sentence", async () => {
+    // `warnAs` is the overview road's and only its (T:10240-10248): the picture
+    // is an aid, the message is what matters, so a strategy that throws is not
+    // news for the model — it is warned under one phrase and the wire gets the
+    // very sentence the TIMEOUT writes. The pane road has no `warnAs` and keeps
+    // "the capture failed (…)" instead, because there the user pressed a button
+    // and is standing in front of the answer (T:11291).
+    const warned: unknown[][] = [];
+    const before = console.warn;
+    console.warn = (...args: unknown[]) => void warned.push(args);
+    try {
+      const out = await captureOverview(frame, [{ x: 1, y: 2, label: "A" }], {
+        timeoutMs: 5,
+        strategies: { native: () => Promise.reject(new Error("boom")) },
+      });
+      // Verbatim T:10239-10248 — the same words the timeout road produces, so
+      // one refusal sentence covers both.
+      expect(out.why).toBe(
+        "no overview screenshot: the capture did not finish within 5ms and was abandoned",
+      );
+      expect(out.blob).toBeNull();
+      expect(out.via).toBe("none");
+      // The reason is not thrown away, it is just not the wire's business.
+      expect(warned).toEqual([["overview screenshot skipped:", "boom"]]);
+    } finally {
+      console.warn = before;
+    }
+  });
+});

--- a/frontend/src/apps/claude/shots/capture.test.ts
+++ b/frontend/src/apps/claude/shots/capture.test.ts
@@ -28,7 +28,9 @@ afterAll(() => {
   });
 });
 
-const { capturePane, capturePaneBitmap, captureOverview } = await import("./capture");
+const { capturePane, capturePaneBitmap, captureOverview, frameIsCrossOrigin } = await import(
+  "./capture"
+);
 const { resetWebpLatchForTests, setCanvasFactory } = await import("./encode");
 const { APP_STATE_UNREADABLE } = await import("../pane/paneUrl");
 type PaneBitmap = import("./types").PaneBitmap;
@@ -124,6 +126,44 @@ describe("capturePaneBitmap order (T:9958)", () => {
     });
     expect(asked).toEqual(["native", "tab"]);
     expect(out.via).toBe("tab");
+  });
+
+  test("A CROSS-ORIGIN FRAME REACHES THE TAB STRATEGY, detected off the frame itself", async () => {
+    // The whole point of `frameIsCrossOrigin`: the camera reads it at gesture
+    // time and hands it down, and without it `xo` was never true — so a pane
+    // this page cannot open fell through to a DOM clone of a document it cannot
+    // read, which is no picture at all (Bugbot, PR #1064).
+    const xoFrame = {
+      isConnected: true,
+      get contentDocument(): Document {
+        throw new Error("cross-origin");
+      },
+    } as unknown as HTMLIFrameElement;
+    expect(frameIsCrossOrigin(xoFrame)).toBe(true);
+    const asked: string[] = [];
+    const out = await capturePaneBitmap(xoFrame, Date.now() + 1000, {
+      xo: frameIsCrossOrigin(xoFrame),
+      strategies: {
+        native: () => (asked.push("native"), Promise.resolve(null)),
+        tab: () => (asked.push("tab"), Promise.resolve(bitmap())),
+        dom: () => (asked.push("dom"), Promise.resolve(bitmap())),
+      },
+    });
+    expect(asked).toEqual(["native", "tab"]);
+    expect(out.via).toBe("tab");
+  });
+
+  test("frameIsCrossOrigin: a reachable document is ours, no frame is nothing at all", () => {
+    // T's `annXO` exactly (T:6123-6129, 6567): a frame is there AND its document
+    // is out of reach. No frame is not a cross-origin pane — there is no pane.
+    expect(frameIsCrossOrigin(null)).toBe(false);
+    expect(
+      frameIsCrossOrigin({ contentDocument: {} as Document } as HTMLIFrameElement),
+    ).toBe(false);
+    // A frame mid-navigation reads the same as a cross-origin one for a beat and
+    // resolves on the next gesture: the cost of being wrong this way is one tab
+    // prompt, the cost of the other way is a capture that can only fail.
+    expect(frameIsCrossOrigin({ contentDocument: null } as HTMLIFrameElement)).toBe(true);
   });
 
   test("a readable one takes the DOM clone, and never the tab share", async () => {

--- a/frontend/src/apps/claude/shots/capture.ts
+++ b/frontend/src/apps/claude/shots/capture.ts
@@ -1,0 +1,302 @@
+// ONE PICTURE OF THE PANE (T:9958 shotPane, 10088 shotCapturePane, 10127
+// annCaptureOverview, 10199 annOverview, 11232 shotFlash).
+//
+// The order is T's exactly, and it is a preference rather than a gate: NATIVE
+// screen shot first (live pixels, no prompt, WebGL included), then the TAB share
+// for a cross-origin target that could not be shot that way, then the DOM clone
+// for a readable one. Nothing that worked stops working.
+//
+// Bounded by SHOT_TIMEOUT_MS, and the timer is only HALF of what makes the budget
+// real: a `setTimeout` cannot fire while synchronous code runs, so the deadline
+// handed DOWN to the style walk is the other half (T:10199). A timed-out capture
+// is abandoned, not cancelled — so it is still watched to the end, because it may
+// still reject (an unhandled rejection in the console) and may still have minted
+// an object URL nobody holds a handle to any more.
+import { APP_STATE_UNREADABLE } from "../pane/paneUrl";
+import { captureDom, caveatsOf } from "./dom-capture";
+import { encode, encodeBadged } from "./encode";
+import { captureNative } from "./native-capture";
+import { captureXO } from "./xo-capture";
+import {
+  SHOT_FLASH_MS,
+  SHOT_TIMEOUT_MS,
+  SHOT_VIEW_BYTES,
+  SHOT_VIEW_EDGE,
+  type CaptureResult,
+  type PaneBitmap,
+  type ShotBadge,
+} from "./types";
+
+/** Injected in tests, and the seam PR3 uses to hand in its own overlay set and
+ *  stage-rect function. */
+export interface CaptureStrategies {
+  native?: (frame: HTMLIFrameElement | null, deadline: number) => Promise<PaneBitmap | null>;
+  tab?: (frame: HTMLIFrameElement | null) => Promise<PaneBitmap | null>;
+  dom?: (win: Window, deadline: number) => Promise<PaneBitmap | null>;
+}
+
+export interface CaptureOptions {
+  /** True when the pane's document is not ours to read (D349) — the only case the
+   *  tab share is tried in (T:9963). */
+  xo?: boolean;
+  /** The app's own window for the DOM path; defaults to the frame's
+   *  `contentWindow`, guarded, since the pane is `/render?path=…` on our own
+   *  origin (D3/D4). */
+  appWindow?: () => Window | null;
+  /** Element rect → pane-bitmap space, for the blank-region caveat. PR3 passes
+   *  `annStageRect`. */
+  rectOf?: (el: Element) => { left: number; top: number; width: number; height: number };
+  strategies?: CaptureStrategies;
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+function appWindowOf(frame: HTMLIFrameElement | null): Window | null {
+  try {
+    if (!frame || !frame.isConnected) return null;
+    const win = frame.contentWindow;
+    if (!win || !win.document) return null;
+    if (String(win.location.href) === "about:blank") return null;
+    return win;
+  } catch {
+    return null;
+  }
+}
+
+/** T's `shotPane`: the three paths, in order, first non-null wins (T:9958). */
+export async function capturePaneBitmap(
+  frame: HTMLIFrameElement | null,
+  deadline: number,
+  opts: CaptureOptions = {},
+): Promise<{ pane: PaneBitmap | null; via: CaptureResult["via"] }> {
+  const s = opts.strategies || {};
+  const native = await (s.native || ((f, d) => captureNative(f, d)))(frame, deadline);
+  if (native) return { pane: native, via: "native" };
+  if (opts.xo) {
+    const tab = await (s.tab || ((f) => captureXO(f)))(frame);
+    return tab ? { pane: tab, via: "tab" } : { pane: null, via: "none" };
+  }
+  const win = (opts.appWindow || (() => appWindowOf(frame)))();
+  if (!win) return { pane: null, via: "none" };
+  const dom = await (s.dom || ((w, d) => captureDom(w, d)))(win, deadline);
+  return dom ? { pane: dom, via: "dom" } : { pane: null, via: "none" };
+}
+
+/** ONE picture of the WHOLE visible pane, encoded but NOT uploaded — the upload
+ *  and the naming belong to `attach.ts`, which is the only place that knows the
+ *  shots dir (T:10088).
+ *
+ *  Never throws for a reason the user could act on: every "cannot" comes back as
+ *  `blob:null` plus the `why` sentence the chip and the wire's `viewNote` carry.
+ *  A failed capture still becomes a chip and still rides the message — degrading
+ *  to "no image" is right, degrading to "no evidence anything was asked for" is
+ *  the silent-failure shape (T:11305). */
+export function capturePane(
+  frame: HTMLIFrameElement | null,
+  opts: CaptureOptions = {},
+): Promise<CaptureResult> {
+  return race((deadline) => paneShot(frame, deadline, opts), "no pane screenshot", opts);
+}
+
+/** The send-time overview: the same picture with a red letter badge burned in at
+ *  each note's spot, so the model reconciles words with pixels through ONE
+ *  picture instead of N (T:10127).
+ *
+ *  The badge POINTS are resolved by the annotation subsystem (PR3's
+ *  `annPointXY` / `iu,iv` content-box fractions / element centres, T:10143-10171)
+ *  and handed in here already in pane-bitmap space. */
+export function captureOverview(
+  frame: HTMLIFrameElement | null,
+  badges: ShotBadge[],
+  opts: CaptureOptions = {},
+): Promise<CaptureResult> {
+  return race(
+    (deadline) => paneShot(frame, deadline, opts, badges),
+    "no overview screenshot",
+    opts,
+    "overview screenshot skipped:",
+  );
+}
+
+async function paneShot(
+  frame: HTMLIFrameElement | null,
+  deadline: number,
+  opts: CaptureOptions,
+  badges?: ShotBadge[],
+): Promise<CaptureResult> {
+  const { pane, via } = await capturePaneBitmap(frame, deadline, opts);
+  if (!pane) {
+    return {
+      blob: null,
+      width: 0,
+      height: 0,
+      notes: [],
+      via: "none",
+      incomplete: false,
+      why: APP_STATE_UNREADABLE,
+    };
+  }
+  const limits = { maxEdge: SHOT_VIEW_EDGE, maxBytes: SHOT_VIEW_BYTES };
+  const blob = badges
+    ? await encodeBadged(pane, badges, limits)
+    : await encode(pane, { left: 0, top: 0, width: pane.width, height: pane.height }, limits);
+  if (!blob) {
+    return {
+      blob: null,
+      width: pane.width,
+      height: pane.height,
+      notes: [],
+      via,
+      incomplete: pane.incomplete,
+      why: "it did not fit the " + SHOT_VIEW_BYTES + "-byte budget",
+    };
+  }
+  return {
+    blob,
+    width: pane.width,
+    height: pane.height,
+    // Never suppressed for a blank canvas, only annotated: suppressing the pane
+    // leaves nothing at all, so the caveat rides beside the real picture
+    // (T:10104).
+    notes: caveatsOf(pane, opts.rectOf),
+    via,
+    incomplete: pane.incomplete,
+    thumb: URL.createObjectURL(blob),
+  };
+}
+
+/** The budget, and the abandoned capture's own aftercare (T:10199, 11278).
+ *
+ *  `warnAs` is the OVERVIEW road's and only its: a throw there is not news for
+ *  the wire — the message is what matters and the picture is an aid — so T
+ *  console.warns it under one phrase and puts the ABANDONED sentence on the
+ *  wire, the same one the timeout writes (T:10240-10248). The pane road has no
+ *  `warnAs` and keeps "the capture failed (…)", because there the user pressed a
+ *  button and is standing in front of the answer (T:11291). */
+function race(
+  run: (deadline: number) => Promise<CaptureResult>,
+  noun: string,
+  opts: CaptureOptions,
+  warnAs?: string,
+): Promise<CaptureResult> {
+  const now = opts.now ?? (() => Date.now());
+  const ms = opts.timeoutMs ?? SHOT_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let abandoned = false;
+  const budget = new Promise<null>((res) => {
+    timer = setTimeout(() => {
+      abandoned = true;
+      res(null);
+    }, ms);
+  });
+  const capture = run(now() + ms);
+  // Attached to the capture ITSELF, not to the race: the race stops listening the
+  // moment the timeout wins, and everything after that point belongs to nobody —
+  // a late rejection is an unhandled promise rejection in the console, and a late
+  // thumbnail is a Blob pinned for the life of the page with no handle left.
+  capture.then(
+    (late) => {
+      if (abandoned && late && late.thumb) {
+        try {
+          URL.revokeObjectURL(late.thumb);
+        } catch {
+          /* already gone */
+        }
+      }
+    },
+    (err: unknown) => {
+      if (abandoned) console.warn("abandoned capture failed:", err);
+    },
+  );
+  return Promise.race([capture, budget])
+    .catch((err: unknown) => {
+      const why = err instanceof Error ? err.message : String(err);
+      // T:10240 — the overview's throw is a console line, and the wire gets the
+      // sentence the timeout would have written (the `null` below).
+      if (warnAs) {
+        console.warn(warnAs, why);
+        return null;
+      }
+      const failed: CaptureResult = {
+        blob: null,
+        width: 0,
+        height: 0,
+        notes: [],
+        via: "none",
+        incomplete: false,
+        why: "the capture failed (" + why + ")",
+      };
+      return failed;
+    })
+    .then((r) => {
+      if (timer) clearTimeout(timer);
+      if (r) return r;
+      return {
+        blob: null,
+        width: 0,
+        height: 0,
+        notes: [],
+        via: "none",
+        incomplete: false,
+        why: "the capture did not finish within " + ms + "ms and was abandoned",
+      } satisfies CaptureResult;
+    })
+    .then((r) => (r.why ? { ...r, why: noun + ": " + r.why } : r));
+}
+
+/** THE SHUTTER (T:11205-11256). A white sheet over the photographed pane, and it
+ *  is not decoration: the first version of this control did its whole job in
+ *  silence and the report was "not obvious that it took a screenshot".
+ *
+ *  It flashes THE PANE, not the button, because the pane is the subject. Styled
+ *  INLINE and animated with the Web Animations API rather than from a stylesheet
+ *  — a rule of ours in a document of theirs is one selector away from being
+ *  overruled, and this element exists for 340ms. Opacity only, no transform:
+ *  that is the reduced-motion-safe form of a flash, so the signal survives
+ *  `prefers-reduced-motion` instead of being switched off with the movement.
+ *
+ *  `[data-shot-flash]` is how the native path finds it to hide: a screen shot
+ *  reads the SCREEN, and the flash is on the screen (T:11241).
+ *
+ *  Returns the cleanup, which is idempotent — the animation's own `finish`
+ *  already runs it. */
+export function flash(host: Element | null): () => void {
+  const doc = host && host.ownerDocument;
+  if (!host || !doc) return () => {};
+  const el = doc.createElement("div");
+  el.setAttribute(
+    "style",
+    "position: absolute; inset: 0; background: #ffffff;" +
+      " opacity: 0; pointer-events: none; z-index: 2147483647;",
+  );
+  el.setAttribute("data-shot-flash", "");
+  host.appendChild(el);
+  const done = (): void => {
+    try {
+      el.remove();
+    } catch {
+      /* gone with the doc */
+    }
+  };
+  // No `animate()` (an old engine, a detached document) is a missed flash, never
+  // a failed capture (T:11248).
+  if (!el.animate) {
+    done();
+    return done;
+  }
+  // Up fast, HELD briefly, then out. The hold is the part that matters: a
+  // symmetric triangle peaked for one frame measured as a flicker people miss —
+  // and being missed is the entire failure this exists to fix (T:11250).
+  const anim = el.animate(
+    [
+      { opacity: 0, offset: 0 },
+      { opacity: 0.45, offset: 0.18 },
+      { opacity: 0.45, offset: 0.45 },
+      { opacity: 0, offset: 1 },
+    ],
+    { duration: SHOT_FLASH_MS, easing: "ease-out" },
+  );
+  anim.onfinish = done;
+  anim.oncancel = done;
+  return done;
+}

--- a/frontend/src/apps/claude/shots/capture.ts
+++ b/frontend/src/apps/claude/shots/capture.ts
@@ -51,6 +51,31 @@ export interface CaptureOptions {
   timeoutMs?: number;
 }
 
+/**
+ * IS THE PANE'S DOCUMENT OURS TO READ? T's `annXO`, and the same test verbatim:
+ * a frame is there and its `contentDocument` cannot be reached — either the
+ * getter throws or it answers null (T:6123-6129 `annTargetDoc`, T:6567).
+ *
+ * The ONE thing the tab share is tried for (T:9963). `capture` used to ask
+ * `attachPane` for a picture with no options at all, so `xo` was never true and
+ * a cross-origin pane that the native path could not shoot fell through to a DOM
+ * clone of a document this page cannot open — which is no picture at all
+ * (Bugbot, PR #1064).
+ *
+ * A same-origin frame mid-navigation reads cross-origin for a beat and simply
+ * resolves on the next gesture, exactly as it does in T: the cost of being wrong
+ * that way is one tab-share prompt, where the cost of the opposite is a capture
+ * that can only fail.
+ */
+export function frameIsCrossOrigin(frame: HTMLIFrameElement | null): boolean {
+  if (!frame) return false;
+  try {
+    return !frame.contentDocument;
+  } catch {
+    return true; // cross-origin: the getter itself is refused
+  }
+}
+
 function appWindowOf(frame: HTMLIFrameElement | null): Window | null {
   try {
     if (!frame || !frame.isConnected) return null;

--- a/frontend/src/apps/claude/shots/dir.test.ts
+++ b/frontend/src/apps/claude/shots/dir.test.ts
@@ -1,0 +1,130 @@
+// Where a shot goes and what it is called: the cached `shots_dir` round trip,
+// the forward-slash join, the stamp's shape and the MIME→extension map.
+import { afterAll, describe, expect, test } from "bun:test";
+import { installDomShim } from "@platform/lib/testDomShim";
+
+installDomShim();
+
+// `bun test` runs every file in ONE process and these globals are shared, so
+// whatever this suite stubbed is put back the moment it is done — a leaked
+// `fetch` or `URL.createObjectURL` breaks whoever runs next (the idiom
+// platform/ui/appdoctor-lib.test.ts sets out).
+const G = globalThis as Record<string, unknown>;
+const BEFORE = {
+  fetch: G.fetch,
+  createImageBitmap: G.createImageBitmap,
+  Image: G.Image,
+  createObjectURL: URL.createObjectURL,
+  revokeObjectURL: URL.revokeObjectURL,
+};
+afterAll(() => {
+  G.fetch = BEFORE.fetch;
+  G.createImageBitmap = BEFORE.createImageBitmap;
+  G.Image = BEFORE.Image;
+  Object.assign(URL, {
+    createObjectURL: BEFORE.createObjectURL,
+    revokeObjectURL: BEFORE.revokeObjectURL,
+  });
+});
+
+const {
+  SHOT_MIME_EXT,
+  resetShotsDirForTests,
+  shotBase,
+  shotDirOf,
+  shotFileExt,
+  shotJoin,
+  shotStamp,
+  shotsDir,
+  shotsDirSeen,
+} = await import("./dir");
+
+/** One `/api/run` answer per call, so the cache's own behaviour is measurable. */
+function stubRun(answers: unknown[]): { calls: number } {
+  const state = { calls: 0 };
+  Object.assign(globalThis, {
+    fetch: () => {
+      const body = answers[Math.min(state.calls, answers.length - 1)];
+      state.calls++;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(body),
+      } as unknown as Response);
+    },
+  });
+  return state;
+}
+
+describe("shotStamp", () => {
+  test("14 digits of UTC, a dash, 8 hex (T:10041)", () => {
+    expect(shotStamp()).toMatch(/^\d{14}-[0-9a-f]{8}$/);
+  });
+
+  test("two stamps in the same second do not collide", () => {
+    expect(shotStamp()).not.toBe(shotStamp());
+  });
+});
+
+describe("shotJoin", () => {
+  test("always '/', whatever the dir ended with (T:9039)", () => {
+    expect(shotJoin("/tmp/shots", "a.png")).toBe("/tmp/shots/a.png");
+    expect(shotJoin("/tmp/shots/", "a.png")).toBe("/tmp/shots/a.png");
+    expect(shotJoin("C:\\shots\\", "a.png")).toBe("C:\\shots/a.png");
+  });
+});
+
+describe("shotFileExt", () => {
+  test("the MIME map (T:11375)", () => {
+    expect(SHOT_MIME_EXT["image/jpeg"]).toBe(".jpg");
+    for (const [type, ext] of Object.entries(SHOT_MIME_EXT)) {
+      expect(shotFileExt(type, "whatever.bin")).toBe(ext);
+    }
+  });
+
+  test("an unknown type falls back to the name's own extension, lowercased", () => {
+    expect(shotFileExt("image/heic", "IMG_4031.HEIC")).toBe(".heic");
+    expect(shotFileExt("", "notes.CSV")).toBe(".csv");
+  });
+
+  test("a nameless blob of an unknown type is a .png", () => {
+    expect(shotFileExt("", "")).toBe(".png");
+    expect(shotFileExt(undefined, undefined)).toBe(".png");
+    // A leading dot is not an extension.
+    expect(shotFileExt("", ".bashrc")).toBe(".png");
+  });
+});
+
+describe("shotBase / shotDirOf", () => {
+  test("either separator, one forward-slash spelling out (T:11651, 11658)", () => {
+    expect(shotBase("/a/b/c.png")).toBe("c.png");
+    expect(shotBase("C:\\a\\b\\c.png")).toBe("c.png");
+    expect(shotDirOf("/a/b/c.png")).toBe("/a/b");
+    expect(shotDirOf("C:\\a\\b\\c.png")).toBe("C:/a/b");
+    expect(shotDirOf("c.png")).toBe("c.png");
+  });
+});
+
+describe("shotsDir", () => {
+  test("one round trip per agent dir, and readable synchronously after (T:9019)", async () => {
+    resetShotsDirForTests();
+    const run = stubRun([{ ok: true, result: { dir: "/tmp/shots" } }]);
+    expect(shotsDirSeen("/tpl")).toBe("");
+    expect(await shotsDir("/tpl")).toBe("/tmp/shots");
+    expect(await shotsDir("/tpl")).toBe("/tmp/shots");
+    expect(run.calls).toBe(1);
+    expect(shotsDirSeen("/tpl")).toBe("/tmp/shots");
+  });
+
+  test("a failure is NOT cached: the next attach tries again (T:9034)", async () => {
+    resetShotsDirForTests();
+    const run = stubRun([
+      { ok: true, result: { error: "nope" } },
+      { ok: true, result: { dir: "/tmp/shots" } },
+    ]);
+    await expect(shotsDir("/tpl")).rejects.toThrow("nope");
+    expect(shotsDirSeen("/tpl")).toBe("");
+    expect(await shotsDir("/tpl")).toBe("/tmp/shots");
+    expect(run.calls).toBe(2);
+  });
+});

--- a/frontend/src/apps/claude/shots/dir.ts
+++ b/frontend/src/apps/claude/shots/dir.ts
@@ -1,0 +1,113 @@
+// WHERE A SHOT GOES, AND WHAT IT IS CALLED (T:9012-9040, T:10041, T:11375).
+//
+// Our own 0700 temp dir, asked for once per agent dir and cached — NOT the
+// user's project, a screenshot is not their file. Fetched lazily rather than at
+// boot so a chat that never attaches never makes the directory, and a failure
+// clears the cache so the next attach tries again instead of degrading forever
+// (T:9019).
+import { runAgent } from "../protocol/agent";
+
+/** Resolved dirs, kept synchronously readable: `readDirs` has to know which
+ *  attachment paths are ALREADY covered by the spawn line's standing Read rule
+ *  and it runs inside the send with nothing to await on, so the answer is
+ *  remembered the moment it lands (T:9018 `shotDirSeen`). */
+const seen = new Map<string, string>();
+const pending = new Map<string, Promise<string>>();
+
+/** The shots dir for one agent dir. One in-flight promise per dir; a rejection
+ *  is not cached (T:9019-9036). */
+export function shotsDir(agentDir: string): Promise<string> {
+  const cached = seen.get(agentDir);
+  if (cached) return Promise.resolve(cached);
+  const running = pending.get(agentDir);
+  if (running) return running;
+  const p = runAgent(agentDir, "shots_dir", {}, { key: null })
+    .then((r) => {
+      // The union is `{dir}` | `{error}`; a handler that answered neither is the
+      // same failure as one that answered `error` (T:9022).
+      const dir = "dir" in r ? r.dir : "";
+      if (!dir) throw new Error(("error" in r && r.error) || "no screenshot directory");
+      seen.set(agentDir, dir);
+      return dir;
+    })
+    .catch((err: unknown) => {
+      pending.delete(agentDir);
+      throw err;
+    });
+  pending.set(agentDir, p);
+  return p;
+}
+
+/** What `shotsDir` has already answered, without awaiting. `""` until then,
+ *  which is a safe default: the worst it costs is one redundant Read rule
+ *  (T:9018). */
+export function shotsDirSeen(agentDir: string): string {
+  return seen.get(agentDir) || "";
+}
+
+/** Test-only: the cache is a page-lifetime memo in production. */
+export function resetShotsDirForTests(): void {
+  seen.clear();
+  pending.clear();
+}
+
+/** Always "/", never a guessed platform separator: agent.py hands the directory
+ *  back through `_wire_path` (forward slashes on every platform) and spells the
+ *  double-slash Read allow-rule from the SAME normalisation, which the CLI
+ *  matches as TEXT — so a backslash join would sit outside its own
+ *  pre-approval and card every shot (T:9039). */
+export function shotJoin(dir: string, name: string): string {
+  return dir.replace(/[\\/]+$/, "") + "/" + name;
+}
+
+/** The filename prefix every file one capture writes shares: a 14-digit UTC
+ *  timestamp plus 8 hex of uuid, so two captures in the same second cannot
+ *  collide (T:10041). */
+export function shotStamp(): string {
+  return (
+    new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14) +
+    "-" +
+    crypto.randomUUID().slice(0, 8)
+  );
+}
+
+/** Name suffixes: the camera's whole-pane shot (T:10096) and the send-time
+ *  badged overview (T:10180). */
+export const SHOT_SUFFIX_VIEW = "-view";
+export const SHOT_SUFFIX_OVERVIEW = "-overview";
+
+/** MIME → extension (T:11375). A clipboard image arrives as `image/png` with NO
+ *  filename at all, so the type is the only evidence there is. */
+export const SHOT_MIME_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+  "image/bmp": ".bmp",
+  "image/avif": ".avif",
+};
+
+/** The extension a pasted blob has EARNED, from its MIME type — the name has to
+ *  follow the content or the agent's `Read` gets bytes its extension lied about
+ *  (T:11375). Falls back to the name's own extension, then `.png`. */
+export function shotFileExt(type: string | undefined, name: string | undefined): string {
+  const known = SHOT_MIME_EXT[type || ""];
+  if (known) return known;
+  const n = name || "";
+  const dot = n.lastIndexOf(".");
+  return dot > 0 ? n.slice(dot).toLowerCase() : ".png";
+}
+
+/** The last segment of a path, either separator (T:11651). */
+export function shotBase(path: string): string {
+  const parts = String(path || "").split(/[\\/]/).filter(Boolean);
+  return parts.length ? parts[parts.length - 1] : String(path || "");
+}
+
+/** The directory part, in the forward-slash spelling `_wire_path` hands the page
+ *  — the Read rule is matched as TEXT, so the two have to agree (T:11658). */
+export function shotDirOf(path: string): string {
+  const norm = String(path || "").replace(/\\/g, "/");
+  const cut = norm.lastIndexOf("/");
+  return cut > 0 ? norm.slice(0, cut) : norm;
+}

--- a/frontend/src/apps/claude/shots/dom-capture.test.ts
+++ b/frontend/src/apps/claude/shots/dom-capture.test.ts
@@ -1,0 +1,1178 @@
+// THE DOM-CLONE CAPTURE's own machinery (T:9044-10022). `capture.test.ts` injects
+// its strategies, so nothing there ever runs the style walk, the childList guard,
+// the yield/deadline arithmetic, the image inlining or the backdrop read. This
+// suite drives those functions directly against a hand-rolled DOM: what is under
+// test is every DECISION each one makes — which verdict a walk returns, whose
+// subtree is dropped when the source re-renders, what a scrolled box gets written
+// onto it, which url() is worth fetching, and what a picture that could not be
+// fetched leaves behind. No pixels: the fake elements only carry the members the
+// production code actually reads.
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { installDomShim } from "@platform/lib/testDomShim";
+
+installDomShim();
+
+// `bun test` runs every file in ONE process against one `globalThis`, so every
+// global this suite stubs is snapshotted here and put back in `afterAll` — a
+// leaked `fetch` or a leaked `Date.now` silently rewrites whoever runs next
+// (the idiom capture.test.ts and platform/ui/appdoctor-lib.test.ts set out).
+const G = globalThis as Record<string, unknown>;
+const BEFORE = {
+  fetch: G.fetch,
+  FileReader: G.FileReader,
+  now: Date.now,
+  Image: G.Image,
+  createImageBitmap: G.createImageBitmap,
+  createObjectURL: URL.createObjectURL,
+  revokeObjectURL: URL.revokeObjectURL,
+  // `captureDom` reaches for these three as well: the serializer, and the
+  // TOP-LEVEL `document`, which is where its output canvas comes from (the app's
+  // own document is the source, never the destination).
+  XMLSerializer: G.XMLSerializer,
+  docCreate: (G.document as { createElement?: unknown } | undefined)?.createElement,
+};
+afterAll(() => {
+  G.fetch = BEFORE.fetch;
+  G.FileReader = BEFORE.FileReader;
+  Date.now = BEFORE.now;
+  G.Image = BEFORE.Image;
+  G.createImageBitmap = BEFORE.createImageBitmap;
+  Object.assign(URL, {
+    createObjectURL: BEFORE.createObjectURL,
+    revokeObjectURL: BEFORE.revokeObjectURL,
+  });
+  G.XMLSerializer = BEFORE.XMLSerializer;
+  const doc = G.document as Record<string, unknown> | undefined;
+  if (doc) {
+    if (BEFORE.docCreate === undefined) delete doc.createElement;
+    else doc.createElement = BEFORE.docCreate;
+  }
+});
+
+// `dataUrl` (encode.ts) reads the bytes through a FileReader, which bun's test
+// runtime does not have — and without it every successful fetch would look like a
+// failed one, which is exactly the distinction these tests are checking. The stub
+// does what the platform one does: base64 of the blob, announced on `onload`.
+G.FileReader = class {
+  result: string | null = null;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  readAsDataURL(blob: Blob): void {
+    void blob.arrayBuffer().then((buf) => {
+      const bytes = new Uint8Array(buf);
+      let raw = "";
+      for (const b of bytes) raw += String.fromCharCode(b);
+      this.result = "data:" + (blob.type || "application/octet-stream") + ";base64," + btoa(raw);
+      this.onload?.();
+    });
+  }
+};
+
+const {
+  applyScroll,
+  backdrop,
+  blankRegions,
+  captureDom,
+  caveatsOf,
+  imageNote,
+  imagePlaceholder,
+  inlineImages,
+  inlineStyles,
+  paneNote,
+  styleUrls,
+  trustLine,
+  urlAsData,
+  viewNoteFrom,
+} = await import("./dom-capture");
+const { SHOT_IMG_MAX, SHOT_MAX_ELEMENTS, SHOT_STYLE_CHUNK } = await import("./types");
+
+// ── the fake DOM ────────────────────────────────────────────────────────────
+//
+// Only what dom-capture.ts touches: attributes (which is all `cloneNode` would
+// have carried), a live `children` array, the scroll PROPERTIES that have no
+// markup, `isConnected` (the detached case the style walk exists to notice), and
+// the four selectors `inlineImages` asks for.
+
+interface FakeStyle {
+  length: number;
+  getPropertyValue(prop: string): string;
+  [i: number]: string;
+}
+
+class El {
+  attrs = new Map<string, string>();
+  kids: El[] = [];
+  parent: El | null = null;
+  isConnected = true;
+  scrollTop = 0;
+  scrollLeft = 0;
+  textContent = "";
+  /** `captureDom`'s canvas size: `<html>`'s client box, `<body>`'s offset box as
+   *  the fallback. */
+  clientWidth = 0;
+  clientHeight = 0;
+  offsetWidth = 0;
+  offsetHeight = 0;
+  /** `<img>` only, and `currentSrc` before `src` on purpose: it is what the
+   *  browser PICKED out of a srcset, which is the picture on screen. */
+  currentSrc = "";
+  alt = "";
+  naturalWidth = 0;
+  naturalHeight = 0;
+  /** What a canvas hands back, so the `urlAsData` second chance can be driven
+   *  down both roads: a data URL, or the throw of a tainted canvas. */
+  dataUrl: string | (() => string) = "data:image/png;base64,CANVAS";
+  drawn = 0;
+  width = 0;
+  height = 0;
+
+  constructor(
+    public tag: string,
+    public ownerDocument: Doc,
+  ) {}
+
+  get children(): El[] {
+    return this.kids;
+  }
+
+  append(...kids: El[]): El {
+    for (const k of kids) {
+      k.parent = this;
+      this.kids.push(k);
+    }
+    return this;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attrs.set(name, value);
+  }
+
+  getAttribute(name: string): string | null {
+    const v = this.attrs.get(name);
+    return v === undefined ? null : v;
+  }
+
+  removeAttribute(name: string): void {
+    this.attrs.delete(name);
+  }
+
+  remove(): void {
+    if (!this.parent) return;
+    this.parent.kids = this.parent.kids.filter((k) => k !== this);
+    this.parent = null;
+  }
+
+  replaceWith(other: El): void {
+    const p = this.parent;
+    if (!p) return;
+    p.kids = p.kids.map((k) => (k === this ? other : k));
+    other.parent = p;
+    this.parent = null;
+  }
+
+  getContext(kind: string): { drawImage: () => void } | null {
+    return kind === "2d" ? { drawImage: () => void this.drawn++ } : null;
+  }
+
+  toDataURL(): string {
+    return typeof this.dataUrl === "function" ? this.dataUrl() : this.dataUrl;
+  }
+
+  /** `body.cloneNode(true)` — attributes and children, a separate object, which
+   *  is the pairing every function in the walk depends on. */
+  cloneNode(deep: boolean): El {
+    const c = new El(this.tag, this.ownerDocument);
+    for (const [k, v] of this.attrs) c.attrs.set(k, v);
+    if (deep) c.append(...this.kids.map((k) => k.cloneNode(true)));
+    return c;
+  }
+
+  descendants(): El[] {
+    const out: El[] = [];
+    const walk = (e: El): void => {
+      for (const k of e.kids) {
+        out.push(k);
+        walk(k);
+      }
+    };
+    walk(this);
+    return out;
+  }
+
+  querySelectorAll(sel: string): El[] {
+    const all = this.descendants();
+    if (sel === "*") return all;
+    if (sel === "picture source") {
+      return all.filter((e) => e.tag === "source" && e.parent?.tag === "picture");
+    }
+    return all.filter((e) => e.tag === sel);
+  }
+}
+
+class Doc {
+  documentElement = new El("html", this);
+  body = new El("body", this);
+  defaultView: Win | null = null;
+  /** The clone's document is where `imagePlaceholder`'s box and `urlAsData`'s
+   *  fallback canvas come from, so a test that needs one of those to misbehave
+   *  reaches it here. */
+  onCreate: ((el: El) => void) | null = null;
+  createElement(tag: string): El {
+    const made = new El(tag, this);
+    this.onCreate?.(made);
+    return made;
+  }
+}
+
+class Win {
+  document = new Doc();
+  MutationObserver: unknown = null;
+  /** Every property name/value pair a walk will copy, plus a hook a test can use
+   *  to make the source re-render mid-walk — a computed-style read is the only
+   *  place the walk yields control to us synchronously. */
+  onStyle: ((el: El) => void) | null = null;
+  props: [string, string][] = [
+    ["color", "rgb(0, 0, 0)"],
+    ["display", "block"],
+  ];
+  bg = new Map<El, string>();
+  styleReads: El[] = [];
+  constructor() {
+    this.document.defaultView = this;
+  }
+  getComputedStyle(el: El): FakeStyle {
+    this.styleReads.push(el);
+    this.onStyle?.(el);
+    const pairs = this.props;
+    const cs: FakeStyle = {
+      length: pairs.length,
+      getPropertyValue: (p: string) => pairs.find(([k]) => k === p)?.[1] || "",
+    };
+    pairs.forEach(([k], i) => {
+      cs[i] = k;
+    });
+    // `backdrop` reads one member that is not a longhand enumeration.
+    (cs as unknown as { backgroundColor: string }).backgroundColor = this.bg.get(el) || "";
+    return cs;
+  }
+}
+
+/** A source tree and its clone, paired the way `body.cloneNode(true)` pairs them
+ *  — same shape, separate objects, so a style written to one is observable as
+ *  NOT having gone to the other. */
+function tree(shape: (make: (tag?: string) => El) => El, win: Win): { src: El; dst: El } {
+  const doc = win.document;
+  const make = (tag = "div"): El => new El(tag, doc);
+  const src = shape(make);
+  const copy = (e: El): El => {
+    const c = new El(e.tag, doc);
+    for (const [k, v] of e.attrs) c.attrs.set(k, v);
+    c.append(...e.kids.map(copy));
+    return c;
+  };
+  return { src, dst: copy(src) };
+}
+
+/** `n` children under one root: the shape that makes the walk's caps and its
+ *  every-SHOT_STYLE_CHUNK yield reachable without a deep tree. */
+function wide(n: number, win: Win): { src: El; dst: El } {
+  return tree((make) => {
+    const root = make("body");
+    for (let i = 0; i < n; i++) root.append(make());
+    return root;
+  }, win);
+}
+
+const el = (e: El): Element => e as unknown as Element;
+const asWin = (w: Win): Window => w as unknown as Window;
+
+/** A MutationObserver whose deliveries a test decides. `records` is what the
+ *  next `takeRecords()` drain hands over; `fire` is the callback road. */
+function fakeMO(win: Win): {
+  drains: number;
+  observed: unknown[];
+  disconnects: number;
+  records: { type: string; target: El }[];
+  fire: (recs: { type: string; target: El }[]) => void;
+} {
+  const state = {
+    drains: 0,
+    observed: [] as unknown[],
+    disconnects: 0,
+    records: [] as { type: string; target: El }[],
+    fire: (_recs: { type: string; target: El }[]) => {},
+  };
+  win.MutationObserver = class {
+    constructor(cb: (recs: unknown[]) => void) {
+      state.fire = (recs) => cb(recs);
+    }
+    observe(target: unknown, opts: unknown): void {
+      state.observed.push({ target, opts });
+    }
+    takeRecords(): unknown[] {
+      state.drains++;
+      const out = state.records;
+      state.records = [];
+      return out;
+    }
+    disconnect(): void {
+      state.disconnects++;
+    }
+  };
+  return state;
+}
+
+/** A monotonic clock the tests own, so "past the deadline" is arithmetic and not
+ *  a race with the machine. Every computed-style read costs 1ms — which is the
+ *  real cost model: the walk's whole expense is that one call per element. */
+function clockPerStyle(win: Win, start = 1_000_000): void {
+  let t = start;
+  Date.now = () => t;
+  const prev = win.onStyle;
+  win.onStyle = (e) => {
+    t++;
+    prev?.(e);
+  };
+}
+
+beforeEach(() => {
+  Date.now = BEFORE.now;
+  G.fetch = BEFORE.fetch;
+});
+
+describe("inlineStyles (T:9044-9218)", () => {
+  test("a quiet tree is complete: every clone gets the computed longhands, and the source is untouched", async () => {
+    const win = new Win();
+    const { src, dst } = tree((make) => make("body").append(make().append(make())), win);
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(out.incomplete).toBe("");
+    // Three elements: the root and both descendants — breadth-first, so the root
+    // is styled before anything under it.
+    expect(out.styled).toBe(3);
+    expect(dst.getAttribute("style")).toBe("color:rgb(0, 0, 0);display:block;");
+    expect(dst.kids[0].kids[0].getAttribute("style")).toBe("color:rgb(0, 0, 0);display:block;");
+    // The walk writes to the CLONE only; a write to the live tree would mutate
+    // the page the user is looking at.
+    expect(src.getAttribute("style")).toBeNull();
+  });
+
+  test("the observer watches the SOURCE, childList only, and is disconnected on the way out (T:9146)", async () => {
+    const win = new Win();
+    const mo = fakeMO(win);
+    const { src, dst } = tree((make) => make("body").append(make()), win);
+    await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(mo.observed).toEqual([{ target: src, opts: { subtree: true, childList: true } }]);
+    // Observing attributes would put the distrust note on every capture of a page
+    // with a clock in it, so `attributes` is deliberately absent above.
+    expect(mo.disconnects).toBe(1);
+  });
+
+  test("a childList record DROPS that parent's subtree rather than pairing it wrong (T:9163)", async () => {
+    const win = new Win();
+    const mo = fakeMO(win);
+    const { src, dst } = tree(
+      (make) => make("body").append(make().append(make(), make())),
+      win,
+    );
+    const child = src.kids[0];
+    // The re-render lands while the walk is inside the root — a computed-style
+    // read is the one synchronous handoff there is. By the time `child` is
+    // dequeued, `reshaped` already holds it.
+    win.onStyle = (e) => {
+      if (e === src) mo.fire([{ type: "childList", target: child }]);
+    };
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(out.incomplete).toBe("mutated");
+    // Root and child are styled; the child's two grandchildren are NOT — pairing
+    // them would have dressed one element in another's layout.
+    expect(out.styled).toBe(2);
+    expect(dst.kids[0].kids[0].getAttribute("style")).toBeNull();
+  });
+
+  test("a non-childList record still says 'mutated' but keeps the pairing", async () => {
+    const win = new Win();
+    const mo = fakeMO(win);
+    const { src, dst } = tree((make) => make("body").append(make().append(make())), win);
+    win.onStyle = (e) => {
+      if (e === src) mo.fire([{ type: "attributes", target: src.kids[0] }]);
+    };
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    // Only a changed CHILD LIST breaks index pairing, so the descent continues
+    // and all three elements are styled — the verdict is about the picture being
+    // a blend, not about the styles landing on strangers.
+    expect(out.incomplete).toBe("mutated");
+    expect(out.styled).toBe(3);
+  });
+
+  test("a child-count mismatch is caught without any observer at all", async () => {
+    const win = new Win();
+    // No MutationObserver on the view: the compare is the fallback detector, and
+    // losing the observer is a loss of precision, not of correctness.
+    const { src, dst } = tree((make) => make("body").append(make(), make()), win);
+    dst.kids.pop();
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(out.incomplete).toBe("mutated");
+    expect(out.styled).toBe(1);
+  });
+
+  test("an observer whose observe() throws is dropped, and the walk still completes", async () => {
+    const win = new Win();
+    win.MutationObserver = class {
+      observe(): void {
+        throw new Error("frame gone");
+      }
+      takeRecords(): unknown[] {
+        throw new Error("frame gone");
+      }
+      disconnect(): void {}
+    };
+    const { src, dst } = tree((make) => make("body").append(make()), win);
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(out).toMatchObject({ styled: 2, incomplete: "" });
+  });
+
+  test("a disconnected node is 'detached', and its subtree is skipped", async () => {
+    const win = new Win();
+    const { src, dst } = tree((make) => make("body").append(make().append(make())), win);
+    src.kids[0].isConnected = false;
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(out.incomplete).toBe("detached");
+    // The root only: a detached element has no cascade, so it is skipped rather
+    // than styled from an empty enumeration, and nothing under it is queued.
+    expect(out.styled).toBe(1);
+  });
+
+  test("mutated OUTRANKS detached: correctness news beats budget news (T:9110)", async () => {
+    const win = new Win();
+    const { src, dst } = tree((make) => make("body").append(make(), make()), win);
+    src.kids[0].isConnected = false;
+    dst.kids.pop();
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(out.incomplete).toBe("mutated");
+  });
+
+  test("the element cap stops the walk at SHOT_MAX_ELEMENTS and says so", async () => {
+    const win = new Win();
+    const { src, dst } = wide(SHOT_MAX_ELEMENTS, win);
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 60_000);
+    expect(out.styled).toBe(SHOT_MAX_ELEMENTS);
+    expect(out.incomplete).toBe("elements");
+    // The cap is a break, not a skip: the tail of the queue is simply never read,
+    // so the last children keep no style at all.
+    expect(dst.kids[SHOT_MAX_ELEMENTS - 1].getAttribute("style")).toBeNull();
+  });
+
+  test("the deadline is re-read per element, so the stop lands where the clock says", async () => {
+    const win = new Win();
+    const { src, dst } = wide(50, win);
+    clockPerStyle(win, 1_000_000);
+    // Six elements' worth of budget: the check runs BEFORE each style read, so
+    // the 7th iteration is the one that finds the clock past the stamp.
+    const out = await inlineStyles(el(src), el(dst), 1_000_005);
+    expect(out.styled).toBe(6);
+    expect(out.incomplete).toBe("deadline");
+  });
+
+  test("an already-expired deadline styles nothing rather than throwing", async () => {
+    const win = new Win();
+    const { src, dst } = wide(3, win);
+    const out = await inlineStyles(el(src), el(dst), Date.now() - 1);
+    expect(out).toMatchObject({ styled: 0, incomplete: "deadline" });
+    expect(win.styleReads.length).toBe(0);
+  });
+
+  test("it yields every SHOT_STYLE_CHUNK elements, and drains the observer each time (T:9163)", async () => {
+    const win = new Win();
+    const mo = fakeMO(win);
+    const { src, dst } = wide(2 * SHOT_STYLE_CHUNK, win);
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 60_000);
+    expect(out.styled).toBe(2 * SHOT_STYLE_CHUNK + 1);
+    // 401 elements is two whole chunks, so two yields — each followed by a drain
+    // — plus the one final drain in the `finally`, which is the only place a
+    // mutation delivered during the last chunk can still be seen.
+    expect(mo.drains).toBe(3);
+    expect(out.incomplete).toBe("");
+  });
+
+  test("a mutation delivered during the LAST chunk is still reported, by the final drain", async () => {
+    const win = new Win();
+    const mo = fakeMO(win);
+    const { src, dst } = tree((make) => make("body").append(make()), win);
+    // Queued for delivery, never handed to the callback: without the drain in the
+    // `finally` this capture would ship as trustworthy.
+    mo.records = [{ type: "childList", target: src }];
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(out.incomplete).toBe("mutated");
+  });
+
+  test("scrolled boxes are recorded against the CLONE, and the root's own scroll is not (T:9186)", async () => {
+    const win = new Win();
+    const { src, dst } = tree((make) => make("body").append(make(), make()), win);
+    // The root is the app's <body>: its offset is the WINDOW's, and the caller
+    // already shifts the whole clone by that — recording it here would scroll the
+    // capture twice.
+    src.scrollTop = 900;
+    src.kids[0].scrollTop = 40;
+    src.kids[0].scrollLeft = 7;
+    const out = await inlineStyles(el(src), el(dst), Date.now() + 10_000);
+    expect(out.scrolled).toEqual([{ clone: el(dst.kids[0]), x: 7, y: 40 }]);
+  });
+});
+
+describe("applyScroll (T:9219-9265)", () => {
+  const win = new Win();
+
+  test("each child of a scrolled box is translated back, and the count is the children moved", () => {
+    const { dst } = tree((make) => make("div").append(make(), make()), win);
+    const shifted = applyScroll([{ clone: el(dst), x: 12, y: 300 }]);
+    expect(shifted).toBe(2);
+    // A transform on the CHILDREN, not an offset on the parent: it is the paint
+    // the browser does when it scrolls, and it changes no layout.
+    for (const k of dst.kids) {
+      expect(k.getAttribute("style")).toBe(";transform:translate(-12px,-300px);");
+    }
+  });
+
+  test("fixed and sticky children do not move with the scroll", () => {
+    const { dst } = tree((make) => make("div").append(make(), make(), make()), win);
+    dst.kids[0].setAttribute("style", "position:fixed;top:0");
+    dst.kids[1].setAttribute("style", "color:red;position:sticky;");
+    dst.kids[2].setAttribute("style", "position:absolute;");
+    const shifted = applyScroll([{ clone: el(dst), x: 0, y: 100 }]);
+    // A stuck header stays where the user saw it; `absolute` is not stuck and is
+    // shifted like everything else.
+    expect(shifted).toBe(1);
+    expect(dst.kids[0].getAttribute("style")).toBe("position:fixed;top:0");
+    expect(dst.kids[1].getAttribute("style")).toBe("color:red;position:sticky;");
+    expect(dst.kids[2].getAttribute("style")).toContain("transform:translate(0px,-100px)");
+  });
+
+  test("the child's own transform is COMPOSED with, ours leftmost, and 'none' is dropped", () => {
+    const { dst } = tree((make) => make("div").append(make(), make()), win);
+    dst.kids[0].setAttribute("style", "transform: scale(2) ;");
+    dst.kids[1].setAttribute("style", "transform:none;");
+    applyScroll([{ clone: el(dst), x: 5, y: 5 }]);
+    // Leftmost is outermost, so the scroll shift has to precede the element's own
+    // transform or the two multiply in the wrong order.
+    expect(dst.kids[0].getAttribute("style")).toBe(
+      "transform: scale(2) ;;transform:translate(-5px,-5px) scale(2);",
+    );
+    expect(dst.kids[1].getAttribute("style")).toBe(
+      "transform:none;;transform:translate(-5px,-5px);",
+    );
+  });
+
+  test("nothing to shift is 0, including a missing list", () => {
+    expect(applyScroll(null)).toBe(0);
+    expect(applyScroll(undefined)).toBe(0);
+    expect(applyScroll([])).toBe(0);
+    // A scrolled box with no children has nothing to translate.
+    expect(applyScroll([{ clone: el(new El("div", new Doc())), x: 1, y: 1 }])).toBe(0);
+  });
+});
+
+describe("styleUrls (T:9451)", () => {
+  test("quoted and unquoted url() references alike, in order", () => {
+    expect(
+      styleUrls("background-image:url('a.png'),url(\"b.png\"),url(c.png),url( d.png );"),
+    ).toEqual(["a.png", "b.png", "c.png", "d.png"]);
+  });
+
+  test("the two already-local forms are skipped: data: and an SVG fragment", () => {
+    // Nothing to fetch for `data:` and nothing to fetch for `url(#id)` — the
+    // fragment target travels with the clone.
+    expect(styleUrls("background:url(data:image/png;base64,AAA);mask:url(#clip);")).toEqual([]);
+    expect(styleUrls("mask:url('#clip');border-image:url(edge.svg)")).toEqual(["edge.svg"]);
+  });
+
+  test("a style with no url() at all, and one whose url() is empty", () => {
+    expect(styleUrls("color:red;display:block")).toEqual([]);
+    expect(styleUrls("")).toEqual([]);
+    expect(styleUrls("background:url();")).toEqual([]);
+  });
+});
+
+describe("imagePlaceholder (T:9466)", () => {
+  test("a dashed box the size of the image, carrying the alt text, in the image's place", () => {
+    const doc = new Doc();
+    const parent = new El("div", doc);
+    const img = new El("img", doc);
+    img.setAttribute("style", "width:120px;height:40px;");
+    parent.append(img);
+    imagePlaceholder(el(img), "the sales chart");
+    const box = parent.kids[0];
+    // Replaced, not hidden: nothing at all would silently redraw the layout
+    // around a hole the user's screen did not have.
+    expect(box).not.toBe(img);
+    expect(box.tag).toBe("div");
+    expect(box.textContent).toBe("image not captured — the sales chart");
+    // The image's own computed style comes FIRST, so the box keeps its box.
+    const style = box.getAttribute("style") || "";
+    expect(style.startsWith("width:120px;height:40px;;")).toBe(true);
+    expect(style).toContain("border:1px dashed #b4b4b4");
+  });
+
+  test("a missing or empty alt is the bare sentence, never a broken-image glyph", () => {
+    const doc = new Doc();
+    for (const alt of [null, undefined, ""]) {
+      const parent = new El("div", doc);
+      const img = new El("img", doc);
+      parent.append(img);
+      imagePlaceholder(el(img), alt);
+      // A broken-image glyph would read as a bug in the page being photographed.
+      expect(parent.kids[0].textContent).toBe("image not captured");
+      expect(img.parent).toBeNull();
+    }
+  });
+});
+
+// ── the image roads (T:9430-9552) ───────────────────────────────────────────
+
+function okFetch(seen: string[]): void {
+  G.fetch = (url: string) => {
+    seen.push(String(url));
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" })),
+    });
+  };
+}
+
+describe("urlAsData (T:9430)", () => {
+  test("a fetchable URL comes back as data: bytes", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const out = await urlAsData("/logo.png", null);
+    expect(seen).toEqual(["/logo.png"]);
+    expect(out.startsWith("data:image/png;base64,")).toBe(true);
+  });
+
+  test("a non-ok response is a failure, not empty bytes", async () => {
+    G.fetch = () => Promise.resolve({ ok: false, status: 404, blob: () => Promise.resolve(null) });
+    // Nothing to fall back to with no element, so the HTTP status is what the
+    // caller gets — a 404 that returned "" would embed a blank picture and call
+    // it captured.
+    await expect(urlAsData("/gone.png", null)).rejects.toThrow("HTTP 404");
+  });
+
+  test("a loaded element is the SECOND chance: the canvas gets the pixels back", async () => {
+    G.fetch = () => Promise.reject(new Error("CORS"));
+    const doc = new Doc();
+    const img = new El("img", doc);
+    img.naturalWidth = 64;
+    img.naturalHeight = 32;
+    const out = await urlAsData("https://other.example/x.png", img as unknown as HTMLImageElement);
+    // A cross-origin image without CORS headers cannot be fetched, but the
+    // browser already decoded it into the element.
+    expect(out).toBe("data:image/png;base64,CANVAS");
+  });
+
+  test("an unloaded element rethrows the fetch failure rather than drawing nothing", async () => {
+    G.fetch = () => Promise.reject(new Error("offline"));
+    const img = new El("img", new Doc());
+    img.naturalWidth = 0;
+    await expect(
+      urlAsData("/x.png", img as unknown as HTMLImageElement),
+    ).rejects.toThrow("offline");
+    await expect(urlAsData("/x.png", null)).rejects.toThrow("offline");
+  });
+
+  test("a tainted canvas throws out of toDataURL, and that throw is the answer", async () => {
+    G.fetch = () => Promise.reject(new Error("CORS"));
+    const doc = new Doc();
+    const img = new El("img", doc);
+    img.naturalWidth = 10;
+    img.naturalHeight = 10;
+    doc.onCreate = (made) => {
+      made.dataUrl = () => {
+        throw new Error("SecurityError: tainted canvases may not be exported");
+      };
+    };
+    // `toDataURL` throwing is precisely how a taint announces itself, so the
+    // caller counts the image as missing instead of embedding a lie.
+    await expect(urlAsData("/x.png", img as unknown as HTMLImageElement)).rejects.toThrow(
+      "tainted",
+    );
+  });
+});
+
+describe("inlineImages (T:9491-9552)", () => {
+  const imgTree = (
+    win: Win,
+    urls: string[],
+  ): { src: El; dst: El } => {
+    const out = tree((make) => {
+      const root = make("body");
+      for (const _u of urls) root.append(make("img"));
+      return root;
+    }, win);
+    urls.forEach((u, i) => {
+      out.src.kids[i].currentSrc = u;
+      out.src.kids[i].alt = "alt" + i;
+    });
+    return out;
+  };
+
+  test("every img is rewritten to data:, and srcset/sizes are removed with it", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const win = new Win();
+    const { src, dst } = imgTree(win, ["/a.png", "/b.png"]);
+    for (const k of dst.kids) {
+      k.setAttribute("srcset", "/a@2x.png 2x");
+      k.setAttribute("sizes", "100vw");
+    }
+    const out = await inlineImages(el(src), el(dst), Date.now() + 10_000);
+    expect(out.missing).toBe(0);
+    expect(seen).toEqual(["/a.png", "/b.png"]);
+    for (const k of dst.kids) {
+      expect((k.getAttribute("src") || "").startsWith("data:")).toBe(true);
+      // Either attribute left in place would have the browser re-select a URL
+      // over the src we just wrote.
+      expect(k.getAttribute("srcset")).toBeNull();
+      expect(k.getAttribute("sizes")).toBeNull();
+    }
+  });
+
+  test("a repeated URL costs ONE fetch, and an inline data: src costs none", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const win = new Win();
+    const { src, dst } = imgTree(win, ["/same.png", "/same.png", "data:image/gif;base64,AA", ""]);
+    const out = await inlineImages(el(src), el(dst), Date.now() + 10_000);
+    expect(seen).toEqual(["/same.png"]);
+    expect(out.missing).toBe(0);
+    // Already local and already nothing: neither is touched, so neither is
+    // counted against the picture.
+    expect(dst.kids[2].getAttribute("src")).toBeNull();
+  });
+
+  test("currentSrc beats the src attribute: the picture on SCREEN is the one photographed", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const win = new Win();
+    const { src, dst } = imgTree(win, [""]);
+    src.kids[0].setAttribute("src", "/small.png");
+    src.kids[0].currentSrc = "/picked-from-srcset.png";
+    await inlineImages(el(src), el(dst), Date.now() + 10_000);
+    expect(seen).toEqual(["/picked-from-srcset.png"]);
+  });
+
+  test("a fetch that fails leaves the dashed placeholder and counts one missing", async () => {
+    G.fetch = () => Promise.reject(new Error("offline"));
+    const win = new Win();
+    const { src, dst } = imgTree(win, ["/a.png", "/b.png"]);
+    const out = await inlineImages(el(src), el(dst), Date.now() + 10_000);
+    expect(out.missing).toBe(2);
+    expect(dst.kids[0].textContent).toBe("image not captured — alt0");
+    expect(dst.kids[1].textContent).toBe("image not captured — alt1");
+  });
+
+  test("past the deadline nothing new is fetched: the rest are placeholders", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const win = new Win();
+    const { src, dst } = imgTree(win, ["/a.png"]);
+    const out = await inlineImages(el(src), el(dst), Date.now() - 1);
+    expect(seen).toEqual([]);
+    expect(out.missing).toBe(1);
+    expect(dst.kids[0].textContent).toBe("image not captured — alt0");
+  });
+
+  test("SHOT_IMG_MAX bounds the DISTINCT urls, and the overflow is counted", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const win = new Win();
+    const urls = Array.from({ length: SHOT_IMG_MAX + 3 }, (_v, i) => "/i" + i + ".png");
+    const { src, dst } = imgTree(win, urls);
+    const out = await inlineImages(el(src), el(dst), Date.now() + 10_000);
+    expect(seen.length).toBe(SHOT_IMG_MAX);
+    expect(out.missing).toBe(3);
+  });
+
+  test("<source> elements are removed before any src is rewritten", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const win = new Win();
+    const { src, dst } = tree((make) => {
+      const root = make("body");
+      const pic = make("picture");
+      pic.append(make("source"), make("source"), make("img"));
+      return root.append(pic);
+    }, win);
+    src.kids[0].kids[2].currentSrc = "/hero.png";
+    const out = await inlineImages(el(src), el(dst), Date.now() + 10_000);
+    // A <source> still pointing at an http URL would have the browser re-resolve
+    // the child over the src we just wrote.
+    expect(dst.querySelectorAll("picture source")).toEqual([]);
+    expect(out.missing).toBe(0);
+    expect((dst.kids[0].kids[0].getAttribute("src") || "").startsWith("data:")).toBe(true);
+  });
+
+  test("background url()s are read back off the CLONE's style and rewritten in place", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const win = new Win();
+    const { src, dst } = tree((make) => make("body").append(make(), make()), win);
+    dst.kids[0].setAttribute("style", "background-image:url(/tile.png);color:red");
+    dst.kids[1].setAttribute("style", "color:blue");
+    const out = await inlineImages(el(src), el(dst), Date.now() + 10_000);
+    expect(out.missing).toBe(0);
+    // The style walk already wrote the computed value onto the clone, so this
+    // needs no second pass over the live tree.
+    expect(seen).toEqual(["/tile.png"]);
+    expect(dst.kids[0].getAttribute("style")).toBe(
+      "background-image:url(data:image/png;base64,AQID);color:red",
+    );
+    // Untouched styles are not rewritten at all.
+    expect(dst.kids[1].getAttribute("style")).toBe("color:blue");
+  });
+
+  test("a background that could not be fetched is counted but gets NO placeholder", async () => {
+    G.fetch = () => Promise.reject(new Error("offline"));
+    const win = new Win();
+    const { src, dst } = tree((make) => make("body").append(make()), win);
+    dst.kids[0].setAttribute("style", "background-image:url(/tile.png);color:red");
+    const out = await inlineImages(el(src), el(dst), Date.now() + 10_000);
+    expect(out.missing).toBe(1);
+    // The element keeps its size and its colour: substituting a dashed box for a
+    // texture would be a bigger lie than leaving it plain.
+    expect(dst.kids[0].getAttribute("style")).toBe("background-image:url(/tile.png);color:red");
+    expect(dst.kids[0].tag).toBe("div");
+  });
+
+  test("a background past the deadline is counted without being fetched", async () => {
+    const seen: string[] = [];
+    okFetch(seen);
+    const win = new Win();
+    const { src, dst } = tree((make) => make("body").append(make()), win);
+    dst.kids[0].setAttribute("style", "background:url(/a.png),url(/b.png)");
+    const out = await inlineImages(el(src), el(dst), Date.now() - 1);
+    expect(seen).toEqual([]);
+    expect(out.missing).toBe(2);
+  });
+});
+
+describe("backdrop (T:10022)", () => {
+  test("<html>'s background wins when it is opaque", () => {
+    const win = new Win();
+    win.bg.set(win.document.documentElement, "rgb(24, 24, 27)");
+    win.bg.set(win.document.body, "rgb(255, 255, 255)");
+    expect(backdrop(asWin(win))).toBe("rgb(24, 24, 27)");
+  });
+
+  test("<body> is the fallback when <html> is transparent, in either spelling", () => {
+    const win = new Win();
+    win.bg.set(win.document.documentElement, "transparent");
+    win.bg.set(win.document.body, "rgb(250, 250, 250)");
+    expect(backdrop(asWin(win))).toBe("rgb(250, 250, 250)");
+    // A zero-alpha rgba paints nothing, so it is not a backdrop either.
+    win.bg.set(win.document.documentElement, "rgba(0, 0, 0, 0)");
+    expect(backdrop(asWin(win))).toBe("rgb(250, 250, 250)");
+  });
+
+  test("both transparent is \"\", which the caller reads as 'use white'", () => {
+    const win = new Win();
+    win.bg.set(win.document.documentElement, "rgba(255, 255, 255, 0)");
+    win.bg.set(win.document.body, "transparent");
+    expect(backdrop(asWin(win))).toBe("");
+    // A partly transparent colour DOES paint, so it is kept.
+    win.bg.set(win.document.body, "rgba(0, 0, 0, 0.5)");
+    expect(backdrop(asWin(win))).toBe("rgba(0, 0, 0, 0.5)");
+  });
+
+  test("a frame that went away mid-read is \"\", never a throw", () => {
+    const win = new Win();
+    win.getComputedStyle = () => {
+      throw new Error("cross-origin");
+    };
+    expect(backdrop(asWin(win))).toBe("");
+    // A missing <body> takes the same road as a missing colour.
+    const bare = new Win();
+    bare.document.body = null as unknown as El;
+    bare.bg.set(bare.document.documentElement, "transparent");
+    expect(backdrop(asWin(bare))).toBe("");
+  });
+});
+
+// ── the caveats (T:9275-9345, 10052) ────────────────────────────────────────
+//
+// These are the SENTENCES, and they are the fidelity thesis of the whole
+// feature: a picture the model cannot fully trust has to say so in words the
+// model will act on, and every cause the walk can report is worded in exactly
+// one place. So they are pinned verbatim — a reworded caveat is a behaviour
+// change, not a copy edit — along with the two decisions around them: which
+// order they are joined in, and which trust line closes them.
+
+type Pane = import("./types").PaneBitmap;
+
+/** Only the members the builders read; the pixels are nobody's business here. */
+function pane(over: Partial<Pane>): Pane {
+  return {
+    canvas: null as unknown as Pane["canvas"],
+    width: 400,
+    height: 300,
+    blanks: [],
+    styled: 0,
+    incomplete: "",
+    imagesMissing: 0,
+    ...over,
+  } as Pane;
+}
+
+describe("paneNote — one sentence per cause (T:9275)", () => {
+  test("the element budget names the count it stopped at", () => {
+    expect(paneNote(pane({ incomplete: "elements", styled: 3000 }))).toBe(
+      "part of this capture is unstyled: the page has more elements than the capture budget allows (it stopped after 3000), so some of what you see may render without its CSS rather than as the user saw it",
+    );
+  });
+
+  test("the deadline says it is about SPEED, not size — the reader's next move", () => {
+    expect(paneNote(pane({ incomplete: "deadline", styled: 12 }))).toBe(
+      "part of this capture is unstyled: it ran out of time after 12 elements, so some of what you see may render without its CSS rather than as the user saw it. This is about capture speed, not page size",
+    );
+  });
+
+  test("detached is the page removing elements; mutated is the page RE-RENDERING", () => {
+    // Two different pieces of news: one subtree lost its cascade, versus the
+    // whole picture possibly being a blend of before and after.
+    expect(paneNote(pane({ incomplete: "detached" }))).toBe(
+      "part of this capture is unstyled: the page removed elements while the capture was running, so some of what you see may render without its CSS",
+    );
+    expect(paneNote(pane({ incomplete: "mutated" }))).toBe(
+      "the page re-rendered while the capture was running, so this picture may not match what was on screen: some elements are missing their styling and the layout may be a blend of before and after",
+    );
+  });
+
+  test("a complete capture says NOTHING, and neither does no capture at all", () => {
+    expect(paneNote(pane({}))).toBe("");
+    expect(paneNote(null)).toBe("");
+  });
+});
+
+describe("imageNote — bounded doubt, and it counts (T:9304)", () => {
+  test("one image is singular all the way through the sentence", () => {
+    expect(imageNote(pane({ imagesMissing: 1 }))).toBe(
+      '1 image could not be embedded in this picture and shows as a dashed "image not captured" box (or, for a background, as plain colour): a page rasterised through SVG cannot load a URL, so every image has to be fetched and inlined first, and that one could not be. The app is very likely showing the image fine',
+    );
+  });
+
+  test("more than one is plural all the way through it", () => {
+    expect(imageNote(pane({ imagesMissing: 4 }))).toBe(
+      '4 images could not be embedded in this picture and show as a dashed "image not captured" box (or, for a background, as plain colour): a page rasterised through SVG cannot load a URL, so every image has to be fetched and inlined first, and those could not be. The app is very likely showing the image fine',
+    );
+  });
+
+  test("none is silence", () => {
+    expect(imageNote(pane({}))).toBe("");
+    expect(imageNote(null)).toBe("");
+  });
+});
+
+describe("trustLine — chosen by the WORST doubt present (T:9332)", () => {
+  test("unbounded doubt replaces the reassurance with corroboration", () => {
+    // Anything the style walk could not finish is doubt over an unknown set of
+    // elements, so the closing instruction changes from "the rest is fine" to
+    // "do not act on this alone".
+    for (const bad of ["elements", "deadline", "detached", "mutated"] as const) {
+      expect(trustLine(bad)).toBe(
+        "Do not act on this image alone — check anything you read from it against the element's anchor and the DOM outline first.",
+      );
+    }
+  });
+
+  test("bounded doubt keeps it: missing pictures and blank canvases are VISIBLE", () => {
+    expect(trustLine("")).toBe("The rest of the image is what the user saw.");
+    expect(trustLine(false)).toBe("The rest of the image is what the user saw.");
+    expect(trustLine(undefined)).toBe("The rest of the image is what the user saw.");
+  });
+});
+
+describe("blankRegions — where the WebGL holes are, as prose (T:10052)", () => {
+  const rect = (r: { left: number; top: number; width: number; height: number }) => () => r;
+
+  test("one region, in pane-bitmap coordinates, grown to whole pixels", () => {
+    const cv = new El("canvas", new Doc());
+    const out = blankRegions(
+      pane({ blanks: [el(cv)] }),
+      rect({ left: 10.4, top: 20.6, width: 100.2, height: 50.9 }),
+    );
+    expect(out).toBe(
+      "the following region is a WebGL canvas whose pixels could not be read back, so it shows the app's background instead of what was drawn there: 101x52 at (10,20). A map/3D library (maplibre, deck.gl) creates its context with preserveDrawingBuffer:false, which is why — the app is very likely drawing fine, so judge the layout around those regions and not inside them",
+    );
+  });
+
+  test("two regions turn the sentence plural and are listed in order", () => {
+    const doc = new Doc();
+    const a = new El("canvas", doc);
+    const b = new El("canvas", doc);
+    const boxes = new Map<El, { left: number; top: number; width: number; height: number }>([
+      [a, { left: 0, top: 0, width: 40, height: 40 }],
+      [b, { left: 100, top: 10, width: 30, height: 30 }],
+    ]);
+    const out = blankRegions(pane({ blanks: [el(a), el(b)] }), (e) => boxes.get(e as unknown as El)!);
+    expect(out).toContain("the following regions are a WebGL canvas");
+    expect(out).toContain("they show the app's background");
+    expect(out).toContain("40x40 at (0,0), 30x30 at (100,10)");
+  });
+
+  test("a canvas the crop refuses is not a region — and then there is no sentence", () => {
+    // `cropRect` drops anything under SHOT_MIN_AREA or off the bitmap, and a
+    // hairline slider is not news; the caveat must not announce an empty list.
+    const cv = new El("canvas", new Doc());
+    expect(
+      blankRegions(pane({ blanks: [el(cv)] }), rect({ left: 0, top: 0, width: 4, height: 4 })),
+    ).toBe("");
+    expect(
+      blankRegions(pane({ blanks: [el(cv)] }), rect({ left: 900, top: 0, width: 50, height: 50 })),
+    ).toBe("");
+    expect(blankRegions(pane({}), rect({ left: 0, top: 0, width: 9, height: 9 }))).toBe("");
+    expect(blankRegions(null)).toBe("");
+  });
+});
+
+describe("caveatsOf / viewNoteFrom — the order and the join (T:10111)", () => {
+  const wide = () => () => ({ left: 0, top: 0, width: 40, height: 40 });
+
+  test("blanks, then images, then the pane note", () => {
+    // WIDEST-FIRST is the order: where the picture is not the app at all, then
+    // what is missing from it, then what may be mis-styled in it.
+    const cv = new El("canvas", new Doc());
+    const out = caveatsOf(
+      pane({ blanks: [el(cv)], imagesMissing: 2, incomplete: "deadline", styled: 7 }),
+      wide(),
+    );
+    expect(out).toHaveLength(3);
+    expect(out[0]!.startsWith("the following region is a WebGL canvas")).toBe(true);
+    expect(out[1]!.startsWith("2 images could not be embedded")).toBe(true);
+    expect(out[2]!.startsWith("part of this capture is unstyled: it ran out of time")).toBe(true);
+  });
+
+  test("only the causes that happened, and no capture is no caveats", () => {
+    expect(caveatsOf(pane({ imagesMissing: 1 }))).toHaveLength(1);
+    expect(caveatsOf(pane({}))).toEqual([]);
+    expect(caveatsOf(null)).toEqual([]);
+  });
+
+  test('joined "; ", full stop, then the trust line — and "" when there is nothing to say', () => {
+    expect(viewNoteFrom(["one", "two"], "")).toBe(
+      "one; two. The rest of the image is what the user saw.",
+    );
+    expect(viewNoteFrom(["one"], "mutated")).toBe(
+      "one. Do not act on this image alone — check anything you read from it against the element's anchor and the DOM outline first.",
+    );
+    // No caveats means no trust line either: a clean capture makes no claims.
+    expect(viewNoteFrom([], "")).toBe("");
+  });
+});
+
+// ── captureDom, end to end (T:9958's third path) ────────────────────────────
+
+interface Canvas2D {
+  fills: { colour: string; box: number[] }[];
+  drawn: number;
+}
+
+/** The three globals `captureDom` reaches for beyond the app's own document: the
+ *  serializer, the `<img>` that rasterises the SVG, and the TOP-LEVEL document
+ *  the output canvas comes from. */
+function installRaster(loads: boolean): { xml: string[]; ctx: Canvas2D; canvas: () => Record<string, unknown> } {
+  const xml: string[] = [];
+  const ctx: Canvas2D = { fills: [], drawn: 0 };
+  G.XMLSerializer = class {
+    serializeToString(node: unknown): string {
+      xml.push((node as El).tag);
+      return "<" + (node as El).tag + "/>";
+    }
+  };
+  G.Image = class {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_v: string) {
+      // Asynchronous, like the real one: the production code installs both
+      // handlers before assigning `src`.
+      setTimeout(() => (loads ? this.onload?.() : this.onerror?.()), 0);
+    }
+  };
+  let made: Record<string, unknown> = {};
+  const out = {
+    width: 0,
+    height: 0,
+    getContext: (kind: string) =>
+      kind === "2d"
+        ? {
+            fillStyle: "",
+            fillRect(x: number, y: number, w: number, h: number) {
+              ctx.fills.push({ colour: String(this.fillStyle), box: [x, y, w, h] });
+            },
+            drawImage: () => void ctx.drawn++,
+          }
+        : null,
+  };
+  made = out as unknown as Record<string, unknown>;
+  (G.document as Record<string, unknown>).createElement = (tag: string) =>
+    tag === "canvas" ? made : {};
+  return { xml, ctx, canvas: () => made };
+}
+
+/** A window whose body is a small styled tree, sized the way a real one is. */
+function page(): Win {
+  const win = new Win();
+  const body = win.document.body;
+  body.clientWidth = 0;
+  body.offsetWidth = 640;
+  body.offsetHeight = 480;
+  win.document.documentElement.clientWidth = 800;
+  win.document.documentElement.clientHeight = 600;
+  body.append(new El("div", win.document), new El("span", win.document));
+  win.bg.set(win.document.documentElement, "rgb(255, 255, 254)");
+  return win;
+}
+
+describe("captureDom", () => {
+  test("the happy path: the clone is styled, serialized and painted on a backdrop", async () => {
+    const win = page();
+    const { xml, ctx, canvas } = installRaster(true);
+    const out = await captureDom(asWin(win), Date.now() + 10_000);
+    expect(out).not.toBeNull();
+    // `<html>`'s client box wins over `<body>`'s offset box.
+    expect(out!.width).toBe(800);
+    expect(out!.height).toBe(600);
+    // The body and its two children were styled, and the count is what the
+    // caveats report.
+    expect(out!.styled).toBe(3);
+    expect(out!.incomplete).toBe("");
+    expect(out!.imagesMissing).toBe(0);
+    expect(out!.blanks).toEqual([]);
+    // The CLONE was serialized, never the live body: putting the clone into the
+    // app's document would duplicate every id and mutate the page on screen.
+    expect(xml).toEqual(["body"]);
+    expect(win.document.body.getAttribute("style")).toBeNull();
+    // A foreignObject paints nothing where the page is transparent and <html>'s
+    // background does not travel with <body>'s clone, so the backdrop is filled
+    // FIRST and the picture drawn over it (T:10009).
+    expect(ctx.fills).toEqual([{ colour: "rgb(255, 255, 254)", box: [0, 0, 800, 600] }]);
+    expect(ctx.drawn).toBe(1);
+    expect(out!.canvas).toBe(canvas() as unknown as Pane["canvas"]);
+    expect((canvas() as { width: number }).width).toBe(800);
+  });
+
+  test("a page with no <body> is `null`, not a throw", async () => {
+    const win = new Win();
+    win.document.body = null as unknown as El;
+    expect(await captureDom(asWin(win), Date.now() + 10_000)).toBeNull();
+    expect(await captureDom(null as unknown as Window, Date.now() + 10_000)).toBeNull();
+  });
+
+  test("markup the browser will not rasterise says what it MEANS (T:9999)", async () => {
+    // An <img> load failure carries no reason at all, so reporting the event
+    // would be reporting nothing: the one thing it can mean is that the clone
+    // did not serialize as valid XHTML.
+    const win = page();
+    installRaster(false);
+    await expect(captureDom(asWin(win), Date.now() + 10_000)).rejects.toThrow(
+      "the pane's markup could not be rasterised",
+    );
+  });
+});

--- a/frontend/src/apps/claude/shots/dom-capture.ts
+++ b/frontend/src/apps/claude/shots/dom-capture.ts
@@ -1,0 +1,557 @@
+// THE DOM-CLONE CAPTURE (T:9044-10022) — the last of the three paths, and the
+// only one that needs a readable document.
+//
+// The clone is serialized into an `<svg>` and loaded through an `<img>`, which
+// renders with external resource loading DISABLED — no network, of any kind, to
+// any origin, same-origin included. So every rule has to be inlined
+// (`inlineStyles`), every picture fetched and rewritten to `data:`
+// (`inlineImages`), every canvas rasterised (`rasterise`) and every scrolled box
+// put back by hand (`applyScroll`) before the bytes leave.
+//
+// Same-origin DIRECT access, guarded exactly as T's is: the framed document can
+// be mid-navigation, absent or cross-origin, and a failure degrades to a
+// caveated picture, never to a throw.
+import { cropRect, dataUrl, rasterise, shrinkImage } from "./encode";
+import {
+  SHOT_IMG_MAX,
+  SHOT_IMG_MAX_BYTES,
+  SHOT_IMG_MS,
+  SHOT_MAX_ELEMENTS,
+  SHOT_STYLE_CHUNK,
+  type PaneBitmap,
+} from "./types";
+
+export interface StyleWalk {
+  styled: number;
+  /** One cause, never a set of booleans that can disagree — the caller turns it
+   *  into ONE sentence. Precedence when several apply: a re-render may have made
+   *  styles WRONG anywhere, while a cap only leaves them MISSING past a point, so
+   *  correctness news outranks budget news (T:9110, 9215). */
+  incomplete: "" | "elements" | "deadline" | "detached" | "mutated";
+  scrolled: { clone: Element; x: number; y: number }[];
+}
+
+/** `<style>` rules do not travel with a serialized element, so every computed
+ *  property is copied onto the clone's inline style — this is what makes the
+ *  capture look like the app instead of like unstyled HTML.
+ *
+ *  It is also the expensive part: one getComputedStyle plus ~340 longhand reads
+ *  PER ELEMENT. So it YIELDS every SHOT_STYLE_CHUNK elements (which is what makes
+ *  the budget's timer able to fire at all — a timer cannot fire while synchronous
+ *  code runs) and STOPS at SHOT_MAX_ELEMENTS or past `deadline`.
+ *
+ *  Breadth-first BECAUSE it can stop early: the elements nearest `<body>` are the
+ *  layout containers, so a truncated capture still has the page's overall shape.
+ *
+ *  And the price of yielding is that the source is LIVE: between chunks the app
+ *  can re-render, after which `s.children`/`d.children` stop corresponding and
+ *  every style past that point lands on the WRONG element. Detected two ways
+ *  (a childList MutationObserver on the source, plus a child-count compare) and
+ *  REPORTED, never retried: a missing style degrades a picture, a wrong one lies
+ *  about it (T:9044-9218). */
+export async function inlineStyles(
+  src: Element,
+  dst: Element,
+  deadline: number,
+): Promise<StyleWalk> {
+  let styled = 0;
+  let stopped: StyleWalk["incomplete"] = "";
+  let detached = false;
+  let mutated = false;
+  const scrolled: StyleWalk["scrolled"] = [];
+  const reshaped = new Set<Node>();
+  const absorb = (records: MutationRecord[] | null | undefined): void => {
+    for (const r of records || []) {
+      mutated = true;
+      if (r.type === "childList") reshaped.add(r.target);
+    }
+  };
+  // The observer watches the SOURCE only; our own writes go to the clone, so the
+  // walk cannot trip its own alarm.
+  const view0 = src.ownerDocument && src.ownerDocument.defaultView;
+  const MO = view0 && view0.MutationObserver;
+  let observer: MutationObserver | null = null;
+  if (MO) {
+    try {
+      observer = new MO(absorb);
+      // childList ONLY, deliberately: what this walk can get WRONG is pairing,
+      // and only a changed child list breaks that. Observing attributes would put
+      // the distrust note on every capture of a page with a clock in it, and a
+      // warning that fires always carries no information (T:9146).
+      observer.observe(src, { subtree: true, childList: true });
+    } catch {
+      observer = null; // no observer is a loss of precision, not of correctness
+    }
+  }
+  // Drained at every yield rather than left to the observer's own callback: a
+  // mutation can only happen while we are yielded (this is one thread), so
+  // draining on the way back in is what guarantees `reshaped` is complete BEFORE
+  // any further pairing is done with it (T:9163).
+  const drain = (): void => {
+    if (!observer) return;
+    try {
+      absorb(observer.takeRecords());
+    } catch {
+      /* frame gone */
+    }
+  };
+  try {
+    const queue: [Element, Element][] = [[src, dst]];
+    while (queue.length) {
+      if (styled >= SHOT_MAX_ELEMENTS) {
+        stopped = stopped || "elements";
+        break;
+      }
+      if (Date.now() > deadline) {
+        stopped = stopped || "deadline";
+        break;
+      }
+      const pair = queue.shift();
+      if (!pair) break;
+      const [s, d] = pair;
+      // Re-checked per node, not once up front: the whole point is that this can
+      // change between chunks.
+      const view = s.isConnected ? s.ownerDocument && s.ownerDocument.defaultView : null;
+      if (!view) {
+        detached = true;
+        continue;
+      }
+      const cs = view.getComputedStyle(s);
+      let css = "";
+      for (let i = 0; i < cs.length; i++) {
+        const prop = cs[i];
+        css += prop + ":" + cs.getPropertyValue(prop) + ";";
+      }
+      d.setAttribute("style", css);
+      // Not for the root: `src` is the app's <body>, whose scroll offset is the
+      // WINDOW's, and the caller already shifts the whole clone by that —
+      // recording it here too would scroll the capture twice (T:9186).
+      if (s !== src && (s.scrollTop || s.scrollLeft)) {
+        scrolled.push({ clone: d, x: s.scrollLeft || 0, y: s.scrollTop || 0 });
+      }
+      const a = s.children;
+      const b = d.children;
+      if (reshaped.has(s) || a.length !== b.length) {
+        // This parent's children have moved since the clone was taken, so `a[i]`
+        // and `b[i]` are no longer the same element. Dropping the subtree costs
+        // its styling; pairing it anyway would put one element's appearance on
+        // another and call it a photograph.
+        mutated = true;
+      } else {
+        for (let i = 0; i < a.length; i++) queue.push([a[i], b[i]]);
+      }
+      if (++styled % SHOT_STYLE_CHUNK === 0) {
+        await new Promise((r) => setTimeout(r, 0));
+        drain();
+      }
+    }
+  } finally {
+    // One last drain: the callback is a microtask, so a mutation during the final
+    // chunk may not have been delivered anywhere else.
+    drain();
+    if (observer) {
+      try {
+        observer.disconnect();
+      } catch {
+        /* gone */
+      }
+    }
+  }
+  const incomplete: StyleWalk["incomplete"] = mutated
+    ? "mutated"
+    : detached
+      ? "detached"
+      : stopped;
+  return { styled, incomplete, scrolled };
+}
+
+/** Put every scrolled box back where the user had it.
+ *
+ *  `cloneNode` copies ATTRIBUTES, and `scrollTop`/`scrollLeft` are PROPERTIES:
+ *  there is no markup for "scrolled 3160px down", so a clone of a scrolled page
+ *  is a clone of that page at the top. The fix has to be expressible in markup,
+ *  so it is a transform on the CHILDREN rather than an offset on the parent —
+ *  exactly the paint the browser does when it scrolls, and it changes no layout.
+ *
+ *  `fixed`/`sticky` children are skipped (a stuck header does not move with the
+ *  scroll), and the child's own transform is COMPOSED with, never replaced —
+ *  ours goes first, leftmost is outermost (T:9219-9265). */
+export function applyScroll(scrolled: StyleWalk["scrolled"] | null | undefined): number {
+  let shifted = 0;
+  for (const box of scrolled || []) {
+    for (const child of Array.from(box.clone.children)) {
+      const style = child.getAttribute("style") || "";
+      const pos = /(?:^|;)\s*position\s*:\s*([a-z-]+)/.exec(style);
+      if (pos && (pos[1] === "fixed" || pos[1] === "sticky")) continue;
+      const own = /(?:^|;)\s*transform\s*:\s*([^;]+)/.exec(style);
+      const keep = own && own[1].trim() !== "none" ? " " + own[1].trim() : "";
+      child.setAttribute(
+        "style",
+        style + ";transform:translate(" + -box.x + "px," + -box.y + "px)" + keep + ";",
+      );
+      shifted++;
+    }
+  }
+  return shifted;
+}
+
+/** Every `url(…)` a style attribute points at, minus the two already local:
+ *  `data:` (nothing to do) and `url(#id)` (an SVG fragment reference, which
+ *  travels with the clone) (T:9451). */
+export function styleUrls(style: string): string[] {
+  const out: string[] = [];
+  const re = /url\((['"]?)([^'")]+)\1\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(style))) {
+    const u = m[2].trim();
+    if (u && u.slice(0, 5) !== "data:" && u[0] !== "#") out.push(u);
+  }
+  return out;
+}
+
+/** What a picture that could not be fetched leaves behind: a dashed box the size
+ *  of the image, saying so. NOT a broken-image glyph (which reads as a bug in the
+ *  page being photographed) and NOT nothing at all (which would silently redraw
+ *  the layout around a hole the user's screen did not have) (T:9466). */
+export function imagePlaceholder(d: Element, alt: string | null | undefined): void {
+  const box = d.ownerDocument.createElement("div");
+  box.setAttribute(
+    "style",
+    (d.getAttribute("style") || "") +
+      ";display:flex;align-items:center;justify-content:center;text-align:center;" +
+      "box-sizing:border-box;overflow:hidden;border:1px dashed #b4b4b4;" +
+      "color:#8a8a8a;font:11px system-ui,sans-serif;",
+  );
+  box.textContent = alt ? "image not captured — " + alt : "image not captured";
+  d.replaceWith(box);
+}
+
+/** One URL's bytes as a `data:` URL. `el` is only ever the SECOND chance: a
+ *  cross-origin image served without CORS headers cannot be fetched, but the
+ *  browser has already loaded it into the element, and drawing that element into
+ *  a canvas gets the pixels back — unless it taints the canvas, which is
+ *  precisely what `toDataURL` throws for (T:9430). */
+export async function urlAsData(url: string, el: HTMLImageElement | null): Promise<string> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error("HTTP " + res.status);
+    const blob = await res.blob();
+    const small = blob.size > SHOT_IMG_MAX_BYTES ? await shrinkImage(blob) : blob;
+    return await dataUrl(small);
+  } catch (err) {
+    if (!el || !el.naturalWidth) throw err;
+    const c = el.ownerDocument.createElement("canvas");
+    c.width = el.naturalWidth;
+    c.height = el.naturalHeight;
+    c.getContext("2d")?.drawImage(el, 0, 0);
+    return c.toDataURL("image/png"); // throws when the canvas is tainted
+  }
+}
+
+/** Rewrite every image reference in the clone to `data:`, and report how many
+ *  could not be. Pairing is by INDEX here, deliberately unlike the style walk's
+ *  guarded descent: a mispaired image swaps one picture for another rather than
+ *  dressing an element in a stranger's layout, and the walk has already reported
+ *  `mutated` for any capture where the pairing could have slipped.
+ *
+ *  `<source>` elements go first: a `<picture>` whose `<source>` still points at
+ *  an http URL would have the browser re-resolve the child over the `src` we just
+ *  rewrote (T:9491-9552). */
+export async function inlineImages(
+  src: Element,
+  dst: Element,
+  deadline: number,
+): Promise<{ missing: number }> {
+  let missing = 0;
+  let fetched = 0;
+  const cache = new Map<string, Promise<string>>();
+  const resolve = (url: string, el: HTMLImageElement | null): Promise<string> => {
+    let hit = cache.get(url);
+    if (!hit) {
+      fetched++;
+      hit = urlAsData(url, el);
+      cache.set(url, hit);
+    }
+    return hit;
+  };
+  // Room for one more DISTINCT url: an image repeated ten times costs one fetch.
+  const room = (url: string): boolean =>
+    cache.has(url) || (fetched < SHOT_IMG_MAX && Date.now() < deadline);
+  try {
+    for (const s of Array.from(dst.querySelectorAll("picture source"))) s.remove();
+  } catch {
+    /* a clone with no <picture> in it */
+  }
+  const ss = src.querySelectorAll("img");
+  const ds = dst.querySelectorAll("img");
+  for (let i = 0; i < ss.length && i < ds.length; i++) {
+    // currentSrc, not src: it is what the browser actually PICKED out of a
+    // srcset, which is the picture on screen and the one being photographed.
+    const url = ss[i].currentSrc || ss[i].getAttribute("src") || "";
+    if (!url || url.slice(0, 5) === "data:") continue;
+    if (!room(url)) {
+      missing++;
+      imagePlaceholder(ds[i], ss[i].alt);
+      continue;
+    }
+    try {
+      ds[i].setAttribute("src", await resolve(url, ss[i]));
+      // Both would re-select a URL over the src we just wrote.
+      ds[i].removeAttribute("srcset");
+      ds[i].removeAttribute("sizes");
+    } catch {
+      missing++;
+      imagePlaceholder(ds[i], ss[i].alt);
+    }
+  }
+  // Backgrounds, masks, borders and list markers: the style walk has already
+  // written the computed value onto every clone element, so this reads them back
+  // off the CLONE and needs no second pass over the live tree.
+  for (const el of Array.from(dst.querySelectorAll("*"))) {
+    const style = el.getAttribute("style") || "";
+    if (style.indexOf("url(") === -1) continue;
+    let out = style;
+    for (const url of styleUrls(style)) {
+      if (!room(url)) {
+        missing++;
+        continue;
+      }
+      try {
+        const data = await resolve(url, null);
+        out = out.split(url).join(data);
+      } catch {
+        // No placeholder for a background: the element keeps its size and its
+        // colour, and the missing layer is counted in the note. Substituting a
+        // dashed box for a texture would be a bigger lie than leaving it plain.
+        missing++;
+      }
+    }
+    if (out !== style) el.setAttribute("style", out);
+  }
+  return { missing };
+}
+
+// ── the caveats (T:9275-9345, 10052) ────────────────────────────────────────
+
+/** The one sentence a shot carries about what its capture could NOT do, or "".
+ *  Every cause `inlineStyles` can report is worded here and nowhere else
+ *  (T:9275). */
+export function paneNote(pane: Pick<PaneBitmap, "styled" | "incomplete"> | null): string {
+  const styled = pane?.styled || 0;
+  switch (pane?.incomplete) {
+    case "elements":
+      return (
+        "part of this capture is unstyled: the page has more elements than " +
+        "the capture budget allows (it stopped after " +
+        styled +
+        "), so some of " +
+        "what you see may render without its CSS rather than as the user saw it"
+      );
+    case "deadline":
+      return (
+        "part of this capture is unstyled: it ran out of time after " +
+        styled +
+        " elements, so some of what you see may render without its CSS rather " +
+        "than as the user saw it. This is about capture speed, not page size"
+      );
+    case "detached":
+      return (
+        "part of this capture is unstyled: the page removed elements while the " +
+        "capture was running, so some of what you see may render without its CSS"
+      );
+    case "mutated":
+      return (
+        "the page re-rendered while the capture was running, so this picture " +
+        "may not match what was on screen: some elements are missing their " +
+        "styling and the layout may be a blend of before and after"
+      );
+    default:
+      return "";
+  }
+}
+
+/** The other caveat, deliberately NOT one of `paneNote`'s causes: those are all
+ *  "some of this may not be what you think it is" over an unknown set of
+ *  elements, while this one is BOUNDED and visible in the image itself (T:9304). */
+export function imageNote(pane: Pick<PaneBitmap, "imagesMissing"> | null): string {
+  const n = pane?.imagesMissing || 0;
+  if (!n) return "";
+  return (
+    n +
+    (n === 1 ? " image" : " images") +
+    " could not be embedded in this " +
+    "picture and " +
+    (n === 1 ? "shows" : "show") +
+    " as a dashed " +
+    '"image not captured" box (or, for a background, as plain colour): a page ' +
+    "rasterised through SVG cannot load a URL, so every image has to be fetched " +
+    "and inlined first, and " +
+    (n === 1 ? "that one" : "those") +
+    " could not " +
+    "be. The app is very likely showing the image fine"
+  );
+}
+
+/** The closing instruction a caveated shot carries: what to DO about the doubt.
+ *  Chosen by the WORST doubt present — bounded doubt keeps the reassurance,
+ *  unbounded doubt replaces it with corroboration (T:9332). */
+export function trustLine(incomplete: StyleWalk["incomplete"] | false | undefined): string {
+  return incomplete
+    ? "Do not act on this image alone — check anything you read from it against " +
+        "the element's anchor and the DOM outline first."
+    : "The rest of the image is what the user saw.";
+}
+
+/** Where the blank WebGL regions ARE, in pane-bitmap coordinates, as prose. A
+ *  crop can be suppressed because the other crops survive it; a pane shot cannot
+ *  — suppressing it leaves nothing at all — so it ships WITH a note saying which
+ *  rectangles are the app's backdrop rather than what was drawn (T:10052).
+ *
+ *  `rectOf` is the element's rect in pane-bitmap space; the default is
+ *  `getBoundingClientRect`, which for a same-origin framed document IS that
+ *  space. PR3's `annStageRect` is passed in where the pane is the host's. */
+export function blankRegions(
+  pane: Pick<PaneBitmap, "blanks" | "width" | "height"> | null,
+  rectOf: (el: Element) => { left: number; top: number; width: number; height: number } = (el) =>
+    el.getBoundingClientRect(),
+): string {
+  const rects: string[] = [];
+  for (const cv of pane?.blanks || []) {
+    const r = cropRect(rectOf(cv), pane?.width || 0, pane?.height || 0);
+    if (r) {
+      rects.push(
+        Math.round(r.width) +
+          "x" +
+          Math.round(r.height) +
+          " at (" +
+          Math.round(r.left) +
+          "," +
+          Math.round(r.top) +
+          ")",
+      );
+    }
+  }
+  if (!rects.length) return "";
+  return (
+    "the following region" +
+    (rects.length === 1 ? " is" : "s are") +
+    " a WebGL canvas whose pixels could not be read back, so " +
+    (rects.length === 1 ? "it shows" : "they show") +
+    " the app's background " +
+    "instead of what was drawn there: " +
+    rects.join(", ") +
+    ". A map/3D library (maplibre, deck.gl) creates its context with " +
+    "preserveDrawingBuffer:false, which is why — the app is very likely drawing " +
+    "fine, so judge the layout around those regions and not inside them"
+  );
+}
+
+/** Every caveat a finished capture carries, joined the way the wire's `viewNote`
+ *  carries them: "; " between the sentences and the trust line last (T:10111). */
+export function caveatsOf(
+  pane: PaneBitmap | null,
+  rectOf?: (el: Element) => { left: number; top: number; width: number; height: number },
+): string[] {
+  if (!pane) return [];
+  const out: string[] = [];
+  const blanks = blankRegions(pane, rectOf);
+  if (blanks) out.push(blanks);
+  const imgs = imageNote(pane);
+  if (imgs) out.push(imgs);
+  const note = paneNote(pane);
+  if (note) out.push(note);
+  return out;
+}
+
+export function viewNoteFrom(caveats: string[], incomplete: PaneBitmap["incomplete"]): string {
+  return caveats.length ? caveats.join("; ") + ". " + trustLine(incomplete) : "";
+}
+
+/** The app's own page background, from `<html>` then `<body>`. "" when both are
+ *  transparent, which the caller reads as "use white" (T:10022). */
+export function backdrop(win: Window): string {
+  const opaque = (el: Element | null): string => {
+    if (!el) return "";
+    const bg = win.getComputedStyle(el).backgroundColor;
+    return bg && bg !== "transparent" && !/^rgba\(.*,\s*0\)$/.test(bg) ? bg : "";
+  };
+  try {
+    return opaque(win.document.documentElement) || opaque(win.document.body);
+  } catch {
+    return "";
+  }
+}
+
+/** Rasterise a readable app document into a bitmap (T:9958's third path).
+ *
+ *  The clone is styled from the LIVE tree, which is what creates the race
+ *  `inlineStyles` defends against: a detached element has no cascade, so
+ *  `getComputedStyle` on one enumerates ZERO properties — and putting the clone
+ *  INTO the app's document would double the DOM, duplicate every id and mutate
+ *  the page the user is looking at. So the live tree is the only source of truth
+ *  and the race is detected rather than avoided. */
+export async function captureDom(win: Window, deadline: number): Promise<PaneBitmap | null> {
+  const doc = win && win.document;
+  const body = doc && doc.body;
+  if (!body) return null;
+  const root = doc.documentElement;
+  const w = Math.max(1, Math.round(root.clientWidth || body.offsetWidth));
+  const h = Math.max(1, Math.round(root.clientHeight || body.offsetHeight));
+  const clone = body.cloneNode(true) as Element;
+  // The style walk stops SHORT of the deadline so the image fetches have a tail
+  // to run in: sharing one stamp would let a big page spend the entire budget and
+  // leave every picture inside it a placeholder (T:9970).
+  const styles = await inlineStyles(body, clone, Math.max(Date.now(), deadline - SHOT_IMG_MS));
+  // BEFORE `rasterise`, which puts data:-URL <img>s of its own into the clone:
+  // running after it would pair those against the source's real images by index
+  // and put a chart's pixels where a logo was (T:9976).
+  const images = await inlineImages(body, clone, deadline);
+  const blanks = rasterise(body, clone);
+  // LAST, so a canvas swapped for an <img> is shifted with the rest of its
+  // scroll box rather than left at the top of it (T:9981).
+  applyScroll(styles.scrolled);
+  // The WINDOW's scroll only; every inner `overflow:auto` box was put back above.
+  const sx = Math.round(win.scrollX || 0);
+  const sy = Math.round(win.scrollY || 0);
+  const xml = new XMLSerializer().serializeToString(clone);
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="' + w + '" height="' + h + '">' +
+    '<foreignObject width="100%" height="100%">' +
+    '<div xmlns="http://www.w3.org/1999/xhtml" style="transform:translate(' +
+    -sx +
+    "px," +
+    -sy +
+    'px)">' +
+    xml +
+    "</div>" +
+    "</foreignObject></svg>";
+  const img = new Image();
+  await new Promise<void>((res, rej) => {
+    img.onload = () => res();
+    // An <img> load failure carries no reason, so say what it MEANS instead of
+    // reporting an empty event: the markup was not valid XHTML (T:9999).
+    img.onerror = () => rej(new Error("the pane's markup could not be rasterised"));
+    img.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svg);
+  });
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  // A foreignObject paints nothing where the page is transparent, and <html>'s
+  // background does not come along with <body>'s clone — without a backdrop a
+  // light app crops as black once the PNG is flattened (T:10009).
+  if (ctx) {
+    ctx.fillStyle = backdrop(win) || "#ffffff";
+    ctx.fillRect(0, 0, w, h);
+    ctx.drawImage(img, 0, 0);
+  }
+  return {
+    canvas,
+    width: w,
+    height: h,
+    blanks,
+    styled: styles.styled,
+    incomplete: styles.incomplete,
+    imagesMissing: images.missing,
+  };
+}

--- a/frontend/src/apps/claude/shots/encode.test.ts
+++ b/frontend/src/apps/claude/shots/encode.test.ts
@@ -1,0 +1,194 @@
+// The budget ladder: quality first, resolution last, and the WebP latch that
+// keeps a WKWebView from paying for the same discovery twice (T:9655, 9611).
+//
+// The canvas is a fake — bun has no DOM, and what is under test is the DECISION
+// sequence, not the browser's encoder. The fake records every `toBlob` it is
+// asked for and answers from a plan.
+import { beforeEach, describe, expect, test } from "bun:test";
+import { installDomShim } from "@platform/lib/testDomShim";
+
+installDomShim();
+
+const {
+  cropRect,
+  encode,
+  encodeBadged,
+  fit,
+  resetWebpLatchForTests,
+  setCanvasFactory,
+  shotExt,
+  webpLatch,
+} = await import("./encode");
+
+interface Ask {
+  type: string | undefined;
+  quality: number | undefined;
+  width: number;
+  height: number;
+}
+type Plan = (ask: Ask) => { type: string; size: number } | null;
+
+const asks: Ask[] = [];
+let drawn = 0;
+let badges = 0;
+
+/** A canvas whose only job is to record what was asked of it. Cast because the
+ *  fake answers the four members `encode` touches and nothing else. */
+function installCanvas(plan: Plan): void {
+  setCanvasFactory(() => {
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({
+        drawImage: () => {
+          drawn++;
+        },
+        save: () => {},
+        restore: () => {},
+        beginPath: () => {},
+        arc: () => {
+          badges++;
+        },
+        fill: () => {},
+        stroke: () => {},
+        fillText: () => {},
+        fillRect: () => {},
+        fillStyle: "",
+        strokeStyle: "",
+        lineWidth: 0,
+        font: "",
+        textAlign: "",
+        textBaseline: "",
+      }),
+      toBlob: (cb: (b: Blob | null) => void, type?: string, quality?: number) => {
+        const ask: Ask = { type, quality, width: canvas.width, height: canvas.height };
+        asks.push(ask);
+        const out = plan(ask);
+        cb(out ? ({ type: out.type, size: out.size } as Blob) : null);
+      },
+    };
+    return canvas as unknown as HTMLCanvasElement;
+  });
+}
+
+const pane = { canvas: {} as CanvasImageSource };
+const rect = { left: 0, top: 0, width: 1000, height: 500 };
+const limits = { maxEdge: 1000, maxBytes: 100 };
+
+beforeEach(() => {
+  asks.length = 0;
+  drawn = 0;
+  badges = 0;
+  resetWebpLatchForTests();
+});
+
+describe("fit", () => {
+  test("longest edge down to maxEdge, never up (T:9598)", () => {
+    expect(fit(1000, 500, 500)).toEqual({ width: 500, height: 250, scale: 0.5 });
+    expect(fit(320, 100, 640)).toEqual({ width: 320, height: 100, scale: 1 });
+  });
+
+  test("edges floor at 1px — a zero-dimension canvas throws on toBlob", () => {
+    expect(fit(1000, 1, 10)).toEqual({ width: 10, height: 1, scale: 0.01 });
+  });
+});
+
+describe("cropRect", () => {
+  test("origin floors, far edge ceils, clamped to the bitmap (T:9578)", () => {
+    expect(cropRect({ left: 10.7, top: 20.2, width: 30.1, height: 40.9 }, 500, 500)).toEqual({
+      left: 10,
+      top: 20,
+      width: 31,
+      height: 42,
+    });
+  });
+
+  test("nothing to look at is null (SHOT_MIN_AREA 64)", () => {
+    expect(cropRect({ left: 0, top: 0, width: 4, height: 4 }, 500, 500)).toBeNull();
+    expect(cropRect({ left: 0, top: 0, width: 0, height: 0 }, 500, 500)).toBeNull();
+  });
+});
+
+describe("shotExt", () => {
+  test("the name follows the CONTENT, not the request (T:9616)", () => {
+    expect(shotExt({ type: "image/webp" } as Blob)).toBe(".webp");
+    expect(shotExt({ type: "image/png" } as Blob)).toBe(".png");
+    expect(shotExt(null)).toBe(".png");
+  });
+});
+
+describe("encode ladder", () => {
+  test("WebP q0.8 first, and it wins when it fits", async () => {
+    installCanvas(() => ({ type: "image/webp", size: 50 }));
+    const out = await encode(pane, rect, limits);
+    expect(out?.type).toBe("image/webp");
+    expect(asks).toEqual([{ type: "image/webp", quality: 0.8, width: 1000, height: 500 }]);
+    expect(webpLatch()).toBe(true);
+  });
+
+  test("q0.6 is tried before any pixel is given up", async () => {
+    installCanvas((a) => ({ type: "image/webp", size: a.quality === 0.8 ? 500 : 50 }));
+    const out = await encode(pane, rect, limits);
+    expect(out?.size).toBe(50);
+    expect(asks.map((a) => a.quality)).toEqual([0.8, 0.6]);
+  });
+
+  test("PNG is tried at each size too — flat UI genuinely beats WebP", async () => {
+    installCanvas((a) => ({ type: a.type === "image/webp" ? "image/webp" : "image/png", size: a.type === "image/webp" ? 500 : 40 }));
+    const out = await encode(pane, rect, limits);
+    expect(out?.type).toBe("image/png");
+    expect(asks.map((a) => a.type)).toEqual(["image/webp", "image/webp", "image/png"]);
+  });
+
+  test("over budget at every format halves the dims, up to 3 attempts (T:9694)", async () => {
+    installCanvas(() => ({ type: "image/png", size: 999 }));
+    const out = await encode(pane, rect, limits);
+    expect(out).toBeNull();
+    // Three sizes: 1000x500, 500x250, 250x125.
+    expect(asks.filter((a) => a.type === "image/png").map((a) => a.width)).toEqual([1000, 500, 250]);
+    expect(drawn).toBe(3);
+  });
+
+  test("`out` reports the size the WINNING encode used, not `fit`'s guess (T:9648)", async () => {
+    installCanvas((a) => ({ type: "image/png", size: a.width > 300 ? 999 : 10 }));
+    const size = { width: 0, height: 0 };
+    const out = await encode(pane, rect, limits, size);
+    expect(out?.size).toBe(10);
+    expect(size).toEqual({ width: 250, height: 125 });
+  });
+
+  test("a null from the encoder ends the ladder (T:9689)", async () => {
+    installCanvas((a) => (a.type === "image/png" ? null : { type: "image/webp", size: 999 }));
+    expect(await encode(pane, rect, limits)).toBeNull();
+    expect(asks.filter((a) => a.type === "image/png").length).toBe(1);
+  });
+
+  test("a PNG-typed 'webp' latches OFF, and no later shot tries webp again (T:9611)", async () => {
+    installCanvas((a) => ({ type: "image/png", size: a.type === "image/webp" ? 10 : 10 }));
+    const first = await encode(pane, rect, limits);
+    expect(first?.type).toBe("image/png");
+    expect(webpLatch()).toBe(false);
+    // One webp attempt, abandoned at 0.8 — 0.6 is never asked for.
+    expect(asks.map((a) => a.type)).toEqual(["image/webp", "image/png"]);
+    asks.length = 0;
+    await encode(pane, rect, limits);
+    expect(asks.map((a) => a.type)).toEqual(["image/png"]);
+  });
+});
+
+describe("encodeBadged", () => {
+  test("the same ladder, with the badges drawn at every size it tries (T:8033)", async () => {
+    installCanvas((a) => ({ type: "image/png", size: a.width > 300 ? 999 : 10 }));
+    const out = await encodeBadged(
+      { canvas: {} as CanvasImageSource, width: 1000, height: 500, blanks: [], styled: 0, incomplete: false, imagesMissing: 0 },
+      [
+        { x: 10, y: 20, label: "A" },
+        { x: 30, y: 40, label: "B" },
+      ],
+      limits,
+    );
+    expect(out?.size).toBe(10);
+    // Two badges per attempt, three attempts.
+    expect(badges).toBe(6);
+  });
+});

--- a/frontend/src/apps/claude/shots/encode.ts
+++ b/frontend/src/apps/claude/shots/encode.ts
@@ -310,23 +310,12 @@ export async function shotPixels(file: Blob): Promise<ShotPixels | null> {
   }
 }
 
-/** One oversize picture, re-encoded small enough to attach. The ladder is
- *  `encode`'s and not a new one, capped at SHOT_VIEW_EDGE — a photo the user
- *  brought in is never carried at a size the app's own screenshots are not.
- *  `null` means even the halvings could not reach the budget (T:11518). */
-export async function shrink(
-  pix: ShotPixels,
-  maxBytes: number,
-): Promise<{ blob: Blob; width: number; height: number } | null> {
-  const size: EncodeSize = { width: 0, height: 0 };
-  const blob = await encode(
-    pix,
-    { left: 0, top: 0, width: pix.width, height: pix.height },
-    { maxEdge: SHOT_VIEW_EDGE, maxBytes },
-    size,
-  );
-  return blob ? { blob, width: size.width, height: size.height } : null;
-}
+/* THERE IS NO `shrink` ANY MORE (Akshil, 2026-09-09, P2-6). It re-encoded a
+   dropped picture over 4 MiB down before the upload; an attachment is handed
+   over as it is now, whatever its size, so nothing calls it. `shrinkImage`
+   below is a DIFFERENT job and stays: it shrinks an oversized <img> found
+   inside a page this app is rasterising, where the alternative is a 4 MB photo
+   inlined as base64 inside the screenshot's own markup. */
 
 /** Re-encode an oversized image found INSIDE a capture down to something worth
  *  embedding: base64 adds a third on top of the bytes and the result is inlined

--- a/frontend/src/apps/claude/shots/encode.ts
+++ b/frontend/src/apps/claude/shots/encode.ts
@@ -1,0 +1,423 @@
+// PIXELS → BYTES (T:9554-9700, T:8033, T:11462-11518).
+//
+// The budget ladder and nothing else: no DOM walk, no network, no upload. One
+// module because every caller shares one WebP latch — the desktop app's
+// WKWebView cannot encode WebP and fails SILENTLY (`toBlob(cb,"image/webp",q)`
+// hands back a blob whose type is "image/png", byte-identical, no throw, no
+// null), so the capability is probed once per page and remembered (T:9611).
+import {
+  SHOT_MAX_BYTES,
+  SHOT_MAX_EDGE,
+  SHOT_MIN_AREA,
+  SHOT_VIEW_EDGE,
+  SHOT_WEBP_QUALITY,
+  type PaneBitmap,
+  type ShotBadge,
+  type ShotRect,
+} from "./types";
+
+/** Canvases come from the document in production; a test hands over a fake
+ *  through `setCanvasFactory`. */
+let canvasFactory: (() => HTMLCanvasElement) | null = null;
+
+export function setCanvasFactory(f: (() => HTMLCanvasElement) | null): void {
+  canvasFactory = f;
+}
+
+function makeCanvas(): HTMLCanvasElement {
+  return canvasFactory ? canvasFactory() : document.createElement("canvas");
+}
+
+/** Whether this engine really encodes WebP: null until the first attempt tells
+ *  us. Probed once per page, not once per shot — the capability cannot change
+ *  mid-session, and re-probing would cost every WKWebView user a wasted encode
+ *  on every single shot (T:9631). */
+let webpOk: boolean | null = null;
+
+export function webpLatch(): boolean | null {
+  return webpOk;
+}
+
+export function resetWebpLatchForTests(): void {
+  webpOk = null;
+}
+
+/** Target size for a shot: longest edge down to `maxEdge`, never UP (a 320px
+ *  button blown up to 640 is more bytes and no more information). Edges floor at
+ *  1px, because a zero-dimension canvas throws on `toBlob` and would cost the
+ *  whole capture rather than one crop (T:9598). */
+export function fit(
+  w: number,
+  h: number,
+  maxEdge?: number,
+): { width: number; height: number; scale: number } {
+  const scale = Math.min(1, (maxEdge || SHOT_MAX_EDGE) / Math.max(w, h));
+  return {
+    width: Math.max(1, Math.round(w * scale)),
+    height: Math.max(1, Math.round(h * scale)),
+    scale,
+  };
+}
+
+/** Integer crop rect inside the pane bitmap, or null when there is nothing to
+ *  cut. Origin floors and the far edge ceils — rounding both the same way shaves
+ *  the element's last row of pixels, which on a 1px border is the entire point
+ *  of the crop (T:9578). */
+export function cropRect(
+  rect: { left: number; top: number; width: number; height: number },
+  paneW: number,
+  paneH: number,
+): ShotRect | null {
+  const l = Math.max(0, Math.floor(rect.left));
+  const t = Math.max(0, Math.floor(rect.top));
+  const r = Math.min(paneW, Math.ceil(rect.left + rect.width));
+  const b = Math.min(paneH, Math.ceil(rect.top + rect.height));
+  const w = r - l;
+  const h = t < b ? b - t : 0;
+  if (w <= 0 || h <= 0 || w * h < SHOT_MIN_AREA) return null;
+  return { left: l, top: t, width: w, height: h };
+}
+
+export function toBlob(
+  canvas: HTMLCanvasElement,
+  type?: string,
+  quality?: number,
+): Promise<Blob | null> {
+  return new Promise((res) => canvas.toBlob(res, type, quality));
+}
+
+/** The extension a blob has EARNED, read off the bytes rather than off what we
+ *  asked the encoder for. A file named `.webp` holding PNG bytes would be worse
+ *  than never trying WebP, so the name follows the content (T:9616). */
+export function shotExt(blob: Blob | null | undefined): string {
+  return blob && blob.type === "image/webp" ? ".webp" : ".png";
+}
+
+export interface EncodeLimits {
+  maxEdge?: number;
+  maxBytes?: number;
+}
+
+/** Filled with the size the WINNING encode used — the attach path's chip has to
+ *  SAY what it did to the pixels ("downscaled from 4200×2800 to 1600×1067") and
+ *  `fit` is only the first guess (T:9648). */
+export interface EncodeSize {
+  width: number;
+  height: number;
+}
+
+/** Cut one region out of a pane bitmap and encode it as small as it can be while
+ *  staying legible (T:9655).
+ *
+ *  Knob order is deliberate: quality first, resolution last. Both formats are
+ *  tried at each size rather than one being assumed smaller — lossy WebP usually
+ *  wins, PNG genuinely beats it on flat UI, and the first encoding that FITS is
+ *  the one we want. `null` = over budget however hard we tried; no shot beats one
+ *  that dominates the turn. */
+export async function encode(
+  pane: Pick<PaneBitmap, "canvas">,
+  rect: ShotRect,
+  limits?: EncodeLimits,
+  out?: EncodeSize,
+): Promise<Blob | null> {
+  const maxEdge = limits?.maxEdge || SHOT_MAX_EDGE;
+  const maxBytes = limits?.maxBytes || SHOT_MAX_BYTES;
+  let box = fit(rect.width, rect.height, maxEdge);
+  const done = (blob: Blob): Blob => {
+    if (out) {
+      out.width = box.width;
+      out.height = box.height;
+    }
+    return blob;
+  };
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const c = makeCanvas();
+    c.width = box.width;
+    c.height = box.height;
+    c.getContext("2d")?.drawImage(
+      pane.canvas,
+      rect.left,
+      rect.top,
+      rect.width,
+      rect.height,
+      0,
+      0,
+      box.width,
+      box.height,
+    );
+    const fitted = await ladder(c, maxBytes);
+    if (fitted.blob) return done(fitted.blob);
+    if (fitted.dead) return null;
+    box = halve(box);
+  }
+  return null;
+}
+
+/** `encode`'s ladder plus the badges: drawn AFTER the pane is scaled into the
+ *  output canvas and BEFORE encoding, at each badge's `x,y` scaled the same way
+ *  the pane was, so every badge lands on its exact spot at every size the loop
+ *  tries rather than needing its own retry (T:8033). */
+export async function encodeBadged(
+  pane: PaneBitmap,
+  badges: ShotBadge[],
+  limits?: EncodeLimits,
+): Promise<Blob | null> {
+  const maxEdge = limits?.maxEdge || SHOT_MAX_EDGE;
+  const maxBytes = limits?.maxBytes || SHOT_MAX_BYTES;
+  let box = fit(pane.width, pane.height, maxEdge);
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const c = makeCanvas();
+    c.width = box.width;
+    c.height = box.height;
+    const ctx = c.getContext("2d");
+    ctx?.drawImage(pane.canvas, 0, 0, pane.width, pane.height, 0, 0, box.width, box.height);
+    if (ctx) {
+      for (const b of badges) drawBadge(ctx, b.x * box.scale, b.y * box.scale, b.label);
+    }
+    const fitted = await ladder(c, maxBytes);
+    if (fitted.blob) return fitted.blob;
+    if (fitted.dead) return null;
+    box = halve(box);
+  }
+  return null;
+}
+
+function halve(box: { width: number; height: number; scale: number }) {
+  return {
+    width: Math.max(1, Math.round(box.width / 2)),
+    height: Math.max(1, Math.round(box.height / 2)),
+    scale: box.scale / 2,
+  };
+}
+
+/** One size's worth of the ladder: WebP 0.8 then 0.6 while the latch allows it,
+ *  then PNG. `dead` = the encoder answered null, which ends the whole ladder
+ *  (T:9673-9686). */
+async function ladder(
+  c: HTMLCanvasElement,
+  maxBytes: number,
+): Promise<{ blob: Blob | null; dead: boolean }> {
+  if (webpOk !== false) {
+    for (const q of SHOT_WEBP_QUALITY) {
+      const webp = await toBlob(c, "image/webp", q);
+      if (!webp) break;
+      if (webp.type !== "image/webp") {
+        // The silent failure. Recorded so no later shot pays for the discovery
+        // again, and fall through to PNG — which is what this blob already is.
+        webpOk = false;
+        break;
+      }
+      webpOk = true;
+      if (webp.size <= maxBytes) return { blob: webp, dead: false };
+    }
+  }
+  const png = await toBlob(c, "image/png");
+  if (!png) return { blob: null, dead: true };
+  if (png.size <= maxBytes) return { blob: png, dead: false };
+  return { blob: null, dead: false };
+}
+
+/** A labeled badge in CANVAS pixel space — legible however small the picture
+ *  ends up, unlike an overlay the picture cannot carry. White ring under a red
+ *  disc so it reads on light and dark app backgrounds alike; the LETTER is the
+ *  payload, the same string the annotation's `label` carries on the wire
+ *  (T:8009). */
+export function drawBadge(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  label: string,
+): void {
+  const r = 11;
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, Math.PI * 2);
+  ctx.fillStyle = "#ff2d55";
+  ctx.fill();
+  ctx.lineWidth = 2.5;
+  ctx.strokeStyle = "#fff";
+  ctx.stroke();
+  ctx.fillStyle = "#fff";
+  ctx.font = "bold " + (label && label.length > 1 ? 11 : 13) + "px system-ui, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(label || "?", x, y + 0.5);
+  ctx.restore();
+}
+
+// ── reading a picture the user brought in (T:11462-11518) ────────────────────
+
+/** Pixels plus the release the caller owes (`close()` for a bitmap, a revoke for
+ *  the `<img>` path). `canvas` is a valid `drawImage` SOURCE named the way
+ *  `encode` reads its pane, so the resize below is a REUSE of the capture ladder
+ *  rather than a second copy of it (T:11462). */
+export interface ShotPixels {
+  canvas: CanvasImageSource;
+  width: number;
+  height: number;
+  free: () => void;
+}
+
+/** The pixels of a picture the user brought in, or null when this engine cannot
+ *  get at them. Two mechanisms because they fail in different places:
+ *  `createImageBitmap` THROWS on a format it does not know, while `<img>` +
+ *  `decode()` is what an engine without it still has. The answer is load-bearing
+ *  twice — it decides whether the downscale is even available, and whether a
+ *  thumbnail would be honest (T:11462). */
+export async function shotPixels(file: Blob): Promise<ShotPixels | null> {
+  if (typeof createImageBitmap === "function") {
+    try {
+      const bmp = await createImageBitmap(file);
+      if (bmp && bmp.width && bmp.height) {
+        return {
+          canvas: bmp,
+          width: bmp.width,
+          height: bmp.height,
+          free: () => {
+            try {
+              bmp.close();
+            } catch {
+              /* no close */
+            }
+          },
+        };
+      }
+    } catch {
+      /* an engine without it, or a format it refuses — try <img> */
+    }
+  }
+  if (typeof Image !== "function") return null;
+  const url = URL.createObjectURL(file);
+  try {
+    const img = new Image();
+    img.src = url;
+    await (img.decode
+      ? img.decode()
+      : new Promise<void>((res, rej) => {
+          img.onload = () => res();
+          img.onerror = () => rej(new Error("undecodable"));
+        }));
+    if (!img.naturalWidth || !img.naturalHeight) throw new Error("no pixels");
+    return {
+      canvas: img,
+      width: img.naturalWidth,
+      height: img.naturalHeight,
+      free: () => URL.revokeObjectURL(url),
+    };
+  } catch {
+    URL.revokeObjectURL(url);
+    return null;
+  }
+}
+
+/** One oversize picture, re-encoded small enough to attach. The ladder is
+ *  `encode`'s and not a new one, capped at SHOT_VIEW_EDGE — a photo the user
+ *  brought in is never carried at a size the app's own screenshots are not.
+ *  `null` means even the halvings could not reach the budget (T:11518). */
+export async function shrink(
+  pix: ShotPixels,
+  maxBytes: number,
+): Promise<{ blob: Blob; width: number; height: number } | null> {
+  const size: EncodeSize = { width: 0, height: 0 };
+  const blob = await encode(
+    pix,
+    { left: 0, top: 0, width: pix.width, height: pix.height },
+    { maxEdge: SHOT_VIEW_EDGE, maxBytes },
+    size,
+  );
+  return blob ? { blob, width: size.width, height: size.height } : null;
+}
+
+/** Re-encode an oversized image found INSIDE a capture down to something worth
+ *  embedding: base64 adds a third on top of the bytes and the result is inlined
+ *  in markup that then has to be parsed, rasterised and encoded again — so a
+ *  4 MB photo would cost more than the whole screenshot it appears in. Drawn
+ *  from an object URL rather than the page's own `<img>`, so the canvas is never
+ *  tainted (T:9396 shotShrinkImage). */
+export async function shrinkImage(blob: Blob): Promise<Blob> {
+  const objUrl = URL.createObjectURL(blob);
+  try {
+    const img = await loadImage(objUrl);
+    const box = fit(img.naturalWidth || 1, img.naturalHeight || 1, SHOT_VIEW_EDGE);
+    const c = makeCanvas();
+    c.width = box.width;
+    c.height = box.height;
+    c.getContext("2d")?.drawImage(img, 0, 0, box.width, box.height);
+    // WebP where it is real, PNG where it silently is not — the same one-line
+    // check `shotExt` spells out, for the same WKWebView reason (T:9414).
+    const webp = await toBlob(c, "image/webp", 0.8);
+    if (webp && webp.type === "image/webp") return webp;
+    return (await toBlob(c, "image/png")) || blob;
+  } finally {
+    URL.revokeObjectURL(objUrl);
+  }
+}
+
+export function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((res, rej) => {
+    const img = new Image();
+    img.onload = () => res(img);
+    img.onerror = () => rej(new Error("the image could not be decoded"));
+    img.src = src;
+  });
+}
+
+/** A blob as a `data:` URL. FileReader rather than manual base64: the only path
+ *  that does not push the whole file through a JS string byte by byte (T:9375). */
+export function dataUrl(blob: Blob): Promise<string> {
+  return new Promise((res, rej) => {
+    const fr = new FileReader();
+    fr.onload = () => res(String(fr.result || ""));
+    fr.onerror = () => rej(new Error("the image bytes could not be read"));
+    fr.readAsDataURL(blob);
+  });
+}
+
+/** Whether a canvas read back nothing we can use. maplibre and deck.gl create
+ *  their WebGL context with `preserveDrawingBuffer:false`, so `toDataURL` hands
+ *  back a fully TRANSPARENT image of the right size — and an agent that believes
+ *  the app is blank spends a whole debugging loop on a bug that does not exist.
+ *  Compared against a same-size EMPTY canvas's encoding: PNG of a transparent
+ *  W×H is deterministic, so equality is the test. "Cannot tell" is unreadable,
+ *  not fine (T:9355). */
+export function readbackIsBlank(url: string, blankUrl: string): boolean {
+  return !url || !blankUrl || url === blankUrl;
+}
+
+/** Replace each `<canvas>` in the clone with an `<img>` of its own pixels: a
+ *  `<canvas>` serializes as an empty element, so without this every chart and map
+ *  in the capture is a hole. Returns the SOURCE canvases whose pixels were not
+ *  readable, for the caveat that reports them (T:9554). */
+export function rasterise(src: Element, dst: Element): Element[] {
+  const cs = src.querySelectorAll("canvas");
+  const cd = dst.querySelectorAll("canvas");
+  const blanks: Element[] = [];
+  const probe = src.ownerDocument.createElement("canvas");
+  for (let i = 0; i < cs.length && i < cd.length; i++) {
+    let url = "";
+    try {
+      url = cs[i].toDataURL("image/png");
+    } catch {
+      url = "";
+    }
+    let blankUrl = "";
+    try {
+      probe.width = cs[i].width;
+      probe.height = cs[i].height;
+      blankUrl = probe.toDataURL("image/png");
+    } catch {
+      blankUrl = "";
+    }
+    if (readbackIsBlank(url, blankUrl)) {
+      // Left as a <canvas> in the clone, which serializes empty — the same hole
+      // it would have been anyway. The caveat is what reports it.
+      blanks.push(cs[i]);
+      continue;
+    }
+    const img = dst.ownerDocument.createElement("img");
+    img.setAttribute("src", url);
+    img.setAttribute("style", cd[i].getAttribute("style") || "");
+    cd[i].replaceWith(img);
+  }
+  return blanks;
+}

--- a/frontend/src/apps/claude/shots/index.ts
+++ b/frontend/src/apps/claude/shots/index.ts
@@ -88,6 +88,7 @@ export {
 export {
   SHOOTING_ATTR,
   captureNative,
+  flashOverlays,
   frameOffset,
   isNativeOff,
   learnTopOrigin,

--- a/frontend/src/apps/claude/shots/index.ts
+++ b/frontend/src/apps/claude/shots/index.ts
@@ -1,0 +1,148 @@
+// The screenshot + attachment pipeline, PR2 (inventory 03 §A/§E, T:9019-11750).
+// Pure TS: no React, no DOM ownership beyond the transient shutter sheet and the
+// canvases the encoders make. The UI (AttachTray, ShotViewer, SentPop, receipts)
+// reads this and `./types` and nothing deeper.
+export type {
+  Attachment,
+  CaptureResult,
+  PaneBitmap,
+  PaneShotEntry,
+  Receipt,
+  ShotBadge,
+  ShotKind,
+  ShotRect,
+} from "./types";
+export {
+  FUSED_PATH_MIME,
+  SHOT_ATTACH_MAX_BYTES,
+  SHOT_FLASH_MS,
+  SHOT_IMG_MAX,
+  SHOT_IMG_MAX_BYTES,
+  SHOT_IMG_MS,
+  SHOT_MAX_BYTES,
+  SHOT_MAX_EDGE,
+  SHOT_MAX_ELEMENTS,
+  SHOT_MIN_AREA,
+  SHOT_NATIVE_MIN,
+  SHOT_PATH_TYPE,
+  SHOT_STYLE_CHUNK,
+  SHOT_TIMEOUT_MS,
+  SHOT_VIEW_BYTES,
+  SHOT_VIEW_EDGE,
+  SHOT_WEBP_QUALITY,
+} from "./types";
+
+export {
+  SHOT_MIME_EXT,
+  SHOT_SUFFIX_OVERVIEW,
+  SHOT_SUFFIX_VIEW,
+  shotBase,
+  shotDirOf,
+  shotFileExt,
+  shotJoin,
+  shotStamp,
+  shotsDir,
+  shotsDirSeen,
+  resetShotsDirForTests,
+} from "./dir";
+
+export {
+  cropRect,
+  dataUrl,
+  encode,
+  encodeBadged,
+  drawBadge,
+  fit,
+  loadImage,
+  rasterise,
+  readbackIsBlank,
+  setCanvasFactory,
+  shotExt,
+  shotPixels,
+  shrink,
+  shrinkImage,
+  toBlob,
+  webpLatch,
+  resetWebpLatchForTests,
+  type EncodeLimits,
+  type EncodeSize,
+  type ShotPixels,
+} from "./encode";
+
+export {
+  applyScroll,
+  backdrop,
+  blankRegions,
+  captureDom,
+  caveatsOf,
+  imageNote,
+  imagePlaceholder,
+  inlineImages,
+  inlineStyles,
+  paneNote,
+  styleUrls,
+  trustLine,
+  urlAsData,
+  viewNoteFrom,
+  type StyleWalk,
+} from "./dom-capture";
+
+export {
+  SHOOTING_ATTR,
+  captureNative,
+  frameOffset,
+  isNativeOff,
+  learnTopOrigin,
+  screenRect,
+  resetNativeOffForTests,
+  resetTopOriginForTests,
+  topOriginForTests,
+  watchTopOrigin,
+  type NativeCaptureOptions,
+} from "./native-capture";
+
+export {
+  captureXO,
+  currentStream,
+  getStream,
+  stopStream,
+  watchStreamTeardown,
+} from "./xo-capture";
+
+export {
+  capturePane,
+  capturePaneBitmap,
+  captureOverview,
+  flash,
+  type CaptureOptions,
+  type CaptureStrategies,
+} from "./capture";
+
+export {
+  attachFile,
+  attachFiles,
+  attachOverview,
+  attachPane,
+  attachPaths,
+  dragHasAttachment,
+  failLabel,
+  filesFromDrop,
+  filesFromPaste,
+  formatLabel,
+  isImage,
+  kindFor,
+  pathsFromDrop,
+  probePruned,
+  prunedLabel,
+  readDirs,
+  readDirsFor,
+  receiptFor,
+  receiptsFromWire,
+  revoke,
+  saveExt,
+  shotAlt,
+  shotNoun,
+  sizeLabel,
+  toWire,
+  type NamedBlob,
+} from "./attach";

--- a/frontend/src/apps/claude/shots/index.ts
+++ b/frontend/src/apps/claude/shots/index.ts
@@ -14,7 +14,6 @@ export type {
 } from "./types";
 export {
   FUSED_PATH_MIME,
-  SHOT_ATTACH_MAX_BYTES,
   SHOT_FLASH_MS,
   SHOT_IMG_MAX,
   SHOT_IMG_MAX_BYTES,
@@ -59,7 +58,6 @@ export {
   setCanvasFactory,
   shotExt,
   shotPixels,
-  shrink,
   shrinkImage,
   toBlob,
   webpLatch,

--- a/frontend/src/apps/claude/shots/index.ts
+++ b/frontend/src/apps/claude/shots/index.ts
@@ -114,6 +114,7 @@ export {
   capturePaneBitmap,
   captureOverview,
   flash,
+  frameIsCrossOrigin,
   type CaptureOptions,
   type CaptureStrategies,
 } from "./capture";

--- a/frontend/src/apps/claude/shots/index.ts
+++ b/frontend/src/apps/claude/shots/index.ts
@@ -141,6 +141,7 @@ export {
   receiptsFromWire,
   revoke,
   saveExt,
+  settleReceipts,
   shotAlt,
   shotNoun,
   sizeLabel,

--- a/frontend/src/apps/claude/shots/native-capture.test.ts
+++ b/frontend/src/apps/claude/shots/native-capture.test.ts
@@ -1,0 +1,531 @@
+// THE NATIVE SHOT'S DECISION POINTS (T:9766-9956). `capture.test.ts` injects
+// `opts.strategies`, so the real native strategy never runs there: what is under
+// test HERE is the arithmetic that turns a frame into a screen rect, the origin
+// it is learned from, and the "cannot" roads — every one of which has to answer
+// null rather than throw, because the caller falls through to the paths that
+// were there before. Nothing about pixels: the hand-rolled fakes below carry
+// only the members the module actually reads.
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { installDomShim } from "@platform/lib/testDomShim";
+
+installDomShim();
+
+// `bun test` runs every file in ONE process against one `globalThis`, so
+// whatever this suite stubs is put back the moment it is done — a leaked
+// `fetch`, `document` or `window` breaks whoever runs next (the idiom
+// platform/ui/appdoctor-lib.test.ts sets out and capture.test.ts follows).
+const G = globalThis as Record<string, unknown>;
+const BEFORE = {
+  fetch: G.fetch,
+  createImageBitmap: G.createImageBitmap,
+  document: G.document,
+  window: G.window,
+};
+afterAll(() => {
+  G.fetch = BEFORE.fetch;
+  G.createImageBitmap = BEFORE.createImageBitmap;
+  G.document = BEFORE.document;
+  G.window = BEFORE.window;
+});
+
+const {
+  SHOOTING_ATTR,
+  captureNative,
+  frameOffset,
+  isNativeOff,
+  learnTopOrigin,
+  resetNativeOffForTests,
+  resetTopOriginForTests,
+  screenRect,
+  topOriginForTests,
+  watchTopOrigin,
+} = await import("./native-capture");
+const { SHOT_NATIVE_MIN } = await import("./types");
+
+// ── the fakes ───────────────────────────────────────────────────────────────
+
+type Rec = Record<string, unknown>;
+
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+  } as DOMRect;
+}
+
+/** A frame ELEMENT as `frameOffset` reads one: a client rect plus the border
+ *  widths it adds on top. */
+function frameEl(r: DOMRect, clientLeft = 0, clientTop = 0): Rec {
+  return { getBoundingClientRect: () => r, clientLeft, clientTop };
+}
+
+/** A top-level window: `w.top === w`, so `frameOffset`'s walk never runs. The
+ *  screen numbers are the fallback origin's inputs — chrome 0px at the sides and
+ *  60px on top, which is what makes the fallback's guess (40, 150) below. */
+function topWin(over: Rec = {}): Window {
+  const w: Rec = {
+    innerWidth: 1200,
+    innerHeight: 800,
+    screenX: 40,
+    screenY: 90,
+    outerWidth: 1200,
+    outerHeight: 860,
+    ...over,
+  };
+  w.top = w;
+  w.parent = w;
+  return w as unknown as Window;
+}
+
+/** A framed window one level below `parent`. */
+function childWin(parent: Window, fe: unknown, top?: Window): Window {
+  return {
+    frameElement: fe,
+    parent,
+    top: top || (parent as unknown as Rec).top,
+  } as unknown as Window;
+}
+
+interface FakeCanvas {
+  width: number;
+  height: number;
+  getContext: () => { drawImage: (...args: unknown[]) => void };
+}
+
+let drawn: unknown[][] = [];
+let canvases: FakeCanvas[] = [];
+let flashEls: Rec[] = [];
+
+function newCanvas(): FakeCanvas {
+  const c: FakeCanvas = {
+    width: 0,
+    height: 0,
+    getContext: () => ({ drawImage: (...args: unknown[]) => drawn.push(args) }),
+  };
+  canvases.push(c);
+  return c;
+}
+
+/** The frame's OWNER document — a distinct object from the global `document` on
+ *  purpose, because `defaultOverlays` collects both into a Set and a single
+ *  shared object would silently test only one of them. */
+function ownerDoc(win: Window | null, body: Rec | null): Rec {
+  return {
+    defaultView: win,
+    body,
+    querySelectorAll: () => flashEls,
+  };
+}
+
+interface FrameOver {
+  isConnected?: boolean;
+  clientWidth?: number;
+  clientHeight?: number;
+  clientLeft?: number;
+  clientTop?: number;
+  r?: DOMRect;
+  win?: Window | null;
+  body?: Rec | null;
+  doc?: Rec;
+}
+
+function makeFrame(over: FrameOver = {}): HTMLIFrameElement {
+  const win = over.win === undefined ? topWin() : over.win;
+  const body: Rec | null =
+    over.body === undefined ? { attrs: {} as Rec, setAttribute() {}, removeAttribute() {} } : over.body;
+  return {
+    isConnected: over.isConnected !== false,
+    clientWidth: over.clientWidth ?? 400,
+    clientHeight: over.clientHeight ?? 300,
+    clientLeft: over.clientLeft ?? 3,
+    clientTop: over.clientTop ?? 4,
+    getBoundingClientRect: () => over.r || rect(100, 50, 400, 300),
+    ownerDocument: over.doc || ownerDoc(win, body),
+  } as unknown as HTMLIFrameElement;
+}
+
+/** A body that REMEMBERS the attribute round trip, so the shot can be asked
+ *  whether the shell's overlay chrome was hidden while the screen was read. */
+function recordingBody(): Rec & { attrs: Record<string, string> } {
+  const attrs: Record<string, string> = {};
+  return {
+    attrs,
+    setAttribute: (k: string, v: string) => {
+      attrs[k] = v;
+    },
+    removeAttribute: (k: string) => {
+      delete attrs[k];
+    },
+  } as Rec & { attrs: Record<string, string> };
+}
+
+interface FetchCall {
+  url: string;
+  body: { rect: number[]; dpr: number };
+}
+let fetches: FetchCall[] = [];
+let respond: () => Promise<unknown> = () => Promise.reject(new Error("no responder"));
+
+beforeEach(() => {
+  // The module-level latches are exactly what these tests are about, so neither
+  // may leak into the next test — a sticky `nativeOff` would make every later
+  // capture answer null before it asked anything.
+  resetNativeOffForTests();
+  resetTopOriginForTests();
+  drawn = [];
+  canvases = [];
+  flashEls = [];
+  fetches = [];
+  respond = () => Promise.reject(new Error("no responder"));
+  G.document = {
+    hidden: false,
+    addEventListener() {},
+    removeEventListener() {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    createElement: (tag: string) => (tag === "canvas" ? newCanvas() : {}),
+  };
+  G.window = { ...(BEFORE.window as Rec), devicePixelRatio: 2 };
+  G.createImageBitmap = () => Promise.resolve({ close: () => {} });
+  G.fetch = (url: string, init: { body: string }) => {
+    fetches.push({ url, body: JSON.parse(init.body) as FetchCall["body"] });
+    return respond();
+  };
+});
+
+/** A server answer with only the members `captureNative` reads off a Response. */
+function reply(status: number, over: Rec = {}): unknown {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve({ _error: "why" }),
+    blob: () => Promise.resolve(new Blob([new Uint8Array(8)], { type: "image/png" })),
+    ...over,
+  };
+}
+
+// ── frameOffset ─────────────────────────────────────────────────────────────
+
+describe("frameOffset (T:9822)", () => {
+  test("a top-level window is at the top viewport's own origin", () => {
+    expect(frameOffset(topWin())).toEqual({ x: 0, y: 0 });
+  });
+
+  test("every frame element between here and the top is summed, borders included", () => {
+    // Two levels, so the test would still fail if the walk stopped after one.
+    // The border widths are part of the sum because the offset has to land on the
+    // framed VIEWPORT, not on the element box around it.
+    const top = topWin();
+    const mid = childWin(top, frameEl(rect(5, 7, 900, 600)));
+    const leaf = childWin(mid, frameEl(rect(10, 20, 400, 300), 1, 2), top);
+    expect(frameOffset(leaf)).toEqual({ x: 16, y: 29 });
+  });
+
+  test("a frame on the way with no element is null, not a partial sum", () => {
+    // Half an offset would be a confidently WRONG screen rect; null makes the
+    // caller fall through instead.
+    const top = topWin();
+    expect(frameOffset(childWin(top, undefined))).toBeNull();
+  });
+
+  test("a cross-origin ancestor that throws on read is null", () => {
+    const top = topWin();
+    const leaf: Rec = { parent: top, top };
+    Object.defineProperty(leaf, "frameElement", {
+      get() {
+        throw new Error("cross-origin");
+      },
+    });
+    expect(frameOffset(leaf as unknown as Window)).toBeNull();
+  });
+});
+
+// ── learnTopOrigin / watchTopOrigin ─────────────────────────────────────────
+
+describe("learnTopOrigin (T:9802, 9812)", () => {
+  test("screen minus client IS the viewport origin, minus our own frame offset", () => {
+    // The whole point of learning from a pointer event: screenX/clientX is exact
+    // for any chrome layout, where the outerWidth arithmetic only guesses.
+    learnTopOrigin({ screenX: 500, clientX: 100, screenY: 300, clientY: 50 }, topWin());
+    expect(topOriginForTests()).toEqual({ x: 400, y: 250 });
+  });
+
+  test("a click inside a frame is walked up to the TOP window's origin", () => {
+    const top = topWin();
+    const mid = childWin(top, frameEl(rect(5, 7, 900, 600)));
+    const leaf = childWin(mid, frameEl(rect(10, 20, 400, 300), 1, 2), top);
+    learnTopOrigin({ screenX: 500, clientX: 100, screenY: 300, clientY: 50 }, leaf);
+    // (500-100) - 16, (300-50) - 29.
+    expect(topOriginForTests()).toEqual({ x: 384, y: 221 });
+  });
+
+  test("an unknowable frame offset teaches NOTHING rather than a wrong origin", () => {
+    learnTopOrigin({ screenX: 500, clientX: 100, screenY: 300, clientY: 50 }, childWin(topWin(), undefined));
+    expect(topOriginForTests()).toBeNull();
+  });
+});
+
+describe("watchTopOrigin (T:9802)", () => {
+  test("the listener is CAPTURE phase, learns on a pointerdown, and the teardown removes it", () => {
+    // Capture phase so a `stopPropagation` in a menu cannot hide the click the
+    // next capture depends on — and registered from here rather than at module
+    // load, so a bundle that merely imports `shots/*` carries no listener.
+    const added: unknown[][] = [];
+    const removed: unknown[][] = [];
+    const host = topWin({
+      addEventListener: (...a: unknown[]) => added.push(a),
+      removeEventListener: (...a: unknown[]) => removed.push(a),
+    });
+    const stop = watchTopOrigin(host);
+    expect(added.length).toBe(1);
+    expect(added[0][0]).toBe("pointerdown");
+    expect(added[0][2]).toEqual({ capture: true, passive: true });
+
+    const onDown = added[0][1] as (e: unknown) => void;
+    onDown({ screenX: 500, clientX: 100, screenY: 300, clientY: 50 });
+    expect(topOriginForTests()).toEqual({ x: 400, y: 250 });
+
+    stop();
+    expect(removed.length).toBe(1);
+    expect(removed[0][0]).toBe("pointerdown");
+    // The SAME function object, or the removal is a no-op that leaves the
+    // listener behind for the life of the page.
+    expect(removed[0][1]).toBe(onDown);
+    expect(removed[0][2]).toEqual({ capture: true });
+  });
+
+  test("no window, or one that cannot listen, is a harmless no-op teardown", () => {
+    expect(() => watchTopOrigin(null)()).not.toThrow();
+    expect(() => watchTopOrigin(undefined)()).not.toThrow();
+    expect(() => watchTopOrigin({} as unknown as Window)()).not.toThrow();
+  });
+});
+
+// ── screenRect ──────────────────────────────────────────────────────────────
+
+describe("screenRect (T:9838)", () => {
+  test("the border is trimmed and the fallback origin is added", () => {
+    // left = frameOffset.x + rect.left + clientLeft = 0 + 100 + 3, and the origin
+    // guess is screenX + 0 chrome at the sides, screenY + 60px on top.
+    expect(screenRect(makeFrame())).toEqual({
+      rect: [40 + 103, 150 + 54, 400, 300],
+      width: 400,
+      height: 300,
+    });
+  });
+
+  test("a LEARNED origin beats the outerWidth guess", () => {
+    learnTopOrigin({ screenX: 500, clientX: 100, screenY: 300, clientY: 50 }, topWin());
+    const box = screenRect(makeFrame());
+    expect(box?.rect).toEqual([400 + 103, 250 + 54, 400, 300]);
+  });
+
+  test("the frame's CLIENT size wins over its client rect", () => {
+    // The rect includes the border; the client size is the framed viewport, which
+    // is the space every pin and crop rect downstream already lives in.
+    const box = screenRect(makeFrame({ clientWidth: 380, clientHeight: 280 }));
+    expect([box?.width, box?.height]).toEqual([380, 280]);
+  });
+
+  test("a frame in a document with no window is null", () => {
+    expect(screenRect(makeFrame({ win: null }))).toBeNull();
+  });
+
+  test("an unknowable frame offset is null", () => {
+    const top = topWin();
+    expect(screenRect(makeFrame({ win: childWin(top, undefined) }))).toBeNull();
+  });
+
+  test("too small to be worth photographing is null", () => {
+    expect(
+      screenRect(makeFrame({ clientWidth: SHOT_NATIVE_MIN.width - 1, clientHeight: 300 })),
+    ).toBeNull();
+    expect(
+      screenRect(makeFrame({ clientWidth: 400, clientHeight: SHOT_NATIVE_MIN.height - 1 })),
+    ).toBeNull();
+    // And the boundary itself is IN: the constant is a minimum, not a threshold
+    // one pixel above it.
+    expect(
+      screenRect(
+        makeFrame({
+          clientWidth: SHOT_NATIVE_MIN.width,
+          clientHeight: SHOT_NATIVE_MIN.height,
+          r: rect(0, 0, SHOT_NATIVE_MIN.width, SHOT_NATIVE_MIN.height),
+        }),
+      ),
+    ).not.toBeNull();
+  });
+
+  test("off screen — scrolled above or left of the viewport — is null", () => {
+    expect(screenRect(makeFrame({ r: rect(-200, 50, 400, 300) }))).toBeNull();
+    expect(screenRect(makeFrame({ r: rect(100, -100, 400, 300) }))).toBeNull();
+  });
+
+  test("a SLIVER hanging out of the top viewport is null, not a wrong picture", () => {
+    // 1000 + 3 + 400 runs past innerWidth 1200: the server would refuse the rect
+    // anyway, and a partial frame is a picture of the wrong thing.
+    expect(screenRect(makeFrame({ r: rect(1000, 50, 400, 300) }))).toBeNull();
+    expect(screenRect(makeFrame({ r: rect(100, 700, 400, 300) }))).toBeNull();
+  });
+
+  test("a top window we cannot read is null — no origin, no rect", () => {
+    const badTop: Rec = {
+      get innerWidth(): number {
+        throw new Error("cross-origin");
+      },
+    };
+    badTop.top = badTop;
+    const win = childWin(badTop as unknown as Window, frameEl(rect(0, 0, 900, 600)));
+    expect(screenRect(makeFrame({ win }))).toBeNull();
+  });
+});
+
+// ── captureNative ───────────────────────────────────────────────────────────
+
+describe("captureNative the 409 sticky latch (T:9790, 9920, 9924)", () => {
+  test("a 409 is REMEMBERED: the second capture makes no request at all", async () => {
+    // 409 means "this platform has no still" — a fact about the backend, not
+    // about this shot, so a page over an unsupported backend pays the round trip
+    // exactly once instead of on every click.
+    const warn = console.warn;
+    console.warn = () => {};
+    try {
+      respond = () => Promise.resolve(reply(409));
+      expect(isNativeOff()).toBe(false);
+      expect(await captureNative(makeFrame())).toBeNull();
+      expect(fetches.length).toBe(1);
+      expect(isNativeOff()).toBe(true);
+
+      expect(await captureNative(makeFrame())).toBeNull();
+      expect(fetches.length).toBe(1);
+    } finally {
+      console.warn = warn;
+    }
+  });
+
+  test("a 400 is about THIS shot only — the next one still asks", async () => {
+    const warned: unknown[] = [];
+    const warn = console.warn;
+    console.warn = (...a: unknown[]) => warned.push(a[0]);
+    try {
+      respond = () => Promise.resolve(reply(400));
+      expect(await captureNative(makeFrame())).toBeNull();
+      expect(isNativeOff()).toBe(false);
+      expect(await captureNative(makeFrame())).toBeNull();
+      expect(fetches.length).toBe(2);
+      // Said, not swallowed: a 400 on every click is a bug in the arithmetic
+      // above that only the console can show.
+      expect(warned[0]).toBe("native pane shot refused (400): why");
+    } finally {
+      console.warn = warn;
+    }
+  });
+});
+
+describe("captureNative the cannot roads answer null (T:9905)", () => {
+  test("no frame, and a frame no longer in the document", async () => {
+    expect(await captureNative(null)).toBeNull();
+    expect(await captureNative(makeFrame({ isConnected: false }))).toBeNull();
+    // Neither reached the network: there is nothing to photograph.
+    expect(fetches.length).toBe(0);
+  });
+
+  test("an uncomputable origin never asks the server", async () => {
+    expect(await captureNative(makeFrame({ win: childWin(topWin(), undefined) }))).toBeNull();
+    expect(fetches.length).toBe(0);
+  });
+
+  test("a hidden pane — too small to photograph — never asks the server", async () => {
+    expect(await captureNative(makeFrame({ clientWidth: 0, clientHeight: 0, r: rect(0, 0, 0, 0) }))).toBeNull();
+    expect(fetches.length).toBe(0);
+  });
+
+  test("an unreachable server is null, not a rejection", async () => {
+    respond = () => Promise.reject(new Error("ECONNREFUSED"));
+    expect(await captureNative(makeFrame())).toBeNull();
+    expect(fetches.length).toBe(1);
+    expect(isNativeOff()).toBe(false);
+  });
+
+  test("bytes that are not a PNG are null", async () => {
+    respond = () =>
+      Promise.resolve(reply(200, { blob: () => Promise.resolve(new Blob([], { type: "text/html" })) }));
+    expect(await captureNative(makeFrame())).toBeNull();
+  });
+});
+
+describe("captureNative the success road (T:9878, 9884, 9944)", () => {
+  test("the rect, the dpr, and the overlay/SHOOTING_ATTR round trip", async () => {
+    const body = recordingBody();
+    const flash: Rec = { style: { visibility: "visible" } };
+    flashEls = [flash];
+    // A no-`style` member of the default overlay set is filtered out rather than
+    // throwing on assignment.
+    const notAnElement: Rec = {};
+    flashEls.push(notAnElement);
+
+    let duringAttr: string | undefined;
+    let duringVis: unknown;
+    respond = () => {
+      duringAttr = body.attrs[SHOOTING_ATTR];
+      duringVis = (flash.style as Rec).visibility;
+      return Promise.resolve(reply(200));
+    };
+
+    const frame = makeFrame({ body });
+    const out = await captureNative(frame, Date.now() + 1000);
+
+    expect(fetches[0].url).toBe("/api/capture/shot-region");
+    expect(fetches[0].body).toEqual({ rect: [143, 204, 400, 300], dpr: 2 });
+    // The screen shot sees everything the user does, so the shell's own chrome
+    // and the flash sheet are hidden WHILE the pixels are read…
+    expect(duringAttr).toBe("");
+    expect(duringVis).toBe("hidden");
+    // …and put back afterwards, whatever happened in between.
+    expect(SHOOTING_ATTR in body.attrs).toBe(false);
+    expect((flash.style as Rec).visibility).toBe("visible");
+
+    // Drawn at the frame's CSS size, not the display's: every crop rect and badge
+    // position downstream is in the framed viewport's CSS pixels.
+    expect(out?.width).toBe(400);
+    expect(out?.height).toBe(300);
+    expect([canvases[0].width, canvases[0].height]).toEqual([400, 300]);
+    expect(drawn[0].slice(1)).toEqual([0, 0, 400, 300]);
+    // A live-pixel capture has no style walk and no image inlining to caveat, so
+    // the doubt fields are simply clean.
+    expect(out?.incomplete).toBe(false);
+    expect(out?.blanks).toEqual([]);
+    expect(out?.imagesMissing).toBe(0);
+  });
+
+  test("the overlays are RESTORED even when the request fails", async () => {
+    const body = recordingBody();
+    const flash: Rec = { style: { visibility: "inherit" } };
+    respond = () => Promise.reject(new Error("boom"));
+    expect(await captureNative(makeFrame({ body }), undefined, { overlays: () => [flash as unknown as Element] })).toBeNull();
+    expect((flash.style as Rec).visibility).toBe("inherit");
+    expect(SHOOTING_ATTR in body.attrs).toBe(false);
+  });
+
+  test("an injected overlay set replaces the default flash lookup", async () => {
+    // PR3 passes its own set, which adds the annotation shadow host.
+    flashEls = [{ style: { visibility: "visible" } }];
+    const mine: Rec = { style: { visibility: "visible" } };
+    let duringFlash: unknown;
+    let duringMine: unknown;
+    respond = () => {
+      duringFlash = (flashEls[0].style as Rec).visibility;
+      duringMine = (mine.style as Rec).visibility;
+      return Promise.resolve(reply(200));
+    };
+    await captureNative(makeFrame(), undefined, { overlays: () => [mine as unknown as Element] });
+    expect(duringMine).toBe("hidden");
+    expect(duringFlash).toBe("visible");
+  });
+});

--- a/frontend/src/apps/claude/shots/native-capture.test.ts
+++ b/frontend/src/apps/claude/shots/native-capture.test.ts
@@ -113,7 +113,7 @@ function newCanvas(): FakeCanvas {
 }
 
 /** The frame's OWNER document — a distinct object from the global `document` on
- *  purpose, because `defaultOverlays` collects both into a Set and a single
+ *  purpose, because `flashOverlays` collects both into a Set and a single
  *  shared object would silently test only one of them. */
 function ownerDoc(win: Window | null, body: Rec | null): Rec {
   return {

--- a/frontend/src/apps/claude/shots/native-capture.ts
+++ b/frontend/src/apps/claude/shots/native-capture.ts
@@ -142,8 +142,18 @@ export interface NativeCaptureOptions {
 }
 
 /** The default overlay set: every flash sheet in this document and in the frame's
- *  owner document. PR3 passes its own, which adds the annotation shadow host. */
-function defaultOverlays(frame: HTMLIFrameElement): Element[] {
+ *  owner document. PR3 passes its own, which adds the annotation shadow host.
+ *
+ *  EXPORTED because the native path is not the only one that photographs what
+ *  the user can see: tab capture reads the same pixels off a video track, and it
+ *  was burning the white sheet into the picture whenever the grab beat the flash
+ *  home (`xo-capture`, Bugbot PR #1064). One finder, so a second overlay this
+ *  page learns to hide is hidden on both roads at once.
+ *
+ *  Every read is guarded: a caller's `frame` may be a stub whose owner document
+ *  is not a real one, and a finder that throws would take the whole capture with
+ *  it rather than simply hiding nothing. */
+export function flashOverlays(frame: HTMLIFrameElement): Element[] {
   const els: Element[] = [];
   const docs = new Set<Document>();
   if (typeof document !== "undefined") docs.add(document);
@@ -153,7 +163,12 @@ function defaultOverlays(frame: HTMLIFrameElement): Element[] {
     /* not ours */
   }
   for (const doc of docs) {
-    for (const el of Array.from(doc.querySelectorAll("[data-shot-flash]"))) els.push(el);
+    try {
+      if (typeof doc.querySelectorAll !== "function") continue;
+      for (const el of Array.from(doc.querySelectorAll("[data-shot-flash]"))) els.push(el);
+    } catch {
+      /* not queryable */
+    }
   }
   return els;
 }
@@ -168,7 +183,7 @@ export async function captureNative(
   if (nativeOff || !frame || !frame.isConnected) return null;
   const box = screenRect(frame);
   if (!box) return null;
-  const hidden = (opts.overlays ? opts.overlays() : defaultOverlays(frame)).filter(
+  const hidden = (opts.overlays ? opts.overlays() : flashOverlays(frame)).filter(
     (el): el is HTMLElement => !!(el as HTMLElement).style,
   );
   const prior = hidden.map((el) => el.style.visibility);

--- a/frontend/src/apps/claude/shots/native-capture.ts
+++ b/frontend/src/apps/claude/shots/native-capture.ts
@@ -1,0 +1,253 @@
+// THE NATIVE SCREEN SHOT (T:9766-9956) — the pane's LIVE pixels, no document
+// needed.
+//
+// `POST /api/capture/shot-region` is the ScreenCaptureKit / GDI / desktop-portal
+// still behind `fused.capture.screenshot()` (SPEC §45), the same one
+// `platform/lib/appShot.ts` drives for the export path (AF-11). Every capture
+// tries it FIRST: no share prompt (so nothing hinges on a click's transient
+// activation, and a walkthrough's tenth note raises no picker), it works in
+// whatever browser opened the page, and the pixels are the ones the user is
+// looking at — WebGL maps included, which the DOM clone can only report blank.
+//
+// It photographs VISIBLE pixels, so the frame must be on screen and the window
+// on ONE display (the server refuses a straddling rect). Every "cannot" — no
+// server, 409 unsupported, 400 off-display, a hidden pane, an origin we cannot
+// compute — answers null, never a throw, and the caller falls through to the
+// paths that were there before.
+import { SHOT_NATIVE_MIN, SHOT_TIMEOUT_MS, type PaneBitmap } from "./types";
+
+/** Set by a 409: "this platform has no still". Remembered, so a page over an
+ *  unsupported backend pays the round trip once (T:9790, 9924). */
+let nativeOff = false;
+
+export function isNativeOff(): boolean {
+  return nativeOff;
+}
+
+export function resetNativeOffForTests(): void {
+  nativeOff = false;
+}
+
+/** The attribute the SHELL hides its own overlay chrome on — the same
+ *  `SHOOTING_ATTR` appShot.ts stamps (T:9878). */
+export const SHOOTING_ATTR = "data-capture-shooting";
+
+/** Where the TOP window's viewport sits on the screen, learned from pointer
+ *  events the way appShot.ts learns it: a MouseEvent carries screenX/Y and
+ *  clientX/Y both, and their difference IS the viewport origin in screen units —
+ *  exact for any chrome layout (a side panel, vertical tabs), where the
+ *  outerWidth/innerWidth arithmetic assumes chrome on top split evenly at the
+ *  sides. Our window may be a frame of the shell's, so the learned origin is
+ *  walked up to the top through the frame offsets (T:9802). */
+let topOrigin: { x: number; y: number } | null = null;
+
+/** `pointerdown` ONLY: a keyboard-activated click is a real MouseEvent with
+ *  every coordinate ZERO, which would teach an origin of (0,0) and send viewport
+ *  coordinates to the server as screen ones (T:9812). */
+export function learnTopOrigin(e: { screenX: number; clientX: number; screenY: number; clientY: number }, win: Window): void {
+  const off = frameOffset(win);
+  if (!off) return;
+  topOrigin = { x: e.screenX - e.clientX - off.x, y: e.screenY - e.clientY - off.y };
+}
+
+export function topOriginForTests(): { x: number; y: number } | null {
+  return topOrigin;
+}
+
+export function resetTopOriginForTests(): void {
+  topOrigin = null;
+}
+
+/**
+ * The origin has to be learned from the click that PRECEDES a capture, and
+ * capture-phase so a `stopPropagation` in a menu cannot hide it.
+ *
+ * NOT at module load, which is where this lived until PR2's review: any bundle
+ * that so much as imports `shots/*` would then carry a document-wide listener
+ * for a feature its page may never turn on — the chat flag off included. It is
+ * the CHAT's listener, so the chat's own mount registers it and the returned
+ * teardown takes it away again (appShot.ts keeps its copy for the export path).
+ */
+export function watchTopOrigin(win: Window | null | undefined): () => void {
+  const host = win;
+  if (!host || typeof host.addEventListener !== "function") return () => {};
+  const onDown = (e: Event): void => learnTopOrigin(e as PointerEvent, host);
+  host.addEventListener("pointerdown", onDown, { capture: true, passive: true });
+  return () => host.removeEventListener("pointerdown", onDown, { capture: true });
+}
+
+/** A window's viewport origin within the TOP window's viewport, summed over every
+ *  frame element between them; null when a frame on the way is not ours to read
+ *  (a cross-origin ancestor — no screen rect can be computed then) (T:9822). */
+export function frameOffset(win: Window): { x: number; y: number } | null {
+  let x = 0;
+  let y = 0;
+  try {
+    for (let w = win; w !== w.top; w = w.parent) {
+      const fe = w.frameElement;
+      if (!fe) return null;
+      const r = fe.getBoundingClientRect();
+      x += r.left + (fe.clientLeft || 0);
+      y += r.top + (fe.clientTop || 0);
+    }
+  } catch {
+    return null;
+  }
+  return { x, y };
+}
+
+/** The frame's CONTENT box in screen units, or null when it is off screen, not
+ *  fully inside the top viewport (a sliver is a wrong picture, and the server
+ *  would refuse the rect anyway) or too small to be worth photographing. The
+ *  border is trimmed because the pixels have to be the framed viewport's: the
+ *  space every pin and crop rect is already in (T:9838). */
+export function screenRect(
+  frame: HTMLIFrameElement,
+): { rect: [number, number, number, number]; width: number; height: number } | null {
+  const win = frame.ownerDocument && frame.ownerDocument.defaultView;
+  if (!win) return null;
+  const off = frameOffset(win);
+  if (!off) return null;
+  const r = frame.getBoundingClientRect();
+  const w = Math.round(frame.clientWidth || r.width);
+  const h = Math.round(frame.clientHeight || r.height);
+  if (w < SHOT_NATIVE_MIN.width || h < SHOT_NATIVE_MIN.height) return null;
+  const left = off.x + r.left + (frame.clientLeft || 0);
+  const top = off.y + r.top + (frame.clientTop || 0);
+  let topWin: Window;
+  try {
+    topWin = win.top as Window;
+    void topWin.innerWidth;
+  } catch {
+    return null;
+  }
+  if (left < 0 || top < 0 || left + w > topWin.innerWidth || top + h > topWin.innerHeight) {
+    return null;
+  }
+  const origin =
+    topOrigin || {
+      x: topWin.screenX + Math.max(0, (topWin.outerWidth - topWin.innerWidth) / 2),
+      y: topWin.screenY + Math.max(0, topWin.outerHeight - topWin.innerHeight),
+    };
+  return { rect: [origin.x + left, origin.y + top, w, h], width: w, height: h };
+}
+
+export interface NativeCaptureOptions {
+  /** What sits ON the pane and must not be in its picture — the annotation layer
+   *  (PR3) and the shutter flash. The DOM clone never had this problem
+   *  (`cloneNode` skips a shadow tree) but a screen shot sees everything the user
+   *  does (T:9884). The default finds the flash, which this module's own
+   *  `flash()` stamps `[data-shot-flash]`. */
+  overlays?: () => Element[];
+}
+
+/** The default overlay set: every flash sheet in this document and in the frame's
+ *  owner document. PR3 passes its own, which adds the annotation shadow host. */
+function defaultOverlays(frame: HTMLIFrameElement): Element[] {
+  const els: Element[] = [];
+  const docs = new Set<Document>();
+  if (typeof document !== "undefined") docs.add(document);
+  try {
+    if (frame.ownerDocument) docs.add(frame.ownerDocument);
+  } catch {
+    /* not ours */
+  }
+  for (const doc of docs) {
+    for (const el of Array.from(doc.querySelectorAll("[data-shot-flash]"))) els.push(el);
+  }
+  return els;
+}
+
+/** One native shot of `frame`, at the frame's CSS size. Null for every "cannot"
+ *  (T:9905). */
+export async function captureNative(
+  frame: HTMLIFrameElement | null,
+  deadline?: number,
+  opts: NativeCaptureOptions = {},
+): Promise<PaneBitmap | null> {
+  if (nativeOff || !frame || !frame.isConnected) return null;
+  const box = screenRect(frame);
+  if (!box) return null;
+  const hidden = (opts.overlays ? opts.overlays() : defaultOverlays(frame)).filter(
+    (el): el is HTMLElement => !!(el as HTMLElement).style,
+  );
+  const prior = hidden.map((el) => el.style.visibility);
+  let hostBody: HTMLElement | null = null;
+  try {
+    hostBody = frame.ownerDocument.body;
+  } catch {
+    /* not ours */
+  }
+  try {
+    for (const el of hidden) el.style.visibility = "hidden";
+    if (hostBody) hostBody.setAttribute(SHOOTING_ATTR, "");
+    // Two frames, so the hiding is PAINTED before the screen is read — bounded,
+    // because rAF never fires in a hidden document and a hang here would eat the
+    // caller's whole deadline (T:9891).
+    await Promise.race([
+      new Promise<void>((res) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => res())),
+      ),
+      new Promise<void>((res) => setTimeout(res, 120)),
+    ]);
+    const ctl = new AbortController();
+    const left = (deadline || Date.now() + SHOT_TIMEOUT_MS) - Date.now();
+    const timer = setTimeout(() => ctl.abort(), Math.max(200, Math.min(4000, left)));
+    let res: Response;
+    try {
+      res = await fetch("/api/capture/shot-region", {
+        method: "POST",
+        signal: ctl.signal,
+        headers: { "X-Fused": "1", "Content-Type": "application/json" },
+        body: JSON.stringify({ rect: box.rect, dpr: window.devicePixelRatio || 1 }),
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+    // 409 is "this platform has no still": remembered. 400 (off-display, bad
+    // rect) and 500 are about THIS shot — the next one may land (T:9920).
+    if (res.status === 409) nativeOff = true;
+    if (!res.ok) {
+      // Said, not swallowed: a 400 on every click is a bug in the arithmetic
+      // above that only the console can show (T:9926).
+      let why = "";
+      try {
+        const body: unknown = await res.json();
+        why = (body as { _error?: string } | null)?._error || "";
+      } catch {
+        /* not JSON */
+      }
+      console.warn("native pane shot refused (" + res.status + "): " + why, {
+        rect: box.rect,
+        dpr: window.devicePixelRatio || 1,
+      });
+      return null;
+    }
+    const blob = await res.blob();
+    if (!blob.size || !blob.type.startsWith("image/png")) return null;
+    const bitmap = await createImageBitmap(blob);
+    // Drawn at the frame's CSS size, not the display's: every crop rect and badge
+    // position downstream is in the framed viewport's CSS pixels (T:9944).
+    const canvas = document.createElement("canvas");
+    canvas.width = box.width;
+    canvas.height = box.height;
+    canvas.getContext("2d")?.drawImage(bitmap, 0, 0, box.width, box.height);
+    bitmap.close();
+    return {
+      canvas,
+      width: box.width,
+      height: box.height,
+      blanks: [],
+      styled: 0,
+      incomplete: false,
+      imagesMissing: 0,
+    };
+  } catch {
+    return null; // unreachable server, aborted, undecodable — the fallbacks answer
+  } finally {
+    hidden.forEach((el, i) => {
+      el.style.visibility = prior[i];
+    });
+    if (hostBody) hostBody.removeAttribute(SHOOTING_ATTR);
+  }
+}

--- a/frontend/src/apps/claude/shots/types.ts
+++ b/frontend/src/apps/claude/shots/types.ts
@@ -90,7 +90,13 @@ export interface CaptureResult {
   why?: string;
 }
 
-export const SHOT_ATTACH_MAX_BYTES = 4 * 1024 * 1024; // T:11355 downscale trigger
+/* THERE IS NO ATTACHMENT SIZE CONSTANT (Akshil, 2026-09-09, P2-6). T re-encoded
+   a dropped picture over 4 MiB before the upload (T:11355) — never a refusal,
+   but still this app changing the bytes someone attached without being asked —
+   and the owner's rule is that "any and every file, size and type must not
+   matter". Only the PANE SCREENSHOT this app takes itself has a budget
+   (`SHOT_IMG_MAX_BYTES` below, and the ladder in `shots/encode`): that is a
+   picture it composed, so it gets to size it. */
 export const SHOT_VIEW_EDGE = 1600; // T:4755
 export const SHOT_VIEW_BYTES = 900 * 1024; // T:4756
 export const SHOT_MAX_EDGE = 640; // T:4702 crops

--- a/frontend/src/apps/claude/shots/types.ts
+++ b/frontend/src/apps/claude/shots/types.ts
@@ -1,0 +1,157 @@
+// Shared contract between the screenshot/attachment pipeline (shots/*.ts, pure
+// TS) and the attachment UI (ui/AttachTray, ui/ShotViewer, ui/SentPop,
+// receipts). Extend, never rename. Source: inventory 03 §D/§E (T:9019-11750).
+
+/** T:11366 shotKindFor — what the agent is told it is looking at. */
+export type ShotKind = "pane" | "overview" | "image" | "file";
+
+/** A pending or sent attachment. Exactly one of `thumb`/`size` is set when
+ *  drawable vs not (T:11603). */
+export interface Attachment {
+  /** Stable client id (chip key, revoke handle). */
+  id: string;
+  kind: ShotKind;
+  /** Absolute path the agent reads (`view` on the wire); null when saving failed. */
+  view: string | null;
+  /** Object URL or `rawUrl(view)` when drawable. */
+  thumb?: string;
+  /** Bytes when not drawable (file / undecodable image). */
+  size?: number;
+  /** Display name for image/file kinds (T:16519 `name`). */
+  name?: string;
+  /** What the picture does NOT show (T: viewNote = caveats + trust line). */
+  viewNote?: string;
+  /** Refusal reason when `view` is null (T: why "could not be saved"). */
+  why?: string;
+  /** Real-path drag: no upload happened, the path is the user's own (T:11644). */
+  brought?: boolean;
+  /** Pane seat is unique (T:11309) — the tray replaces the previous one. */
+  seat?: "pane";
+  /** True while capture/upload is in flight (chip shows spinner/disabled). */
+  pending?: boolean;
+}
+
+/** Wire entry inside `<pane-shot>` — mirrors protocol/wire.ts PaneShotEntry. */
+export interface PaneShotEntry {
+  kind: ShotKind;
+  view: string | null;
+  viewNote?: string;
+  why?: string;
+  name?: string;
+  size?: number;
+}
+
+/** Receipt row under a sent user turn (T:10815 annsum / shotReceipt). */
+export interface Receipt {
+  /** The `Attachment.id` this receipt was built from, when it was built from
+   *  one. THE IDENTITY THE UI MATCHES ON: every refusal has `view: null`, so a
+   *  kind+view match cannot tell two failed pictures apart (PR2 review). Absent
+   *  on a receipt rebuilt from the wire — nothing there is discardable. */
+  id?: string;
+  kind: ShotKind;
+  label: string; // "screenshot attached" | "image attached: name" | shotFailLabel…
+  view: string | null;
+  thumb?: string;
+  /** Set once a HEAD probe says the file is gone (T:10903 pruned detection). */
+  pruned?: boolean;
+  viewNote?: string;
+  /** What to DISPLAY: a blob URL this session, `rawUrl(view)` for a restored
+   *  turn. A FILE never gets one — an `<img>` pointed at a .csv is a
+   *  broken-image glyph, which reads as a bug (T:10820). */
+  src?: string;
+  /** The HEAD target for a row with nothing to draw: a picture's pruned copy
+   *  announces itself through the `<img>`'s own error, a glyph row has to ASK
+   *  (T:10871). Set only by the restore — a live send's bytes were written
+   *  seconds ago, so a fresh turn costs no request. */
+  probe?: string;
+  name?: string;
+  size?: number;
+  why?: string;
+}
+
+export interface CaptureResult {
+  blob: Blob | null;
+  width: number;
+  height: number;
+  /** Caveat sentences joined "; " (T:9275 shotPaneNote, 9304 shotImageNote, 10052 blank regions). */
+  notes: string[];
+  /** Which path produced it (T:9958 order). */
+  via: "native" | "tab" | "dom" | "none";
+  /** The style walk's verdict, which is what picks the closing trust line:
+   *  bounded doubt keeps the reassurance, unbounded doubt replaces it with
+   *  corroboration (T:9332). Always `false` on the native and tab paths. */
+  incomplete?: PaneBitmap["incomplete"];
+  /** Object URL for the encoded bytes — a screenshot nobody can look at before
+   *  it goes out is one nobody can check (T:10101). Owned by the caller: pass it
+   *  to `revoke` when the attachment goes. */
+  thumb?: string;
+  /** Set when nothing could be captured or encoded, as the sentence the chip and
+   *  the wire's `viewNote` carry (T:10093, 10098). */
+  why?: string;
+}
+
+export const SHOT_ATTACH_MAX_BYTES = 4 * 1024 * 1024; // T:11355 downscale trigger
+export const SHOT_VIEW_EDGE = 1600; // T:4755
+export const SHOT_VIEW_BYTES = 900 * 1024; // T:4756
+export const SHOT_MAX_EDGE = 640; // T:4702 crops
+export const SHOT_MAX_BYTES = 300 * 1024; // T:4706
+export const SHOT_TIMEOUT_MS = 6000; // T:10225
+export const SHOT_FLASH_MS = 340; // T:11232
+export const FUSED_PATH_MIME = "application/x-fused-path"; // T:11644
+
+// ── the rest of T's capture budget (T:4702-4756, 9791) ──────────────────────
+/** px² below which there is nothing to look at — a 0x0 rect (display:none) or a
+ *  hairline border (T:4708 SHOT_MIN_AREA). */
+export const SHOT_MIN_AREA = 64;
+/** Elements whose computed style one capture will inline before it gives up
+ *  (T:4718 SHOT_MAX_ELEMENTS). */
+export const SHOT_MAX_ELEMENTS = 3000;
+/** Elements between yields to the event loop during that walk — what makes
+ *  SHOT_TIMEOUT_MS able to fire at all (T:4729 SHOT_STYLE_CHUNK). */
+export const SHOT_STYLE_CHUNK = 200;
+/** Distinct image URLs resolved per capture (T:4741 SHOT_IMG_MAX). */
+export const SHOT_IMG_MAX = 30;
+/** Bytes past which a fetched image is re-encoded down to the size it is DRAWN
+ *  at rather than embedded whole (T:4745 SHOT_IMG_MAX_BYTES). */
+export const SHOT_IMG_MAX_BYTES = 256 * 1024;
+/** The tail of the budget reserved for those fetches (T:4749 SHOT_IMG_MS). */
+export const SHOT_IMG_MS = 1500;
+/** Quality steps tried before any resolution is given up. JPEG is deliberately
+ *  absent: measured on this UI it LOST to PNG (T:9626). */
+export const SHOT_WEBP_QUALITY: number[] = [0.8, 0.6];
+/** Min frame size worth photographing natively (T:9791 SHOT_NATIVE_MIN). */
+export const SHOT_NATIVE_MIN = { width: 120, height: 75 };
+/** The drag payload naming a real path (T:11644). */
+export const SHOT_PATH_TYPE = FUSED_PATH_MIME;
+
+/** A rasterised pane: whatever `drawImage` can read out of, plus the doubt
+ *  fields every caveat writer reads (T:9958 shotPane's answer shape — the
+ *  native and tab paths answer the same shape with the doubts clean). */
+export interface PaneBitmap {
+  canvas: CanvasImageSource;
+  width: number;
+  height: number;
+  /** Source canvases whose pixels could not be read back (T:9554). */
+  blanks: Element[];
+  /** Elements the style walk finished (T:9124). */
+  styled: number;
+  /** One cause, never a set of booleans that can disagree (T:9215). */
+  incomplete: "" | "elements" | "deadline" | "detached" | "mutated" | false;
+  /** Images that could not be inlined (T:9491). */
+  imagesMissing: number;
+}
+
+/** An integer rect inside a pane bitmap (T:9578 shotCropRect). */
+export interface ShotRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/** One badge burned into the overview (T:8009 annBadgeDraw). */
+export interface ShotBadge {
+  x: number;
+  y: number;
+  label: string;
+}

--- a/frontend/src/apps/claude/shots/xo-capture.test.ts
+++ b/frontend/src/apps/claude/shots/xo-capture.test.ts
@@ -1,0 +1,392 @@
+// THE CROSS-ORIGIN PANE'S DECISION POINTS (T:9706-9764). `capture.test.ts`
+// injects `opts.strategies`, so the real tab-share strategy never runs there.
+// What is under test HERE is the share CONTRACT — which constraints are asked
+// for, how often the prompt is paid, when the stream is released — and the crop
+// arithmetic, asserted as `drawImage`'s argument values rather than as pixels.
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { installDomShim } from "@platform/lib/testDomShim";
+
+installDomShim();
+
+// `bun test` runs every file in ONE process against one `globalThis`, so
+// whatever this suite stubs is put back the moment it is done — a leaked
+// `navigator` or `document` breaks whoever runs next (the idiom
+// platform/ui/appdoctor-lib.test.ts sets out and capture.test.ts follows).
+const G = globalThis as Record<string, unknown>;
+const BEFORE = {
+  navigator: G.navigator,
+  document: G.document,
+};
+afterAll(() => {
+  G.navigator = BEFORE.navigator;
+  G.document = BEFORE.document;
+});
+
+const { captureXO, currentStream, getStream, stopStream, watchStreamTeardown } = await import(
+  "./xo-capture"
+);
+
+// ── the fakes ───────────────────────────────────────────────────────────────
+
+type Rec = Record<string, unknown>;
+
+interface FakeTrack {
+  readyState: string;
+  stops: number;
+  listeners: unknown[][];
+  stop: () => void;
+  addEventListener: (...a: unknown[]) => void;
+}
+
+function track(readyState = "live", throwOnStop = false): FakeTrack {
+  const t: FakeTrack = {
+    readyState,
+    stops: 0,
+    listeners: [],
+    stop: () => {
+      t.stops++;
+      if (throwOnStop) throw new Error("already ended");
+    },
+    addEventListener: (...a: unknown[]) => t.listeners.push(a),
+  };
+  return t;
+}
+
+interface FakeStream {
+  tracks: FakeTrack[];
+  getTracks: () => FakeTrack[];
+  getVideoTracks: () => FakeTrack[];
+}
+
+function stream(...tracks: FakeTrack[]): FakeStream {
+  return { tracks, getTracks: () => tracks, getVideoTracks: () => tracks };
+}
+
+interface FakeVideo {
+  muted: boolean;
+  srcObject: unknown;
+  play: () => Promise<void>;
+  requestVideoFrameCallback?: (cb: () => void) => void;
+  videoWidth: number;
+  videoHeight: number;
+}
+
+interface FakeCanvas {
+  width: number;
+  height: number;
+  getContext: () => { drawImage: (...args: unknown[]) => void };
+}
+
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+  return {
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+  } as DOMRect;
+}
+
+function hostWindow(innerWidth = 1000, innerHeight = 600): Window {
+  return { innerWidth, innerHeight } as unknown as Window;
+}
+
+function makeFrame(r: DOMRect, win: Window | null = hostWindow()): HTMLIFrameElement {
+  return {
+    getBoundingClientRect: () => r,
+    ownerDocument: { defaultView: win },
+  } as unknown as HTMLIFrameElement;
+}
+
+let prompts: Rec[] = [];
+let drawn: unknown[][] = [];
+let canvases: FakeCanvas[] = [];
+let videos: FakeVideo[] = [];
+/** No `requestVideoFrameCallback` exercises the 150ms setTimeout fallback; a
+ *  function exercises the "one PAINTED frame" road. */
+let hasVfc = true;
+let nextStream: () => FakeStream = () => stream(track());
+
+function newVideo(): FakeVideo {
+  const v: FakeVideo = {
+    muted: false,
+    srcObject: undefined,
+    play: () => Promise.resolve(),
+    videoWidth: 2000,
+    videoHeight: 1200,
+  };
+  if (hasVfc) v.requestVideoFrameCallback = (cb: () => void) => cb();
+  videos.push(v);
+  return v;
+}
+
+function newCanvas(): FakeCanvas {
+  const c: FakeCanvas = {
+    width: 0,
+    height: 0,
+    getContext: () => ({ drawImage: (...args: unknown[]) => drawn.push(args) }),
+  };
+  canvases.push(c);
+  return c;
+}
+
+function installNavigator(over?: Rec): void {
+  G.navigator =
+    over ||
+    ({
+      mediaDevices: {
+        getDisplayMedia: (c: Rec) => {
+          prompts.push(c);
+          return Promise.resolve(nextStream());
+        },
+      },
+    } as Rec);
+}
+
+beforeEach(() => {
+  // The kept stream is module-level state and the whole point of the module, so
+  // it must never leak into the next test — a live leftover would make a test
+  // that expects a fresh prompt silently reuse the previous one.
+  stopStream();
+  prompts = [];
+  drawn = [];
+  canvases = [];
+  videos = [];
+  hasVfc = true;
+  nextStream = () => stream(track());
+  G.document = {
+    hidden: false,
+    addEventListener() {},
+    removeEventListener() {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    createElement: (tag: string) => (tag === "canvas" ? newCanvas() : newVideo()),
+  };
+  installNavigator();
+});
+
+// ── getStream ───────────────────────────────────────────────────────────────
+
+describe("getStream constraints (T:9706)", () => {
+  test("the current-tab hints that make the right choice the one-click one", async () => {
+    // The crop is only ever computed against THIS tab's own layout, so any other
+    // surface would be cropped wrong: the hints preselect this tab and offer no
+    // switching and no monitors (ignored, not fatal, where unsupported).
+    await getStream();
+    expect(prompts.length).toBe(1);
+    expect(prompts[0]).toEqual({
+      video: { displaySurface: "browser" },
+      audio: false,
+      preferCurrentTab: true,
+      selfBrowserSurface: "include",
+      surfaceSwitching: "exclude",
+      monitorTypeSurfaces: "exclude",
+    });
+  });
+
+  test("a LIVE kept stream is reused — the prompt is paid once, not once per note", async () => {
+    // A walkthrough clicking ten spots must not raise ten pickers.
+    const first = await getStream();
+    const second = await getStream();
+    expect(second).toBe(first);
+    expect(prompts.length).toBe(1);
+  });
+
+  test("a dead track means the share is gone: a fresh one is asked for", async () => {
+    const dead = track("ended");
+    nextStream = () => stream(dead);
+    const first = await getStream();
+    nextStream = () => stream(track("live"));
+    const second = await getStream();
+    expect(second).not.toBe(first);
+    expect(prompts.length).toBe(2);
+    // And the corpse is stopped on the way out rather than left held.
+    expect(dead.stops).toBe(1);
+  });
+
+  test("the `ended` listener releases the kept stream", async () => {
+    // The user ending the share from the browser's own indicator has to leave the
+    // module with nothing held, or the next capture reuses a dead track.
+    const t = track();
+    nextStream = () => stream(t);
+    await getStream();
+    expect(currentStream()).not.toBeNull();
+    expect(t.listeners[0][0]).toBe("ended");
+    expect(t.listeners[0][2]).toEqual({ once: true });
+    (t.listeners[0][1] as () => void)();
+    expect(currentStream()).toBeNull();
+  });
+});
+
+describe("stopStream (T:9731 annXOStreamStop)", () => {
+  test("idempotent — both `ended` and an explicit teardown reach it", async () => {
+    const t = track();
+    nextStream = () => stream(t);
+    await getStream();
+    stopStream();
+    stopStream();
+    expect(t.stops).toBe(1);
+    expect(currentStream()).toBeNull();
+  });
+
+  test("every track is stopped even when one `stop()` throws", async () => {
+    // A track that has already ended throws on stop in some engines; the stream
+    // is not left half-released because of it.
+    const bad = track("live", true);
+    const good = track();
+    nextStream = () => stream(bad, good);
+    await getStream();
+    expect(() => stopStream()).not.toThrow();
+    expect([bad.stops, good.stops]).toEqual([1, 1]);
+  });
+});
+
+describe("watchStreamTeardown (T:9731 annXOStreamStop)", () => {
+  test("`pagehide` ends the share, and the teardown both unregisters and ends it", async () => {
+    // A kept stream IS the browser's "sharing this tab" indicator, so one that
+    // survives leaving the chat is the page claiming to watch a screen nobody is
+    // looking at any more.
+    const added: unknown[][] = [];
+    const removed: unknown[][] = [];
+    const win = {
+      addEventListener: (...a: unknown[]) => added.push(a),
+      removeEventListener: (...a: unknown[]) => removed.push(a),
+    } as unknown as Window;
+
+    const stop = watchStreamTeardown(win);
+    expect(added.length).toBe(1);
+    expect(added[0][0]).toBe("pagehide");
+
+    const t = track();
+    nextStream = () => stream(t);
+    await getStream();
+    (added[0][1] as () => void)();
+    expect(currentStream()).toBeNull();
+    expect(t.stops).toBe(1);
+
+    const t2 = track();
+    nextStream = () => stream(t2);
+    await getStream();
+    stop();
+    // The SAME function object, or the removal is a no-op that leaves the
+    // listener behind for the life of the page.
+    expect(removed[0][0]).toBe("pagehide");
+    expect(removed[0][1]).toBe(added[0][1]);
+    expect(currentStream()).toBeNull();
+    expect(t2.stops).toBe(1);
+  });
+
+  test("no window still hands back a teardown that releases the share", async () => {
+    const t = track();
+    nextStream = () => stream(t);
+    await getStream();
+    watchStreamTeardown(null)();
+    expect(currentStream()).toBeNull();
+    expect(t.stops).toBe(1);
+    expect(() => watchStreamTeardown(undefined)()).not.toThrow();
+    expect(() => watchStreamTeardown({} as unknown as Window)()).not.toThrow();
+  });
+});
+
+// ── captureXO ───────────────────────────────────────────────────────────────
+
+describe("captureXO the cannot roads answer null (T:9735)", () => {
+  test("no frame", async () => {
+    expect(await captureXO(null)).toBeNull();
+    expect(prompts.length).toBe(0);
+  });
+
+  test("no mediaDevices at all, and mediaDevices with no getDisplayMedia", async () => {
+    // An older or a non-secure context: never a throw, because the caller falls
+    // through to the DOM clone.
+    installNavigator({});
+    expect(await captureXO(makeFrame(rect(0, 0, 400, 300)))).toBeNull();
+    installNavigator({ mediaDevices: {} });
+    expect(await captureXO(makeFrame(rect(0, 0, 400, 300)))).toBeNull();
+  });
+
+  test("a host window that throws on read is null before any prompt is raised", async () => {
+    // The crop needs the host's innerWidth; without it there is no arithmetic to
+    // do, so the user is not asked to share a tab we could not have cropped.
+    const bad = {
+      get innerWidth(): number {
+        throw new Error("cross-origin");
+      },
+    } as unknown as Window;
+    expect(await captureXO(makeFrame(rect(0, 0, 400, 300)), bad)).toBeNull();
+    expect(prompts.length).toBe(0);
+  });
+
+  test("a frame whose ownerDocument throws is null", async () => {
+    const frame: Rec = { getBoundingClientRect: () => rect(0, 0, 400, 300) };
+    Object.defineProperty(frame, "ownerDocument", {
+      get() {
+        throw new Error("cross-origin");
+      },
+    });
+    expect(await captureXO(frame as unknown as HTMLIFrameElement)).toBeNull();
+    expect(prompts.length).toBe(0);
+  });
+});
+
+describe("captureXO the crop arithmetic (T:9748, 9752)", () => {
+  test("videoWidth/innerWidth scales the frame's rect into drawImage's SOURCE box", async () => {
+    // The captured frame is the tab's viewport at the capture's own resolution;
+    // the iframe's rect in that viewport, scaled the same way, is the crop. Here
+    // 2000/1000 and 1200/600 make the scale exactly 2 in both axes.
+    const out = await captureXO(makeFrame(rect(100, 50, 300.5, 200.25)));
+    const video = videos[0];
+    expect(drawn.length).toBe(1);
+    expect(drawn[0][0]).toBe(video);
+    expect(drawn[0].slice(1)).toEqual([200, 100, 601, 400.5, 0, 0, 301, 200]);
+    // The OUTPUT canvas is the frame's CSS size, not the capture's resolution:
+    // every pin and crop rect downstream is in the framed viewport's CSS pixels.
+    expect([canvases[0].width, canvases[0].height]).toEqual([301, 200]);
+    expect([out?.width, out?.height]).toEqual([301, 200]);
+    // A capture off live pixels has no style walk, no image inlining and no WebGL
+    // readback to caveat, so the doubt fields are simply clean.
+    expect(out?.incomplete).toBe(false);
+    expect(out?.blanks).toEqual([]);
+    expect(out?.styled).toBe(0);
+    expect(out?.imagesMissing).toBe(0);
+    // Muted, and let go of afterwards — a held srcObject keeps decoding a stream
+    // nobody is drawing.
+    expect(video.muted).toBe(true);
+    expect(video.srcObject).toBeNull();
+  });
+
+  test("an explicit host window wins over the frame's own, and rescales the crop", async () => {
+    // The overlay's host is the window the rect was measured in; a different
+    // innerWidth is a different scale for the same rect.
+    await captureXO(makeFrame(rect(100, 50, 300, 200)), hostWindow(2000, 1200));
+    expect(drawn[0].slice(1)).toEqual([100, 50, 300, 200, 0, 0, 300, 200]);
+  });
+
+  test("a degenerate rect still yields a 1x1 canvas rather than a 0-sized one", async () => {
+    // `getContext` on a 0-width canvas is a hard failure in real browsers, so the
+    // floor is not cosmetic.
+    const out = await captureXO(makeFrame(rect(0, 0, 0, 0)));
+    expect([out?.width, out?.height]).toEqual([1, 1]);
+  });
+
+  test("no requestVideoFrameCallback falls back to a timed wait, and still crops", async () => {
+    // `play()` resolving does not mean pixels arrived; where the frame callback
+    // does not exist the wait is a plain timer.
+    hasVfc = false;
+    const out = await captureXO(makeFrame(rect(100, 50, 300, 200)));
+    expect(videos[0].requestVideoFrameCallback).toBeUndefined();
+    expect(drawn[0].slice(1)).toEqual([200, 100, 600, 400, 0, 0, 300, 200]);
+    expect(out).not.toBeNull();
+  });
+
+  test("the second capture reuses the share: one prompt, two crops", async () => {
+    await captureXO(makeFrame(rect(0, 0, 400, 300)));
+    await captureXO(makeFrame(rect(0, 0, 400, 300)));
+    expect(prompts.length).toBe(1);
+    expect(drawn.length).toBe(2);
+    expect(videos[0].srcObject).toBeNull();
+  });
+});

--- a/frontend/src/apps/claude/shots/xo-capture.test.ts
+++ b/frontend/src/apps/claude/shots/xo-capture.test.ts
@@ -22,9 +22,8 @@ afterAll(() => {
   G.document = BEFORE.document;
 });
 
-const { captureXO, currentStream, getStream, stopStream, watchStreamTeardown } = await import(
-  "./xo-capture"
-);
+const { captureXO, currentStream, getStream, stopStream, streamWatchers, watchStreamTeardown } =
+  await import("./xo-capture");
 
 // ── the fakes ───────────────────────────────────────────────────────────────
 
@@ -277,6 +276,63 @@ describe("watchStreamTeardown (T:9731 annXOStreamStop)", () => {
     expect(removed[0][1]).toBe(added[0][1]);
     expect(currentStream()).toBeNull();
     expect(t2.stops).toBe(1);
+  });
+
+  test("REFERENCE-COUNTED: one chat closing does not revoke another's share", async () => {
+    // The stream is a module singleton and EVERY `ChatBody` registers a
+    // teardown, so a teardown that always stopped meant a card or peek
+    // unmounting killed the share the chat next to it was mid-walkthrough with
+    // (Bugbot, PR #1064).
+    const listeners: Record<string, unknown[]> = { added: [], removed: [] };
+    const win = {
+      addEventListener: (...a: unknown[]) => listeners.added.push(a),
+      removeEventListener: (...a: unknown[]) => listeners.removed.push(a),
+    } as unknown as Window;
+
+    const first = watchStreamTeardown(win);
+    const second = watchStreamTeardown(win);
+    expect(streamWatchers()).toBe(2);
+
+    const t = track();
+    nextStream = () => stream(t);
+    await getStream();
+
+    // The first one out unregisters ITS listener and leaves the share alone.
+    first();
+    expect(listeners.removed.length).toBe(1);
+    expect(currentStream()).not.toBeNull();
+    expect(t.stops).toBe(0);
+    // Twice is the same as once: a double-invoked teardown must not decrement a
+    // registration it already gave back.
+    first();
+    expect(streamWatchers()).toBe(1);
+    expect(currentStream()).not.toBeNull();
+
+    // The LAST one out ends it.
+    second();
+    expect(streamWatchers()).toBe(0);
+    expect(currentStream()).toBeNull();
+    expect(t.stops).toBe(1);
+  });
+
+  test("`pagehide` ends the share outright, watchers or not", async () => {
+    // There is no page left to share to, so the count does not get a vote.
+    const hides: (() => void)[] = [];
+    const win = {
+      addEventListener: (_k: unknown, fn: () => void) => hides.push(fn),
+      removeEventListener: () => {},
+    } as unknown as Window;
+    const a = watchStreamTeardown(win);
+    const b = watchStreamTeardown(win);
+    const t = track();
+    nextStream = () => stream(t);
+    await getStream();
+    hides[0]!();
+    expect(currentStream()).toBeNull();
+    expect(t.stops).toBe(1);
+    a();
+    b();
+    expect(streamWatchers()).toBe(0);
   });
 
   test("no window still hands back a teardown that releases the share", async () => {

--- a/frontend/src/apps/claude/shots/xo-capture.test.ts
+++ b/frontend/src/apps/claude/shots/xo-capture.test.ts
@@ -122,11 +122,20 @@ function newVideo(): FakeVideo {
   return v;
 }
 
+/** Called at the instant `drawImage` reads the video — the only moment at which
+ *  "was the flash on screen?" has an answer. */
+let onDraw: (() => void) | null = null;
+
 function newCanvas(): FakeCanvas {
   const c: FakeCanvas = {
     width: 0,
     height: 0,
-    getContext: () => ({ drawImage: (...args: unknown[]) => drawn.push(args) }),
+    getContext: () => ({
+      drawImage: (...args: unknown[]) => {
+        drawn.push(args);
+        if (onDraw) onDraw();
+      },
+    }),
   };
   canvases.push(c);
   return c;
@@ -155,6 +164,7 @@ beforeEach(() => {
   canvases = [];
   videos = [];
   hasVfc = true;
+  onDraw = null;
   nextStream = () => stream(track());
   G.document = {
     hidden: false,
@@ -444,5 +454,108 @@ describe("captureXO the crop arithmetic (T:9748, 9752)", () => {
     expect(prompts.length).toBe(1);
     expect(drawn.length).toBe(2);
     expect(videos[0].srcObject).toBeNull();
+  });
+});
+
+// ── the shutter flash (Bugbot, PR #1064) ────────────────────────────────────
+//
+// This road photographs the SCREEN, so it sees everything the user does — the
+// white sheet `flash()` puts over the pane included. The native path always hid
+// it; here, with a KEPT share, there is no picker to sit through and the grab
+// beat the flash's 340 ms home, so the sheet was burned into the picture.
+
+describe("captureXO hides what sits ON the pane", () => {
+  function flashSheet(visibility = ""): { style: { visibility: string } } {
+    const el = { style: { visibility } };
+    const doc = G.document as Rec;
+    doc.querySelectorAll = (sel: string) => (sel === "[data-shot-flash]" ? [el] : []);
+    return el;
+  }
+
+  test("the sheet is hidden for the grab and put back exactly as it was", async () => {
+    const el = flashSheet("visible");
+    let during = "?";
+    onDraw = () => {
+      during = el.style.visibility;
+    };
+    const out = await captureXO(makeFrame(rect(0, 0, 400, 300)));
+    expect(out).not.toBeNull();
+    expect(during).toBe("hidden");
+    // PUT BACK, and to its own prior value rather than to "": a page left with
+    // an invisible overlay is worse than a flash in one picture.
+    expect(el.style.visibility).toBe("visible");
+  });
+
+  test("a hide waits for a FRESH frame — the one in flight was composited before it", async () => {
+    // A video element hands over the last frame it decoded, and that frame was
+    // painted while the sheet was still up.
+    const el = flashSheet();
+    const frames: string[] = [];
+    const doc = G.document as Rec;
+    const make = doc.createElement as (tag: string) => FakeVideo | FakeCanvas;
+    doc.createElement = (tag: string) => {
+      const node = make(tag);
+      const v = node as FakeVideo;
+      if (v.requestVideoFrameCallback) {
+        v.requestVideoFrameCallback = (cb: () => void) => {
+          frames.push(el.style.visibility);
+          cb();
+        };
+      }
+      return node;
+    };
+    await captureXO(makeFrame(rect(0, 0, 400, 300)));
+    expect(frames).toEqual(["hidden", "hidden"]);
+  });
+
+  test("nothing to hide is one frame's wait, unchanged", async () => {
+    // The overlay is only up for a click that flashed; the common capture pays
+    // nothing for this.
+    const frames: number[] = [];
+    const doc = G.document as Rec;
+    const make = doc.createElement as (tag: string) => FakeVideo | FakeCanvas;
+    doc.createElement = (tag: string) => {
+      const node = make(tag);
+      const v = node as FakeVideo;
+      if (v.requestVideoFrameCallback) {
+        v.requestVideoFrameCallback = (cb: () => void) => {
+          frames.push(1);
+          cb();
+        };
+      }
+      return node;
+    };
+    await captureXO(makeFrame(rect(0, 0, 400, 300)));
+    expect(frames.length).toBe(1);
+  });
+
+  test("the sheet comes back even when the grab throws", async () => {
+    const el = flashSheet("visible");
+    const doc = G.document as Rec;
+    const make = doc.createElement as (tag: string) => FakeVideo | FakeCanvas;
+    doc.createElement = (tag: string) =>
+      tag === "canvas"
+        ? ({
+            width: 0,
+            height: 0,
+            getContext: () => {
+              throw new Error("context lost");
+            },
+          } as unknown as FakeCanvas)
+        : make(tag);
+    await expect(captureXO(makeFrame(rect(0, 0, 400, 300)))).rejects.toThrow("context lost");
+    expect(el.style.visibility).toBe("visible");
+  });
+
+  test("an overlay with no style, and a document that refuses to be queried", async () => {
+    // A finder that throws would take the whole capture with it rather than
+    // simply hiding nothing.
+    const doc = G.document as Rec;
+    doc.querySelectorAll = () => {
+      throw new Error("not queryable");
+    };
+    expect(await captureXO(makeFrame(rect(0, 0, 400, 300)))).not.toBeNull();
+    doc.querySelectorAll = () => [{} as unknown as Element];
+    expect(await captureXO(makeFrame(rect(0, 0, 400, 300)))).not.toBeNull();
   });
 });

--- a/frontend/src/apps/claude/shots/xo-capture.ts
+++ b/frontend/src/apps/claude/shots/xo-capture.ts
@@ -16,6 +16,17 @@ import type { PaneBitmap } from "./types";
 
 let stream: MediaStream | null = null;
 
+/**
+ * HOW MANY MOUNTS ARE STILL WATCHING. The stream is a MODULE singleton and
+ * every `ChatBody` registers a teardown for it, so a teardown that always
+ * stopped meant one card or peek closing killed a share another chat on the
+ * same page was mid-walkthrough with — the prompt paid once and then revoked by
+ * somebody else's unmount (Bugbot, PR #1064). The share ends when the LAST
+ * watcher leaves; `pagehide` still ends it outright, because there is no page
+ * left to share to.
+ */
+let watchers = 0;
+
 /** Stop the kept stream. Idempotent — both `ended` and an explicit teardown
  *  reach it (T:9731 annXOStreamStop). */
 export function stopStream(): void {
@@ -47,16 +58,34 @@ export function currentStream(): MediaStream | null {
  * `watchTopOrigin` is: any bundle that so much as imports `shots/*` would
  * otherwise carry a listener for a feature its page never turns on (T:9731
  * `annXOStreamStop`).
+ *
+ * REFERENCE-COUNTED, because several chats can be mounted at once (a card
+ * behind a peek, two cards in the stack) over ONE module-level stream: the
+ * returned teardown always unregisters its own listener, but only the LAST one
+ * out ends the share.
  */
 export function watchStreamTeardown(win: Window | null | undefined): () => void {
-  const host = win;
-  if (!host || typeof host.addEventListener !== "function") return stopStream;
+  const host = win && typeof win.addEventListener === "function" ? win : null;
   const onHide = (): void => stopStream();
-  host.addEventListener("pagehide", onHide);
+  if (host) host.addEventListener("pagehide", onHide);
+  watchers += 1;
+  // IDEMPOTENT, so a double-invoked teardown (StrictMode, a defensive caller)
+  // cannot decrement a registration it already gave back and pull the count
+  // below the mounts that are really still watching.
+  let released = false;
   return () => {
-    host.removeEventListener("pagehide", onHide);
-    stopStream();
+    if (released) return;
+    released = true;
+    if (host) host.removeEventListener("pagehide", onHide);
+    watchers = Math.max(0, watchers - 1);
+    if (!watchers) stopStream();
   };
+}
+
+/** Registrations still outstanding — for the tests that assert the counting,
+ *  and the only way to observe it from outside. */
+export function streamWatchers(): number {
+  return watchers;
 }
 
 /** The kept stream, or a fresh share. Chromium's current-tab hints preselect

--- a/frontend/src/apps/claude/shots/xo-capture.ts
+++ b/frontend/src/apps/claude/shots/xo-capture.ts
@@ -1,0 +1,142 @@
+// THE CROSS-ORIGIN PANE'S PICTURE: tab capture, cropped to the frame
+// (T:9706-9764).
+//
+// The DOM clone needs a readable document and a cross-origin target has none
+// (D349). What the browser can still hand over is the TAB's own pixels:
+// `getDisplayMedia` with `preferCurrentTab`, one frame grabbed off the video
+// track and cropped to the marked iframe's rect — the same box the overlay (and
+// so every point coordinate) lives in, so the crops and the whole-pane shot line
+// up with the pins for free.
+//
+// The stream is KEPT between captures: the share prompt is paid once, not once
+// per note — a walkthrough clicking ten spots must not raise ten pickers.
+// Released when the user ends the share (`ended`), when the target stops being
+// cross-origin, and on pagehide.
+import type { PaneBitmap } from "./types";
+
+let stream: MediaStream | null = null;
+
+/** Stop the kept stream. Idempotent — both `ended` and an explicit teardown
+ *  reach it (T:9731 annXOStreamStop). */
+export function stopStream(): void {
+  const s = stream;
+  stream = null;
+  if (!s) return;
+  for (const t of s.getTracks()) {
+    try {
+      t.stop();
+    } catch {
+      /* already ended */
+    }
+  }
+}
+
+export function currentStream(): MediaStream | null {
+  return stream;
+}
+
+/**
+ * THE TEARDOWN THE HEADER PROMISES. A kept stream is the browser's "sharing
+ * this tab" indicator, and an indicator that survives leaving the chat is the
+ * page claiming to watch a screen nobody is looking at any more — so the share
+ * ends on `pagehide` (the navigation away, and the only event a discarded page
+ * reliably gets) and on the chat's own unmount, which is what the returned
+ * teardown is for.
+ *
+ * Registered from the chat's MOUNT rather than at module load, for the reason
+ * `watchTopOrigin` is: any bundle that so much as imports `shots/*` would
+ * otherwise carry a listener for a feature its page never turns on (T:9731
+ * `annXOStreamStop`).
+ */
+export function watchStreamTeardown(win: Window | null | undefined): () => void {
+  const host = win;
+  if (!host || typeof host.addEventListener !== "function") return stopStream;
+  const onHide = (): void => stopStream();
+  host.addEventListener("pagehide", onHide);
+  return () => {
+    host.removeEventListener("pagehide", onHide);
+    stopStream();
+  };
+}
+
+/** The kept stream, or a fresh share. Chromium's current-tab hints preselect
+ *  THIS tab and offer no switching and no monitors: the crop is only ever
+ *  computed against this tab's own layout, so any other surface would be cropped
+ *  wrong — the hints make the right choice the one-click one (they are ignored,
+ *  not fatal, where unsupported) (T:9706). */
+export async function getStream(): Promise<MediaStream> {
+  if (stream && stream.getVideoTracks().some((t) => t.readyState === "live")) {
+    return stream;
+  }
+  stopStream();
+  stream = await navigator.mediaDevices.getDisplayMedia({
+    video: { displaySurface: "browser" },
+    audio: false,
+    // Not in TS's `DisplayMediaStreamOptions` yet — Chromium-only hints the spec
+    // has not caught up with, and the reason this cast exists rather than `any`.
+    preferCurrentTab: true,
+    selfBrowserSurface: "include",
+    surfaceSwitching: "exclude",
+    monitorTypeSurfaces: "exclude",
+  } as DisplayMediaStreamOptions);
+  const track = stream.getVideoTracks()[0];
+  if (track) track.addEventListener("ended", stopStream, { once: true });
+  return stream;
+}
+
+/** One frame of the tab, cropped to `frame`'s rect and drawn at its CSS size.
+ *
+ *  Same answer shape as the other two paths, so every consumer runs unchanged: a
+ *  capture off live pixels has no style walk, no image inlining and no WebGL
+ *  readback to caveat, so the doubt fields are simply clean. Null (not a throw)
+ *  for every "cannot" (T:9735). */
+export async function captureXO(
+  frame: HTMLIFrameElement | null,
+  hostWin?: Window | null,
+): Promise<PaneBitmap | null> {
+  if (!frame || !navigator.mediaDevices || !navigator.mediaDevices.getDisplayMedia) {
+    return null;
+  }
+  let host: Window;
+  try {
+    host = (hostWin || frame.ownerDocument.defaultView) as Window;
+    void host.innerWidth;
+  } catch {
+    return null;
+  }
+  if (!host) return null;
+  const live = await getStream();
+  const video = document.createElement("video");
+  video.muted = true;
+  video.srcObject = live;
+  await video.play();
+  // One PAINTED frame — `play()` resolving does not mean pixels arrived (T:9748).
+  if (video.requestVideoFrameCallback) {
+    await new Promise<void>((res) => video.requestVideoFrameCallback(() => res()));
+  } else {
+    await new Promise<void>((res) => setTimeout(res, 150));
+  }
+  // The captured frame is the tab's viewport at the capture's own resolution; the
+  // iframe's rect in that viewport, scaled the same way, is the crop (T:9752).
+  const sx = video.videoWidth / host.innerWidth;
+  const sy = video.videoHeight / host.innerHeight;
+  const r = frame.getBoundingClientRect();
+  const w = Math.max(1, Math.round(r.width));
+  const h = Math.max(1, Math.round(r.height));
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  canvas
+    .getContext("2d")
+    ?.drawImage(video, r.left * sx, r.top * sy, r.width * sx, r.height * sy, 0, 0, w, h);
+  video.srcObject = null;
+  return {
+    canvas,
+    width: w,
+    height: h,
+    blanks: [],
+    styled: 0,
+    incomplete: false,
+    imagesMissing: 0,
+  };
+}

--- a/frontend/src/apps/claude/shots/xo-capture.ts
+++ b/frontend/src/apps/claude/shots/xo-capture.ts
@@ -12,6 +12,7 @@
 // per note — a walkthrough clicking ten spots must not raise ten pickers.
 // Released when the user ends the share (`ended`), when the target stops being
 // cross-origin, and on pagehide.
+import { flashOverlays } from "./native-capture";
 import type { PaneBitmap } from "./types";
 
 let stream: MediaStream | null = null;
@@ -113,6 +114,30 @@ export async function getStream(): Promise<MediaStream> {
   return stream;
 }
 
+/** One frame of the SHARE. A video element hands over whatever frame it last
+ *  decoded, so every wait for fresh pixels goes through here; the timeout is the
+ *  answer where `requestVideoFrameCallback` is not implemented, and it is a
+ *  bound rather than a promise the caller can hang on. */
+function nextFrame(video: HTMLVideoElement): Promise<void> {
+  if (video.requestVideoFrameCallback) {
+    return new Promise<void>((res) => video.requestVideoFrameCallback(() => res()));
+  }
+  return new Promise<void>((res) => setTimeout(res, 150));
+}
+
+/** One PAINT of this document, so a style change is composited before the tab's
+ *  pixels are read. Bounded exactly as the native path bounds it (T:9891): rAF
+ *  never fires in a hidden document (a cmux pane, a background tab) and a hang
+ *  here would eat the capture. */
+function painted(): Promise<void> {
+  const raf = typeof requestAnimationFrame === "function" ? requestAnimationFrame : null;
+  if (!raf) return new Promise<void>((res) => setTimeout(res, 32));
+  return Promise.race([
+    new Promise<void>((res) => raf(() => raf(() => res()))),
+    new Promise<void>((res) => setTimeout(res, 120)),
+  ]);
+}
+
 /** One frame of the tab, cropped to `frame`'s rect and drawn at its CSS size.
  *
  *  Same answer shape as the other two paths, so every consumer runs unchanged: a
@@ -139,33 +164,53 @@ export async function captureXO(
   video.muted = true;
   video.srcObject = live;
   await video.play();
-  // One PAINTED frame — `play()` resolving does not mean pixels arrived (T:9748).
-  if (video.requestVideoFrameCallback) {
-    await new Promise<void>((res) => video.requestVideoFrameCallback(() => res()));
-  } else {
-    await new Promise<void>((res) => setTimeout(res, 150));
+  // THE SHUTTER FLASH IS ON SCREEN, and this road photographs the screen: the
+  // same white sheet the native path hides is in the tab's pixels too, and with
+  // a KEPT share there is no picker to sit through — the grab beats the flash's
+  // 340 ms home and the sheet is burned into the picture (Bugbot, PR #1064).
+  // So it is hidden here as well, through native-capture's own finder, and put
+  // back in `finally` — an early return or a throw between here and the draw
+  // must not leave the page with an invisible overlay.
+  const hidden = flashOverlays(frame).filter(
+    (el): el is HTMLElement => !!(el as HTMLElement).style,
+  );
+  const prior = hidden.map((el) => el.style.visibility);
+  try {
+    for (const el of hidden) el.style.visibility = "hidden";
+    if (hidden.length) await painted();
+    // One PAINTED frame — `play()` resolving does not mean pixels arrived
+    // (T:9748) — and TWO once something was hidden, because the frame already in
+    // flight was composited before the hide and is the one `drawImage` would
+    // otherwise read.
+    await nextFrame(video);
+    if (hidden.length) await nextFrame(video);
+    // The captured frame is the tab's viewport at the capture's own resolution;
+    // the iframe's rect in that viewport, scaled the same way, is the crop
+    // (T:9752).
+    const sx = video.videoWidth / host.innerWidth;
+    const sy = video.videoHeight / host.innerHeight;
+    const r = frame.getBoundingClientRect();
+    const w = Math.max(1, Math.round(r.width));
+    const h = Math.max(1, Math.round(r.height));
+    const canvas = document.createElement("canvas");
+    canvas.width = w;
+    canvas.height = h;
+    canvas
+      .getContext("2d")
+      ?.drawImage(video, r.left * sx, r.top * sy, r.width * sx, r.height * sy, 0, 0, w, h);
+    video.srcObject = null;
+    return {
+      canvas,
+      width: w,
+      height: h,
+      blanks: [],
+      styled: 0,
+      incomplete: false,
+      imagesMissing: 0,
+    };
+  } finally {
+    hidden.forEach((el, i) => {
+      el.style.visibility = prior[i];
+    });
   }
-  // The captured frame is the tab's viewport at the capture's own resolution; the
-  // iframe's rect in that viewport, scaled the same way, is the crop (T:9752).
-  const sx = video.videoWidth / host.innerWidth;
-  const sy = video.videoHeight / host.innerHeight;
-  const r = frame.getBoundingClientRect();
-  const w = Math.max(1, Math.round(r.width));
-  const h = Math.max(1, Math.round(r.height));
-  const canvas = document.createElement("canvas");
-  canvas.width = w;
-  canvas.height = h;
-  canvas
-    .getContext("2d")
-    ?.drawImage(video, r.left * sx, r.top * sy, r.width * sx, r.height * sy, 0, 0, w, h);
-  video.srcObject = null;
-  return {
-    canvas,
-    width: w,
-    height: h,
-    blanks: [],
-    styled: 0,
-    incomplete: false,
-    imagesMissing: 0,
-  };
 }

--- a/frontend/src/apps/claude/styles/chat.css
+++ b/frontend/src/apps/claude/styles/chat.css
@@ -292,6 +292,27 @@
 .chat-root.chat-compact .seg-notice-glyph {
   font-size: var(--c-fs-small);
 }
+/* THE RECEIPT TAKES THE CUTS TOO. Every neighbour in this block shrank at 0.75
+   while the receipt under a sent turn kept its 11.5px rows and its 140px
+   thumbnail — the one thing on a 380px tile still drawn at full size, and by far
+   the tallest (transcript.css:1143-1240). */
+.chat-root.chat-compact .annsum .annsum-row,
+.chat-root.chat-compact .annsum .annsum-el,
+.chat-root.chat-compact .annsum .annsum-gone {
+  font-size: var(--c-fs-meta);
+}
+/* Same 0.75 the four type tokens take, so the picture keeps its proportion to
+   the words beside it. */
+.chat-root.chat-compact .annsum .annsum-pane img {
+  max-width: min(165px, 100%);
+  max-height: 105px;
+}
+/* PEEK keeps its composer and its transcript at full size — the head above is
+   the host's — so the type is left alone and only the picture is capped: the
+   popup is short, and a 140px receipt is a third of what it can show at once. */
+.chat-root.chat-peek .annsum .annsum-pane img {
+  max-height: 96px;
+}
 .chat-root.chat-compact .perm .qtext {
   font-size: var(--c-fs-lead);
 }
@@ -336,4 +357,92 @@
 /* Same halving as compact, for the same reason: the head above is the host's. */
 .chat-root.chat-peek .chat-log {
   padding-top: 12px;
+}
+
+/* ---- the `#anncta` group in the control strip (T:195-320) ---------------
+   Screenshot · Comment · Annotate: the three controls that act on the PREVIEW
+   rather than on the draft. Comment and Annotate are PR3's and ship disabled;
+   their seats are here so the row does not grow two buttons under the reader's
+   hand when they come alive. */
+.chat-root .c-anncta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.chat-root .c-anncta button {
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--c-dim);
+  font: inherit;
+  font-size: 12px;
+  white-space: nowrap;
+  height: 26px;
+  padding: 0 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition:
+    color 0.12s,
+    background 0.12s,
+    border-color 0.12s;
+}
+/* `:not(.on)` keeps hover a RESTING-seat affair: a bare hover rule beat the
+   armed state on order, so crossing an armed seat wiped the accent fill — the
+   mode's only on-screen signal — on the way to the click that ends it (Bugbot,
+   PR #644). PR3 arms the seats; the guard belongs with the hover. */
+.chat-root .c-anncta button:hover:not(:disabled):not(.on) {
+  color: var(--c-fg);
+  background: var(--c-surface);
+}
+.chat-root .c-anncta button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+/* Stroke glyphs in the button's own ink, so state colours reach them for free;
+   `.fill` seats are the solid parts. */
+.chat-root .c-anncta svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  flex-shrink: 0;
+}
+.chat-root .c-anncta svg .fill {
+  fill: currentColor;
+  stroke: none;
+}
+/* Icon-plus-word seats keep their words only while the strip has ROOM —
+   collision-detected, never a breakpoint (T:264-283, Akshil 2026-08-19: a fixed
+   width dropped the words while there was still space for them). `useFitStrip`
+   measures the row with the words ON and stamps `.tight` on the strip only when
+   the content truly would not fit; a tight strip sets the token to `none` and
+   every word yields at once.
+
+   The var rather than a plain `.tight .c-lbl { display: none }`: PR3's face-swap
+   rules SHOW their words back through higher-specificity selectors, and only a
+   token they all read wins without a specificity war. */
+.chat-root .c-anntools.tight .c-anncta {
+  --c-annlbl: none;
+}
+.chat-root .c-anncta .c-lbl {
+  display: var(--c-annlbl, inline);
+}
+/* Icon-only, so the seat hugs its glyph instead of keeping a word's padding and
+   an empty gap seat beside it (T:203-213 sizes the seat off its content). */
+.chat-root .c-anntools.tight .c-anncta button {
+  padding: 0 7px;
+}
+
+/* A picture is being dragged over the column. An INSET ring rather than a
+   border or an overlay: a border would resize the column mid-drag (the layout
+   jumping under a pointer that is holding something is the worst possible moment
+   for it), and a full-bleed overlay would sit between the pointer and the drop
+   target it is describing (T:1265-1276). */
+.chat-root .c-chat.dropping {
+  box-shadow: inset 0 0 0 2px var(--c-accent);
+  background: color-mix(in srgb, var(--c-accent) 6%, var(--c-panel));
 }

--- a/frontend/src/apps/claude/styles/chat.css
+++ b/frontend/src/apps/claude/styles/chat.css
@@ -180,11 +180,17 @@
 .chat-root .c-anntools {
   display: flex;
   align-items: center;
+  /* T:3934's own gap between the strip's members. `.c-anncta` keeps its tighter
+     6px between the three seats. */
   gap: 8px;
   flex-shrink: 0;
-  padding: 6px 10px;
+  /* T's box for this row: 26px seats in 8px/16px padding (inventory 02 §D). It
+     was 6px/10px while this was a strip of its own above the header; it IS the
+     header now, so it takes the padding the top bar under it has. */
+  padding: 8px 16px;
   border-bottom: 1px solid var(--c-border);
   background: var(--c-panel);
+  min-width: 0;
 }
 
 /* ---- the narrow single-view layout, chat-column half (T:3776-3884) --------
@@ -221,7 +227,6 @@
 
 /* COMPACT (`compact=1`, the cards wall): a read-mostly tile. T hides #topbar,
    #anntools, #inputbox, #home and #footnote and halves #log's top padding. */
-.chat-root.chat-compact .c-header,
 .chat-root.chat-compact .c-topbar,
 .chat-root.chat-compact .c-anntools,
 .chat-root.chat-compact .c-composer-chat,
@@ -349,7 +354,6 @@
    HOST draws. The strip and the top bar go; THE COMPOSER STAYS, which is the
    whole difference from compact — answering a question without leaving the wall
    is what the popup exists for (T:1434-1438). */
-.chat-root.chat-peek .c-header,
 .chat-root.chat-peek .c-topbar,
 .chat-root.chat-peek .c-anntools {
   display: none;

--- a/frontend/src/apps/claude/styles/composer.css
+++ b/frontend/src/apps/claude/styles/composer.css
@@ -632,6 +632,62 @@ select.c-pill {
   padding: 3px 6px 3px 10px;
   font-size: 12px;
   color: var(--c-fg);
+  transition:
+    background 0.12s,
+    border-color 0.12s;
+}
+/* THE PILL'S BODY IS ONE BUTTON (P2-4): thumb-or-glyph and the words together,
+   with the ✕ as its only sibling. A door made of the 22px thumbnail alone left
+   most of the pill — the part a pointer actually lands on — dead. `display:
+   contents` is deliberately NOT used: the button has to BE the hit area, so it
+   is a flex row of its own that inherits the pill's type and colour and adds no
+   box of its own. */
+.chat-root .c-annchip .c-chip-door {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  border: 0;
+  background: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+/* A refusal (and a seat still uploading) has no room behind the door, so it is
+   not one: the plain pill, and the words say why (T:10722-10726). */
+.chat-root .c-annchip .c-chip-door.is-inert {
+  cursor: default;
+}
+/* The chip answers the pointer as ONE shape — the pill lifts, and the thumb's
+   own accent ring rides along with it, which is the only thing 22px can say
+   about being a door (T:956, T:971). */
+.chat-root .c-annchip:has(.c-chip-door:hover),
+.chat-root .c-annchip:has(.c-chip-door:focus-visible) {
+  background: var(--c-surface);
+  border-color: var(--c-border-strong);
+}
+.chat-root .c-annchip:has(.c-chip-door.is-inert:hover) {
+  background: var(--c-surface-2);
+  border-color: var(--c-border);
+}
+.chat-root .c-annchip .c-chip-door:hover .c-shotthumb,
+.chat-root .c-annchip .c-chip-door:focus-visible .c-shotthumb {
+  border-color: var(--c-accent);
+}
+.chat-root .c-annchip .c-chip-door:hover .c-pinlbl,
+.chat-root .c-annchip .c-chip-door:focus-visible .c-pinlbl {
+  color: var(--c-fg);
+}
+/* The focus ring belongs to the whole pill, not to the inner row. */
+.chat-root .c-annchip .c-chip-door:focus-visible {
+  outline: none;
+}
+.chat-root .c-annchip:has(.c-chip-door:focus-visible) {
+  outline: 2px solid var(--c-accent);
+  outline-offset: 1px;
 }
 .chat-root .c-annchip .c-txt {
   overflow: hidden;
@@ -644,7 +700,7 @@ select.c-pill {
   font-weight: 600;
   flex-shrink: 0;
 }
-.chat-root .c-annchip button {
+.chat-root .c-annchip .c-chip-x {
   border: 0;
   background: transparent;
   color: var(--c-dim);
@@ -652,11 +708,12 @@ select.c-pill {
   font-size: 12px;
   padding: 0 3px;
   border-radius: 50%;
+  flex-shrink: 0;
 }
-.chat-root .c-annchip button:hover {
+.chat-root .c-annchip .c-chip-x:hover {
   color: var(--c-fg);
 }
-.chat-root .c-annchip button:disabled {
+.chat-root .c-annchip .c-chip-x:disabled {
   cursor: default;
   opacity: 0.55;
 }
@@ -674,7 +731,7 @@ select.c-pill {
   border-radius: 3px;
   overflow: hidden;
   line-height: 0;
-  cursor: zoom-in;
+  transition: border-color 0.12s;
 }
 .chat-root .c-annchip .c-shotthumb img {
   display: block;
@@ -682,28 +739,19 @@ select.c-pill {
   max-width: 64px;
   object-fit: cover;
 }
-.chat-root .c-annchip .c-shotthumb:hover,
-.chat-root .c-annchip .c-shotthumb:focus-visible {
-  border-color: var(--c-accent);
-  outline: none;
-}
 /* A NON-picture attachment's door into the viewer. A file has no thumbnail —
    nothing 22px wide can say about a .csv what its name already says better — so
    the GLYPH is the button, which keeps the chip one shape (glyph, words, ✕)
    across both kinds instead of giving files a second control images lack. */
-.chat-root .c-annchip .c-shotdoc {
-  flex-shrink: 0;
+/* THE GLYPH IS A LUCIDE ICON (P2-7), sized off the chip's own 12px through the
+   `1em` the component sets, so it lines up with the words beside it rather than
+   sitting a font's worth of leading above them. Its accent is T's `.shotdoc`
+   colour; the door's hover takes it to `--c-fg`, above. */
+.chat-root .c-annchip .c-pinlbl {
+  display: inline-flex;
+  align-items: center;
   font-size: 13px;
-  color: var(--c-accent);
-  padding: 0 1px;
-  cursor: pointer;
-  border: 0;
-  background: transparent;
-}
-.chat-root .c-annchip .c-shotdoc:hover,
-.chat-root .c-annchip .c-shotdoc:focus-visible {
-  color: var(--c-fg);
-  outline: none;
+  transition: color 0.12s;
 }
 /* A seat whose bytes are still on their way. Quieter, and not a spinner: the
    row already says "attaching…", and one more moving thing beside a capture

--- a/frontend/src/apps/claude/styles/composer.css
+++ b/frontend/src/apps/claude/styles/composer.css
@@ -562,10 +562,22 @@ select.c-pill {
    focus handling all come from `platform/ui/modal/Modal` — the chassis the
    Delete task dialog uses — so nothing about the chrome is styled here any
    more (the old sentpop box/bar/body skin is gone with it).
-   What is left is the two things inside the body, and they paint with the
-   PLATFORM palette (`--bg`, `--border`, `--fg-muted`), not the chat's `--c-*`
-   aliases: the dialog is portaled to <body>, outside .chat-root's cascade, and
-   it is now a dialog of the app rather than a popup of the chat. */
+   What is left is what goes INSIDE the body: the section headings and the wire
+   block paint with the PLATFORM palette (`--bg`, `--border`, `--fg-muted`)
+   like the chrome around them, while the pictures and comment pills below keep
+   the chat's `--c-*` aliases — a comment's label pill has to match the badge
+   burnt into the screenshot above it. The body carries `.c-overlay` to
+   re-anchor those aliases, because the dialog is portaled to <body>, outside
+   .chat-root's cascade. */
+
+/* A column of sections — heading, picture, caveat, comment rows, then the
+   wire. `Modal` already owns the padding and the scroll, so all this adds is
+   the rhythm between them. */
+.c-sent-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
 .c-sent-head {
   margin: 0;
   font-size: 12px;
@@ -608,4 +620,354 @@ select.c-pill {
   align-items: center;
   justify-content: center;
   padding: 24px;
+}
+
+/* ---- the attachment chips (T:896-988) ----------------------------------
+   The pending screenshot's chip is the SAME pill an annotation's is, with the
+   picture where the note's words would be. That likeness is the point: both are
+   things this message is about to carry, both sit above the composer, and both
+   come off with the same ✕ — so one row reads as "what is attached" rather than
+   as two features that happen to be neighbours. */
+.chat-root .c-annchips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chat-root .c-annchips:not(:empty) {
+  padding: 0 0 8px;
+}
+.chat-root .c-annchip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 999px;
+  padding: 3px 6px 3px 10px;
+  font-size: 12px;
+  color: var(--c-fg);
+}
+.chat-root .c-annchip .c-txt {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 240px;
+}
+.chat-root .c-annchip .c-pinlbl {
+  color: var(--c-accent);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.chat-root .c-annchip button {
+  border: 0;
+  background: transparent;
+  color: var(--c-dim);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0 3px;
+  border-radius: 50%;
+}
+.chat-root .c-annchip button:hover {
+  color: var(--c-fg);
+}
+.chat-root .c-annchip button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+/* A real <button>, not decoration: it opens the full-size viewer. `cursor` and
+   the hover ring are the only things that can say so at 22px, and they have to,
+   because a thumbnail this small proves a picture EXISTS and cannot show what is
+   in it. The button is the frame (border, clip, hit area) and the <img> inside
+   it does the sizing — a button cannot `object-fit` its own content. */
+.chat-root .c-annchip .c-shotthumb {
+  display: block;
+  flex-shrink: 0;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--c-border);
+  border-radius: 3px;
+  overflow: hidden;
+  line-height: 0;
+  cursor: zoom-in;
+}
+.chat-root .c-annchip .c-shotthumb img {
+  display: block;
+  height: 22px;
+  max-width: 64px;
+  object-fit: cover;
+}
+.chat-root .c-annchip .c-shotthumb:hover,
+.chat-root .c-annchip .c-shotthumb:focus-visible {
+  border-color: var(--c-accent);
+  outline: none;
+}
+/* A NON-picture attachment's door into the viewer. A file has no thumbnail —
+   nothing 22px wide can say about a .csv what its name already says better — so
+   the GLYPH is the button, which keeps the chip one shape (glyph, words, ✕)
+   across both kinds instead of giving files a second control images lack. */
+.chat-root .c-annchip .c-shotdoc {
+  flex-shrink: 0;
+  font-size: 13px;
+  color: var(--c-accent);
+  padding: 0 1px;
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+}
+.chat-root .c-annchip .c-shotdoc:hover,
+.chat-root .c-annchip .c-shotdoc:focus-visible {
+  color: var(--c-fg);
+  outline: none;
+}
+/* A seat whose bytes are still on their way. Quieter, and not a spinner: the
+   row already says "attaching…", and one more moving thing beside a capture
+   flash is noise. */
+.chat-root .c-annchip.is-pending {
+  opacity: 0.7;
+}
+/* The chip arriving. HALF of the "did it even do anything?" answer — the other
+   half is the flash over the pane itself — and deliberately the loud half: the
+   pane is where the user was looking, the composer is where they look next, so
+   the chip has to still be moving when their eye gets there. One 220ms
+   scale+fade, no bounce: a receipt, not a celebration. */
+@keyframes c-shotchip-in {
+  from {
+    opacity: 0;
+    transform: scale(0.82);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+.chat-root .c-annchip.c-shotchip {
+  animation: c-shotchip-in 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-root .c-annchip.c-shotchip {
+    animation: none;
+  }
+}
+
+/* ---- the screenshot viewer (T:997-1140) --------------------------------
+   The Dialog primitive owns the scrim and the centring; `.c-shotview-box` is T's
+   `figure#shotview-box`, and it is what SCROLLS at natural size.
+
+   THE CARD'S OWN WIDTH BOUND, and it has to be stated here rather than left to
+   a utility in the className. `DialogContent` ships `sm:max-w-sm` — 384px — and
+   Tailwind emits a variant AFTER the unprefixed utility inside the same layer,
+   so `sm:max-w-sm` won over the `max-w-none` written beside it (a variant adds
+   no specificity; the order it is emitted in is the whole of it). Above 640px
+   the card was therefore pinned at 384px while the box inside it, a GRID ITEM
+   with an automatic minimum size of its own min-content, overflowed straight
+   past it: QA measured the caption bar 856px wide inside a 384px card, with
+   Close 35px past the right edge of a 1280px viewport and Escape the only way
+   out.
+
+   THE FIX IS THE CASCADE LAYER, not specificity. `src/styles/tailwind.css:7-8`
+   imports Tailwind's utilities as `layer(utilities)`, and this sheet arrives
+   UNLAYERED through a plain `import` in four TSX modules — and an unlayered
+   declaration beats every layered one whatever its selector or emit order. So
+   the rule below wins because of where it lives, and scoping it more tightly
+   costs nothing.
+
+   Scoped `.c-overlay.c-shotview`, which is the scope this app has for a PORTALED
+   surface: the dialog renders outside `.chat-root`, so the `.chat-root` prefix
+   every `.c-annchip*` rule above carries is not available here.
+
+   The number is T's: `#shotview` is the viewport with 12px of padding on each
+   side (T:997-1007), so the card gets the viewport minus 24. */
+/* AND ABOVE THE APP'S MODAL, which is a number this file now has to state.
+   "What was sent" is a `platform/ui/modal/Modal` (R4-1) and that chassis sits
+   at `z-index: 1000` (styles/deploy.css `.deploy-overlay`), while the Dialog
+   primitive here ships `z-50`. A picture opened from inside the record would
+   therefore land UNDER it and the click would look dead — the one failure the
+   viewer exists to prevent. The backdrop is an earlier sibling of the popup in
+   the portal (Base UI puts a positioner span between them, so `~` and not `+`),
+   and it is lifted with it rather than left behind the modal's scrim. */
+.c-overlay.c-shotview,
+[data-slot="dialog-overlay"]:has(~ .c-shotview) {
+  z-index: 1100;
+}
+.c-overlay.c-shotview {
+  width: auto;
+  min-width: 0;
+  max-width: calc(100vw - 24px);
+}
+.c-shotview-box {
+  position: relative;
+  margin: 0;
+  /* `min-width: 0` for the same reason the bar below has it: a grid item whose
+     automatic minimum size is its min-content ignores `max-width` outright. */
+  min-width: 0;
+  max-width: min(100vw - 24px, 100%);
+  max-height: calc(100vh - 24px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--c-panel);
+  border: 1px solid var(--c-border-strong);
+  border-radius: 10px;
+  padding: 10px;
+  box-shadow: 0 18px 50px var(--c-shadow);
+}
+/* `min-height: 0` so the flex column may actually shrink the image — without it
+   a tall screenshot pushes the caption bar off the bottom of the viewport, which
+   is where Discard lives.
+
+   TWO SIZES, and the second is not a nicety: fitted, a 1600px-wide capture lands
+   at ~310px in the sidebar — four times the chip, still not enough to read the
+   UI it is a picture OF. The cursor names which click you are about to make. */
+.c-shotview-img {
+  min-height: 0;
+  max-width: 100%;
+  object-fit: contain;
+  border-radius: 4px;
+  background: var(--c-surface-2);
+  cursor: zoom-in;
+}
+.c-shotview-box[data-zoom] {
+  overflow: auto;
+}
+.c-shotview-box[data-zoom] .c-shotview-img {
+  max-width: none;
+  max-height: none;
+  /* `align-self` is the load-bearing one: the box is a COLUMN flex container, so
+     its default `stretch` sizes the image to the container's width on the cross
+     axis, and lifting max-width alone left the picture pinned at the box's own
+     width — visibly identical to the fitted view, with a zoom-out cursor
+     promising something that had not happened. */
+  align-self: flex-start;
+  width: auto;
+  cursor: zoom-out;
+}
+/* The scrolled state needs the caption to stay put — it holds Discard and
+   Close, and a bar that scrolls away with a 1600px image takes the way out with
+   it. */
+.c-shotview-box[data-zoom] .c-shotview-bar {
+  position: sticky;
+  bottom: 0;
+  background: var(--c-panel);
+  padding-top: 6px;
+}
+.c-shotview-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--c-dim);
+  /* NEVER WIDER THAN THE CARD. The bar is what holds Discard and Close, so it
+     is the one row in this dialog that must not be the thing that decides the
+     dialog's width — and `min-width: 0` is what stops it: the default
+     `min-width: auto` on a flex item is its MIN-CONTENT, and a nowrap path is
+     min-content-wide however small its own `min-width` is. */
+  min-width: 0;
+  max-width: 100%;
+  align-self: stretch;
+}
+.c-shotview-bar .c-spacer {
+  flex: 1;
+}
+/* The path the AGENT was given, which is the one fact a picture cannot show
+   about itself. Truncated from the LEFT: the filename identifies it.
+
+   `flex: 1 1 0` and not T's `flex: 0 1 auto` — a definite zero basis is what
+   keeps a 90-character temp path out of the bar's MAX-content width too, so the
+   dialog is sized by the picture and the path truncates into whatever room that
+   leaves. T needs neither, because its `#shotview` is a flex container with the
+   viewport's own definite width to shrink against. */
+.c-shotview-path {
+  flex: 1 1 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  text-align: left;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--c-faint);
+}
+.c-shotview-drop {
+  color: var(--c-error);
+}
+/* Whatever the picture does NOT show, in the one place the user is actually
+   looking at the picture. It rode the wire from the first version of this
+   feature (`viewNote`) and had nowhere on screen to be said until then. */
+.c-shotview-note {
+  max-width: 60ch;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--c-dim);
+}
+/* What a FILE viewer has instead of a picture: the name the user called it and
+   how big it is. An image says both of those by BEING shown, so this is simply
+   not rendered there. */
+.c-shotview-name {
+  font-size: 12.5px;
+  color: var(--c-fg);
+  font-weight: 600;
+  word-break: break-word;
+}
+/* The file's own template, in the footprint the picture gets — written against
+   the VIEWPORT rather than against the box (a box sized by its content cannot
+   give a percentage height to a child), minus the dialog's padding, and capped
+   at 900px so a wide window does not stretch a table across a metre of screen. */
+.c-shotview-frame {
+  flex: 1 1 auto;
+  min-height: 0;
+  width: calc(100vw - 44px);
+  max-width: 900px;
+  height: calc(100vh - 120px);
+  border: 1px solid var(--c-border-strong);
+  border-radius: 4px;
+  background: var(--c-surface-2);
+}
+.c-shotview-loading {
+  font-size: 11.5px;
+  color: var(--c-dim);
+}
+.c-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ---- "what was sent": the sections a receipt stands for (T:1157-1181) --- */
+/* `display: contents`, so a picture's heading, the picture and its caveat are
+   three children of the body's own flex column rather than one boxed group. */
+.c-sent-group {
+  display: contents;
+}
+.c-sent-body .c-sent-shot {
+  max-width: 100%;
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  cursor: zoom-in;
+}
+.c-sent-body .c-sent-note-row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 13px;
+}
+.c-sent-body .c-sent-note-lbl {
+  flex: none;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: 10px;
+  background: var(--c-accent);
+  color: var(--c-on-accent);
+  font-weight: 700;
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.c-sent-body .c-sent-note-meta {
+  color: var(--c-dim);
+  font-size: 12px;
+}
+.c-sent-body .c-sent-caveat {
+  color: var(--c-dim);
+  font-size: 12px;
 }

--- a/frontend/src/apps/claude/styles/composer.css
+++ b/frontend/src/apps/claude/styles/composer.css
@@ -43,31 +43,16 @@
   --c-scrim: rgba(0, 0, 0, 0.48);
 }
 
-/* ---- the header's two rows (T:163-172 + T:1285-1310) --------------------
-   Row one is the CONTROL strip (T's `#anntools`: the way out at its left end,
-   the menu at its right, and the seat PR2/PR3's screenshot / comment /
-   annotate buttons land in). Row two is the chat's IDENTITY (T's `#topbar`).
-   One row carrying all six things is how a 43px strip in a narrow pane ends up
-   with the file name and the id fighting for the same inch (Akshil,
-   2026-09-08, #7). */
-.c-header {
-  flex-shrink: 0;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-}
-.c-hdr-tools {
-  flex-shrink: 0;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--c-border);
-}
-/* ONE auto margin per row: everything before it sits left, everything after
-   rides the right-hand end with it (T:255-262). Two of them would split the
-   slack and park the kebab mid-strip. */
+/* ---- the header (T:163-172 + T:1285-1310) -------------------------------
+   ONE control row and one identity row, which is T's own shape: `#anntools` (the
+   way out at its left end, the preview seats and the ⋮ at its right) is
+   `ClaudeChat`'s `.c-anntools` and is styled in `styles/chat.css`, because it is
+   the row BOTH views share; `#topbar` below it is the chat's identity and is
+   what is left in this file. A control row of our own here as well is what put
+   PR2's seats on a third row above the ⋮ (Akshil, 2026-09-09, P2-1). */
+/* ONE auto margin in the control row: everything before it sits left,
+   everything after rides the right-hand end with it (T:255-262). Two of them
+   would split the slack and park the kebab mid-strip. */
 .c-hdr-slack {
   flex: 1 1 auto;
   min-width: 0;

--- a/frontend/src/apps/claude/styles/composer.css
+++ b/frontend/src/apps/claude/styles/composer.css
@@ -842,6 +842,15 @@ select.c-pill {
 .c-shotview-img {
   min-height: 0;
   max-width: 100%;
+  /* FITTED MEANS FITTED, and inside a scrolling body that has to be said as a
+     number. T got it for free: its `#shotview-box` had a definite
+     `max-height: calc(100vh - 24px)` and the image was a flex child that SHRANK
+     into it. Here the body is what scrolls (P2-5), so an unbounded image simply
+     hands it a scrollbar — a 1600×1860 capture opened 1860px tall in a 712px
+     body, which is the zoomed view arriving uninvited. The bound is the card's
+     own: 85vh less the head, the footer, the body's padding and room for a
+     caveat line under the picture. `object-fit: contain` keeps the aspect. */
+  max-height: calc(85vh - 160px);
   object-fit: contain;
   border-radius: 4px;
   background: var(--c-surface-2);

--- a/frontend/src/apps/claude/styles/composer.css
+++ b/frontend/src/apps/claude/styles/composer.css
@@ -784,74 +784,61 @@ select.c-pill {
 }
 
 /* ---- the screenshot viewer (T:997-1140) --------------------------------
-   The Dialog primitive owns the scrim and the centring; `.c-shotview-box` is T's
-   `figure#shotview-box`, and it is what SCROLLS at natural size.
+   THE BOX IS THE APP'S MODAL (P2-3): overlay, card, head with the ✕, footer,
+   focus trap and Esc all come from `platform/ui/modal/Modal`, the chassis the
+   Delete task dialog and "what was sent" use. So the whole shadcn-Dialog skin
+   that used to live here — the card's own width bound, the cascade-layer
+   argument against `sm:max-w-sm`, the scrim, the sticky bottom bar — is gone
+   with the primitive it was fighting. What is left is the BODY: the picture, the
+   framed preview, the caveat, and the path in the footer.
 
-   THE CARD'S OWN WIDTH BOUND, and it has to be stated here rather than left to
-   a utility in the className. `DialogContent` ships `sm:max-w-sm` — 384px — and
-   Tailwind emits a variant AFTER the unprefixed utility inside the same layer,
-   so `sm:max-w-sm` won over the `max-w-none` written beside it (a variant adds
-   no specificity; the order it is emitted in is the whole of it). Above 640px
-   the card was therefore pinned at 384px while the box inside it, a GRID ITEM
-   with an automatic minimum size of its own min-content, overflowed straight
-   past it: QA measured the caption bar 856px wide inside a 384px card, with
-   Close 35px past the right edge of a 1280px viewport and Escape the only way
-   out.
-
-   THE FIX IS THE CASCADE LAYER, not specificity. `src/styles/tailwind.css:7-8`
-   imports Tailwind's utilities as `layer(utilities)`, and this sheet arrives
-   UNLAYERED through a plain `import` in four TSX modules — and an unlayered
-   declaration beats every layered one whatever its selector or emit order. So
-   the rule below wins because of where it lives, and scoping it more tightly
-   costs nothing.
-
-   Scoped `.c-overlay.c-shotview`, which is the scope this app has for a PORTALED
-   surface: the dialog renders outside `.chat-root`, so the `.chat-root` prefix
-   every `.c-annchip*` rule above carries is not available here.
-
-   The number is T's: `#shotview` is the viewport with 12px of padding on each
-   side (T:997-1007), so the card gets the viewport minus 24. */
-/* AND ABOVE THE APP'S MODAL, which is a number this file now has to state.
-   "What was sent" is a `platform/ui/modal/Modal` (R4-1) and that chassis sits
-   at `z-index: 1000` (styles/deploy.css `.deploy-overlay`), while the Dialog
-   primitive here ships `z-50`. A picture opened from inside the record would
-   therefore land UNDER it and the click would look dead — the one failure the
-   viewer exists to prevent. The backdrop is an earlier sibling of the popup in
-   the portal (Base UI puts a positioner span between them, so `~` and not `+`),
-   and it is lifted with it rather than left behind the modal's scrim. */
-.c-overlay.c-shotview,
-[data-slot="dialog-overlay"]:has(~ .c-shotview) {
+   AND ABOVE THE APP'S MODAL, which is a number this file still has to state.
+   "What was sent" is a `Modal` too and the chassis sits at `z-index: 1000`
+   (`styles/deploy.css` `.deploy-overlay`), so a picture opened from inside the
+   record would land in the same plane as it and the click would look dead — the
+   one failure the viewer exists to prevent. The overlay is selected through the
+   dialog it holds, because `dialogClassName` is the only hook a caller has. */
+.modal-overlay:has(> .c-shotview-modal) {
   z-index: 1100;
 }
-.c-overlay.c-shotview {
-  width: auto;
-  min-width: 0;
-  max-width: calc(100vw - 24px);
+/* WIDER THAN A FORM DIALOG's 600px, because the content is a picture of a
+   screen — but still bounded, so a wide window does not stretch a table across
+   a metre of glass. T's own number for the framed preview was 900. */
+.modal-dialog.c-shotview-modal {
+  width: min(960px, 100%);
+}
+/* THE BODY IS WHAT SCROLLS, AND THE FOOTER NEVER MOVES (P2-5). The card is
+   `max-height: 85vh` (`.deploy-dialog`) with head and footer as fixed rows, so
+   stating the body's own max-height is belt to that braces: `85vh` minus the
+   head's 45 and the footer's 57, which is the height a body may take before the
+   card would have to grow past the card's own bound and push the footer out of
+   the viewport. `overflow: auto` on both axes — a natural-size screenshot is
+   wider than the card as well as taller. */
+.modal-dialog.c-shotview-modal .modal-body {
+  max-height: calc(85vh - 102px);
+  overflow: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 .c-shotview-box {
   position: relative;
   margin: 0;
-  /* `min-width: 0` for the same reason the bar below has it: a grid item whose
+  /* `min-width: 0` for the same reason the path has it: a flex item whose
      automatic minimum size is its min-content ignores `max-width` outright. */
   min-width: 0;
-  max-width: min(100vw - 24px, 100%);
-  max-height: calc(100vh - 24px);
+  min-height: 0;
+  max-width: 100%;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background: var(--c-panel);
-  border: 1px solid var(--c-border-strong);
-  border-radius: 10px;
-  padding: 10px;
-  box-shadow: 0 18px 50px var(--c-shadow);
 }
-/* `min-height: 0` so the flex column may actually shrink the image — without it
-   a tall screenshot pushes the caption bar off the bottom of the viewport, which
-   is where Discard lives.
-
-   TWO SIZES, and the second is not a nicety: fitted, a 1600px-wide capture lands
+/* TWO SIZES, and the second is not a nicety: fitted, a 1600px-wide capture lands
    at ~310px in the sidebar — four times the chip, still not enough to read the
-   UI it is a picture OF. The cursor names which click you are about to make. */
+   UI it is a picture OF. The cursor names which click you are about to make.
+
+   `min-height: 0` so the flex column may actually shrink the image rather than
+   handing the body a scrollbar for a picture that would have fitted. */
 .c-shotview-img {
   min-height: 0;
   max-width: 100%;
@@ -860,9 +847,6 @@ select.c-pill {
   background: var(--c-surface-2);
   cursor: zoom-in;
 }
-.c-shotview-box[data-zoom] {
-  overflow: auto;
-}
 .c-shotview-box[data-zoom] .c-shotview-img {
   max-width: none;
   max-height: none;
@@ -870,48 +854,21 @@ select.c-pill {
      its default `stretch` sizes the image to the container's width on the cross
      axis, and lifting max-width alone left the picture pinned at the box's own
      width — visibly identical to the fitted view, with a zoom-out cursor
-     promising something that had not happened. */
+     promising something that had not happened. The body above is what scrolls. */
   align-self: flex-start;
   width: auto;
   cursor: zoom-out;
 }
-/* The scrolled state needs the caption to stay put — it holds Discard and
-   Close, and a bar that scrolls away with a 1600px image takes the way out with
-   it. */
-.c-shotview-box[data-zoom] .c-shotview-bar {
-  position: sticky;
-  bottom: 0;
-  background: var(--c-panel);
-  padding-top: 6px;
-}
-.c-shotview-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 11.5px;
-  color: var(--c-dim);
-  /* NEVER WIDER THAN THE CARD. The bar is what holds Discard and Close, so it
-     is the one row in this dialog that must not be the thing that decides the
-     dialog's width — and `min-width: 0` is what stops it: the default
-     `min-width: auto` on a flex item is its MIN-CONTENT, and a nowrap path is
-     min-content-wide however small its own `min-width` is. */
-  min-width: 0;
-  max-width: 100%;
-  align-self: stretch;
-}
-.c-shotview-bar .c-spacer {
-  flex: 1;
-}
 /* The path the AGENT was given, which is the one fact a picture cannot show
    about itself. Truncated from the LEFT: the filename identifies it.
 
-   `flex: 1 1 0` and not T's `flex: 0 1 auto` — a definite zero basis is what
-   keeps a 90-character temp path out of the bar's MAX-content width too, so the
-   dialog is sized by the picture and the path truncates into whatever room that
-   leaves. T needs neither, because its `#shotview` is a flex container with the
-   viewport's own definite width to shrink against. */
+   `margin-right: auto` is the footer grammar's far-left seat, and `flex: 1 1 0`
+   with a definite zero basis is what keeps a 90-character temp path from being
+   the thing that decides the dialog's width — the card is sized by the picture
+   and the path truncates into whatever room that leaves. */
 .c-shotview-path {
   flex: 1 1 0;
+  margin-right: auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -919,10 +876,7 @@ select.c-pill {
   text-align: left;
   min-width: 0;
   font-size: 11px;
-  color: var(--c-faint);
-}
-.c-shotview-drop {
-  color: var(--c-error);
+  color: var(--fg-muted);
 }
 /* Whatever the picture does NOT show, in the one place the user is actually
    looking at the picture. It rode the wire from the first version of this
@@ -933,25 +887,20 @@ select.c-pill {
   line-height: 1.45;
   color: var(--c-dim);
 }
-/* What a FILE viewer has instead of a picture: the name the user called it and
-   how big it is. An image says both of those by BEING shown, so this is simply
-   not rendered there. */
-.c-shotview-name {
-  font-size: 12.5px;
-  color: var(--c-fg);
-  font-weight: 600;
-  word-break: break-word;
-}
-/* The file's own template, in the footprint the picture gets — written against
-   the VIEWPORT rather than against the box (a box sized by its content cannot
-   give a percentage height to a child), minus the dialog's padding, and capped
-   at 900px so a wide window does not stretch a table across a metre of screen. */
+/* The file's own template, in the footprint the picture gets. It FILLS THE BODY
+   (P2-5): `width: 100%` of the body's content box rather than T's
+   `calc(100vw - 44px)`, which was written against the viewport because T's
+   overlay had no card to measure against — inside a 960px card that number was
+   wider than its container on any window over ~1000px, and the frame spilled
+   past the card and over the bar. The height is the same story: a fraction of
+   the body's own bound, so head, body and footer add up to a card that fits and
+   the footer is always the last thing on screen. */
 .c-shotview-frame {
   flex: 1 1 auto;
-  min-height: 0;
-  width: calc(100vw - 44px);
-  max-width: 900px;
-  height: calc(100vh - 120px);
+  width: 100%;
+  min-width: 0;
+  min-height: 240px;
+  height: calc(85vh - 150px);
   border: 1px solid var(--c-border-strong);
   border-radius: 4px;
   background: var(--c-surface-2);
@@ -959,6 +908,18 @@ select.c-pill {
 .c-shotview-loading {
   font-size: 11.5px;
   color: var(--c-dim);
+}
+/* Nothing to show and nothing to frame (a .zip, a refusal, an extension with no
+   template): the glyph, big and quiet, so the body is not empty. */
+.c-shotview-blank {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 0;
+  color: var(--c-faint);
+}
+.c-shotview-glyph {
+  font-size: 44px;
 }
 .c-mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;

--- a/frontend/src/apps/claude/styles/home.css
+++ b/frontend/src/apps/claude/styles/home.css
@@ -25,18 +25,10 @@
 }
 /* The strip, sized to `#anntools` (T:163-172) so the two views' first rows are
    the same height and nothing shifts on entering a chat. */
-.c-home-tools {
-  flex-shrink: 0;
-  min-width: 0;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--c-border);
-}
-/* The row's ONE auto margin: everything before it sits left, everything after
-   rides the right-hand end with it (T:255-262). PR2/PR3's seats land in
-   between. */
+/* The control row's ONE auto margin: everything before it sits left, everything
+   after rides the right-hand end with it (T:255-262). The landing's own copy of
+   that row is gone (P2-1) — it is `.c-anntools`, above both views — and this
+   stays because the strip is what reads it. */
 .c-hdr-slack {
   flex: 1 1 auto;
   min-width: 0;

--- a/frontend/src/apps/claude/styles/transcript.css
+++ b/frontend/src/apps/claude/styles/transcript.css
@@ -1833,6 +1833,18 @@
   font-weight: 600;
   flex-shrink: 0;
 }
+/* THE GLYPH IS A LUCIDE ICON (P2-7), not 📄/🖼/📌. The row is baseline-aligned,
+   so the icon stays INLINE and is nudged onto the text's optical centre rather
+   than being wrapped in a flex box whose own baseline would move the whole row.
+   `1em` comes from the component, so it tracks this row's 11.5px. */
+.chat-root .annsum .annsum-lbl svg {
+  vertical-align: -0.15em;
+}
+/* A comment row's pin sits BEFORE its letter, so it needs the gap a glyph on its
+   own does not. */
+.chat-root .annsum .annsum-note .annsum-lbl svg {
+  margin-right: 4px;
+}
 /* A file's receipt glyph is the DOOR into the viewer (D616), so it is a real
    <button> — which arrives wearing the UA's border, background and font. Reset
    to exactly the span it replaces, and nothing more: the row must not shift by a
@@ -1851,6 +1863,21 @@
 .chat-root .annsum button.annsum-lbl:focus-visible {
   color: var(--c-fg);
   outline: none;
+}
+/* ---- a wordless send's bubble (P2-7, T:10525-10545) --------------------
+   "pane screenshot", "files", "annotations" — the words the bubble carries when
+   the reader typed none, each behind the same lucide glyph its chip and its
+   receipt wear. Inline-flex per part so the icon and its word can never break
+   apart at a wrap; the " + " between them is a part of its own so it wraps
+   where a join belongs. */
+.chat-root .bubble .c-marker {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.chat-root .bubble .c-marker-join {
+  margin-right: 4px;
+  opacity: 0.7;
 }
 .chat-root .annsum .annsum-el {
   color: var(--c-faint);

--- a/frontend/src/apps/claude/styles/transcript.css
+++ b/frontend/src/apps/claude/styles/transcript.css
@@ -1811,3 +1811,102 @@
   color: var(--c-fg);
   text-decoration: underline;
 }
+/* ---- the receipt under a sent user turn (T:1716-1801) ------------------
+   What this message carried, in the log where it was sent. Right-aligned with
+   the bubble it belongs to, and small on purpose: it is a receipt, not a
+   viewer — the viewer is one click behind the thumbnail. */
+.chat-root .annsum {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.chat-root .annsum .annsum-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--c-dim);
+  justify-content: flex-end;
+}
+.chat-root .annsum .annsum-lbl {
+  color: var(--c-accent);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+/* A file's receipt glyph is the DOOR into the viewer (D616), so it is a real
+   <button> — which arrives wearing the UA's border, background and font. Reset
+   to exactly the span it replaces, and nothing more: the row must not shift by a
+   pixel depending on whether the attachment is openable. */
+.chat-root .annsum button.annsum-lbl {
+  appearance: none;
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  font-weight: 600;
+  line-height: inherit;
+  cursor: pointer;
+}
+.chat-root .annsum button.annsum-lbl:hover,
+.chat-root .annsum button.annsum-lbl:focus-visible {
+  color: var(--c-fg);
+  outline: none;
+}
+.chat-root .annsum .annsum-el {
+  color: var(--c-faint);
+  flex-shrink: 0;
+  font-size: 11px;
+}
+.chat-root .annsum .annsum-txt {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+/* A comment row IS the door into the "what was sent" popup — no separate
+   button, the row itself is the affordance. */
+.chat-root .annsum .annsum-note {
+  cursor: pointer;
+  border-radius: 4px;
+}
+.chat-root .annsum .annsum-note:hover .annsum-txt {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+/* The whole-pane picture a SENT turn carried. Bigger than a crop's receipt and
+   on its own line, because it is a different claim: "the screen, as it was when
+   I asked" — and that is the row a user scrolls back to find. */
+.chat-root .annsum .annsum-pane {
+  display: block;
+  align-self: flex-end;
+  margin-top: 2px;
+  padding: 0;
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  overflow: hidden;
+  line-height: 0;
+  cursor: zoom-in;
+}
+/* Cropped from the TOP, not centred: a screenshot of a page is read from its
+   top edge, so that is the part worth showing in 140px. */
+.chat-root .annsum .annsum-pane img {
+  display: block;
+  max-width: min(220px, 100%);
+  max-height: 140px;
+  object-fit: cover;
+  object-position: top;
+}
+.chat-root .annsum .annsum-pane:hover,
+.chat-root .annsum .annsum-pane:focus-visible {
+  border-color: var(--c-accent);
+  outline: none;
+}
+/* A restored turn whose file the shots directory has since pruned (12h/200
+   files). Said plainly rather than left as a broken-image glyph, which reads as
+   a bug in the chat rather than as a temp file that expired. */
+.chat-root .annsum .annsum-gone {
+  font-size: 11px;
+  color: var(--c-faint);
+  align-self: flex-end;
+}

--- a/frontend/src/apps/claude/ui/AnnStrip.tsx
+++ b/frontend/src/apps/claude/ui/AnnStrip.tsx
@@ -14,10 +14,18 @@
 // (T:3823 `body.view-chat .viewshot`) because the pane it photographs is not on
 // screen there.
 //
-// Comment and Annotate are PR3's. They are rendered DISABLED rather than
-// omitted: the strip is Screenshot · Comment · Annotate in every state (Akshil,
-// 2026-09-06), and a row that grows two buttons when the next PR lands is a row
-// that moves under the reader's hand.
+// COMMENT AND ANNOTATE ARE NOT DRAWN IN PR2 (Akshil, 2026-09-09, P2-2). They
+// shipped as DISABLED seats, on the argument that the strip is Screenshot ·
+// Comment · Annotate in every state (2026-09-06) and a row that grows two
+// buttons when the next PR lands is a row that moves under the reader's hand.
+// That argument lost to a plainer one: in T neither is EVER disabled — only the
+// other seat greys while a mode is armed (T:320-322) — so a permanently dead
+// pair says the feature is broken rather than unbuilt, and "absent beats dead"
+// (T:238-241) is this strip's own rule for a control with nothing behind it.
+//
+// The seats' markup and every word, glyph and title in them stay right here,
+// behind one flag: PR3 passes `modes` and the row is T's three again, with
+// nothing to re-derive.
 import "../styles/chat.css";
 
 import { annotateLabelFor, shotLabelFor, type PaneNoun } from "../pane/paneUrl";
@@ -34,9 +42,12 @@ export interface AnnStripProps {
    *  still reach a control a poll has not caught up with (T:11265). */
   capturing: boolean;
   onScreenshot(): void;
+  /** PR3's two seats. Off in PR2: there is no comment mode and no recorder
+   *  behind them yet, and T never draws either one dead. */
+  modes?: boolean;
 }
 
-export function AnnStrip({ paneNoun, shown, capturing, onScreenshot }: AnnStripProps) {
+export function AnnStrip({ paneNoun, shown, capturing, onScreenshot, modes }: AnnStripProps) {
   if (!shown) return null;
   return (
     <div className="c-anncta">
@@ -59,33 +70,38 @@ export function AnnStrip({ paneNoun, shown, capturing, onScreenshot }: AnnStripP
       </button>
       {/* PR3 (inventory 02): the comment mode and the spoken walkthrough. The
           words and the glyphs are T's, so the seats are the right width the
-          moment they come alive. */}
-      <button
-        type="button"
-        aria-pressed="false"
-        aria-label={annotateLabelFor(paneNoun)}
-        title={"Comment on the " + paneNoun + ", then send the notes to Claude"}
-        disabled
-      >
-        <svg className="c-cmt-bubble" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M13.5 2.5h-11a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2.5v2.9l3.4-2.9h5.1a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z" />
-        </svg>
-        <span className="c-lbl">Comment</span>
-      </button>
-      <button
-        type="button"
-        aria-pressed="false"
-        aria-label="Annotate with a spoken walkthrough"
-        title="Annotate with a spoken walkthrough — talk while you click, and each click becomes a note"
-        disabled
-      >
-        <svg className="c-rec-mic" viewBox="0 0 16 16" aria-hidden="true">
-          <rect x="6" y="1.5" width="4" height="7.5" rx="2" />
-          <path d="M3.5 7.5a4.5 4.5 0 0 0 9 0" />
-          <line x1="8" y1="12" x2="8" y2="14.5" />
-        </svg>
-        <span className="c-lbl">Annotate</span>
-      </button>
+          moment they come alive — and each keeps its `disabled` only until PR3
+          hands it a handler, which is the same commit that passes `modes`. */}
+      {modes ? (
+        <>
+          <button
+            type="button"
+            aria-pressed="false"
+            aria-label={annotateLabelFor(paneNoun)}
+            title={"Comment on the " + paneNoun + ", then send the notes to Claude"}
+            disabled
+          >
+            <svg className="c-cmt-bubble" viewBox="0 0 16 16" aria-hidden="true">
+              <path d="M13.5 2.5h-11a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2.5v2.9l3.4-2.9h5.1a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z" />
+            </svg>
+            <span className="c-lbl">Comment</span>
+          </button>
+          <button
+            type="button"
+            aria-pressed="false"
+            aria-label="Annotate with a spoken walkthrough"
+            title="Annotate with a spoken walkthrough — talk while you click, and each click becomes a note"
+            disabled
+          >
+            <svg className="c-rec-mic" viewBox="0 0 16 16" aria-hidden="true">
+              <rect x="6" y="1.5" width="4" height="7.5" rx="2" />
+              <path d="M3.5 7.5a4.5 4.5 0 0 0 9 0" />
+              <line x1="8" y1="12" x2="8" y2="14.5" />
+            </svg>
+            <span className="c-lbl">Annotate</span>
+          </button>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/apps/claude/ui/AnnStrip.tsx
+++ b/frontend/src/apps/claude/ui/AnnStrip.tsx
@@ -1,0 +1,93 @@
+// THE `#anncta` GROUP: the three controls that act on the PREVIEW rather than on
+// the draft — Screenshot · Comment · Annotate (T:3975-4000 markup, CSS
+// T:195-320).
+//
+// The camera was a pill beside Send in both composers and moved up here on
+// 2026-08-27, because it acts on the pane like its two neighbours; the picture it
+// takes still lands as a chip above the composer, where the message is. The
+// order is Screenshot first (Akshil, 2026-09-04).
+//
+// WHERE the group lives is a layout question and the answer is the pane's
+// (`pickerHost`, pane/LeftModePicker): the strip is the one row BOTH narrow views
+// keep, and the wide layout's chat column keeps it too — so the group renders
+// once, in the chat column's strip, and the narrow chat view HIDES the camera
+// (T:3823 `body.view-chat .viewshot`) because the pane it photographs is not on
+// screen there.
+//
+// Comment and Annotate are PR3's. They are rendered DISABLED rather than
+// omitted: the strip is Screenshot · Comment · Annotate in every state (Akshil,
+// 2026-09-06), and a row that grows two buttons when the next PR lands is a row
+// that moves under the reader's hand.
+import "../styles/chat.css";
+
+import { annotateLabelFor, shotLabelFor, type PaneNoun } from "../pane/paneUrl";
+
+export interface AnnStripProps {
+  /** "preview" for a file target, "app" for a project — every label names it. */
+  paneNoun: PaneNoun;
+  /** No pane to photograph: the buttons are HIDDEN, not disabled. The sidebar
+   *  layout's case, where the target is the host's content pane and the host may
+   *  be showing something unmarked — "absent beats dead" (T:238-241). */
+  shown: boolean;
+  /** A capture is in flight (`shotBusy`): the button says so by going inert, and
+   *  the guard in the handler is the belt to that braces — a keyboard user can
+   *  still reach a control a poll has not caught up with (T:11265). */
+  capturing: boolean;
+  onScreenshot(): void;
+}
+
+export function AnnStrip({ paneNoun, shown, capturing, onScreenshot }: AnnStripProps) {
+  if (!shown) return null;
+  return (
+    <div className="c-anncta">
+      <button
+        type="button"
+        className="c-viewshot"
+        aria-label={shotLabelFor(paneNoun)}
+        title={shotLabelFor(paneNoun)}
+        disabled={capturing}
+        onClick={onScreenshot}
+      >
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M2.6 5.4h2.1l1-1.6h4.6l1 1.6h2.1a1 1 0 0 1 1 1v5.6a1 1 0 0 1-1 1H2.6a1 1 0 0 1-1-1V6.4a1 1 0 0 1 1-1Z"
+            strokeLinejoin="round"
+          />
+          <circle cx="8" cy="9" r="2.4" />
+        </svg>
+        <span className="c-lbl">Screenshot</span>
+      </button>
+      {/* PR3 (inventory 02): the comment mode and the spoken walkthrough. The
+          words and the glyphs are T's, so the seats are the right width the
+          moment they come alive. */}
+      <button
+        type="button"
+        aria-pressed="false"
+        aria-label={annotateLabelFor(paneNoun)}
+        title={"Comment on the " + paneNoun + ", then send the notes to Claude"}
+        disabled
+      >
+        <svg className="c-cmt-bubble" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M13.5 2.5h-11a1 1 0 0 0-1 1v7a1 1 0 0 0 1 1h2.5v2.9l3.4-2.9h5.1a1 1 0 0 0 1-1v-7a1 1 0 0 0-1-1z" />
+        </svg>
+        <span className="c-lbl">Comment</span>
+      </button>
+      <button
+        type="button"
+        aria-pressed="false"
+        aria-label="Annotate with a spoken walkthrough"
+        title="Annotate with a spoken walkthrough — talk while you click, and each click becomes a note"
+        disabled
+      >
+        <svg className="c-rec-mic" viewBox="0 0 16 16" aria-hidden="true">
+          <rect x="6" y="1.5" width="4" height="7.5" rx="2" />
+          <path d="M3.5 7.5a4.5 4.5 0 0 0 9 0" />
+          <line x1="8" y1="12" x2="8" y2="14.5" />
+        </svg>
+        <span className="c-lbl">Annotate</span>
+      </button>
+    </div>
+  );
+}
+
+export default AnnStrip;

--- a/frontend/src/apps/claude/ui/AttachIcon.tsx
+++ b/frontend/src/apps/claude/ui/AttachIcon.tsx
@@ -1,0 +1,111 @@
+// WHAT AN ATTACHMENT LOOKS LIKE WHEN IT HAS NO PICTURE — one glyph, and it is a
+// LUCIDE icon rather than an emoji (Akshil, 2026-09-09, P2-7).
+//
+// T drew these as stroke SVGs in the button's own ink; the port shipped 📄 and 🖼
+// instead, and an emoji is the one glyph an app cannot draw: it arrives at a
+// weight and a hue the platform font picked, it is a different picture on macOS,
+// Windows and Linux, and beside the shell's own icons it reads as text someone
+// pasted in. Every icon in this app comes from `lucide-react` (the shell's
+// sidebar, the explorer's rows, the download manager), so these do too —
+// `currentColor`, `1em` off the type around them, and the same 1.5 stroke T's
+// own strip glyphs use.
+//
+// ONE MAP, read by the chip, the receipt row and the viewer's head, for the
+// reason T keeps one copy of the vocabulary (T:7067): a picture called a file in
+// one of the three is a chip that describes the wrong thing.
+import { Camera, FileText, Image as ImageIcon, MessageSquare } from "lucide-react";
+
+import {
+  MARKER_ANN,
+  MARKER_FILE,
+  MARKER_IMG,
+  MARKER_JOIN,
+  MARKER_VIEW,
+} from "../protocol/wire";
+import type { ShotKind } from "../shots/types";
+
+/** T:7141's `shotGlyph`, in icons. A screenshot OF the pane is a camera — that
+ *  is what took it and what the seat that took it wears; a picture the user
+ *  brought in is a picture; anything else is a file. */
+const ICONS = {
+  pane: Camera,
+  overview: Camera,
+  image: ImageIcon,
+  file: FileText,
+} as const satisfies Record<ShotKind, unknown>;
+
+export interface AttachIconProps {
+  kind: ShotKind;
+  /** Extra class, for the one caller that sizes it off a heading rather than off
+   *  body type. */
+  className?: string;
+}
+
+/**
+ * SIZED TO THE TEXT, not to a number: `1em` means the glyph tracks the chip's
+ * 12px, the receipt row's 11px and the dialog head's 15px without any of the
+ * three restating a size. `aria-hidden` because the words beside it — the noun,
+ * the name, the size — already say what it is, and a screen reader announcing
+ * "image" before "screenshot of the preview" says it twice.
+ */
+export function AttachIcon({ kind, className }: AttachIconProps) {
+  const Glyph = ICONS[kind] ?? FileText;
+  return (
+    <Glyph
+      className={className}
+      width="1em"
+      height="1em"
+      strokeWidth={1.5}
+      aria-hidden="true"
+      focusable="false"
+    />
+  );
+}
+
+// ── the marker bubble (T:10525-10545) ───────────────────────────────────────
+//
+// A send with no typed words still gets a bubble, and what it says is what the
+// message CARRIED: "pane screenshot", "images", "files", "annotations", joined
+// with " + " (`protocol/wire`'s MARKER_*). T put an emoji in front of each; this
+// puts the same lucide icon the chip and the receipt use in front of each, so
+// one glyph vocabulary answers for the pill, the receipt row, the dialog head
+// and the bubble.
+//
+// The bubble's TEXT is unchanged by this — the icons are `aria-hidden` svgs and
+// the words are the same nodes — which matters because a turn's bubble text is
+// what the re-attach probe matches a prior send on.
+const MARKER_KIND: Record<string, ShotKind> = {
+  [MARKER_VIEW]: "pane",
+  [MARKER_IMG]: "image",
+  [MARKER_FILE]: "file",
+};
+
+/** One `" + "`-joined marker string, drawn with its icons. Only ever called for
+ *  a bubble `isMarkerOnly` has already vouched for, so every part is a known
+ *  marker; an unknown one would simply draw its words. */
+export function MarkerText({ text }: { text: string }) {
+  const parts = text.split(MARKER_JOIN);
+  return (
+    <>
+      {parts.map((part, i) => (
+        <span className="c-marker" key={part + ":" + i}>
+          {i ? <span className="c-marker-join">{MARKER_JOIN}</span> : null}
+          {part === MARKER_ANN ? (
+            <MessageSquare
+              width="1em"
+              height="1em"
+              strokeWidth={1.5}
+              aria-hidden="true"
+              focusable="false"
+            />
+          ) : (
+            <AttachIcon kind={MARKER_KIND[part] ?? "file"} />
+          )}
+          {part}
+        </span>
+      ))}
+    </>
+  );
+}
+
+export default AttachIcon;

--- a/frontend/src/apps/claude/ui/AttachIcon.tsx
+++ b/frontend/src/apps/claude/ui/AttachIcon.tsx
@@ -21,6 +21,7 @@ import {
   MARKER_IMG,
   MARKER_JOIN,
   MARKER_VIEW,
+  markerWord,
 } from "../protocol/wire";
 import type { ShotKind } from "../shots/types";
 
@@ -74,6 +75,10 @@ export function AttachIcon({ kind, className }: AttachIconProps) {
 // The bubble's TEXT is unchanged by this — the icons are `aria-hidden` svgs and
 // the words are the same nodes — which matters because a turn's bubble text is
 // what the re-attach probe matches a prior send on.
+//
+// What IS peeled off here is the marker sigil: the U+2063 that tells a marker
+// apart from a reader who typed the word "files" is machinery, and the bubble
+// shows the word (`markerWord`, protocol/wire).
 const MARKER_KIND: Record<string, ShotKind> = {
   [MARKER_VIEW]: "pane",
   [MARKER_IMG]: "image",
@@ -101,7 +106,7 @@ export function MarkerText({ text }: { text: string }) {
           ) : (
             <AttachIcon kind={MARKER_KIND[part] ?? "file"} />
           )}
-          {part}
+          {markerWord(part)}
         </span>
       ))}
     </>

--- a/frontend/src/apps/claude/ui/AttachTray.tsx
+++ b/frontend/src/apps/claude/ui/AttachTray.tsx
@@ -1,0 +1,155 @@
+// THE CHIP ROW above the composer: what this message is about to carry
+// (T:7129 `shotChip`, T:7192 `shotThumbBtn`, markup T:4154/4220, CSS T:896-988).
+//
+// The chip's job is to be a DOOR. 22 pixels can prove a picture EXISTS and
+// nothing that size can show what is in it — so the thumbnail is a `<button>`
+// rather than an `<img>`, and one click opens the picture full size where the
+// user can actually read it and, if it is the wrong moment, throw it away from
+// there (T:7121-7128).
+//
+// The same pill an annotation's chip is (`.annchip`), because both are things
+// this message is about to carry and both come off with the same ✕ — one row
+// reading "what is attached" rather than two features that happen to be
+// neighbours (T:927-932). `shotchip` is only the entrance-animation hook.
+import "../styles/composer.css";
+
+import type { Attachment } from "../shots/types";
+import {
+  failLabel,
+  glyphDoor,
+  shotAlt,
+  shotGlyph,
+  shotNoun,
+  shownSize,
+  toViewable,
+  type Viewable,
+} from "./attachApi";
+
+export interface AttachTrayProps {
+  /** The tray, in the order the user brought them (T:11625). */
+  items: readonly Attachment[];
+  /** "preview" for a file target, "app" for a project (`PaneState.paneNoun`). */
+  paneNoun: string;
+  /** The thumbnail / glyph door: open this at full size. */
+  onOpen(shot: Viewable): void;
+  /** The ✕ (T:10654 `shotDrop`). */
+  onRemove(att: Attachment): void;
+  /** PR3's annotation chips share this row; they are handed in as-is. */
+  children?: React.ReactNode;
+}
+
+/** T:7192 `shotThumbBtn` — ONE builder for every place a screenshot is shown
+ *  small, the pending chip and every sent turn's receipt, because they are one
+ *  affordance: a picture the user can open while drafting but not after sending
+ *  is exactly the inconsistency that makes a control feel arbitrary. */
+export function ShotThumb({
+  className,
+  shot,
+  alt,
+  title,
+  onOpen,
+  onError,
+}: {
+  className: string;
+  shot: Viewable;
+  alt: string;
+  /** The receipt's thumb hovers the PATH; the chip's says what a click does. */
+  title?: string;
+  onOpen(): void;
+  onError?(): void;
+}) {
+  return (
+    <button
+      type="button"
+      className={className}
+      title={title ?? "Click to see this screenshot full size"}
+      aria-label={alt + " — open full size"}
+      onClick={onOpen}
+    >
+      <img src={shot.src || shot.thumb || ""} alt={alt} {...(onError ? { onError } : {})} />
+    </button>
+  );
+}
+
+function Chip({
+  att,
+  paneNoun,
+  onOpen,
+  onRemove,
+}: {
+  att: Attachment;
+  paneNoun: string;
+  onOpen(shot: Viewable): void;
+  onRemove(att: Attachment): void;
+}) {
+  const shot = toViewable(att);
+  const noun = shotNoun(shot, paneNoun);
+  const alt = shotAlt(shot, paneNoun);
+  const pic = !!shot.thumb;
+  const door = glyphDoor(shot);
+  // Keyed off the PICTURE and not off the kind: an image this browser cannot
+  // decode has no thumbnail either, and then its size is the only thing on the
+  // chip that tells it apart from another one (T:7172-7177).
+  const size = shownSize(shot);
+  return (
+    <div className={"c-annchip c-shotchip" + (att.pending ? " is-pending" : "")}>
+      {pic ? (
+        <ShotThumb className="c-shotthumb" shot={shot} alt={alt} onOpen={() => onOpen(shot)} />
+      ) : door ? (
+        <button
+          type="button"
+          className="c-pinlbl c-shotdoc"
+          title="Click to see what is attached"
+          aria-label={alt + " — open details"}
+          onClick={() => onOpen(shot)}
+        >
+          {shotGlyph(shot)}
+        </button>
+      ) : (
+        <span className="c-pinlbl">{shotGlyph(shot)}</span>
+      )}
+      <span className="c-txt" title={shot.viewNote || shot.view || ""}>
+        {/* Says WHICH it is: "here is your picture" and "no picture, and here is
+            why" are different facts, and the second is the one a user has to be
+            told BEFORE they press send — the whole advantage of attaching on the
+            gesture rather than during the send (T:7157-7163). */}
+        {att.pending
+          ? // The one state T has no chip for: there a chip exists only once its
+            // upload has answered. Here the drop of six puts six seats up at
+            // once so nothing re-orders itself as the uploads land, and a seat
+            // whose bytes are still on their way has to say so. Its own name is
+            // deliberately NOT guessed — the pipeline decides whether a file is
+            // a picture, and a chip that said "pasted image" and became a file
+            // chip would have told the user the wrong thing first.
+            "attaching…"
+          : shot.view
+            ? noun + (size ? " · " + size : "")
+            : failLabel(shot)}
+      </span>
+      <button
+        type="button"
+        aria-label={"Remove " + noun}
+        // Nothing to take back yet, and the pipeline's own late-arrival handling
+        // (T:11288 abandoned captures) is what cleans up an in-flight one.
+        disabled={att.pending}
+        onClick={() => onRemove(att)}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+export function AttachTray({ items, paneNoun, onOpen, onRemove, children }: AttachTrayProps) {
+  if (!items.length && !children) return null;
+  return (
+    <div className="c-annchips">
+      {children}
+      {items.map((att) => (
+        <Chip key={att.id} att={att} paneNoun={paneNoun} onOpen={onOpen} onRemove={onRemove} />
+      ))}
+    </div>
+  );
+}
+
+export default AttachTray;

--- a/frontend/src/apps/claude/ui/AttachTray.tsx
+++ b/frontend/src/apps/claude/ui/AttachTray.tsx
@@ -1,11 +1,15 @@
 // THE CHIP ROW above the composer: what this message is about to carry
 // (T:7129 `shotChip`, T:7192 `shotThumbBtn`, markup T:4154/4220, CSS T:896-988).
 //
-// The chip's job is to be a DOOR. 22 pixels can prove a picture EXISTS and
-// nothing that size can show what is in it — so the thumbnail is a `<button>`
-// rather than an `<img>`, and one click opens the picture full size where the
-// user can actually read it and, if it is the wrong moment, throw it away from
-// there (T:7121-7128).
+// THE WHOLE CHIP IS THE DOOR (Akshil, 2026-09-09, P2-4). 22 pixels can prove a
+// picture EXISTS and nothing that size can show what is in it, so one click
+// opens it full size where the user can read it and, if it is the wrong moment,
+// throw it away from there (T:7121-7128). What changed is the HIT AREA: the port
+// made a door of the 22px thumbnail alone (and, for a file, of the glyph alone),
+// so the name and the size beside it — most of the pill, and the part a pointer
+// actually lands on — were dead. Thumb, glyph and words are now one `<button>`
+// filling the pill, with the ✕ as its only sibling; the pill's own hover moves
+// with it, so the affordance is the shape the pointer is over.
 //
 // The same pill an annotation's chip is (`.annchip`), because both are things
 // this message is about to carry and both come off with the same ✕ — one row
@@ -14,14 +18,14 @@
 import "../styles/composer.css";
 
 import type { Attachment } from "../shots/types";
+import { AttachIcon } from "./AttachIcon";
 import {
   failLabel,
-  glyphDoor,
   shotAlt,
-  shotGlyph,
   shotNoun,
   shownSize,
   toViewable,
+  viewerOpens,
   type Viewable,
 } from "./attachApi";
 
@@ -86,48 +90,71 @@ function Chip({
   const noun = shotNoun(shot, paneNoun);
   const alt = shotAlt(shot, paneNoun);
   const pic = !!shot.thumb;
-  const door = glyphDoor(shot);
   // Keyed off the PICTURE and not off the kind: an image this browser cannot
   // decode has no thumbnail either, and then its size is the only thing on the
   // chip that tells it apart from another one (T:7172-7177).
   const size = shownSize(shot);
+  // A REFUSAL HAS NO ROOM BEHIND ITS DOOR (T:10722-10726): no pixels, no path,
+  // nothing for the viewer to open — so that chip stays a plain pill and says
+  // why in words. A seat still uploading is the same answer for now.
+  const opens = !att.pending && viewerOpens(shot);
+  const label = att.pending
+    ? // The one state T has no chip for: there a chip exists only once its
+      // upload has answered. Here the drop of six puts six seats up at once so
+      // nothing re-orders itself as the uploads land, and a seat whose bytes are
+      // still on their way has to say so. Its own name is deliberately NOT
+      // guessed — the pipeline decides whether a file is a picture, and a chip
+      // that said "pasted image" and became a file chip would have told the user
+      // the wrong thing first.
+      "attaching…"
+    : shot.view
+      ? // Says WHICH it is: "here is your picture" and "no picture, and here is
+        // why" are different facts, and the second is the one a user has to be
+        // told BEFORE they press send — the whole advantage of attaching on the
+        // gesture rather than during the send (T:7157-7163).
+        noun + (size ? " · " + size : "")
+      : failLabel(shot);
+  // Thumb-or-glyph, NEVER BOTH: where there is a thumbnail the picture IS the
+  // icon, and putting a picture icon in front of a picture captions a photo with
+  // a drawing of one (T:7143-7148).
+  const face = pic ? (
+    <span className="c-shotthumb">
+      <img src={shot.src || shot.thumb || ""} alt="" />
+    </span>
+  ) : (
+    <span className="c-pinlbl">
+      <AttachIcon kind={shot.kind} />
+    </span>
+  );
+  const words = (
+    <span className="c-txt" title={shot.viewNote || shot.view || ""}>
+      {label}
+    </span>
+  );
   return (
     <div className={"c-annchip c-shotchip" + (att.pending ? " is-pending" : "")}>
-      {pic ? (
-        <ShotThumb className="c-shotthumb" shot={shot} alt={alt} onOpen={() => onOpen(shot)} />
-      ) : door ? (
+      {opens ? (
         <button
           type="button"
-          className="c-pinlbl c-shotdoc"
-          title="Click to see what is attached"
-          aria-label={alt + " — open details"}
+          className="c-chip-door"
+          title={
+            pic ? "Click to see this screenshot full size" : "Click to see what is attached"
+          }
+          aria-label={alt + " — open full size"}
           onClick={() => onOpen(shot)}
         >
-          {shotGlyph(shot)}
+          {face}
+          {words}
         </button>
       ) : (
-        <span className="c-pinlbl">{shotGlyph(shot)}</span>
+        <span className="c-chip-door is-inert">
+          {face}
+          {words}
+        </span>
       )}
-      <span className="c-txt" title={shot.viewNote || shot.view || ""}>
-        {/* Says WHICH it is: "here is your picture" and "no picture, and here is
-            why" are different facts, and the second is the one a user has to be
-            told BEFORE they press send — the whole advantage of attaching on the
-            gesture rather than during the send (T:7157-7163). */}
-        {att.pending
-          ? // The one state T has no chip for: there a chip exists only once its
-            // upload has answered. Here the drop of six puts six seats up at
-            // once so nothing re-orders itself as the uploads land, and a seat
-            // whose bytes are still on their way has to say so. Its own name is
-            // deliberately NOT guessed — the pipeline decides whether a file is
-            // a picture, and a chip that said "pasted image" and became a file
-            // chip would have told the user the wrong thing first.
-            "attaching…"
-          : shot.view
-            ? noun + (size ? " · " + size : "")
-            : failLabel(shot)}
-      </span>
       <button
         type="button"
+        className="c-chip-x"
         aria-label={"Remove " + noun}
         // Nothing to take back yet, and the pipeline's own late-arrival handling
         // (T:11288 abandoned captures) is what cleans up an in-flight one.

--- a/frontend/src/apps/claude/ui/Composer.test.tsx
+++ b/frontend/src/apps/claude/ui/Composer.test.tsx
@@ -126,6 +126,44 @@ test("a bare attachment is sendable with no words at all (T:17903)", () => {
   expect(c.sent).toEqual([{ text: "", model: DEFAULT_MODEL }]);
 });
 
+test("a chip still ATTACHING holds the send back and keeps the words", () => {
+  // `hasAttachments` counts in-flight placeholders but `take()` leaves them in
+  // the tray, so a send fired now goes out without them — wordless it is an
+  // EMPTY send, worded it is the message minus its files (Bugbot, PR #1064).
+  const c = mount({ hasAttachments: true, attachPending: true });
+  const send = () => c.root.findByProps({ className: "c-send" });
+  expect(send().props.disabled).toBe(true);
+  expect(send().props.title).toBe("Attaching…");
+
+  // Wordless: nothing at all leaves.
+  c.press("Enter");
+  expect(c.sent).toEqual([]);
+
+  // Worded: refused, and THE BOX IS KEPT — the same Enter a moment later is the
+  // message the user actually wrote.
+  c.type("look at these");
+  expect(c.press("Enter")).toBe(true);
+  expect(c.sent).toEqual([]);
+  expect(c.box().props.value).toBe("look at these");
+  // The button is the same door.
+  c.submitForm();
+  expect(c.sent).toEqual([]);
+
+  // And a follow-up road is no way around it.
+  const live = mount({ status: "running", hasAttachments: true, attachPending: true });
+  live.type("and this");
+  live.press("Enter");
+  expect(live.followups).toEqual([]);
+  expect(live.stops()).toBe(0);
+});
+
+test("the bytes land ⇒ the send opens again", () => {
+  const c = mount({ hasAttachments: true, attachPending: false });
+  expect(c.root.findByProps({ className: "c-send" }).props.disabled).toBe(false);
+  c.press("Enter");
+  expect(c.sent).toEqual([{ text: "", model: DEFAULT_MODEL }]);
+});
+
 test("Enter NEVER stops a run — it hands the text to the live turn (T:17915)", () => {
   const c = mount({ status: "running" });
   c.type("also fix the tests");

--- a/frontend/src/apps/claude/ui/Composer.tsx
+++ b/frontend/src/apps/claude/ui/Composer.tsx
@@ -200,6 +200,17 @@ export interface ComposerCardProps {
   onStop(): void;
   /** Notes or pictures alone are sendable, with no words at all (T:17903). */
   hasAttachments?: boolean;
+  /**
+   * A CHIP IS STILL ATTACHING, so nothing leaves this box yet — the camera's
+   * own `shotBusy` gate (T:11203), one level up.
+   *
+   * `hasAttachments` counts in-flight placeholders (they are chips the user can
+   * see), but `take()` deliberately leaves a `pending` item in the tray for the
+   * NEXT message. Sendable-because-of-chips plus taken-without-them is a
+   * wordless Enter dispatching an EMPTY send, and a worded one going out
+   * without the files it was written about (Bugbot, PR #1064).
+   */
+  attachPending?: boolean;
   /** A pending scheduled message closes the composer (`schedBlocked`, PR4). */
   blocked?: boolean;
   blockedPlaceholder?: string;
@@ -260,6 +271,7 @@ export function ComposerCard({
   onFollowUp,
   onStop,
   hasAttachments,
+  attachPending,
   blocked,
   blockedPlaceholder,
   autoFocus,
@@ -327,12 +339,19 @@ export function ComposerCard({
     grow();
   }, [restore, boxRef, grow]);
 
-  const canSend = text.trim().length > 0 || !!hasAttachments;
+  // A tray still uploading holds the send back rather than sending half of it.
+  const attaching = !!attachPending;
+  const canSend = !attaching && (text.trim().length > 0 || !!hasAttachments);
 
   const submit = useCallback(() => {
     // Nothing leaves this composer while a scheduled message is pending — not a
     // typed line, not a follow-up (T:17871).
     if (blocked) return;
+    // ... nor while a chip is still attaching, on EITHER road: both of them
+    // empty the tray, and both would leave the pending files behind. The box
+    // KEEPS its words (the `setText("")` below is past this door), so the same
+    // Enter a moment later sends the message the user actually wrote.
+    if (attaching) return;
     const message = text.trim();
     if (!message && !hasAttachments) return;
     setText("");
@@ -346,7 +365,7 @@ export function ComposerCard({
         permission: controls.permission,
       });
     }
-  }, [blocked, text, hasAttachments, running, onFollowUp, onSend, controls]);
+  }, [blocked, attaching, text, hasAttachments, running, onFollowUp, onSend, controls]);
 
   const onKeyDown = useCallback(
     (ev: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -442,7 +461,7 @@ export function ComposerCard({
           className="c-send"
           type="submit"
           aria-label={running ? "Stop" : "Send"}
-          title={running ? "Stop" : "Send"}
+          title={running ? "Stop" : attaching ? "Attaching…" : "Send"}
           disabled={blocked || (!running && !canSend)}
         >
           {running ? (

--- a/frontend/src/apps/claude/ui/Composer.tsx
+++ b/frontend/src/apps/claude/ui/Composer.tsx
@@ -221,6 +221,30 @@ export interface ComposerCardProps {
   columnRef?: React.RefObject<HTMLElement | null>;
   /** Chips above the box: attachments (PR2), annotations (PR3). */
   chips?: ReactNode;
+  /**
+   * ⌘V of a picture or a file (T:11719 `shotPasteHandler`). The handler decides
+   * whether the paste was an attachment — a paste of WORDS must reach the box,
+   * and stealing an ordinary paste in a composer the user types in all day would
+   * be a far worse bug than never having had the feature.
+   */
+  onPaste?: React.ClipboardEventHandler<HTMLTextAreaElement>;
+  /**
+   * THE CAMERA'S OLD SEAT, immediately left of Schedule (T:4166-4171). The
+   * screenshot button lived here as a pill and moved into the `#anncta` strip on
+   * 2026-08-27 because it acts on the PREVIEW rather than on this draft — so
+   * `ClaudeChat` passes nothing and the seat stands empty. It stays a seat
+   * because the row's fit is MEASURED: a control appearing here changes what
+   * fits, and the revision below is what re-prices the row when it does.
+   */
+  camera?: ReactNode;
+  /**
+   * Anything OUTSIDE this row whose arrival changes the row's geometry — the
+   * chip row growing, the camera seat filling. T watches for those with a
+   * MutationObserver on the rows' subtree `hidden` and on the body/chat classes
+   * (T:12455-12474); in React they arrive as a re-render, so the caller bumps
+   * this instead (inventory 03 §G, and `useRowFit`'s `revision`).
+   */
+  fitRevision?: unknown;
   back: string;
   onNavigate?(url: string): void;
 }
@@ -244,6 +268,9 @@ export function ComposerCard({
   boxRef: hostBoxRef,
   columnRef,
   chips,
+  onPaste,
+  camera,
+  fitRevision,
   back,
   onNavigate,
 }: ComposerCardProps) {
@@ -263,7 +290,13 @@ export function ComposerCard({
   const fit = useRowFit(
     rowRef,
     columnRef,
-    `${controls.model}|${controls.effort}|${controls.permission}|${blocked ? 1 : 0}`,
+    // The camera seat is IN the key and not merely a dependency of it: a seat
+    // appearing or leaving changes `composerRowNeed` by a whole control plus a
+    // gap, which is exactly the kind of change T's MutationObserver existed to
+    // catch (T:12455-12474).
+    `${controls.model}|${controls.effort}|${controls.permission}|${blocked ? 1 : 0}|${
+      camera ? 1 : 0
+    }|${String(fitRevision ?? "")}`,
   );
 
   // THIS IS THE NATIVE `initialFocus`, and it has to be, because a modal's
@@ -374,6 +407,7 @@ export function ComposerCard({
           grow();
         }}
         onKeyDown={onKeyDown}
+        {...(onPaste ? { onPaste } : {})}
       />
       {count > 0 ? (
         <div className="c-queued">
@@ -391,6 +425,7 @@ export function ComposerCard({
           compact={fit !== "full"}
         />
         <span className="c-spacer" />
+        {camera}
         {/* IMMEDIATELY LEFT OF SEND, and that seat is the whole idea: these two
             are the ways this draft leaves the box — now, or as a task
             (T:4174-4183). The landing card's copy is never blocked. */}

--- a/frontend/src/apps/claude/ui/Home.tsx
+++ b/frontend/src/apps/claude/ui/Home.tsx
@@ -4,7 +4,6 @@
 import "../styles/home.css";
 import type { SessionRow } from "../protocol/types";
 import { HomeCard, type HomeCardProps } from "./HomeCard";
-import { Kebab } from "./Kebab";
 import { Lists } from "./Lists";
 import { useArtifacts } from "./useArtifacts";
 import { useSnapshots } from "./useSnapshots";
@@ -37,27 +36,15 @@ export function Home({
 
   return (
     <div className="c-home">
-      {/* THE CONTROL ROW, and it is a REAL ROW — T's `#anntools` is a layout row
-          above both views, never an overlay (T:3926-3931), and it is also what
-          puts this column where :1777 puts it: floating the ⋮ over the page took
-          the strip's ~40px out of the top of the column, so the whole landing
-          sat that much higher than the template's (Akshil, 2026-09-08, #4).
-
-          The menu is REAL here too, with the one item that can mean anything
-          without a session: "New session in terminal" (T:13415). It was drawn
-          inert, which is the one thing a control must never be. */}
-      <div className="c-home-tools">
-        <span className="c-hdr-slack" />
-        <Kebab
-          agentDir={agentDir ?? null}
-          file={cardProps.file}
-          sessionId=""
-          running={false}
-          landing
-        />
-      </div>
-      {/* The scroller is INSIDE the row above, not around it: the strip is
-          chrome and must not slide away under the lists. */}
+      {/* NO CONTROL ROW OF ITS OWN (P2-1). The landing used to draw one here
+          just to hold the ⋮; T has a single `#anntools` strip above BOTH views
+          carrying the preview seats and the menu together (T:3934-4010), and
+          `#chat.home #topbar` hides only the identity line on this view — so the
+          row is `ClaudeChat`'s and this column starts at the card. The 40px the
+          strip occupies is still above us, which is what puts this column where
+          :1777 puts it. */}
+      {/* The scroller does not swallow the strip above it: that row is chrome
+          and must not slide away under the lists. */}
       <div className="c-home-scroll">
         {/* One 32px of air at the bottom of the column, one margin per block
             inside it (T:3245-3252). */}

--- a/frontend/src/apps/claude/ui/Receipts.tsx
+++ b/frontend/src/apps/claude/ui/Receipts.tsx
@@ -10,6 +10,8 @@
 // `<pane-shot>` block its `raw` still holds.
 import { useEffect, useMemo, useState } from "react";
 
+import { Pin } from "lucide-react";
+
 import "../styles/transcript.css";
 
 import type { UserTurn } from "../protocol/controller-api";
@@ -17,12 +19,12 @@ import { parseInbound, type AnnotationWire } from "../protocol/wire";
 import { probePruned, receiptsFromWire } from "../shots";
 import type { Receipt } from "../shots/types";
 import { ShotThumb } from "./AttachTray";
+import { AttachIcon } from "./AttachIcon";
 import {
   glyphDoor,
   prunedLabel,
   receiptViewable,
   shotAlt,
-  shotGlyph,
   SHOT_GONE,
   type Viewable,
 } from "./attachApi";
@@ -68,8 +70,12 @@ function NoteRow({ note, onOpen }: { note: AnnotationWire; onOpen?: () => void }
         : {})}
     >
       {/* The stored label — the same letter burned into the overview and sent on
-          the wire, so the receipt, the picture and the JSON can never drift. */}
-      <span className="annsum-lbl">{"📌 " + (note.label || "•")}</span>
+          the wire, so the receipt, the picture and the JSON can never drift.
+          The pin beside it is a lucide glyph, not 📌 (P2-7). */}
+      <span className="annsum-lbl">
+        <Pin width="1em" height="1em" strokeWidth={1.5} aria-hidden="true" focusable="false" />
+        {note.label || "•"}
+      </span>
       <span className="annsum-txt">{note.content || ""}</span>
       {meta ? <span className="annsum-el">{meta}</span> : null}
     </div>
@@ -133,10 +139,12 @@ function ShotRow({
             aria-label={alt + " — open details"}
             onClick={() => onOpenShot(shot)}
           >
-            {shotGlyph(shot)}
+            <AttachIcon kind={shot.kind} />
           </button>
         ) : (
-          <span className="annsum-lbl">{shotGlyph(shot)}</span>
+          <span className="annsum-lbl">
+            <AttachIcon kind={shot.kind} />
+          </span>
         )}
         <span className="annsum-txt" title={receipt.viewNote || receipt.view || ""}>
           {receipt.label}

--- a/frontend/src/apps/claude/ui/Receipts.tsx
+++ b/frontend/src/apps/claude/ui/Receipts.tsx
@@ -101,7 +101,19 @@ function ShotRow({
   // reads as a bug (T:10819).
   const src = receipt.kind === "file" ? "" : shot.src || "";
   const [pruned, setPruned] = useState(!!receipt.pruned);
-  const [gone, setGone] = useState(false);
+  // WHICH src was found missing, not merely THAT one was.
+  //
+  // A row's `src` MOVES: a live send's receipt is drawn with the attachment's
+  // own object URL and is re-pointed at `rawUrl(view)` the moment the bytes are
+  // on disk (`settleReceipts`). Two things follow, and a bare boolean got both
+  // wrong. A `blob:` handle that stops resolving is this page letting go of a
+  // picture it has already replaced — never the pruner, which deletes files on
+  // disk and cannot touch a handle — so it is not "no longer on disk" and says
+  // nothing about the copy the row is about to show. And a verdict about the
+  // URL BEFORE the swap must not outlive it: keyed on the src, the question is
+  // simply asked again of the new one (Bugbot, PR #1064).
+  const [goneSrc, setGoneSrc] = useState("");
+  const gone = !!src && goneSrc === src;
 
   // A picture's pruned copy announces itself (the <img> 404s and `onError` says
   // so in words); a row with no <img> has to ASK, or it goes on claiming a path
@@ -179,7 +191,9 @@ function ShotRow({
           alt={alt}
           title={onShowSent ? "Click to see exactly what was sent to the agent" : receipt.view || ""}
           onOpen={openThumb}
-          onError={() => setGone(true)}
+          onError={() => {
+            if (!src.startsWith("blob:")) setGoneSrc(src);
+          }}
         />
       )}
     </>

--- a/frontend/src/apps/claude/ui/Receipts.tsx
+++ b/frontend/src/apps/claude/ui/Receipts.tsx
@@ -1,0 +1,225 @@
+// THE RECEIPT a sent turn wears (T:10815 `shotReceipt`, T:11079 `annReceiptRow`,
+// T:10903 `shotRestoreReceipt`; CSS T:1716-1801).
+//
+// ONE builder for the live send and for a restored transcript, which is the
+// whole point: a screenshot that is visible while the session lasts and gone the
+// moment it is reopened is a screenshot the user cannot rely on having sent
+// (T:10809-10814). So this component takes ONE input either way — the turn — and
+// the two sources differ in exactly one thing: a live send carries its
+// `Receipt[]` (blob thumbnails and all), a restored one rebuilds them from the
+// `<pane-shot>` block its `raw` still holds.
+import { useEffect, useMemo, useState } from "react";
+
+import "../styles/transcript.css";
+
+import type { UserTurn } from "../protocol/controller-api";
+import { parseInbound, type AnnotationWire } from "../protocol/wire";
+import { probePruned, receiptsFromWire } from "../shots";
+import type { Receipt } from "../shots/types";
+import { ShotThumb } from "./AttachTray";
+import {
+  glyphDoor,
+  prunedLabel,
+  receiptViewable,
+  shotAlt,
+  shotGlyph,
+  SHOT_GONE,
+  type Viewable,
+} from "./attachApi";
+
+export interface ReceiptsProps {
+  turn: UserTurn;
+  paneNoun: string;
+  /** A thumbnail / glyph door opens the full-size viewer. */
+  onOpenShot(shot: Viewable): void;
+  /** The HEAD probe, injectable so a render test makes no request (T:10875). */
+  probe?: (receipt: Receipt) => Promise<boolean>;
+  /**
+   * "What was sent". A comment ROW is the door — no separate button, the row
+   * itself is the affordance (T:11053-11056) — and when comments ride the
+   * message the screenshot thumbs open the same popup instead of the plain
+   * viewer, because the picture belongs to the comments there (T:11068-11077).
+   * A picture-only send is never wired, so a lone picture keeps the viewer.
+   */
+  onShowSent?(turn: UserTurn): void;
+}
+
+/** T:11079 `annReceiptRow` — one comment row, the same rendering for a live send
+ *  and for a turn restored from the transcript, so the two cannot drift. */
+function NoteRow({ note, onOpen }: { note: AnnotationWire; onOpen?: () => void }) {
+  const meta = note.tag ? "<" + note.tag + ">" : "";
+  const clickable = !!onOpen;
+  return (
+    <div
+      className="annsum-row annsum-note"
+      {...(clickable
+        ? {
+            title: "Click to see exactly what was sent to the agent",
+            tabIndex: 0,
+            role: "button",
+            onClick: onOpen,
+            onKeyDown: (ev: React.KeyboardEvent) => {
+              if (ev.key === "Enter" || ev.key === " ") {
+                ev.preventDefault();
+                onOpen?.();
+              }
+            },
+          }
+        : {})}
+    >
+      {/* The stored label — the same letter burned into the overview and sent on
+          the wire, so the receipt, the picture and the JSON can never drift. */}
+      <span className="annsum-lbl">{"📌 " + (note.label || "•")}</span>
+      <span className="annsum-txt">{note.content || ""}</span>
+      {meta ? <span className="annsum-el">{meta}</span> : null}
+    </div>
+  );
+}
+
+function ShotRow({
+  receipt,
+  paneNoun,
+  onOpenShot,
+  onShowSent,
+  probe,
+}: {
+  receipt: Receipt;
+  paneNoun: string;
+  onOpenShot(shot: Viewable): void;
+  onShowSent?(): void;
+  probe: (receipt: Receipt) => Promise<boolean>;
+}) {
+  const shot = receiptViewable(receipt);
+  const alt = shotAlt(shot, paneNoun);
+  // Never for a FILE: an <img> pointed at a .csv is a broken-image glyph, which
+  // reads as a bug (T:10819).
+  const src = receipt.kind === "file" ? "" : shot.src || "";
+  const [pruned, setPruned] = useState(!!receipt.pruned);
+  const [gone, setGone] = useState(false);
+
+  // A picture's pruned copy announces itself (the <img> 404s and `onError` says
+  // so in words); a row with no <img> has to ASK, or it goes on claiming a path
+  // the pruner deleted. Only a RESTORED receipt has the question — a live send's
+  // bytes were written seconds ago (T:10869-10879).
+  useEffect(() => {
+    if (src || receipt.pruned || !receipt.probe) return;
+    let live = true;
+    void probe(receipt).then((isGone) => {
+      if (live && isGone) setPruned(true);
+    });
+    return () => {
+      live = false;
+    };
+  }, [probe, receipt, src]);
+
+  // T:11068-11077 `sentPopWire` overrides exactly TWO things when comments ride
+  // the message: the `.annsum-pane` thumb and the `.annsum-note` rows. The
+  // `.annsum-lbl` GLYPH DOOR is not one of them — T:10851 leaves it on
+  // `shotViewOpen`, because a file's receipt opens the same viewer (with the same
+  // template preview inside it, D616) that its pending chip did, and a door that
+  // led somewhere else once the message was sent is the very inconsistency the
+  // thumbnail-as-button was added to end.
+  const openThumb = onShowSent ?? (() => onOpenShot(shot));
+
+  if (!src) {
+    const door = glyphDoor(shot);
+    return (
+      <div className="annsum-row">
+        {door ? (
+          <button
+            type="button"
+            className="annsum-lbl"
+            title="Click to see what was attached"
+            aria-label={alt + " — open details"}
+            onClick={() => onOpenShot(shot)}
+          >
+            {shotGlyph(shot)}
+          </button>
+        ) : (
+          <span className="annsum-lbl">{shotGlyph(shot)}</span>
+        )}
+        <span className="annsum-txt" title={receipt.viewNote || receipt.view || ""}>
+          {receipt.label}
+        </span>
+        {pruned ? (
+          <span className="annsum-gone" title={receipt.view || ""}>
+            {prunedLabel(receipt.kind)}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="annsum-row">
+        <span className="annsum-txt" title={receipt.viewNote || receipt.view || ""}>
+          {receipt.label}
+        </span>
+      </div>
+      {/* A restored turn whose file the shots directory has pruned (12h/200
+          files) 404s here. Said in words rather than left as a broken-image
+          glyph, which a reader takes for a bug in the chat (T:10886-10894). */}
+      {gone ? (
+        <div className="annsum-gone" title={receipt.view || ""}>
+          {SHOT_GONE}
+        </div>
+      ) : (
+        <ShotThumb
+          className="annsum-pane"
+          shot={shot}
+          alt={alt}
+          title={onShowSent ? "Click to see exactly what was sent to the agent" : receipt.view || ""}
+          onOpen={openThumb}
+          onError={() => setGone(true)}
+        />
+      )}
+    </>
+  );
+}
+
+export function Receipts({
+  turn,
+  paneNoun,
+  onOpenShot,
+  onShowSent,
+  probe = probePruned,
+}: ReceiptsProps) {
+  // The turn's own receipts when it is one this page just sent; otherwise the
+  // wire block it still carries. `raw` is read ONCE per turn object, and a
+  // settled turn's object is carried across every poll (Turn is memoized).
+  const { receipts, notes } = useMemo(() => {
+    if (turn.attachments && turn.attachments.length) {
+      return { receipts: turn.attachments, notes: parseInbound(turn.raw).annotations ?? [] };
+    }
+    const wire = parseInbound(turn.raw);
+    return { receipts: receiptsFromWire(wire.paneShots), notes: wire.annotations ?? [] };
+  }, [turn.attachments, turn.raw]);
+
+  if (!receipts.length && !notes.length) return null;
+  // A send with no comments never gets wired to the popup (T:11068-11077).
+  const sent = notes.length && onShowSent ? () => onShowSent(turn) : undefined;
+
+  return (
+    <div className="annsum">
+      {/* The overview first — it is the one picture every annotation row refers
+          to — then the user's own attachments, then the labelled rows
+          (T:16565-16572). */}
+      {receipts.map((r, i) => (
+        <ShotRow
+          key={(r.view || r.label) + ":" + i}
+          receipt={r}
+          paneNoun={paneNoun}
+          onOpenShot={onOpenShot}
+          probe={probe}
+          {...(sent ? { onShowSent: sent } : {})}
+        />
+      ))}
+      {notes.map((note, i) => (
+        <NoteRow key={(note.id || note.label || "n") + ":" + i} note={note} {...(sent ? { onOpen: sent } : {})} />
+      ))}
+    </div>
+  );
+}
+
+export default Receipts;

--- a/frontend/src/apps/claude/ui/SentPop.tsx
+++ b/frontend/src/apps/claude/ui/SentPop.tsx
@@ -1,32 +1,181 @@
 // "What was sent": the composed message a receipt stands for, on demand
 // (T:10965-11045, 4403-4413).
 //
-// THE DOOR IS THE RECEIPT (R4-1). This box is opened by clicking the "app state
-// attached" line under the bubble it belongs to — T's own affordance
-// (T:11059 `row.title = "Click to see exactly what was sent to the agent"`,
-// T:1249) — not by a second control beside it. `ui/Turn` owns that press.
+// A receipt is a summary; this is the RECORD — the overview screenshot (badges
+// and all), each comment with its label, anchor, timing and no-badge caveat, the
+// other attached pictures, and the exact composed text. T stashes a live payload
+// on the receipt at send time and rebuilds a restored turn's from the wire
+// (T:10932); here there is only the second road, because `UserTurn.raw` IS the
+// wire and every section below is a `parseInbound` away from it — ONE source, so
+// a live popup and a reopened one cannot say different things.
+//
+// THE DOOR IS THE RECEIPT (R4-1). This box is opened by clicking the receipt
+// line under the bubble it belongs to — "app state attached", "screenshot
+// attached", "image attached: …" — T's own affordance (T:11059
+// `row.title = "Click to see exactly what was sent to the agent"`, T:1249), not
+// a second control beside it. `ui/Turn` and `ui/Receipts` own those presses.
 //
 // AND IT WEARS THE APP'S MODAL CHROME, not a skin of its own: the shared
 // `platform/ui/modal/Modal` chassis, the same one `EraseTaskModal` (the Delete
-// task dialog this chat's kebab opens) uses — same overlay, same 600px card,
-// same head with the ✕, same focus trap and Esc/backdrop close. Before this it
-// was a shadcn `Dialog` with hand-rolled bar and pill, so the two dialogs the
-// same menu could put on screen looked like they came from different apps.
-//
-// PR1 shows the one part that always exists — the exact text the agent was
-// handed. The overview screenshot, each comment with its label/anchor/timing
-// and the other attached pictures are PR2/PR3's sections of this same box; the
-// heading they sit under is the one below.
+// task dialog this chat's kebab opens) uses — same overlay, same card, same
+// head with the ✕, same focus trap and Esc/backdrop close. Before this it was a
+// shadcn `Dialog` with a hand-rolled bar and pill, so the two dialogs the same
+// menu could put on screen looked like they came from different apps.
+import { useMemo } from "react";
+
+import { rawUrl } from "@platform/lib/api";
 import { Modal } from "@platform/ui/modal/Modal";
+
+import { annClock, parseInbound, type AnnotationWire, type PaneShotWire } from "../protocol/wire";
+import { receiptsFromWire } from "../shots";
+import { receiptViewable, shotAlt, shotNoun, type Viewable } from "./attachApi";
 
 export interface SentPopProps {
   open: boolean;
   onClose(): void;
   /** The raw outgoing text, wire blocks and all (`UserTurn.raw`). */
   outgoing: string;
+  /** "preview" for a file target, "app" for a project (`PaneState.paneNoun`). */
+  paneNoun?: string;
+  /** A picture in here opens the full-size viewer OVER this popup — the click
+   *  looks dead otherwise. */
+  onOpenShot?(shot: Viewable): void;
 }
 
-export function SentPop({ open, onClose, outgoing }: SentPopProps) {
+/** The kind/name pair the vocabulary functions read, off a wire entry. */
+function asViewable(shot: PaneShotWire): Pick<Viewable, "kind" | "name"> {
+  return {
+    kind: shot.kind as Viewable["kind"],
+    ...(shot.name ? { name: shot.name } : {}),
+  };
+}
+
+/** T:10975 `addShot` — the picture, then the caveat that rode the wire with it.
+ *  A caveat with NO picture is still shown: it is the whole story of an
+ *  attachment that failed. */
+function SentShot({
+  shot,
+  paneNoun,
+  onOpenShot,
+}: {
+  shot: PaneShotWire;
+  paneNoun: string;
+  onOpenShot?(shot: Viewable): void;
+}) {
+  // Never for a file: an <img> pointed at a .csv is a broken-image glyph.
+  const src = shot.view && shot.kind !== "file" ? rawUrl(shot.view) : "";
+  const alt = shotAlt(asViewable(shot), paneNoun);
+  const open = onOpenShot;
+  return (
+    <>
+      {src ? (
+        <img
+          className="c-sent-shot"
+          src={src}
+          alt={alt}
+          title="Click to see full size"
+          {...(open
+            ? {
+                onClick: () => {
+                  const restored = receiptsFromWire([shot])[0];
+                  if (restored) open({ ...receiptViewable(restored), src });
+                },
+              }
+            : {})}
+        />
+      ) : null}
+      {shot.viewNote ? (
+        <div className="c-sent-caveat">{(src ? "caveat: " : "") + shot.viewNote}</div>
+      ) : null}
+    </>
+  );
+}
+
+/** T:11007-11026 — one comment: the accent label pill, the words (or that there
+ *  were none), and the context that makes the words checkable. */
+function SentNote({ note }: { note: AnnotationWire }) {
+  const bits: string[] = [];
+  bits.push(
+    note.kind === "point"
+      ? "exact spot (" + note.x + ", " + note.y + ")"
+      : "<" + (note.tag || "element") + ">",
+  );
+  if (typeof note.t === "number") bits.push("at " + annClock(note.t));
+  if (note.offscreen) bits.push("no badge: " + note.offscreen);
+  return (
+    <div className="c-sent-note-row">
+      <span className="c-sent-note-lbl">{note.label || "•"}</span>
+      <span>{note.content || "(no words)"}</span>
+      <span className="c-sent-note-meta">{bits.join(" · ")}</span>
+    </div>
+  );
+}
+
+/**
+ * The body's sections, in T's order. Its own component because the modal
+ * chassis PORTALS itself and a `react-test-renderer` suite has no document to
+ * portal into — so this is the seam the tests drive, and it is every section
+ * there is.
+ *
+ * `c-overlay` rides along on the wrapper: the pictures and the comment pills
+ * paint with the CHAT's `--c-*` aliases on purpose — a comment's label pill has
+ * to be the same colour as the badge burnt into the screenshot above it — and
+ * the modal is portaled to <body>, outside .chat-root's cascade, so the aliases
+ * have to be re-anchored here. The headings and the wire block stay on the
+ * platform palette, like the chrome around them.
+ */
+export function SentPopBody({
+  outgoing,
+  paneNoun = "preview",
+  onOpenShot,
+}: Omit<SentPopProps, "open" | "onClose">) {
+  const wire = useMemo(() => parseInbound(outgoing), [outgoing]);
+  const shots = wire.paneShots ?? [];
+  // The overview is the one picture every comment row refers to, so it leads —
+  // and the rest keep the order the wire carried them in (T:10996-11006).
+  const overview = shots.find((s) => s.kind === "overview");
+  const pics = shots.filter((s) => s.kind !== "overview");
+  const notes = wire.annotations ?? [];
+
+  return (
+    <div className="c-overlay c-sent-body">
+      {/* WHY the reader is looking at more than they typed: the pane's app
+          state — and any picture they attached — rides along with the prompt,
+          and this is the whole of it. */}
+      <p className="deploy-muted">
+        Everything the agent received for this turn — your message and whatever
+        rode along with it.
+      </p>
+      {overview ? (
+        <>
+          <h4 className="c-sent-head">Overview screenshot (badges mark each comment)</h4>
+          <SentShot shot={overview} paneNoun={paneNoun} {...(onOpenShot ? { onOpenShot } : {})} />
+        </>
+      ) : null}
+      {pics.map((pic, i) => (
+        // `display: contents`, so the heading, the picture and its caveat are
+        // three children of the body's flex column exactly as T appends them,
+        // rather than one boxed group with its own spacing.
+        <div className="c-sent-group" key={(pic.view || pic.name || "p") + ":" + i}>
+          <h4 className="c-sent-head">{shotNoun(asViewable(pic), paneNoun)}</h4>
+          <SentShot shot={pic} paneNoun={paneNoun} {...(onOpenShot ? { onOpenShot } : {})} />
+        </div>
+      ))}
+      {notes.length ? (
+        <>
+          <h4 className="c-sent-head">Comments</h4>
+          {notes.map((note, i) => (
+            <SentNote key={(note.id || note.label || "n") + ":" + i} note={note} />
+          ))}
+        </>
+      ) : null}
+      <h4 className="c-sent-head">Exact message the agent received</h4>
+      <pre className="c-sent-wire">{outgoing}</pre>
+    </div>
+  );
+}
+
+export function SentPop({ open, onClose, ...body }: SentPopProps) {
   // `Modal` cannot unmount itself (it defers `onClose` to animate the exit), so
   // it is rendered conditionally — the shape every other caller of the chassis
   // uses. The `open` prop stays because the hosts hold the turn, not a boolean.
@@ -41,14 +190,7 @@ export function SentPop({ open, onClose, outgoing }: SentPopProps) {
         </button>
       }
     >
-      {/* WHY the reader is looking at more than they typed: the pane's app
-          state rides along with the prompt, and this is the whole of it. */}
-      <p className="deploy-muted">
-        Everything the agent received for this turn — your message and the app
-        state that rode along with it.
-      </p>
-      <h4 className="c-sent-head">Exact message the agent received</h4>
-      <pre className="c-sent-wire">{outgoing}</pre>
+      <SentPopBody {...body} />
     </Modal>
   );
 }

--- a/frontend/src/apps/claude/ui/ShotViewer.tsx
+++ b/frontend/src/apps/claude/ui/ShotViewer.tsx
@@ -1,0 +1,220 @@
+// ONE PICTURE, FULL SIZE, OVER EVERYTHING (T:4369-4397 markup, T:10681-10805
+// behaviour, CSS T:997-1140).
+//
+// The other half of the report that produced the chip: a 22px thumbnail proved a
+// screenshot existed and there was "no way to preview it before sending", so
+// what the user was asked to do was trust a smudge and press send. Every
+// thumbnail the chat draws opens this, pending or sent, through one builder.
+//
+// TWO SIZES, and the second is not a nicety: fitted, a 1600px capture lands at
+// ~310px in the sidebar — four times the chip, still not enough to read the UI
+// it is a picture OF. One click on the image swaps to natural size with the box
+// scrolling, which is the only way a narrow column can show a wide screenshot at
+// a legible scale (T:1030-1048).
+import { useEffect, useRef, useState } from "react";
+
+import { Dialog, DialogContent, DialogTitle } from "@platform/shadcn/ui/dialog";
+
+import "../styles/composer.css";
+import { previewSrcFor, shotAlt, shotNoun, sizeLabel, type Viewable } from "./attachApi";
+
+export interface ShotViewerProps {
+  /** The shot on screen, or null. IDENTITY, not a copy: `pending` is what
+   *  decides whether Discard can tell the truth (T:10768). */
+  shot: Viewable | null;
+  paneNoun: string;
+  onClose(): void;
+  /** Discard, from the one place the user can judge that this is the wrong
+   *  picture. It closes too — the thing it was showing is gone (T:10961). */
+  onDiscard?(shot: Viewable): void;
+}
+
+/**
+ * T's `figure#shotview-box` — the box that SCROLLS at natural size, and
+ * everything inside it.
+ *
+ * Its own component, not an inline block, for two reasons: the `Dialog` panel is
+ * a plain function component here (React 18, no `forwardRef`) so a ref cannot
+ * reach its element, and a Base UI dialog PORTALS itself, which a
+ * `react-test-renderer` suite has no document to portal into — so this is the
+ * seam the tests drive, and it is the whole viewer.
+ */
+export function ShotViewerBody({ shot, paneNoun, onClose, onDiscard }: ShotViewerProps) {
+  const [zoom, setZoom] = useState(false);
+  const [frameSrc, setFrameSrc] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const boxRef = useRef<HTMLDivElement | null>(null);
+
+  const pic = shot ? shot.src || shot.thumb || "" : "";
+  // A FILE is the one thing worth opening that has no pixels, and so is an IMAGE
+  // this engine could not decode: a real path, a real size, no pixels, which is
+  // a file in every way that matters here (T:10722-10726).
+  const bare = !!shot && !pic && (shot.kind === "file" || shot.kind === "image");
+
+  // Every open starts FITTED. A zoom is something you do to one picture while
+  // looking at it, not a preference that follows you to the next one — and a
+  // viewer that opened already scrolled into the middle of an image would look
+  // broken rather than zoomed (T:10739-10744).
+  useEffect(() => {
+    setZoom(false);
+    const box = boxRef.current;
+    if (box) {
+      box.scrollTop = 0;
+      box.scrollLeft = 0;
+    }
+  }, [shot]);
+
+  // ESCAPE BELONGS TO THE TOP DIALOG, and here that has to be said out loud.
+  // This viewer opens OVER "what was sent", which is a `platform/ui/modal/Modal`
+  // (R4-1) — and that chassis listens for Escape on `document` in the BUBBLE
+  // phase so the key keeps working when focus slips to <body>. Left alone, one
+  // press would dismiss the picture AND the record behind it, throwing away the
+  // thing the reader was in the middle of checking. So the viewer takes the key
+  // first, in the CAPTURE phase, and stops it: whoever is on top closes, and
+  // only them. Standalone (no modal underneath) this is the same one press it
+  // always was.
+  useEffect(() => {
+    if (!shot) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.stopPropagation();
+      onClose();
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [shot, onClose]);
+
+  // THE FILE'S OWN PREVIEW, and only a file's: an image already has the picture
+  // viewer above (a better view of pixels than any template), and a refusal has
+  // no path to frame (T:10775-10784).
+  useEffect(() => {
+    if (!shot || !bare || shot.kind !== "file" || !shot.view) {
+      setFrameSrc(null);
+      setLoading(false);
+      return;
+    }
+    let live = true;
+    setFrameSrc(null);
+    // A first render can take seconds (a folder venv, a big parquet), and a
+    // blank box for those seconds reads as a preview that failed (T:4384).
+    setLoading(true);
+    void previewSrcFor(shot.view).then((src) => {
+      // The user may have closed this, or opened another attachment, in the
+      // seconds the stat took — the same identity test Discard uses.
+      if (!live) return;
+      if (!src) {
+        // No template for this extension (or the copy is gone): the viewer is
+        // what it was before D616, and the line promising a preview goes away.
+        setLoading(false);
+        return;
+      }
+      setFrameSrc(src);
+    });
+    return () => {
+      live = false;
+    };
+  }, [shot, bare]);
+
+  if (!shot) return null;
+
+  const alt = shotAlt(shot, paneNoun);
+  const size = bare ? sizeLabel(shot.size) : "";
+  const name = bare ? shotNoun(shot, paneNoun) + (size ? " · " + size : "") : "";
+
+  return (
+    <div className="c-shotview-box" data-zoom={zoom ? "" : undefined} ref={boxRef}>
+      {pic ? (
+        // The click target is the picture itself, which is where the hand
+        // already is and what the two cursors have been advertising; a button
+        // in the bar would be a second place to look for something the image
+        // is already offering (T:10937-10941).
+        <img
+          className="c-shotview-img"
+          src={pic}
+          alt={alt + ", full size"}
+          onClick={() => {
+            const next = !zoom;
+            setZoom(next);
+            if (!next && boxRef.current) {
+              boxRef.current.scrollTop = 0;
+              boxRef.current.scrollLeft = 0;
+            }
+          }}
+        />
+      ) : null}
+      {/* What a FILE viewer has instead of a picture: the name the user called
+          it and how big it is. An image says both by BEING shown (T:1108). */}
+      {name ? <div className="c-shotview-name">{name}</div> : null}
+      {frameSrc ? (
+        <iframe
+          className="c-shotview-frame"
+          src={frameSrc}
+          title=""
+          tabIndex={-1}
+          aria-hidden="true"
+          // Sealed exactly as the shell seals a display-only frame.
+          sandbox="allow-scripts allow-same-origin"
+          allow=""
+          onLoad={() => setLoading(false)}
+        />
+      ) : null}
+      {loading ? <div className="c-shotview-loading">loading preview…</div> : null}
+      {/* Whatever the picture does NOT show, in the one place the user is
+          actually looking at the pixels it is about (T:1094-1100). */}
+      {shot.viewNote ? <div className="c-shotview-note">{shot.viewNote}</div> : null}
+      <div className="c-shotview-bar">
+        {/* The path the AGENT was given, which is the one fact a picture
+            cannot show about itself. Truncated from the LEFT: the filename is
+            the half that identifies it (T:1084-1092). */}
+        <span className="c-shotview-path c-mono">{shot.view || ""}</span>
+        <span className="c-spacer" />
+        {/* Shown only for a PENDING shot: a sent picture is already in the
+            agent's hands, and a Discard that cannot un-send it would be a
+            lie (T:4392). */}
+        {shot.pending && onDiscard ? (
+          <button
+            type="button"
+            className="c-pill c-shotview-drop"
+            onClick={() => {
+              onDiscard(shot);
+              onClose();
+            }}
+          >
+            Discard
+          </button>
+        ) : null}
+        <button type="button" className="c-pill" onClick={onClose} autoFocus>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** T:10786 — the file's own template comes down on every close, because a
+ *  template with a folder venv holds a warm worker and can poll, so a frame
+ *  merely hidden goes on running behind a modal the user shut. In React that is
+ *  UNMOUNTING the element, which a closed dialog does for free. */
+export function ShotViewer(props: ShotViewerProps) {
+  if (!props.shot) return null;
+  const alt = shotAlt(props.shot, props.paneNoun);
+  return (
+    <Dialog open onOpenChange={(next) => (next ? undefined : props.onClose())}>
+      {/* The card's width is the sheet's alone (`.c-overlay.c-shotview`), which
+          is why there is no `w-auto max-w-none` in the className: two statements
+          of one box's width, one of which the other overrides, is a box that
+          disagrees with itself. */}
+      <DialogContent
+        showCloseButton={false}
+        className="c-overlay c-shotview gap-0 border-0 bg-transparent p-0 shadow-none ring-0"
+      >
+        {/* Named for a screen reader, drawn for nobody: the picture and its path
+            are the dialog's whole content. */}
+        <DialogTitle className="sr-only">{alt}</DialogTitle>
+        <ShotViewerBody {...props} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default ShotViewer;

--- a/frontend/src/apps/claude/ui/ShotViewer.tsx
+++ b/frontend/src/apps/claude/ui/ShotViewer.tsx
@@ -1,10 +1,28 @@
-// ONE PICTURE, FULL SIZE, OVER EVERYTHING (T:4369-4397 markup, T:10681-10805
-// behaviour, CSS T:997-1140).
+// ONE PICTURE, FULL SIZE, IN THE APP'S OWN MODAL (T:4369-4397 markup,
+// T:10681-10805 behaviour, CSS T:997-1140).
 //
 // The other half of the report that produced the chip: a 22px thumbnail proved a
 // screenshot existed and there was "no way to preview it before sending", so
 // what the user was asked to do was trust a smudge and press send. Every
 // thumbnail the chat draws opens this, pending or sent, through one builder.
+//
+// THE CHASSIS IS `platform/ui/modal/Modal` (Akshil, 2026-09-09, P2-3) — the same
+// one the kebab's Delete task dialog (`platform/ui/EraseTaskModal`) and "what was
+// sent" (`ui/SentPop`) use. T's viewer was an overlay of its own with a bar along
+// the bottom holding the path, Discard and Close; ported as a shadcn `Dialog`
+// with that bar hand-rolled inside it, it was the third dialog design the same
+// conversation could put on screen, and its box was sized by its CONTENT — so a
+// framed file preview overflowed the card and pushed the bar, Discard included,
+// past the bottom of the viewport (P2-5). The chassis brings the overlay, the
+// card, the head with the ✕, the footer, the focus trap, the backdrop and Esc —
+// and a card that is `max-height: 85vh` with a scrolling body, which is the
+// whole of the overflow report. What is T's own and stays is inside the body.
+//
+// ESCAPE PEELS ONE LAYER, and the chassis owns that now. This viewer opens OVER
+// "what was sent", and the port took the key in the CAPTURE phase and stopped it
+// so one press could not dismiss both. `modal/esc-stack` is that same rule
+// written once for every caller of the chassis — only the topmost registered
+// modal reacts — so the phase games go with the overlay they belonged to.
 //
 // TWO SIZES, and the second is not a nicety: fitted, a 1600px capture lands at
 // ~310px in the sidebar — four times the chip, still not enough to read the UI
@@ -13,9 +31,10 @@
 // a legible scale (T:1030-1048).
 import { useEffect, useRef, useState } from "react";
 
-import { Dialog, DialogContent, DialogTitle } from "@platform/shadcn/ui/dialog";
+import { Modal } from "@platform/ui/modal/Modal";
 
 import "../styles/composer.css";
+import { AttachIcon } from "./AttachIcon";
 import { previewSrcFor, shotAlt, shotNoun, sizeLabel, type Viewable } from "./attachApi";
 
 export interface ShotViewerProps {
@@ -29,27 +48,47 @@ export interface ShotViewerProps {
   onDiscard?(shot: Viewable): void;
 }
 
+/** A FILE is the one thing worth opening that has no pixels, and so is an IMAGE
+ *  this engine could not decode: a real path, a real size, no pixels, which is a
+ *  file in every way that matters here (T:10722-10726). */
+function isBare(shot: Viewable): boolean {
+  const pic = shot.src || shot.thumb || "";
+  return !pic && (shot.kind === "file" || shot.kind === "image");
+}
+
+/**
+ * THE DIALOG'S HEAD (T:1108 `#shotview-name`). What a file viewer had instead of
+ * a picture — the name the user called it and how big it is — is the TITLE now,
+ * where the chassis puts every other dialog's identity; a picture says both by
+ * BEING shown, so it gets its noun and no size (T:7099 — a size is only ever
+ * shown for something with no picture to look at).
+ *
+ * Exported because the head belongs to the chassis, which a `react-test-renderer`
+ * suite cannot mount (it portals), so this is the seam that pins the words.
+ */
+export function shotViewerTitle(shot: Viewable, paneNoun: string): string {
+  const noun = shotNoun(shot, paneNoun);
+  if (!isBare(shot)) return noun;
+  const size = sizeLabel(shot.size);
+  return size ? noun + " · " + size : noun;
+}
+
 /**
  * T's `figure#shotview-box` — the box that SCROLLS at natural size, and
  * everything inside it.
  *
- * Its own component, not an inline block, for two reasons: the `Dialog` panel is
- * a plain function component here (React 18, no `forwardRef`) so a ref cannot
- * reach its element, and a Base UI dialog PORTALS itself, which a
- * `react-test-renderer` suite has no document to portal into — so this is the
- * seam the tests drive, and it is the whole viewer.
+ * Its own component, not an inline block, because the chassis PORTALS itself and
+ * a `react-test-renderer` suite has no document to portal into — so this is the
+ * seam the tests drive, and it is the whole of what the viewer shows.
  */
-export function ShotViewerBody({ shot, paneNoun, onClose, onDiscard }: ShotViewerProps) {
+export function ShotViewerBody({ shot, paneNoun }: Omit<ShotViewerProps, "onClose" | "onDiscard">) {
   const [zoom, setZoom] = useState(false);
   const [frameSrc, setFrameSrc] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const boxRef = useRef<HTMLDivElement | null>(null);
 
   const pic = shot ? shot.src || shot.thumb || "" : "";
-  // A FILE is the one thing worth opening that has no pixels, and so is an IMAGE
-  // this engine could not decode: a real path, a real size, no pixels, which is
-  // a file in every way that matters here (T:10722-10726).
-  const bare = !!shot && !pic && (shot.kind === "file" || shot.kind === "image");
+  const bare = !!shot && isBare(shot);
 
   // Every open starts FITTED. A zoom is something you do to one picture while
   // looking at it, not a preference that follows you to the next one — and a
@@ -63,26 +102,6 @@ export function ShotViewerBody({ shot, paneNoun, onClose, onDiscard }: ShotViewe
       box.scrollLeft = 0;
     }
   }, [shot]);
-
-  // ESCAPE BELONGS TO THE TOP DIALOG, and here that has to be said out loud.
-  // This viewer opens OVER "what was sent", which is a `platform/ui/modal/Modal`
-  // (R4-1) — and that chassis listens for Escape on `document` in the BUBBLE
-  // phase so the key keeps working when focus slips to <body>. Left alone, one
-  // press would dismiss the picture AND the record behind it, throwing away the
-  // thing the reader was in the middle of checking. So the viewer takes the key
-  // first, in the CAPTURE phase, and stops it: whoever is on top closes, and
-  // only them. Standalone (no modal underneath) this is the same one press it
-  // always was.
-  useEffect(() => {
-    if (!shot) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "Escape") return;
-      e.stopPropagation();
-      onClose();
-    };
-    document.addEventListener("keydown", onKey, true);
-    return () => document.removeEventListener("keydown", onKey, true);
-  }, [shot, onClose]);
 
   // THE FILE'S OWN PREVIEW, and only a file's: an image already has the picture
   // viewer above (a better view of pixels than any template), and a refusal has
@@ -118,8 +137,6 @@ export function ShotViewerBody({ shot, paneNoun, onClose, onDiscard }: ShotViewe
   if (!shot) return null;
 
   const alt = shotAlt(shot, paneNoun);
-  const size = bare ? sizeLabel(shot.size) : "";
-  const name = bare ? shotNoun(shot, paneNoun) + (size ? " · " + size : "") : "";
 
   return (
     <div className="c-shotview-box" data-zoom={zoom ? "" : undefined} ref={boxRef}>
@@ -142,9 +159,6 @@ export function ShotViewerBody({ shot, paneNoun, onClose, onDiscard }: ShotViewe
           }}
         />
       ) : null}
-      {/* What a FILE viewer has instead of a picture: the name the user called
-          it and how big it is. An image says both by BEING shown (T:1108). */}
-      {name ? <div className="c-shotview-name">{name}</div> : null}
       {frameSrc ? (
         <iframe
           className="c-shotview-frame"
@@ -159,61 +173,86 @@ export function ShotViewerBody({ shot, paneNoun, onClose, onDiscard }: ShotViewe
         />
       ) : null}
       {loading ? <div className="c-shotview-loading">loading preview…</div> : null}
+      {/* NO PICTURE AND NO PREVIEW — a .zip, a refusal, an extension with no
+          template. The glyph is then the only thing in the body that says what
+          this is, and an empty body reads as a viewer that failed. The name and
+          the size are in the head above. */}
+      {!pic && !frameSrc && !loading ? (
+        <div className="c-shotview-blank">
+          <AttachIcon kind={shot.kind} className="c-shotview-glyph" />
+        </div>
+      ) : null}
       {/* Whatever the picture does NOT show, in the one place the user is
           actually looking at the pixels it is about (T:1094-1100). */}
       {shot.viewNote ? <div className="c-shotview-note">{shot.viewNote}</div> : null}
-      <div className="c-shotview-bar">
-        {/* The path the AGENT was given, which is the one fact a picture
-            cannot show about itself. Truncated from the LEFT: the filename is
-            the half that identifies it (T:1084-1092). */}
-        <span className="c-shotview-path c-mono">{shot.view || ""}</span>
-        <span className="c-spacer" />
-        {/* Shown only for a PENDING shot: a sent picture is already in the
-            agent's hands, and a Discard that cannot un-send it would be a
-            lie (T:4392). */}
-        {shot.pending && onDiscard ? (
-          <button
-            type="button"
-            className="c-pill c-shotview-drop"
-            onClick={() => {
-              onDiscard(shot);
-              onClose();
-            }}
-          >
-            Discard
-          </button>
-        ) : null}
-        <button type="button" className="c-pill" onClick={onClose} autoFocus>
-          Close
-        </button>
-      </div>
     </div>
+  );
+}
+
+/**
+ * T's `#shotview-bar`, as the chassis' FOOTER. The path is the one fact a picture
+ * cannot show about itself, so it rides the row with the buttons and stays put
+ * however far the body has scrolled — which is what the sticky bar inside the old
+ * box was for.
+ */
+export function ShotViewerFooter({ shot, onClose, onDiscard }: ShotViewerProps) {
+  if (!shot) return null;
+  return (
+    <>
+      {/* Truncated from the LEFT: the filename is the half that identifies it
+          (T:1084-1092). It takes the footer grammar's far-left seat, the one
+          `.modal-dirty-hint` and `.btn-danger-text` use. */}
+      <span className="c-shotview-path c-mono" title={shot.view || ""}>
+        {shot.view || ""}
+      </span>
+      {/* Shown only for a PENDING shot: a sent picture is already in the agent's
+          hands, and a Discard that cannot un-send it would be a lie (T:4392). */}
+      {shot.pending && onDiscard ? (
+        <button
+          type="button"
+          className="btn btn-danger-text c-shotview-drop"
+          onClick={() => {
+            onDiscard(shot);
+            onClose();
+          }}
+        >
+          Discard
+        </button>
+      ) : null}
+      <button type="button" className="btn btn-secondary" onClick={onClose}>
+        Close
+      </button>
+    </>
   );
 }
 
 /** T:10786 — the file's own template comes down on every close, because a
  *  template with a folder venv holds a warm worker and can poll, so a frame
  *  merely hidden goes on running behind a modal the user shut. In React that is
- *  UNMOUNTING the element, which a closed dialog does for free. */
+ *  UNMOUNTING the element, which a closed dialog does for free — and the chassis
+ *  cannot unmount itself (it defers `onClose` to animate the exit), so it is
+ *  rendered conditionally, the shape every other caller of it uses. */
 export function ShotViewer(props: ShotViewerProps) {
   if (!props.shot) return null;
-  const alt = shotAlt(props.shot, props.paneNoun);
   return (
-    <Dialog open onOpenChange={(next) => (next ? undefined : props.onClose())}>
-      {/* The card's width is the sheet's alone (`.c-overlay.c-shotview`), which
-          is why there is no `w-auto max-w-none` in the className: two statements
-          of one box's width, one of which the other overrides, is a box that
-          disagrees with itself. */}
-      <DialogContent
-        showCloseButton={false}
-        className="c-overlay c-shotview gap-0 border-0 bg-transparent p-0 shadow-none ring-0"
-      >
-        {/* Named for a screen reader, drawn for nobody: the picture and its path
-            are the dialog's whole content. */}
-        <DialogTitle className="sr-only">{alt}</DialogTitle>
-        <ShotViewerBody {...props} />
-      </DialogContent>
-    </Dialog>
+    <Modal
+      title={shotViewerTitle(props.shot, props.paneNoun)}
+      onClose={props.onClose}
+      // `plainBody`: the body hosts a picture, a framed page and a caveat, not a
+      // form, and `deploy-body`'s descendant `button`/`p` skins would re-style a
+      // surface that arrives already designed (D489).
+      plainBody
+      dialogClassName="c-shotview-modal"
+      footer={<ShotViewerFooter {...props} />}
+    >
+      {/* `c-overlay` re-anchors the chat's `--c-*` aliases: the dialog is
+          portaled to <body>, outside `.chat-root`'s cascade, and the picture and
+          its caveat paint on the chat's palette exactly as `SentPop`'s body
+          does. */}
+      <div className="c-overlay">
+        <ShotViewerBody shot={props.shot} paneNoun={props.paneNoun} />
+      </div>
+    </Modal>
   );
 }
 

--- a/frontend/src/apps/claude/ui/Topbar.tsx
+++ b/frontend/src/apps/claude/ui/Topbar.tsx
@@ -1,30 +1,25 @@
-// The chat's header: TWO ROWS, which is what T actually has (T:3920-4083,
-// inventory 04 §E/§F).
+// The chat's IDENTITY LINE — T's `#topbar` (T:1285-1310, 4030-4083, inventory
+// 04 §F): the Claude mark, "Claude", the target's name, then the task number and
+// the "running" mark at the right end.
 //
-// Row one is the CONTROL strip — the way out at its left end, the menu at its
-// right (`#anntools`: `#back` … `#kebab`), and it is the row PR2/PR3 hang the
-// screenshot, comment and annotate seats on. Row two is the chat's IDENTITY
-// (`#topbar`): the Claude mark, "Claude", the target's name, then the task
-// number and the "running" mark at the right end.
-//
-// It shipped as one row with all six things in it, which is how a 43px strip in
-// a narrow pane ends up with the file name and the id fighting for the same
-// inch and the ⋮ pressed against the running mark (Akshil, 2026-09-08). Two
-// rows give each half its own line and its own right-hand anchor, and the
-// identity line can then ellipsise the one thing that is arbitrarily long — the
-// name — without moving anything else.
+// IT USED TO BE TWO ROWS, and the first of them was a second control strip: back
+// at its left end, the ⋮ at its right, and the seat PR2's screenshot button was
+// meant to land in. T has no such row — its `#anntools` is ONE strip above both
+// views carrying `← Chats`, the three preview seats and the ⋮ together, and
+// `#chat.home #topbar` (T:1277) hides only THIS line on the landing. Rendering
+// our own copy of the controls here put the seats on a row of their own above
+// the row that held the menu (Akshil, 2026-09-09, P2-1), so back and the kebab
+// moved up into the shared strip (`ClaudeChat`'s `.c-anntools`) and what is left
+// is the identity, which is all T ever had here.
 //
 // The name is TASK-nnn and not a session hash: a session IS a task, 1:1, and
 // TASK-023 is the identifier every other surface in this app prints, so a
 // reader can carry it to the Tasks page and quote it to someone (T:12660-12672).
-import { useCallback, useRef } from "react";
 import "../styles/composer.css";
 import { ClaudeMark } from "./ClaudeMark";
-import { Kebab, knownTaskId } from "./Kebab";
+import { knownTaskId } from "./Kebab";
 
 export interface TopbarProps {
-  agentDir: string | null;
-  file: string | null;
   sessionId: string;
   /** The target's own name under "Claude" (`#banner-sub`). */
   subtitle?: string;
@@ -33,40 +28,9 @@ export interface TopbarProps {
   /** A turn is live: one source of truth for the mark and the composer's stop
    *  square (T:1342-1349). */
   running: boolean;
-  /** Back to chats — clears the transcript and lands on the landing composer
-   *  (`newChat`). Refused while an annotation mode holds the reader here
-   *  (`annNavLocked`, PR3). */
-  onBack(): void;
-  backDisabled?: boolean;
-  /** ACCEPTED AND UNUSED. The raw outgoing text of the last turn fed a "What
-   *  was sent" item in this menu, which is gone (Akshil, 2026-09-08 — T opens
-   *  that panel from a receipt row under the bubble it belongs to, never from a
-   *  menu hanging off the whole conversation). The prop stays in the shape so
-   *  the host does not have to stop handing it over mid-flight. */
-  lastRaw?: string;
 }
 
-export function Topbar({
-  agentDir,
-  file,
-  sessionId,
-  subtitle,
-  taskId,
-  running,
-  onBack,
-  backDisabled,
-}: TopbarProps) {
-  // Where focus goes when the delete confirm closes, whichever way it closed
-  // (T:13293, 13319-13321). The menu owns that dialog now; this is the seat it
-  // returns to.
-  const kebabBtn = useRef<HTMLElement | null>(null);
-
-  const onErased = useCallback(() => {
-    // The page must not stay on a transcript that no longer exists
-    // (T:13348-13366); the menu has already dropped every cache keyed by it.
-    onBack();
-  }, [onBack]);
-
+export function Topbar({ sessionId, subtitle, taskId, running }: TopbarProps) {
   // The number, or the session hash until it lands (T:12698 — the answer to a
   // slow listing is the old label, never a gap).
   const label =
@@ -75,52 +39,28 @@ export function Topbar({
     (sessionId ? sessionId.slice(0, 8) : "");
 
   return (
-    <div className="c-header">
-      {/* ROW 1 — the controls, and nothing else. */}
-      <div className="c-hdr-tools">
-        <button
-          type="button"
-          className="c-back"
-          aria-label="Back to chats"
-          disabled={backDisabled}
-          onClick={onBack}
-        >
-          ← Chats
-        </button>
-        <span className="c-hdr-slack" />
-        <Kebab
-          agentDir={agentDir}
-          file={file}
-          sessionId={sessionId}
-          btnRef={kebabBtn}
-          running={running}
-          onErased={onErased}
-        />
-      </div>
-      {/* ROW 2 — who this conversation is with, and about what. */}
-      <div className="c-topbar">
-        <ClaudeMark className="c-spark" />
-        <span className="c-tb-title">Claude</span>
-        <span className="c-tb-file" title={subtitle || undefined}>
-          {subtitle ?? ""}
+    <div className="c-topbar">
+      <ClaudeMark className="c-spark" />
+      <span className="c-tb-title">Claude</span>
+      <span className="c-tb-file" title={subtitle || undefined}>
+        {subtitle ?? ""}
+      </span>
+      {label ? (
+        // The full session id stays reachable for the reader who actually wants
+        // it (a log line, a bug report) without spending header width on it
+        // (T:12700).
+        <span className="c-session" title={sessionId || undefined}>
+          {label}
         </span>
-        {label ? (
-          // The full session id stays reachable for the reader who actually
-          // wants it (a log line, a bug report) without spending header width
-          // on it (T:12700).
-          <span className="c-session" title={sessionId || undefined}>
-            {label}
-          </span>
-        ) : null}
-        {/* `aria-live="polite"`, not assertive: this is an ambient state, and a
-            reader that interrupts to announce the start of every turn is worse
-            than one that mentions it when it next comes up for air (T:4078). */}
-        {running ? (
-          <span className="c-tb-run" aria-live="polite">
-            running
-          </span>
-        ) : null}
-      </div>
+      ) : null}
+      {/* `aria-live="polite"`, not assertive: this is an ambient state, and a
+          reader that interrupts to announce the start of every turn is worse
+          than one that mentions it when it next comes up for air (T:4078). */}
+      {running ? (
+        <span className="c-tb-run" aria-live="polite">
+          running
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/apps/claude/ui/Transcript.tsx
+++ b/frontend/src/apps/claude/ui/Transcript.tsx
@@ -27,6 +27,7 @@ import type { ChatController, ChatState, UserTurn } from "../protocol/controller
 import type { PermissionMode, Segment } from "../protocol/types";
 import { CardStack, type CardActions } from "./CardStack";
 import { TroubleView } from "./TroubleView";
+import type { Viewable } from "./attachApi";
 import { Turn } from "./Turn";
 import { WorkingLine } from "./WorkingLine";
 import "../styles/transcript.css";
@@ -67,6 +68,10 @@ export interface TranscriptProps {
    *  (`null`, not `""`) so a copied address carries no dangling `&msg=`. */
   onAnchorSpent?: () => void;
   onShowSent?: (turn: UserTurn) => void;
+  /** PR2: a receipt's thumbnail or glyph opens the full-size viewer. */
+  onOpenShot?: (shot: Viewable) => void;
+  /** "preview" / "app" — the word a receipt's nouns use (`PaneState.paneNoun`). */
+  paneNoun?: string;
   /** What the app was doing, for a trouble card's report. */
   what?: string;
 }
@@ -80,6 +85,8 @@ export const Transcript = memo(function Transcript({
   msgAnchor,
   onAnchorSpent,
   onShowSent,
+  onOpenShot,
+  paneNoun,
   what,
 }: TranscriptProps) {
   const port = useRef<HTMLDivElement>(null);
@@ -358,6 +365,8 @@ export const Transcript = memo(function Transcript({
                   {...(tail && tail.turnKey === turn.key ? { tail } : {})}
                   {...(onShowSent ? { onShowSent } : {})}
                   {...(after ? { cardsAfter: after } : {})}
+                  {...(onOpenShot ? { onOpenShot } : {})}
+                  {...(paneNoun ? { paneNoun } : {})}
                 >
                   {/* Parked cards belong to the turn they were answered in —
                       whichever turn that was, streaming or long finished.

--- a/frontend/src/apps/claude/ui/Turn.tsx
+++ b/frontend/src/apps/claude/ui/Turn.tsx
@@ -7,9 +7,11 @@ import { memo } from "react";
 import { cn } from "@platform/lib/utils";
 
 import type { Turn as TurnRow, UserTurn } from "../protocol/controller-api";
+import type { Viewable } from "./attachApi";
 import { Caret } from "./Caret";
 import { ClaudeMark } from "./ClaudeMark";
 import { MarkdownView } from "./MarkdownView";
+import { Receipts } from "./Receipts";
 import { SegmentView } from "./SegmentView";
 import { TroubleMessage } from "./TroubleView";
 
@@ -40,6 +42,11 @@ export interface TurnProps {
    *  Offered only when the turn actually carries one, and reached through the
    *  RECEIPT LINE itself wherever the turn has one (R4-1) — see below. */
   onShowSent?: (turn: UserTurn) => void;
+  /** The receipt rows under a sent user turn (PR2): what this message carried,
+   *  from the turn's own `attachments` or from its `raw` wire (T:10815). */
+  onOpenShot?: (shot: Viewable) => void;
+  /** "preview" / "app" — every noun in a receipt names the pane (T:7073). */
+  paneNoun?: string;
   /** The typer's attachment INSIDE this turn, when it has one: `index` is the
    *  growing segment, or -1 for the flat body of a turn with no segments, and
    *  `text` is the frame's slice (protocol/segments.ts `streamingTailOf`).
@@ -61,6 +68,8 @@ export const Turn = memo(function Turn({
   turn,
   anchored,
   onShowSent,
+  onOpenShot,
+  paneNoun,
   tail,
   children,
   cardsAfter,
@@ -94,6 +103,19 @@ export const Turn = memo(function Turn({
         {...(turn.uuid ? { "data-msg": turn.uuid } : {})}
       >
         <div className="bubble">{turn.text}</div>
+        {/* SIBLINGS of the bubble, not wrappers around it: the re-attach probe
+            matches on `.user .bubble`'s text, and folding a receipt inside
+            would make every such turn stop matching (T:16584-16588). Legacy's
+            order too — the attachment rows first, then the push channel's own
+            line (T:16565-16596). */}
+        {onOpenShot ? (
+          <Receipts
+            turn={turn}
+            paneNoun={paneNoun ?? "preview"}
+            onOpenShot={onOpenShot}
+            {...(onShowSent ? { onShowSent } : {})}
+          />
+        ) : null}
         {turn.appState ? (
           // The push channel's receipt (T:16588-16596, `.user .attach` T:1802):
           // this message carried a description of the app the user is looking at.

--- a/frontend/src/apps/claude/ui/Turn.tsx
+++ b/frontend/src/apps/claude/ui/Turn.tsx
@@ -7,7 +7,9 @@ import { memo } from "react";
 import { cn } from "@platform/lib/utils";
 
 import type { Turn as TurnRow, UserTurn } from "../protocol/controller-api";
+import { isMarkerOnly } from "../protocol/wire";
 import type { Viewable } from "./attachApi";
+import { MarkerText } from "./AttachIcon";
 import { Caret } from "./Caret";
 import { ClaudeMark } from "./ClaudeMark";
 import { MarkdownView } from "./MarkdownView";
@@ -102,7 +104,14 @@ export const Turn = memo(function Turn({
         // anchor is looked for right after the append (T:13459-13463).
         {...(turn.uuid ? { "data-msg": turn.uuid } : {})}
       >
-        <div className="bubble">{turn.text}</div>
+        {/* A WORDLESS SEND'S BUBBLE says what the message carried instead —
+            "pane screenshot", "files", "annotations" — and each of those gets
+            the same lucide glyph the chip and the receipt wear (P2-7). Anything
+            the reader actually typed is their own words and gets none. The
+            bubble's TEXT is identical either way. */}
+        <div className="bubble">
+          {isMarkerOnly(turn.text) ? <MarkerText text={turn.text} /> : turn.text}
+        </div>
         {/* SIBLINGS of the bubble, not wrappers around it: the re-attach probe
             matches on `.user .bubble`'s text, and folding a receipt inside
             would make every such turn stop matching (T:16584-16588). Legacy's

--- a/frontend/src/apps/claude/ui/attach.test.tsx
+++ b/frontend/src/apps/claude/ui/attach.test.tsx
@@ -138,7 +138,7 @@ test("a REFUSED recapture keeps the picture already in the seat (Bugbot #1064)",
     attachPane: async () => {
       shots += 1;
       return shots === 1
-        ? att({ kind: "pane", seat: "pane", thumb: "blob:pane" })
+        ? att({ kind: "pane", seat: "pane", thumb: "blob:pane", viewNote: "the map tiles were still loading" })
         : att({ kind: "pane", seat: "pane", view: null, viewNote: "the pane did not answer" });
     },
   });
@@ -158,8 +158,11 @@ test("a REFUSED recapture keeps the picture already in the seat (Bugbot #1064)",
   expect(panes[0]!.view).toBe(good.view);
   // …and it never had its only handle pulled.
   expect(spy.revoked.map((a) => a.id)).not.toContain(good.id);
-  // …while the attempt is still reported.
-  expect(panes[0]!.viewNote).toBe("the pane did not answer");
+  // THE REFUSAL DOES NOT SPEAK THROUGH THE PICTURE'S CAVEAT. `viewNote` says
+  // what THIS picture does not show and rides the wire under the receipt, so
+  // the retry's sentence must not land on a screenshot that is perfectly good —
+  // and the original capture's own caveat must survive (Bugbot #1064).
+  expect(panes[0]!.viewNote).toBe("the map tiles were still loading");
 });
 
 test("the camera is inert while a capture is in flight (T:11203 shotBusy)", async () => {

--- a/frontend/src/apps/claude/ui/attach.test.tsx
+++ b/frontend/src/apps/claude/ui/attach.test.tsx
@@ -127,6 +127,41 @@ test("the pane seat is unique: a second capture REPLACES the first (D285, T:1130
   expect(tray.get().items[0]!.name).toBe("note.csv");
 });
 
+test("a REFUSED recapture keeps the picture already in the seat (Bugbot #1064)", async () => {
+  // The seat is unique, so the second click replaces the first — but a capture
+  // that timed out or failed to encode is still an attachment, with `view: null`
+  // and the reason in `viewNote`. Swapping it in threw away a screenshot the
+  // reader already had and could still send. The picture stays, and the refusal
+  // speaks through its caveat instead.
+  let shots = 0;
+  const { api, spy } = fakeApi({
+    attachPane: async () => {
+      shots += 1;
+      return shots === 1
+        ? att({ kind: "pane", seat: "pane", thumb: "blob:pane" })
+        : att({ kind: "pane", seat: "pane", view: null, viewNote: "the pane did not answer" });
+    },
+  });
+  const tray = mountTray(api);
+  await act(async () => {
+    await tray.get().capture();
+  });
+  const good = tray.get().items.find((s) => s.kind === "pane")!;
+  expect(good.view).toBeTruthy();
+  await act(async () => {
+    await tray.get().capture();
+  });
+  const panes = tray.get().items.filter((s) => s.kind === "pane");
+  expect(panes.length).toBe(1);
+  // THE PICTURE SURVIVED, and it is the same one.
+  expect(panes[0]!.id).toBe(good.id);
+  expect(panes[0]!.view).toBe(good.view);
+  // …and it never had its only handle pulled.
+  expect(spy.revoked.map((a) => a.id)).not.toContain(good.id);
+  // …while the attempt is still reported.
+  expect(panes[0]!.viewNote).toBe("the pane did not answer");
+});
+
 test("the camera is inert while a capture is in flight (T:11203 shotBusy)", async () => {
   let release: ((a: Attachment) => void) | null = null;
   const { api } = fakeApi({

--- a/frontend/src/apps/claude/ui/attach.test.tsx
+++ b/frontend/src/apps/claude/ui/attach.test.tsx
@@ -269,24 +269,39 @@ function chipsOf(items: Attachment[]) {
   return renderer!.root;
 }
 
-test("a picture is a thumbnail button, a file is a glyph door, a refusal is neither", () => {
+test("the WHOLE chip is the door for a picture and for a file, and a refusal has none", () => {
   const root = chipsOf([
     att({ kind: "pane", thumb: "blob:x" }),
     att({ kind: "file", name: "rows.csv", size: 2048 }),
     att({ kind: "image", view: null, why: "could not be saved" }),
   ]);
-  // The picture: one <img> inside a button that opens the viewer.
-  expect(root.findAllByProps({ className: "c-shotthumb" }).length).toBeGreaterThan(0);
-  // The file: the glyph IS the button (T:7143 `isDoor`).
+  // P2-4: one button per openable chip, holding the thumb-or-glyph AND the
+  // words — not a 22px hit area with dead text beside it.
   const doors = root.findAll(
-    (n) => n.type === "button" && n.props.className === "c-pinlbl c-shotdoc",
+    (n) => n.type === "button" && String(n.props.className) === "c-chip-door",
   );
-  expect(doors.length).toBe(1);
-  expect(doors[0]!.props.children).toBe("📄");
-  // A refused attachment has nothing to open, so its glyph is a plain span —
-  // one "failed" chip shape, whatever kind failed.
-  const plain = root.findAll((n) => n.type === "span" && n.props.className === "c-pinlbl");
-  expect(plain.length).toBe(1);
+  expect(doors.length).toBe(2);
+  // The picture's door holds the thumbnail; the file's holds the lucide glyph.
+  expect(doors[0]!.findAllByProps({ className: "c-shotthumb" }).length).toBe(1);
+  expect(doors[1]!.findAllByProps({ className: "c-pinlbl" }).length).toBe(1);
+  // Both doors hold their own words, which is the point of the change.
+  for (const door of doors) {
+    expect(door.findAllByProps({ className: "c-txt" }).length).toBe(1);
+  }
+  // A refused attachment has nothing to open, so its body is not a button —
+  // one "failed" chip shape, whatever kind failed (T:10722-10726).
+  const inert = root.findAll(
+    (n) => n.type === "span" && String(n.props.className) === "c-chip-door is-inert",
+  );
+  expect(inert.length).toBe(1);
+});
+
+test("NO EMOJI on a chip — the glyph is a lucide icon (P2-7)", () => {
+  const root = chipsOf([att({ kind: "file", name: "rows.csv", size: 2048 })]);
+  const glyph = root.findByProps({ className: "c-pinlbl" });
+  // An svg element, not a text node: `findAllByType("svg")` is what a lucide
+  // icon renders down to under react-test-renderer.
+  expect(glyph.findAllByType("svg").length).toBe(1);
 });
 
 test("a file says how big it is and a refusal says why, on the row (T:7112, 7172)", () => {

--- a/frontend/src/apps/claude/ui/attach.test.tsx
+++ b/frontend/src/apps/claude/ui/attach.test.tsx
@@ -1,0 +1,413 @@
+// The tray's own rules, the chip row that shows them, and the two gestures that
+// fill it (inventory 03 §A/§C/§E). The pipeline is replaced wholesale — these
+// are decisions this half of the app makes, and none of them needs a capture
+// engine, a clipboard or a server.
+import { installDomShim } from "@platform/lib/testDomShim";
+installDomShim();
+import { expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+const { AttachTray } = await import("./AttachTray");
+const { useAttachments } = await import("./useAttachments");
+const { ComposerCard } = await import("./Composer");
+const { DEFAULT_EFFORT, DEFAULT_MODEL, DEFAULT_PERMISSION } = await import("./composer-defaults");
+const { paneShotIn } = await import("../protocol/wire");
+type Attachment = import("../shots/types").Attachment;
+type Receipt = import("../shots/types").Receipt;
+type AttachApi = import("./attachApi").AttachApi;
+type Attachments = import("./useAttachments").Attachments;
+
+let ids = 0;
+function att(over: Partial<Attachment> = {}): Attachment {
+  return { id: "a" + ++ids, kind: "image", view: "/shots/" + ids + ".png", ...over };
+}
+
+interface Spy {
+  revoked: Attachment[];
+  flashed: number;
+}
+
+function fakeApi(over: Partial<AttachApi> = {}): { api: AttachApi; spy: Spy } {
+  const spy: Spy = { revoked: [], flashed: 0 };
+  const api: AttachApi = {
+    flash: () => {
+      spy.flashed += 1;
+      return () => {};
+    },
+    attachPane: async () => att({ kind: "pane", seat: "pane", thumb: "blob:pane" }),
+    attachFiles: async function* (_dir, files) {
+      for (const f of files) yield att({ kind: "file", name: f.name, view: "/shots/" + f.name });
+    },
+    attachPaths: (_dir, paths) =>
+      paths.map((p) => att({ kind: "file", view: p, name: p, brought: true })),
+    readDirs: (list) =>
+      (list || []).map((s) => (s.view || "").replace(/\/[^/]*$/, "")).filter(Boolean),
+    readDirsFor: (_dir, list) =>
+      (list || []).map((s) => (s.view || "").replace(/\/[^/]*$/, "")).filter(Boolean),
+    revoke: (a) => {
+      if (a) spy.revoked.push(a);
+    },
+    toWire: (list) => (list || []).map((s) => ({ kind: s.kind, view: s.view })),
+    receiptFor: (a): Receipt => ({ kind: a.kind, label: "attached", view: a.view }),
+    probePruned: async () => false,
+    dragHasAttachment: () => true,
+    pathsFromDrop: () => [],
+    filesFromPaste: () => [],
+    ...over,
+  };
+  return { api, spy };
+}
+
+function mountTray(api: AttachApi) {
+  let hook: Attachments | undefined;
+  function Host() {
+    hook = useAttachments({
+      api,
+      agentDir: "/t/claude",
+      frame: () => null,
+      flashHost: () => null,
+      paneNoun: "preview",
+      shotsDir: "/shots",
+    });
+    return (
+      <AttachTray
+        items={hook.items}
+        paneNoun="preview"
+        onOpen={() => {}}
+        onRemove={hook.remove}
+      />
+    );
+  }
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(<Host />);
+  });
+  return {
+    get: () => hook!,
+    root: () => renderer!.root,
+    /** Deliberately OUTSIDE `act` in the unmount test below, so React's paint
+     *  cannot slip in ahead of the teardown. */
+    unmount: () => renderer!.unmount(),
+  };
+}
+
+test("chips land in the order the user brought them (T:11625)", async () => {
+  const { api } = fakeApi();
+  const tray = mountTray(api);
+  await act(async () => {
+    await tray.get().addFiles([
+      { name: "one.csv" } as File,
+      { name: "two.csv" } as File,
+      { name: "three.csv" } as File,
+    ]);
+  });
+  expect(tray.get().items.map((s) => s.name)).toEqual(["one.csv", "two.csv", "three.csv"]);
+  // Three chips, and no pending seat left behind.
+  expect(tray.get().items.every((s) => !s.pending)).toBe(true);
+});
+
+test("the pane seat is unique: a second capture REPLACES the first (D285, T:11309)", async () => {
+  const { api, spy } = fakeApi();
+  const tray = mountTray(api);
+  await act(async () => {
+    await tray.get().addFiles([{ name: "note.csv" } as File]);
+  });
+  await act(async () => {
+    await tray.get().capture();
+  });
+  await act(async () => {
+    await tray.get().capture();
+  });
+  const panes = tray.get().items.filter((s) => s.kind === "pane");
+  expect(panes.length).toBe(1);
+  // The replaced picture's blob URL is the only handle to it.
+  expect(spy.revoked.length).toBe(1);
+  expect(spy.flashed).toBe(2);
+  // The file it stacked on top of keeps its place.
+  expect(tray.get().items[0]!.name).toBe("note.csv");
+});
+
+test("the camera is inert while a capture is in flight (T:11203 shotBusy)", async () => {
+  let release: ((a: Attachment) => void) | null = null;
+  const { api } = fakeApi({
+    attachPane: () =>
+      new Promise<Attachment>((res) => {
+        release = res;
+      }),
+  });
+  const tray = mountTray(api);
+  let first: Promise<void> | undefined;
+  act(() => {
+    first = tray.get().capture();
+  });
+  expect(tray.get().capturing).toBe(true);
+  // A second press while the first is out is refused, and adds nothing.
+  await act(async () => {
+    await tray.get().capture();
+  });
+  expect(tray.get().items.length).toBe(0);
+  await act(async () => {
+    release!(att({ kind: "pane" }));
+    await first;
+  });
+  expect(tray.get().capturing).toBe(false);
+  expect(tray.get().items.length).toBe(1);
+});
+
+test("the chip's ✕ removes THIS one, revokes it, and leaves the others (T:10654)", async () => {
+  const { api, spy } = fakeApi();
+  const tray = mountTray(api);
+  await act(async () => {
+    await tray.get().addFiles([{ name: "a.csv" } as File, { name: "b.csv" } as File]);
+  });
+  const gone = tray.get().items[0]!;
+  act(() => {
+    tray.get().remove(gone);
+  });
+  expect(tray.get().items.map((s) => s.name)).toEqual(["b.csv"]);
+  expect(spy.revoked).toContain(gone);
+});
+
+test("a send empties the tray into the wire, the read rules and the receipts", async () => {
+  const { api } = fakeApi();
+  const tray = mountTray(api);
+  await act(async () => {
+    await tray.get().addPaths(["/home/me/data/rows.csv"]);
+  });
+  let out: ReturnType<Attachments["take"]> | undefined;
+  act(() => {
+    out = tray.get().take();
+  });
+  expect(tray.get().items.length).toBe(0);
+  expect(out!.blocks.length).toBe(1);
+  expect(paneShotIn(out!.blocks[0]!)).toEqual([{ kind: "file", view: "/home/me/data/rows.csv" }]);
+  // One Read rule per directory, and never the shots dir the spawn line already
+  // allows (T:11698).
+  expect(out!.readDirs).toEqual(["/home/me/data"]);
+  expect(out!.receipts.length).toBe(1);
+  expect(out!.items.length).toBe(1);
+});
+
+test("a send that never landed hands them back PREPENDED (T:16093, 16708)", async () => {
+  const { api } = fakeApi();
+  const tray = mountTray(api);
+  await act(async () => {
+    await tray.get().addFiles([{ name: "was-in-flight.csv" } as File]);
+  });
+  let out: ReturnType<Attachments["take"]> | undefined;
+  act(() => {
+    out = tray.get().take();
+  });
+  // A picture attached WHILE the send was in flight keeps its place after the
+  // ones that were already waiting.
+  await act(async () => {
+    await tray.get().addFiles([{ name: "typed-after.csv" } as File]);
+  });
+  act(() => {
+    tray.get().giveBack(out!.items);
+  });
+  expect(tray.get().items.map((s) => s.name)).toEqual(["was-in-flight.csv", "typed-after.csv"]);
+});
+
+test("an empty tray puts nothing on the wire", () => {
+  const { api } = fakeApi();
+  const tray = mountTray(api);
+  let out: ReturnType<Attachments["take"]> | undefined;
+  act(() => {
+    out = tray.get().take();
+  });
+  expect(out).toEqual({ blocks: [], readDirs: [], receipts: [], items: [] });
+});
+
+// ---- the chips themselves --------------------------------------------------
+
+function chipsOf(items: Attachment[]) {
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(
+      <AttachTray items={items} paneNoun="preview" onOpen={() => {}} onRemove={() => {}} />
+    );
+  });
+  return renderer!.root;
+}
+
+test("a picture is a thumbnail button, a file is a glyph door, a refusal is neither", () => {
+  const root = chipsOf([
+    att({ kind: "pane", thumb: "blob:x" }),
+    att({ kind: "file", name: "rows.csv", size: 2048 }),
+    att({ kind: "image", view: null, why: "could not be saved" }),
+  ]);
+  // The picture: one <img> inside a button that opens the viewer.
+  expect(root.findAllByProps({ className: "c-shotthumb" }).length).toBeGreaterThan(0);
+  // The file: the glyph IS the button (T:7143 `isDoor`).
+  const doors = root.findAll(
+    (n) => n.type === "button" && n.props.className === "c-pinlbl c-shotdoc",
+  );
+  expect(doors.length).toBe(1);
+  expect(doors[0]!.props.children).toBe("📄");
+  // A refused attachment has nothing to open, so its glyph is a plain span —
+  // one "failed" chip shape, whatever kind failed.
+  const plain = root.findAll((n) => n.type === "span" && n.props.className === "c-pinlbl");
+  expect(plain.length).toBe(1);
+});
+
+test("a file says how big it is and a refusal says why, on the row (T:7112, 7172)", () => {
+  const root = chipsOf([
+    att({ kind: "file", name: "rows.csv", size: 2048 }),
+    att({ kind: "pane", view: null, why: "could not be saved" }),
+  ]);
+  const rows = root
+    .findAll((n) => n.type === "span" && n.props.className === "c-txt")
+    .map((n) => String(n.props.children));
+  expect(rows[0]).toBe("rows.csv · 2 KB");
+  expect(rows[1]).toBe("no pane screenshot — could not be saved");
+});
+
+test("a chip whose bytes are still on their way says so, and cannot be removed yet", () => {
+  let removed = 0;
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(
+      <AttachTray
+        items={[att({ kind: "file", view: null, pending: true })]}
+        paneNoun="preview"
+        onOpen={() => {}}
+        onRemove={() => {
+          removed += 1;
+        }}
+      />
+    );
+  });
+  const x = renderer!.root.findAll((n) => n.type === "button" && !!n.props.disabled);
+  expect(x.length).toBe(1);
+  expect(removed).toBe(0);
+});
+
+test("an empty tray with no annotation chips draws no row at all", () => {
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(
+      <AttachTray items={[]} paneNoun="preview" onOpen={() => {}} onRemove={() => {}} />
+    );
+  });
+  expect(renderer!.toJSON()).toBe(null);
+});
+
+// ---- paste and drop gating (T:11719-11790) --------------------------------
+
+test("paste: only a clipboard carrying FILES is taken; words reach the box", () => {
+  const { api } = fakeApi({
+    filesFromPaste: (ev) => (ev.clipboardData ? [{ name: "shot.png" } as File] : []),
+  });
+  const taken: File[][] = [];
+  const onPaste = (ev: { clipboardData?: DataTransfer | null; preventDefault(): void }) => {
+    const picks = api.filesFromPaste(ev);
+    if (!picks.length) return;
+    ev.preventDefault();
+    taken.push(picks);
+  };
+  let prevented = 0;
+  onPaste({ clipboardData: null, preventDefault: () => (prevented += 1) });
+  expect(taken.length).toBe(0);
+  expect(prevented).toBe(0);
+  onPaste({ clipboardData: {} as DataTransfer, preventDefault: () => (prevented += 1) });
+  expect(taken.length).toBe(1);
+  expect(prevented).toBe(1);
+});
+
+test("drop: real paths win over a copy of the same bytes (T:11777)", async () => {
+  const { api } = fakeApi({
+    pathsFromDrop: () => ["/home/me/x.png"],
+  });
+  const tray = mountTray(api);
+  const dt = {
+    types: ["Files", "application/x-fused-path"],
+    files: [{ name: "x.png" } as File],
+  } as unknown as DataTransfer;
+  await act(async () => {
+    const paths = api.pathsFromDrop(dt);
+    if (paths.length) await tray.get().addPaths(paths);
+    else await tray.get().addFiles(Array.from(dt.files));
+  });
+  // No upload happened: the path is the user's own file (`brought`).
+  expect(tray.get().items.map((s) => s.view)).toEqual(["/home/me/x.png"]);
+  expect(tray.get().items[0]!.brought).toBe(true);
+});
+
+// ---- the composer row re-prices itself when the seat changes (§G) ---------
+
+const controls = {
+  model: DEFAULT_MODEL,
+  effort: DEFAULT_EFFORT,
+  permission: DEFAULT_PERMISSION,
+  setModel() {},
+  setEffort() {},
+  setPermission() {},
+};
+
+test("the camera seat and the chip row both bump the row's fit revision", () => {
+  let renderer: ReactTestRenderer | undefined;
+  const card = (over: Record<string, unknown>) => (
+    <ComposerCard
+      variant="chat"
+      file="/p/app.py"
+      sessionId=""
+      controls={controls}
+      status="idle"
+      back="/explorer/view/p"
+      onSend={() => {}}
+      onStop={() => {}}
+      {...over}
+    />
+  );
+  act(() => {
+    renderer = create(card({}));
+  });
+  const seats = () => renderer!.root.findByProps({ className: "c-composer-row" }).props.children;
+  // Empty by default: the camera moved into the `#anncta` strip on 2026-08-27,
+  // so nothing occupies the seat — but the seat exists.
+  expect(seats().some((c: unknown) => c === undefined || c === null || c === false)).toBe(true);
+  act(() => {
+    renderer!.update(
+      card({ camera: <button type="button" className="c-viewshot-pill" />, fitRevision: 2 }),
+    );
+  });
+  expect(
+    renderer!.root.findAll((n) => n.props.className === "c-viewshot-pill").length,
+  ).toBe(1);
+  // Attachments alone make the composer sendable, with no words at all (T:17903).
+  act(() => {
+    renderer!.update(card({ hasAttachments: true }));
+  });
+  const send = renderer!.root.findByProps({ className: "c-send" });
+  expect(send.props.disabled).toBe(false);
+});
+
+test("the tray's own record is what a send and an unmount read — not the last render", async () => {
+  // WHAT `live.current` IS FOR, and why a render is too late to write it.
+  //
+  // Every road into the tray writes after an await (`api` is the network), and
+  // two things read the result without waiting for a paint: `take()`, which must
+  // send what the tray holds at THAT moment, and the unmount cleanup, which is
+  // the only thing left that can release these Blobs. Refreshed in the RENDER
+  // body, the record missed everything written since the last paint — so a send
+  // fired in that window went out WITHOUT the picture the user just added, and a
+  // chat closed in it pinned that picture's Blob for the life of the page with
+  // the chip that was its only other handle already gone.
+  //
+  // One `act` batch, no paint between the calls, which is that window exactly.
+  const { api, spy } = fakeApi();
+  const tray = mountTray(api);
+  const back = att({ kind: "file", view: "/x/a.png", name: "a.png", brought: true });
+  act(() => {
+    // `giveBack` stands in for all four roads — they share one committer, and it
+    // is the only one that needs no await to reach it.
+    tray.get().giveBack([back]);
+    // A send fired before the chip has painted carries it...
+    expect(tray.get().take().items).toEqual([back]);
+    // ...and so does the unmount revoke, which reads the same record.
+    tray.get().giveBack([back]);
+    tray.unmount();
+  });
+  expect(spy.revoked).toEqual([back]);
+});

--- a/frontend/src/apps/claude/ui/attach.test.tsx
+++ b/frontend/src/apps/claude/ui/attach.test.tsx
@@ -58,13 +58,13 @@ function fakeApi(over: Partial<AttachApi> = {}): { api: AttachApi; spy: Spy } {
   return { api, spy };
 }
 
-function mountTray(api: AttachApi) {
+function mountTray(api: AttachApi, frame: HTMLIFrameElement | null = null) {
   let hook: Attachments | undefined;
   function Host() {
     hook = useAttachments({
       api,
       agentDir: "/t/claude",
-      frame: () => null,
+      frame: () => frame,
       flashHost: () => null,
       paneNoun: "preview",
       shotsDir: "/shots",
@@ -410,4 +410,64 @@ test("the tray's own record is what a send and an unmount read — not the last 
     tray.unmount();
   });
   expect(spy.revoked).toEqual([back]);
+});
+
+test("THE CAMERA TELLS THE PIPELINE WHETHER THE PANE IS OURS TO READ (Bugbot #1064)", async () => {
+  // `xo` is the only thing that admits the tab share (T:9963), and the camera is
+  // the only caller that knows which frame is being photographed. Asked for with
+  // no options at all — as it was — a cross-origin pane the native path could
+  // not shoot fell through to a DOM clone of a document this page cannot open.
+  const seen: (boolean | undefined)[] = [];
+  const { api } = fakeApi({
+    attachPane: async (_dir, _frame, opts) => {
+      seen.push(opts?.xo);
+      return att({ kind: "pane", seat: "pane", thumb: "blob:pane" });
+    },
+  });
+  const xoFrame = {
+    get contentDocument(): Document {
+      throw new Error("cross-origin");
+    },
+  } as unknown as HTMLIFrameElement;
+  const xo = mountTray(api, xoFrame);
+  await act(async () => {
+    await xo.get().capture();
+  });
+  expect(seen).toEqual([true]);
+
+  // And a pane on our own origin is NOT offered the tab share: it has a document
+  // to clone, and a share prompt for a page we can read is a prompt for nothing.
+  const ours = mountTray(api, { contentDocument: {} as Document } as HTMLIFrameElement);
+  await act(async () => {
+    await ours.get().capture();
+  });
+  expect(seen).toEqual([true, false]);
+});
+
+test("A PLACEHOLDER ALWAYS BECOMES A CHIP, even when the pipeline throws", async () => {
+  // `attachFile` is written never to throw, and the tray must not depend on it:
+  // a rejected iteration used to have the placeholder REMOVED, so the picture the
+  // user dropped vanished with no chip, no error and nothing to retry from
+  // (Bugbot, PR #1064). Every gesture gets an answer, even a refusal.
+  const { api } = fakeApi({
+    attachFiles: async function* (_dir, files) {
+      yield att({ kind: "file", name: files[0]!.name, view: "/shots/one.csv" });
+      throw new Error("disk full");
+    },
+  });
+  const tray = mountTray(api);
+  await act(async () => {
+    await tray.get().addFiles([{ name: "one.csv" } as File, { name: "two.csv" } as File]);
+  });
+  const items = tray.get().items;
+  expect(items.map((s) => s.name)).toEqual(["one.csv", "two.csv"]);
+  // The one that landed is an ordinary attachment; the one that did not says so
+  // ON THE ROW, and rides the message as a refusal exactly as a failed upload
+  // does (T:11305).
+  expect(items[0]!.view).toBe("/shots/one.csv");
+  expect(items[1]!.view).toBeNull();
+  expect(items[1]!.why).toBe("could not be saved");
+  expect(items[1]!.viewNote).toBe("not attached: it could not be saved (disk full)");
+  // And no placeholder is left claiming a file is still on its way.
+  expect(items.every((s) => !s.pending)).toBe(true);
 });

--- a/frontend/src/apps/claude/ui/attachApi.ts
+++ b/frontend/src/apps/claude/ui/attachApi.ts
@@ -120,11 +120,8 @@ export function glyphDoor(shot: Viewable): boolean {
   return !shot.src && !shot.thumb && !!shot.view && (shot.kind === "file" || shot.kind === "image");
 }
 
-/** T:7141 — the glyph itself. Where there is a thumbnail the picture IS the
- *  icon, and putting 🖼 in front of it captions a photo with a drawing of one. */
-export function shotGlyph(shot: Pick<Viewable, "kind">): string {
-  return shot.kind === "file" ? "📄" : "🖼";
-}
+/** T:7141's glyph is `ui/AttachIcon` now — a lucide icon rather than 📄/🖼
+ *  (P2-7), so it cannot be a string and does not belong in this module. */
 
 /** T:10722-10726 `shotViewOpen`'s admission test: something to show, or a file /
  *  undecodable image — a real path, a real size and no pixels, which is a file

--- a/frontend/src/apps/claude/ui/attachApi.ts
+++ b/frontend/src/apps/claude/ui/attachApi.ts
@@ -1,0 +1,210 @@
+// THE ATTACHMENT SEAM: what the chip row, the viewer, the receipts and the
+// "what was sent" popup need from the pipeline, and the few decisions that are
+// the UI's own.
+//
+// The VOCABULARY IS NOT REDEFINED HERE. `shotNoun` / `shotAlt` / `sizeLabel` /
+// `failLabel` / `receiptFor` / `receiptsFromWire` / `prunedLabel` come from
+// `shots/attach.ts` and are re-exported, for the reason T keeps one copy of each
+// (T:7067): "a pasted image called 'preview screenshot' in the receipt is a
+// receipt that describes the wrong thing". What lives here is the drawing side —
+// picture-or-glyph, door-or-not, what the viewer will open — plus `AttachApi`,
+// the injectable face of the pipeline the tray calls.
+//
+// Sources: T:7067-7215, T:10637-10877, inventory 03 §A/§B/§E.
+import { statPath } from "@platform/lib/api";
+
+import { paneOfferable, paneSrcFor } from "../pane/paneUrl";
+import {
+  attachFiles,
+  attachPane,
+  attachPaths,
+  dragHasAttachment,
+  filesFromPaste,
+  flash,
+  pathsFromDrop,
+  probePruned,
+  readDirs,
+  readDirsFor,
+  receiptFor,
+  revoke,
+  sizeLabel,
+  toWire,
+} from "../shots";
+import type { Attachment, Receipt, ShotKind } from "../shots/types";
+
+export {
+  failLabel,
+  prunedLabel,
+  receiptFor,
+  receiptsFromWire,
+  shotAlt,
+  shotNoun,
+  sizeLabel,
+} from "../shots";
+
+/**
+ * The pipeline as the tray calls it. Every member is `shots/*.ts`'s own; there
+ * is no implementation here.
+ *
+ * INJECTABLE for the reason `ControllerDeps.run` is: a chip row's ordering, its
+ * one pane seat and its hand-back on a failed send are all decisions this half
+ * of the app makes, and testing them must not need a capture engine, a
+ * clipboard or a server.
+ */
+export interface AttachApi {
+  flash: typeof flash;
+  attachPane: typeof attachPane;
+  attachFiles: typeof attachFiles;
+  attachPaths: typeof attachPaths;
+  readDirs: typeof readDirs;
+  /** `readDirs` against the shots dir the pipeline has already resolved for
+   *  this agent — the synchronous read T's `shotDirSeen` exists for (T:9018). */
+  readDirsFor: typeof readDirsFor;
+  revoke: typeof revoke;
+  toWire: typeof toWire;
+  receiptFor: typeof receiptFor;
+  probePruned: typeof probePruned;
+  dragHasAttachment: typeof dragHasAttachment;
+  pathsFromDrop: typeof pathsFromDrop;
+  filesFromPaste: typeof filesFromPaste;
+}
+
+/** The real pipeline. One object rather than twelve imports at every call site,
+ *  and the seam a test replaces wholesale. */
+export const ATTACH_API: AttachApi = {
+  flash,
+  attachPane,
+  attachFiles,
+  attachPaths,
+  readDirs,
+  readDirsFor,
+  revoke,
+  toWire,
+  receiptFor,
+  probePruned,
+  dragHasAttachment,
+  pathsFromDrop,
+  filesFromPaste,
+};
+
+// ---- what gets drawn (T:7129-7215, T:10717-10760) --------------------------
+
+/** Anything the chip row, the viewer, a receipt or the popup can show: the union
+ *  of `Attachment` and `Receipt` as far as the DRAWING is concerned. `src` is
+ *  what to display (a blob URL this session, `/api/fs/raw` for a restored turn)
+ *  and `view` is the path the agent was handed, which is a different string and
+ *  the one worth showing (T:7195-7203). */
+export interface Viewable {
+  /** The `Attachment.id` this was drawn from, where there was one. Discard looks
+   *  the attachment up BY THIS: every refusal has `view: null`, so matching on
+   *  kind+view discarded the wrong chip of two failed pictures (PR2 review). */
+  id?: string;
+  kind: ShotKind;
+  view: string | null;
+  src?: string;
+  thumb?: string;
+  size?: number;
+  name?: string;
+  viewNote?: string;
+  why?: string;
+  /** Still in the tray: only then can Discard tell the truth (T:10768). */
+  pending?: boolean;
+}
+
+/** T:7143-7148 / T:10832-10834 — A PICTURE OR A GLYPH, NEVER BOTH, and the
+ *  glyph is a DOOR only where there is a room behind it: a real path, and one of
+ *  the two kinds the viewer opens without pixels. A refused attachment keeps the
+ *  plain span, so one "failed" chip shape serves whatever kind failed. */
+export function glyphDoor(shot: Viewable): boolean {
+  return !shot.src && !shot.thumb && !!shot.view && (shot.kind === "file" || shot.kind === "image");
+}
+
+/** T:7141 — the glyph itself. Where there is a thumbnail the picture IS the
+ *  icon, and putting 🖼 in front of it captions a photo with a drawing of one. */
+export function shotGlyph(shot: Pick<Viewable, "kind">): string {
+  return shot.kind === "file" ? "📄" : "🖼";
+}
+
+/** T:10722-10726 `shotViewOpen`'s admission test: something to show, or a file /
+ *  undecodable image — a real path, a real size and no pixels, which is a file
+ *  in every way that matters here. */
+export function viewerOpens(shot: Viewable | null | undefined): boolean {
+  if (!shot) return false;
+  if (shot.src || shot.thumb) return true;
+  return !!shot.view && (shot.kind === "file" || shot.kind === "image");
+}
+
+/** A PENDING attachment, as everything that draws one sees it. */
+export function toViewable(att: Attachment, pending = true): Viewable {
+  return {
+    id: att.id,
+    kind: att.kind,
+    view: att.view,
+    ...(att.thumb ? { thumb: att.thumb } : {}),
+    ...(typeof att.size === "number" ? { size: att.size } : {}),
+    ...(att.name ? { name: att.name } : {}),
+    ...(att.viewNote ? { viewNote: att.viewNote } : {}),
+    ...(att.why ? { why: att.why } : {}),
+    pending,
+  };
+}
+
+/** A SENT receipt, as everything that draws one sees it. */
+export function receiptViewable(r: Receipt): Viewable {
+  return {
+    ...(r.id ? { id: r.id } : {}),
+    kind: r.kind,
+    view: r.view,
+    ...(r.src || r.thumb ? { src: r.src || r.thumb } : {}),
+    ...(typeof r.size === "number" ? { size: r.size } : {}),
+    ...(r.name ? { name: r.name } : {}),
+    ...(r.viewNote ? { viewNote: r.viewNote } : {}),
+    ...(r.why ? { why: r.why } : {}),
+    pending: false,
+  };
+}
+
+/** T:10891 — an `<img>` that 404s. Said in words rather than left as a broken
+ *  image, which a reader takes for a bug in the chat rather than for a temp file
+ *  that expired. */
+export const SHOT_GONE = "screenshot no longer on disk";
+
+/** T:7099 — a size is only ever shown for something with no picture to look at:
+ *  a picture answers "is this the right one" by being looked at, where a
+ *  spreadsheet or a log answers it by name and size and nothing else. */
+export function shownSize(shot: Viewable): string {
+  return shot.src || shot.thumb ? "" : sizeLabel(shot.size);
+}
+
+// ---- an attachment's own preview (T:10712 `shotPreviewSrc`, D616) ---------
+
+/**
+ * The file's own fused-render template, framed inside the viewer. EXACTLY the
+ * pane's rule through the pane's own two functions — stat's offerable entries
+ * minus the conditional ones, first one wins, then `paneSrcFor` for the URL.
+ * Reused rather than re-derived, because a per-extension table here would drift
+ * from the registry on the next rebinding and ignore a user's own override
+ * (§16).
+ *
+ * `null` is the ORDINARY answer, not an error: a file with no template, a path
+ * the pruner has deleted, a server that declined. The viewer then stays exactly
+ * as it was before D616 — name, size, path, Discard, Close.
+ */
+export async function previewSrcFor(path: string | null): Promise<string | null> {
+  if (!path) return null;
+  try {
+    // T reads `{error}` off the body; `statPath` THROWS on a non-ok reply
+    // (platform/lib/api), and the catch below is the same answer.
+    const st = await statPath(path);
+    if (!st || st.is_dir) return null;
+    const entry = paneOfferable(st.templates)[0];
+    if (!entry) return null;
+    // The two stamps the shell puts on a display-only frame: this is a picture
+    // of a page, not an open the recents list should record, and the framed page
+    // may not steal the keyboard — the viewer is modal, and Escape has to keep
+    // belonging to it.
+    return paneSrcFor(entry, path, !!st.remote, { preview: true, noFocus: true });
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/apps/claude/ui/attachApi.ts
+++ b/frontend/src/apps/claude/ui/attachApi.ts
@@ -37,6 +37,7 @@ export {
   prunedLabel,
   receiptFor,
   receiptsFromWire,
+  settleReceipts,
   shotAlt,
   shotNoun,
   sizeLabel,

--- a/frontend/src/apps/claude/ui/index.ts
+++ b/frontend/src/apps/claude/ui/index.ts
@@ -177,6 +177,7 @@ export {
   receiptFor,
   receiptsFromWire,
   receiptViewable,
+  settleReceipts,
   shotAlt,
   shotGlyph,
   shotNoun,

--- a/frontend/src/apps/claude/ui/index.ts
+++ b/frontend/src/apps/claude/ui/index.ts
@@ -150,3 +150,42 @@ export {
   cardOverride,
   type CardPolicy,
 } from "./cardPolicy";
+
+// ---- attachments (PR2, inventory 03) --------------------------------------
+export { AttachTray, ShotThumb } from "./AttachTray";
+export type { AttachTrayProps } from "./AttachTray";
+export { ShotViewer, ShotViewerBody } from "./ShotViewer";
+export type { ShotViewerProps } from "./ShotViewer";
+export { Receipts } from "./Receipts";
+export type { ReceiptsProps } from "./Receipts";
+export { AnnStrip } from "./AnnStrip";
+export type { AnnStripProps } from "./AnnStrip";
+export { useAttachments } from "./useAttachments";
+export { fitStrip, useFitStrip } from "./useFitStrip";
+export { mergeSendOptions } from "./sendMerge";
+export type {
+  Attachments,
+  OutgoingAttachments,
+  UseAttachmentsOptions,
+} from "./useAttachments";
+export {
+  ATTACH_API,
+  failLabel,
+  glyphDoor,
+  prunedLabel,
+  previewSrcFor,
+  receiptFor,
+  receiptsFromWire,
+  receiptViewable,
+  shotAlt,
+  shotGlyph,
+  shotNoun,
+  shownSize,
+  sizeLabel,
+  toViewable,
+  viewerOpens,
+  SHOT_GONE,
+} from "./attachApi";
+export type { AttachApi, Viewable } from "./attachApi";
+export { SentPopBody } from "./SentPop";
+export type { SentPopProps } from "./SentPop";

--- a/frontend/src/apps/claude/ui/index.ts
+++ b/frontend/src/apps/claude/ui/index.ts
@@ -159,6 +159,8 @@ export type { ShotViewerProps } from "./ShotViewer";
 export { Receipts } from "./Receipts";
 export type { ReceiptsProps } from "./Receipts";
 export { AnnStrip } from "./AnnStrip";
+export { AttachIcon, MarkerText } from "./AttachIcon";
+export type { AttachIconProps } from "./AttachIcon";
 export type { AnnStripProps } from "./AnnStrip";
 export { useAttachments } from "./useAttachments";
 export { fitStrip, useFitStrip } from "./useFitStrip";
@@ -179,7 +181,6 @@ export {
   receiptViewable,
   settleReceipts,
   shotAlt,
-  shotGlyph,
   shotNoun,
   shownSize,
   sizeLabel,

--- a/frontend/src/apps/claude/ui/list-rows.ts
+++ b/frontend/src/apps/claude/ui/list-rows.ts
@@ -13,8 +13,8 @@ const MARKER_JOIN = " · ";
 /** The sentences `formatAnnotations` / the shot receipts always open with, and
  *  the marker that stands in for each once the words are cut (T:18060-18087). */
 const BLOCK_OPENERS: readonly (readonly [string, string])[] = [
-  ["The user attached ", "🖼 picture"],
-  ["The user annotated ", "💬 comments"],
+  ["The user attached ", "picture"],
+  ["The user annotated ", "comments"],
 ];
 
 /** Everything from `<live-app-state>` on is machinery, not a title. */

--- a/frontend/src/apps/claude/ui/marker-bubble.test.tsx
+++ b/frontend/src/apps/claude/ui/marker-bubble.test.tsx
@@ -1,0 +1,92 @@
+// THE WORDLESS SEND'S BUBBLE, and the reader who happens to type its words.
+//
+// A send with no typed text still gets a bubble, and what it says is what the
+// message CARRIED — "files", "images", "annotations", "pane screenshot" — each
+// with the lucide glyph the chip and the receipt wear (P2-7).
+//
+// T could tell those apart from a prompt because it wrote them with an emoji in
+// front. The port dropped the emoji and kept matching on the WORD, so a message
+// that was literally "files" — an ordinary thing to say to an agent — was drawn
+// as a wordless attachment send, icon and all (Bugbot, PR #1064). Marker-ness
+// is a private sigil now, and this suite pins both directions of that: the
+// marker still draws its icons and still SAYS only the word, and the reader's
+// own "files" is a plain bubble.
+import { installDomShim } from "@platform/lib/testDomShim";
+installDomShim();
+import { afterEach, expect, test } from "bun:test";
+import { act, create, type ReactTestRendererJSON } from "react-test-renderer";
+
+// Loaded AFTER the shim: `Turn` reaches the platform router through the receipt
+// row, and that module reads `location` at import time.
+const { MARKER_FILE, MARKER_JOIN, MARKER_VIEW } = await import("../protocol/wire");
+const { Turn } = await import("./Turn");
+type UserTurn = import("../protocol/controller-api").UserTurn;
+
+const mounted: Array<ReturnType<typeof create>> = [];
+function mount(el: React.ReactElement) {
+  let r!: ReturnType<typeof create>;
+  act(() => {
+    r = create(el);
+  });
+  mounted.push(r);
+  return r;
+}
+afterEach(() => {
+  for (const r of mounted.splice(0)) act(() => r.unmount());
+});
+
+type Json = ReactTestRendererJSON;
+function walk(node: Json | string | null, hit: (n: Json | string) => void): void {
+  if (!node) return;
+  hit(node);
+  if (typeof node === "string") return;
+  for (const k of node.children ?? []) walk(k as Json, hit);
+}
+
+/** Every text node under the bubble, joined: what the reader actually reads. */
+function bubbleText(r: ReturnType<typeof create>): string {
+  let out = "";
+  walk(r.toJSON() as Json, (n) => {
+    if (typeof n === "string") out += n;
+  });
+  return out;
+}
+
+function count(r: ReturnType<typeof create>, type: string): number {
+  let n = 0;
+  walk(r.toJSON() as Json, (node) => {
+    if (typeof node !== "string" && node.type === type) n += 1;
+  });
+  return n;
+}
+
+function markers(r: ReturnType<typeof create>): number {
+  let n = 0;
+  walk(r.toJSON() as Json, (node) => {
+    if (typeof node === "string") return;
+    const c = (node.props as { className?: string } | undefined)?.className;
+    if (typeof c === "string" && c.split(/\s+/).includes("c-marker")) n += 1;
+  });
+  return n;
+}
+
+const user = (text: string): UserTurn => ({ role: "user", key: "u:1", text });
+
+test("a wordless send's bubble draws one icon per marker, and only the words", () => {
+  const r = mount(<Turn turn={user(MARKER_FILE + MARKER_JOIN + MARKER_VIEW)} />);
+  expect(markers(r)).toBe(2);
+  // Two lucide glyphs, and no emoji anywhere near them (P2-7).
+  expect(count(r, "svg")).toBe(2);
+  // The SIGIL IS MACHINERY: it is invisible, and it does not reach the page.
+  expect(bubbleText(r)).toBe("files" + MARKER_JOIN + "pane screenshot");
+  expect(bubbleText(r)).not.toContain("⁣");
+});
+
+test("a reader who types a marker's word gets a plain bubble (Bugbot, PR #1064)", () => {
+  for (const typed of ["files", "images", "annotations", "pane screenshot", "files + images"]) {
+    const r = mount(<Turn turn={user(typed)} />);
+    expect(markers(r)).toBe(0);
+    expect(count(r, "svg")).toBe(0);
+    expect(bubbleText(r)).toBe(typed);
+  }
+});

--- a/frontend/src/apps/claude/ui/no-emoji.test.ts
+++ b/frontend/src/apps/claude/ui/no-emoji.test.ts
@@ -1,0 +1,48 @@
+// NO EMOJI IN THE CHAT'S UI (Akshil, 2026-09-09, P2-7).
+//
+// The port shipped 📄/🖼 on the attachment chips and receipts, 📌 on a comment
+// row, and 📌/🖼/📄 in the markers a wordless send's bubble shows. Every icon in
+// this app comes from `lucide-react`, and an emoji is the one glyph an app
+// cannot draw: it arrives at a weight and a hue the platform font picked and is
+// a different picture on each OS.
+//
+// A GREP, not a render assertion, because the failure mode is a new one being
+// typed somewhere else next week — the icon vocabulary is `ui/AttachIcon` and a
+// literal in any other file is the bug. Comments are stripped first: a line
+// EXPLAINING which emoji was replaced is exactly the note that must survive.
+import { expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/** Pictographs and the variation selector that dresses a symbol up as one.
+ *  NOT the plain symbol ranges: `✕`, `✓`, `✗`, `←`, `→` and `⋮` are T's own
+ *  typographic marks, they take the surrounding ink and metrics, and every one
+ *  of them is in the template verbatim. */
+const EMOJI = /[\u{1F000}-\u{1FAFF}\u{FE0F}]|[\u{2600}-\u{27BF}]\u{FE0F}/u;
+
+/** Line and block comments out, so a note about the emoji that was removed can
+ *  stay where the reader will need it. Strings are deliberately kept. */
+function code(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.(ts|tsx|css)$/.test(name) && !/\.test\.tsx?$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+test("no emoji literal anywhere in the chat's own source", () => {
+  const root = join(import.meta.dir, "..");
+  const bad: string[] = [];
+  for (const file of walk(root)) {
+    const lines = code(readFileSync(file, "utf8")).split("\n");
+    lines.forEach((line, i) => {
+      if (EMOJI.test(line)) bad.push(file.slice(root.length + 1) + ":" + (i + 1) + " " + line.trim());
+    });
+  }
+  expect(bad).toEqual([]);
+});

--- a/frontend/src/apps/claude/ui/receipts.test.tsx
+++ b/frontend/src/apps/claude/ui/receipts.test.tsx
@@ -126,6 +126,48 @@ test("a live send wears the receipts it was given, not a re-read of the wire", (
   expect(img[0]!.props.src).toBe("blob:live");
 });
 
+test("the blob → disk hand-off is not a pruned file (Bugbot, PR #1064)", () => {
+  // A live send's receipt is drawn with the attachment's own object URL and is
+  // re-pointed at the copy on disk the moment the bytes are written. The handle
+  // is released on the way past, and the <img> showing it errors — which used to
+  // be read as "the pruner deleted this", so EVERY successful send of a pasted
+  // or captured picture ended in "screenshot no longer on disk".
+  //
+  // A `blob:` handle is this page's own and the pruner cannot touch one, so its
+  // error says nothing about the file. And the verdict is keyed on the src, so
+  // one reached before the swap does not outlive it.
+  const live: UserTurn = {
+    ...turn,
+    attachments: [
+      { kind: "pane", label: "screenshot attached", view: "/shots/x.png", thumb: "blob:live" },
+    ],
+  };
+  const row = (t: UserTurn) => (
+    <Receipts turn={t} paneNoun="preview" onOpenShot={() => {}} probe={async () => false} />
+  );
+  const r = mount(row(live));
+  const img = () => r.root.findAllByType("img")[0]!;
+  act(() => img().props.onError());
+  expect(texts(r, "annsum-gone")).toEqual([]);
+  expect(img().props.src).toBe("blob:live");
+
+  // The settled turn: the same row, now pointed at the server's copy.
+  const onDisk = "/api/fs/raw?path=%2Fshots%2Fx.png";
+  const settled: UserTurn = {
+    ...live,
+    attachments: [{ ...live.attachments![0]!, thumb: onDisk }],
+  };
+  act(() => {
+    r.update(row(settled));
+  });
+  expect(img().props.src).toBe(onDisk);
+  expect(texts(r, "annsum-gone")).toEqual([]);
+
+  // …and a copy that really is gone still says so, in words.
+  act(() => img().props.onError());
+  expect(texts(r, "annsum-gone")).toEqual(["screenshot no longer on disk"]);
+});
+
 test("a turn that carried nothing draws no receipt", () => {
   const bare: UserTurn = { role: "user", key: "u:2", text: "hello", raw: "hello" };
   const r = mount(<Receipts turn={bare} paneNoun="preview" onOpenShot={() => {}} probe={async () => false} />);

--- a/frontend/src/apps/claude/ui/receipts.test.tsx
+++ b/frontend/src/apps/claude/ui/receipts.test.tsx
@@ -12,7 +12,7 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 const { Receipts } = await import("./Receipts");
 // The dialogs' BODIES: a Base UI dialog portals itself, and this suite has no
 // document to portal into — the body is the whole content either way.
-const { ShotViewerBody } = await import("./ShotViewer");
+const { ShotViewerBody, ShotViewerFooter, shotViewerTitle } = await import("./ShotViewer");
 const { SentPopBody } = await import("./SentPop");
 const { composeOutgoing, formatAnnotations, paneShotBlock, APP_STATE_TAG } = await import(
   "../protocol/wire"
@@ -200,12 +200,12 @@ const pending: Viewable = {
 };
 
 test("the viewer shows nothing at all until it is given a picture", () => {
-  const r = mount(<ShotViewerBody shot={null} paneNoun="preview" onClose={() => {}} />);
+  const r = mount(<ShotViewerBody shot={null} paneNoun="preview" />);
   expect(r.toJSON()).toBe(null);
 });
 
 test("the picture toggles fitted ⇄ actual size on click (T:10937)", () => {
-  const r = mount(<ShotViewerBody shot={pending} paneNoun="preview" onClose={() => {}} />);
+  const r = mount(<ShotViewerBody shot={pending} paneNoun="preview" />);
   const box = () => r.root.findByProps({ className: "c-shotview-box" });
   expect(box().props["data-zoom"]).toBe(undefined);
   act(() => r.root.findByProps({ className: "c-shotview-img" }).props.onClick());
@@ -214,18 +214,25 @@ test("the picture toggles fitted ⇄ actual size on click (T:10937)", () => {
   expect(box().props["data-zoom"]).toBe(undefined);
 });
 
+// P2-3: the viewer is a `platform/ui/modal/Modal` now, so the path, Discard and
+// Close are the chassis' FOOTER and the name is its TITLE. The chassis portals
+// itself and this suite has no document, so the seams are the footer and the
+// title function.
 test("Discard is offered for a PENDING shot only, and closes with it (T:4392)", () => {
   let discarded = 0;
   let closed = 0;
   const r = mount(
-    <ShotViewerBody
+    <ShotViewerFooter
       shot={pending}
       paneNoun="preview"
       onClose={() => (closed += 1)}
       onDiscard={() => (discarded += 1)}
     />,
   );
-  const drop = () => els(r, "c-pill c-shotview-drop");
+  const drop = () =>
+    r.root.findAll(
+      (n) => n.type === "button" && String(n.props.className).includes("c-shotview-drop"),
+    );
   expect(drop().length).toBe(1);
   act(() => drop()[0]!.props.onClick());
   expect(discarded).toBe(1);
@@ -234,7 +241,7 @@ test("Discard is offered for a PENDING shot only, and closes with it (T:4392)", 
   // un-send it would be a lie.
   act(() => {
     r.update(
-      <ShotViewerBody
+      <ShotViewerFooter
         shot={{ ...pending, pending: false }}
         paneNoun="preview"
         onClose={() => {}}
@@ -242,18 +249,34 @@ test("Discard is offered for a PENDING shot only, and closes with it (T:4392)", 
       />,
     );
   });
-  expect(els(r, "c-pill c-shotview-drop").length).toBe(0);
+  expect(drop().length).toBe(0);
+  // Close is always there, and it is the app's own secondary button rather than
+  // a pill of this component's own.
+  const close = r.root.findAll(
+    (n) => n.type === "button" && String(n.props.className) === "btn btn-secondary",
+  );
+  expect(close.length).toBe(1);
 });
 
-test("the caveat and the path are shown where the pixels are (T:1094, 1084)", () => {
-  const r = mount(<ShotViewerBody shot={pending} paneNoun="preview" onClose={() => {}} />);
-  expect(texts(r, "c-shotview-note")).toEqual(["the map did not render"]);
-  expect(texts(r, "c-shotview-path c-mono")).toEqual(["/shots/view.png"]);
-  // A picture says its own name by being shown, so the file stand-in stays away.
-  expect(els(r, "c-shotview-name").length).toBe(0);
+test("the caveat rides the pixels and the path rides the footer (T:1094, 1084)", () => {
+  const body = mount(<ShotViewerBody shot={pending} paneNoun="preview" />);
+  expect(texts(body, "c-shotview-note")).toEqual(["the map did not render"]);
+  const foot = mount(<ShotViewerFooter shot={pending} paneNoun="preview" onClose={() => {}} />);
+  expect(texts(foot, "c-shotview-path c-mono")).toEqual(["/shots/view.png"]);
 });
 
-test("a FILE has no pixels, so it gets its name, its size and its own template", async () => {
+test("the HEAD names it: a picture by its noun, a file by name and size", () => {
+  // A picture says how big it is by being looked at (T:7099), so no size.
+  expect(shotViewerTitle(pending, "preview")).toBe("preview screenshot");
+  expect(
+    shotViewerTitle(
+      { kind: "file", view: "/home/me/data/rows.csv", name: "rows.csv", size: 4096 },
+      "preview",
+    ),
+  ).toBe("rows.csv · 4 KB");
+});
+
+test("a FILE has no pixels, so it gets its own template framed in the body", async () => {
   const file: Viewable = {
     kind: "file",
     view: "/home/me/data/rows.csv",
@@ -261,18 +284,20 @@ test("a FILE has no pixels, so it gets its name, its size and its own template",
     size: 4096,
     pending: false,
   };
-  const r = mount(<ShotViewerBody shot={file} paneNoun="preview" onClose={() => {}} />);
-  expect(texts(r, "c-shotview-name")).toEqual(["rows.csv · 4 KB"]);
+  const r = mount(<ShotViewerBody shot={file} paneNoun="preview" />);
   // The line that promises a preview is up while the stat is in flight: a blank
   // box for those seconds reads as a preview that failed (T:4384).
   expect(texts(r, "c-shotview-loading")).toEqual(["loading preview…"]);
   expect(r.root.findAll((n) => n.type === "img").length).toBe(0);
   // No stat answer here (no server): the promise settles to null and the line
-  // goes, which is the D616 "no template for this extension" case.
+  // goes, which is the D616 "no template for this extension" case — and the
+  // glyph takes the empty body, so the viewer never shows nothing at all.
   await act(async () => {
     await Promise.resolve();
     await Promise.resolve();
   });
+  expect(els(r, "c-shotview-loading").length).toBe(0);
+  expect(els(r, "c-shotview-blank").length).toBe(1);
 });
 
 // ---- "what was sent" -------------------------------------------------------

--- a/frontend/src/apps/claude/ui/receipts.test.tsx
+++ b/frontend/src/apps/claude/ui/receipts.test.tsx
@@ -170,7 +170,7 @@ test("comments ride the message, so every row opens the popup instead (T:11068)"
 
 test("a picture-only send keeps the plain viewer on its thumb (T:11075)", () => {
   const pics = composeOutgoing("", [paneShotBlock([{ kind: "pane", view: "/shots/a.png" }], "preview")]);
-  const only: UserTurn = { role: "user", key: "u:3", text: "🖼 pane screenshot", raw: pics };
+  const only: UserTurn = { role: "user", key: "u:3", text: "pane screenshot", raw: pics };
   const shots: Viewable[] = [];
   const r = mount(
     <Receipts

--- a/frontend/src/apps/claude/ui/receipts.test.tsx
+++ b/frontend/src/apps/claude/ui/receipts.test.tsx
@@ -1,0 +1,335 @@
+// The receipt a sent turn wears, restored from the wire it was sent on, and the
+// two overlays behind it (inventory 03 §C/§D/§E).
+//
+// The FIXTURE is the point of this suite: one composed message carrying all
+// three blocks, read back exactly as a reopened session reads it — so a receipt
+// that is visible while the session lasts is provably there when it is reopened.
+import { installDomShim } from "@platform/lib/testDomShim";
+installDomShim();
+import { expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+const { Receipts } = await import("./Receipts");
+// The dialogs' BODIES: a Base UI dialog portals itself, and this suite has no
+// document to portal into — the body is the whole content either way.
+const { ShotViewerBody } = await import("./ShotViewer");
+const { SentPopBody } = await import("./SentPop");
+const { composeOutgoing, formatAnnotations, paneShotBlock, APP_STATE_TAG } = await import(
+  "../protocol/wire"
+);
+type UserTurn = import("../protocol/controller-api").UserTurn;
+type Receipt = import("../shots/types").Receipt;
+type Viewable = import("./attachApi").Viewable;
+
+/** A turn as a reopened session hands it over: nothing but `raw`. */
+const OUTGOING = composeOutgoing("have a look at this", [
+  "<" + APP_STATE_TAG + ">\n{}\n</" + APP_STATE_TAG + ">",
+  paneShotBlock(
+    [
+      { kind: "overview", view: "/shots/20260908-over.png", viewNote: "the footer was cut off" },
+      { kind: "pane", view: "/shots/20260908-view.png" },
+      { kind: "image", view: "/shots/pasted.png", name: "pasted.png" },
+      { kind: "file", view: "/home/me/data/rows.csv", name: "rows.csv", size: 4096 },
+      { kind: "image", view: null, why: "could not be saved" },
+    ],
+    "preview",
+  ),
+  formatAnnotations(
+    [
+      { label: "A", kind: "element", tag: "button", content: "this is the wrong colour", t: 65 },
+      { label: "B", kind: "point", x: 12, y: 40, content: "" },
+    ],
+    "file",
+  ),
+]);
+
+const turn: UserTurn = { role: "user", key: "u:1", text: "have a look at this", raw: OUTGOING };
+
+function mount(node: React.ReactElement) {
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(node);
+  });
+  return renderer!;
+}
+
+/** ELEMENT nodes only: `findAll` also matches the composite component whose
+ *  props carry the same className, and a composite has no `onClick` to fire. */
+function els(root: ReactTestRenderer, className: string) {
+  return root.root.findAll(
+    (n) => typeof n.type === "string" && n.props.className === className,
+  );
+}
+
+const panes = (root: ReactTestRenderer) => els(root, "annsum-pane");
+
+function texts(root: ReactTestRenderer, className: string): string[] {
+  return root.root
+    .findAll((n) => typeof n.type === "string" && n.props.className === className)
+    .map((n) => String(n.props.children));
+}
+
+test("a restored turn rebuilds every receipt row from its own wire (T:10903)", () => {
+  const r = mount(<Receipts turn={turn} paneNoun="preview" onOpenShot={() => {}} probe={async () => false} />);
+  expect(texts(r, "annsum-txt")).toEqual([
+    "annotated overview attached",
+    "screenshot attached",
+    "image attached: pasted.png",
+    "file attached: rows.csv",
+    "no image — could not be saved",
+    // The comment rows, with the user's own words (and nothing for the wordless
+    // spot — the placeholder is a wire token, not a receipt's line).
+    "this is the wrong colour",
+    "",
+  ]);
+  // Pictures are drawn; a file and a refusal are not (an <img> pointed at a .csv
+  // is a broken-image glyph, which reads as a bug).
+  expect(panes(r).length).toBe(3);
+});
+
+test("a pruned copy is said in words, once the probe answers (T:10875)", async () => {
+  const asked: Receipt[] = [];
+  const r = mount(
+    <Receipts
+      turn={turn}
+      paneNoun="preview"
+      onOpenShot={() => {}}
+      probe={async (receipt) => {
+        asked.push(receipt);
+        return true;
+      }}
+    />,
+  );
+  await act(async () => {
+    await Promise.resolve();
+  });
+  // Only the rows with a path and nothing to draw have a question at all: the
+  // file. A refusal has no path, and a picture's 404 announces itself.
+  expect(asked.map((a) => a.view)).toEqual(["/home/me/data/rows.csv"]);
+  expect(texts(r, "annsum-gone")).toEqual([" — file pruned"]);
+});
+
+test("a live send wears the receipts it was given, not a re-read of the wire", () => {
+  const live: UserTurn = {
+    ...turn,
+    attachments: [
+      { kind: "pane", label: "screenshot attached", view: "/shots/x.png", thumb: "blob:live" },
+    ],
+  };
+  const r = mount(<Receipts turn={live} paneNoun="preview" onOpenShot={() => {}} probe={async () => false} />);
+  expect(texts(r, "annsum-txt")).toEqual([
+    "screenshot attached",
+    "this is the wrong colour",
+    "",
+  ]);
+  const img = r.root.findAll((n) => n.type === "img");
+  expect(img[0]!.props.src).toBe("blob:live");
+});
+
+test("a turn that carried nothing draws no receipt", () => {
+  const bare: UserTurn = { role: "user", key: "u:2", text: "hello", raw: "hello" };
+  const r = mount(<Receipts turn={bare} paneNoun="preview" onOpenShot={() => {}} probe={async () => false} />);
+  expect(r.toJSON()).toBe(null);
+});
+
+test("comments ride the message, so every row opens the popup instead (T:11068)", () => {
+  let opened = 0;
+  const r = mount(
+    <Receipts
+      turn={turn}
+      paneNoun="preview"
+      onOpenShot={() => {}}
+      onShowSent={() => {
+        opened += 1;
+      }}
+      probe={async () => false}
+    />,
+  );
+  const note = els(r, "annsum-row annsum-note")[0]!;
+  expect(note.props.role).toBe("button");
+  expect(note.props.tabIndex).toBe(0);
+  act(() => note.props.onClick());
+  // Space and Enter reach it too: a div with an onclick is invisible to a
+  // keyboard (T:11061-11065).
+  let prevented = false;
+  act(() =>
+    note.props.onKeyDown({
+      key: " ",
+      preventDefault: () => {
+        prevented = true;
+      },
+    }),
+  );
+  expect(prevented).toBe(true);
+  // ... and so does the screenshot thumb, because the picture belongs to the
+  // comments here.
+  const thumb = panes(r)[0]!;
+  act(() => thumb.props.onClick());
+  expect(opened).toBe(3);
+});
+
+test("a picture-only send keeps the plain viewer on its thumb (T:11075)", () => {
+  const pics = composeOutgoing("", [paneShotBlock([{ kind: "pane", view: "/shots/a.png" }], "preview")]);
+  const only: UserTurn = { role: "user", key: "u:3", text: "🖼 pane screenshot", raw: pics };
+  const shots: Viewable[] = [];
+  const r = mount(
+    <Receipts
+      turn={only}
+      paneNoun="preview"
+      onOpenShot={(s) => shots.push(s)}
+      onShowSent={() => {
+        throw new Error("a send with no comments must not be wired to the popup");
+      }}
+      probe={async () => false}
+    />,
+  );
+  const thumb = panes(r)[0]!;
+  act(() => thumb.props.onClick());
+  expect(shots.length).toBe(1);
+  expect(shots[0]!.view).toBe("/shots/a.png");
+});
+
+// ---- the viewer ------------------------------------------------------------
+
+const pending: Viewable = {
+  kind: "pane",
+  view: "/shots/view.png",
+  src: "blob:v",
+  viewNote: "the map did not render",
+  pending: true,
+};
+
+test("the viewer shows nothing at all until it is given a picture", () => {
+  const r = mount(<ShotViewerBody shot={null} paneNoun="preview" onClose={() => {}} />);
+  expect(r.toJSON()).toBe(null);
+});
+
+test("the picture toggles fitted ⇄ actual size on click (T:10937)", () => {
+  const r = mount(<ShotViewerBody shot={pending} paneNoun="preview" onClose={() => {}} />);
+  const box = () => r.root.findByProps({ className: "c-shotview-box" });
+  expect(box().props["data-zoom"]).toBe(undefined);
+  act(() => r.root.findByProps({ className: "c-shotview-img" }).props.onClick());
+  expect(box().props["data-zoom"]).toBe("");
+  act(() => r.root.findByProps({ className: "c-shotview-img" }).props.onClick());
+  expect(box().props["data-zoom"]).toBe(undefined);
+});
+
+test("Discard is offered for a PENDING shot only, and closes with it (T:4392)", () => {
+  let discarded = 0;
+  let closed = 0;
+  const r = mount(
+    <ShotViewerBody
+      shot={pending}
+      paneNoun="preview"
+      onClose={() => (closed += 1)}
+      onDiscard={() => (discarded += 1)}
+    />,
+  );
+  const drop = () => els(r, "c-pill c-shotview-drop");
+  expect(drop().length).toBe(1);
+  act(() => drop()[0]!.props.onClick());
+  expect(discarded).toBe(1);
+  expect(closed).toBe(1);
+  // A SENT picture is already in the agent's hands, and a Discard that cannot
+  // un-send it would be a lie.
+  act(() => {
+    r.update(
+      <ShotViewerBody
+        shot={{ ...pending, pending: false }}
+        paneNoun="preview"
+        onClose={() => {}}
+        onDiscard={() => {}}
+      />,
+    );
+  });
+  expect(els(r, "c-pill c-shotview-drop").length).toBe(0);
+});
+
+test("the caveat and the path are shown where the pixels are (T:1094, 1084)", () => {
+  const r = mount(<ShotViewerBody shot={pending} paneNoun="preview" onClose={() => {}} />);
+  expect(texts(r, "c-shotview-note")).toEqual(["the map did not render"]);
+  expect(texts(r, "c-shotview-path c-mono")).toEqual(["/shots/view.png"]);
+  // A picture says its own name by being shown, so the file stand-in stays away.
+  expect(els(r, "c-shotview-name").length).toBe(0);
+});
+
+test("a FILE has no pixels, so it gets its name, its size and its own template", async () => {
+  const file: Viewable = {
+    kind: "file",
+    view: "/home/me/data/rows.csv",
+    name: "rows.csv",
+    size: 4096,
+    pending: false,
+  };
+  const r = mount(<ShotViewerBody shot={file} paneNoun="preview" onClose={() => {}} />);
+  expect(texts(r, "c-shotview-name")).toEqual(["rows.csv · 4 KB"]);
+  // The line that promises a preview is up while the stat is in flight: a blank
+  // box for those seconds reads as a preview that failed (T:4384).
+  expect(texts(r, "c-shotview-loading")).toEqual(["loading preview…"]);
+  expect(r.root.findAll((n) => n.type === "img").length).toBe(0);
+  // No stat answer here (no server): the promise settles to null and the line
+  // goes, which is the D616 "no template for this extension" case.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});
+
+// ---- "what was sent" -------------------------------------------------------
+
+test("the popup's sections are the wire's, in T's order (T:10973-11040)", () => {
+  const r = mount(<SentPopBody outgoing={OUTGOING} paneNoun="preview" />);
+  const heads = r.root.findAll((n) => n.type === "h4").map((n) => String(n.props.children));
+  expect(heads).toEqual([
+    "Overview screenshot (badges mark each comment)",
+    // One per other picture, named by what it IS (`shotNoun`).
+    "preview screenshot",
+    "pasted.png",
+    "rows.csv",
+    "pasted image",
+    "Comments",
+    "Exact message the agent received",
+  ]);
+  // The overview's caveat is prefixed, because there is a picture above it.
+  expect(texts(r, "c-sent-caveat")).toEqual(["caveat: the footer was cut off"]);
+  // A file is never drawn, and neither is a refusal.
+  expect(els(r, "c-sent-shot").length).toBe(3);
+});
+
+test("each comment carries its label, its words and its context", () => {
+  const r = mount(<SentPopBody outgoing={OUTGOING} paneNoun="preview" />);
+  expect(texts(r, "c-sent-note-lbl")).toEqual(["A", "B"]);
+  expect(texts(r, "c-sent-note-meta")).toEqual(["<button> · at 1:05", "exact spot (12, 40)"]);
+  // A spot the user marked without saying anything still gets a row.
+  const rows = els(r, "c-sent-note-row");
+  expect(String(rows[1]!.props.children[1].props.children)).toBe("(no words)");
+});
+
+test("the exact message is the wire itself, blocks and all", () => {
+  const r = mount(<SentPopBody outgoing={OUTGOING} paneNoun="preview" />);
+  const pre = r.root.findByProps({ className: "c-sent-wire" });
+  expect(String(pre.props.children)).toBe(OUTGOING);
+});
+
+test("a send with no blocks still has the one section that always exists", () => {
+  const r = mount(<SentPopBody outgoing="just words" />);
+  expect(r.root.findAll((n) => n.type === "h4").map((n) => String(n.props.children))).toEqual([
+    "Exact message the agent received",
+  ]);
+});
+
+test("a picture inside the popup opens the viewer over it (T:1147)", () => {
+  const shots: Viewable[] = [];
+  const r = mount(
+    <SentPopBody
+      outgoing={OUTGOING}
+      paneNoun="preview"
+      onOpenShot={(s) => shots.push(s)}
+    />,
+  );
+  const img = els(r, "c-sent-shot")[0]!;
+  act(() => img.props.onClick());
+  expect(shots.length).toBe(1);
+  expect(shots[0]!.view).toBe("/shots/20260908-over.png");
+  expect(shots[0]!.pending).toBe(false);
+});

--- a/frontend/src/apps/claude/ui/sendMerge.test.ts
+++ b/frontend/src/apps/claude/ui/sendMerge.test.ts
@@ -1,0 +1,153 @@
+// THE ONE THING THAT MUST NOT BE A SPREAD (inventory 03 §D).
+//
+// Both send roads used to read `{ ...opts, ...takeAttachments() }`, which does
+// not merge and fixes no order: the tray's `blocks` REPLACED the caller's, so
+// PR3's `<annotations>` and PR4's `<live-app-state>` would have gone out missing
+// with the run succeeding and nothing on screen to say so. These tests are the
+// enforcement point that finding asked for — they fail if a future PR's block
+// can be lost, or lands in front of one that has a stated place.
+import { describe, expect, test } from "bun:test";
+
+import {
+  ANN_TAG,
+  APP_STATE_TAG,
+  BLOCK_ORDER,
+  blockRank,
+  composeBlocks,
+  composeOutgoing,
+  PANE_SHOT_TAG,
+  stripBlocks,
+} from "../protocol/wire";
+import { mergeSendOptions } from "./sendMerge";
+
+const state = "<" + APP_STATE_TAG + ">\nrows\n</" + APP_STATE_TAG + ">";
+const shots = "<" + PANE_SHOT_TAG + ">\n[]\n</" + PANE_SHOT_TAG + ">";
+const notes = "<" + ANN_TAG + ">\nnote\n</" + ANN_TAG + ">";
+
+describe("composeBlocks owns §D's order", () => {
+  test("state, pane-shot, annotations — whatever order the owners arrive in", () => {
+    // The three orders that matter: T's own, its reverse, and the one PR2's
+    // spread produced by accident (the tray last).
+    expect(composeBlocks([state], [shots], [notes])).toEqual([state, shots, notes]);
+    expect(composeBlocks([notes], [shots], [state])).toEqual([state, shots, notes]);
+    expect(composeBlocks([notes, state], [shots])).toEqual([state, shots, notes]);
+  });
+
+  test("NOTHING IS DROPPED — the whole point of the helper", () => {
+    // The failure this replaces: `{ ...opts, ...mine }` kept exactly one of
+    // these two lists.
+    expect(composeBlocks([state, notes], [shots])).toHaveLength(3);
+    // And an unrecognised block is kept too, at the end rather than in front of
+    // the three with a stated place: an owner nobody has written yet is still an
+    // owner whose words the user typed.
+    const mine = "<something-new>x</something-new>";
+    expect(composeBlocks([mine], [state])).toEqual([state, mine]);
+  });
+
+  test("empties and blanks fall out, so an empty tray adds no joiner", () => {
+    expect(composeBlocks(null, undefined, [], ["", null, undefined])).toEqual([]);
+    // Which is what keeps `composeOutgoing`'s "\n\n" from leading the message.
+    expect(composeOutgoing("hi", composeBlocks(null, []))).toBe("hi");
+  });
+
+  test("the sort is STABLE: two blocks of one kind keep their owner's order", () => {
+    const a = "<" + PANE_SHOT_TAG + ">\nA\n</" + PANE_SHOT_TAG + ">";
+    const b = "<" + PANE_SHOT_TAG + ">\nB\n</" + PANE_SHOT_TAG + ">";
+    expect(composeBlocks([a, b], [state])).toEqual([state, a, b]);
+  });
+
+  test("an opening tag with ATTRIBUTES still takes its own seat", () => {
+    // The silent failure this pins: `<live-app-state v="2">` is PR4's tag to
+    // write, and a bare `<tag>` sniff would have dropped it to the unranked tail
+    // — state after the pictures, message still sent, nothing to say so.
+    const versioned = "<" + APP_STATE_TAG + ' v="2">\nrows\n</' + APP_STATE_TAG + ">";
+    expect(blockRank(versioned)).toBe(0);
+    expect(composeBlocks([notes], [versioned])).toEqual([versioned, notes]);
+    // A tag NAME that merely starts like one of the three is not one of them.
+    expect(blockRank("<" + APP_STATE_TAG + "-draft>x</" + APP_STATE_TAG + "-draft>")).toBe(
+      BLOCK_ORDER.length,
+    );
+    // And the sniff stops at the end of the tag it is reading: a `>` inside an
+    // attribute is the attribute's, not the tag's end.
+    expect(blockRank("<" + PANE_SHOT_TAG + ' alt="a>b">x</' + PANE_SHOT_TAG + ">")).toBe(1);
+  });
+
+  test("blockRank reads the opening tag, and only the opening tag", () => {
+    expect(BLOCK_ORDER).toEqual([APP_STATE_TAG, PANE_SHOT_TAG, ANN_TAG]);
+    expect(blockRank(state)).toBe(0);
+    expect(blockRank(shots)).toBe(1);
+    expect(blockRank(notes)).toBe(2);
+    // Leading whitespace is not a different block.
+    expect(blockRank("\n  " + notes)).toBe(2);
+    // Plain prose has no tag and therefore no claim on a seat.
+    expect(blockRank("just words")).toBe(BLOCK_ORDER.length);
+  });
+
+  test("the composed message still strips back to the typed text", () => {
+    // The invariant PR3/PR4 inherit: reordering blocks must not break the
+    // round trip the transcript and the receipts both read through.
+    const out = composeOutgoing("please fix", composeBlocks([notes], [shots], [state]));
+    expect(out.indexOf(state)).toBeLessThan(out.indexOf(shots));
+    expect(out.indexOf(shots)).toBeLessThan(out.indexOf(notes));
+    expect(stripBlocks(out)).toBe("please fix");
+  });
+});
+
+describe("mergeSendOptions", () => {
+  test("the three ADDITIVE fields are unioned, not overwritten", () => {
+    const r1 = { kind: "image" as const, label: "a", view: "/a.png" };
+    const r2 = { kind: "file" as const, label: "b", view: "/b.csv" };
+    const out = mergeSendOptions(
+      { blocks: [notes], readDirs: ["/notes"], attachments: [r1] },
+      { blocks: [shots], readDirs: ["/shots"], attachments: [r2] },
+    );
+    expect(out.blocks).toEqual([shots, notes]);
+    expect(out.readDirs).toEqual(["/notes", "/shots"]);
+    expect(out.attachments).toEqual([r1, r2]);
+  });
+
+  test("a Read rule granted twice is granted once (T:11698)", () => {
+    const out = mergeSendOptions({ readDirs: ["/shots", "/w"] }, { readDirs: ["/shots"] });
+    expect(out.readDirs).toEqual(["/shots", "/w"]);
+  });
+
+  test("the scalars are the caller's, and the empty fields are absent", () => {
+    // `model`/`effort`/`permission` are the composer's answer; the tray never
+    // has one, so a merge must not blank them.
+    const out = mergeSendOptions({ model: "opus", effort: "high" }, {});
+    expect(out.model).toBe("opus");
+    expect(out.effort).toBe("high");
+    // Absent rather than `[]`: `sendFollowUp` refuses a send with no text and no
+    // blocks by asking `blocks.length`, and an empty array on the wire would
+    // also cost `read_dirs: "[]"` a place in every start.
+    expect("blocks" in out).toBe(false);
+    expect("readDirs" in out).toBe(false);
+    expect("attachments" in out).toBe(false);
+  });
+
+  test("THE CALLER WINS A CONFLICTING SCALAR — the doc's rule, enforced", () => {
+    // Latent only while `take()` returns no scalar at all: `{ ...base, ...extra }`
+    // reads as a merge and gives EXTRA precedence, so the day the tray carries a
+    // `model` of its own it would overrule the pill the user set.
+    const out = mergeSendOptions(
+      { model: "opus", effort: "high", permission: "prompt" },
+      { model: "haiku", effort: "low", permission: "acceptEdits" },
+    );
+    expect(out.model).toBe("opus");
+    expect(out.effort).toBe("high");
+    expect(out.permission).toBe("prompt");
+  });
+
+  test("a scalar the caller merely left `undefined` is not an answer", () => {
+    // The other half of the rule: "the caller's unless ONLY the tray named it".
+    const out = mergeSendOptions({ model: undefined, effort: "high" }, { model: "haiku" });
+    expect(out.model).toBe("haiku");
+    expect(out.effort).toBe("high");
+  });
+
+  test("an empty tray leaves the caller's own lists exactly as they were", () => {
+    const out = mergeSendOptions({ blocks: [state], readDirs: ["/w"] }, {});
+    expect(out.blocks).toEqual([state]);
+    expect(out.readDirs).toEqual(["/w"]);
+  });
+});

--- a/frontend/src/apps/claude/ui/sendMerge.ts
+++ b/frontend/src/apps/claude/ui/sendMerge.ts
@@ -1,0 +1,51 @@
+// ONE MERGE FOR EVERY SEND, because a spread is not a merge.
+//
+// Both send roads used to read `{ ...opts, ...takeAttachments() }`, which is a
+// REPLACEMENT: the tray's `blocks` / `readDirs` / `attachments` overwrote the
+// caller's, and the caller's overwrote the tray's for anything the tray left
+// out. Latent through PR2 — nothing else supplies blocks yet — and a silent
+// dropped `<annotations>` block the moment PR3 lands, which is the worst shape
+// this bug could have: the message goes out, the run succeeds, and the notes the
+// user typed are simply not in it.
+//
+// So the three ADDITIVE fields of `SendOptions` are concatenated here, once, and
+// the blocks go through `composeBlocks` so their order on the wire is §D's
+// (state, pane-shot, annotations, then the typed text) rather than whichever
+// owner happened to be spread last.
+import { composeBlocks } from "../protocol/wire";
+import type { SendOptions } from "../protocol/controller-api";
+
+/**
+ * `base` is the caller's (the composer's pills, PR3's annotations, PR4's app
+ * state); `extra` is what the tray took out of itself for THIS message. Every
+ * scalar is the caller's unless only the tray named it; the three lists are the
+ * union.
+ *
+ * THE CALLER WINS THE SCALARS, and the code has to say so rather than rely on
+ * `take()` never returning one: `{ ...base, ...extra }` reads as a merge but
+ * gives EXTRA precedence, so the day the tray learns to carry a `model` (a
+ * per-attachment vision model, say) it would silently overrule the pill the user
+ * set. `model`/`effort`/`permission` are the composer's answer about this turn
+ * and there is no second claimant. A key the caller merely left `undefined` is
+ * NOT an answer, so it does not blank what the tray put there — which is the
+ * "unless only the tray named it" half of the rule above.
+ */
+export function mergeSendOptions(base: SendOptions, extra: SendOptions): SendOptions {
+  const out: SendOptions = { ...extra };
+  for (const [k, v] of Object.entries(base)) {
+    if (v !== undefined) (out as Record<string, unknown>)[k] = v;
+  }
+  const blocks = composeBlocks(base.blocks, extra.blocks);
+  if (blocks.length) out.blocks = blocks;
+  else delete out.blocks;
+  const readDirs = [...(base.readDirs ?? []), ...(extra.readDirs ?? [])];
+  // Deduped: a Read rule granted twice is a rule that grows on every turn
+  // (T:11698 keeps one copy of each for the same reason).
+  const dirs = [...new Set(readDirs)];
+  if (dirs.length) out.readDirs = dirs;
+  else delete out.readDirs;
+  const attachments = [...(base.attachments ?? []), ...(extra.attachments ?? [])];
+  if (attachments.length) out.attachments = attachments;
+  else delete out.attachments;
+  return out;
+}

--- a/frontend/src/apps/claude/ui/useAttachments.ts
+++ b/frontend/src/apps/claude/ui/useAttachments.ts
@@ -163,8 +163,26 @@ export function useAttachments(opts: UseAttachmentsOptions): Attachments {
       commit((prev) => {
         const seat = prev.findIndex((s) => s.kind === "pane");
         if (seat === -1) return [...prev, shot];
+        const held = prev[seat]!;
+        // A REFUSAL NEVER EVICTS A PICTURE (Bugbot, PR #1064). The pane seat is
+        // unique, so a second click REPLACES what is in it — and a capture that
+        // timed out or failed to encode still comes back as an attachment, with
+        // `view: null` and the reason in `viewNote` (`uploadCapture`). Swapping
+        // that in threw away a screenshot the reader already had and could still
+        // send: one flaky retry, and the evidence was gone with no way back.
+        //
+        // So the picture stays and the refusal's reason rides ONTO it as the
+        // caveat. The attempt is still reported, which is the whole point of a
+        // failed capture becoming a chip at all (T:11305) — it just no longer
+        // costs the picture to say it.
+        if (!shot.view && held.view) {
+          api.revoke(shot); // nothing of its own to hold, but symmetrical
+          const next = prev.slice();
+          next[seat] = shot.viewNote ? { ...held, viewNote: shot.viewNote } : held;
+          return next;
+        }
         // The replaced picture's blob URL is the only handle to it.
-        api.revoke(prev[seat]);
+        api.revoke(held);
         const next = prev.slice();
         next[seat] = shot;
         return next;

--- a/frontend/src/apps/claude/ui/useAttachments.ts
+++ b/frontend/src/apps/claude/ui/useAttachments.ts
@@ -171,15 +171,19 @@ export function useAttachments(opts: UseAttachmentsOptions): Attachments {
         // that in threw away a screenshot the reader already had and could still
         // send: one flaky retry, and the evidence was gone with no way back.
         //
-        // So the picture stays and the refusal's reason rides ONTO it as the
-        // caveat. The attempt is still reported, which is the whole point of a
-        // failed capture becoming a chip at all (T:11305) — it just no longer
-        // costs the picture to say it.
+        // THE HELD PICTURE IS RETURNED UNTOUCHED, its own `viewNote` included.
+        // The refusal's sentence is NOT copied onto it (Bugbot, PR #1064, second
+        // pass): `viewNote` says what THIS picture does not show, and it rides
+        // the wire (`toWire`) as the caveat under the receipt — so borrowing it
+        // for the retry told the agent not to trust a screenshot that is
+        // perfectly good, and overwrote whatever the original capture had
+        // genuinely caveated. A refusal becoming a chip (T:11305) is the rule
+        // for a seat with NOTHING in it, where the chip is the only news there
+        // is; here the tray still shows exactly what the send will carry, which
+        // is the thing that had to stay true.
         if (!shot.view && held.view) {
           api.revoke(shot); // nothing of its own to hold, but symmetrical
-          const next = prev.slice();
-          next[seat] = shot.viewNote ? { ...held, viewNote: shot.viewNote } : held;
-          return next;
+          return prev.slice();
         }
         // The replaced picture's blob URL is the only handle to it.
         api.revoke(held);

--- a/frontend/src/apps/claude/ui/useAttachments.ts
+++ b/frontend/src/apps/claude/ui/useAttachments.ts
@@ -19,6 +19,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { paneShotBlock } from "../protocol/wire";
+import { frameIsCrossOrigin } from "../shots";
 import type { Attachment, Receipt } from "../shots/types";
 import { ATTACH_API, type AttachApi } from "./attachApi";
 
@@ -69,6 +70,10 @@ export interface Attachments {
   take(): OutgoingAttachments;
   /** The send never landed: put them back, prepended. */
   giveBack(items: readonly Attachment[]): void;
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 export function useAttachments(opts: UseAttachmentsOptions): Attachments {
@@ -141,7 +146,15 @@ export function useAttachments(opts: UseAttachmentsOptions): Attachments {
     // opened (T:11267).
     api.flash(flashHost());
     try {
-      const shot = await api.attachPane(agentDir, frame());
+      // READ AT GESTURE TIME, and handed DOWN: `xo` is the only thing that
+      // admits the tab share, and the camera is the only caller that knows which
+      // frame is being photographed. Asked for with no options at all, a
+      // cross-origin pane the native path could not shoot went to a DOM clone of
+      // a document this page cannot open (Bugbot, PR #1064).
+      const target = frame();
+      const shot = await api.attachPane(agentDir, target, {
+        xo: frameIsCrossOrigin(target),
+      });
       if (!alive.current) {
         // No chip will ever show it, so this is the last handle to its Blob.
         api.revoke(shot);
@@ -182,6 +195,9 @@ export function useAttachments(opts: UseAttachmentsOptions): Attachments {
         ),
       ]);
       let i = 0;
+      /** Why the iteration stopped, when it stopped badly: the sentence the
+       *  chips left standing get to say. */
+      let broke: unknown = null;
       try {
         for await (const att of api.attachFiles(agentDir, [...files])) {
           const id = ids[i++];
@@ -194,13 +210,33 @@ export function useAttachments(opts: UseAttachmentsOptions): Attachments {
           }
           commit((prev) => prev.map((s) => (s.id === id ? att : s)));
         }
+      } catch (err) {
+        // `attachFile` is written never to throw, and a pipeline that does
+        // anyway (a rejected generator, an injected fake) must not be the reason
+        // a gesture the user made goes unanswered.
+        broke = err;
       } finally {
-        // Anything the pipeline never answered for (an aborted iteration, a
-        // shorter answer than the question) must not sit in the tray claiming a
-        // file is on its way.
-        const unspent = new Set(ids.slice(i));
-        if (unspent.size && alive.current) {
-          commit((prev) => prev.filter((s) => !unspent.has(s.id)));
+        // ANYTHING THE PIPELINE NEVER ANSWERED FOR BECOMES A REFUSAL CHIP, never
+        // a hole: a placeholder must not sit in the tray claiming a file is
+        // still on its way, and removing it outright — what stood here — is the
+        // dropped picture vanishing with no answer at all (Bugbot, PR #1064).
+        const unspent = ids.slice(i);
+        if (unspent.length && alive.current) {
+          const why = broke ? " (" + errText(broke) + ")" : "";
+          const refused = new Map<string, Attachment>(
+            unspent.map((id, n) => [
+              id,
+              {
+                id,
+                kind: "file",
+                view: null,
+                name: files[i + n]?.name || "attached file",
+                viewNote: "not attached: it could not be saved" + why,
+                why: "could not be saved",
+              },
+            ]),
+          );
+          commit((prev) => prev.map((s) => refused.get(s.id) ?? s));
         }
       }
     },

--- a/frontend/src/apps/claude/ui/useAttachments.ts
+++ b/frontend/src/apps/claude/ui/useAttachments.ts
@@ -1,0 +1,264 @@
+// THE TRAY: the attachments this message is about to carry, and the four ways
+// they get in (camera, paste, drop, real-path drag).
+//
+// T keeps them in one module-level array (`shotAttached`, T:5995) and calls
+// `renderAnn()` after every mutation; here it is state, and the rules that array
+// carried come with it:
+//
+//   * ONE PANE SEAT — a second camera click REPLACES the first picture (D285,
+//     T:11309). "The pane, now" has exactly one answer, and two photographs of
+//     the same screen in one message is a receipt nobody reads. Pasted pictures
+//     are the other kind and stack freely.
+//   * NO COUNT CAP (D617) and no size refusal (D615).
+//   * CHIPS LAND IN ORDER (T:11625): the upload is sequential, so a drop of six
+//     arrives as six chips in the order the user brought them.
+//   * A FAILED SEND HANDS THEM BACK, PREPENDED (T:16093, 16708): the user
+//     attached them deliberately and may not be able to retake them, and a
+//     picture attached WHILE the send was in flight keeps its place after the
+//     ones that were already waiting.
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { paneShotBlock } from "../protocol/wire";
+import type { Attachment, Receipt } from "../shots/types";
+import { ATTACH_API, type AttachApi } from "./attachApi";
+
+export interface UseAttachmentsOptions {
+  /** The real pipeline by default; replaced whole in tests (`ATTACH_API`). */
+  api?: AttachApi;
+  agentDir: string;
+  /** The pane's iframe, read at gesture time. */
+  frame(): HTMLIFrameElement | null;
+  /** What the shutter flashes over — the frame's own box (T:11233 uses the
+   *  highlight layer's parent, which is that same box). */
+  flashHost(): HTMLElement | null;
+  /** "preview" / "app": the word the wire block uses for the pane. */
+  paneNoun: string;
+  /** The shots dir, when a caller knows it. Left out, the pipeline's own
+   *  resolved answer for `agentDir` is used — either way it is FILTERED OUT of
+   *  the Read rules, because the spawn line pre-approves it unconditionally and
+   *  a duplicate rule would grow on every turn (T:11698).  */
+  shotsDir?: string;
+}
+
+/** What a send takes out of the tray. */
+export interface OutgoingAttachments {
+  /** The `<pane-shot>` block, or nothing at all when the tray was empty. */
+  blocks: string[];
+  /** One Read rule each, for the directories real-path attachments live in. */
+  readDirs: string[];
+  /** The rows the sent turn wears. */
+  receipts: Receipt[];
+  /** The attachments themselves, so a send that never landed can hand them
+   *  back. */
+  items: Attachment[];
+}
+
+export interface Attachments {
+  items: Attachment[];
+  /** A capture is in flight: the camera goes inert (T:11203 `shotBusy`). */
+  capturing: boolean;
+  /** The camera (T:11258 `shotAttachPane`). */
+  capture(): Promise<void>;
+  /** ⌘V and a drop of bytes (T:11557 `shotAttachFiles`). */
+  addFiles(files: readonly File[]): Promise<void>;
+  /** A drag from inside fused-render: the real path, no upload (T:11680). */
+  addPaths(paths: readonly string[]): Promise<void>;
+  /** The chip's ✕ and the viewer's Discard (T:10654 `shotDrop`). */
+  remove(att: Attachment): void;
+  /** Empty the tray INTO a send. */
+  take(): OutgoingAttachments;
+  /** The send never landed: put them back, prepended. */
+  giveBack(items: readonly Attachment[]): void;
+}
+
+export function useAttachments(opts: UseAttachmentsOptions): Attachments {
+  const { api = ATTACH_API, agentDir, frame, flashHost, paneNoun, shotsDir } = opts;
+  const [items, setItems] = useState<Attachment[]>([]);
+  const [capturing, setCapturing] = useState(false);
+  /**
+   * THE TRAY, AS OF NOW. Read by `take()`, which must see what the tray holds at
+   * THAT moment rather than what the render it was created in closed over — and
+   * read by the unmount cleanup below, which is the only thing left that can
+   * release these Blobs.
+   *
+   * It is written by `commit` and NOT in the render body, because a render is
+   * too late for the one case the unmount revoke exists for: a picture added by
+   * `capture`/`addFiles`/`addPaths` whose `setItems` had not painted yet when the
+   * parent went away was never in `live.current`, so its Blob was pinned for the
+   * life of the page — exactly the leak the cleanup is for. So the ref is the
+   * source of truth for the tray's contents and `setItems` is what paints it.
+   */
+  const live = useRef<Attachment[]>(items);
+  /** Every mutation of the tray, in one place, so the ref and the state can
+   *  never disagree — computed eagerly off the ref rather than inside React's
+   *  updater, whose timing is the whole bug. */
+  const commit = useCallback((fn: (prev: readonly Attachment[]) => Attachment[]): void => {
+    const next = fn(live.current);
+    live.current = next;
+    setItems(next);
+  }, []);
+  const seq = useRef(0);
+  /**
+   * T:11203 `shotBusy`, and a ref because that is the whole point: a boolean in
+   * STATE is only read as of the render that closed over it, so two activations
+   * in one tick — a double click, a click racing the keyboard — both passed the
+   * guard and two captures ran, the second's seat-swap revoking a thumbnail a
+   * chip was already showing. Latched synchronously here; `capturing` stays as
+   * the thing the BUTTON reads.
+   */
+  const busy = useRef(false);
+  /** Mounted. Every write below lands after an await (`api` is the network), and
+   *  a write into a chat the user has closed is at best a React warning and at
+   *  worst a tray that comes back. */
+  const alive = useRef(true);
+  // `api` through a ref so the unmount cleanup can run ONCE, on the real
+  // unmount, rather than on every identity change of an injected pipeline.
+  const apiRef = useRef(api);
+  apiRef.current = api;
+
+  useEffect(() => {
+    // Set on the way IN as well: React re-runs an effect's setup after its
+    // cleanup, and StrictMode does it on the first mount, so a flag only ever
+    // cleared would leave the tray inert for the rest of the page's life.
+    alive.current = true;
+    return () => {
+      alive.current = false;
+      // NOTHING ELSE HOLDS THESE. A chat closed with three pending pictures in
+      // the tray pinned three full-pane Blobs for the life of the page: the
+      // chips that were the only handles to them went with the unmount, and the
+      // send that would have revoked them never happened.
+      for (const att of live.current) apiRef.current.revoke(att);
+    };
+  }, []);
+
+  const capture = useCallback(async () => {
+    if (busy.current) return;
+    busy.current = true;
+    setCapturing(true);
+    // BEFORE the capture, not after: the whole point is that the click is
+    // answered immediately, and the capture can take a second on a large page.
+    // It is also honest about the moment — the flash marks when the shutter
+    // opened (T:11267).
+    api.flash(flashHost());
+    try {
+      const shot = await api.attachPane(agentDir, frame());
+      if (!alive.current) {
+        // No chip will ever show it, so this is the last handle to its Blob.
+        api.revoke(shot);
+        return;
+      }
+      commit((prev) => {
+        const seat = prev.findIndex((s) => s.kind === "pane");
+        if (seat === -1) return [...prev, shot];
+        // The replaced picture's blob URL is the only handle to it.
+        api.revoke(prev[seat]);
+        const next = prev.slice();
+        next[seat] = shot;
+        return next;
+      });
+    } finally {
+      busy.current = false;
+      if (alive.current) setCapturing(false);
+    }
+  }, [api, agentDir, flashHost, frame, commit]);
+
+  /**
+   * A PLACEHOLDER PER FILE, replaced as its bytes land. The pipeline yields
+   * sequentially and in order, so the n-th attachment belongs to the n-th
+   * placeholder — which is what keeps a drop of six from re-ordering itself
+   * while the uploads race, and gives the chip a state to show meanwhile (T's
+   * chips simply appear one at a time; a chip that says it is on its way is the
+   * same news, earlier).
+   */
+  const addFiles = useCallback(
+    async (files: readonly File[]) => {
+      if (!files.length) return;
+      if (!alive.current) return;
+      const ids = files.map(() => "pending:" + ++seq.current);
+      commit((prev) => [
+        ...prev,
+        ...ids.map(
+          (id): Attachment => ({ id, kind: "file", view: null, pending: true }),
+        ),
+      ]);
+      let i = 0;
+      try {
+        for await (const att of api.attachFiles(agentDir, [...files])) {
+          const id = ids[i++];
+          if (!id) break;
+          if (!alive.current) {
+            // Same reasoning as the camera's: the chip that would have held this
+            // one's thumbnail is gone, so this is the last handle to it.
+            api.revoke(att);
+            break;
+          }
+          commit((prev) => prev.map((s) => (s.id === id ? att : s)));
+        }
+      } finally {
+        // Anything the pipeline never answered for (an aborted iteration, a
+        // shorter answer than the question) must not sit in the tray claiming a
+        // file is on its way.
+        const unspent = new Set(ids.slice(i));
+        if (unspent.size && alive.current) {
+          commit((prev) => prev.filter((s) => !unspent.has(s.id)));
+        }
+      }
+    },
+    [api, agentDir, commit],
+  );
+
+  const addPaths = useCallback(
+    async (paths: readonly string[]) => {
+      if (!paths.length) return;
+      const added = await api.attachPaths(agentDir, [...paths]);
+      if (!alive.current) {
+        for (const att of added) api.revoke(att);
+        return;
+      }
+      if (added.length) commit((prev) => [...prev, ...added]);
+    },
+    [api, agentDir, commit],
+  );
+
+  const remove = useCallback(
+    (att: Attachment) => {
+      api.revoke(att);
+      commit((prev) => prev.filter((s) => s !== att && s.id !== att.id));
+    },
+    [api, commit],
+  );
+
+  const take = useCallback((): OutgoingAttachments => {
+    const sending = live.current.filter((s) => !s.pending);
+    // A pending chip is not part of THIS message: its bytes are still on their
+    // way, so it stays in the tray for the next one rather than riding as a
+    // half-attachment.
+    commit((prev) => prev.filter((s) => s.pending));
+    if (!sending.length) return { blocks: [], readDirs: [], receipts: [], items: [] };
+    const block = paneShotBlock(api.toWire(sending), paneNoun);
+    return {
+      blocks: block ? [block] : [],
+      readDirs: shotsDir
+        ? api.readDirs(sending, shotsDir)
+        : api.readDirsFor(agentDir, sending),
+      receipts: sending.map((s) => api.receiptFor(s)),
+      items: sending,
+    };
+  }, [api, agentDir, paneNoun, shotsDir, commit]);
+
+  const giveBack = useCallback(
+    (back: readonly Attachment[]) => {
+      if (!back.length) return;
+      // The chat this send belonged to is gone, and the pictures it was carrying
+      // have no tray to come back to.
+      if (!alive.current) {
+        for (const att of back) apiRef.current.revoke(att);
+        return;
+      }
+      commit((prev) => [...back, ...prev]);
+    },
+    [commit],
+  );
+
+  return { items, capturing, capture, addFiles, addPaths, remove, take, giveBack };
+}

--- a/frontend/src/apps/claude/ui/useFitStrip.test.ts
+++ b/frontend/src/apps/claude/ui/useFitStrip.test.ts
@@ -1,0 +1,245 @@
+// THE STRIP'S VERDICT, PROVEN WITHOUT A LAYOUT ENGINE (inventory 03 §C).
+//
+// `fitStrip(row, need = measureRowNeed)` carries that second parameter for one
+// reason: the decision it makes is arithmetic — what the content needs against
+// what the box has — and the only thing standing between a test and that
+// arithmetic is a browser's layout. So `need` is injected here and every branch
+// of the verdict is driven directly.
+//
+// What is under test is the DECISION and the invariant around it, not the
+// classList plumbing: the measurement happens with the words ON (`.tight` off,
+// or the row measures the folded width and never unfolds), an unmeasurable row
+// gets no verdict at all (the first-frame flash), and re-seating the observers
+// on the same row leaves one set behind and not two.
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { installDomShim } from "@platform/lib/testDomShim";
+
+installDomShim();
+
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+
+const { fitStrip, useFitStrip } = await import("./useFitStrip");
+
+// ── the fake row ────────────────────────────────────────────────────────────
+// Only the four members `fitStrip` and the observer seating touch: the class
+// list it writes, the width it reads, and the children the child observer sits
+// on.
+
+class Row {
+  classes = new Set<string>();
+  clientWidth = 0;
+  kids: unknown[] = [];
+  classList = {
+    add: (c: string): void => void this.classes.add(c),
+    remove: (c: string): void => void this.classes.delete(c),
+    contains: (c: string): boolean => this.classes.has(c),
+  };
+  get children(): unknown[] {
+    return this.kids;
+  }
+  get tight(): boolean {
+    return this.classes.has("tight");
+  }
+}
+
+const el = (r: Row): HTMLElement => r as unknown as HTMLElement;
+
+/** A `need` that answers `px` and records what the row looked like WHILE it was
+ *  being asked — the one thing a caller cannot observe afterwards, because
+ *  `fitStrip` puts the class back before it returns. */
+function needing(px: number): { need: (row: HTMLElement) => number; calls: boolean[] } {
+  const calls: boolean[] = [];
+  return {
+    need: (row) => {
+      calls.push((row as unknown as Row).tight);
+      return px;
+    },
+    calls,
+  };
+}
+
+describe("fitStrip — the verdict (T:7566)", () => {
+  test("what the content needs does not fit: `.tight` goes on", () => {
+    const row = new Row();
+    row.clientWidth = 308;
+    fitStrip(el(row), () => 308.3);
+    expect(row.tight).toBe(true);
+  });
+
+  test("it fits: `.tight` comes back off, so widening undoes itself", () => {
+    const row = new Row();
+    row.clientWidth = 420;
+    // The state a narrow layout left behind — the whole point of recomputing
+    // from scratch rather than keeping a flag.
+    row.classes.add("tight");
+    fitStrip(el(row), () => 308.3);
+    expect(row.tight).toBe(false);
+  });
+
+  test("exactly the width available FITS: the compare is `>` and not `>=`", () => {
+    const row = new Row();
+    row.clientWidth = 300;
+    fitStrip(el(row), () => 300);
+    expect(row.tight).toBe(false);
+  });
+
+  test("MEASURED WITH THE WORDS ON — `need` is asked with `.tight` off", () => {
+    const row = new Row();
+    row.clientWidth = 100;
+    row.classes.add("tight");
+    const { need, calls } = needing(200);
+    fitStrip(el(row), need);
+    // Asked once, and asked of the row as the user would see it unfolded. Asking
+    // a folded row what it needs measures the icons and the strip never unfolds
+    // again.
+    expect(calls).toEqual([false]);
+    expect(row.tight).toBe(true);
+  });
+
+  test("A ROW WITH NO WIDTH GETS NO VERDICT — the first-frame `.tight` flash", () => {
+    // The mount order: the ref callback runs during commit, `clientWidth` is
+    // still 0, and any `need > 0` against that stamped `.tight` for one frame
+    // before the ResizeObserver's first real delivery took it off — the strip
+    // painted icon-only on every mount.
+    const row = new Row();
+    row.clientWidth = 0;
+    const { need, calls } = needing(200);
+    fitStrip(el(row), need);
+    expect(calls).toEqual([]);
+    expect(row.tight).toBe(false);
+  });
+
+  test("and it is left EXACTLY as it was: unmeasurable is not `it fits`", () => {
+    // A strip already folded that is momentarily unmeasurable (a collapsed
+    // parent, a display:none ancestor) must not unfold on the way back.
+    const row = new Row();
+    row.clientWidth = 0;
+    row.classes.add("tight");
+    const { need, calls } = needing(1);
+    fitStrip(el(row), need);
+    expect(calls).toEqual([]);
+    expect(row.tight).toBe(true);
+  });
+
+  test("no row at all is a no-op, not a throw", () => {
+    const { need, calls } = needing(200);
+    expect(() => fitStrip(null, need)).not.toThrow();
+    expect(() => fitStrip(undefined, need)).not.toThrow();
+    expect(calls).toEqual([]);
+  });
+});
+
+// ── the observers ───────────────────────────────────────────────────────────
+
+const G = globalThis as Record<string, unknown>;
+const BEFORE = { RO: G.ResizeObserver, MO: G.MutationObserver };
+afterAll(() => {
+  G.ResizeObserver = BEFORE.RO;
+  G.MutationObserver = BEFORE.MO;
+});
+
+interface Seen {
+  ro: { targets: unknown[]; disconnects: number; fire: () => void };
+  mo: { observed: { target: unknown; opts: unknown }[]; disconnects: number };
+}
+
+/** Both observer constructors, counted. `fire` is the ResizeObserver's delivery
+ *  road — the one that hands over the first verdict that means anything. */
+function observers(): Seen {
+  const seen: Seen = {
+    ro: { targets: [], disconnects: 0, fire: () => {} },
+    mo: { observed: [], disconnects: 0 },
+  };
+  G.ResizeObserver = class {
+    constructor(cb: () => void) {
+      seen.ro.fire = cb;
+    }
+    observe(target: unknown): void {
+      seen.ro.targets.push(target);
+    }
+    disconnect(): void {
+      seen.ro.disconnects++;
+    }
+  };
+  G.MutationObserver = class {
+    observe(target: unknown, opts: unknown): void {
+      seen.mo.observed.push({ target, opts });
+    }
+    disconnect(): void {
+      seen.mo.disconnects++;
+    }
+  };
+  return seen;
+}
+
+/** The hook hands out a ref CALLBACK, so a host is mounted to get at it — the
+ *  teardown under test lives in the ref the hook keeps between calls. */
+function mountHook(): (row: HTMLElement | null) => void {
+  let seat!: (row: HTMLElement | null) => void;
+  function Host(): null {
+    seat = useFitStrip();
+    return null;
+  }
+  act(() => {
+    mounted.push(create(createElement(Host)));
+  });
+  return seat;
+}
+
+const mounted: ReturnType<typeof create>[] = [];
+let seen: Seen;
+beforeEach(() => {
+  for (const r of mounted.splice(0)) act(() => r.unmount());
+  seen = observers();
+});
+
+describe("useFitStrip — the wiring", () => {
+  test("the row gets a ResizeObserver, its CHILDREN get the mutation one", () => {
+    const row = new Row();
+    row.kids = [{ tag: "a" }, { tag: "b" }];
+    row.clientWidth = 0;
+    mountHook()(el(row));
+    expect(seen.ro.targets).toEqual([row]);
+    // Two child observers plus the childList-only one on the row itself, which
+    // is what re-seats them when React adds or removes a seat.
+    const onRow = seen.mo.observed.filter((o) => o.target === row);
+    expect(onRow).toHaveLength(1);
+    expect(onRow[0]!.opts).toEqual({ childList: true });
+    expect(seen.mo.observed.filter((o) => o.target !== row).map((o) => o.target)).toEqual(row.kids);
+  });
+
+  test("re-seating the SAME row leaves one set of observers behind, not two", () => {
+    // React calls a ref callback again whenever the callback's identity or the
+    // node changes; without the teardown every re-seat doubled the deliveries
+    // and each verdict scheduled the next.
+    const row = new Row();
+    row.kids = [{ tag: "a" }];
+    const seat = mountHook();
+    seat(el(row));
+    const first = seen.ro.targets.length;
+    seat(el(row));
+    // The previous set is disconnected before the new one is wired: one
+    // ResizeObserver and both MutationObservers.
+    expect(seen.ro.disconnects).toBe(1);
+    expect(seen.ro.targets).toHaveLength(first + 1);
+    // And the row on the way OUT takes everything with it.
+    seat(null);
+    expect(seen.ro.disconnects).toBe(2);
+  });
+
+  test("the ref callback's first run does NOT measure a just-committed row", () => {
+    // No injected `need` here on purpose: the default is `measureRowNeed`, which
+    // reads `getComputedStyle` — so if the mount verdict ran at all against this
+    // fake it would either throw or stamp `.tight`. It does neither, which is
+    // the guard.
+    const row = new Row();
+    row.clientWidth = 0;
+    expect(() => mountHook()(el(row))).not.toThrow();
+    expect(row.tight).toBe(false);
+    // Once the box is real, the observer's delivery is the first verdict.
+    row.clientWidth = 10;
+    fitStrip(el(row), () => 99);
+    expect(row.tight).toBe(true);
+  });
+});

--- a/frontend/src/apps/claude/ui/useFitStrip.ts
+++ b/frontend/src/apps/claude/ui/useFitStrip.ts
@@ -1,0 +1,95 @@
+// THE CONTROL STRIP'S WORDS FIT OR FOLD — T:7554-7595 `annFitStrip`, the same
+// collision detection `fit.ts` does for the composer row one pane over.
+//
+// COLLISION-DETECTED, NEVER A BREAKPOINT (Akshil, 2026-08-19: a fixed width
+// dropped the words while there was still space for them). Measure with the
+// words ON — take `.tight` off, ask what the row needs, put it back only if the
+// content truly would not fit — so widening undoes itself with no state to get
+// stale. The stylesheet does the rest through the `--c-annlbl` token every
+// `.c-lbl` span already reads.
+//
+// This is what QA #2 was missing: at 1280px with the pane taking most of the
+// width the chat column is ~308px, and `Screenshot · Comment · Annotate` at full
+// labels measured 308.3px with its right edge 8px past the viewport — legacy has
+// rendered the same row icon-only since 2026-08-19.
+//
+// TWO OBSERVERS, ONE VERDICT, and the split is the load-bearing part:
+//   * ResizeObserver on the row — the box changes (the divider drags, the window
+//     resizes, a narrow layout flips).
+//   * MutationObserver on the row's CHILDREN — the content changes width with
+//     the box standing still (the picker slides in, a seat swaps faces, a label
+//     grows). Deliberately NOT on the row itself for attributes: this function
+//     writes the row's own class list, and observing the node it writes would
+//     make every verdict schedule the next one, forever (T:7551). A second
+//     childList-only observer on the row re-seats the child observers when React
+//     adds or removes one.
+import { useCallback, useRef } from "react";
+
+import { measureRowNeed } from "./fit";
+
+/** T:7566 — `.tight` on or off, recomputed from scratch. `need` is injected so a
+ *  test can prove the verdict without a layout engine. */
+export function fitStrip(
+  row: HTMLElement | null | undefined,
+  need: (row: HTMLElement) => number = measureRowNeed,
+): void {
+  if (!row) return;
+  // NOT LAID OUT YET IS NOT A VERDICT. The first `run()` fires from the ref
+  // callback during commit, when the row can still measure `clientWidth: 0` —
+  // and any `need > 0` against that stamps `.tight`, which the ResizeObserver's
+  // first real delivery then takes back off, so the strip painted icon-only for
+  // one frame on every mount. A row with no width has no answer to give, so the
+  // class is left exactly as it is (unmeasurable is not "it fits") and the
+  // observers deliver the first verdict that means anything.
+  if (!row.clientWidth) return;
+  // MEASURED WITH THE WORDS ON. Both halves run synchronously inside an
+  // observer callback, which fires before paint, so the probe never shows.
+  row.classList.remove("tight");
+  if (need(row) > row.clientWidth) row.classList.add("tight");
+}
+
+const KID_OPTS: MutationObserverInit = {
+  subtree: true,
+  childList: true,
+  characterData: true,
+  attributes: true,
+  attributeFilter: ["class", "hidden"],
+};
+
+/**
+ * A ref CALLBACK rather than a ref plus an effect, because the row is
+ * conditionally rendered (`stripShown`) and the observers have to follow it in
+ * and out rather than be wired once against a node that may not be there.
+ */
+export function useFitStrip(): (row: HTMLElement | null) => void {
+  const off = useRef<(() => void) | null>(null);
+  return useCallback((row: HTMLElement | null) => {
+    off.current?.();
+    off.current = null;
+    if (!row) return;
+    const run = (): void => fitStrip(row);
+    const ro = typeof ResizeObserver === "function" ? new ResizeObserver(run) : null;
+    ro?.observe(row);
+    const kids = typeof MutationObserver === "function" ? new MutationObserver(run) : null;
+    const seat = (): void => {
+      kids?.disconnect();
+      for (const kid of Array.from(row.children)) kids?.observe(kid, KID_OPTS);
+    };
+    const self =
+      typeof MutationObserver === "function"
+        ? new MutationObserver(() => {
+            seat();
+            run();
+          })
+        : null;
+    // childList ONLY: the row's own attributes are what this writes.
+    self?.observe(row, { childList: true });
+    seat();
+    run();
+    off.current = () => {
+      ro?.disconnect();
+      kids?.disconnect();
+      self?.disconnect();
+    };
+  }, []);
+}


### PR DESCRIPTION
Stacked on #1061 (PR1). Merge #1061 first; this PR's base then retargets to `main`.

## What

Ports the template's screenshot/attachment pipeline into the native chat (`frontend/src/apps/claude/shots`, pure TS) and adds the attachment UI. Flag-gated like PR1 (`native_chat_enabled`, default off); flag off is unchanged.

- **Capture** — native `/api/capture/shot-region` → tab capture (cross-origin) → DOM clone, in the template's order; same encode ladder (WebP 0.8/0.6 → PNG, halve ×3), 1600 px / 900 KiB pane budget, caveat sentences + trust line verbatim, 6 s abandon, shutter flash.
- **Attach** — camera in the annotate strip (Comment/Annotate seats rendered disabled until PR3), paste, drop onto the chat column with the accent ring, real-path drags (`application/x-fused-path`, no upload), sequential uploads in order, >4 MiB images downscaled, undecodable images transcoded via `image_to_png`, unique pane seat, `read_dirs` on start/follow-up.
- **UI** — chip tray, shot viewer (fitted/actual zoom, rtl path, caveat, Discard, template iframe for files), receipts under sent turns restored from history with pruned detection, "What was sent" sections, strip collapses to icons by measurement.
- **Send seam** — `composeBlocks` enforces wire block order (state → pane-shot → annotations → text); attachments ride the bubble and return to the tray on a failed send.

## Verification

- typecheck · boundaries (591 files) · `bun test` 3788/0 (685 in `apps/claude`, incl. direct suites for the three capture strategies) · build.
- pytest legacy suites green (7 `test_claude_health.py` failures are environmental, identical on `main`).
- Browser QA (cmux) 2 rounds, native on: camera/flash/chip/viewer, drop ring, paste-once, discard-by-id, send → receipts → reload restore → What-was-sent wire, compact cards; zero console errors. Two clipping bugs found in round 1 (viewer bar, strip) fixed and re-measured.
- Code review 2 rounds: 8 major + 17 minor fixed; 1 declined with template cite (receipt meta bits belong to the popover, T:11007-11026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to the message send path, attachment lifecycle, and blob URL bookkeeping; behavior is heavily tested but regressions would affect every send with screenshots or files.
> 
> **Overview**
> **Native Claude chat (PR2)** connects the new `shots/attach` pipeline and attachment UI into `ClaudeChat`: tray chips, column-level paste/drop (depth counter for `.dropping`), screenshot via `AnnStrip`, and `ShotViewer` discard-by-id.
> 
> **Send path** is reworked so both message and follow-up sends go through `beginSend` + `mergeSendOptions`, park attachments in an `inFlight` map keyed by receipt arrays, merge wire blocks via `composeBlocks` (state → pane-shot → annotations → text), and call `onSendReturned` when a send never lands. Successful sends re-point receipt thumbnails to on-disk URLs before revoking blob URLs (post-commit effect), with unmount cleanup for in-flight sends.
> 
> **Attachment behavior** adds the full attach module (capture order, wire/receipts, path drags, server HEIC conversion) with **no user-file size downscale** (P2-6); wordless-send markers use an invisible sigil so typed words like "files" are not treated as markers. **Chrome** keeps one always-visible `#anntools` row (kebab/back) while seats show only when there is an annotate target, not merely when not `chatOnly`.
> 
> **Tests** add integration coverage for real `ClaudeChat` gesture handlers, boot strip visibility, attach/capture unit suites, and controller send-return/stop/stranding cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e20f0d9ad09ca0a83fb3b5dae89c603b2ce39f9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->