### PR TITLE
Map Viewer: fix geo_paths ModuleNotFoundError, drop CARTO for OpenFreeMap basemaps

### DIFF
--- a/fused_render/templates/map/geo_classify.py
+++ b/fused_render/templates/map/geo_classify.py
@@ -41,6 +41,16 @@ from raster_categories import classify_categories, read_pam_aux_xml, resolve_ren
 # ---- output caps (keep artifacts screen-sized / network-friendly) -----------
 MAX_RASTER_DIM = 1400        # longest edge of the reprojected raster PNG
 MAX_VECTOR_FEATURES = 400_000    # cap for the GeoJSON (polygon/line) path
+# A handful of features can still carry a huge vertex TOTAL between them even
+# under MAX_VECTOR_FEATURES (survey-grade boundary digitization is the usual
+# cause) — the oneshot path hands the whole GeoJSON straight to deck.gl's
+# WebGL buffers in one layer, and at a few hundred thousand vertices that
+# corrupts rather than just slowing down: an edge renders as a stray straight
+# line to an unrelated vertex elsewhere in the buffer instead of a slow frame.
+# Simplifying (topology-preserving) back under budget avoids it; there is no
+# byte-size proxy for this — a compact WKB source can still unpack into a
+# huge coordinate count.
+MAX_VECTOR_VERTICES = 150_000
 BINARY_POINT_THRESHOLD = 50_000  # points beyond this go through the fast binary path
 LONLAT_PAD = 1e-6
 
@@ -394,6 +404,34 @@ def _from_dataframe(df, artifact_dir, artifact_id, opts, detected="DataFrame"):
     )
 
 
+def _simplify_to_vertex_budget(gdf, max_vertices, warnings):
+    """Topology-preserving simplify, escalating the tolerance until the
+    GeoDataFrame's total vertex count is back under `max_vertices` (see
+    MAX_VECTOR_VERTICES). A no-op, at zero cost beyond the count itself, for
+    the overwhelming majority of files that never approach the budget."""
+    import shapely
+
+    total = int(shapely.get_num_coordinates(gdf.geometry.values).sum())
+    if total <= max_vertices:
+        return gdf
+
+    w, s, e, n = gdf.total_bounds
+    tolerance = max(e - w, n - s, 1e-9) / 20_000
+    gdf = gdf.copy()
+    geom_name = gdf.geometry.name
+    for _ in range(16):
+        gdf[geom_name] = shapely.simplify(gdf.geometry.values, tolerance, preserve_topology=True)
+        total = int(shapely.get_num_coordinates(gdf.geometry.values).sum())
+        if total <= max_vertices:
+            break
+        tolerance *= 2
+    warnings.append(
+        f"Geometry simplified to {total:,} vertices (tolerance {tolerance:.6g}°) "
+        "to stay renderable."
+    )
+    return gdf
+
+
 def _json_safe_columns(gdf):
     """Coerce non-JSON dtypes (datetime, category, object-non-str) to str so
     GeoDataFrame.to_json() doesn't choke."""
@@ -452,6 +490,8 @@ def _from_gdf(gdf, artifact_dir, artifact_id, opts, detected):
     if n > MAX_VECTOR_FEATURES:
         warnings.append(f"{n:,} features — showing first {MAX_VECTOR_FEATURES:,} for performance.")
         gdf = gdf.iloc[:MAX_VECTOR_FEATURES]
+
+    gdf = _simplify_to_vertex_budget(gdf, MAX_VECTOR_VERTICES, warnings)
 
     gdf = _json_safe_columns(gdf)
 

--- a/fused_render/templates/map/template.html
+++ b/fused_render/templates/map/template.html
@@ -478,7 +478,7 @@
       <div id="georesults"></div>
     </div>
 
-    <div id="attr">Made with <b>fused-render</b> · © OpenStreetMap © CARTO</div>
+    <div id="attr">Made with <b>fused-render</b> · © OpenStreetMap © OpenFreeMap</div>
     <div id="coordpill"><span id="coords">—</span></div>
     <div id="toast" class="hidden"></div>
   </main>
@@ -606,9 +606,13 @@ function rasterStyle(tiles, attribution, maxzoom) {
   return { version: 8, sources: { base: { type: "raster", tiles, tileSize: 256, attribution, maxzoom } },
            layers: [{ id: "base", type: "raster", source: "base" }] };
 }
+// OpenFreeMap (openfreemap.org) — free, no API key, no usage cap. Vector
+// tiles rather than CARTO's raster PNGs, which require a paid plan past
+// CARTO's free tier. maplibregl.Map.style/setStyle both accept a style-JSON
+// URL directly, so these are handed to it as-is rather than fetched here.
 const BASEMAPS = {
-  dark:  rasterStyle(["a","b","c","d"].map(s=>`https://${s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png`), "© OpenStreetMap © CARTO", 20),
-  light: rasterStyle(["a","b","c","d"].map(s=>`https://${s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}@2x.png`), "© OpenStreetMap © CARTO", 20),
+  dark:  "https://tiles.openfreemap.org/styles/dark",
+  light: "https://tiles.openfreemap.org/styles/positron",
   sat:   rasterStyle(["https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"], "Esri, Maxar, Earthstar Geographics", 18),
 };
 

--- a/fused_render/templates/map/template.html
+++ b/fused_render/templates/map/template.html
@@ -1675,8 +1675,8 @@ function rebuildVectorTiles() {
       });
       L._vtileUrl = tileUrl;
     }
-    const fillColor = cssColor(s.fill_color, [56, 135, 255, 90]);
-    const lineColor = cssColor(s.line_color, [90, 200, 255, 220]);
+    const fillColor = cssColor(s.fill_color, [56, 135, 255, 255]);
+    const lineColor = cssColor(s.line_color, [90, 200, 255, 255]);
     if (!map.getLayer(ids.fill)) {
       map.addLayer({
         id: ids.fill, type: "fill", source: sourceId, "source-layer": sourceLayer,
@@ -1815,7 +1815,7 @@ map.on("error", event => {
 
 function makePointsBinaryLayer(key, L) {
   const s = L.style, b = L.binary;
-  const fill = s.fill_color || [...L.defaultColor, 220];
+  const fill = s.fill_color || [...L.defaultColor, 255];
   const useCB = s.color_by && b.columns[s.color_by] && L._colorBuf;
   return new deck.ScatterplotLayer({
     id: "v_" + key,
@@ -1841,7 +1841,7 @@ async function computeBinaryColors(L) {
   const s = L.style, b = L.binary;
   if (!s.color_by || !b.columns[s.color_by]) { L._colorBuf = null; L._cb = null; return; }
   const { arr, meta } = await ensureColumn(L, s.color_by);
-  const a = (s.fill_color && s.fill_color[3]) ?? 220;
+  const a = (s.fill_color && s.fill_color[3]) ?? 255;
   const out = new Uint8Array(b.count * 4);
   const name = s.colormap || "viridis";
   if (meta.dtype === "f32") {
@@ -1857,8 +1857,8 @@ async function computeBinaryColors(L) {
 
 function makeGeoJsonLayer(key, L) {
   const s = L.style;
-  const fill = s.fill_color || [...L.defaultColor, 90];
-  const line = s.line_color || [...L.defaultColor, 220];
+  const fill = s.fill_color || [...L.defaultColor, 255];
+  const line = s.line_color || [...L.defaultColor, 255];
   let getFill = fill, getLine = line;
   if (s.color_by && L._cb) {
     const cb = L._cb, name = s.colormap || "viridis";
@@ -1866,10 +1866,10 @@ function makeGeoJsonLayer(key, L) {
       if (v === undefined || v === null) return [130,130,140,180];
       if (cb.numeric) {
         const t = cb.max > cb.min ? (Number(v) - cb.min) / (cb.max - cb.min) : 0.5;
-        const c = cmapColor(name, t); return [c[0], c[1], c[2], fill[3] ?? 200];
+        const c = cmapColor(name, t); return [c[0], c[1], c[2], fill[3] ?? 255];
       }
       const i = cb.cats.indexOf(String(v)); const c = CATEGORICAL[(i < 0 ? 0 : i) % CATEGORICAL.length];
-      return [c[0], c[1], c[2], fill[3] ?? 200];
+      return [c[0], c[1], c[2], fill[3] ?? 255];
     };
     getFill = f => colorFor(f.properties && f.properties[s.color_by]);
     getLine = f => colorFor(f.properties && f.properties[s.color_by]);
@@ -2325,18 +2325,18 @@ function vectorControls(body, L) {
     // fill + line color pickers
     if (!isLine) {
       body.appendChild(colorCtl("Fill", rgbToHex(s.fill_color||L.defaultColor), hex => {
-        const a = (s.fill_color && s.fill_color[3]) ?? 90; s.fill_color = [...hexToRgb(hex), a]; s._touched=true; rebuildDeck(); renderLayerCards();
+        const a = (s.fill_color && s.fill_color[3]) ?? 255; s.fill_color = [...hexToRgb(hex), a]; s._touched=true; rebuildDeck(); renderLayerCards();
       }));
-      body.appendChild(alphaCtl("Fill opacity", s.fill_color && s.fill_color[3], 90, a => {
+      body.appendChild(alphaCtl("Fill opacity", s.fill_color && s.fill_color[3], 255, a => {
         s.fill_color = [...(s.fill_color||L.defaultColor).slice(0,3), a]; s._touched=true; rebuildDeck(); renderLayerCards();
       }));
     }
     body.appendChild(colorCtl("Line / point", rgbToHex(s.line_color||L.defaultColor), hex => {
-      const a = (s.line_color && s.line_color[3]) ?? 220; s.line_color = [...hexToRgb(hex), a]; s._touched=true;
-      if (isPoint) { const fa=(s.fill_color&&s.fill_color[3])??220; s.fill_color=[...hexToRgb(hex),fa]; }
+      const a = (s.line_color && s.line_color[3]) ?? 255; s.line_color = [...hexToRgb(hex), a]; s._touched=true;
+      if (isPoint) { const fa=(s.fill_color&&s.fill_color[3])??255; s.fill_color=[...hexToRgb(hex),fa]; }
       rebuildDeck(); renderLayerCards();
     }));
-    body.appendChild(alphaCtl("Line opacity", s.line_color && s.line_color[3], 220, a => {
+    body.appendChild(alphaCtl("Line opacity", s.line_color && s.line_color[3], 255, a => {
       s.line_color = [...(s.line_color||L.defaultColor).slice(0,3), a]; s._touched=true;
       if (isPoint) { s.fill_color = [...(s.fill_color||L.defaultColor).slice(0,3), a]; }
       rebuildDeck(); renderLayerCards();
@@ -2355,25 +2355,25 @@ function vectorTileControls(body, L) {
   const isLine = gtypes.some(g => g.includes("Line"));
   if (!isLine) {
     body.appendChild(colorCtl("Fill", rgbToHex(s.fill_color || L.defaultColor), hex => {
-      const alpha = (s.fill_color && s.fill_color[3]) ?? 90;
+      const alpha = (s.fill_color && s.fill_color[3]) ?? 255;
       s.fill_color = [...hexToRgb(hex), alpha]; s._touched = true;
       rebuildVectorTiles(); renderLayerCards();
     }));
-    body.appendChild(alphaCtl("Fill opacity", s.fill_color && s.fill_color[3], 90, a => {
+    body.appendChild(alphaCtl("Fill opacity", s.fill_color && s.fill_color[3], 255, a => {
       s.fill_color = [...(s.fill_color || L.defaultColor).slice(0,3), a]; s._touched = true;
       rebuildVectorTiles(); renderLayerCards();
     }));
   }
   body.appendChild(colorCtl("Line / point", rgbToHex(s.line_color || L.defaultColor), hex => {
-    const alpha = (s.line_color && s.line_color[3]) ?? 220;
+    const alpha = (s.line_color && s.line_color[3]) ?? 255;
     s.line_color = [...hexToRgb(hex), alpha]; s._touched = true;
     if (isPoint) {
-      const fillAlpha = (s.fill_color && s.fill_color[3]) ?? 220;
+      const fillAlpha = (s.fill_color && s.fill_color[3]) ?? 255;
       s.fill_color = [...hexToRgb(hex), fillAlpha];
     }
     rebuildVectorTiles(); renderLayerCards();
   }));
-  body.appendChild(alphaCtl("Line opacity", s.line_color && s.line_color[3], 220, a => {
+  body.appendChild(alphaCtl("Line opacity", s.line_color && s.line_color[3], 255, a => {
     s.line_color = [...(s.line_color || L.defaultColor).slice(0,3), a]; s._touched = true;
     if (isPoint) { s.fill_color = [...(s.fill_color || L.defaultColor).slice(0,3), a]; }
     rebuildVectorTiles(); renderLayerCards();
@@ -2401,9 +2401,9 @@ function binaryPointControls(body, L) {
     body.appendChild(leg);
   } else {
     body.appendChild(colorCtl("Color", rgbToHex(s.fill_color||L.defaultColor), hex => {
-      const a = (s.fill_color && s.fill_color[3]) ?? 220; s.fill_color = [...hexToRgb(hex), a]; s._touched = true; rebuildDeck(); renderLayerCards();
+      const a = (s.fill_color && s.fill_color[3]) ?? 255; s.fill_color = [...hexToRgb(hex), a]; s._touched = true; rebuildDeck(); renderLayerCards();
     }));
-    body.appendChild(alphaCtl("Opacity", s.fill_color && s.fill_color[3], 220, a => {
+    body.appendChild(alphaCtl("Opacity", s.fill_color && s.fill_color[3], 255, a => {
       s.fill_color = [...(s.fill_color||L.defaultColor).slice(0,3), a]; s._touched = true; rebuildDeck(); renderLayerCards();
     }));
   }

--- a/fused_render/templates/map/worker.py
+++ b/fused_render/templates/map/worker.py
@@ -17,7 +17,18 @@ import os
 import sys
 import time
 import traceback
+from pathlib import Path
 from typing import Any
+
+# The warm daemon imports this module with its own directory already on
+# sys.path (daemon.py). The one-shot CLI fallback spawns this file directly
+# instead, and the project venv's interpreter does not always add a run
+# script's own directory to sys.path (SPEC PY-16 python-build-standalone
+# builds use a `._pth` file, which skips that), so `geo_paths` next door
+# would not resolve without this.
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
 
 from geo_paths import multidim_suffix
 


### PR DESCRIPTION
## Summary
- Fix `ModuleNotFoundError: No module named 'geo_paths'` in the map template's one-shot CLI fallback (`worker.py`), which happens whenever the warm tile daemon can't start and `map_render.py` falls back to spawning `worker.py` directly — that subprocess invocation doesn't get the automatic script-directory `sys.path` entry on this template's project-venv interpreter, so the sibling `geo_paths` import failed. Bootstraps `sys.path` explicitly, matching `map_render.py`/`daemon.py`/`discover.py`.
- Replace the default light/dark basemaps (CARTO raster tiles, free only under a usage threshold) with [OpenFreeMap](https://openfreemap.org) vector tiles — free, no API key, no usage cap, and native MapLibre vector styles instead of raster PNGs. Satellite (Esri) is unchanged.
- Default vector-layer fill/line/point opacity to 100% (was a mixed 35–86% depending on geometry type) across the raster-tile, vector-tile, GeoJSON and binary-point render paths and their matching style-panel slider defaults.
- Fix a WebGL rendering corruption bug: a vector file well under the byte-size threshold for the oneshot GeoJSON path can still carry an enormous vertex count when digitized at high precision (reproduced with a 4.5MB, 13-feature province-boundary `.gpkg` that unpacked to ~275k vertices — one feature alone at 90k). Handing that straight to a single deck.gl `GeoJsonLayer` corrupts the WebGL buffers rather than just rendering slowly: an edge shows up as a stray straight line connecting two vertices with no real edge between them in the source data (screenshot in the linked investigation showed a line from Saudi Arabia to the Gulf of Guinea). Adds a vertex-count budget (`MAX_VECTOR_VERTICES`) with topology-preserving simplification back under budget before serializing.

## Test plan
- [x] Reproduced the `ModuleNotFoundError` by invoking the map template's actual project-venv `worker.py` directly, confirmed the fix resolves it (import succeeds, execution reaches real request handling).
- [x] Verified both `https://tiles.openfreemap.org/styles/dark` and `https://tiles.openfreemap.org/styles/positron` return valid MapLibre style-spec v8 documents (200 OK, `version: 8`, populated `sources`/`layers`).
- [x] Reproduced the stray-line rendering bug against a real-world province-boundary `.gpkg`, confirmed the fix: 274,786 → 19,370 vertices, all 13 features stay valid and within 0.06% of their original area.
- [ ] Live browser check of map pan/zoom, layer opacity, and the simplified boundary render (Chrome extension wasn't connected in this environment).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly rendering and import-path fixes; vertex simplification can change appearance for very dense vectors but avoids known deck.gl corruption.
> 
> **Overview**
> Adds a **150k vertex cap** on the GeoJSON/deck.gl path: dense polygons (e.g. survey boundaries) can corrupt WebGL rendering even under the feature-count limit, so `geo_classify.py` now runs topology-preserving **Shapely simplify** with escalating tolerance and surfaces a warning when geometry is reduced.
> 
> **Map viewer** switches light/dark basemaps from CARTO raster tiles to **OpenFreeMap** vector style URLs (no API key; attribution updated). Default fill/line **alpha** in `template.html` moves from ~90/220 to **255** across deck layers, vector tiles, and style controls so opacity sliders start fully opaque.
> 
> **One-shot `worker.py`** prepends its directory to `sys.path` (same as `daemon.py`) so `geo_paths` imports work when the warm tile daemon is unavailable and the CLI fallback runs the worker directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a409833106b999c7d1d04866866e403ab65a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->