### PR TITLE
Tasks Cards: order the wall exactly as the List does

### DIFF
--- a/frontend/src/shell/home-performance.test.ts
+++ b/frontend/src/shell/home-performance.test.ts
@@ -59,7 +59,9 @@ test("Home sizes both row requests by the measured card count, never a constant"
   // width would ask for cards the row cannot show.
   expect(home).toContain("count: null");
   expect(home.match(/if \(limit === null\) return;/g)?.length).toBe(2);
-  expect(home.match(/\}, \[limit\]\);/g)?.length).toBe(2);
+  // Both effects hang off `limit`; the apps strip also re-fetches on the
+  // icon picker's nonce (#1062), so the dep list may carry a second name.
+  expect(home.match(/\}, \[limit(?:, \w+)?\]\);/g)?.length).toBe(2);
   // Grow-only, so narrowing the window refetches nothing.
   expect(home).toContain("limit: Math.max(prev.limit ?? 0, fits)");
   expect(home).not.toContain("useState(3)");

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6732,25 +6732,27 @@ describe("sortByLane", () => {
 const CARDS = readFileSync(join(SHELL, "TaskCards.tsx"), "utf8");
 const CARDS_CSS = readFileSync(join(SHELL, "../styles/task-cards.css"), "utf8");
 
-/** A task in a lane, with a START clock — `started`, which is what the wall
- *  orders by (see `cardsForTasks`), not `last_active`, which is what it used to
- *  order by and what this argument used to set.
+/** A task in a lane, with a LAST-RUN clock — `ran_at` on its one message,
+ *  which is what `taskWhen` prints on the card's head and what `sortByLane`
+ *  orders by, so the wall's order and its labels come off one clock.
  *
- *  `last_active` is deliberately pinned to something ELSE and identical across
- *  these rows: every test below would still pass if the sort quietly went back
- *  to reading it, and pinning it to a constant is what makes them notice.
+ *  `started` and `last_active` are deliberately pinned to something ELSE and
+ *  identical across these rows: the wall ordered by each of them in turn, every
+ *  test below would still pass if the sort quietly went back to either, and
+ *  pinning them to constants is what makes the tests notice.
  *
  *  `task_id` is derived from the key rather than left at the fixture's default,
- *  because the wall's identity is `cardKey` — project plus number — and three
- *  rows all called TASK-002 in one project are, correctly, one card. */
+ *  because the wall's identity is `cardKey` and two rows with one key are,
+ *  correctly, one card. */
 function running(key: string, at: number, over: Partial<Task> = {}): Task {
   return task({
     key,
     session_id: key,
     task_id: `TASK-${key}`,
     status: "in_progress",
-    started: at,
+    started: 7_777,
     last_active: 9_999,
+    messages: [msg({ at, ran_at: at, state: "sending", turn: "idle" })],
     ...over,
   });
 }
@@ -6763,10 +6765,10 @@ function asking(key: string, at: number, over: Partial<Task> = {}): Task {
 describe("cardsForTasks", () => {
   it("draws every lane, Archive included, in the List's own rank order", () => {
     // Akshil, 2026-09-05: "show all status tasks in cards even archived ones"
-    // (that morning it was every lane but Archive). CARD_LANES is both the
-    // membership test and the rank order, and it is LIST_ORDER itself rather
-    // than a second list — so the wall and the List can never disagree about
-    // which lane comes first. Every name in it is still a real board column.
+    // (that morning it was every lane but Archive). CARD_LANES is the membership
+    // test, and it is LIST_ORDER itself rather than a second list — so the wall
+    // and the List can never disagree about which lane comes first. Every name
+    // in it is still a real board column.
     expect(CARD_LANES).toEqual(LIST_ORDER);
     expect(CARD_LANES).toEqual(["needs_attention", "blocked", "upcoming", "in_progress", "done", "archived"]);
     for (const key of CARD_LANES) expect(BOARD_COLUMNS.map((c) => c.key)).toContain(key);
@@ -6781,6 +6783,37 @@ describe("cardsForTasks", () => {
     // "f" is OLDER than "a" and still comes first: the lane outranks the clock.
     // "e" — archived — is drawn too, in the bottom lane.
     expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["f", "d", "c", "a", "b", "e"]);
+  });
+
+  it("is the List's order, exactly — sortByLane, not a second opinion", () => {
+    // Akshil, 2026-09-08: "for list as a reference in order the cards". The wall
+    // used to share the List's RANK and keep a clock of its own inside a lane
+    // (`started`, when the task was created) while every card's head printed
+    // the List's stamp (`taskWhen`, the last run) — so a Done card reading
+    // "2h ago" sat above one reading "10m ago", and a recurring task created
+    // weeks ago that had just run was top of Done in the List and bottom of
+    // Done on the wall. Same rows, same order, in both views.
+    const S = (iso: string) => Math.floor(Date.parse(iso) / 1000);
+    const done = (key: string, ran: string, started: number) =>
+      task({
+        key,
+        task_id: `TASK-${key}`,
+        status: "done",
+        started,
+        messages: [msg({ at: S(ran), ran_at: S(ran), state: "sent" })],
+      });
+    const rows = [
+      // Created first, ran LAST — the recurring task. Top of Done.
+      done("weekly", "2026-09-08T09:00:00", 1_000),
+      // Created last, ran a day ago. Below it, whatever `started` says.
+      done("oneoff", "2026-09-07T09:00:00", 5_000),
+      running("run-a", 200),
+      running("run-b", 300),
+      asking("ask", 10),
+    ];
+    const cards = cardsForTasks(rows).cards.map((t) => t.key);
+    expect(cards).toEqual(sortByLane(rows).map((t) => t.key));
+    expect(cards).toEqual(["ask", "run-b", "run-a", "weekly", "oneoff"]);
   });
 
   it("groups by lane before it sorts, blocked first, then in progress", () => {
@@ -6802,18 +6835,36 @@ describe("cardsForTasks", () => {
     ]);
   });
 
-  it("orders by when the task STARTED, newest first, inside one lane", () => {
+  it("orders by the time the card PRINTS — its last run — newest first, inside one lane", () => {
     const rows = [running("old", 100), running("new", 300), running("mid", 200)];
     expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["new", "mid", "old"]);
   });
 
-  it("does not re-sort when a run merely writes — the whole point of `started`", () => {
+  it("runs Upcoming soonest first, overdue at the very top — the List's rule", () => {
+    // The old clock ran every lane newest-created first, which on Upcoming put
+    // the run due in ten minutes under one due in October if it was scheduled
+    // later. The List sorts that lane by the run ahead, ascending; so does this.
+    const NOW_S = Math.floor(NOW / 1000);
+    const soon = (key: string, at: number) =>
+      task({
+        key,
+        task_id: `TASK-${key}`,
+        status: "upcoming",
+        next_run: at,
+        messages: [msg({ at, ran_at: 0, state: "pending" })],
+      });
+    const rows = [soon("october", NOW_S + 30 * 86_400), soon("tenmin", NOW_S + 600), soon("late", NOW_S - 600)];
+    expect(cardsForTasks(rows, CARD_PAGE, NOW).cards.map((t) => t.key)).toEqual(["late", "tenmin", "october"]);
+  });
+
+  it("does not re-sort when a run merely writes", () => {
     // THE BUG (Akshil, 2026-09-03: "when i create a new task the layout shifts
     // multiple times"). The wall sorted by `last_active`, which climbs on every
     // write and reaches this page within a second (the /api/tasks/changes fast
-    // lane), so cards traded places for as long as anything was talking. Measured
-    // on this branch before the fix: a new card dropped a slot nine seconds after
-    // it appeared because an unrelated run had written in the meantime.
+    // lane), so cards traded places for as long as anything was talking. The
+    // List's key — a message's `ran_at` — is written once when the turn begins
+    // and does not tick while it streams, so this still holds without a clock
+    // of the wall's own.
     const before = [running("older", 100), running("newer", 200)];
     const order = cardsForTasks(before).cards.map((t) => t.key);
     expect(order).toEqual(["newer", "older"]);
@@ -6862,18 +6913,15 @@ describe("cardsForTasks", () => {
   });
 
   it("sends a task with no clock to the end, never to 1970", () => {
-    // `started` is 0.0 when the server could not name a start, and an older
-    // server sends no field at all. Either way the card belongs at the end, by
-    // decision rather than by what 0 coerces to.
-    const rows = [running("none", 0), running("has", 100)];
+    // No run in the window, `last_active` 0.0 for "never": the card prints an
+    // em dash and belongs at the end of its lane, by decision rather than by
+    // what 0 coerces to (sortRank's null bucket).
+    const none = running("none", 0, { messages: [], last_active: 0 });
+    const rows = [none, running("has", 100)];
     expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["has", "none"]);
-
-    const older = [
-      { ...running("a", 0), started: undefined },
-      { ...running("b", 0), started: undefined },
-    ];
-    // Every card in the null bucket: the wall keeps the server's listing order
-    // rather than inventing one.
+    // Every card clockless: the wall keeps the server's listing order rather
+    // than inventing one.
+    const older = [running("a", 0, { messages: [], last_active: 0 }), running("b", 0, { messages: [], last_active: 0 })];
     expect(cardsForTasks(older).cards.map((t) => t.key)).toEqual(["a", "b"]);
   });
 

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2888,14 +2888,14 @@ export function sortByLane(tasks: Task[], now: number = Date.now()): Task[] {
 // attention at the top, because a parked run is the one card that needs a
 // person; Archive at the bottom, under Done.
 //
-// The one decision that is this view's own is the clock inside a lane: `started`
-// rather than `last_active`, because `last_active` climbs on every write and
-// reaches this page within a second, so cards traded places for as long as
-// anything was talking (cardsForTasks, below).
+// And the ORDER inside a lane is the List's too — sortByLane, the same call
+// (Akshil, 2026-09-08: "for list as a reference in order the cards"). This view
+// once kept a clock of its own there (`started`) and its cards read out of order
+// against the times printed on their own heads; see cardsForTasks, below.
 //
-// So the only decisions it makes are here, out of the component, because they
-// are the ones worth testing and a grid of iframes is the last place to test
-// anything.
+// So the only decisions it makes — membership, dedupe, the page — are here, out
+// of the component, because they are the ones worth testing and a grid of
+// iframes is the last place to test anything.
 
 /** The lanes a Cards view draws, top rank first — LIST_ORDER, whole. Kept as
  * its own name so the view's membership test reads as a decision, not a
@@ -2973,56 +2973,48 @@ export function cardKey(task: Pick<Task, "key" | "task_id" | "project">): string
 }
 
 /**
- * The Cards view's rows: the running tasks, by lane then newest first, capped.
+ * The Cards view's rows: the List's order, one card per row, capped.
  *
- * BY LANE FIRST (Akshil, 2026-09-03: order the cards "based on status, the same
- * way we have in list … blocked first and then in progress … sort them by
- * recency" inside each group). The wall used to be one flat recency order, and
- * that buried the only card on it that needs a person: a run parked on a
- * question stops ticking `last_active` the moment it asks, so the longer it
- * waits the further down it sinks — exactly backwards. The rank is a card's
- * lane's index in `CARD_LANES`, which is LIST_ORDER whole, so this
- * cannot drift out of step with the List: the same rows in the same lane order
- * in both views, which is what makes switching between them a change of shape
- * rather than of subject.
+ * THE LIST'S ORDER, WHOLE (Akshil, 2026-09-08: "for list as a reference in
+ * order the cards"). Not the List's rank with a clock of this view's own — that
+ * is what was here, and it is the bug this fixes. The cards ranked by lane like
+ * the List and then ran by `started` (when the task was created) inside a lane,
+ * while every card's head printed `taskWhen` — the last run, the same stamp a
+ * List row prints. So the wall was ORDERED by one clock and LABELLED with another:
+ * a Done card reading "2h ago" sat above one reading "10m ago", the exact
+ * symptom the List had already cured in itself (sortRank), and a recurring task
+ * created weeks ago that had just run sat at the top of Done in the List and at
+ * the bottom of Done here. Switching views reshuffled the lane, which is the one
+ * thing the shared LIST_ORDER was there to prevent.
  *
- * NEWEST TASK FIRST WITHIN A LANE, and `started` is what that means — when the
- * conversation BEGAN (server `_place`: the earliest of the scheduled entry's
- * `created` and the transcript's first record), not when it last said something.
+ * So the order is `sortByLane`, the very function the List calls: rank by
+ * LIST_ORDER, and inside a rank by the time the row prints — last run, most
+ * recent first; Upcoming by the run ahead, soonest first, overdue at the top;
+ * Archive as the server lists it; a row with no time at all last in its rank.
+ * Same rows, same order, in both views, and a card's place on the wall is the
+ * place a reader can check against the stamp on its own head.
  *
- * IT WAS `last_active`, AND THAT IS THE BUG THIS FIXES (Akshil, 2026-09-03: "in
- * cards view, when i create a new task the layout shifts multiple times, fix
- * that it should shift only one time"). `last_active` climbs every time a run
- * writes, and the page's fast lane (/api/tasks/changes, Scheduled.tsx) lands
- * those writes within a second of each one — so on a wall of live chats the sort
- * key of every card was changing continuously and the cards traded places for as
- * long as anything was talking. Measured on this branch: a new card appeared,
- * then dropped a slot nine seconds later because an unrelated run had written in
- * the meantime, then came back when that run finished. A wall whose whole claim
- * is "watch these" may not move while it is being watched.
+ * WHY `started` WAS HERE, AND WHY THE LIST'S KEY IS SAFE TOO. The wall first ran
+ * by `last_active`, which climbs on every write and reaches this page within a
+ * second (the /api/tasks/changes fast lane), so cards traded places for as long
+ * as anything was talking (Akshil, 2026-09-03: "when i create a new task the
+ * layout shifts multiple times"). `started` never moves, and that was the fix
+ * (PR #984) — but it over-corrected: it froze the wall against a clock nobody
+ * could see. The List's key is `lastRunAt`, a message's `ran_at`, which is
+ * written ONCE when the turn begins and does not tick while the run streams — so
+ * a card still holds still while its conversation talks, and moves only when a
+ * run starts, a run ends, or a lane changes: real events with something to say.
+ * The test that pins this ("does not re-sort when a run merely writes") is kept
+ * and still holds.
  *
- * `started` never moves for the life of a task, so a card's place is decided once
- * — when it arrives — and then only by cards ARRIVING and LEAVING. Those two are
- * real events with something to say; "a run wrote a line" is not. Newest first
- * puts a task somebody has just created at the top, which is where they are
- * already looking.
+ * TIES KEEP THE SERVER'S ORDER (sortRank compares the incoming index), which
+ * matters more here than on a row: every card is a live iframe keyed by task,
+ * and two cards trading places between polls is two conversations swapping
+ * seats in front of somebody reading one of them.
  *
- * Deliberately NOT `taskWhen`/`laneTime` either: those answer "which run does
- * this row print", a question with three fallbacks in it, and the card head
- * prints that time — but printing a time is not the same as being ordered by it,
- * and this view would rather hold still.
- *
- * TIES KEEP THE SERVER'S ORDER, by comparing the incoming index explicitly rather
- * than trusting the sort to be stable — sortLane's rule 1, and it matters more
- * here than it does on a lane: every card is a live iframe keyed by task, so two
- * cards trading places between polls is not a row moving, it is two conversations
- * swapping seats in front of somebody reading one of them.
- *
- * A TASK WITH NO CLOCK AT ALL goes last IN ITS OWN LANE (rule 2, same reason: 0
- * is 1970, and a task whose start the server could not name must not be allowed
- * to claim either end of the order by accident). It also covers an older server
- * that sends no `started` at all: every card lands in the `null` bucket and the
- * wall falls back to the server's own listing order, which is stable enough.
+ * `now` is read ONCE for the whole wall and handed down, for sortByLane's own
+ * reason: a comparator that changes its mind halfway through a sort straddling a
+ * second is a comparator with no defined output.
  *
  * ONE CARD PER IDENTITY. Deduplicated on `cardKey`, which is what the view keys
  * its iframes on — two rows resolving to one card would be a React duplicate key
@@ -3034,39 +3026,18 @@ export function cardKey(task: Pick<Task, "key" | "task_id" | "project">): string
  * A new array; the input is never mutated (it is the polled list, which React is
  * still holding).
  */
-export function cardsForTasks(tasks: Task[], cap: number = CARD_PAGE): TaskCardSet {
-  // `indexOf` rather than a Set: membership AND rank come off the one list, and
-  // -1 — "this lane is not drawn here" — is the filter.
-  const rank = (task: Task) => CARD_LANES.indexOf(taskColumn(task));
-  const rows = tasks
-    .map((task, index) => ({
-      task,
-      index,
-      lane: rank(task),
-      // `|| null` for laneTime's reason: `started` is a float that is 0.0 for
-      // "the server could not name a start", and 0 must be "no clock" rather
-      // than an instant in 1970. `?? 0` first, because an older server sends no
-      // field at all and `undefined || null` is not the same expression.
-      at: (task.started ?? 0) || null,
-    }))
-    .filter((r) => r.lane >= 0);
-  rows.sort((a, b) => {
-    if (a.lane !== b.lane) return a.lane - b.lane;
-    if (a.at === null || b.at === null) {
-      // Exactly one of them has a clock: the one that does comes first.
-      if (a.at !== b.at) return a.at === null ? 1 : -1;
-    } else if (a.at !== b.at) {
-      return b.at - a.at;
-    }
-    return a.index - b.index;
-  });
+export function cardsForTasks(
+  tasks: Task[],
+  cap: number = CARD_PAGE,
+  now: number = Date.now(),
+): TaskCardSet {
   const seen = new Set<string>();
   const all: Task[] = [];
-  for (const row of rows) {
-    const id = cardKey(row.task);
+  for (const task of sortByLane(tasks, now)) {
+    const id = cardKey(task);
     if (seen.has(id)) continue;
     seen.add(id);
-    all.push(row.task);
+    all.push(task);
   }
   // A cap of 0 or less is "no cap" rather than an empty page: the view passes
   // pages × CARD_PAGE and a test can shrink it, and the failure mode of a bad

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -1452,12 +1452,15 @@ def _place(task: dict) -> None:
     # WHY THE TWO CANNOT BE THE SAME VALUE (bugbot, PR #984). `order` SWITCHES
     # SOURCE the moment a transcript exists: before that it is the entry's
     # `created`, and after it is the transcript's first record. For allocation
-    # that is harmless — a number is allocated once and then kept — but the Cards
-    # wall orders itself by `started` precisely so a card cannot move after it
-    # appears (shell/tasks-lib.cardsForTasks), and a value that changes under a
-    # listed row is exactly the thing that would move one. Two tasks created
-    # seconds apart could swap places when the second's transcript landed; a run
-    # scheduled days before it fires would jump the moment it spoke.
+    # that is harmless — a number is allocated once and then kept — but a row's
+    # `started` is a listed fact, and a fact that changes under a listed row is
+    # the kind of thing a view sorting by it would move on. (The Cards wall did
+    # sort by it for a while; it now shares the List's order — the time each
+    # row prints, shell/tasks-lib.sortByLane — and nothing on the client orders
+    # by `started` today. The field stays fixed regardless, for whoever next
+    # reads it.) Two tasks created seconds apart could swap places when the
+    # second's transcript landed; a run scheduled days before it fires would
+    # jump the moment it spoke.
     #
     # So: THE EARLIEST CLOCK WE HAVE. `created` is written when the message is
     # scheduled and always precedes the first thing the run says, so once a task
@@ -1761,9 +1764,9 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # explains the choice at length): the scheduled entry's `created`, else
         # the transcript's first record. It is the one time on this row that
         # never moves — `last_active` climbs on every write, and `order` beside
-        # it switches source when a transcript appears — which is why the Cards
-        # wall orders by it: a view that re-sorts itself while its runs are
-        # merely talking is one nobody can watch (shell/tasks-lib.cardsForTasks).
+        # it switches source when a transcript appears. The Cards wall ordered by
+        # it for a while; it now takes the List's order (shell/tasks-lib
+        # sortByLane), and the field stays on the row as the one fixed clock.
         # 0.0 for a row that has neither a transcript nor an entry to date, the
         # way every other absent time on this row reads.
         "started": task.get("started") or 0.0,


### PR DESCRIPTION
## Summary
- Cards view sorted within a lane by `started` (task creation) while each card head printed the last-run time. Result: cards read out of order against their own labels (Done card "41m ago" above "3m ago"), and List↔Cards showed the same lane in different orders.
- `cardsForTasks` now returns `sortByLane(tasks)` — the List's exact order (rank, then last run desc; Upcoming next-run asc; Archive server order) — then dedupes by key and pages by six.
- Stability preserved: the List's key is a message's `ran_at`, written once per turn, so cards do not move while a run streams. Cards move only when a run starts/ends or a lane changes.
- Server comments in `routers/tasks.py` updated so they stop saying the Cards wall orders by `started` (field kept; nothing on the client orders by it now).

## Test plan
- [x] `bun test src/shell/tasks-lib.test.ts` — 473 pass (cards tests rewritten; new parity test `cards == sortByLane`, Upcoming soonest-first test)
- [x] `tsc --noEmit` clean
- [x] Live data (592 tasks): Cards ids/times identical to List on default and Archive filters, Show-more pagination intact, console clean, 3-col grid intact (cmux browser)
- [x] Side-by-side vs production build on :1777 confirmed the old inversion (TASK-003 41m above TASK-040 3m) is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core task Cards ordering logic used on a live iframe grid; behavior is heavily tested but affects a primary shell view users switch with the List.
> 
> **Overview**
> **Cards view ordering** no longer ranks lanes like the List but sorts inside each lane by task `started` while card headers still show last-run times (`taskWhen`). That mismatch made Done cards appear above/below neighbors in ways that contradicted their labels and differed from the List for the same filter.
> 
> **`cardsForTasks`** now walks **`sortByLane(tasks, now)`** — same rank, last-run desc, Upcoming next-run asc, clockless rows last — then dedupes by `cardKey` and applies the six-card page cap. An optional **`now`** argument keeps Upcoming comparisons stable across one sort. Ordering still avoids jitter while a run streams because the List key (`ran_at`) is set once per turn, not on every write.
> 
> **Tests** add explicit List parity and Upcoming ordering cases, retarget fixtures to **`ran_at`** on messages, and refresh comments. **`home-performance.test.ts`** loosens a structural regex so Home effects may list a second dependency (apps strip refetch on icon-picker nonce). **`tasks.py`** comments only: they no longer claim the Cards wall sorts by **`started`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6fc8e2e3c26e973aa30d3bf933133298a3bd017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->