### PR TITLE
Explorer: VS Code-style git decorations on entry names

### DIFF
--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -14,7 +14,7 @@
 //   pane.ts                preview-pane split (usePreviewPane: width + drag)
 //   pane-side.ts           the pane's three modes + the `_side` param (pure)
 //   row-utils.ts           RowCtx batch helpers
-//   bits.tsx               skeleton rows, ClipMark, highlight, scroll anchor
+//   bits.tsx               skeleton rows, ClipMark, GitMark, highlight, anchor
 //   useDirListing.ts       /api/fs/list fetch, Load more, dir watch, new-row cue
 //   useWalkSearch.ts       streamed walk + scoring + throttles + result paging
 //   useListingSelection.ts selection state + keyboard nav + reconcile
@@ -77,9 +77,11 @@ import { resolveSort, sortEntries } from "@apps/explorer/listing/sorting";
 import {
   skeletonRows,
   ClipMark,
+  GitMark,
   renderHighlight,
   measureScrollAnchor,
 } from "@apps/explorer/listing/bits";
+import { gitRowClass } from "@apps/explorer/listing/git-mark";
 import { usePreviewPane } from "@apps/explorer/listing/pane";
 import {
   activePaneSide,
@@ -1614,6 +1616,7 @@ export default function Listing({
           data-fs-drop-dir={entry.is_dir ? "1" : "0"}
           className={
             (entry.ignored ? "row ignored" : "row") +
+            gitRowClass(entry.git) + // git tints the NAME, not the row
             (newNames.has(entry.name) ? " row-new" : "") + // brief dir-watch tint
             (selectedSet.has(childPath) ? " selected" : "") +
             (childPath === selectedPath ? " lead" : "") + // scroll-into-view marker
@@ -1639,6 +1642,7 @@ export default function Listing({
               </span>
               {entry.name}
             </span>
+            <GitMark status={entry.git} />
             <ClipMark
               cut={cutSet.has(childPath)}
               copied={copiedSet.has(childPath)}

--- a/frontend/src/apps/explorer/listing/bits.tsx
+++ b/frontend/src/apps/explorer/listing/bits.tsx
@@ -1,7 +1,8 @@
 // Small presentational pieces of the listing: skeleton rows, the clipboard
-// pill, and search-match highlighting.
+// pill, the git status badge, and search-match highlighting.
 import { highlightSegments } from "@platform/lib/fuzzy";
 import { FLIP_KEY_ATTR } from "@platform/lib/flip";
+import { gitMarkFor } from "./git-mark";
 
 // Shimmering placeholder rows shown while the listing fetch is in flight —
 // same column shape as the real rows (icon + name + size + mtime), just with
@@ -36,6 +37,21 @@ export function ClipMark({ cut, copied }: { cut: boolean; copied: boolean }) {
   return (
     <span className={"clip-mark" + (cut ? " cut" : " copied")} title="Press Esc to cancel">
       {cut ? "Cut" : "Copied"}
+    </span>
+  );
+}
+
+// The git status badge in a row's name cell: one letter, tinted the same as the
+// name it follows (styles/explorer.css keys both off the row's `git-*` class).
+// See listing/git-mark.ts for why a letter exists at all rather than colour
+// alone. Renders nothing when git has nothing to say — which is the common case
+// and must cost the row no layout.
+export function GitMark({ status }: { status?: string }) {
+  const mark = gitMarkFor(status);
+  if (!mark) return null;
+  return (
+    <span className="git-mark" title={mark.label} aria-label={mark.label}>
+      {mark.letter}
     </span>
   );
 }

--- a/frontend/src/apps/explorer/listing/bits.tsx
+++ b/frontend/src/apps/explorer/listing/bits.tsx
@@ -50,7 +50,13 @@ export function GitMark({ status }: { status?: string }) {
   const mark = gitMarkFor(status);
   if (!mark) return null;
   return (
-    <span className="git-mark" title={mark.label} aria-label={mark.label}>
+    // role="img": a plain `<span>` is `role=generic`, where `aria-label` is
+    // unsupported and dropped — a screen reader would announce the bare
+    // glyph ("!" as an exclamation mark), defeating the whole reason this
+    // badge carries a letter and a label instead of colour alone (see this
+    // file's header). Same trap, same fix, as ScheduleTaskViews.tsx's own
+    // status dot.
+    <span className="git-mark" role="img" title={mark.label} aria-label={mark.label}>
       {mark.letter}
     </span>
   );

--- a/frontend/src/apps/explorer/listing/fsChangeBus.ts
+++ b/frontend/src/apps/explorer/listing/fsChangeBus.ts
@@ -1,0 +1,34 @@
+// The one thing missing from `window._fusedFsChanged` (main.tsx): it forgets
+// what the 5-second prefetch cache knows (api.ts's `clearListPrefetch`), but
+// it never told an ALREADY-MOUNTED `useDirListing` that the folder it is
+// showing might be wrong. A write from inside a preview iframe — most
+// pointedly the git template's stage/unstage running through `fused.runPython`
+// — left an open Explorer pane showing exactly what it had before the write,
+// because nothing bumped that pane's `refresh` counter. The dir-watch
+// WebSocket (useDirListing.ts) has no opinion either: `git add` / `git
+// restore --staged` only rewrite bytes inside the existing `.git/index` file,
+// so no watched directory's mtime moves and the poller's baseline never
+// budges (fused_render/server/watch.py).
+//
+// A small subscriber list, not a DOM CustomEvent: every mounted listing wants
+// the SAME "something changed, re-check" nudge `useDirListing` already gives
+// its own WebSocket messages, and a plain callback set is enough to reach
+// every one of them without going through the DOM at all.
+const subscribers = new Set<() => void>();
+
+/** Register for "a filesystem write happened somewhere, of unknown shape".
+ * Returns the unsubscribe function — call it on unmount so an unmounted
+ * listing's `setRefresh` is never reached (no leak, no
+ * setState-after-unmount). */
+export function subscribeFsChanged(cb: () => void): () => void {
+  subscribers.add(cb);
+  return () => subscribers.delete(cb);
+}
+
+/** Tell every subscribed listing to re-check. Called from `window._fusedFsChanged`
+ * (main.tsx) alongside `clearListPrefetch`, in addition to it — this reaches
+ * listings already mounted; the prefetch cache only protects a listing that
+ * mounts LATER. */
+export function notifyFsChanged(): void {
+  for (const cb of subscribers) cb();
+}

--- a/frontend/src/apps/explorer/listing/git-mark.test.ts
+++ b/frontend/src/apps/explorer/listing/git-mark.test.ts
@@ -27,6 +27,16 @@ describe("gitRowClass", () => {
     // leave the row looking decorated and coloured like nothing.
     expect(gitRowClass("deleted")).toBe("");
   });
+
+  it("does not resolve an inherited Object.prototype property", () => {
+    // `GIT_MARKS[status] ?? null` resolves the PROTOTYPE CHAIN, not just the
+    // object's own keys — `GIT_MARKS["constructor"]` is `Object`, a truthy
+    // value, so this class name must not fall out of a cross-version guard
+    // that only means to reject values this build has never heard of.
+    expect(gitRowClass("constructor")).toBe("");
+    expect(gitRowClass("toString")).toBe("");
+    expect(gitRowClass("hasOwnProperty")).toBe("");
+  });
 });
 
 describe("gitMarkFor", () => {
@@ -51,6 +61,13 @@ describe("gitMarkFor", () => {
     expect(gitMarkFor(undefined)).toBeNull();
     expect(gitMarkFor("")).toBeNull();
     expect(gitMarkFor("deleted")).toBeNull();
+  });
+
+  it("is null for an inherited Object.prototype property", () => {
+    // Same trap as gitRowClass above, on the other function that indexes
+    // GIT_MARKS: `gitMarkFor("constructor")` must not return `Object`.
+    expect(gitMarkFor("constructor")).toBeNull();
+    expect(gitMarkFor("toString")).toBeNull();
   });
 
   it("agrees with gitRowClass on every input", () => {

--- a/frontend/src/apps/explorer/listing/git-mark.test.ts
+++ b/frontend/src/apps/explorer/listing/git-mark.test.ts
@@ -1,0 +1,61 @@
+// The git decoration's two halves must agree: a row is never tinted without
+// its badge, or badged without its tint. They are separate functions because
+// they are called from separate places (the <tr> class and a cell's child), and
+// this is where "separate" is kept from becoming "divergent".
+import { describe, expect, it } from "bun:test";
+
+import { GIT_MARKS, gitMarkFor, gitRowClass } from "./git-mark";
+
+const STATES = Object.keys(GIT_MARKS);
+
+describe("gitRowClass", () => {
+  it("names one class per known state", () => {
+    expect(STATES.map(gitRowClass)).toEqual([
+      " git-conflicted",
+      " git-modified",
+      " git-untracked",
+      " git-staged",
+    ]);
+  });
+
+  it("is empty for a clean entry", () => {
+    expect(gitRowClass(undefined)).toBe("");
+  });
+
+  it("is empty for a state this build does not know", () => {
+    // A newer server can send a fifth state; an unstyled `git-…` class would
+    // leave the row looking decorated and coloured like nothing.
+    expect(gitRowClass("deleted")).toBe("");
+  });
+});
+
+describe("gitMarkFor", () => {
+  it("gives every state a distinct letter", () => {
+    const letters = STATES.map((s) => gitMarkFor(s)!.letter);
+    expect(new Set(letters).size).toBe(STATES.length);
+  });
+
+  it("never lends git's staged-add letter to untracked", () => {
+    // `A` means "staged add" in `git status`; reusing it here would make the
+    // listing and the terminal disagree about what A is.
+    expect(STATES.map((s) => gitMarkFor(s)!.letter)).not.toContain("A");
+  });
+
+  it("labels every state in words, for the tooltip and the screen reader", () => {
+    for (const state of STATES) {
+      expect(gitMarkFor(state)!.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("is null for a clean entry and for an unknown state", () => {
+    expect(gitMarkFor(undefined)).toBeNull();
+    expect(gitMarkFor("")).toBeNull();
+    expect(gitMarkFor("deleted")).toBeNull();
+  });
+
+  it("agrees with gitRowClass on every input", () => {
+    for (const input of [...STATES, "deleted", "", undefined]) {
+      expect(!!gitMarkFor(input)).toBe(gitRowClass(input) !== "");
+    }
+  });
+});

--- a/frontend/src/apps/explorer/listing/git-mark.ts
+++ b/frontend/src/apps/explorer/listing/git-mark.ts
@@ -44,5 +44,18 @@ export function gitRowClass(status: string | undefined): string {
 /** The mark for an entry, or null when git has nothing to say about it. */
 export function gitMarkFor(status: string | undefined): GitMark | null {
   if (!status) return null;
-  return GIT_MARKS[status as GitEntryStatus] ?? null;
+  // `GIT_MARKS[status] ?? null` would resolve `Object.prototype` for a
+  // status this build doesn't know: `gitMarkFor("constructor")` returns
+  // `Object` (a truthy value, so `GitMark` would render `mark.letter` as
+  // `undefined`), and `gitRowClass("constructor")` would name a CSS class
+  // for a state that was never meant to exist.
+  //
+  // `Object.prototype.hasOwnProperty.call`, not `Object.hasOwn` (ES2022) —
+  // this project's tsconfig targets ES2020 — but the effect is identical:
+  // it checks only GIT_MARKS's own keys, never the prototype chain behind
+  // it, so a status matching an inherited property name is rejected the
+  // same as any other status this build has never heard of.
+  return Object.prototype.hasOwnProperty.call(GIT_MARKS, status)
+    ? GIT_MARKS[status as GitEntryStatus]
+    : null;
 }

--- a/frontend/src/apps/explorer/listing/git-mark.ts
+++ b/frontend/src/apps/explorer/listing/git-mark.ts
@@ -1,0 +1,48 @@
+// How a git status becomes a decoration on a listing row: the class the name is
+// tinted through, and the one-letter badge beside it.
+//
+// The BADGE is not decoration on the decoration. Colour is the whole signal in
+// VS Code's file tree, and colour alone excludes anyone who cannot separate the
+// green from the amber — roughly one reader in twelve for the commonest form of
+// colour-vision deficiency, which is exactly the added/modified pair. The
+// letter says the same thing without the hue, and its tooltip says it in words
+// for a screen reader.
+//
+// Letters follow git's own porcelain vocabulary rather than our state names, so
+// they mean the same thing here as in `git status` — `U` for untracked (`??`),
+// `M` for a dirty work tree, `S` for staged-and-clean, `!` for an unresolved
+// merge. `A` is deliberately unused: git spells the STAGED add `A`, and lending
+// that letter to "untracked" would make the two states swap names between the
+// listing and the terminal.
+import type { GitEntryStatus } from "@platform/lib/api";
+
+export interface GitMark {
+  letter: string;
+  label: string;
+}
+
+export const GIT_MARKS: Record<GitEntryStatus, GitMark> = {
+  conflicted: { letter: "!", label: "Unresolved merge conflict" },
+  modified: { letter: "M", label: "Modified, not staged" },
+  untracked: { letter: "U", label: "Untracked — new to git" },
+  staged: { letter: "S", label: "Staged for the next commit" },
+};
+
+/**
+ * The row's git class, or `""` when there is nothing to tint it with.
+ *
+ * Unknown values answer `""` for the same reason `gitMarkFor` answers null:
+ * the field crosses a version boundary (a newer server talking to a shell
+ * built before a fifth state existed), and an unstyled `git-…` class is worse
+ * than an undecorated row. The two functions therefore agree on every input —
+ * a row is never tinted without its badge, or badged without its tint.
+ */
+export function gitRowClass(status: string | undefined): string {
+  return gitMarkFor(status) ? ` git-${status}` : "";
+}
+
+/** The mark for an entry, or null when git has nothing to say about it. */
+export function gitMarkFor(status: string | undefined): GitMark | null {
+  if (!status) return null;
+  return GIT_MARKS[status as GitEntryStatus] ?? null;
+}

--- a/frontend/src/apps/explorer/listing/useDirListing.ts
+++ b/frontend/src/apps/explorer/listing/useDirListing.ts
@@ -6,6 +6,7 @@ import { clearListPrefetch, listDir, prefetchListDir, type HttpError } from "@pl
 import { appearedKeys } from "@platform/lib/flip";
 import { pushToast } from "@platform/lib/toast";
 import { ROW_NEW_MS, type ListingState } from "@apps/explorer/listing/types";
+import { subscribeFsChanged } from "@apps/explorer/listing/fsChangeBus";
 
 // `listPath` is what actually gets fetched — `fsPath` itself, UNLESS this
 // folder sits under an active git snapshot, in which case it is the same
@@ -111,6 +112,25 @@ export function useDirListing(fsPath: string, listPath: string = fsPath) {
     let retry: ReturnType<typeof setTimeout> | null = null;
     let timer: ReturnType<typeof setTimeout> | null = null;
     let closed = false;
+    // Same 300ms debounce as the socket path below, and deliberately the SAME
+    // timer variable: a stage-then-immediately-typed external `git add`
+    // (or any other pair of near-simultaneous changes) should coalesce into
+    // one refetch, not race two independent ones against each other.
+    const scheduleRefresh = () => {
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(() => setRefresh((n) => n + 1), 300);
+    };
+    // A write from inside a preview iframe (fused.writeFile/uploadFile/mkdir,
+    // or any runPython — including the git template's stage/unstage, which
+    // only rewrites `.git/index` and so never moves this directory's own
+    // mtime — see window._fusedFsChanged in main.tsx). The dir-watch socket
+    // below only ever hears about a change to `fsPath` ITSELF; this is the
+    // only way an already-mounted listing hears about a change whose origin
+    // isn't a plain filesystem write to the watched directory.
+    const unsubscribe = subscribeFsChanged(() => {
+      clearListPrefetch();
+      scheduleRefresh();
+    });
     const connect = () => {
       const proto = location.protocol === "https:" ? "wss://" : "ws://";
       sock = new WebSocket(proto + location.host + "/api/fs/events?path=" + encodeURIComponent(fsPath));
@@ -139,8 +159,7 @@ export function useDirListing(fsPath: string, listPath: string = fsPath) {
         // Before the debounce, not inside it: the cache should be dead the moment
         // we know it is wrong, whether or not this listing goes on to refetch.
         clearListPrefetch();
-        if (timer !== null) clearTimeout(timer);
-        timer = setTimeout(() => setRefresh((n) => n + 1), 300);
+        scheduleRefresh();
       };
       // WebSockets don't auto-reconnect the way EventSource did.
       sock.onclose = () => {
@@ -150,6 +169,7 @@ export function useDirListing(fsPath: string, listPath: string = fsPath) {
     connect();
     return () => {
       closed = true;
+      unsubscribe();
       if (retry !== null) clearTimeout(retry);
       if (timer !== null) clearTimeout(timer);
       sock?.close();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { TroubleCard } from "@platform/ui/TroubleCard";
 import { IS_EMBED, IS_SNAPSHOT } from "@platform/lib/router";
 import { clearListPrefetch, getConfig } from "@platform/lib/api";
+import { notifyFsChanged } from "@apps/explorer/listing/fsChangeBus";
 import { hydrateBookmarks, refreshBookmarks } from "@platform/lib/bookmarks";
 import { hydrateRecents } from "@apps/explorer/lib/recents";
 import { notifyBookmarksChanged } from "@platform/lib/hooks";
@@ -53,7 +54,20 @@ declare global {
 // off ancestor URLs directly (D3/D4, D46) — same-origin by construction — and
 // installed here, beside the history wrapping, because both are contracts with
 // that runtime that must exist before any frame can load.
-window._fusedFsChanged = clearListPrefetch;
+//
+// Two effects, not one: `clearListPrefetch` protects a listing that mounts
+// LATER (within the 5s TTL) from painting pre-write contents, but it cannot
+// reach a listing that is ALREADY mounted — nothing pops its `refresh`
+// counter. `notifyFsChanged` (listing/fsChangeBus.ts) is that missing half:
+// every live `useDirListing` subscribes to it and re-fetches through the same
+// 300ms debounce its own dir-watch socket uses. Without it, staging a file
+// through the git template left an open Explorer pane showing what it had
+// before the stage — the write never touched the watched directory's own
+// mtime, so the socket-driven watch had nothing to notice either.
+window._fusedFsChanged = () => {
+  clearListPrefetch();
+  notifyFsChanged();
+};
 
 if (IS_EMBED) document.body.classList.add("embed");
 // Frozen-tree framing (router.ts IS_SNAPSHOT): a body class rather than props

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -65,7 +65,17 @@ export interface FsEntry {
   size: number | null;
   mtime: number | null;
   ignored?: boolean; // matched by .gitignore inside a git repo (dimmed in the UI)
+  // What git says about this entry, when the folder is inside a repo and git
+  // has something to say — the name is tinted with it (styles/explorer.css).
+  // A folder carries the most urgent state anywhere BENEATH it, so a collapsed
+  // subtree can't hide a change; see fused_render/server/git_status.py for the
+  // ranking. Absent means clean, not-in-a-repo, or a server that predates the
+  // field — all three render undecorated, which is the same true statement:
+  // there is nothing to point at.
+  git?: GitEntryStatus;
 }
+
+export type GitEntryStatus = "conflicted" | "modified" | "untracked" | "staged";
 
 export interface ListResult {
   path: string;

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -516,6 +516,14 @@ const listPrefetch = new Map<string, { promise: Promise<ListResult>; ts: number 
 //                              same-origin ancestor chain. This is the only cover
 //                              for a template view of a FILE, which mounts no
 //                              listing and so has no watcher at all.
+//
+// This map only protects a listing that mounts (or re-fetches) AFTER the
+// clear — it says nothing to a listing already sitting on screen, which is
+// why window._fusedFsChanged also calls listing/fsChangeBus.ts's
+// `notifyFsChanged` right alongside `clearListPrefetch`: that is the half
+// that reaches an ALREADY-MOUNTED useDirListing (e.g. an Explorer pane open
+// on a repo while the git template's stage/unstage runs in another pane,
+// which rewrites `.git/index` and so moves no watched directory's mtime).
 export function clearListPrefetch(): void {
   listPrefetch.clear();
 }

--- a/frontend/src/platform/lib/list-prefetch.test.ts
+++ b/frontend/src/platform/lib/list-prefetch.test.ts
@@ -134,5 +134,10 @@ test("the shell installs the hook the preview runtime reports writes through", (
   // hear about it. static/runtime.js walks the same-origin ancestor chain calling
   // this global (its noteFsChanged).
   const src = source("main.tsx");
-  expect(src).toContain("window._fusedFsChanged = clearListPrefetch");
+  const assignment = src.slice(src.indexOf("window._fusedFsChanged ="));
+  expect(assignment).toContain("clearListPrefetch()");
+  // Clearing the prefetch cache alone only protects a listing that mounts
+  // LATER — it does nothing for one already on screen. notifyFsChanged is the
+  // other half, reaching every currently-mounted useDirListing.
+  expect(assignment).toContain("notifyFsChanged()");
 });

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1891,6 +1891,52 @@ table.listing-table tr.row.ignored {
   opacity: 0.45;
 }
 
+/* Git decoration, the file-tree convention: a name in a colour because git has
+   something to say about that path (server/git_status.py decides what). The ROW
+   carries the state as a class and only the NAME cell wears it — a tinted SIZE
+   or MODIFIED would read as a second, unrelated signal about the same row.
+   Folders are tinted by whatever is most urgent beneath them, so a change can't
+   hide inside a folder nobody opened.
+
+   The state is funnelled through one `--git-tint` rather than four colour rules
+   so the badge in listing/bits.tsx picks up the same value from the same place;
+   the two cannot drift into disagreeing about what a row's colour is. */
+table.listing-table tr.row.git-untracked {
+  --git-tint: var(--git-untracked);
+}
+table.listing-table tr.row.git-modified {
+  --git-tint: var(--git-modified);
+}
+table.listing-table tr.row.git-staged {
+  --git-tint: var(--git-staged);
+}
+table.listing-table tr.row.git-conflicted {
+  --git-tint: var(--git-conflicted);
+}
+table.listing-table tr.row.git-untracked > td.name,
+table.listing-table tr.row.git-modified > td.name,
+table.listing-table tr.row.git-staged > td.name,
+table.listing-table tr.row.git-conflicted > td.name {
+  color: var(--git-tint);
+}
+
+/* The one-letter badge beside a tinted name (listing/git-mark.ts says why a
+   letter exists at all). Same tint as the name, at the muted weight of a
+   margin note: it annotates the filename rather than competing with it.
+   `flex: 0 0 auto` keeps it from being the thing that shrinks — the name has
+   `min-width: 0` and ellipsizes, and a badge clipped to "M" reading as "!" is
+   the one failure this element cannot afford. */
+table.listing-table td.name .git-mark {
+  flex: 0 0 auto;
+  color: var(--git-tint);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  opacity: 0.85;
+  cursor: default;
+  user-select: none;
+}
+
 table.listing-table tr.row:hover {
   background: var(--bg-alt);
   opacity: 1;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -150,6 +150,27 @@
   --series-5: #4fd1c5;
   --series-6: #ff8f8f;
 
+  /* Git decoration for a file listing's NAME — the explorer's row tinting
+     (styles/explorer.css, fused_render/server/git_status.py). Not the
+     --success/--warning/--error family, for the same reason --series-* is not:
+     those three carry SENTIMENT, and "you have edited this file" is not good
+     news or bad news. They are also not interchangeable with the chart hues,
+     which are chosen for mutual separation and mean nothing individually —
+     each of these does mean one specific thing, and the meanings are the
+     conventional ones (green new, amber edited) that a reader arrives with
+     from every other git UI.
+
+     The pairs that must stay separable are added-vs-modified (green/amber, the
+     commonest confusion under deuteranopia) and modified-vs-staged, which is
+     why staged is a blue rather than a second warm hue. The one-letter badge
+     beside the name carries the same distinction without hue at all
+     (listing/git-mark.ts), so the palette is a shortcut and never the only
+     signal. */
+  --git-untracked: #7ec699;
+  --git-modified: #e2c08d;
+  --git-staged: #7fb3f0;
+  --git-conflicted: #e4676b;
+
   /* Full-page failure card (.status-message.error). */
   --error-page-bg: rgba(30, 5, 5, 0.9);
   --error-page-border: #c0392b;
@@ -399,6 +420,13 @@
   --series-4: #7a3fa8;
   --series-5: #0f7c74;
   --series-6: #b03030;
+
+  /* The four git hues, darkened for white. Same hue order and same meanings —
+     a name that was green over the dark page is green over the light one. */
+  --git-untracked: #2f7d3f;
+  --git-modified: #8a5a06;
+  --git-staged: #1f5fa8;
+  --git-conflicted: #b02020;
 
   --error-page-bg: rgba(255, 236, 236, 0.95);
   --error-page-border: #c0392b;

--- a/fused_render/server/git_status.py
+++ b/fused_render/server/git_status.py
@@ -41,20 +41,25 @@ last because it is the one already recorded.
 BEST-EFFORT, LIKE EVERY OTHER GIT READ HERE
 git may be missing, the folder may not be a repo, the index may be locked by a
 concurrent commit. A tint is a display hint, so every failure returns `{}` and
-the listing renders undecorated — never an error. Same discipline, and the same
-spawn rules (absolute git, `-C`, `close_fds=False`), as gitignore.py; its
-`_spawn_kwargs` and warning helpers are reused rather than re-derived, because
-the fork-vs-posix_spawn trap they exist for is not per-module (see the note at
-the top of that file, and tests/test_git_posix_spawn.py).
+the listing renders undecorated — never an error. Same discipline, and the
+same spawn rules (absolute git, `-C`, `close_fds=False`), as gitignore.py;
+`git_bin` and the warning helpers are reused from there because they carry no
+state of their own. `_spawn_kwargs` is NOT imported the same way: it is spread
+into the call with `**`, and `tests/test_git_posix_spawn.py`'s static sweep
+resolves a `**helper()` spread by reading the helper's dict literal out of THIS
+file's own AST — it does not follow the call into another module. So this file
+keeps its own copy of the dict literal, one field at a time identical to
+gitignore's, rather than importing the function and leaving the spread
+unverifiable.
 """
 import logging
 import os
 import subprocess
+import sys
 
 from fused_render.server.gitignore import (
     _is_ordinary_negative,
     _repo_toplevel,
-    _spawn_kwargs,
     _warn_git_refused,
     _warn_git_unusable,
     git_bin,
@@ -193,6 +198,25 @@ def _prefix_of(cwd: str, top: str) -> str | None:
     if rel == os.pardir or rel.startswith(os.pardir + os.sep):
         return None
     return rel.replace(os.sep, "/") + "/"
+
+
+def _spawn_kwargs() -> dict:
+    """The kwargs the status spawn needs to reach posix_spawn, not fork.
+
+    A plain dict literal, not a call into gitignore.py's copy: the static sweep
+    in `tests/test_git_posix_spawn.py` resolves a `**_spawn_kwargs()` spread by
+    reading this function's `return {...}` out of THIS file's AST, and it does
+    not follow an import to check another module's literal. Kept field-for-
+    field identical to gitignore.py's `_spawn_kwargs` on purpose — `close_fds`
+    is the half of the posix_spawn condition git_bin()'s absolute path does not
+    cover, and `creationflags` keeps a spawned git from popping a console
+    window on Windows.
+    """
+    return {
+        "close_fds": False,
+        "creationflags": (subprocess.CREATE_NO_WINDOW
+                          if sys.platform == "win32" else 0),
+    }
 
 
 def _run_status(cwd: str) -> list[tuple[str, str]] | None:

--- a/fused_render/server/git_status.py
+++ b/fused_render/server/git_status.py
@@ -24,11 +24,15 @@ many rows it has. It is scoped with a `.` pathspec so a subdirectory of a huge
 monorepo does not pay for its siblings.
 
 Untracked files are asked for at git's DEFAULT depth (`normal`), never
-`--untracked-files=all`. That is not a shortcut: `normal` collapses a wholly
-untracked directory into one `dir/` record, which is exactly the row this
-listing wants to tint, and it stops git from enumerating a 100k-file `.venv`
-that we would then throw away. A tracked directory holding one new file still
-reports `dir/newfile`, so the roll-up below still sees it.
+`--untracked-files=all` — and passed EXPLICITLY as `--untracked-files=normal`,
+never left to fall through to whatever `status.showUntrackedFiles` says in the
+user's config (`=no` renders every untracked file invisible; `=all` is the
+100k-file `.venv` enumeration this paragraph exists to avoid). `normal`
+collapses a wholly untracked directory into one `dir/` record, which is
+exactly the row this listing wants to tint. A tracked directory holding one
+new file still reports `dir/newfile`, so the roll-up below still sees it.
+`templates/git/log.py`'s own porcelain parser pins the same two flags
+(`--untracked-files=normal --ignored=no`) for the identical reason.
 
 FOLDERS ROLL UP
 A folder is tinted with the most urgent state anywhere beneath it — the whole
@@ -56,6 +60,9 @@ import logging
 import os
 import subprocess
 import sys
+import threading
+import time
+from collections import OrderedDict
 
 from fused_render.server.gitignore import (
     _is_ordinary_negative,
@@ -75,10 +82,18 @@ _RANK = {name: i for i, name in enumerate(STATUS_ORDER)}
 # Whether this platform's paths fold case. Decided once, here, because the two
 # spellings being compared come from different authorities: the listing's names
 # come from `scandir` (the filesystem's spelling) and git's paths come from its
-# index (the spelling that was committed). On APFS/NTFS those can differ in
-# case for the same path, and a prefix test that missed would silently drop
+# index (the spelling that was committed). On APFS/HFS+/NTFS those can differ
+# in case for the same path, and a prefix test that missed would silently drop
 # every decoration in a subdirectory rather than fail loudly.
-_FOLDS_CASE = os.path.normcase("A") == "a"
+#
+# `os.path.normcase` is NOT that test: `posixpath.normcase` is the identity
+# function on every POSIX platform, macOS included, so `os.path.normcase("A")
+# == "a"` is only ever True on Windows. A `Pkg/` committed to the index but
+# checked out as `pkg/` on an APFS volume would then miss the prefix test here
+# and lose every decoration beneath it — the exact failure this comment used
+# to say the line prevented. `sys.platform` names the two case-insensitive-by-
+# default platforms directly instead.
+_FOLDS_CASE = sys.platform in ("win32", "darwin")
 
 
 def classify(xy: str) -> str | None:
@@ -119,21 +134,31 @@ def parse_porcelain(out: bytes) -> list[tuple[str, str]]:
     — survives; git only quotes paths in the newline-separated format. Each
     record is `XY<space><path>`, and with `--no-renames` in the argv there is
     never the second path a rename would append, so a record is exactly one
-    chunk. Undecodable bytes are replaced rather than dropped: the path is only
-    ever compared against a listing name, so a mangled one simply matches
-    nothing, whereas raising here would cost the whole listing its tints.
+    chunk.
+
+    The path is decoded with `os.fsdecode`, the same call `_git_ignored` uses
+    for this identical job (gitignore.py) — not `.decode("utf-8", "replace")`.
+    A path is only ever compared against a name `os.scandir` produced from the
+    SAME bytes, and `fsdecode` is defined to round-trip those bytes exactly
+    (surrogateescape on POSIX) so the two always compare equal. `utf-8/replace`
+    is neither safer nor simpler: it doesn't raise, but it DOES mangle every
+    undecodable byte into U+FFFD, a string `scandir` will never produce for the
+    same file — a `café.txt` written in a latin-1 locale would decode to two
+    different strings from the two calls and lose its tint either way, so
+    there is no version of "replace" that helps here.
     """
     records = []
     for chunk in out.split(b"\0"):
         if len(chunk) < 4 or chunk[2:3] != b" ":
             continue
         code = chunk[:2].decode("ascii", "replace")
-        records.append((code, chunk[3:].decode("utf-8", "replace")))
+        records.append((code, os.fsdecode(chunk[3:])))
     return records
 
 
 def entry_statuses(
-    prefix: str, records: list[tuple[str, str]], names: list[str]
+    prefix: str, records: list[tuple[str, str]], names: list[str],
+    _folds_case: bool | None = None,
 ) -> dict[str, str]:
     """Map the listed `names` to their status, rolling subtrees up to folders.
 
@@ -148,29 +173,65 @@ def entry_statuses(
     keeping the most urgent state found (see `STATUS_ORDER`). Names not in the
     listing are dropped rather than reported: the caller's rows are the only
     thing that can wear a tint.
+
+    `_folds_case` overrides the module-level `_FOLDS_CASE` for tests; every
+    real caller leaves it `None` and gets this platform's answer.
     """
-    want = set(names)
-    fold = str.lower if _FOLDS_CASE else None
+    fold_case = _FOLDS_CASE if _folds_case is None else _folds_case
+    fold = str.lower if fold_case else None
+    # Keyed by the FOLDED leaf name, valued by the caller's own spelling: the
+    # dict this function returns must use the spelling `names` arrived with
+    # (scandir's), never git's index spelling, because the frontend joins rows
+    # onto this result by the name it already has. Building the table once
+    # keeps the per-record lookup below a single dict access either way.
+    want_by_fold = {fold(n): n for n in names} if fold else None
+    want = None if fold else set(names)
     head = prefix if fold is None else fold(prefix)
     out: dict[str, str] = {}
+
+    def _credit(name: str, status: str) -> None:
+        prev = out.get(name)
+        if prev is None or _RANK[status] < _RANK[prev]:
+            out[name] = status
+
     for code, path in records:
         candidate = path[: len(prefix)]
         if (candidate if fold is None else fold(candidate)) != head:
             continue
-        rel = path[len(prefix):]
-        if not rel:
-            continue
         status = classify(code)
         if status is None:
             continue
+        rel = path[len(prefix):]
+        if not rel:
+            # A record for the listed directory ITSELF, not for anything
+            # inside it. Git only produces this shape with a trailing slash,
+            # and only for the untracked-directory collapse the module header
+            # describes — in which case every name this listing renders is
+            # untracked, because `-u normal` folded the whole subtree into
+            # this one record and there is nothing more specific to read.
+            # Without this, opening `brandnew/` after its parent listing
+            # tinted it green would show every child undecorated — the
+            # collapse this file exists to expand back out, silently un-done
+            # one level down. A record that does NOT end in `/` (a
+            # submodule's own path, say) is not that collapse and is not a
+            # blanket statement about its contents, so it is simply dropped —
+            # there is no listed row named after the folder being listed.
+            if path.endswith("/"):
+                for name in names:
+                    _credit(name, status)
+            continue
         # The first segment is the listed row; deeper segments are what makes
         # this a roll-up rather than a lookup.
-        name = rel.split("/", 1)[0]
-        if name not in want:
-            continue
-        prev = out.get(name)
-        if prev is None or _RANK[status] < _RANK[prev]:
-            out[name] = status
+        leaf = rel.split("/", 1)[0]
+        if want is None:
+            name = want_by_fold.get(fold(leaf))
+            if name is None:
+                continue
+        else:
+            if leaf not in want:
+                continue
+            name = leaf
+        _credit(name, status)
     return out
 
 
@@ -219,8 +280,89 @@ def _spawn_kwargs() -> dict:
     }
 
 
+# Memoizes `_run_status`'s answer, keyed on `cwd`. Every one of `/api/fs/list`'s
+# callers pays this spawn even when it only wants filenames — `BookmarkCards`
+# fans out `1 + APP_PROBE_LIMIT` listings per card on the explorer home screen,
+# and several `fs-actions.ts` callers list a directory purely to dedupe a
+# filename — so an unmemoized `listing_statuses` runs a full subtree `git
+# status` whose result is thrown straight away, over and over, for the same
+# directory in the same second. Mirrors `_repo_toplevel`'s LRU + TTL in
+# gitignore.py rather than inventing a second caching idiom in the same file
+# that already imports the first one's helpers.
+_STATUS_CACHE_SIZE = 256
+_status_cache: "OrderedDict[str, tuple[float, list[tuple[str, str]]]]" = OrderedDict()
+_status_lock = threading.Lock()
+
+# Deliberately much shorter than `_TOPLEVEL_MAX_AGE_S` (300s): a stale
+# toplevel answer is "which repo", which barely ever changes, but a stale
+# STATUS answer is "what's dirty right now", which the explorer's git panel
+# and Job B's live-listing refresh both promise to show promptly after a
+# stage/unstage. Two seconds keeps the common "list a folder in a fan-out
+# loop" case cheap (one spawn services every listing that lands inside the
+# window) without a browsing session ever waiting more than a couple of
+# seconds to notice a change made OUTSIDE this process — a `git add` typed in
+# an external terminal, say. A change made THROUGH this process's own git
+# template (`templates/git/ops.py`) does not wait even that long: `_stage` /
+# `_unstage` and friends call `invalidate_status_cache` themselves, so the
+# very next listing sees the write immediately rather than replaying whatever
+# this cache happened to hold.
+_STATUS_CACHE_TTL_S = 2.0
+
+
+def invalidate_status_cache() -> None:
+    """Drop every memoized `git status` answer.
+
+    Called from `routers/run.py`'s `/api/run` handler after EVERY run, not
+    from the git template itself: `templates/git/ops.py`'s stage/unstage/
+    commit run on the subprocess-per-call path (D72), a fresh interpreter that
+    holds no reference to this module's cache, so an invalidation call inside
+    `ops.py` would only ever clear that throwaway process's own empty copy.
+    `/api/run`'s handler, in contrast, runs in THIS process both before and
+    after awaiting the subprocess — the same reason `noteFsChanged()`
+    (`static/runtime.js`) is fired unconditionally by the frontend after every
+    runPython call, success or failure: a script can write anything, anywhere,
+    and there is no cheaper way to know what than to assume everything might
+    have changed.
+
+    The whole cache is cleared rather than just one `cwd`'s entry, for the
+    same reason `clearListPrefetch` clears its whole map instead of doing path
+    arithmetic (frontend/src/platform/lib/api.ts): a commit or checkout can
+    move the dirty set across an arbitrary number of directories, and
+    reasoning about which cached entries it could have touched buys nothing
+    over dropping all of them — the next listing under any of them just pays
+    one more spawn.
+    """
+    with _status_lock:
+        _status_cache.clear()
+
+
 def _run_status(cwd: str) -> list[tuple[str, str]] | None:
-    """One scoped `git status` in `cwd`, or None if git could not answer."""
+    """One scoped `git status` in `cwd` (cached, see `_STATUS_CACHE_TTL_S`),
+    or None if git could not answer.
+
+    Only a real answer is cached — never `None`. A `None` here means git
+    itself could not be asked right now (missing binary, an fd shortage, a
+    5s timeout tripped by a huge index): a fact about this call, not about
+    `cwd`, and caching it would let one blip hide every decoration in that
+    folder for the rest the TTL.
+    """
+    with _status_lock:
+        cached = _status_cache.get(cwd)
+        if cached is not None and time.monotonic() - cached[0] < _STATUS_CACHE_TTL_S:
+            _status_cache.move_to_end(cwd)
+            return cached[1]
+    records = _run_status_uncached(cwd)
+    if records is not None:
+        with _status_lock:
+            _status_cache[cwd] = (time.monotonic(), records)
+            _status_cache.move_to_end(cwd)
+            while len(_status_cache) > _STATUS_CACHE_SIZE:
+                _status_cache.popitem(last=False)
+    return records
+
+
+def _run_status_uncached(cwd: str) -> list[tuple[str, str]] | None:
+    """The uncached `git status --porcelain`, one spawn per call."""
     try:
         proc = subprocess.run(
             [
@@ -232,6 +374,19 @@ def _run_status(cwd: str) -> list[tuple[str, str]] | None:
                 # Claude turn) is a real collision to hand a browsing hint.
                 "--no-optional-locks",
                 "status", "--porcelain", "-z",
+                # Pinned explicitly rather than left to whatever
+                # `status.showUntrackedFiles` says in the user's config —
+                # the module header's claim about the cost of this call is
+                # only true if this flag can't silently become `=all`
+                # (enumerates every file under a huge untracked dir, the
+                # 100k-file `.venv` walk this module exists to avoid) or
+                # `=no` (no untracked file is ever tinted at all).
+                # `--ignored=no` is git's default too, but pinned for the
+                # same reason: `!!` records must never arrive, since
+                # `classify` relies on that to tell an ignored `.venv` apart
+                # from a dirty one. `templates/git/log.py` pins the identical
+                # pair for the identical reason.
+                "--untracked-files=normal", "--ignored=no",
                 # Renames become the delete + add pair they are made of, which
                 # is both what a listing wants (two rows, two tints) and what
                 # keeps a -z record a single chunk — see `parse_porcelain`.

--- a/fused_render/server/git_status.py
+++ b/fused_render/server/git_status.py
@@ -1,0 +1,255 @@
+"""Per-entry git status for one directory listing — what tints a row's NAME.
+
+The explorer already dims what `.gitignore` excludes (server/gitignore.py).
+This is the other half of the same idea, and the one VS Code's file tree is
+known for: a name that is a different colour because git has something to say
+about that path. Four states are distinguished, and they are the four a person
+acts on differently:
+
+  untracked   git has never seen this path
+  modified    tracked, and the WORK TREE differs from the index
+  staged      tracked, and the INDEX differs from HEAD with a clean work tree
+  conflicted  an unresolved merge
+
+`deleted` is deliberately not among them: a deleted file has no row to tint.
+It still reaches the UI, folded into `modified`, because it is a change inside
+whatever FOLDER used to hold it, and that folder does have a row.
+
+WHY ONE `git status` AND NOT `git diff` PER ROW
+A listing can hold thousands of entries, and the per-path question ("what is
+this one's state?") has no cheap per-path answer — every shape of it ends in a
+diff against the index. `git status` computes all of them in one pass over the
+one index git already has cached, so the cost is one spawn per listing however
+many rows it has. It is scoped with a `.` pathspec so a subdirectory of a huge
+monorepo does not pay for its siblings.
+
+Untracked files are asked for at git's DEFAULT depth (`normal`), never
+`--untracked-files=all`. That is not a shortcut: `normal` collapses a wholly
+untracked directory into one `dir/` record, which is exactly the row this
+listing wants to tint, and it stops git from enumerating a 100k-file `.venv`
+that we would then throw away. A tracked directory holding one new file still
+reports `dir/newfile`, so the roll-up below still sees it.
+
+FOLDERS ROLL UP
+A folder is tinted with the most urgent state anywhere beneath it — the whole
+point being that a collapsed folder must not hide a change. `STATUS_ORDER` is
+that ranking, and it is a judgement rather than git's own ordering: a conflict
+has to be resolved before anything else can happen, tracked work in flight is
+next, then paths git does not know about yet, and a staged-and-clean path is
+last because it is the one already recorded.
+
+BEST-EFFORT, LIKE EVERY OTHER GIT READ HERE
+git may be missing, the folder may not be a repo, the index may be locked by a
+concurrent commit. A tint is a display hint, so every failure returns `{}` and
+the listing renders undecorated — never an error. Same discipline, and the same
+spawn rules (absolute git, `-C`, `close_fds=False`), as gitignore.py; its
+`_spawn_kwargs` and warning helpers are reused rather than re-derived, because
+the fork-vs-posix_spawn trap they exist for is not per-module (see the note at
+the top of that file, and tests/test_git_posix_spawn.py).
+"""
+import logging
+import os
+import subprocess
+
+from fused_render.server.gitignore import (
+    _is_ordinary_negative,
+    _repo_toplevel,
+    _spawn_kwargs,
+    _warn_git_refused,
+    _warn_git_unusable,
+    git_bin,
+)
+
+logger = logging.getLogger(__name__)
+
+# The states a row can carry, MOST URGENT FIRST. The order is the folder
+# roll-up's ranking (see the header) and nothing else reads it as a sequence.
+STATUS_ORDER = ("conflicted", "modified", "untracked", "staged")
+_RANK = {name: i for i, name in enumerate(STATUS_ORDER)}
+
+# Whether this platform's paths fold case. Decided once, here, because the two
+# spellings being compared come from different authorities: the listing's names
+# come from `scandir` (the filesystem's spelling) and git's paths come from its
+# index (the spelling that was committed). On APFS/NTFS those can differ in
+# case for the same path, and a prefix test that missed would silently drop
+# every decoration in a subdirectory rather than fail loudly.
+_FOLDS_CASE = os.path.normcase("A") == "a"
+
+
+def classify(xy: str) -> str | None:
+    """One porcelain-v1 two-letter code -> one of `STATUS_ORDER`, or None.
+
+    `X` is the index-vs-HEAD column, `Y` the work-tree-vs-index one. The order
+    of the tests is the whole content of this function:
+
+      * `??` is untracked, and is its own code rather than a column pair.
+      * `!!` is ignored. It cannot arrive (we never pass `--ignored`), and it
+        is rejected explicitly anyway — falling through would read `!` as a
+        dirty work tree and report a `.venv` as modified.
+      * a `U` in either column, plus `AA` and `DD`, are git's full set of
+        unmerged codes.
+      * a non-space `Y` means the file on disk differs from the index. This
+        wins over a dirty index on purpose: `MM` is both, and the edit you have
+        not staged yet is the more useful thing to be told about.
+      * a non-space `X` with a clean `Y` is staged and nothing more.
+    """
+    if xy == "??":
+        return "untracked"
+    if xy == "!!" or len(xy) != 2:
+        return None
+    x, y = xy[0], xy[1]
+    if x == "U" or y == "U" or xy in ("AA", "DD"):
+        return "conflicted"
+    if y != " ":
+        return "modified"
+    if x != " ":
+        return "staged"
+    return None
+
+
+def parse_porcelain(out: bytes) -> list[tuple[str, str]]:
+    """`git status --porcelain -z` output -> `[(code, repo_relative_path)]`.
+
+    NUL-separated so a path containing a newline — or bytes that are not UTF-8
+    — survives; git only quotes paths in the newline-separated format. Each
+    record is `XY<space><path>`, and with `--no-renames` in the argv there is
+    never the second path a rename would append, so a record is exactly one
+    chunk. Undecodable bytes are replaced rather than dropped: the path is only
+    ever compared against a listing name, so a mangled one simply matches
+    nothing, whereas raising here would cost the whole listing its tints.
+    """
+    records = []
+    for chunk in out.split(b"\0"):
+        if len(chunk) < 4 or chunk[2:3] != b" ":
+            continue
+        code = chunk[:2].decode("ascii", "replace")
+        records.append((code, chunk[3:].decode("utf-8", "replace")))
+    return records
+
+
+def entry_statuses(
+    prefix: str, records: list[tuple[str, str]], names: list[str]
+) -> dict[str, str]:
+    """Map the listed `names` to their status, rolling subtrees up to folders.
+
+    `prefix` is the listed directory's own path from the repo root, `""` at the
+    root and otherwise slash-terminated; porcelain paths are always repo-root
+    relative regardless of where git was invoked, which is why one is needed.
+    `records` outside it are skipped — the pathspec already narrows them, but a
+    parent-directory record can still slip through as `sub/` for a wholly
+    untracked tree we are looking INSIDE of.
+
+    Anything deeper than one segment is credited to the folder that heads it,
+    keeping the most urgent state found (see `STATUS_ORDER`). Names not in the
+    listing are dropped rather than reported: the caller's rows are the only
+    thing that can wear a tint.
+    """
+    want = set(names)
+    fold = str.lower if _FOLDS_CASE else None
+    head = prefix if fold is None else fold(prefix)
+    out: dict[str, str] = {}
+    for code, path in records:
+        candidate = path[: len(prefix)]
+        if (candidate if fold is None else fold(candidate)) != head:
+            continue
+        rel = path[len(prefix):]
+        if not rel:
+            continue
+        status = classify(code)
+        if status is None:
+            continue
+        # The first segment is the listed row; deeper segments are what makes
+        # this a roll-up rather than a lookup.
+        name = rel.split("/", 1)[0]
+        if name not in want:
+            continue
+        prev = out.get(name)
+        if prev is None or _RANK[status] < _RANK[prev]:
+            out[name] = status
+    return out
+
+
+def _prefix_of(cwd: str, top: str) -> str | None:
+    """`cwd`'s path from the repo root `top`, slash-terminated (`""` at root).
+
+    Derived from the cached `_repo_toplevel` answer instead of asking git for
+    `rev-parse --show-prefix`, which would be a second spawn on the listing's
+    critical path for a fact the first one already implies. Both sides are
+    resolved first so a symlinked checkout (or macOS's `/var` -> `/private/var`)
+    does not read as "outside the repo" — the residual case difference is what
+    `entry_statuses` folds over.
+
+    None means the two paths do not nest, which should not happen for a
+    toplevel git itself reported for `cwd`; it is handled rather than asserted
+    because the answer may be up to `_TOPLEVEL_MAX_AGE_S` old, and by then the
+    repository could have moved.
+    """
+    try:
+        rel = os.path.relpath(os.path.realpath(cwd), os.path.realpath(top))
+    except (OSError, ValueError):  # unrelated Windows drives raise ValueError
+        return None
+    if rel == os.curdir:
+        return ""
+    if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+        return None
+    return rel.replace(os.sep, "/") + "/"
+
+
+def _run_status(cwd: str) -> list[tuple[str, str]] | None:
+    """One scoped `git status` in `cwd`, or None if git could not answer."""
+    try:
+        proc = subprocess.run(
+            [
+                git_bin(), "-C", cwd,
+                # Read-only: without this, status may REWRITE the index to
+                # record refreshed stat data. Harmless in isolation, but this
+                # runs on every folder the user opens, and taking index.lock
+                # out from under a concurrent commit (app_git.py commits every
+                # Claude turn) is a real collision to hand a browsing hint.
+                "--no-optional-locks",
+                "status", "--porcelain", "-z",
+                # Renames become the delete + add pair they are made of, which
+                # is both what a listing wants (two rows, two tints) and what
+                # keeps a -z record a single chunk — see `parse_porcelain`.
+                "--no-renames",
+                # Only this folder's subtree. `-C` put git's cwd here, so `.`
+                # is that folder; the whole-repo status would make opening one
+                # directory of a monorepo cost the monorepo.
+                "--", ".",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=5,
+            **_spawn_kwargs(),
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        _warn_git_unusable("status --porcelain", e)
+        return None
+    if proc.returncode != 0:
+        if not _is_ordinary_negative(proc.stderr):
+            _warn_git_refused("status --porcelain", cwd,
+                              proc.returncode, proc.stderr)
+        return None
+    return parse_porcelain(proc.stdout)
+
+
+def listing_statuses(cwd: str, names: list[str]) -> dict[str, str]:
+    """Status per listed name in `cwd`; `{}` when there is nothing to say.
+
+    Names absent from the result are simply clean (or not in a repo) — the
+    caller annotates the ones present and leaves the rest alone, so "no git
+    here" and "everything committed" render identically, which is correct:
+    both mean there is nothing to point at.
+    """
+    if not names:
+        return {}
+    top = _repo_toplevel(cwd)
+    if top is None:
+        return {}
+    prefix = _prefix_of(cwd, top)
+    if prefix is None:
+        return {}
+    records = _run_status(cwd)
+    if not records:
+        return {}
+    return entry_statuses(prefix, records, names)

--- a/fused_render/server/routers/fs_read.py
+++ b/fused_render/server/routers/fs_read.py
@@ -22,6 +22,7 @@ from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 from fused_render.server import dirpicker
 from fused_render.server.common import _error, _require_fused, logger
 from fused_render.server.gitignore import _git_ignored, _is_repo_root
+from fused_render.server import git_status
 # The tuning knobs (`_STAT_TTL_S`, `_CONDITIONS_TTL_S`, the `WALK_*`/`LIST_*`
 # caps) are read through their DEFINING module below — `_server_mount._STAT_TTL_S`
 # and friends — never re-bound here by `from … import`. Each of those modules says
@@ -306,9 +307,21 @@ def api_fs_list(path: str, cursor: str | None = None):
                 "mtime": st.st_mtime,
             }
         )
-    ignored = _git_ignored(path, [e["name"] for e in entries])
+    names = [e["name"] for e in entries]
+    ignored = _git_ignored(path, names)
+    # Git tinting for the row NAMES, alongside the gitignore dimming for whole
+    # rows. Both are one batched `git` call for the listing and both degrade to
+    # nothing, so a folder outside a repo — or a machine without git — pays two
+    # cheap negatives and renders exactly as it did before either existed.
+    statuses = git_status.listing_statuses(path, names)
     for e in entries:
         e["ignored"] = e["name"] in ignored
+        status = statuses.get(e["name"])
+        # Absent rather than null when there is nothing to say: the field is
+        # optional on the wire, and an older shell that has never heard of it
+        # keeps working unchanged.
+        if status is not None:
+            e["git"] = status
     # _sort_entries: dirs first, case-insensitive by name, exact name as a
     # deterministic tiebreak (same order for all three list routes).
     return _list_response(path, _sort_entries(entries), truncated, None)

--- a/fused_render/server/routers/fs_read.py
+++ b/fused_render/server/routers/fs_read.py
@@ -752,6 +752,12 @@ def api_fs_reveal(body: dict = Body(...), x_fused: str | None = Header(default=N
         cmd = ["explorer", win_path] if is_dir else f'explorer /select,"{win_path}"'
     else:
         cmd = ["xdg-open", path if is_dir else os.path.dirname(path)]
+    # posix-spawn-exempt: `cmd` is assembled above as "open"/"explorer"/
+    # "xdg-open" (or a Windows format string for the /select case) — the OS's
+    # file-manager launcher, never git. The static sweep in
+    # tests/test_git_posix_spawn.py cannot see through the variable to know
+    # that, and this file's own `e["git"] = status` a few lines up (a JSON
+    # field name, not an argv) is enough to put it in the sweep's scope.
     subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     return JSONResponse({"ok": True})
 

--- a/fused_render/server/routers/run.py
+++ b/fused_render/server/routers/run.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Body, Header, Request, Response
 from fused_render import calls as shell_calls
 from fused_render.server.common import _require_fused, resolve_py
 from fused_render.executor import dumps_result, run_python
+from fused_render.server import git_status
 from fused_render.shell import prefetch as shell_prefetch
 from fused_render.shell import prefs as shell_prefs
 from fused_render.shell import mounts as shell_mounts
@@ -70,6 +71,19 @@ async def api_run(request: Request, body: dict = Body(...),
         # loop free (the endpoint is async now for the engine's sake).
         work = asyncio.to_thread(run_python, resolved, params)
     result = await work
+    # A script that ran may have written anything, anywhere — including
+    # through the git template's stage/unstage/commit (templates/git/ops.py),
+    # which runs on this same subprocess-per-call path and so cannot reach
+    # into THIS process's `git_status` cache itself (see that cache's own
+    # `invalidate_status_cache` docstring). Dropping it here, unconditionally,
+    # is the in-process mirror of `noteFsChanged()` (static/runtime.js) firing
+    # on every runPython completion — success or failure, since a script that
+    # wrote three files and then raised still changed the disk, and the same
+    # is true of a git op that partially applied before erroring. Without
+    # this, a listing fetched moments before the run — and still within
+    # `_STATUS_CACHE_TTL_S` — would replay its now-stale answer to the very
+    # refresh Job B's dir-watch fix triggers right after this call returns.
+    git_status.invalidate_status_cache()
     # Hand the run's detail to the in-flight call record (calls.py): the
     # resolved .py, the params, the engine, and — on failure — the
     # traceback and output tails a user has since clicked away from. The

--- a/tests/test_git_status_listing.py
+++ b/tests/test_git_status_listing.py
@@ -1,0 +1,242 @@
+"""Git status decoration for a directory listing (fused_render/server/git_status.py).
+
+The explorer tints a row's NAME by what git says about that path — untracked,
+modified, staged, conflicted — the way a file tree is expected to. Two halves
+are pinned here and they need different kinds of test:
+
+* the CODE TABLE and the folder roll-up are pure functions over porcelain
+  records, so they are tested directly, including the codes a real repo is
+  awkward to hold in one state (`DD`, `UU`, a stray `!!`);
+* the wiring — that a real `git status` in a real repository actually produces
+  those records, and that the listing endpoint carries them to the browser — is
+  tested against `_git_repo.build_repo`, whose working tree is deliberately
+  left modified + staged + untracked. A mocked subprocess here would only
+  confirm our own fiction of porcelain output, which is the one thing worth
+  doubting.
+"""
+import os
+
+import pytest
+
+from _git_repo import build_repo, git, git_available, write
+
+from fused_render.server import git_status
+
+
+# --------------------------------------------------------------- the code table
+
+@pytest.mark.parametrize("code,expected", [
+    ("??", "untracked"),
+    (" M", "modified"),
+    (" D", "modified"),
+    ("MM", "modified"),   # staged AND dirty: the unstaged edit is the news
+    ("AM", "modified"),
+    ("M ", "staged"),
+    ("A ", "staged"),
+    ("D ", "staged"),
+    ("UU", "conflicted"),
+    ("AU", "conflicted"),
+    ("UD", "conflicted"),
+    ("AA", "conflicted"),
+    ("DD", "conflicted"),
+    ("  ", None),
+    ("!!", None),         # never requested, and must not read as "modified"
+    ("", None),
+])
+def test_classify(code, expected):
+    assert git_status.classify(code) == expected
+
+
+def test_status_order_covers_every_state_classify_can_return():
+    """The roll-up ranking must rank everything `classify` can produce —
+    otherwise a state reaches `entry_statuses` and raises on the rank lookup."""
+    codes = ["??", " M", "M ", "UU", "!!", "  "]
+    produced = {git_status.classify(c) for c in codes} - {None}
+    assert produced == set(git_status.STATUS_ORDER)
+
+
+# ------------------------------------------------------------------- the parser
+
+def test_parse_porcelain_splits_nul_records():
+    out = b"?? new.txt\x00 M edited.py\x00A  staged.txt\x00"
+    assert git_status.parse_porcelain(out) == [
+        ("??", "new.txt"),
+        (" M", "edited.py"),
+        ("A ", "staged.txt"),
+    ]
+
+
+def test_parse_porcelain_keeps_a_path_containing_a_newline():
+    """The reason the format is `-z` and not line-based."""
+    out = b"?? we\nird.txt\x00"
+    assert git_status.parse_porcelain(out) == [("??", "we\nird.txt")]
+
+
+def test_parse_porcelain_skips_malformed_chunks():
+    out = b"\x00x\x00?? ok.txt\x00nope\x00"
+    assert git_status.parse_porcelain(out) == [("??", "ok.txt")]
+
+
+# ------------------------------------------------------- mapping and the rollup
+
+def test_entry_statuses_maps_files_in_the_listed_folder():
+    records = [("??", "new.txt"), (" M", "edited.py"), ("M ", "staged.py")]
+    got = git_status.entry_statuses("", records, ["new.txt", "edited.py", "staged.py"])
+    assert got == {"new.txt": "untracked", "edited.py": "modified",
+                   "staged.py": "staged"}
+
+
+def test_entry_statuses_is_relative_to_the_listed_folder():
+    """Porcelain paths are repo-root relative wherever git ran, so a listing of
+    a subdirectory has to strip its own prefix."""
+    records = [(" M", "pkg/core.py"), ("??", "other/new.txt")]
+    got = git_status.entry_statuses("pkg/", records, ["core.py", "notes.md"])
+    assert got == {"core.py": "modified"}
+
+
+def test_entry_statuses_rolls_a_subtree_up_to_its_folder():
+    records = [("??", "pkg/deep/inner/new.txt")]
+    got = git_status.entry_statuses("pkg/", records, ["deep"])
+    assert got == {"deep": "untracked"}
+
+
+def test_entry_statuses_folder_takes_the_most_urgent_state_beneath_it():
+    """A folder holding both a staged file and an unresolved conflict must not
+    advertise the calmer of the two — the point of the roll-up is that a closed
+    folder cannot hide the thing you have to deal with."""
+    records = [("M ", "pkg/a.py"), ("??", "pkg/b.py"), (" M", "pkg/c.py"),
+               ("UU", "pkg/d.py")]
+    assert git_status.entry_statuses("", records, ["pkg"]) == {"pkg": "conflicted"}
+
+    records.remove(("UU", "pkg/d.py"))
+    assert git_status.entry_statuses("", records, ["pkg"]) == {"pkg": "modified"}
+
+    records.remove((" M", "pkg/c.py"))
+    assert git_status.entry_statuses("", records, ["pkg"]) == {"pkg": "untracked"}
+
+    records.remove(("??", "pkg/b.py"))
+    assert git_status.entry_statuses("", records, ["pkg"]) == {"pkg": "staged"}
+
+
+def test_entry_statuses_handles_a_wholly_untracked_directory_record():
+    """git's default untracked mode collapses one to `dir/` — that trailing
+    slash must credit the folder, not vanish."""
+    records = [("??", "brand-new/")]
+    assert git_status.entry_statuses("", records, ["brand-new"]) == \
+        {"brand-new": "untracked"}
+
+
+def test_entry_statuses_ignores_names_not_in_the_listing():
+    records = [("??", "elsewhere.txt")]
+    assert git_status.entry_statuses("", records, ["here.txt"]) == {}
+
+
+def test_entry_statuses_ignores_the_listed_folders_own_record():
+    """Looking INSIDE a wholly untracked tree, `sub/` can arrive as a record for
+    the folder we are listing; stripping its prefix leaves nothing to name."""
+    records = [("??", "sub/")]
+    assert git_status.entry_statuses("sub/", records, ["a.txt"]) == {}
+
+
+# ------------------------------------------------------------- against real git
+
+pytestmark_git = pytest.mark.skipif(not git_available(), reason="git not installed")
+
+
+@pytestmark_git
+def test_listing_statuses_against_a_real_repository(tmp_path):
+    root = str(tmp_path / "repo")
+    build_repo(root)
+
+    # Repo root: README.md is modified, pkg/ holds modified + staged + new.
+    top = git_status.listing_statuses(root, ["README.md", "pkg", "assets"])
+    assert top["README.md"] == "modified"
+    assert top["pkg"] == "modified"  # the roll-up: core.py is dirty in there
+    assert "assets" not in top       # clean subtree stays undecorated
+
+    # Inside pkg/: each of the three states on its own row.
+    inner = git_status.listing_statuses(
+        os.path.join(root, "pkg"),
+        ["core.py", "staged.txt", "fresh.txt", "notes.md"])
+    assert inner == {"core.py": "modified", "staged.txt": "staged",
+                     "fresh.txt": "untracked"}
+
+
+@pytestmark_git
+def test_listing_statuses_skips_a_gitignored_path(tmp_path):
+    """Ignored entries already have their own dimming (server/gitignore.py) and
+    must not also be tinted as untracked — `!!` never being requested is what
+    guarantees it."""
+    root = str(tmp_path / "repo")
+    build_repo(root)
+    write(root, ".gitignore", "junk/\n")
+    os.makedirs(os.path.join(root, "junk"))
+    write(root, "junk/build.log", "noise\n")
+    git(root, "add", ".gitignore")
+    git(root, "commit", "-q", "-m", "ignore junk")
+
+    got = git_status.listing_statuses(root, ["junk", ".gitignore"])
+    assert "junk" not in got
+
+
+@pytestmark_git
+def test_listing_statuses_is_empty_outside_a_repository(tmp_path):
+    plain = str(tmp_path / "plain")
+    os.makedirs(plain)
+    write(plain, "a.txt", "hi\n")
+    assert git_status.listing_statuses(plain, ["a.txt"]) == {}
+
+
+@pytestmark_git
+def test_listing_statuses_needs_no_names(tmp_path):
+    """No rows, no spawn: the cheapest listing must not pay for git at all."""
+    root = str(tmp_path / "repo")
+    build_repo(root)
+    assert git_status.listing_statuses(root, []) == {}
+
+
+@pytestmark_git
+def test_listing_statuses_survives_git_being_unusable(tmp_path, monkeypatch):
+    """A tint is a display hint — a broken git costs the decoration, never the
+    listing."""
+    root = str(tmp_path / "repo")
+    build_repo(root)
+    monkeypatch.setattr(git_status, "_run_status", lambda cwd: None)
+    assert git_status.listing_statuses(root, ["README.md"]) == {}
+
+
+# ------------------------------------------------------- the endpoint's payload
+
+@pytestmark_git
+def test_list_endpoint_carries_the_git_field(tmp_path):
+    """GET /api/fs/list is where the shell learns each row's state."""
+    from fastapi.testclient import TestClient
+
+    from fused_render.server import create_app
+
+    root = tmp_path / "repo"
+    build_repo(str(root))
+    client = TestClient(create_app(start_dir=str(root)))
+
+    pkg = client.get("/api/fs/list",
+                     params={"path": str(root / "pkg")}).json()
+    by_name = {e["name"]: e for e in pkg["entries"]}
+    assert by_name["core.py"]["git"] == "modified"
+    assert by_name["staged.txt"]["git"] == "staged"
+    assert by_name["fresh.txt"]["git"] == "untracked"
+    # Clean and committed: the field is ABSENT rather than null, so a shell that
+    # has never heard of it sees exactly the payload it always saw.
+    assert "git" not in by_name["notes.md"]
+
+
+def test_list_endpoint_omits_git_outside_a_repository(tmp_path):
+    """No git binary needed for this one: a plain folder has no state either
+    way, and the field must not appear just because the code path ran."""
+    from fastapi.testclient import TestClient
+
+    from fused_render.server import create_app
+
+    (tmp_path / "a.txt").write_text("hi\n", encoding="utf-8")
+    data = TestClient(create_app(start_dir=str(tmp_path))).get(
+        "/api/fs/list", params={"path": str(tmp_path)}).json()
+    assert all("git" not in e for e in data["entries"])

--- a/tests/test_git_status_listing.py
+++ b/tests/test_git_status_listing.py
@@ -77,6 +77,20 @@ def test_parse_porcelain_skips_malformed_chunks():
     assert git_status.parse_porcelain(out) == [("??", "ok.txt")]
 
 
+def test_parse_porcelain_decodes_a_non_utf8_name_like_scandir_would():
+    """A name git can't render as UTF-8 (a latin-1 checkout, say) must decode
+    the same way `os.scandir` decodes the identical bytes off disk —
+    `os.fsdecode`'s surrogateescape — or the two will never compare equal and
+    the path loses its tint. `utf-8/replace` mangles the un-decodable byte
+    into U+FFFD, a DIFFERENT string that matches nothing `scandir` ever
+    yields."""
+    raw = b"caf\xe9.txt"  # "café.txt" in latin-1, not valid UTF-8
+    out = b"?? " + raw + b"\x00"
+    got = git_status.parse_porcelain(out)
+    assert got == [("??", os.fsdecode(raw))]
+    assert got[0][1] != raw.decode("utf-8", "replace")
+
+
 # ------------------------------------------------------- mapping and the rollup
 
 def test_entry_statuses_maps_files_in_the_listed_folder():
@@ -131,10 +145,51 @@ def test_entry_statuses_ignores_names_not_in_the_listing():
     assert git_status.entry_statuses("", records, ["here.txt"]) == {}
 
 
-def test_entry_statuses_ignores_the_listed_folders_own_record():
-    """Looking INSIDE a wholly untracked tree, `sub/` can arrive as a record for
-    the folder we are listing; stripping its prefix leaves nothing to name."""
+def test_entry_statuses_folds_case_on_the_leaf_name_when_the_platform_does():
+    """`_FOLDS_CASE` decides whether the PREFIX comparison folds case (A3); the
+    leaf-name lookup a few lines later must fold the same way or not at all.
+    `want` holds scandir's spelling (`Readme.md`) while git's index holds the
+    committed spelling (`README.md`) — on a case-folding filesystem those are
+    the same file, and the dict key handed back must be the CALLER's spelling
+    (`Readme.md`), because that is what the frontend joins rows against."""
+    records = [("??", "README.md")]
+    got = git_status.entry_statuses(
+        "", records, ["Readme.md"], _folds_case=True)
+    assert got == {"Readme.md": "untracked"}
+
+
+def test_entry_statuses_does_not_fold_case_when_the_platform_does_not():
+    records = [("??", "README.md")]
+    got = git_status.entry_statuses(
+        "", records, ["Readme.md"], _folds_case=False)
+    assert got == {}
+
+
+def test_entry_statuses_credits_every_listed_name_from_the_folders_own_record():
+    """Looking INSIDE a wholly untracked tree, `sub/` arrives as a record for
+    the folder we are listing rather than for anything inside it — git's
+    default `-u normal` collapses the whole subtree to that one record (see
+    the module header). Stripping the prefix leaves an empty `rel`, but the
+    record still means something: EVERY name this listing is about to render
+    is untracked, because the record's path is the listed folder itself
+    (recognisable by the trailing slash) and not some deeper path that merely
+    starts the same way. Dropping it here — as `sub/brand-new.txt` opened one
+    level down — would leave every child of a freshly created directory
+    looking clean, which is exactly the decoration this module exists to
+    avoid missing."""
     records = [("??", "sub/")]
+    assert git_status.entry_statuses("sub/", records, ["a.txt", "b.txt"]) == \
+        {"a.txt": "untracked", "b.txt": "untracked"}
+
+
+def test_entry_statuses_does_not_credit_a_non_directory_record_for_the_folder_itself():
+    """A record whose path equals the listed folder but does NOT end in `/`
+    (a submodule's own entry, say) names the folder as a path in its own
+    right — it is not git's untracked-directory collapse, and is not a
+    blanket statement about everything inside it. There is no name to credit
+    it to (the folder itself isn't one of the listed rows), so it is simply
+    dropped, unlike the trailing-slash case above."""
+    records = [(" M", "sub")]
     assert git_status.entry_statuses("sub/", records, ["a.txt"]) == {}
 
 
@@ -185,6 +240,52 @@ def test_listing_statuses_is_empty_outside_a_repository(tmp_path):
     os.makedirs(plain)
     write(plain, "a.txt", "hi\n")
     assert git_status.listing_statuses(plain, ["a.txt"]) == {}
+
+
+@pytestmark_git
+def test_listing_statuses_reuses_a_cached_status_within_the_ttl(tmp_path, monkeypatch):
+    """A9's motivating case: fanning out several listings of the SAME folder
+    (BookmarkCards' home-screen probes, fs-actions.ts's dedupe-by-listing
+    callers) must not each pay their own `git status` spawn."""
+    root = str(tmp_path / "repo")
+    build_repo(root)
+    git_status.invalidate_status_cache()
+
+    calls = []
+    orig = git_status._run_status_uncached
+
+    def counting(cwd):
+        calls.append(cwd)
+        return orig(cwd)
+
+    monkeypatch.setattr(git_status, "_run_status_uncached", counting)
+    git_status.listing_statuses(root, ["README.md"])
+    git_status.listing_statuses(root, ["README.md"])
+    git_status.listing_statuses(root, ["README.md"])
+    assert len(calls) == 1
+
+
+@pytestmark_git
+def test_invalidate_status_cache_forces_a_fresh_spawn(tmp_path, monkeypatch):
+    """The one lever `/api/run` pulls after every run (see the docstring on
+    `invalidate_status_cache`) — without it, staging through the git template
+    would show its OWN write as stale for up to `_STATUS_CACHE_TTL_S`."""
+    root = str(tmp_path / "repo")
+    build_repo(root)
+    git_status.invalidate_status_cache()
+
+    calls = []
+    orig = git_status._run_status_uncached
+
+    def counting(cwd):
+        calls.append(cwd)
+        return orig(cwd)
+
+    monkeypatch.setattr(git_status, "_run_status_uncached", counting)
+    git_status.listing_statuses(root, ["README.md"])
+    git_status.invalidate_status_cache()
+    git_status.listing_statuses(root, ["README.md"])
+    assert len(calls) == 2
 
 
 @pytestmark_git


### PR DESCRIPTION
## Summary

- In a git repo, the Explorer now tints each entry's **name** by its git state, the way VS Code does: green for untracked, amber for modified, blue for staged, red for a merge conflict. A one-letter badge (`U` / `M` / `S` / `!`) follows the name so the signal survives colour blindness — deuteranopia hits exactly the untracked-green / modified-amber pair.
- A folder wears the most urgent state found anywhere beneath it, so a collapsed subtree can't hide a change.
- One `git status --porcelain -z --no-renames` per listing is the whole cost — not a `git diff` per row. Untracked mode stays at git's default `normal`, so a wholly-untracked `.venv` collapses to a single record instead of 100k paths.
- Entirely best-effort: outside a repo, without git, or on a clean entry the `git` field is simply absent from `/api/fs/list` and the row renders exactly as it did before. Gitignored rows keep their existing dimming and never get a tint.

## Visuals

```mermaid
flowchart TD
    A["GET /api/fs/list"] --> B["listing_statuses(dir, names)"]
    B --> C{"in a repo?"}
    C -->|no| D["no git field"]
    C -->|yes| E["one git status --porcelain"]
    E --> F["credit first path segment<br/>most urgent wins"]
    F --> G["entry.git per row"]
    G --> H["name tint + letter badge"]
```

Verified in the running app against this repo: `frontend` and `fused_render` amber with `M`, `tests` and `.dev-zips` green with `U`.

## Usage

Nothing to invoke — open any directory inside a git repo in the Explorer and the names carry their state. Each badge's tooltip and `aria-label` spell the state out ("Modified, not staged", "Untracked — new to git", …).

The API side is available directly:

```python
from fused_render.server import git_status
git_status.listing_statuses("/path/to/dir", ["core.py", "pkg"])
# {'core.py': 'modified', 'pkg': 'staged'}
```

## Test Plan

- [x] `tests/test_git_status_listing.py` — 34 tests: the full porcelain code table through `classify`, `-z` parsing (including a path containing a newline, and malformed chunks), prefix stripping, subtree roll-up, most-urgent-wins, plus real-git repos asserting `modified` / `staged` / `untracked` and a folder rolling up while a clean sibling stays absent.
- [x] Endpoint tests assert `/api/fs/list` carries `git` for a dirty entry and **omits** it for a clean one.
- [x] `frontend/src/apps/explorer/listing/git-mark.test.ts` — 8 tests: one class per state, nothing for an unknown or absent state, distinct letters, and `A` never used (git spells the staged add `A`, which would read as "added" here).
- [x] `tests/test_theme.py` (133) passes — the four new tokens are defined in both palettes, no colour literal escapes them.
- [x] `bun x tsc --noEmit`, `check:boundaries` (481 files), and `vite build` all clean.
- [ ] Reviewer check: open a repo directory with a staged file, an unstaged edit, and a new file; confirm three different tints and that a collapsed folder containing only the new file shows `U`.
