### PR TITLE
Onboarding: Models stage refresh, brand row, Playground links, dismiss on every exit

### DIFF
--- a/frontend/src/shell/ActivityDock.tsx
+++ b/frontend/src/shell/ActivityDock.tsx
@@ -39,9 +39,11 @@
 // this component is the shell's one place that fetches for it.
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getRunningEngines, stopEngine, type RunningEngine } from "@platform/lib/api";
-import { terminalNotifications, type Job } from "@platform/lib/jobs";
+import { isRunning, terminalNotifications, type Job } from "@platform/lib/jobs";
 import { pushToast } from "@platform/lib/toast";
 import DownloadManager, { engineLabel } from "@platform/ui/DownloadManager";
+
+import { noteProgressMayHaveMoved } from "./onboarding/progress";
 
 // Matches the (former) Engines chip's own cadence: a "what is running" readout,
 // not progress, so it does not need to tick every second.
@@ -184,12 +186,28 @@ export default function ActivityDock({
   const onTerminalRef = useRef(onTerminalJobs);
   onTerminalRef.current = onTerminalJobs;
   const terminalIdsRef = useRef("");
+  // The setup meter (onboarding/progress.ts) reads stage statuses the server
+  // observes on each read — and a model download starting or finishing is
+  // exactly when the Models stage moves. This poll is the shell's one view of
+  // every job, so it is the cheapest place to know that moment: re-read the
+  // meter when the set of RUNNING jobs or the set of terminal ones changes,
+  // not on every tick.
+  const runningIdsRef = useRef("");
   const onJobsReported = useCallback((next: Job[]) => {
+    const running = next.filter(isRunning).map((j) => j.id).join(" ");
+    let moved = false;
+    if (running !== runningIdsRef.current) {
+      runningIdsRef.current = running;
+      moved = true;
+    }
     const terminal = terminalNotifications(next);
     const key = terminal.map((j) => j.id).join(" ");
-    if (key === terminalIdsRef.current) return;
-    terminalIdsRef.current = key;
-    onTerminalRef.current?.(terminal);
+    if (key !== terminalIdsRef.current) {
+      terminalIdsRef.current = key;
+      onTerminalRef.current?.(terminal);
+      moved = true;
+    }
+    if (moved) noteProgressMayHaveMoved();
   }, []);
 
   const onStopEngine = async (engineId: string) => {

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -26,10 +26,12 @@ import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, Check, HardDrive } from "lucide-react";
 
+import { AI_MODELS_PREFIX } from "@apps/ai_models/routes";
 import { fitNote } from "@apps/ai_models/shared/fitNote";
 import { modelSizeLabel } from "@apps/ai_models/shared/modelSize";
 import { downloadAiModel, getAiCatalog } from "@platform/lib/api";
 import { formatSize } from "@platform/lib/format";
+import { navigateUrl } from "@platform/lib/router";
 import {
   fetchJobs,
   isRunning,
@@ -467,6 +469,10 @@ function ModelRow({
   // (owner, 2026-09-04). Same for the engine: "MLX LM" answers a question
   // only somebody comparing backends is asking.
   const name = model.nickname || model.label;
+  const playgroundHref = `${AI_MODELS_PREFIX}/playground?${new URLSearchParams({
+    model: model.id,
+    cap: pick.capability,
+  })}`;
   // A fresh install builds the runner's environment before any bytes move
   // (`supervisor._env_install_worker`, states `venv` -> `downloading`), so the
   // job's own caption is what makes a row at 0 bytes read as working rather
@@ -498,13 +504,31 @@ function ModelRow({
           />
         )}
         <div className="min-w-0 flex-1">
-          <label
-            htmlFor={busy || here ? undefined : `model-${model.id}`}
-            className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm font-medium"
-          >
-            {name}
-            <span className="text-xs font-normal text-muted-foreground">{pick.capabilityLabel}</span>
-          </label>
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm font-medium">
+            {/* The NAME opens this model in the Playground (`?model=` +
+                `?cap=` seed its picker, ai_models/routes.ts) — for a reader
+                who wants to see what it does before spending the download,
+                or to try one that is already here. Leaving the wizard this
+                way is a close (OnboardingWizard's unmount dismisses). The
+                checkbox keeps the rest of the row, via the caption's label. */}
+            <a
+              href={playgroundHref}
+              onClick={(e) => {
+                e.preventDefault();
+                navigateUrl(playgroundHref);
+              }}
+              title="Open in Playground"
+              className="text-foreground no-underline hover:text-[var(--accent-soft)] hover:underline"
+            >
+              {name}
+            </a>
+            <label
+              htmlFor={busy || here ? undefined : `model-${model.id}`}
+              className="text-xs font-normal text-muted-foreground"
+            >
+              {pick.capabilityLabel}
+            </label>
+          </div>
           {fit && (
             <div
               className="mt-1 inline-flex items-center gap-1.5 text-xs text-muted-foreground"

--- a/frontend/src/shell/onboarding/ModelsStep.tsx
+++ b/frontend/src/shell/onboarding/ModelsStep.tsx
@@ -290,15 +290,16 @@ export function ModelsStep({
   // Download is the yellow button while something is selected and not yet
   // fetched; once started (or nothing to do) Next takes the colour.
   useEffect(() => onWork(pending.length > 0), [onWork, pending.length]);
-  // THE STAGE (progress.ts): every offered model here = complete; some here
-  // or any download in flight = partial; nothing = pending. Nothing until the
+  // THE STAGE (progress.ts): ANY offered model here = complete (one local
+  // model is a working machine; the rest are a choice, not a chore); none here
+  // but a download in flight = partial; nothing = pending. Nothing until the
   // catalog has answered (an empty catalog is the wizard's `n/a`, not ours).
   // Keyed on the counts, so the jobs poll does not re-send the same verdict.
   const hereCount = rows.filter((r) => r.here).length;
   const rowCount = rows.length;
   useEffect(() => {
     if (picks === null || rowCount === 0) return;
-    const status = hereCount === rowCount ? "complete" : hereCount > 0 || busyCount > 0 ? "partial" : "pending";
+    const status = hereCount > 0 ? "complete" : busyCount > 0 ? "partial" : "pending";
     reportStage("models", status, {
       offered: rows.map((r) => r.pick.model.id),
       here: rows.filter((r) => r.here).map((r) => r.pick.model.id),

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -301,13 +301,16 @@ export function OnboardingWizard({ config }: { config: Config }) {
             + styles/sidebar.css .sidebar-brand): same mark, same "Render"
             title, same 9px gap / 13.5px / 650 weight, one click target that
             goes Home, title turning --accent-soft on hover. Leaving this way
-            is a close (the unmount dismisses, below). */}
+            is a CLOSE, so it goes through `finish("dismiss")` like the ✕ —
+            not a bare navigate, which on the last step the unmount would
+            read as completion (a navigation off step 5 is how a built app
+            reports itself; bugbot). */}
         <a
           href={EXIT_PATH}
           title="Home"
           onClick={(e) => {
             e.preventDefault();
-            navigateUrl(EXIT_PATH);
+            finish("dismiss");
           }}
           className="group flex min-w-0 items-center gap-[9px] text-[13.5px] font-[650] tracking-[0.01em] text-foreground no-underline"
         >

--- a/frontend/src/shell/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/shell/onboarding/OnboardingWizard.tsx
@@ -214,9 +214,19 @@ export function OnboardingWizard({ config }: { config: Config }) {
   // The FLAG only: this unmount also fires on browser Back from the last
   // step, where nothing was built. The First-app STAGE is claimed by the step
   // itself, which checks the page it landed on (FirstAppStep onShowcaseOpened).
+  //
+  // Any OTHER way out is a close, and a close is dismissed — the ✕ and
+  // Escape said so already, but browser Back, the brand link, the sidebar
+  // meter, a Models row opening the Playground all leave the same way (this
+  // unmount) without a word to the server, and the auto-show then had only
+  // `opened_at` to go on. `settled` keeps a ✕ press from stamping twice.
   useEffect(
     () => () => {
       if (lastRef.current) markComplete();
+      else if (!settled.current) {
+        settled.current = true;
+        dismissOnboarding().catch(() => undefined);
+      }
     },
     [markComplete],
   );
@@ -287,18 +297,32 @@ export function OnboardingWizard({ config }: { config: Config }) {
           the ✕). In flow, so a squeeze shrinks the side tracks instead of
           painting the pills over the wordmark. */}
       <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4 border-b border-border px-5 py-3">
-        <div className="flex min-w-0 items-center gap-2 text-[13.5px] font-semibold tracking-[0.01em]">
+        {/* The sidebar's brand row, verbatim (platform/ui/sidebar/SidebarFrame
+            + styles/sidebar.css .sidebar-brand): same mark, same "Render"
+            title, same 9px gap / 13.5px / 650 weight, one click target that
+            goes Home, title turning --accent-soft on hover. Leaving this way
+            is a close (the unmount dismisses, below). */}
+        <a
+          href={EXIT_PATH}
+          title="Home"
+          onClick={(e) => {
+            e.preventDefault();
+            navigateUrl(EXIT_PATH);
+          }}
+          className="group flex min-w-0 items-center gap-[9px] text-[13.5px] font-[650] tracking-[0.01em] text-foreground no-underline"
+        >
           <span className="flex shrink-0 items-center text-[var(--accent)]">
             <FusedMark size={20} />
           </span>
           {/* Only where the pills are actually competing for the row: from
               `sm` (where they appear) up to 760px (measured as the width at
               which the centred pills stop leaving the side track room for the
-              wordmark) it would truncate to "Fused Rend…", and the mark alone
-              says it better. Under `sm` the pills are hidden, so the wordmark
-              has the row to itself and stays. */}
-          <span className="truncate sm:max-[760px]:hidden">Fused Render</span>
-        </div>
+              wordmark) the mark alone says it better. Under `sm` the pills are
+              hidden, so the wordmark has the row to itself and stays. */}
+          <span className="truncate transition-colors group-hover:text-[var(--accent-soft)] sm:max-[760px]:hidden">
+            Render
+          </span>
+        </a>
 
         {/* Every step is a link, in both directions: nothing before step 4
             gates anything after it, so a user who knows what they want can go

--- a/frontend/src/shell/onboarding/progress.ts
+++ b/frontend/src/shell/onboarding/progress.ts
@@ -128,12 +128,35 @@ export function getProgress(): OnboardingState | null {
   return snapshot;
 }
 
+// WHEN THE STORE RE-READS. The server overrules stored statuses with what it
+// can observe (a grant, a folder under local/, a cached model), but only on a
+// read — and a store that read once at mount would show a download finished
+// an hour ago as still pending. So, while anyone is subscribed: on every
+// return to the tab (the DownloadManager's own pattern), and whenever the
+// Activity dock sees a job reach a terminal state (`noteProgressMayHaveMoved`,
+// called from ActivityDock). No timer of its own: the dock's poll already runs at
+// the right cadence, and finishing a job is the moment a stage can change.
+const onVisible = () => {
+  if (document.visibilityState === "visible") void refreshProgress();
+};
+
 export function subscribeProgress(cb: () => void): () => void {
   listeners.add(cb);
-  if (listeners.size === 1) void refreshProgress();
+  if (listeners.size === 1) {
+    void refreshProgress();
+    document.addEventListener("visibilitychange", onVisible);
+  }
   return () => {
     listeners.delete(cb);
+    if (listeners.size === 0) document.removeEventListener("visibilitychange", onVisible);
   };
+}
+
+/** Something that could move a stage just happened elsewhere in the shell (a
+ *  download finished, a task ended). Re-read if anyone is looking; a store
+ *  with no subscriber re-reads at its next mount anyway. */
+export function noteProgressMayHaveMoved(): void {
+  if (listeners.size > 0) void refreshProgress();
 }
 
 export function useOnboardingState(): OnboardingState | null {

--- a/frontend/src/shell/onboarding/progress.ts
+++ b/frontend/src/shell/onboarding/progress.ts
@@ -10,8 +10,8 @@
 //   claude   not installed/unknown  runs, but outdated/signed    installed, new
 //                                   out/unknown                  enough, signed in
 //   fda      not granted            granted, relaunch pending    granted
-//   models   none fetched           some here or downloading     every offered
-//                                                                model is here
+//   models   none fetched, none     none here, one or more       one or more
+//            downloading            downloading                  models here
 //   app      nothing built          —                            composer made an
 //                                                                app, or a showcase
 //                                                                app was opened

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -225,19 +225,22 @@ def _observe(stages: dict) -> None:
     # it. `hub_cache.cached_models()` is memoised on the cache folders' mtimes
     # (its docstring: ~four stats per repo, a completed download visible on
     # the very next read), so it is cheap enough for /api/config; the job
-    # registry is in-memory. One loadable model here = complete; none here but
-    # a model download running = partial. Otherwise only a stored complete or
-    # partial is walked back to pending — `n/a` (no engine can serve anything
-    # on this machine) and a never-written stage are left alone, or a Linux
-    # box would find its `n/a` back in the denominator.
+    # registry is in-memory. One model here = complete; none here but a model
+    # download running = partial. Otherwise only a stored complete or partial
+    # is walked back to pending — `n/a` (no engine can serve anything on this
+    # machine) and a never-written stage are left alone, or a Linux box would
+    # find its `n/a` back in the denominator.
+    #
+    # "Here" is the same reading the wizard's tick uses (`hub_cache.
+    # is_downloaded`: the repo is in `cached_models()`, full stop) — not
+    # `loaders`, which is about whether the CURRENT runner opens it: an MLX
+    # repo on a Mac switched to llama.cpp is downloaded, ticked in the step,
+    # and would be walked back to pending here under the stricter test.
     try:
         from fused_render import jobs
         from fused_render.ai import hub_cache, supervisor
 
-        here = [
-            m.repo_id for m in hub_cache.cached_models()
-            if m.capability is not None and m.loaders
-        ]
+        here = [m.repo_id for m in hub_cache.cached_models() if m.capability is not None]
         if here:
             put("models", "complete", here=here[:8])
         else:

--- a/fused_render/shell/onboarding.py
+++ b/fused_render/shell/onboarding.py
@@ -219,6 +219,42 @@ def _observe(stages: dict) -> None:
     except Exception:  # noqa: BLE001
         log.debug("onboarding: claude observe failed", exc_info=True)
 
+    # Local models: the wizard's Models step reports only the picks it OFFERED,
+    # and only while it is on screen. A model fetched later from the AI Models
+    # page — or one deleted since — would leave the meter where the wizard left
+    # it. `hub_cache.cached_models()` is memoised on the cache folders' mtimes
+    # (its docstring: ~four stats per repo, a completed download visible on
+    # the very next read), so it is cheap enough for /api/config; the job
+    # registry is in-memory. One loadable model here = complete; none here but
+    # a model download running = partial. Otherwise only a stored complete or
+    # partial is walked back to pending — `n/a` (no engine can serve anything
+    # on this machine) and a never-written stage are left alone, or a Linux
+    # box would find its `n/a` back in the denominator.
+    try:
+        from fused_render import jobs
+        from fused_render.ai import hub_cache, supervisor
+
+        here = [
+            m.repo_id for m in hub_cache.cached_models()
+            if m.capability is not None and m.loaders
+        ]
+        if here:
+            put("models", "complete", here=here[:8])
+        else:
+            downloading = [
+                r.get("model") or r["id"]
+                for r in jobs.list_jobs()
+                if str(r.get("id", "")).startswith(supervisor.JOB_PREFIX)
+                and r.get("kind") == "download"
+                and r.get("state") == "running"
+            ]
+            if downloading:
+                put("models", "partial", here=[], downloading=downloading[:8])
+            elif stages.get("models", {}).get("status") in ("complete", "partial"):
+                put("models", "pending", here=[], downloading=[])
+    except Exception:  # noqa: BLE001
+        log.debug("onboarding: models observe failed", exc_info=True)
+
 
 def snapshot() -> dict:
     """The `onboarding` field of /api/config: `{completed_at, dismissed_at,


### PR DESCRIPTION
Models stage of the onboarding progress meter, two changes.

**Rule** (`ModelsStep.tsx`):
- **complete** — one or more models on disk
- **partial** — none on disk, one or more downloading
- **pending** — nothing on disk, nothing downloading

Was: complete only when every offered model was here.

**Refresh** — the stage used to move only while the wizard's Models step was on screen, and only for the picks it offered. Now:
- Server (`shell/onboarding.py` `_observe`) overrules the stored status on every read from `hub_cache.cached_models()` (mtime-memoised, ~0.2ms warm) and the job registry. Any loadable cached model → complete; a running model download → partial; otherwise a stored complete/partial walks back to pending. `n/a` and never-written stages are left alone.
- Client (`progress.ts`) re-reads on `visibilitychange` while subscribed, and `ActivityDock` calls `noteProgressMayHaveMoved()` when the running or terminal job set changes — so every observed stage (FDA, app, Claude, models) refreshes within a poll tick, not just at sidebar mount.

Smoke: `onboarding.snapshot()` on this machine reports models complete off eight cached repos; first call 20ms, second 0.2ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding state persistence and server-side stage observation on config reads; incorrect dismiss/completion timing could affect auto-show behavior, but scope is limited to onboarding UX rather than auth or data integrity.
> 
> **Overview**
> **Models setup meter** now treats **complete** as one or more cached models (not every wizard pick), with **partial** when downloads are running and nothing is on disk yet. The wizard step and `progress.ts` docs/rules match that logic.
> 
> **Live refresh:** On each `/api/config` read, the server **re-observes** the models stage from `hub_cache.cached_models()` and running download jobs, walking stale complete/partial back to pending when nothing is cached. The client re-fetches progress on tab visibility and when **ActivityDock** sees the running or terminal job set change via `noteProgressMayHaveMoved()`.
> 
> **Wizard UX:** The top-left brand matches the sidebar (mark + “Render”, home link) and exits through **`finish("dismiss")`** so last-step unmount is not mistaken for completion. Model names link to **Playground** with `?model=` / `?cap=`. Any non-completion unmount (Back, brand, Playground, etc.) now stamps **`dismissed_at`**, with `settled` preventing double dismiss alongside ✕/Escape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f877a0695f8ff260509263df173b0dbaa06ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

**Wizard brand row** (`OnboardingWizard.tsx`): top-left is now the sidebar's brand row verbatim — mark + "Render", 9px gap / 13.5px / 650 weight, one link to `/home`, title turns `--accent-soft` on hover. Wordmark still hides between `sm` and 760px where the step pills need the row.

**Playground links** (`ModelsStep.tsx`): a model's name opens `/ai-models/playground?model=<id>&cap=<capability>`. The capability caption keeps the checkbox's label.

**Dismiss on every exit**: leaving the wizard any way but completing it — Back, brand link, sidebar meter, a Playground link — stamps `dismissed_at` on unmount. ✕ and Escape already did; `settled` stops a double stamp.