### PR TITLE
Tasks: persist the transcript scan cache across server processes

### DIFF
--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -504,6 +504,22 @@ def create_app(start_dir: str) -> FastAPI:
         # before they count listings of their own.
         app.state.tasks_warm = thread
 
+    # ...and put the caches to sleep on the way out, so the next launch reads
+    # only what the transcripts grew by (routers/tasks.py `save_scan_cache`).
+    # Under the listing's own lock inside, so a listing in flight finishes
+    # first; the write itself is a few hundred KB.
+    @on_shutdown
+    async def _shutdown_tasks_scan_cache():
+        from fused_render.server.routers import tasks as tasks_router_mod
+
+        def _save():
+            with tasks_router_mod._ROWS_LOCK:
+                tasks_router_mod.save_scan_cache()
+        # On a thread: a listing mid-scan holds the lock for seconds on a big
+        # ~/.claude, and waiting for it here would stall the event loop — every
+        # other request in flight — not just this coroutine.
+        await asyncio.to_thread(_save)
+
     @on_shutdown
     async def _startup_shutdown_ai():
         await shutdown_ai_session(app)

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -2031,8 +2031,8 @@ def load_scan_cache() -> int:
     # Heads are keyed by size alone in `tasks_store.head` — a same-size rewrite
     # (a compaction, a resume) kept a stale cwd and first prompt for the life of
     # the process, and a restart was what healed it. Persisting them would end
-    # that, so a head comes back ONLY for a file whose size AND mtime still
-    # match what the scan record saved beside it; anything else is left for
+    # that, so a head comes back ONLY for a file whose size, mtime AND inode
+    # still match what the scan record saved beside it; anything else is left for
     # `head` to parse afresh (Bugbot, #1081). One stat per head, once per boot.
     heads = data.get("head")
     if isinstance(heads, dict):
@@ -2045,7 +2045,8 @@ def load_scan_cache() -> int:
                 st = os.stat(path)
             except OSError:
                 continue
-            if st.st_size == rec["size"] and st.st_mtime == rec["mtime"]:
+            if (st.st_size == rec["size"] and st.st_mtime == rec["mtime"]
+                    and st.st_ino == rec["ino"]):
                 fresh[path] = entry
         tasks_store.import_heads(fresh)
     return taken

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -176,6 +176,11 @@ _SCAN: dict[str, dict] = {}
 _SCAN_DIRTY = False
 _SCAN_SAVED_AT = 0.0
 _SCAN_MAX = 20000
+# Has this process read the cache file yet? A save before that would replace a
+# populated file with the empty caches of a process that never got going — a
+# shutdown that beats the warm thread to it (Bugbot, #1081). Until the load
+# has happened there is nothing here worth writing over what is on disk.
+_SCAN_LOADED = False
 # path -> (size, [every prompt]). The expensive parse, kept only for the handful
 # of threads a user actually opens.
 _FULL: dict[str, tuple[int, list[dict]]] = {}
@@ -191,12 +196,13 @@ _WINDOW_MAX = 16
 def reset_cache() -> None:
     """Forget every cached transcript read. For tests, and for any caller that
     wants the next listing to re-read from disk unconditionally."""
-    global _SCAN_DIRTY, _SCAN_SAVED_AT, _BUILD_SEQ, _OBSERVED_SEQ
+    global _SCAN_DIRTY, _SCAN_SAVED_AT, _BUILD_SEQ, _OBSERVED_SEQ, _SCAN_LOADED
     _SCAN.clear()
     _FULL.clear()
     _WINDOW.clear()
     _SCAN_DIRTY = False
     _SCAN_SAVED_AT = 0.0
+    _SCAN_LOADED = False
     _BUILD_SEQ = 0
     _OBSERVED_SEQ = 0
     tasks_store.reset_cache()
@@ -1948,6 +1954,8 @@ def load_scan_cache() -> int:
     still matches is a hit, one that grew is read from `offset`, one that
     shrank or vanished is re-read from zero or skipped. Returns how many scan
     records were taken. Never raises."""
+    global _SCAN_LOADED
+    _SCAN_LOADED = True  # even a missing or bad file: saving is fair from here
     try:
         data = storage.read_json(_scan_cache_path())
     except Exception:  # noqa: BLE001 — a cache that cannot be read is no cache
@@ -1974,6 +1982,8 @@ def save_scan_cache(prune: bool = True) -> None:
     nobody is waiting. Never raises: a store that cannot be written costs the
     next launch a full read, not the listing."""
     global _SCAN_DIRTY, _SCAN_SAVED_AT
+    if not _SCAN_LOADED:
+        return  # nothing read yet: the file on disk knows more than we do
     try:
         if prune:
             scan = {p: rec for p, rec in _SCAN.items() if os.path.exists(p)}

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -323,7 +323,7 @@ def _new_scan() -> dict:
     # Every reader of `command` uses `.get`, so a record built before this key
     # existed — one already in `_SCAN` when the module is hot-reloaded under the
     # dev server — degrades to "no command" instead of raising.
-    return {"offset": 0, "size": -1, "mtime": 0.0, "count": 0, "tail": [],
+    return {"offset": 0, "size": -1, "mtime": 0.0, "ino": 0, "count": 0, "tail": [],
             "title": "", "command": "", "anchor": ""}
 
 
@@ -356,7 +356,7 @@ def _scan(path: str) -> dict | None:
         st = os.stat(path)
     except OSError:
         return None  # vanished mid-listing: costs this task, not the listing
-    size, mtime = st.st_size, st.st_mtime
+    size, mtime, ino = st.st_size, st.st_mtime, st.st_ino
     rec = _SCAN.get(path)
     # A hit is the same size AND the same mtime. Size alone let a transcript
     # rewritten to the same length with different content (a compaction, a
@@ -366,12 +366,17 @@ def _scan(path: str) -> dict | None:
     # with coarse mtimes (FAT's two seconds) can hide a same-size rewrite that
     # lands within one tick of the write before it; no content hash is kept,
     # and that is the accepted cost.
-    if rec is not None and rec["size"] == size and rec.get("mtime") == mtime:
+    # ...and the same inode: a restore or an editor writes a new file and
+    # renames it over the old one, and that shows here whatever the mtime says.
+    # Free — it is in the stat we already took.
+    if (rec is not None and rec["size"] == size and rec.get("mtime") == mtime
+            and rec.get("ino", ino) == ino):
         _SCAN_STATS["hit"] += 1
         return rec
-    if rec is None or size < rec["offset"] or (rec["size"] == size and rec["offset"] > 0):
-        # New, shrunk, or same length with a different mtime: the bytes we hold
-        # may not be the bytes on disk, so read from the top.
+    if (rec is None or size < rec["offset"] or rec.get("ino", ino) != ino
+            or (rec["size"] == size and rec["offset"] > 0)):
+        # New, shrunk, replaced, or same length with a different mtime: the
+        # bytes we hold may not be the bytes on disk, so read from the top.
         rec = _new_scan()
         _SCAN_STATS["zero"] += 1
     else:
@@ -404,6 +409,7 @@ def _scan(path: str) -> dict | None:
                 _absorb(rec, line)
     rec["size"] = size
     rec["mtime"] = mtime
+    rec["ino"] = ino
     _SCAN[path] = rec
     return rec
 
@@ -1968,11 +1974,11 @@ SCAN_CACHE_FILE = "tasks-scan.json"
 # whose bytes have not changed is never re-parsed. Without this, a release that
 # changed how a title or a count is derived would keep the old answer for every
 # unchanged transcript for good. One full read per upgrade is the price, once.
-_SCAN_CACHE_VERSION = f"2/{fused_render.__version__}"
+_SCAN_CACHE_VERSION = f"3/{fused_render.__version__}"
 # A listing that read bytes writes the file at most this often; the warm and
 # the shutdown write unconditionally.
 SCAN_CACHE_SAVE_EVERY_S = 30.0
-_SCAN_KEYS = ("offset", "size", "mtime", "count", "tail", "title", "command", "anchor")
+_SCAN_KEYS = ("offset", "size", "mtime", "ino", "count", "tail", "title", "command", "anchor")
 
 
 def _scan_cache_path() -> str:
@@ -1985,6 +1991,7 @@ def _valid_scan_record(rec) -> bool:
             and isinstance(rec["offset"], int) and rec["offset"] >= 0
             and isinstance(rec["size"], int)
             and isinstance(rec["mtime"], (int, float))
+            and isinstance(rec["ino"], int)
             and isinstance(rec["count"], int)
             and isinstance(rec["tail"], list)
             and isinstance(rec["title"], str)

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -335,7 +335,10 @@ def _scan(path: str) -> dict | None:
     # rewritten to the same length with different content (a compaction, a
     # resume) serve its old tail for the life of the process — and now that
     # records outlive the process (`load_scan_cache`), for good. A record from
-    # before mtime was kept (`.get`) simply misses once.
+    # before mtime was kept (`.get`) simply misses once. Residual: a filesystem
+    # with coarse mtimes (FAT's two seconds) can hide a same-size rewrite that
+    # lands within one tick of the write before it; no content hash is kept,
+    # and that is the accepted cost.
     if rec is not None and rec["size"] == size and rec.get("mtime") == mtime:
         return rec
     if rec is None or size < rec["offset"] or (rec["size"] == size and rec["offset"] > 0):
@@ -359,10 +362,6 @@ def _scan(path: str) -> dict | None:
                 _absorb(rec, line)
     rec["size"] = size
     rec["mtime"] = mtime
-    if len(_SCAN) > _SCAN_MAX and path not in _SCAN:
-        # Unbounded only if the user has twenty thousand sessions — the same
-        # guard the head cache keeps, and now also what bounds the file.
-        _SCAN.clear()
     _SCAN[path] = rec
     return rec
 
@@ -1954,8 +1953,12 @@ def load_scan_cache() -> int:
     still matches is a hit, one that grew is read from `offset`, one that
     shrank or vanished is re-read from zero or skipped. Returns how many scan
     records were taken. Never raises."""
-    global _SCAN_LOADED
+    global _SCAN_LOADED, _SCAN_SAVED_AT
     _SCAN_LOADED = True  # even a missing or bad file: saving is fair from here
+    # The debounce clock starts now, or the first listing's own save would fire
+    # (a zero clock is always "old enough") right before warm's unconditional
+    # one — the same file written twice within a second (review).
+    _SCAN_SAVED_AT = time.monotonic()
     try:
         data = storage.read_json(_scan_cache_path())
     except Exception:  # noqa: BLE001 — a cache that cannot be read is no cache
@@ -2093,6 +2096,13 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     are built for the named keys alone, and the day-one read initialisation is
     left to the full listing, which is the only caller that knows every count.
     """
+    # Bounded only if the user has twenty thousand sessions — the same guard the
+    # head cache keeps, and what bounds the file on disk. Checked ONCE per
+    # listing, here, not per path inside `_scan`: there it fired on every new
+    # path for the rest of the pass and threw away records this same pass had
+    # just built (review, #1081).
+    if len(_SCAN) > _SCAN_MAX:
+        _SCAN.clear()
     triage = sessions._load_state("triage.json")
     read = tasks_store.read_state()
     now = time.time()

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -101,6 +101,7 @@ from pydantic import BaseModel
 
 from fused_render import current_apps, schedule, tasks_store, tasks_watch
 from fused_render._view_url_codec import canonical_fs_path
+from fused_render.shell import storage
 from fused_render.server.routers import claude_sessions as sessions
 
 router = APIRouter()
@@ -170,6 +171,11 @@ _IN_TRANSCRIPT = (schedule.SENT, schedule.SENDING)
 
 # path -> incremental scan record. See `_scan`.
 _SCAN: dict[str, dict] = {}
+# Has `_scan` read bytes since the cache was last written to disk? Set by the
+# read, cleared by `save_scan_cache`. See `_maybe_save_scan_cache`.
+_SCAN_DIRTY = False
+_SCAN_SAVED_AT = 0.0
+_SCAN_MAX = 20000
 # path -> (size, [every prompt]). The expensive parse, kept only for the handful
 # of threads a user actually opens.
 _FULL: dict[str, tuple[int, list[dict]]] = {}
@@ -185,9 +191,14 @@ _WINDOW_MAX = 16
 def reset_cache() -> None:
     """Forget every cached transcript read. For tests, and for any caller that
     wants the next listing to re-read from disk unconditionally."""
+    global _SCAN_DIRTY, _SCAN_SAVED_AT, _BUILD_SEQ, _OBSERVED_SEQ
     _SCAN.clear()
     _FULL.clear()
     _WINDOW.clear()
+    _SCAN_DIRTY = False
+    _SCAN_SAVED_AT = 0.0
+    _BUILD_SEQ = 0
+    _OBSERVED_SEQ = 0
     tasks_store.reset_cache()
     tasks_watch.reset()
 
@@ -291,8 +302,8 @@ def _new_scan() -> dict:
     # Every reader of `command` uses `.get`, so a record built before this key
     # existed — one already in `_SCAN` when the module is hot-reloaded under the
     # dev server — degrades to "no command" instead of raising.
-    return {"offset": 0, "size": -1, "count": 0, "tail": [], "title": "",
-            "command": ""}
+    return {"offset": 0, "size": -1, "mtime": 0.0, "count": 0, "tail": [],
+            "title": "", "command": ""}
 
 
 def _scan(path: str) -> dict | None:
@@ -309,20 +320,30 @@ def _scan(path: str) -> dict | None:
     is re-read whole on the next call rather than being dropped.
     """
     try:
-        size = os.path.getsize(path)
+        st = os.stat(path)
     except OSError:
         return None  # vanished mid-listing: costs this task, not the listing
+    size, mtime = st.st_size, st.st_mtime
     rec = _SCAN.get(path)
-    if rec is not None and rec["size"] == size:
+    # A hit is the same size AND the same mtime. Size alone let a transcript
+    # rewritten to the same length with different content (a compaction, a
+    # resume) serve its old tail for the life of the process — and now that
+    # records outlive the process (`load_scan_cache`), for good. A record from
+    # before mtime was kept (`.get`) simply misses once.
+    if rec is not None and rec["size"] == size and rec.get("mtime") == mtime:
         return rec
-    if rec is None or size < rec["offset"]:
-        rec = _new_scan()  # a shrunk file was replaced: re-read from the top
+    if rec is None or size < rec["offset"] or (rec["size"] == size and rec["offset"] > 0):
+        # New, shrunk, or same length with a different mtime: the bytes we hold
+        # may not be the bytes on disk, so read from the top.
+        rec = _new_scan()
     try:
         with open(path, "rb") as f:
             f.seek(rec["offset"])
             chunk = f.read()
     except OSError:
         return rec if rec["size"] >= 0 else None
+    global _SCAN_DIRTY
+    _SCAN_DIRTY = True
     cut = chunk.rfind(b"\n")
     if cut >= 0:
         text = chunk[:cut + 1].decode("utf-8", "replace")
@@ -331,6 +352,11 @@ def _scan(path: str) -> dict | None:
             if line.strip():
                 _absorb(rec, line)
     rec["size"] = size
+    rec["mtime"] = mtime
+    if len(_SCAN) > _SCAN_MAX and path not in _SCAN:
+        # Unbounded only if the user has twenty thousand sessions — the same
+        # guard the head cache keeps, and now also what bounds the file.
+        _SCAN.clear()
     _SCAN[path] = rec
     return rec
 
@@ -1871,6 +1897,103 @@ def _row_order(row: dict) -> tuple:
 # that arrives while `warm` is still reading waits for that one scan rather
 # than starting a second.
 _ROWS_LOCK = threading.Lock()
+# The desk update runs after the lock is released (see `_task_rows`), so two
+# listings can finish out of order. `observe` prunes what it does not see, so
+# an OLDER row set landing last would undo what the newer one recorded: each
+# build takes a ticket under `_ROWS_LOCK`, and only a ticket newer than the last
+# one observed gets to speak.
+_OBSERVE_LOCK = threading.Lock()
+_BUILD_SEQ = 0
+_OBSERVED_SEQ = 0
+
+
+# ------------------------------------------------------- the scan cache file
+# Where the two transcript caches sleep between processes. The listing's cost
+# is reading every transcript from byte zero, once per PROCESS — and the app
+# restores its last URL, so a launch straight onto /tasks paid that inside its
+# first request even with `warm` running beside it. This file carries the
+# offsets across: a launch reads it, and then reads only the bytes each
+# transcript grew by since. Next to `read.json` and `task_ids.json`, so the
+# per-branch state isolation the dev server already does applies.
+SCAN_CACHE_FILE = "tasks-scan.json"
+_SCAN_CACHE_VERSION = 1
+# A listing that read bytes writes the file at most this often; the warm and
+# the shutdown write unconditionally.
+SCAN_CACHE_SAVE_EVERY_S = 30.0
+_SCAN_KEYS = ("offset", "size", "mtime", "count", "tail", "title", "command")
+
+
+def _scan_cache_path() -> str:
+    return os.path.join(tasks_store.STATE_DIR, SCAN_CACHE_FILE)
+
+
+def _valid_scan_record(rec) -> bool:
+    return (isinstance(rec, dict)
+            and all(k in rec for k in _SCAN_KEYS)
+            and isinstance(rec["offset"], int) and rec["offset"] >= 0
+            and isinstance(rec["size"], int)
+            and isinstance(rec["mtime"], (int, float))
+            and isinstance(rec["count"], int)
+            and isinstance(rec["tail"], list)
+            and isinstance(rec["title"], str)
+            and isinstance(rec["command"], str))
+
+
+def load_scan_cache() -> int:
+    """Seed `_SCAN` and the head cache from the file, if there is one.
+
+    Only records that look right are taken; the rest are dropped without a
+    word, because this is a cache and a dropped record costs one re-read. The
+    existing `_scan` rules do every invalidation there is: a path whose size
+    still matches is a hit, one that grew is read from `offset`, one that
+    shrank or vanished is re-read from zero or skipped. Returns how many scan
+    records were taken. Never raises."""
+    try:
+        data = storage.read_json(_scan_cache_path())
+    except Exception:  # noqa: BLE001 — a cache that cannot be read is no cache
+        logger.debug("tasks scan cache unreadable", exc_info=True)
+        return 0
+    if not isinstance(data, dict) or data.get("version") != _SCAN_CACHE_VERSION:
+        return 0
+    taken = 0
+    scan = data.get("scan")
+    if isinstance(scan, dict):
+        for path, rec in scan.items():
+            if isinstance(path, str) and _valid_scan_record(rec):
+                _SCAN[path] = {k: rec[k] for k in _SCAN_KEYS}
+                taken += 1
+    tasks_store.import_heads(data.get("head"))
+    return taken
+
+
+def save_scan_cache(prune: bool = True) -> None:
+    """Write both caches. With `prune`, paths that no longer exist are left
+    out — a deleted session should not ride along forever. That is one stat
+    per record under the listing's lock, so the debounced save after a listing
+    passes False and leaves it to the warm and the shutdown, which run when
+    nobody is waiting. Never raises: a store that cannot be written costs the
+    next launch a full read, not the listing."""
+    global _SCAN_DIRTY, _SCAN_SAVED_AT
+    try:
+        if prune:
+            scan = {p: rec for p, rec in _SCAN.items() if os.path.exists(p)}
+        else:
+            scan = dict(_SCAN)
+        heads = {p: e for p, e in tasks_store.export_heads().items() if p in scan}
+        storage.write_json(_scan_cache_path(),
+                           {"version": _SCAN_CACHE_VERSION, "scan": scan, "head": heads})
+    except Exception:  # noqa: BLE001
+        logger.debug("tasks scan cache not written", exc_info=True)
+        return
+    _SCAN_DIRTY = False
+    _SCAN_SAVED_AT = time.monotonic()
+
+
+def _maybe_save_scan_cache() -> None:
+    """After a listing: write if a scan read bytes and the last write is old
+    enough. Called under `_ROWS_LOCK`, so it never interleaves with a scan."""
+    if _SCAN_DIRTY and time.monotonic() - _SCAN_SAVED_AT >= SCAN_CACHE_SAVE_EVERY_S:
+        save_scan_cache(prune=False)
 
 
 def warm() -> None:
@@ -1879,23 +2002,52 @@ def warm() -> None:
     The process starts with `_SCAN` and the head cache empty, and the first
     `_task_rows` reads every transcript on the machine from byte zero — close to
     a gigabyte and three seconds on a busy laptop — synchronously, inside
-    whichever request asked first. Called from the app's startup event on a
-    thread of its own (server/app.py), never from create_app: tests build apps
-    without lifespan and must not read the developer's real ~/.claude.
+    whichever request asked first. The scan cache file cuts that to the bytes
+    written since the last process saved it. Called from the app's startup
+    event on a thread of its own (server/app.py), never from create_app: tests
+    build apps without lifespan and must not read the developer's real ~/.claude.
     """
     started = time.monotonic()
+    with _ROWS_LOCK:
+        cached = load_scan_cache()
     try:
         rows = _task_rows()
     except Exception:  # noqa: BLE001 — a warm that fails costs nothing but the warmth
         logger.debug("tasks warm failed", exc_info=True)
         return
-    logger.info("tasks warm: %d rows in %.2fs", len(rows), time.monotonic() - started)
+    with _ROWS_LOCK:
+        save_scan_cache()
+    logger.info("tasks warm: %d rows in %.2fs (%d from cache)",
+                len(rows), time.monotonic() - started, cached)
 
 
 def _task_rows(only: frozenset | set | None = None) -> list[dict]:
-    """`_build_task_rows`, one caller at a time. See `_ROWS_LOCK`."""
+    """`_build_task_rows`, one caller at a time. See `_ROWS_LOCK`.
+
+    The desk update runs OUTSIDE the lock: it reads the finished rows and
+    writes its own store, and a slow write there must not hold up the pulse
+    or the page (review, #1079)."""
+    global _BUILD_SEQ, _OBSERVED_SEQ
     with _ROWS_LOCK:
-        return _build_task_rows(only)
+        rows = _build_task_rows(only)
+        _maybe_save_scan_cache()
+        _BUILD_SEQ += 1
+        seq = _BUILD_SEQ
+    # The Current apps desk (current_apps.py) learns about NEW tasks here —
+    # the one place every task on the machine passes, whatever started it.
+    # Best-effort: the desk is a side table, and a store that cannot be
+    # written costs an app on the sidebar, never the listing.
+    # Not from a partial listing: `observe` reads its argument as EVERY live
+    # task and prunes what it does not see (bugbot, PR #892).
+    if only is None:
+        with _OBSERVE_LOCK:
+            if seq > _OBSERVED_SEQ:
+                _OBSERVED_SEQ = seq
+                try:
+                    current_apps.observe(rows)
+                except OSError:
+                    pass
+    return rows
 
 
 def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
@@ -1956,17 +2108,6 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     if only is None and not tasks_store.initialized(read):
         tasks_store.initialize([(r["key"], r["message_count"]) for r in rows])
     rows.sort(key=_row_order)
-    # The Current apps desk (current_apps.py) learns about NEW tasks here —
-    # the one place every task on the machine passes, whatever started it.
-    # Best-effort: the desk is a side table, and a store that cannot be
-    # written costs an app on the sidebar, never the listing.
-    # Not from a partial listing: `observe` reads its argument as EVERY live
-    # task and prunes what it does not see (bugbot, PR #892).
-    if only is None:
-        try:
-            current_apps.observe(rows)
-        except OSError:
-            pass
     return rows
 
 

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -1970,7 +1970,26 @@ def load_scan_cache() -> int:
             if isinstance(path, str) and _valid_scan_record(rec):
                 _SCAN[path] = {k: rec[k] for k in _SCAN_KEYS}
                 taken += 1
-    tasks_store.import_heads(data.get("head"))
+    # Heads are keyed by size alone in `tasks_store.head` — a same-size rewrite
+    # (a compaction, a resume) kept a stale cwd and first prompt for the life of
+    # the process, and a restart was what healed it. Persisting them would end
+    # that, so a head comes back ONLY for a file whose size AND mtime still
+    # match what the scan record saved beside it; anything else is left for
+    # `head` to parse afresh (Bugbot, #1081). One stat per head, once per boot.
+    heads = data.get("head")
+    if isinstance(heads, dict):
+        fresh = {}
+        for path, entry in heads.items():
+            rec = _SCAN.get(path)
+            if rec is None:
+                continue
+            try:
+                st = os.stat(path)
+            except OSError:
+                continue
+            if st.st_size == rec["size"] and st.st_mtime == rec["mtime"]:
+                fresh[path] = entry
+        tasks_store.import_heads(fresh)
     return taken
 
 

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -99,6 +99,7 @@ import time
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
+import fused_render
 from fused_render import current_apps, schedule, tasks_store, tasks_watch
 from fused_render._view_url_codec import canonical_fs_path
 from fused_render.shell import storage
@@ -203,6 +204,8 @@ def reset_cache() -> None:
     _SCAN_DIRTY = False
     _SCAN_SAVED_AT = 0.0
     _SCAN_LOADED = False
+    for k in _SCAN_STATS:
+        _SCAN_STATS[k] = 0
     _BUILD_SEQ = 0
     _OBSERVED_SEQ = 0
     tasks_store.reset_cache()
@@ -304,12 +307,36 @@ def _absorb(rec: dict, line: str) -> None:
         rec["tail"].pop(0)
 
 
+# How many bytes just before `offset` a record remembers (hex), so a file that
+# GREW can be checked to still be the file we read: the delta is read from the
+# offset only if those bytes are still there. Transcripts are append-only, so
+# this only ever fails for a file replaced by different, longer content — a
+# restore from backup, a hand edit — which is exactly the case where reading
+# from the old offset would fold foreign bytes into the record.
+_ANCHOR_BYTES = 32
+# Where the cache file is counted as read/missed since load; the warm's log
+# line prints them so a stale row can be traced to the path that took it.
+_SCAN_STATS = {"hit": 0, "grown": 0, "zero": 0, "anchor_miss": 0}
+
+
 def _new_scan() -> dict:
     # Every reader of `command` uses `.get`, so a record built before this key
     # existed — one already in `_SCAN` when the module is hot-reloaded under the
     # dev server — degrades to "no command" instead of raising.
     return {"offset": 0, "size": -1, "mtime": 0.0, "count": 0, "tail": [],
-            "title": "", "command": ""}
+            "title": "", "command": "", "anchor": ""}
+
+
+def _anchor_holds(f, rec: dict) -> bool:
+    """Are the bytes just before the record's offset still what we read? `f` is
+    open for reading; the position is left at the offset either way."""
+    anchor = rec.get("anchor") or ""
+    n = len(anchor) // 2
+    if n == 0 or rec["offset"] < n:
+        f.seek(rec["offset"])
+        return True  # nothing remembered (an older record): trust the offset
+    f.seek(rec["offset"] - n)
+    return f.read(n).hex() == anchor
 
 
 def _scan(path: str) -> dict | None:
@@ -340,14 +367,24 @@ def _scan(path: str) -> dict | None:
     # lands within one tick of the write before it; no content hash is kept,
     # and that is the accepted cost.
     if rec is not None and rec["size"] == size and rec.get("mtime") == mtime:
+        _SCAN_STATS["hit"] += 1
         return rec
     if rec is None or size < rec["offset"] or (rec["size"] == size and rec["offset"] > 0):
         # New, shrunk, or same length with a different mtime: the bytes we hold
         # may not be the bytes on disk, so read from the top.
         rec = _new_scan()
+        _SCAN_STATS["zero"] += 1
+    else:
+        _SCAN_STATS["grown"] += 1
     try:
         with open(path, "rb") as f:
-            f.seek(rec["offset"])
+            if rec["offset"] and not _anchor_holds(f, rec):
+                # Longer, but not the file we read: the bytes before our offset
+                # are gone. Foreign content from the offset on would be folded
+                # into a record built from the old file — start over instead.
+                _SCAN_STATS["anchor_miss"] += 1
+                rec = _new_scan()
+                f.seek(0)
             chunk = f.read()
     except OSError:
         return rec if rec["size"] >= 0 else None
@@ -356,7 +393,12 @@ def _scan(path: str) -> dict | None:
     cut = chunk.rfind(b"\n")
     if cut >= 0:
         text = chunk[:cut + 1].decode("utf-8", "replace")
+        consumed = chunk[:cut + 1]
         rec["offset"] += cut + 1
+        # The last bytes of what we consumed, or of what we consumed before
+        # plus this, are the new anchor.
+        keep = (bytes.fromhex(rec.get("anchor") or "") + consumed)[-_ANCHOR_BYTES:]
+        rec["anchor"] = keep.hex()
         for line in text.split("\n"):
             if line.strip():
                 _absorb(rec, line)
@@ -1921,11 +1963,16 @@ _OBSERVED_SEQ = 0
 # transcript grew by since. Next to `read.json` and `task_ids.json`, so the
 # per-branch state isolation the dev server already does applies.
 SCAN_CACHE_FILE = "tasks-scan.json"
-_SCAN_CACHE_VERSION = 1
+# The file's version carries the APP version too: the records are derived by
+# this module's parsing (`_absorb`, `_prompt`, ai_title, _BODY_MAX), and a file
+# whose bytes have not changed is never re-parsed. Without this, a release that
+# changed how a title or a count is derived would keep the old answer for every
+# unchanged transcript for good. One full read per upgrade is the price, once.
+_SCAN_CACHE_VERSION = f"2/{fused_render.__version__}"
 # A listing that read bytes writes the file at most this often; the warm and
 # the shutdown write unconditionally.
 SCAN_CACHE_SAVE_EVERY_S = 30.0
-_SCAN_KEYS = ("offset", "size", "mtime", "count", "tail", "title", "command")
+_SCAN_KEYS = ("offset", "size", "mtime", "count", "tail", "title", "command", "anchor")
 
 
 def _scan_cache_path() -> str:
@@ -1941,7 +1988,8 @@ def _valid_scan_record(rec) -> bool:
             and isinstance(rec["count"], int)
             and isinstance(rec["tail"], list)
             and isinstance(rec["title"], str)
-            and isinstance(rec["command"], str))
+            and isinstance(rec["command"], str)
+            and isinstance(rec["anchor"], str))
 
 
 def load_scan_cache() -> int:
@@ -2049,8 +2097,10 @@ def warm() -> None:
         return
     with _ROWS_LOCK:
         save_scan_cache()
-    logger.info("tasks warm: %d rows in %.2fs (%d from cache)",
-                len(rows), time.monotonic() - started, cached)
+    logger.info("tasks warm: %d rows in %.2fs (%d records from cache; "
+                "scan hits %d, grown %d, from zero %d, anchor misses %d)",
+                len(rows), time.monotonic() - started, cached, _SCAN_STATS["hit"],
+                _SCAN_STATS["grown"], _SCAN_STATS["zero"], _SCAN_STATS["anchor_miss"])
 
 
 def _task_rows(only: frozenset | set | None = None) -> list[dict]:

--- a/fused_render/tasks_store.py
+++ b/fused_render/tasks_store.py
@@ -590,6 +590,43 @@ def reset_cache() -> None:
     _HEAD_CACHE.clear()
 
 
+def export_heads() -> dict[str, list]:
+    """The head cache as JSON-shaped rows, for routers/tasks `save_scan_cache`.
+    A list per entry, not the tuple: json.dump would make one anyway, and
+    `import_heads` is written against the list.
+
+    COMPLETE entries only. An incomplete head (no prompt, timestamp or cwd yet)
+    is retried in-process only once the file grows, and a restart used to be
+    its other chance — a fresh parse from scratch. Persisting it would take
+    that chance away for good, so it is left for the next process to parse."""
+    return {
+        path: list(entry) for path, entry in _HEAD_CACHE.items()
+        if entry[3] and entry[2] is not None and entry[1] is not None
+    }
+
+
+def import_heads(rows: dict) -> int:
+    """Seed the head cache from what `export_heads` wrote in an earlier process.
+    Anything not shaped like a head entry is skipped, not raised on: the file is
+    a cache, and a bad row in it costs one re-parse, never the listing. Returns
+    how many were taken."""
+    taken = 0
+    if not isinstance(rows, dict):
+        return 0
+    for path, entry in rows.items():
+        if (not isinstance(path, str) or not isinstance(entry, list)
+                or len(entry) != 5 or not isinstance(entry[0], int)):
+            continue
+        size, cwd, first_ts, prompt, pane = entry
+        if ((cwd is not None and not isinstance(cwd, str))
+                or (first_ts is not None and not isinstance(first_ts, (int, float)))
+                or not isinstance(prompt, str) or not isinstance(pane, str)):
+            continue
+        _HEAD_CACHE[path] = (size, cwd, first_ts, prompt, pane)
+        taken += 1
+    return taken
+
+
 def epoch(value) -> float | None:
     """A transcript's ISO-8601 timestamp as an epoch float, or None. A stamp
     with no zone is read as UTC — every writer of these records emits UTC, and

--- a/tests/test_app_lifespan.py
+++ b/tests/test_app_lifespan.py
@@ -132,6 +132,7 @@ EXPECTED_STARTUP = [
 EXPECTED_SHUTDOWN = [
     "_shutdown_pooled_client",
     "_shutdown_background_apps_resurrection",
+    "_shutdown_tasks_scan_cache",
     "_startup_shutdown_ai",
     "_shutdown_server_json",
     "_shutdown_captures",

--- a/tests/test_tasks_scan_cache.py
+++ b/tests/test_tasks_scan_cache.py
@@ -95,7 +95,7 @@ def test_warm_writes_the_file_and_the_next_process_reads_nothing(
     cache = state_dir / tasks_mod.SCAN_CACHE_FILE
     assert cache.exists()
     data = json.loads(cache.read_text())
-    assert data["version"] == 1
+    assert data["version"] == tasks_mod._SCAN_CACHE_VERSION
     assert data["scan"][str(path)]["count"] == 1
     assert data["scan"][str(path)]["title"] == "Pull today's news"
     assert str(path) in data["head"]
@@ -142,7 +142,9 @@ def test_a_transcript_that_grew_between_processes_is_read_from_its_offset(
     rows = tasks_mod._task_rows()
 
     assert rows[0]["message_count"] == 2
-    assert seen and seen[0] == offset, "read from where the last process stopped"
+    # One seek, to the anchor just before the offset: the check reads those 32
+    # bytes and the delta read continues from the offset. Never from zero.
+    assert seen == [offset - tasks_mod._ANCHOR_BYTES], "read from where the last process stopped"
 
 
 def test_a_transcript_that_shrank_between_processes_is_read_from_zero(projects_dir):
@@ -167,7 +169,7 @@ def test_a_transcript_that_shrank_between_processes_is_read_from_zero(projects_d
 @pytest.mark.parametrize("body", [
     "not json{",
     json.dumps({"version": 99, "scan": {}, "head": {}}),
-    json.dumps({"version": 1, "scan": "nope", "head": []}),
+    json.dumps({"version": tasks_mod._SCAN_CACHE_VERSION, "scan": "nope", "head": []}),
     json.dumps([1, 2, 3]),
 ])
 def test_a_corrupt_or_foreign_file_is_ignored_not_raised_on(projects_dir, state_dir, body):
@@ -340,3 +342,69 @@ def test_a_head_comes_back_only_for_an_unchanged_file(projects_dir, state_dir):
     assert str(path) not in tasks_store._HEAD_CACHE, "stale head left for a fresh parse"
     rows = tasks_mod._task_rows()
     assert rows[0]["project"] == "/home/me/othr"
+
+
+def test_a_file_replaced_by_longer_different_content_is_read_from_zero(projects_dir):
+    """Growth is read from the saved offset on the strength of transcripts being
+    append-only. A file REPLACED by different, longer content (a restore, a hand
+    edit) breaks that, and reading from the old offset would fold foreign bytes
+    into a record built from the old file. The anchor — the bytes just before
+    the offset — catches it."""
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    assert tasks_mod._SCAN[str(path)]["count"] == 1
+    old_size = path.stat().st_size
+    # Entirely different, and LONGER — long enough that the shrink rule cannot
+    # be what catches it; only the anchor can.
+    path.write_text("\n".join(json.dumps(r) for r in [
+        {"type": "user", "uuid": "sess-a-0", "sessionId": "sess-a", "cwd": "/home/me/proj",
+         "timestamp": "2023-11-14T22:13:20Z", "message": {"role": "user", "content": "first of the new file"}},
+        {"type": "user", "uuid": "sess-a-1", "sessionId": "sess-a", "cwd": "/home/me/proj",
+         "timestamp": "2023-11-14T22:14:20Z", "message": {"role": "user", "content": "second " * 200}},
+    ]) + "\n")
+    assert path.stat().st_size > old_size
+    os.utime(path, (OLD + 60, OLD + 60))
+
+    _new_process()
+    tasks_mod.load_scan_cache()
+    rows = tasks_mod._task_rows()
+
+    assert rows[0]["message_count"] == 2
+    bodies = [m["body"] for m in rows[0]["messages"]]
+    assert "first of the new file" in bodies, "the new file's own first message, not a fold over foreign bytes"
+    assert tasks_mod._SCAN_STATS["anchor_miss"] == 1
+
+
+def test_an_appended_file_keeps_its_anchor_and_reads_only_the_delta(projects_dir):
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    with path.open("a") as f:
+        f.write('{"type":"user","uuid":"sess-a-9","sessionId":"sess-a",'
+                '"cwd":"/home/me/proj","timestamp":"2023-11-14T22:14:00Z",'
+                '"message":{"role":"user","content":"and tomorrow"}}\n')
+    os.utime(path, (OLD + 60, OLD + 60))
+
+    _new_process()
+    tasks_mod.load_scan_cache()
+    rows = tasks_mod._task_rows()
+
+    assert rows[0]["message_count"] == 2
+    assert tasks_mod._SCAN_STATS["grown"] == 1
+    assert tasks_mod._SCAN_STATS["anchor_miss"] == 0
+    assert tasks_mod._SCAN_STATS["zero"] == 0
+
+
+def test_a_file_written_by_another_app_version_is_read_afresh(projects_dir, state_dir):
+    """Records are what THIS code derived from the bytes; an unchanged file is
+    never re-parsed. So a release that changes the parsing must not inherit the
+    old answers: the version in the file carries the app version."""
+    _transcript(projects_dir)
+    tasks_mod.warm()
+    cache = state_dir / tasks_mod.SCAN_CACHE_FILE
+    data = json.loads(cache.read_text())
+    assert data["version"].endswith("/" + __import__("fused_render").__version__)
+    data["version"] = "2/0.0.1"
+    cache.write_text(json.dumps(data))
+
+    _new_process()
+    assert tasks_mod.load_scan_cache() == 0

--- a/tests/test_tasks_scan_cache.py
+++ b/tests/test_tasks_scan_cache.py
@@ -218,6 +218,7 @@ def test_listings_write_at_most_once_per_window(projects_dir, state_dir, monkeyp
     monkeypatch.setattr(tasks_mod.storage, "write_json",
                         lambda p, d: (p == str(cache) and writes.append(p), real(p, d)))
 
+    tasks_mod.load_scan_cache()  # a process that has looked at the file may write it
     tasks_mod._task_rows()  # cold: read bytes → dirty → first write
     assert len(writes) == 1
     tasks_mod._task_rows()  # nothing read: not dirty → no write
@@ -294,3 +295,22 @@ def test_an_older_listing_never_overwrites_the_desk_after_a_newer_one(projects_d
     monkeypatch.setattr(tasks_mod, "_OBSERVED_SEQ", tasks_mod._BUILD_SEQ + 5)
     tasks_mod._task_rows()
     assert seen == [1], "the stale ticket did not reach the desk"
+
+
+def test_a_save_before_the_load_leaves_the_file_alone(projects_dir, state_dir):
+    """Shutdown can beat the warm thread. A process that never read the file
+    has empty caches, and writing them would throw away every offset the last
+    process saved (Bugbot, #1081)."""
+    _transcript(projects_dir)
+    tasks_mod.warm()
+    cache = state_dir / tasks_mod.SCAN_CACHE_FILE
+    before = cache.read_text()
+    assert json.loads(before)["scan"]
+
+    _new_process()
+    tasks_mod.save_scan_cache()  # the shutdown handler, before any load
+    assert cache.read_text() == before
+
+    tasks_mod.load_scan_cache()
+    tasks_mod.save_scan_cache()  # after a load, saving is fair again
+    assert json.loads(cache.read_text())["scan"]

--- a/tests/test_tasks_scan_cache.py
+++ b/tests/test_tasks_scan_cache.py
@@ -427,6 +427,7 @@ def test_a_file_replaced_by_rename_is_read_from_zero_even_with_size_and_mtime_ke
 
     _new_process()
     tasks_mod.load_scan_cache()
+    assert str(path) not in tasks_store._HEAD_CACHE, "the head is not trusted either"
     rows = tasks_mod._task_rows()
 
     assert rows[0]["title"] == "Pull today's newz"

--- a/tests/test_tasks_scan_cache.py
+++ b/tests/test_tasks_scan_cache.py
@@ -219,6 +219,10 @@ def test_listings_write_at_most_once_per_window(projects_dir, state_dir, monkeyp
                         lambda p, d: (p == str(cache) and writes.append(p), real(p, d)))
 
     tasks_mod.load_scan_cache()  # a process that has looked at the file may write it
+    # The load starts the debounce clock (so warm's own save is not doubled);
+    # pretend a window has passed so the first listing is allowed to write.
+    monkeypatch.setattr(tasks_mod, "_SCAN_SAVED_AT",
+                        tasks_mod._SCAN_SAVED_AT - tasks_mod.SCAN_CACHE_SAVE_EVERY_S - 1)
     tasks_mod._task_rows()  # cold: read bytes → dirty → first write
     assert len(writes) == 1
     tasks_mod._task_rows()  # nothing read: not dirty → no write

--- a/tests/test_tasks_scan_cache.py
+++ b/tests/test_tasks_scan_cache.py
@@ -403,8 +403,30 @@ def test_a_file_written_by_another_app_version_is_read_afresh(projects_dir, stat
     cache = state_dir / tasks_mod.SCAN_CACHE_FILE
     data = json.loads(cache.read_text())
     assert data["version"].endswith("/" + __import__("fused_render").__version__)
-    data["version"] = "2/0.0.1"
+    data["version"] = "3/0.0.1"
     cache.write_text(json.dumps(data))
 
     _new_process()
     assert tasks_mod.load_scan_cache() == 0
+
+
+def test_a_file_replaced_by_rename_is_read_from_zero_even_with_size_and_mtime_kept(projects_dir):
+    """An editor or a restore writes a new file and renames it over the old one.
+    Force the worst case — same size, same mtime — and the inode still tells."""
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    st = path.stat()
+    before = path.read_bytes()
+    after = before.replace(b"Pull today's news", b"Pull today's newz")
+    tmp = path.with_suffix(".tmp")
+    tmp.write_bytes(after)
+    os.utime(tmp, (st.st_mtime, st.st_mtime))
+    os.replace(tmp, path)
+    assert path.stat().st_size == st.st_size and path.stat().st_mtime == st.st_mtime
+    assert path.stat().st_ino != st.st_ino
+
+    _new_process()
+    tasks_mod.load_scan_cache()
+    rows = tasks_mod._task_rows()
+
+    assert rows[0]["title"] == "Pull today's newz"

--- a/tests/test_tasks_scan_cache.py
+++ b/tests/test_tasks_scan_cache.py
@@ -314,3 +314,25 @@ def test_a_save_before_the_load_leaves_the_file_alone(projects_dir, state_dir):
     tasks_mod.load_scan_cache()
     tasks_mod.save_scan_cache()  # after a load, saving is fair again
     assert json.loads(cache.read_text())["scan"]
+
+
+def test_a_head_comes_back_only_for_an_unchanged_file(projects_dir, state_dir):
+    """`head` keys on size alone, so a same-size rewrite kept a stale cwd for
+    the life of a process and a restart healed it. The file must not take that
+    away: a head is imported only when size AND mtime still match the scan
+    record saved beside it (Bugbot, #1081)."""
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    assert tasks_store.head(str(path))[0] == "/home/me/proj"
+    before = path.read_bytes()
+    # Same length, different folder — nine characters each.
+    after = before.replace(b"/home/me/proj", b"/home/me/othr")
+    assert len(after) == len(before)
+    path.write_bytes(after)
+    os.utime(path, (OLD + 60, OLD + 60))
+
+    _new_process()
+    tasks_mod.load_scan_cache()
+    assert str(path) not in tasks_store._HEAD_CACHE, "stale head left for a fresh parse"
+    rows = tasks_mod._task_rows()
+    assert rows[0]["project"] == "/home/me/othr"

--- a/tests/test_tasks_scan_cache.py
+++ b/tests/test_tasks_scan_cache.py
@@ -1,0 +1,296 @@
+"""The scan cache FILE — `tasks-scan.json`, the two transcript caches carried
+across server processes (routers/tasks `load_scan_cache` / `save_scan_cache`).
+
+The listing's cost is reading every transcript from byte zero once per process.
+The file carries the offsets over, so a launch reads only what each transcript
+grew by. These tests pin: a saved cache makes the next process read nothing for
+an unchanged file; growth is read from the saved offset; a shrunk file is
+re-read from zero; a corrupt or foreign file is ignored, not raised on; vanished
+paths are not written; and listings write at most once per save window.
+"""
+
+import builtins
+import json
+import os
+
+import pytest
+
+from fused_render import tasks_store
+from fused_render.server.routers import claude_sessions as sessions_mod
+from fused_render.server.routers import tasks as tasks_mod
+from tests.test_tasks_api import _already_using, _ai_title, _assistant, _user, _write_transcript
+
+
+@pytest.fixture(autouse=True)
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+
+
+@pytest.fixture(autouse=True)
+def projects_dir(tmp_path, monkeypatch):
+    d = tmp_path / "claude-projects"
+    d.mkdir()
+    monkeypatch.setattr(tasks_store, "PROJECTS_DIR", str(d))
+    monkeypatch.setattr(sessions_mod, "PROJECTS_DIR", str(d))
+    return d
+
+
+@pytest.fixture(autouse=True)
+def state_dir(tmp_path, monkeypatch):
+    d = tmp_path / "state" / "claude-sessions"
+    d.mkdir(parents=True)
+    monkeypatch.setattr(tasks_store, "STATE_DIR", str(d))
+    monkeypatch.setattr(sessions_mod, "STATE_DIR", str(d))
+    _already_using(d)
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    tasks_mod.reset_cache()
+    yield
+    tasks_mod.reset_cache()
+
+
+OLD = 1_700_000_000
+
+
+def _transcript(projects_dir, sid="sess-a"):
+    # ISO stamps, as Claude writes them: a record with no readable timestamp
+    # leaves the head INCOMPLETE, and an incomplete head is deliberately not
+    # persisted (tasks_store.export_heads).
+    path = _write_transcript(projects_dir, sid, "/home/me/proj", [
+        _user("pull today's news", "2023-11-14T22:13:20Z"),
+        _assistant("done", "2023-11-14T22:13:30Z"),
+        _ai_title("Pull today's news"),
+    ])
+    # Old enough that liveness does not tail it: `_live` reads the last 16KB
+    # of any transcript touched in the last 90s, every time, by design.
+    os.utime(path, (OLD, OLD))
+    return path
+
+
+def _opens_of(monkeypatch, path):
+    opened = []
+    real_open = builtins.open
+
+    def counting_open(file, *args, **kwargs):
+        if str(file) == str(path):
+            opened.append(file)
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+    return opened
+
+
+def _new_process():
+    """What a relaunch is to the caches: everything in RAM gone, the file kept."""
+    tasks_mod.reset_cache()
+
+
+def test_warm_writes_the_file_and_the_next_process_reads_nothing(
+        projects_dir, state_dir, monkeypatch):
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    cache = state_dir / tasks_mod.SCAN_CACHE_FILE
+    assert cache.exists()
+    data = json.loads(cache.read_text())
+    assert data["version"] == 1
+    assert data["scan"][str(path)]["count"] == 1
+    assert data["scan"][str(path)]["title"] == "Pull today's news"
+    assert str(path) in data["head"]
+
+    _new_process()
+    assert str(path) not in tasks_mod._SCAN
+    opened = _opens_of(monkeypatch, path)
+    tasks_mod.warm()
+    rows = tasks_mod._task_rows()
+
+    assert [r["key"] for r in rows] == ["sess-a"]
+    assert rows[0]["title"] == "Pull today's news"
+    assert rows[0]["project"] == "/home/me/proj", "the head came from the file too"
+    assert opened == [], "an unchanged transcript is stats only after a cached launch"
+
+
+def test_a_transcript_that_grew_between_processes_is_read_from_its_offset(
+        projects_dir, monkeypatch):
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    offset = tasks_mod._SCAN[str(path)]["offset"]
+    with path.open("a") as f:
+        f.write('{"type":"user","uuid":"sess-a-9","sessionId":"sess-a",'
+                '"cwd":"/home/me/proj","timestamp":"2023-11-14T22:14:00Z",'
+                '"message":{"role":"user","content":"and tomorrow"}}\n')
+    os.utime(path, (OLD, OLD))
+
+    _new_process()
+    tasks_mod.load_scan_cache()
+    seen = []
+    real_open = builtins.open
+
+    def spying_open(file, *args, **kwargs):
+        f = real_open(file, *args, **kwargs)
+        if str(file) == str(path):
+            real_seek = f.seek
+
+            def seek(pos, *a):
+                seen.append(pos)
+                return real_seek(pos, *a)
+            f.seek = seek
+        return f
+    monkeypatch.setattr(builtins, "open", spying_open)
+    rows = tasks_mod._task_rows()
+
+    assert rows[0]["message_count"] == 2
+    assert seen and seen[0] == offset, "read from where the last process stopped"
+
+
+def test_a_transcript_that_shrank_between_processes_is_read_from_zero(projects_dir):
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    assert tasks_mod._SCAN[str(path)]["count"] == 1
+    # Replaced by a shorter file: one prompt, no ai-title.
+    path.write_text(json.dumps({
+        "type": "user", "uuid": "sess-a-0", "sessionId": "sess-a",
+        "cwd": "/home/me/proj", "timestamp": "2023-11-14T22:13:20Z",
+        "message": {"role": "user", "content": "fresh start"}}) + "\n")
+    os.utime(path, (OLD, OLD))
+
+    _new_process()
+    tasks_mod.load_scan_cache()
+    rows = tasks_mod._task_rows()
+
+    assert rows[0]["message_count"] == 1
+    assert rows[0]["title"] == "fresh start"
+
+
+@pytest.mark.parametrize("body", [
+    "not json{",
+    json.dumps({"version": 99, "scan": {}, "head": {}}),
+    json.dumps({"version": 1, "scan": "nope", "head": []}),
+    json.dumps([1, 2, 3]),
+])
+def test_a_corrupt_or_foreign_file_is_ignored_not_raised_on(projects_dir, state_dir, body):
+    path = _transcript(projects_dir)
+    (state_dir / tasks_mod.SCAN_CACHE_FILE).write_text(body)
+
+    assert tasks_mod.load_scan_cache() == 0
+    rows = tasks_mod._task_rows()
+    assert rows[0]["title"] == "Pull today's news"
+
+
+def test_a_record_of_the_wrong_shape_is_dropped_alone(projects_dir, state_dir):
+    good = _transcript(projects_dir, "sess-a")
+    bad = _transcript(projects_dir, "sess-b")
+    tasks_mod.warm()
+    cache = state_dir / tasks_mod.SCAN_CACHE_FILE
+    data = json.loads(cache.read_text())
+    data["scan"][str(bad)] = {"offset": "zero", "size": 1}
+    cache.write_text(json.dumps(data))
+
+    _new_process()
+    assert tasks_mod.load_scan_cache() == 1
+    assert str(good) in tasks_mod._SCAN
+    assert str(bad) not in tasks_mod._SCAN
+    rows = tasks_mod._task_rows()
+    assert sorted(r["key"] for r in rows) == ["sess-a", "sess-b"], "the bad one is simply re-read"
+
+
+def test_a_vanished_transcript_is_not_written(projects_dir, state_dir):
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    path.unlink()
+
+    tasks_mod.save_scan_cache()
+
+    data = json.loads((state_dir / tasks_mod.SCAN_CACHE_FILE).read_text())
+    assert data["scan"] == {}
+    assert data["head"] == {}
+
+
+def test_listings_write_at_most_once_per_window(projects_dir, state_dir, monkeypatch):
+    path = _transcript(projects_dir)
+    cache = state_dir / tasks_mod.SCAN_CACHE_FILE
+    writes = []
+    real = tasks_mod.storage.write_json
+    # Only THIS file's writes: the desk (current_apps) writes its own store
+    # through the same helper on every listing.
+    monkeypatch.setattr(tasks_mod.storage, "write_json",
+                        lambda p, d: (p == str(cache) and writes.append(p), real(p, d)))
+
+    tasks_mod._task_rows()  # cold: read bytes → dirty → first write
+    assert len(writes) == 1
+    tasks_mod._task_rows()  # nothing read: not dirty → no write
+    assert len(writes) == 1
+    with path.open("a") as f:
+        f.write('{"type":"user","uuid":"sess-a-9","sessionId":"sess-a",'
+                '"cwd":"/home/me/proj","timestamp":"2023-11-14T22:14:00Z",'
+                '"message":{"role":"user","content":"and tomorrow"}}\n')
+    os.utime(path, (OLD, OLD))
+    tasks_mod._task_rows()  # read bytes, but inside the window → held
+    assert len(writes) == 1
+    monkeypatch.setattr(tasks_mod, "_SCAN_SAVED_AT",
+                        tasks_mod._SCAN_SAVED_AT - tasks_mod.SCAN_CACHE_SAVE_EVERY_S - 1)
+    tasks_mod._task_rows()  # still dirty, window over → written
+    assert len(writes) == 2
+    assert json.loads(cache.read_text())["scan"][str(path)]["count"] == 2
+
+
+def test_an_unwritable_state_dir_costs_nothing_but_the_cache(projects_dir, monkeypatch):
+    _transcript(projects_dir)
+    monkeypatch.setattr(tasks_mod, "_scan_cache_path",
+                        lambda: "/nonexistent-root/nope/tasks-scan.json")
+    tasks_mod.warm()  # must not raise
+    assert [r["key"] for r in tasks_mod._task_rows()] == ["sess-a"]
+
+
+def test_a_transcript_rewritten_to_the_same_size_is_read_again(projects_dir):
+    """Size alone used to be the hit test, and a compaction that lands on the
+    same byte count kept the old tail for the life of the process — and, once
+    records outlive the process, for good. mtime is part of the key now."""
+    path = _transcript(projects_dir)
+    tasks_mod.warm()
+    before = path.read_bytes()
+    assert tasks_mod._SCAN[str(path)]["title"] == "Pull today's news"
+    # Same length, one letter different in the ai-title.
+    after = before.replace(b"Pull today's news", b"Pull today's newz")
+    assert len(after) == len(before)
+    path.write_bytes(after)
+    os.utime(path, (OLD + 60, OLD + 60))
+
+    _new_process()
+    tasks_mod.load_scan_cache()
+    rows = tasks_mod._task_rows()
+
+    assert rows[0]["title"] == "Pull today's newz"
+
+
+def test_an_incomplete_head_is_not_persisted(projects_dir, state_dir):
+    """A head with no prompt yet is retried in-process only when the file grows;
+    a restart used to give it a fresh parse. Persisting it would end that."""
+    good = _transcript(projects_dir, "sess-a")
+    empty = projects_dir / "-encoded-sess-b"
+    empty.mkdir()
+    bare = empty / "sess-b.jsonl"
+    bare.write_text('{"type":"summary","summary":"nothing here"}\n')
+    os.utime(bare, (OLD, OLD))
+    tasks_mod.warm()
+
+    data = json.loads((state_dir / tasks_mod.SCAN_CACHE_FILE).read_text())
+    assert str(good) in data["head"]
+    assert str(bare) not in data["head"], "no prompt, no timestamp: left for the next process"
+
+
+def test_an_older_listing_never_overwrites_the_desk_after_a_newer_one(projects_dir, monkeypatch):
+    """Two listings can leave the lock in one order and reach the desk in the
+    other. `observe` prunes what it does not see, so the older set must lose."""
+    from fused_render import current_apps
+    _transcript(projects_dir)
+    seen = []
+    monkeypatch.setattr(current_apps, "observe", lambda rows: seen.append(len(rows)))
+    tasks_mod._task_rows()
+    assert seen == [1]
+    # Pretend a newer build already spoke: an older ticket must stay quiet.
+    monkeypatch.setattr(tasks_mod, "_OBSERVED_SEQ", tasks_mod._BUILD_SEQ + 5)
+    tasks_mod._task_rows()
+    assert seen == [1], "the stale ticket did not reach the desk"


### PR DESCRIPTION
Stacked on #1079 (base is its branch; retarget to `main` once that merges).

## Problem

`GET /api/tasks` builds rows from in-memory caches that start empty in every server process. The first listing reads every transcript from byte zero — 641 files / 0.94 GB here, **2.9 s alone, ~10 s under startup contention**. #1079 moved that read onto a warm thread at boot, but the app restores its last URL: launching (or reloading) straight onto `/tasks` still queued the first request behind the scan, skeleton for seconds.

## Change

- **`tasks-scan.json`** in the claude-sessions state dir carries `_SCAN` and the head cache between processes: per transcript, the byte offset the last process stopped at, size, mtime, message count, three-message tail, ai-title, slash command. ~700 KB for 670 sessions.
- **Load** on the warm thread before its listing; **save** after warm, at most once per 30 s after a listing whose scan read bytes (no per-record stat on that path), and on shutdown (on a thread, so a scan in flight cannot stall the event loop).
- **Invalidation is the existing `_scan` rules**: same size and mtime → hit; grown → read from offset; shrunk, same-size-different-mtime, or vanished → re-read from zero / dropped. mtime joined the key because size alone let a same-length rewrite (compaction, resume) keep a stale tail — for the life of the process before, for good once records persist.
- Corrupt / foreign-version / malformed-record / unwritable file → ignored or dropped per record, never raises. `_SCAN` capped at 20k like the head cache. Only **complete** heads are persisted so an unresolved head keeps the fresh parse a restart used to give it.
- **Lock narrowed** (review on #1079): `current_apps.observe` now runs on the finished rows outside `_ROWS_LOCK`, serialized by a build ticket so an older listing leaving the lock second can never prune what a newer one recorded.

## Measured (this machine, 670 sessions)

| | before | after |
|---|---|---|
| `/api/tasks` immediately after a cold worker boot | 4–10 s | 0.62 s |
| reload straight onto `/tasks`, cold worker → rows visible | 4–10 s | 0.58 s |
| cache file | — | 727 KB, written in < 20 ms |

## Tests

`tests/test_tasks_scan_cache.py`: next process reads nothing for an unchanged file; grown file read from the saved offset; shrunk file and same-size rewrite re-read from zero; corrupt / wrong-version / wrong-shape file ignored; a single bad record dropped alone; vanished path not written; debounced writes (once per window); unwritable dir never raises; incomplete head not persisted; stale build ticket never reaches the desk. `test_app_lifespan` shutdown list updated.

Local: tasks suites green (271); full suite failures are the same pre-existing env ones as on `main` (claude_health, map/gdal, joblib import, env_install; `test_ai_worker_base[empty-transfer-encoding]` fails on `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path task listing, on-disk cache invalidation, and sidebar desk updates; bugs could show stale task metadata or wrong current-apps state, but failures are designed to degrade to full re-reads without raising.
> 
> **Overview**
> **Tasks listings no longer pay a full transcript read on every cold server process.** The PR adds **`tasks-scan.json`** in the claude-sessions state dir, holding incremental **`_SCAN`** offsets (plus tails, titles, counts) and **complete** head-cache rows. **Warm** loads the file before listing and saves afterward; listings may **debounce-save** (30s) when scans read bytes; **shutdown** flushes the cache on a background thread under **`_ROWS_LOCK`** so in-flight scans finish first without blocking the event loop.
> 
> **Cache correctness** is tightened for persistence: hits require **size, mtime, and inode**; **anchor bytes** before each offset detect “longer but different” file replacements; version includes **`fused_render.__version__`** so parsing changes force a one-time full re-read. Saves skip until **`load_scan_cache`** has run (avoids wiping a good file if shutdown beats warm), prune vanished paths on warm/shutdown saves, and cap **`_SCAN`** at 20k once per listing.
> 
> **Concurrency:** **`current_apps.observe`** runs **outside** the listing lock with a **build sequence** so an older listing cannot prune the desk after a newer one. **`tasks_store`** gains **`export_heads` / `import_heads`** with strict re-validation on import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb17233ee798139fe257f67221fdd6bc689be84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->