### PR TITLE
Tasks page: warm the listing at boot, paint rows before /api/tasks answers

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2979,6 +2979,7 @@ export type TaskPulseTask = Pick<
   | "title"
   | "target"
   | "session_id"
+  | "next_run"
 >;
 
 export function getTasks(): Promise<{ tasks: Task[]; generation?: number }> {

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2947,6 +2947,12 @@ export interface Task {
   // this list is built by a tail parse because it runs for every row, and a
   // full transcript parse per task would not survive a few hundred of them.
   messages: TaskMessage[];
+  // CLIENT-ONLY, never sent by the server: this row was built from the
+  // /api/tasks/pulse fields (shell/tasks-lib.provisionalTasks) while the full
+  // listing is still in flight, so the fields pulse does not carry hold
+  // neutral defaults rather than facts. The views that would otherwise print
+  // one of those defaults as a number read this and draw a placeholder.
+  provisional?: true;
 }
 
 // The global sidebar needs task state, not the Tasks page's paths, descriptions

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2980,6 +2980,7 @@ export type TaskPulseTask = Pick<
   | "target"
   | "session_id"
   | "next_run"
+  | "next_run_entry"
 >;
 
 export function getTasks(): Promise<{ tasks: Task[]; generation?: number }> {

--- a/frontend/src/shell/ScheduleCalendar.tsx
+++ b/frontend/src/shell/ScheduleCalendar.tsx
@@ -1096,6 +1096,14 @@ export default function ScheduleCalendar({
 
   const cols = { ["--cal-days" as string]: days.length } as React.CSSProperties;
 
+  // The grid below unmounts while the set is empty, and with it the scroll box
+  // the placement effect aims. Forget the aim with it, or the effect on remount
+  // sees the same range and the same "had chips" answer, skips, and the grid
+  // opens at midnight instead of on the now-line (Bugbot, #1079).
+  useEffect(() => {
+    if (tasks.length === 0) aimed.current = { key: "", withChips: false };
+  }, [tasks.length]);
+
   // Nothing to place on ANY week. Tasks alone decide: every chip on this grid
   // hangs off a task (calendarThreads), and a scheduled entry with no session
   // is already a task in the listing (routers/tasks `_collect`), so `entries`,

--- a/frontend/src/shell/ScheduleCalendar.tsx
+++ b/frontend/src/shell/ScheduleCalendar.tsx
@@ -908,6 +908,7 @@ export default function ScheduleCalendar({
   entries = [],
   queued = [],
   running = [],
+  emptyLabel = "Nothing to show here.",
   onReload,
   onCreateAt,
   onEditEntry,
@@ -926,6 +927,10 @@ export default function ScheduleCalendar({
   queued?: ScheduledMessage[];
   /** getScheduleQueue().running — mid-flight, same treatment. */
   running?: ScheduledMessage[];
+  /** The page's sentence for an empty set (Scheduled `emptyLabel`), printed in
+   * place of the grid when there is nothing at all to put on it — not when a
+   * WEEK is quiet, which is a real answer the grid gives on its own. */
+  emptyLabel?: string;
   onReload: () => void;
   onCreateAt: (time: Date) => void;
   /** Opens the New task modal on an existing entry (a rule, or a one-off). */
@@ -1090,6 +1095,16 @@ export default function ScheduleCalendar({
   };
 
   const cols = { ["--cal-days" as string]: days.length } as React.CSSProperties;
+
+  // Nothing to place on ANY week. Tasks alone decide: every chip on this grid
+  // hangs off a task (calendarThreads), and a scheduled entry with no session
+  // is already a task in the listing (routers/tasks `_collect`), so `entries`,
+  // `queued` and `running` only annotate chips that exist. A bare grid here
+  // read as a calendar with nothing on this week, which is a different thing
+  // from a page with nothing on it at all. After every hook, like the Board.
+  if (tasks.length === 0) {
+    return <p className="schedule-tv-empty">{emptyLabel}</p>;
+  }
 
   return (
     <div className={"schedule-cal" + (range === "4day" ? " is-wide" : "")} style={cols}>

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -2885,7 +2885,12 @@ export function TaskBoard({
   home = "",
   onReload,
   missing,
+  emptyLabel = "Nothing to show here.",
 }: {
+  /** The page's sentence for an empty set (Scheduled `emptyLabel`). Five bare
+   * rails said nothing about WHY the board was empty; the List's sentence does,
+   * and the four views now share it. */
+  emptyLabel?: string;
   /** Already filtered, in the SERVER's order — the LANES re-order it
    * (tasks-lib.groupByColumn), which is the one thing this view does to the
    * order it is handed and the one place it is decided. */
@@ -3115,6 +3120,13 @@ export function TaskBoard({
       return next.size === cur.size ? cur : next;
     });
   }, [byLane]);
+
+  // After every hook above, so a set that empties and refills does not change
+  // the hook order. The List's element and class, for the List's reason: one
+  // page, one way of saying there is nothing here.
+  if (tasks.length === 0) {
+    return <p className="schedule-tv-empty">{emptyLabel}</p>;
+  }
 
   return (
     <>

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1636,7 +1636,13 @@ function TaskNode({
   // stops being expandable closes itself instead of being stuck open with no
   // control to close it. That cannot happen today (a thread never shrinks), but
   // "cannot happen" is not a thing to leave a render depending on.
-  const expandable = isExpandable(task);
+  // A PROVISIONAL row is never an accordion: its `message_count` is a default
+  // (tasks-lib.provisionalTasks), not a count, so "does this thread have more
+  // than one message in it" is a question pulse cannot answer yet. The gutter
+  // still draws — only the chevron goes — which is the same placeholder a
+  // one-message row already gets, and the row becomes expandable on its own
+  // when the listing lands and replaces it.
+  const expandable = isExpandable(task) && !task.provisional;
   const open = expandable && requested;
   const view = threadView(task, loaded);
   // Everything this thread holds, one list: the listing window before Show more,
@@ -2527,6 +2533,19 @@ function TaskNode({
             because none of its user entries is typed prose. This default is the
             preventive fix; the counter is a separate job.) */}
         {(() => {
+          // A PROVISIONAL row has no count to show — /api/tasks/pulse does not
+          // carry `message_count`, so the floor of one below would be a number
+          // this client invented. The cell is still DRAWN, with its ink hidden
+          // rather than its box removed: an absent chip would widen the title
+          // beside it and snap it back the moment the listing lands, and the
+          // whole point of painting early is that nothing jumps when it does.
+          if (task.provisional) {
+            return (
+              <span className="tasks-row-msgs tasks-row-msgs--blank" aria-hidden>
+                1<span className="tasks-row-msgs-icon">{ICON_MSG}</span>
+              </span>
+            );
+          }
           const shown = Math.max(1, task.message_count);
           return (
             <span

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -2600,9 +2600,22 @@ function TaskNode({
             {soon.text}
           </span>
         )}
-        <span className="tasks-row-time" data-hint={when.title}>
-          {when.text}
-        </span>
+        {/* A PROVISIONAL row's time is not this row's time. taskWhen reads the
+            run off the three-message window, and pulse carries no window, so it
+            falls through to `last_active` — the session's clock, which on a live
+            session says "just now" while the listing a beat later says "56m
+            ago" for the last run (cmux-ux-tester, 2026-09-09). Two different
+            answers to one cell reads as a bug. Same treatment as the count cell
+            above: drawn, ink hidden, width held. */}
+        {task.provisional ? (
+          <span className="tasks-row-time tasks-row-time--blank" aria-hidden>
+            {when.text}
+          </span>
+        ) : (
+          <span className="tasks-row-time" data-hint={when.title}>
+            {when.text}
+          </span>
+        )}
       </div>
 
       {/* Why the refusal is quiet: see runNow. The class is the board's own

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -3125,7 +3125,16 @@ export function TaskBoard({
   // the hook order. The List's element and class, for the List's reason: one
   // page, one way of saying there is nothing here.
   if (tasks.length === 0) {
-    return <p className="schedule-tv-empty">{emptyLabel}</p>;
+    return (
+      <>
+        {/* The note rides along: an unarchive or a refused drop that removed
+            the LAST matching card is exactly when "where did it go" needs
+            answering, and the empty sentence alone read as a disappearance
+            (Bugbot, #1079). */}
+        {note && <p className="schedule-tv-note">{note}</p>}
+        <p className="schedule-tv-empty">{emptyLabel}</p>
+      </>
+    );
   }
 
   return (

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -511,6 +511,18 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // folder, so a row can say "Folder missing" instead of opening an Explorer
   // that can only answer with a stat error (useMissingFolders).
   const missing = useMissingFolders(shown);
+  // ONE sentence for "there is nothing here", handed to all four views, so a
+  // reader flipping List → Board → Cards → Calendar over the same empty set
+  // reads the same words in the same place (Akshil, 2026-09-09). Which sentence
+  // is the page's call, not a view's: only the page knows whether the set is
+  // empty because the machine has no tasks, this app has none, or the filters
+  // matched none.
+  const emptyLabel =
+    inScope.length === 0
+      ? scope
+        ? "No tasks for this app yet."
+        : "No tasks yet. Everything Claude runs for you shows up here."
+      : "Nothing matches these filters.";
 
   // Editing is addressed by ENTRY id, not by task: a task is a thread, and a
   // thread has nothing to edit — only a message that has not gone out yet does.
@@ -677,6 +689,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
             <TasksSkeleton view={view} />
           ) : view === "calendar" ? (
             <ScheduleCalendar
+              emptyLabel={emptyLabel}
               // The FILTERED set, same as the other two views get: the toolbar's
               // three controls are live here now, and a filter that is shown but
               // does nothing is worse than one that is hidden.
@@ -689,9 +702,16 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               onEditEntry={editEntry}
             />
           ) : view === "board" ? (
-            <TaskBoard tasks={shown} home={home} onReload={reload} missing={missing} />
+            <TaskBoard
+              tasks={shown}
+              home={home}
+              onReload={reload}
+              missing={missing}
+              emptyLabel={emptyLabel}
+            />
           ) : view === "cards" ? (
             <TaskCards
+              emptyLabel={emptyLabel}
               // The FILTERED set, like every other view: Cards only ORDERS it
               // (tasks-lib.cardsForTasks — every lane, Archive last), and a
               // Project, Status or Search the reader set on another view is a
@@ -732,13 +752,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               // catch it anyway, so this is about the row not looking stuck for
               // twenty seconds, not about correctness.
               onReload={reload}
-              emptyLabel={
-                inScope.length === 0
-                  ? scope
-                    ? "No tasks for this app yet."
-                    : "No tasks yet. Everything Claude runs for you shows up here."
-                  : "Nothing matches these filters."
-              }
+              emptyLabel={emptyLabel}
             />
           )}
         </section>

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -82,8 +82,21 @@ import {
   projectOptions,
 } from "./ScheduleTaskViews";
 import type { TaskFilters } from "./ScheduleTaskViews";
-import { publishTasks, TASKS_POKE_EVENT, useTasksFeeder } from "./tasksPulse";
-import { TASK_VIEWS, mergeTaskChanges, viewFromSearch, viewUrl } from "./tasks-lib";
+import {
+  publishTasks,
+  readListing,
+  readTasksRows,
+  rememberListing,
+  TASKS_POKE_EVENT,
+  useTasksFeeder,
+} from "./tasksPulse";
+import {
+  TASK_VIEWS,
+  mergeTaskChanges,
+  provisionalTasks,
+  viewFromSearch,
+  viewUrl,
+} from "./tasks-lib";
 import type { TaskView } from "./tasks-lib";
 import { TaskCards } from "./TaskCards";
 import { useMissingFolders } from "./useMissingFolders";
@@ -136,7 +149,19 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // make no calls", so the shared store stands down until this unmounts.
   useTasksFeeder();
   const [state, setState] = useState<ScheduleResult | null>(null);
-  const [tasks, setTasks] = useState<Task[]>([]);
+  // NOT `[]`, because this page remounts on every navigation and /api/tasks is
+  // 2.9s on the first call of a server process — so a bare `[]` meant List →
+  // Home → List went back to a skeleton over a listing this session had already
+  // read, and a cold first visit showed nothing while the sidebar beside it
+  // already knew every task's name (see .claude-design/tasks-cold-load.md).
+  //
+  // Two seeds, best first: the last full listing of this JS session, else rows
+  // upcast from the pulse store the sidebar has been filling all along. Both
+  // are replaced whole by the poll below — this is what the page paints WHILE
+  // that call is in the air, not a cache it trusts.
+  const [tasks, setTasks] = useState<Task[]>(
+    () => readListing() ?? provisionalTasks(readTasksRows()),
+  );
   const [tasksFailed, setTasksFailed] = useState(false);
   // The rows as the changes loop below last saw them, and the server
   // generation they answer to. Refs, not state: the loop is one long-lived
@@ -295,6 +320,10 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
         // twenty seconds at a time. Publishing also restarts that module's own
         // timer, so while this page is open nothing else calls /api/tasks.
         publishTasks(r.tasks ?? []);
+        // And keep it for the next mount: this page is remounted on every
+        // navigation, and the seed above is what saves the trip back from
+        // paying for the listing twice.
+        rememberListing(r.tasks ?? []);
       },
       () => {
         setTasks([]);
@@ -384,6 +413,9 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
             tasksRef.current = merged;
             setTasks(merged);
             publishTasks(merged);
+            // The merge is now the freshest full listing there is, so it — not
+            // the poll's older answer — is what a remount should seed from.
+            rememberListing(merged);
           }
         } catch {
           if (stopped) return;

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -83,6 +83,7 @@ import {
 } from "./ScheduleTaskViews";
 import type { TaskFilters } from "./ScheduleTaskViews";
 import {
+  forgetListing,
   publishTasks,
   readListing,
   readTasksRows,
@@ -163,6 +164,14 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     () => readListing() ?? provisionalTasks(readTasksRows()),
   );
   const [tasksFailed, setTasksFailed] = useState(false);
+  // Has ANY listing been on this page yet — a seed above, a poll's answer, or a
+  // poll's failure? Until one has, `tasks` being `[]` means "not asked yet",
+  // not "none", and the view below must not say "No tasks yet" over it: a
+  // reload straight onto /tasks (or the app launching onto it) showed that
+  // empty state for the whole cold listing — up to seconds after a server
+  // start — then filled in, which reads as the page having lost the tasks and
+  // found them again (Akshil, 2026-09-09). A skeleton is the honest state.
+  const [tasksLoaded, setTasksLoaded] = useState(() => tasks.length > 0);
   // The rows as the changes loop below last saw them, and the server
   // generation they answer to. Refs, not state: the loop is one long-lived
   // effect and must read the newest value without re-subscribing on every
@@ -313,6 +322,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
         if (typeof r.generation === "number" && r.generation < generationRef.current) return;
         setTasks(r.tasks ?? []);
         setTasksFailed(false);
+        setTasksLoaded(true);
         if (typeof r.generation === "number") generationRef.current = r.generation;
         // The sidebar's Tasks entry reads the same rows (shell/tasksPulse): the
         // dot and the counts beside the label are this answer, not a second poll
@@ -328,6 +338,8 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
       () => {
         setTasks([]);
         setTasksFailed(true);
+        setTasksLoaded(true);
+        forgetListing();
       },
     );
     getScheduleQueue().then(
@@ -650,7 +662,12 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
             <p className="schedule-tv-note">Tasks could not be loaded.</p>
           )}
 
-          {view === "calendar" ? (
+          {!tasksLoaded ? (
+            // The rows' own skeleton, under the toolbar the schedule already
+            // let us draw: the page shape is settled, only the list is in the
+            // air. Eight bars — about a screen of rows at this row height.
+            <SkeletonLines rows={8} label="Loading tasks" />
+          ) : view === "calendar" ? (
             <ScheduleCalendar
               // The FILTERED set, same as the other two views get: the toolbar's
               // three controls are live here now, and a filter that is shown but

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -100,6 +100,7 @@ import {
 } from "./tasks-lib";
 import type { TaskView } from "./tasks-lib";
 import { TaskCards } from "./TaskCards";
+import { TasksSkeleton } from "./TasksSkeleton";
 import { useMissingFolders } from "./useMissingFolders";
 import { isUnderDir } from "./current-apps-lib";
 
@@ -670,10 +671,10 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           )}
 
           {!tasksLoaded ? (
-            // The rows' own skeleton, under the toolbar the schedule already
-            // let us draw: the page shape is settled, only the list is in the
-            // air. Eight bars — about a screen of rows at this row height.
-            <SkeletonLines rows={8} label="Loading tasks" />
+            // The view's own ghost, under the toolbar the schedule already let
+            // us draw: the page has its final shape from the first paint, and
+            // the reader can tell which view they are on before a row lands.
+            <TasksSkeleton view={view} />
           ) : view === "calendar" ? (
             <ScheduleCalendar
               // The FILTERED set, same as the other two views get: the toolbar's

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -171,7 +171,14 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // empty state for the whole cold listing — up to seconds after a server
   // start — then filled in, which reads as the page having lost the tasks and
   // found them again (Akshil, 2026-09-09). A skeleton is the honest state.
-  const [tasksLoaded, setTasksLoaded] = useState(() => tasks.length > 0);
+  //
+  // A remembered listing counts even when it is EMPTY: a machine with no tasks
+  // asked once and got `[]`, and a remount must show the empty state it earned,
+  // not a skeleton over it (Bugbot, #1079). Provisional rows count only when
+  // there are some — an empty pulse store is exactly "not asked yet".
+  const [tasksLoaded, setTasksLoaded] = useState(
+    () => readListing() !== null || tasks.length > 0,
+  );
   // The rows as the changes loop below last saw them, and the server
   // generation they answer to. Refs, not state: the loop is one long-lived
   // effect and must read the newest value without re-subscribing on every

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -170,7 +170,11 @@ export function TaskCards({
   onPickProject,
   pinnedProjects = [],
   missing,
+  emptyLabel = CARDS_EMPTY,
 }: {
+  /** The page's sentence for an empty set (Scheduled `emptyLabel`) — the same
+   * one the List, Board and Calendar print, so the four views agree. */
+  emptyLabel?: string;
   /** Already filtered, in the SERVER's order — `cardsForTasks` orders it by
    * lane (every lane, Archive last), which is the one thing this view does to
    * the set it is handed and the one place it is decided. */
@@ -307,7 +311,7 @@ export function TaskCards({
     // there is nothing here.
     return (
       <>
-        <p className="schedule-tv-empty">{CARDS_EMPTY}</p>
+        <p className="schedule-tv-empty">{emptyLabel}</p>
         {popup}
       </>
     );

--- a/frontend/src/shell/TasksSkeleton.tsx
+++ b/frontend/src/shell/TasksSkeleton.tsx
@@ -110,18 +110,19 @@ function ListGhost() {
 function BoardGhost() {
   return (
     <div {...ghost("board", "schedule-tv-board")}>
+      {/* Every lane and rail is decoration; the root's label says it all. */}
       {BOARD_LANES.map((col, laneIx) => {
         const cards = LANE_CARDS[laneIx % LANE_CARDS.length];
         if (cards === 0) {
           return (
-            <div key={col.key} className="schedule-tv-rail tasks-skel-rail">
+            <div key={col.key} className="schedule-tv-rail tasks-skel-rail" aria-hidden="true">
               <Ring />
               <span className="skel-bar tasks-skel-rail-label" />
             </div>
           );
         }
         return (
-        <div key={col.key} className="schedule-tv-lane">
+        <div key={col.key} className="schedule-tv-lane" aria-hidden="true">
           <div className="schedule-tv-lane-head tasks-skel-lane-head">
             <Ring />
             <Bar w={72} />
@@ -180,14 +181,14 @@ function CalendarGhost() {
     >
       {/* The calendar's own bar — range nav on the left, view range on the
           right — so the head below sits where the real head will. */}
-      <div className="schedule-cal-bar tasks-skel-cal-bar">
+      <div className="schedule-cal-bar tasks-skel-cal-bar" aria-hidden="true">
         <Bar w={24} className="tasks-skel-cal-btn" />
         <Bar w={24} className="tasks-skel-cal-btn" />
         <Bar w={140} />
         <span className="tasks-grow" />
         <Bar w={92} className="tasks-skel-cal-btn" />
       </div>
-      <div className="schedule-cal-head">
+      <div className="schedule-cal-head" aria-hidden="true">
         <div className="schedule-cal-gutter" />
         {Array.from({ length: days }, (_, d) => (
           <div key={d} className="schedule-cal-day-head">
@@ -196,7 +197,7 @@ function CalendarGhost() {
           </div>
         ))}
       </div>
-      <div className="schedule-cal-scroll">
+      <div className="schedule-cal-scroll" aria-hidden="true">
         <div className="schedule-cal-grid tasks-skel-cal-grid">
           <div className="tasks-skel-cal-gutter">
             {Array.from({ length: CAL_ROWS }, (_, r) => (

--- a/frontend/src/shell/TasksSkeleton.tsx
+++ b/frontend/src/shell/TasksSkeleton.tsx
@@ -18,20 +18,20 @@
 // One `role="status"` wrapper carries the label; the bars inside are decoration
 // and are hidden from the accessibility tree.
 import type React from "react";
-import { BOARD_COLUMNS, initialRange } from "./schedule-lib";
+import { BOARD_LANES, initialRange } from "./schedule-lib";
 import type { TaskView } from "./tasks-lib";
 
 /** Title bar widths, as a percentage of the row, cycled. Ragged on purpose: a
  *  column of equal bars reads as a table header, not as titles. */
 const TITLE_WIDTHS = [34, 52, 41, 60, 38, 47, 55, 30];
 const LIST_ROWS = 8;
-/** Cards per board lane, in `BOARD_COLUMNS` order — a board that is never
- *  evenly full, like a real one. A count of 0 draws the lane ROLLED UP into
- *  its 52px rail, which is what the real board does with an empty column
- *  (TaskBoard `laneRolledUp`): Needs attention and Blocked are empty on most
- *  days, and a ghost with six open lanes was wider than the board it stood
- *  in for. */
-const LANE_CARDS = [2, 3, 0, 0, 3, 2];
+/** Cards per board lane, in `BOARD_LANES` order — the five the board DRAWS
+ *  (Needs attention shares Blocked's lane, schedule-lib.laneOf), not the six
+ *  statuses; a sixth ghost column was a layout shift on the swap (Bugbot,
+ *  #1079). Never evenly full, like a real board. A count of 0 draws the lane
+ *  ROLLED UP into its 52px rail, which is what the real board does with an
+ *  empty column (TaskBoard `laneRolledUp`): Blocked is empty on most days. */
+const LANE_CARDS = [2, 3, 0, 3, 2];
 const CARD_TILES = 6;
 const CAL_ROWS = 8;
 /** The calendar's own memory of its range (ScheduleCalendar RANGE_KEY), read
@@ -110,7 +110,7 @@ function ListGhost() {
 function BoardGhost() {
   return (
     <div {...ghost("board", "schedule-tv-board")}>
-      {BOARD_COLUMNS.map((col, laneIx) => {
+      {BOARD_LANES.map((col, laneIx) => {
         const cards = LANE_CARDS[laneIx % LANE_CARDS.length];
         if (cards === 0) {
           return (

--- a/frontend/src/shell/TasksSkeleton.tsx
+++ b/frontend/src/shell/TasksSkeleton.tsx
@@ -1,0 +1,232 @@
+// The Tasks page's loading state, one ghost per VIEW.
+//
+// Before this (2026-09-09) every view waited behind the same eight ragged
+// bars, which told the reader "something is coming" and nothing about what —
+// and then the List, or six cards, or a week grid, snapped into a space shaped
+// nothing like the bars. A ghost that is shaped like the view it stands in for
+// does two things the bars could not: the page has its final geometry from the
+// first paint, and the reader knows which view they are on before a row lands
+// (Akshil: "skeleton loader should be different per view and closer to the UI").
+//
+// Each ghost REUSES the real view's container classes (`.tasks-list-frame`,
+// `.schedule-tv-board`/`-lane`, `.task-cards`, `.schedule-cal-*`) so the
+// dimensions come from the same CSS the rows will use — a change to a row's
+// padding changes the ghost's too, and the swap moves nothing. Only the bars
+// are new, and they are the shell's own `.skel-bar` shimmer (platform/ui/
+// Skeleton), so this adds no colour and no motion of its own.
+//
+// One `role="status"` wrapper carries the label; the bars inside are decoration
+// and are hidden from the accessibility tree.
+import type React from "react";
+import { BOARD_COLUMNS, initialRange } from "./schedule-lib";
+import type { TaskView } from "./tasks-lib";
+
+/** Title bar widths, as a percentage of the row, cycled. Ragged on purpose: a
+ *  column of equal bars reads as a table header, not as titles. */
+const TITLE_WIDTHS = [34, 52, 41, 60, 38, 47, 55, 30];
+const LIST_ROWS = 8;
+/** Cards per board lane, in `BOARD_COLUMNS` order — a board that is never
+ *  evenly full, like a real one. A count of 0 draws the lane ROLLED UP into
+ *  its 52px rail, which is what the real board does with an empty column
+ *  (TaskBoard `laneRolledUp`): Needs attention and Blocked are empty on most
+ *  days, and a ghost with six open lanes was wider than the board it stood
+ *  in for. */
+const LANE_CARDS = [2, 3, 0, 0, 3, 2];
+const CARD_TILES = 6;
+const CAL_ROWS = 8;
+/** The calendar's own memory of its range (ScheduleCalendar RANGE_KEY), read
+ *  the same way it reads it — through schedule-lib.initialRange, which is also
+ *  what decides the default for a reader who never chose — so the ghost has the
+ *  day count the grid will. */
+const CAL_RANGE_KEY = "fused-render:scheduled-cal-range";
+
+function calendarDays(): number {
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(CAL_RANGE_KEY);
+  } catch {
+    stored = null;
+  }
+  return initialRange(stored) === "4day" ? 4 : 7;
+}
+/** Where a chip ghost sits per day column: [row offset, rows tall]; a day
+ *  with none is a quiet day. Index = day column. */
+const CAL_CHIPS: ([number, number] | null)[] = [
+  [1, 1], [3, 2], null, [2, 1], [5, 1], null, [4, 2],
+];
+
+/** What every ghost's root carries: the view's own container class first, so
+ *  the CSS that keys on `.schedule-main > .task-cards-scroll` (task-cards.css)
+ *  or `.schedule-page:has(> .schedule-main > …)` sees the ghost exactly where it
+ *  sees the view — a wrapper in between broke those selectors, and the Cards
+ *  ghost drew three columns where the wall would draw one. */
+function ghost(view: TaskView, base: string) {
+  return {
+    className: `${base} tasks-skel tasks-skel--${view}`,
+    role: "status",
+    "aria-busy": true,
+    "aria-label": "Loading tasks",
+  } as const;
+}
+
+function Bar({ w, className = "" }: { w: number | string; className?: string }) {
+  return (
+    <span
+      className={`skel-bar ${className}`.trim()}
+      style={{ width: typeof w === "number" ? `${w}px` : w }}
+    />
+  );
+}
+
+/** The 12px status ring, as a round bar. */
+function Ring() {
+  return <span className="skel-bar tasks-skel-ring" />;
+}
+
+function ListGhost() {
+  return (
+    <div {...ghost("list", "tasks-list")}>
+      <div className="tasks-list-frame" aria-hidden="true">
+        {Array.from({ length: LIST_ROWS }, (_, i) => (
+          <div key={i} className="tasks-node">
+            <div className="tasks-row tasks-skel-row">
+              <span className="tasks-caret tasks-skel-caret" />
+              <span className="tasks-rowmark tasks-skel-rowmark">
+                <Ring />
+              </span>
+              <Bar w={56} className="tasks-skel-id" />
+              <Bar w={`${TITLE_WIDTHS[i % TITLE_WIDTHS.length]}%`} className="tasks-skel-title" />
+              <span className="tasks-grow" />
+              <Bar w={28} />
+              <Bar w={44} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BoardGhost() {
+  return (
+    <div {...ghost("board", "schedule-tv-board")}>
+      {BOARD_COLUMNS.map((col, laneIx) => {
+        const cards = LANE_CARDS[laneIx % LANE_CARDS.length];
+        if (cards === 0) {
+          return (
+            <div key={col.key} className="schedule-tv-rail tasks-skel-rail">
+              <Ring />
+              <span className="skel-bar tasks-skel-rail-label" />
+            </div>
+          );
+        }
+        return (
+        <div key={col.key} className="schedule-tv-lane">
+          <div className="schedule-tv-lane-head tasks-skel-lane-head">
+            <Ring />
+            <Bar w={72} />
+            <span className="tasks-grow" />
+            <Bar w={16} />
+          </div>
+          <div className="schedule-tv-lane-body">
+            {Array.from({ length: cards }, (_, i) => (
+              <div key={i} className="schedule-tv-card tasks-skel-card">
+                <div className="schedule-tv-card-head">
+                  <Bar w={48} />
+                  <span className="tasks-grow" />
+                  <Ring />
+                </div>
+                <Bar w="90%" />
+                <Bar w={`${TITLE_WIDTHS[(laneIx + i) % TITLE_WIDTHS.length] + 10}%`} />
+                <div className="schedule-tv-card-foot">
+                  <Bar w={40} />
+                  <Bar w={40} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CardsGhost() {
+  return (
+    <div {...ghost("cards", "task-cards-scroll")}>
+      <div className="task-cards" aria-hidden="true">
+        {Array.from({ length: CARD_TILES }, (_, i) => (
+          <div key={i} className="tasks-skel-tile">
+            <div className="tasks-skel-tile-head">
+              <Ring />
+              <Bar w={`${TITLE_WIDTHS[i % TITLE_WIDTHS.length] + 15}%`} />
+            </div>
+            <div className="skel-bar tasks-skel-tile-body" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CalendarGhost() {
+  const days = calendarDays();
+  const cols = { ["--cal-days" as string]: days } as React.CSSProperties;
+  return (
+    <div
+      {...ghost("calendar", "schedule-cal tasks-skel-cal" + (days === 4 ? " is-wide" : ""))}
+      style={cols}
+    >
+      {/* The calendar's own bar — range nav on the left, view range on the
+          right — so the head below sits where the real head will. */}
+      <div className="schedule-cal-bar tasks-skel-cal-bar">
+        <Bar w={24} className="tasks-skel-cal-btn" />
+        <Bar w={24} className="tasks-skel-cal-btn" />
+        <Bar w={140} />
+        <span className="tasks-grow" />
+        <Bar w={92} className="tasks-skel-cal-btn" />
+      </div>
+      <div className="schedule-cal-head">
+        <div className="schedule-cal-gutter" />
+        {Array.from({ length: days }, (_, d) => (
+          <div key={d} className="schedule-cal-day-head">
+            <Bar w={24} />
+            <Bar w={18} className="tasks-skel-cal-num" />
+          </div>
+        ))}
+      </div>
+      <div className="schedule-cal-scroll">
+        <div className="schedule-cal-grid tasks-skel-cal-grid">
+          <div className="tasks-skel-cal-gutter">
+            {Array.from({ length: CAL_ROWS }, (_, r) => (
+              <Bar key={r} w={28} />
+            ))}
+          </div>
+          {Array.from({ length: days }, (_, d) => {
+            const chip = CAL_CHIPS[d];
+            return (
+              <div key={d} className="schedule-cal-col tasks-skel-cal-col">
+                {chip && (
+                  <span
+                    className="skel-bar tasks-skel-cal-chip"
+                    style={{ gridRow: `${chip[0] + 1} / span ${chip[1]}` }}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function TasksSkeleton({ view }: { view: TaskView }) {
+  if (view === "board") return <BoardGhost />;
+  if (view === "cards") return <CardsGhost />;
+  if (view === "calendar") return <CalendarGhost />;
+  return <ListGhost />;
+}
+
+export default TasksSkeleton;

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6476,7 +6476,9 @@ describe("the tasks toolbar", () => {
     // and the scope is applied BEFORE these filters (`tasks` unscoped = what
     // publishTasks hands the sidebar).
     expect(PAGE).toContain("filterTasks(inScope, filtersForView(filters, view))");
-    expect(PAGE).toContain("<TaskBoard tasks={shown}");
+    // Multi-line since the Board took the page's `emptyLabel` (2026-09-09).
+    const board = PAGE.slice(PAGE.indexOf("<TaskBoard"));
+    expect(board.slice(0, board.indexOf("/>"))).toContain("tasks={shown}");
   });
 
   it("hides the dead Archive option from Status only on the calendar", () => {
@@ -7189,7 +7191,8 @@ describe("the Cards view's frame", () => {
     expect(HOOK).toContain("This task's folder was deleted, so its chat can't be opened. Archive the task to remove it.");
     expect(HOOK).toContain('pushToast({ msg: MISSING_FOLDER_TOAST, tone: "error" });');
     expect(SCHEDULED).toContain("const missing = useMissingFolders(shown);");
-    expect(SCHEDULED).toContain("<TaskBoard tasks={shown} home={home} onReload={reload} missing={missing} />");
+    const board = SCHEDULED.slice(SCHEDULED.indexOf("<TaskBoard"));
+    expect(board.slice(0, board.indexOf("/>"))).toContain("missing={missing}");
     expect(SCHEDULED).toContain("home={home}\n              missing={missing}");
     expect(VIEWS).toContain("folderMissing={missing?.has(taskFolder(task)) ?? false}");
     // A TOAST, not a line under the row (Akshil, 2026-09-06, screenshot).
@@ -8302,6 +8305,21 @@ describe("provisionalTasks", () => {
     expect(taskUnread(t, new Set())).toBe(2);
     const [none] = provisionalTasks([row({ unread: 0 })]);
     expect(taskUnread(none, new Set())).toBe(0);
+  });
+
+  it("the four views print the PAGE's one empty sentence, full width, centred", () => {
+    // One `emptyLabel` computed in Scheduled and handed to List, Board, Cards
+    // and Calendar; each prints it as the same `.schedule-tv-empty` paragraph.
+    // The Board used to show five bare rails and the Calendar a bare grid.
+    const SCHED = readFileSync(join(SHELL, "Scheduled.tsx"), "utf8");
+    expect((SCHED.match(/emptyLabel=\{emptyLabel\}/g) ?? []).length).toBe(4);
+    expect(VIEWS).toContain("if (tasks.length === 0) {\n    return <p className=\"schedule-tv-empty\">{emptyLabel}</p>;");
+    const CAL = readFileSync(join(SHELL, "ScheduleCalendar.tsx"), "utf8");
+    expect(CAL).toContain('return <p className="schedule-tv-empty">{emptyLabel}</p>;');
+    const CARDS_SRC = readFileSync(join(SHELL, "TaskCards.tsx"), "utf8");
+    expect(CARDS_SRC).toContain('<p className="schedule-tv-empty">{emptyLabel}</p>');
+    expect(block(SCHEDULE_CSS, ".schedule-tv-empty")).toContain("width: 100%");
+    expect(block(SCHEDULE_CSS, ".schedule-tv-empty")).toContain("text-align: center");
   });
 
   it("the page waits behind a ghost of the CURRENT view, not eight bars", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { Task, TaskMessage } from "@platform/lib/api";
+import type { Task, TaskMessage, TaskPulseTask } from "@platform/lib/api";
 import { BOARD_COLUMNS, BOARD_LANES, cardFrameSrc, laneOf, peekFrameSrc } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 import {
@@ -110,6 +110,7 @@ import {
   viewFromSearch,
   viewUrl,
   mergeTaskChanges,
+  provisionalTasks,
   emptyPaneText,
 } from "./tasks-lib";
 
@@ -3159,7 +3160,10 @@ describe("the one-message row's missing chevron", () => {
     // The guard is in the derived value, not in the render: a row in the List's
     // expanded set that stops being expandable closes, instead of being stuck open
     // with nothing left to close it.
-    expect(VIEWS).toContain("const expandable = isExpandable(task);");
+    // `&& !task.provisional` since 2026-09-09: a row painted from pulse has a
+    // DEFAULT message_count, not a count, so it is not an accordion until the
+    // full listing replaces it (tasks-lib.provisionalTasks).
+    expect(VIEWS).toContain("const expandable = isExpandable(task) && !task.provisional;");
     expect(VIEWS).toContain("const open = expandable && requested;");
     // The toggle is the CHEVRON's press now (2026-08-18) — the row's own press
     // opens the conversation — so the guard is the arm that renders the button at
@@ -8214,5 +8218,76 @@ describe("attentionRows", () => {
              project: "" }),
     ]);
     expect(nowhere[0].href).toBeNull();
+  });
+});
+
+describe("provisionalTasks", () => {
+  const row = (over: Partial<TaskPulseTask> = {}): TaskPulseTask => ({
+    key: "sess-1",
+    status: "in_progress",
+    unread: 2,
+    last_active: 1_700_000_000,
+    happened_at: 1_699_999_000,
+    project: "/Users/me/proj",
+    task_id: "TASK-002",
+    title: "Pull today's news",
+    target: "/Users/me/proj/news.py",
+    session_id: "sess-1",
+    ...over,
+  });
+
+  it("carries every pulse field through untouched", () => {
+    // The point of the seed: these ten fields are what a row DRAWS — its link,
+    // its ring, its chip, its title, its time — so a provisional row and the
+    // listing row that replaces it say the same things about all of them.
+    const [t] = provisionalTasks([row()]);
+    expect(t.key).toBe("sess-1");
+    expect(t.task_id).toBe("TASK-002");
+    expect(t.project).toBe("/Users/me/proj");
+    expect(t.target).toBe("/Users/me/proj/news.py");
+    expect(t.session_id).toBe("sess-1");
+    expect(t.title).toBe("Pull today's news");
+    expect(t.status).toBe("in_progress");
+    expect(t.unread).toBe(2);
+    expect(t.last_active).toBe(1_700_000_000);
+    expect(t.happened_at).toBe(1_699_999_000);
+  });
+
+  it("fills everything pulse does not carry with a neutral default", () => {
+    // NEUTRAL, not plausible: a guessed `live` or `failed` would put a shimmer
+    // or a red ring on a row this client knows nothing about, and every one of
+    // these is replaced whole when /api/tasks lands.
+    const [t] = provisionalTasks([row()]);
+    expect(t.messages).toEqual([]);
+    expect(t.message_count).toBe(0);
+    expect(t.live).toBe(false);
+    expect(t.failed).toBe(false);
+    expect(t.attention).toBeNull();
+    expect(t.description).toBe("");
+    expect(t.title_source).toBe("message");
+    expect(t.blocked_reason).toBe("");
+    expect(t.next_run).toBe(0);
+    expect(t.next_run_entry).toBe("");
+    expect(t.started).toBe(0);
+  });
+
+  it("marks the row provisional, and is not expandable", () => {
+    // The flag is the whole contract with the views: the count cell and the
+    // caret read it and draw placeholders rather than printing `message_count`
+    // as if it were a count (ScheduleTaskViews).
+    const [t] = provisionalTasks([row()]);
+    expect(t.provisional).toBe(true);
+    expect(isExpandable(t)).toBe(false);
+  });
+
+  it("is empty for an empty store, and keeps the store's order", () => {
+    // A fresh reload straight to /tasks has nothing in the pulse store yet, and
+    // the seed is then exactly the `[]` the page used to start from.
+    expect(provisionalTasks([])).toEqual([]);
+    const keys = provisionalTasks([
+      row({ key: "a", task_id: "TASK-001" }),
+      row({ key: "b", task_id: "TASK-002" }),
+    ]).map((t) => t.key);
+    expect(keys).toEqual(["a", "b"]);
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -8291,6 +8291,25 @@ describe("provisionalTasks", () => {
     expect(taskUnread(none, new Set())).toBe(0);
   });
 
+  it("the page waits behind a ghost of the CURRENT view, not eight bars", () => {
+    // One ghost per view (TasksSkeleton), each built from the real view's
+    // container classes so the swap to rows moves nothing. Gated on the same
+    // `tasksLoaded` as before; the toolbar above it is already real.
+    const SCHED = readFileSync(join(SHELL, "Scheduled.tsx"), "utf8");
+    expect(SCHED).toContain("{!tasksLoaded ? (");
+    expect(SCHED).toContain("<TasksSkeleton view={view} />");
+    const SKEL = readFileSync(join(SHELL, "TasksSkeleton.tsx"), "utf8");
+    for (const cls of ["tasks-list-frame", "schedule-tv-board", "schedule-tv-lane",
+                       "task-cards", "schedule-cal-grid"]) {
+      expect(SKEL).toContain(`"${cls}`);
+    }
+    // The a11y attrs ride the ghost's ROOT, which is the view's own container
+    // class — `.schedule-main > .task-cards-scroll` and friends must match it.
+    expect(SKEL).toContain('role: "status"');
+    expect(SKEL).toContain('"aria-label": "Loading tasks"');
+    expect(SKEL).toContain('ghost("cards", "task-cards-scroll")');
+  });
+
   it("the List blanks the count AND the time cell of a provisional row", () => {
     // Both cells would otherwise print a default as a fact: `message_count` is
     // 0 by construction, and taskWhen, with no message window to read, falls

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -8280,6 +8280,17 @@ describe("provisionalTasks", () => {
     expect(isExpandable(t)).toBe(false);
   });
 
+  it("keeps pulse's unread on the ring: taskUnread does not read the empty window as read", () => {
+    // `message_count` 0 with no messages is how a fully read empty thread ALSO
+    // looks, and the exact-thread arm of taskUnread would answer 0 — a hollow
+    // ring on a task the server says has two unread, for the whole wait the seed
+    // covers (Bugbot on #1079). A provisional row hands back the pulse number.
+    const [t] = provisionalTasks([row({ unread: 2 })]);
+    expect(taskUnread(t, new Set())).toBe(2);
+    const [none] = provisionalTasks([row({ unread: 0 })]);
+    expect(taskUnread(none, new Set())).toBe(0);
+  });
+
   it("the List blanks the count AND the time cell of a provisional row", () => {
     // Both cells would otherwise print a default as a fact: `message_count` is
     // 0 by construction, and taskWhen, with no message window to read, falls

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -8280,6 +8280,17 @@ describe("provisionalTasks", () => {
     expect(isExpandable(t)).toBe(false);
   });
 
+  it("the List blanks the count AND the time cell of a provisional row", () => {
+    // Both cells would otherwise print a default as a fact: `message_count` is
+    // 0 by construction, and taskWhen, with no message window to read, falls
+    // through to `last_active` — which on a live session is "just now" while
+    // the listing's last run is an hour ago. Ink hidden, box kept, so the swap
+    // to the real row moves nothing.
+    expect(VIEWS).toContain('className="tasks-row-msgs tasks-row-msgs--blank"');
+    expect(VIEWS).toContain('className="tasks-row-time tasks-row-time--blank"');
+    expect(TASKS_CSS).toMatch(/\.tasks-row-msgs--blank,\s*\.tasks-row-time--blank \{\s*visibility: hidden;/);
+  });
+
   it("is empty for an empty store, and keeps the store's order", () => {
     // A fresh reload straight to /tasks has nothing in the pulse store yet, and
     // the seed is then exactly the `[]` the page used to start from.

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -8233,6 +8233,7 @@ describe("provisionalTasks", () => {
     title: "Pull today's news",
     target: "/Users/me/proj/news.py",
     session_id: "sess-1",
+    next_run: 0,
     ...over,
   });
 
@@ -8266,9 +8267,16 @@ describe("provisionalTasks", () => {
     expect(t.description).toBe("");
     expect(t.title_source).toBe("message");
     expect(t.blocked_reason).toBe("");
-    expect(t.next_run).toBe(0);
     expect(t.next_run_entry).toBe("");
     expect(t.started).toBe(0);
+  });
+
+  it("carries the next run, so an Upcoming card sorts where the real one will", () => {
+    // The Board's Upcoming lane orders by next run (LANE_SORTS); a default of
+    // 0 sent every provisional card to the bottom and then moved it when the
+    // listing landed — the one reorder the seed was meant to avoid.
+    const [t] = provisionalTasks([row({ next_run: 1_700_100_000 })]);
+    expect(t.next_run).toBe(1_700_100_000);
   });
 
   it("marks the row provisional, and is not expandable", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -8234,6 +8234,7 @@ describe("provisionalTasks", () => {
     target: "/Users/me/proj/news.py",
     session_id: "sess-1",
     next_run: 0,
+    next_run_entry: "",
     ...over,
   });
 
@@ -8268,6 +8269,7 @@ describe("provisionalTasks", () => {
     expect(t.title_source).toBe("message");
     expect(t.blocked_reason).toBe("");
     expect(t.next_run_entry).toBe("");
+    expect(nextRunAt(t)).toBeNull();
     expect(t.started).toBe(0);
   });
 
@@ -8275,8 +8277,11 @@ describe("provisionalTasks", () => {
     // The Board's Upcoming lane orders by next run (LANE_SORTS); a default of
     // 0 sent every provisional card to the bottom and then moved it when the
     // listing landed — the one reorder the seed was meant to avoid.
-    const [t] = provisionalTasks([row({ next_run: 1_700_100_000 })]);
+    // Time AND entry: nextRunAt names the run only when both are there.
+    const [t] = provisionalTasks([row({ next_run: 1_700_100_000, next_run_entry: "e-9" })]);
     expect(t.next_run).toBe(1_700_100_000);
+    expect(t.next_run_entry).toBe("e-9");
+    expect(nextRunAt(t)).toBe(1_700_100_000);
   });
 
   it("marks the row provisional, and is not expandable", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -8313,9 +8313,17 @@ describe("provisionalTasks", () => {
     // The Board used to show five bare rails and the Calendar a bare grid.
     const SCHED = readFileSync(join(SHELL, "Scheduled.tsx"), "utf8");
     expect((SCHED.match(/emptyLabel=\{emptyLabel\}/g) ?? []).length).toBe(4);
-    expect(VIEWS).toContain("if (tasks.length === 0) {\n    return <p className=\"schedule-tv-empty\">{emptyLabel}</p>;");
+    // The Board keeps its `note` beside the sentence: a move that emptied the
+    // board is when "where did it go" matters most (Bugbot).
+    const boardEmpty = VIEWS.slice(VIEWS.indexOf("if (tasks.length === 0) {"));
+    expect(boardEmpty.slice(0, boardEmpty.indexOf("return (\n    <>"))).toContain(
+      '{note && <p className="schedule-tv-note">{note}</p>}\n        <p className="schedule-tv-empty">{emptyLabel}</p>',
+    );
     const CAL = readFileSync(join(SHELL, "ScheduleCalendar.tsx"), "utf8");
     expect(CAL).toContain('return <p className="schedule-tv-empty">{emptyLabel}</p>;');
+    // ...and the Calendar forgets its aim while the grid is gone, so a remount
+    // scrolls to the now-line again instead of opening at midnight (Bugbot).
+    expect(CAL).toContain('if (tasks.length === 0) aimed.current = { key: "", withChips: false };');
     const CARDS_SRC = readFileSync(join(SHELL, "TaskCards.tsx"), "utf8");
     expect(CARDS_SRC).toContain('<p className="schedule-tv-empty">{emptyLabel}</p>');
     expect(block(SCHEDULE_CSS, ".schedule-tv-empty")).toContain("width: 100%");

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3660,3 +3660,51 @@ export function mergeTaskChanges(tasks: Task[], upserts: Task[], gone: string[])
   for (const t of upserts) if (!drop.has(t.key)) byKey.set(t.key, t);
   return [...byKey.values()].sort((a, b) => b.last_active - a.last_active);
 }
+
+/**
+ * PAINT BEFORE /api/tasks ANSWERS: the sidebar's compact rows, upcast into the
+ * listing's own shape.
+ *
+ * `_task_rows()` reads every transcript from byte 0 on the first call of a
+ * server process — 2.9s on this machine — and the page spent all of it behind a
+ * skeleton while `/api/tasks/pulse` had already told the sidebar the key,
+ * status, project, title, target, session and times of every task. Those are
+ * most of what a row draws, so a row can be drawn from them.
+ *
+ * Everything pulse does not carry gets a NEUTRAL default, never a guess: no
+ * message window, no count, nothing live, nothing failed, nothing blocked and
+ * no next run. `provisional: true` is how the views tell the two apart — the
+ * message count and the expand caret are the two cells that would otherwise
+ * print one of these defaults as a fact, and they draw placeholders instead
+ * (ScheduleTaskViews). Every row is replaced whole the moment the listing
+ * lands, and the keys are the same, so nothing reorders on the swap.
+ */
+export function provisionalTasks(rows: TaskPulseTask[]): Task[] {
+  return rows.map((row) => ({
+    key: row.key,
+    task_id: row.task_id,
+    project: row.project,
+    target: row.target,
+    session_id: row.session_id,
+    title: row.title,
+    // `message` and not `entry`: the difference between those two only decides
+    // whether a title may be a message being composed right now, and a row
+    // this page did not fetch is not one of those.
+    title_source: "message",
+    description: "",
+    status: row.status,
+    failed: false,
+    blocked_reason: "",
+    attention: null,
+    live: false,
+    unread: row.unread,
+    started: 0,
+    last_active: row.last_active,
+    happened_at: row.happened_at,
+    message_count: 0,
+    next_run: 0,
+    next_run_entry: "",
+    messages: [],
+    provisional: true,
+  }));
+}

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3711,10 +3711,11 @@ export function provisionalTasks(rows: TaskPulseTask[]): Task[] {
     message_count: 0,
     // From pulse since 2026-09-09: the Board's Upcoming lane sorts by it, and a
     // default of 0 put every provisional card at the bottom of that lane until
-    // the listing landed and moved it (review, #1079). The entry id it belongs
-    // to is still unknown, and nothing on a row needs it before the swap.
+    // the listing landed and moved it (review, #1079). BOTH fields: namedNextRun
+    // reads the time only when the entry is named too — a time nobody can fire
+    // is not sorted by — so the time alone changed nothing (Bugbot).
     next_run: row.next_run,
-    next_run_entry: "",
+    next_run_entry: row.next_run_entry,
     messages: [],
     provisional: true,
   }));

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3709,7 +3709,11 @@ export function provisionalTasks(rows: TaskPulseTask[]): Task[] {
     last_active: row.last_active,
     happened_at: row.happened_at,
     message_count: 0,
-    next_run: 0,
+    // From pulse since 2026-09-09: the Board's Upcoming lane sorts by it, and a
+    // default of 0 put every provisional card at the bottom of that lane until
+    // the listing landed and moved it (review, #1079). The entry id it belongs
+    // to is still unknown, and nothing on a row needs it before the swap.
+    next_run: row.next_run,
     next_run_entry: "",
     messages: [],
     provisional: true,

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -749,6 +749,13 @@ export function taskUnread(
   // never applied, a message that arrived since — falls through to the
   // arithmetic below and the server's number is what the row draws.
   if (isAllRead(read, task)) return 0;
+  // A PROVISIONAL row (provisionalTasks) holds no messages and a `message_count`
+  // of 0 — a default, not a count — so the "we hold the whole thread" arm below
+  // would read it as an empty, fully read thread and hollow the ring on a task
+  // pulse says has unread, for exactly the wait the seed exists to cover
+  // (Bugbot, #1079). Pulse's `unread` IS the server's number, and there is
+  // nothing held here to discount it by.
+  if (task.provisional) return task.unread;
   const known = held ?? task.messages ?? [];
   // Once Show more has run we hold the WHOLE thread, and then the count is not
   // arithmetic at all — it is the dots, counted. Same predicate (isUnread), same

--- a/frontend/src/shell/tasksPulse.ts
+++ b/frontend/src/shell/tasksPulse.ts
@@ -21,7 +21,7 @@
 // changes.
 import { useEffect, useState } from "react";
 import { getTasksPulse } from "@platform/lib/api";
-import type { TaskPulseTask } from "@platform/lib/api";
+import type { Task, TaskPulseTask } from "@platform/lib/api";
 import {
   EMPTY_TASKS_PULSE,
   TASKS_SEEN_KEY,
@@ -183,6 +183,42 @@ export const CHAT_ACTIVITY_KEY = "fused-render:chat-activity";
  *  origin writes (seen stamps, list memory) are the readers' own state. */
 export function pokeOnChatActivity(key: string | null) {
   if (key === CHAT_ACTIVITY_KEY) pokeTasks();
+}
+
+/**
+ * The rows as they stand RIGHT NOW, read synchronously.
+ *
+ * For a first render, not for a subscription — useTasksPulseRows is still the
+ * way to follow the rows over time. The Tasks page seeds its own state from
+ * this so it can paint before /api/tasks answers (which is 2.9s on a cold
+ * process): the sidebar's poll has usually already put every task's key,
+ * status, project and title in here, and a row drawn from those is the same row
+ * the listing will confirm. Empty until the first answer lands, which is the
+ * behaviour the page had before this existed.
+ */
+export function readTasksRows(): TaskPulseTask[] {
+  return tasks;
+}
+
+/**
+ * The last FULL /api/tasks answer of this JS session — remembered here, beside
+ * the pulse rows, because both are the same question asked at two widths.
+ *
+ * The Tasks page unmounts on every navigation (App keys it on the nav epoch),
+ * so List → Home → List used to throw away a complete listing and go back to a
+ * skeleton while the same 2.9s call ran again. Module scope outlives the
+ * component and dies with the reload, which is the right lifetime: a listing
+ * carried across a reload could be arbitrarily old, and there is nothing to
+ * invalidate it against before the page's own poll answers anyway.
+ */
+let listing: Task[] | null = null;
+
+export function rememberListing(next: Task[]) {
+  listing = next;
+}
+
+export function readListing(): Task[] | null {
+  return listing;
 }
 
 /** Hand over a known-fresh answer — what the Tasks page's own poll returned. */

--- a/frontend/src/shell/tasksPulse.ts
+++ b/frontend/src/shell/tasksPulse.ts
@@ -221,6 +221,15 @@ export function readListing(): Task[] | null {
   return listing;
 }
 
+/** A poll that FAILED is news about the listing too: what is remembered may
+ *  describe a server that has since gone away, and a remount seeding from it
+ *  would paint rows over a page that then says "Tasks could not be loaded".
+ *  Forgetting makes the next mount start from the skeleton, as a first visit
+ *  does (review, #1079). */
+export function forgetListing() {
+  listing = null;
+}
+
 /** Hand over a known-fresh answer — what the Tasks page's own poll returned. */
 export function publishTasks(next: TaskPulseTask[]) {
   generation += 1;

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -3168,6 +3168,12 @@ input.schedule-when-field {
   text-align: center;
   font-size: 13px;
   color: var(--fg-muted);
+  /* The page's width, whatever the parent's layout: the Cards wall and the
+     Board are flex children, and a shrink-wrapped paragraph there would centre
+     its text in its own box, not the page's. */
+  width: 100%;
+  box-sizing: border-box;
+  align-self: stretch;
 }
 
 /* -- Kanban (Board view) ------------------------------------------------------ */

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -620,6 +620,16 @@ button.tasks-caret,
   gap: 3px;
 }
 
+/* A PROVISIONAL row's count cell (ScheduleTaskViews, tasks-lib.provisionalTasks):
+   the box a one-message row would occupy, with nothing visible in it. Painted
+   from /api/tasks/pulse before the full listing lands, this row has no count to
+   print — and `visibility` rather than `display: none` is the point, because the
+   cell has to hold its width until the real number arrives or the title beside
+   it would widen and then snap back on the swap. */
+.tasks-row-msgs--blank {
+  visibility: hidden;
+}
+
 /* Optically centred with the digits rather than sitting on their baseline: the
    glyph's box is taller than the numerals it stands beside. */
 .tasks-row-msgs-icon {

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -1844,3 +1844,150 @@ button.tasks-caret,
   outline: 1px solid var(--accent);
   outline-offset: -1px;
 }
+
+/* ------------------------------------------------------------- the ghosts
+   TasksSkeleton: the loading state, shaped like the view it stands in for. Each
+   ghost reuses the real container classes for its geometry (`.tasks-row`,
+   `.schedule-tv-lane`, `.task-cards`, `.schedule-cal-grid`); what follows is
+   only what a ghost needs on TOP of them — no hover, no pointer, bars where
+   the text would be — and the few boxes that have no real class to borrow
+   (a card tile's body, the calendar's row grid). Every bar is `.skel-bar`
+   (explorer.css): same shimmer, same colour, nothing new to the eye. */
+/* No wrapper of its own: each ghost's ROOT is the view's real container (see
+   TasksSkeleton `ghost`), so the page's flex chain and every selector keyed on
+   `.schedule-main > …` treat it as the view. Only the bars differ. */
+.tasks-skel {
+  min-width: 0;
+}
+.tasks-skel .skel-bar {
+  display: block;
+  flex: 0 0 auto;
+}
+.tasks-skel-ring {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+/* List: the real row's padding and gap; hover and pointer off. */
+.tasks-skel-row,
+.tasks-skel-row:hover {
+  cursor: default;
+  background: transparent;
+  align-items: center;
+}
+.tasks-skel-caret {
+  width: var(--tasks-caret-w);
+  flex: 0 0 var(--tasks-caret-w);
+}
+.tasks-skel-rowmark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.tasks-skel-title {
+  max-width: 60%;
+}
+
+/* Board: a lane head that is a div, not a button; cards with no hover. */
+.tasks-skel-lane-head {
+  display: flex;
+  align-items: center;
+}
+.schedule-tv-board .tasks-skel-card,
+.schedule-tv-board .tasks-skel-card:hover {
+  border-color: var(--border);
+  background: var(--tasks-card-bg);
+  cursor: default;
+}
+.tasks-skel-card .schedule-tv-card-head,
+.tasks-skel-card .schedule-tv-card-foot {
+  align-items: center;
+}
+
+/* A rolled-up lane: the real rail's 52px column with a ring and, where the
+   vertical label reads, one upright bar. Not a button: nothing to press yet. */
+.tasks-skel-rail {
+  align-items: center;
+  gap: 10px;
+  padding-top: 8px;
+}
+.tasks-skel-rail-label {
+  width: 10px;
+  height: 64px;
+}
+
+/* Cards: the tile is `.task-card`'s box (1px border, 8px radius) with a head
+   row and a body that shimmers as one block where the frame will be. */
+.tasks-skel-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+  min-height: 0;
+  box-sizing: border-box;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--tasks-card-bg, var(--bg));
+}
+.tasks-skel-tile-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.tasks-skel-tile-body {
+  flex: 1 1 auto;
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+}
+
+/* Calendar: the real head; a grid of the real columns, with rows of the real
+   hour height standing in for the hour lines, and one chip ghost per busy day. */
+.tasks-skel-cal .schedule-cal-day-head {
+  gap: 6px;
+}
+.tasks-skel-cal-bar {
+  align-items: center;
+  gap: 8px;
+}
+.tasks-skel-cal-btn {
+  height: 32px;
+  border-radius: 6px;
+}
+.tasks-skel-cal-num {
+  height: 18px;
+  border-radius: 9px;
+}
+.tasks-skel-cal-grid {
+  /* Eight hours of the real grid's 44px rows (ScheduleCalendar HOUR_H), as a
+     fixed height like the real one sets inline — the columns inside are laid
+     out by their own row template, and without a height here the grid took
+     the head's height and nothing more. */
+  grid-auto-rows: 44px;
+  height: calc(8 * 44px);
+  overflow: hidden;
+}
+.tasks-skel-cal-gutter {
+  display: grid;
+  grid-auto-rows: 44px;
+  align-items: start;
+  justify-items: end;
+  padding: 0 6px 0 0;
+  box-sizing: border-box;
+}
+.tasks-skel-cal-gutter .skel-bar {
+  margin-top: -5px;
+}
+.tasks-skel-cal-col {
+  display: grid;
+  grid-template-rows: repeat(8, 44px);
+  padding: 0 3px;
+  box-sizing: border-box;
+}
+.tasks-skel-cal-chip {
+  height: auto;
+  margin: 2px 0;
+  border-radius: 6px;
+}

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -626,7 +626,8 @@ button.tasks-caret,
    print — and `visibility` rather than `display: none` is the point, because the
    cell has to hold its width until the real number arrives or the title beside
    it would widen and then snap back on the swap. */
-.tasks-row-msgs--blank {
+.tasks-row-msgs--blank,
+.tasks-row-time--blank {
   visibility: hidden;
 }
 

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -1936,10 +1936,15 @@ button.tasks-caret,
   align-items: center;
   gap: 8px;
 }
-.tasks-skel-tile-body {
+/* Compound with `.tasks-skel`, or the `.tasks-skel .skel-bar { flex: 0 0 auto }`
+   rule above outranks this one and the body cannot grow — the tile drew as an
+   empty framed box (Bugbot, #1079). A floor, so a tile short of room still
+   shows a body rather than a hairline. */
+.tasks-skel .tasks-skel-tile-body {
   flex: 1 1 auto;
   width: 100%;
   height: auto;
+  min-height: 96px;
   border-radius: 6px;
 }
 

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -487,6 +487,23 @@ def create_app(start_dir: str) -> FastAPI:
 
         tasks_watch.start()
 
+    # Warm the Tasks listing's transcript caches (routers/tasks.py `warm`) so
+    # the first `/api/tasks` or `/api/tasks/pulse` of the process answers in
+    # milliseconds instead of reading every transcript on the machine inside
+    # that request. A daemon thread: the read is seconds on a big ~/.claude and
+    # must not hold up the rest of startup or the first page paint. A startup
+    # event for the same reason as `_startup_tasks_watch`.
+    @on_startup
+    async def _startup_tasks_warm():
+        from fused_render.server.routers import tasks as tasks_router_mod
+
+        thread = threading.Thread(target=tasks_router_mod.warm, daemon=True,
+                                  name="fused-tasks-warm")
+        thread.start()
+        # For tests, which need to know when the warm's own listing is done
+        # before they count listings of their own.
+        app.state.tasks_warm = thread
+
     @on_shutdown
     async def _startup_shutdown_ai():
         await shutdown_ai_session(app)

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -2043,6 +2043,11 @@ _PULSE_FIELDS = (
     # row's unread. `last_active` cannot stand in — a recurring task whose run
     # finished early keeps its due time there and the digest would not move.
     "happened_at",
+    # The Tasks page paints these rows before its own listing answers
+    # (shell/tasks-lib provisionalTasks), and the Board's Upcoming lane sorts by
+    # the next run: without it a provisional card sat at the bottom of the lane
+    # and jumped into place when the listing landed. One float per row.
+    "next_run",
 )
 
 

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -2046,8 +2046,12 @@ _PULSE_FIELDS = (
     # The Tasks page paints these rows before its own listing answers
     # (shell/tasks-lib provisionalTasks), and the Board's Upcoming lane sorts by
     # the next run: without it a provisional card sat at the bottom of the lane
-    # and jumped into place when the listing landed. One float per row.
+    # and jumped into place when the listing landed. One float per row — and
+    # the entry it belongs to, because the client reads the time only when it
+    # can also name the entry (shell/tasks-lib namedNextRun): a time with no
+    # entry is one nobody can fire, and is not sorted by.
     "next_run",
+    "next_run_entry",
 )
 
 

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -1863,7 +1863,42 @@ def _row_order(row: dict) -> tuple:
     return (rank, -float(row.get("last_active") or 0.0))
 
 
+# One listing at a time. The scan caches above are filled by whichever request
+# first asks; two requests landing on a cold process (the sidebar's pulse and
+# the Tasks page fire within the same second) would otherwise each read every
+# transcript on the machine from byte zero. A warm listing is tens of
+# milliseconds, so serializing them costs nothing anyone can see, and a request
+# that arrives while `warm` is still reading waits for that one scan rather
+# than starting a second.
+_ROWS_LOCK = threading.Lock()
+
+
+def warm() -> None:
+    """Fill the transcript caches once, so the first real listing is warm.
+
+    The process starts with `_SCAN` and the head cache empty, and the first
+    `_task_rows` reads every transcript on the machine from byte zero — close to
+    a gigabyte and three seconds on a busy laptop — synchronously, inside
+    whichever request asked first. Called from the app's startup event on a
+    thread of its own (server/app.py), never from create_app: tests build apps
+    without lifespan and must not read the developer's real ~/.claude.
+    """
+    started = time.monotonic()
+    try:
+        rows = _task_rows()
+    except Exception:  # noqa: BLE001 — a warm that fails costs nothing but the warmth
+        logger.debug("tasks warm failed", exc_info=True)
+        return
+    logger.info("tasks warm: %d rows in %.2fs", len(rows), time.monotonic() - started)
+
+
 def _task_rows(only: frozenset | set | None = None) -> list[dict]:
+    """`_build_task_rows`, one caller at a time. See `_ROWS_LOCK`."""
+    with _ROWS_LOCK:
+        return _build_task_rows(only)
+
+
+def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     """Build the authoritative task rows shared by the two listing shapes.
 
     Keeping collection here makes the compact sidebar endpoint a projection of

--- a/tests/test_app_lifespan.py
+++ b/tests/test_app_lifespan.py
@@ -118,6 +118,7 @@ EXPECTED_STARTUP = [
     "_startup_sync_user_plugin",
     "_startup_schedule",
     "_startup_tasks_watch",
+    "_startup_tasks_warm",
     "_startup_ai_idle_reaper",
     "_startup_ai_hardware_refresh",
     "_startup_ai_hub_metadata_refresh",

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -368,6 +368,7 @@ def test_sidebar_pulse_is_the_compact_projection_of_the_task_rows(
     pulse_fields = (
         "key", "status", "unread", "last_active", "project",
         "task_id", "title", "target", "session_id", "happened_at", "next_run",
+        "next_run_entry",
     )
     assert pulse == [
         {field: row[field] for field in pulse_fields}

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -362,10 +362,12 @@ def test_sidebar_pulse_is_the_compact_projection_of_the_task_rows(
     # anyway; the alternative was a second /api/tasks poll from the status bar.
     # `happened_at` (2026-09-07) is the Projects section's change detector: the
     # desk refetches when a task actually ran, which `last_active` cannot say
-    # (it keeps a scheduled due time for sorting).
+    # (it keeps a scheduled due time for sorting). `next_run` (2026-09-09) is
+    # for the Tasks page's own first paint: it builds rows from these before its
+    # listing answers, and the Board's Upcoming lane sorts by the next run.
     pulse_fields = (
         "key", "status", "unread", "last_active", "project",
-        "task_id", "title", "target", "session_id", "happened_at",
+        "task_id", "title", "target", "session_id", "happened_at", "next_run",
     )
     assert pulse == [
         {field: row[field] for field in pulse_fields}

--- a/tests/test_tasks_warm.py
+++ b/tests/test_tasks_warm.py
@@ -1,0 +1,159 @@
+"""`tasks.warm()` — the boot-time read that makes the first listing fast.
+
+The process starts with the transcript caches empty, and the first
+`_task_rows` reads every transcript from byte zero inside whichever request
+asked first. `warm` does that read once, on a thread of its own, at startup.
+These tests pin the contract: a warm listing reads nothing, a failing warm
+raises nothing, and the endpoints keep answering while a warm is under way.
+"""
+
+import builtins
+import os
+import threading
+
+import pytest
+
+from fused_render import tasks_store
+from fused_render.server.routers import claude_sessions as sessions_mod
+from fused_render.server.routers import tasks as tasks_mod
+from tests.test_tasks_api import _already_using, _ai_title, _assistant, _user, _write_transcript
+
+
+@pytest.fixture(autouse=True)
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+
+
+@pytest.fixture(autouse=True)
+def projects_dir(tmp_path, monkeypatch):
+    d = tmp_path / "claude-projects"
+    d.mkdir()
+    monkeypatch.setattr(tasks_store, "PROJECTS_DIR", str(d))
+    monkeypatch.setattr(sessions_mod, "PROJECTS_DIR", str(d))
+    return d
+
+
+@pytest.fixture(autouse=True)
+def state_dir(tmp_path, monkeypatch):
+    d = tmp_path / "state" / "claude-sessions"
+    d.mkdir(parents=True)
+    monkeypatch.setattr(tasks_store, "STATE_DIR", str(d))
+    monkeypatch.setattr(sessions_mod, "STATE_DIR", str(d))
+    _already_using(d)
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    tasks_mod.reset_cache()
+    yield
+    tasks_mod.reset_cache()
+
+
+def _transcript(projects_dir, sid="sess-a"):
+    return _write_transcript(projects_dir, sid, "/home/me/proj", [
+        _user("pull today's news", 1_700_000_000.0),
+        _assistant("done", 1_700_000_010.0),
+        _ai_title("Pull today's news"),
+    ])
+
+
+def _opens_of(monkeypatch, path):
+    """Count how many times `path` is opened for reading."""
+    opened = []
+    real_open = builtins.open
+
+    def counting_open(file, *args, **kwargs):
+        if str(file) == str(path):
+            opened.append(file)
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+    return opened
+
+
+def test_warm_fills_the_scan_cache(projects_dir):
+    path = _transcript(projects_dir)
+    assert str(path) not in tasks_mod._SCAN
+
+    tasks_mod.warm()
+
+    rec = tasks_mod._SCAN[str(path)]
+    assert rec["count"] == 1
+    assert rec["title"] == "Pull today's news"
+
+
+def test_a_listing_after_warm_does_not_reopen_an_unchanged_transcript(
+        projects_dir, monkeypatch):
+    path = _transcript(projects_dir)
+    # Old enough that liveness does not tail it either: `_live` reads the last
+    # 16KB of any transcript touched in the last 90s, on purpose, every time.
+    os.utime(path, (1_700_000_000, 1_700_000_000))
+    tasks_mod.warm()
+
+    opened = _opens_of(monkeypatch, path)
+    rows = tasks_mod._task_rows()
+
+    assert [r["key"] for r in rows] == ["sess-a"]
+    assert opened == [], "a warm listing is stats only; the bytes were read at warm"
+
+
+def test_a_transcript_that_grew_after_warm_is_read_from_its_offset(
+        projects_dir, monkeypatch):
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    before = tasks_mod._SCAN[str(path)]["offset"]
+    with path.open("a") as f:
+        f.write('{"type":"user","uuid":"sess-a-9","sessionId":"sess-a",'
+                '"cwd":"/home/me/proj","timestamp":"2023-11-14T22:14:00Z",'
+                '"message":{"role":"user","content":"and tomorrow"}}\n')
+
+    rows = tasks_mod._task_rows()
+
+    assert rows[0]["message_count"] == 2
+    assert tasks_mod._SCAN[str(path)]["offset"] > before
+
+
+def test_warm_swallows_a_failing_listing(monkeypatch):
+    def boom(only=None):
+        raise RuntimeError("disk on fire")
+    monkeypatch.setattr(tasks_mod, "_build_task_rows", boom)
+
+    tasks_mod.warm()  # must not raise: a cold first request is the only cost
+
+
+def test_a_request_during_warm_waits_for_that_scan_rather_than_starting_another(
+        projects_dir, monkeypatch):
+    """Two cold callers must not both read every transcript. The lock makes the
+    second wait for the first, and the first's cache is what it then reads."""
+    path = _transcript(projects_dir)
+    entered = threading.Event()
+    release = threading.Event()
+    real_build = tasks_mod._build_task_rows
+    calls = []
+
+    def slow_build(only=None):
+        calls.append(threading.current_thread().name)
+        entered.set()
+        release.wait(5)
+        return real_build(only)
+    monkeypatch.setattr(tasks_mod, "_build_task_rows", slow_build)
+
+    warm = threading.Thread(target=tasks_mod.warm, name="warm")
+    warm.start()
+    assert entered.wait(5)
+    # The "request" lands while warm is still inside the scan.
+    result = {}
+    req = threading.Thread(
+        target=lambda: result.setdefault("rows", tasks_mod._task_rows()), name="req")
+    req.start()
+    req.join(0.2)
+    assert req.is_alive(), "the request must block on the lock, not run alongside"
+    assert calls == ["warm"]
+
+    release.set()
+    warm.join(5)
+    req.join(5)
+    assert [r["key"] for r in result["rows"]] == ["sess-a"]
+    assert calls == ["warm", "req"], "the request ran only after warm let go"
+    assert str(path) in tasks_mod._SCAN

--- a/tests/test_tasks_watch.py
+++ b/tests/test_tasks_watch.py
@@ -162,11 +162,16 @@ def test_changes_listing_does_not_prune_current_apps(claude_home, monkeypatch):
     _transcript(claude_home, SID)
     _transcript(claude_home, SID2)
     with TestClient(create_app(str(claude_home))) as client:
-        gen = client.get("/api/tasks").json()["generation"]
+        # Startup warms the listing on a thread (app.py `_startup_tasks_warm`),
+        # and that warm is a full listing, so it tells the desk once too. Let it
+        # finish before counting, or the count depends on a race.
+        client.app.state.tasks_warm.join(10)
         assert calls == [2]
+        gen = client.get("/api/tasks").json()["generation"]
+        assert calls == [2, 2]
         tasks_watch.notify({SID})
         client.get(f"/api/tasks/changes?since={gen}&wait=0")
-        assert calls == [2]  # the partial listing told the desk nothing
+        assert calls == [2, 2]  # the partial listing told the desk nothing
 
 
 def test_registry_row_without_status_has_no_opinion(claude_home):


### PR DESCRIPTION
## Problem

The Tasks page took seconds to show rows even though every transcript is local. `GET /api/tasks` builds rows from in-memory caches (`_SCAN`, `_HEAD_CACHE`) that start empty in every server process. The first listing after a launch reads every transcript from byte zero — on this machine 641 files / 0.94 GB, **2.9 s alone and ~10 s under startup contention** — synchronously inside whichever request asked first. Warm, the same call is 35 ms. The page showed a skeleton (or, on a reload straight onto `/tasks`, the "No tasks yet" empty state) for all of it, while the sidebar's `/api/tasks/pulse` store already knew every task's title, status and project.

## Change

**Server**
- `tasks.warm()` runs the first listing once on a daemon thread from a new `_startup_tasks_warm` startup event (after `_startup_tasks_watch`).
- `_task_rows()` now runs under `_ROWS_LOCK`: a request that lands mid-warm waits for that scan instead of starting a second full read (the sidebar pulse and the page fire within the same second on a cold process).
- Thread exposed on `app.state.tasks_warm` so tests can join it before counting listings.

**Client**
- `Scheduled` seeds its rows synchronously on mount: the last full listing of this JS session (`rememberListing`/`readListing` in `tasksPulse`), else `provisionalTasks(readTasksRows())` — pulse rows upcast into `Task` with neutral defaults and `provisional: true`.
- List rows with `provisional` draw the message-count, time and expand-chevron cells as hidden-ink spacers (width held). Title, ring, project chip and link come from pulse and render normally; `taskUnread` trusts pulse's count so the unread ring stays filled. Rows are replaced in place when `/api/tasks` lands; same keys, so no reorder.
- `tasksLoaded`: until any listing has been on the page (seed, answer or failure) the views render a skeleton under the toolbar instead of "No tasks yet". A failed poll forgets the remembered listing.

## What this does and does not fix

- Arriving at Tasks from anywhere else in the app after launch: instant (warm thread already paid the scan; rows paint from pulse before the answer).
- Launching the app **straight onto `/tasks`** (last-URL restore, or a reload right after a server start): the page still waits for the cold scan — now behind a skeleton instead of an empty state — because the warm thread and the request share one lock and the scan itself is the cost. That case needs the cache persisted across processes: follow-up PR.

## Measured

| | before | after |
|---|---|---|
| first `/api/tasks` after boot, isolated | 2.9 s | paid by the warm thread at boot |
| `/api/tasks` 1 s after boot | cold | 0.12 s |
| sidebar click → rows visible, `/api/tasks` delayed 3 s | skeleton until answer | 380 ms (provisional), swap at answer, no layout shift |
| Home → Tasks remount | skeleton until answer | immediate, remembered listing |
| reload straight onto `/tasks`, cold worker | "No tasks yet" for the scan, then rows | skeleton for the scan, then rows |

## Tests
- `tests/test_tasks_warm.py`: warm fills `_SCAN`; a listing after warm re-opens nothing; a grown transcript re-reads from its offset; a failing warm never raises; a request during warm waits on the lock.
- `test_tasks_watch` joins the warm thread before counting `observe` calls; `test_app_lifespan` expected-startup list updated.
- `tasks-lib.test.ts`: `provisionalTasks` passthrough / defaults / flag / order / unread / blanked cells.
- Local: pytest tasks suites green; `tsc --noEmit`, boundaries, `bun test` (3222 pass; 3 pre-existing failures reproduce identically on `main`). `test-python-windows` is red on `main` too (rotating flaky tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task listing concurrency, startup behavior, and first-paint task UI; server lock/warm paths and client provisional state must stay consistent with pulse and full listing merges.
> 
> **Overview**
> **Boot and API:** The server warms task transcript caches on a startup daemon thread and serializes full listings behind `_ROWS_LOCK` so pulse and `/api/tasks` do not double-scan cold disks. `/api/tasks/pulse` now includes `next_run` and `next_run_entry` for early client sorting.
> 
> **Tasks page load:** `Scheduled` seeds rows from the session’s last full listing or from pulse via `provisionalTasks` (`provisional: true` with neutral defaults). Until the first listing completes or fails, views show per-view `TasksSkeleton` instead of “no tasks” copy; failed polls clear remembered listings. Provisional list rows keep layout with hidden count/time cells, skip accordion expand, and trust pulse for unread.
> 
> **Empty UX:** One page-computed `emptyLabel` is shared by List, Board, Cards, and Calendar; Board/Calendar return that message when there are zero tasks (not a quiet week). Calendar resets scroll-aim state when the grid unmounts empty.
> 
> **Styles/tests:** Skeleton and blank-row CSS; `test_tasks_warm.py` and expanded `provisionalTasks` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7dd2d7379e249be2baac8b546f160f0c5e6f5e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->