### PR TITLE
Explorer topbar: app actions fold into a kebab, sidebar switcher becomes tabs

### DIFF
--- a/frontend/src/apps/explorer/BarMenu.tsx
+++ b/frontend/src/apps/explorer/BarMenu.tsx
@@ -311,9 +311,9 @@ export function OverflowMenu({
 }: {
   items: OverflowEntry[];
   title?: string;
-  // Something pinned to the trigger's corner while the menu is SHUT — the App
-  // Doctor's status dot, whose whole job is to be seen without a click. A dot
-  // that only shows on a row inside a closed menu is a dot nobody sees.
+  // Something pinned to the trigger's corner — the App Doctor's status dot,
+  // whose whole job is to be seen without a click. A dot that only shows on a
+  // row inside a closed menu is a dot nobody sees.
   badge?: ReactNode;
 }) {
   const { pos, rootRef, toggle, close } = useMenuAnchor("right");

--- a/frontend/src/apps/explorer/BarMenu.tsx
+++ b/frontend/src/apps/explorer/BarMenu.tsx
@@ -269,6 +269,15 @@ export interface OverflowItem {
   // one iconless row among icon'd ones reads as a broken row — so a caller
   // either gives every item one or none.
   icon?: ReactNode;
+  // Listed but not clickable, with `title` saying why (the native tooltip, the
+  // same carrier ModeMenu's disabledReason uses). A row that vanishes while its
+  // precondition is unmet reads as a menu that changes shape; a dimmed row
+  // reads as the same menu with one thing unavailable right now.
+  disabled?: boolean;
+  title?: string;
+  // Something small after the label — a status dot, a spinner — in the row's
+  // trailing slot.
+  trailing?: ReactNode;
 }
 
 // A menu may group its items. Same shape as ContextMenu's entry list, so the
@@ -287,12 +296,26 @@ export type OverflowEntry = OverflowItem | "separator";
 // where they cost no chrome at all — and which is also how Rename and "Open in
 // Claude Code", both missing from the four-item dropdown, joined them.
 //
-// `OverflowMenu` below stays: the panel pane bars still use it for their own
-// one-shot ("Open in a new tab").
+// `OverflowMenu` below stays: the panel pane bars use it for their own one-shot
+// ("Open in a new tab"), and the file preview's crumb bar uses it as THE kebab
+// for the app-level actions that used to stand in that bar as bordered buttons
+// (EntryActionsMenu.tsx: App Doctor, Download app, Open as project, Open in
+// embed, MCP config).
 
 // `⋮` menu for the bars. Renders nothing when it has no items, so a caller can
 // pass a conditional list without guarding the control itself.
-export function OverflowMenu({ items, title = "More actions" }: { items: OverflowEntry[]; title?: string }) {
+export function OverflowMenu({
+  items,
+  title = "More actions",
+  badge,
+}: {
+  items: OverflowEntry[];
+  title?: string;
+  // Something pinned to the trigger's corner while the menu is SHUT — the App
+  // Doctor's status dot, whose whole job is to be seen without a click. A dot
+  // that only shows on a row inside a closed menu is a dot nobody sees.
+  badge?: ReactNode;
+}) {
   const { pos, rootRef, toggle, close } = useMenuAnchor("right");
   if (items.length === 0) return null;
   return (
@@ -313,6 +336,7 @@ export function OverflowMenu({ items, title = "More actions" }: { items: Overflo
         onClick={toggle}
       >
         <EllipsisIcon />
+        {badge && <span className="bar-overflow-badge">{badge}</span>}
       </button>
       {pos && (
         <div
@@ -330,6 +354,8 @@ export function OverflowMenu({ items, title = "More actions" }: { items: Overflo
                 type="button"
                 role="menuitem"
                 className="bar-menu-item"
+                disabled={item.disabled}
+                title={item.title}
                 onClick={() => {
                   close();
                   item.onClick();
@@ -337,6 +363,7 @@ export function OverflowMenu({ items, title = "More actions" }: { items: Overflo
               >
                 {item.icon && <span className="bar-menu-item-icon">{item.icon}</span>}
                 <span className="bar-menu-item-label">{item.label}</span>
+                {item.trailing && <span className="bar-menu-item-trailing">{item.trailing}</span>}
               </button>
             )
           )}

--- a/frontend/src/apps/explorer/EntryActionsMenu.tsx
+++ b/frontend/src/apps/explorer/EntryActionsMenu.tsx
@@ -98,6 +98,12 @@ export interface EntryActionsMenuProps {
   // over a folder that may well be one.
   mcp?: { available: boolean; pending: boolean; reason?: string };
   onOpenMcp: () => void;
+  // The host surface's OWN actions, appended after the app rows under a
+  // separator. The folder listing hands in its folder menu (lib/bar-menus'
+  // folderBarMenu: rename, new file/folder, paste, refresh, reveal, copy path,
+  // the splits) so the folder has ONE kebab rather than this one in the bar and
+  // a second `⋮` on the column header.
+  extraItems?: OverflowEntry[];
 }
 
 export function EntryActionsMenu({
@@ -110,6 +116,7 @@ export function EntryActionsMenu({
   onOpenEmbed,
   mcp,
   onOpenMcp,
+  extraItems,
 }: EntryActionsMenuProps) {
   const dir = fsPath.slice(0, fsPath.lastIndexOf("/")) || "/";
   const name = basename(dir);
@@ -271,9 +278,15 @@ export function EntryActionsMenu({
       : []),
   ];
 
+  if (extraItems && extraItems.length) {
+    if (items.length) items.push("separator");
+    items.push(...extraItems);
+  }
   // A trailing separator with nothing after it (an entry page over a surface
-  // with neither embed nor MCP) would draw a rule under the last row.
+  // with neither embed nor MCP) would draw a rule under the last row; a leading
+  // one (extras under no app rows) a rule over the first.
   while (items.length && items[items.length - 1] === "separator") items.pop();
+  while (items.length && items[0] === "separator") items.shift();
 
   // NOTHING QUALIFIES, NO KEBAB: OverflowMenu already renders nothing for an
   // empty list, so a plain folder that is not an app and publishes no MCP gets

--- a/frontend/src/apps/explorer/EntryActionsMenu.tsx
+++ b/frontend/src/apps/explorer/EntryActionsMenu.tsx
@@ -73,10 +73,14 @@ export interface EntryActionsMenuProps {
   // Opens this page under the chrome-free embed prefix in a new tab. The URL
   // (and its `_mode` stamp) is Preview.tsx's rule, so it builds it.
   onOpenEmbed: () => void;
-  // The MCP row: `null` when the parent folder offers no MCP companion (not an
-  // app, a mount) — the row is then listed disabled, since a menu that changes
-  // shape per file reads as broken; `pending` while the parent's probe is out.
-  mcp: { available: boolean; pending: boolean; reason?: string };
+  // The MCP row. `available: false` when the parent folder offers no MCP
+  // companion (not an app, a mount) — the row is then listed disabled with the
+  // reason, since a menu that changes shape per file reads as broken; `pending`
+  // while the parent's probe is out. OMITTED (undefined) by a surface that never
+  // probes the parent at all — a panel/tab pane (Preview's `splitCapable` is
+  // false there) — so the menu says nothing about MCP rather than "not an app"
+  // over a folder that may well be one.
+  mcp?: { available: boolean; pending: boolean; reason?: string };
   onOpenMcp: () => void;
 }
 
@@ -222,17 +226,21 @@ export function EntryActionsMenu({
       title: "Open this page in a new tab, without the sidebar and toolbar",
       onClick: onOpenEmbed,
     },
-    {
-      label: "MCP config",
-      icon: mcp.pending ? <span className="mode-icon-spinner" /> : <Plug {...LUCIDE} />,
-      title: mcp.pending
-        ? "Checking if this folder publishes MCP tools…"
-        : mcp.available
-          ? "The MCP tools " + name + " publishes"
-          : mcp.reason ?? "This folder publishes no MCP tools",
-      disabled: mcp.pending || !mcp.available,
-      onClick: onOpenMcp,
-    },
+    ...(mcp
+      ? [
+          {
+            label: "MCP config",
+            icon: mcp.pending ? <span className="mode-icon-spinner" /> : <Plug {...LUCIDE} />,
+            title: mcp.pending
+              ? "Checking if this folder publishes MCP tools…"
+              : mcp.available
+                ? "The MCP tools " + name + " publishes"
+                : mcp.reason ?? "This folder publishes no MCP tools",
+            disabled: mcp.pending || !mcp.available,
+            onClick: onOpenMcp,
+          } satisfies OverflowEntry,
+        ]
+      : []),
   ];
 
   return (

--- a/frontend/src/apps/explorer/EntryActionsMenu.tsx
+++ b/frontend/src/apps/explorer/EntryActionsMenu.tsx
@@ -58,7 +58,11 @@ const LUCIDE = { size: 16, strokeWidth: 1.5, "aria-hidden": true } as const;
 // the shell's canonical forward-slash form — same drive-letter-only
 // normalization rule as the URL codec (a backslash in a POSIX filename must not
 // be rewritten).
-const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
+// Exported for the folder listing, which hands this component the server's own
+// entry answer as `fsPath` and has to canonicalise it the same way first.
+export const canonEntryPath = (p: string) =>
+  /^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p;
+const canon = canonEntryPath;
 
 export interface EntryActionsMenuProps {
   // The app's ENTRY PAGE, or the page that might be one. Over a file preview
@@ -245,7 +249,12 @@ export function EntryActionsMenu({
           } satisfies OverflowEntry,
         ]
       : []),
-    ...(mcp
+    // The MCP row is worth listing DISABLED only where its absence is news: on
+    // an app (an entry page exists, so "this app publishes no tools" says
+    // something) or while the probe is still out. A plain folder that is not an
+    // app would otherwise get a kebab that opens on one dead row — and the
+    // empty-list collapse below could never run for it.
+    ...(mcp && (mcp.available || mcp.pending || isEntry)
       ? [
           {
             label: "MCP config",

--- a/frontend/src/apps/explorer/EntryActionsMenu.tsx
+++ b/frontend/src/apps/explorer/EntryActionsMenu.tsx
@@ -1,0 +1,250 @@
+// THE CRUMB BAR'S KEBAB over a file preview: every app-level action that used to
+// stand in that bar as its own bordered button — App Doctor, Export App, Open in
+// project — plus the fullscreen glyph and the MCP companion, in one `⋮`
+// (BarMenu's OverflowMenu). Four labelled buttons and two glyphs in a 28px strip
+// was a toolbar competing with the mode control for the bar; the mode control is
+// what the bar is FOR, and these are things you do to the app once in a while.
+//
+// ONE ENTRY PROBE. The three buttons each asked /api/apps/entry whether the
+// previewed page is its folder's app entry (the server's own entry rule, never
+// the filename) and each hid itself when it was not. That is one question asked
+// three times per file; it is asked once here, and the answer gates the three
+// entry-only rows together. The two rows that are not about "the app" — Open in
+// embed, MCP config — are gated on their own facts (always, and whether the parent
+// folder offers an MCP companion), so a plain html file still gets a kebab.
+//
+// The App Doctor's STATUS DOT rides the trigger's corner while the menu is shut
+// (OverflowMenu's `badge`): its whole job is to be seen without a click, and a
+// dot on a row inside a closed menu is a dot nobody sees. It repeats on the row
+// so the two agree.
+//
+// The bodies are the deleted buttons' bodies, verbatim where it matters:
+//   * Export keeps its `busy || snapshotPending || snapshotError` guard and its
+//     `.preview-frame.is-shown` capture source (see the row's comments);
+//   * Open as project puts the folder on the sidebar's desk first, then
+//     navigates in THIS tab, spelled by hand since an app may not import
+//     shell/current-apps-lib;
+//   * Open in embed is a NEW TAB now (`window.open`) — the old fullscreen button
+//     replaced this document (`location.assign`), and a way out only through
+//     EmbedStrip's "Open in explorer" is a poor trade for a menu row that says
+//     "open"; the explorer stays where it was. Its URL is still the caller's
+//     (Preview.tsx owns the `_mode` stamp rule).
+//   * MCP config opens the parent folder's `mcp` template in a dialog
+//     (McpDialog) rather than in the sidebar, whose two remaining companions are
+//     tabs now (SideChrome's SideTabs). The dialog's open state lives in
+//     Preview.tsx because Open With → MCP has to reach it too.
+import { useEffect, useState } from "react";
+import { Plug, Stethoscope } from "lucide-react";
+import { addCurrentApp, getAppEntry, statPath } from "@platform/lib/api";
+import { exportAppFile } from "@platform/lib/appShot";
+import { AppDoctorModal } from "@platform/ui/AppDoctorModal";
+import { AppDoctorStatusDot } from "@platform/ui/AppDoctorStatusDot";
+import { useAppDoctorChecks } from "@platform/ui/useAppDoctorChecks";
+import { announceCurrentAppsChanged } from "@platform/lib/tasksChanged";
+import { navigateUrl, encodeFsPathSegments } from "@platform/lib/router";
+import { basename } from "@platform/lib/format";
+import { pushToast } from "@platform/lib/toast";
+import { useAppVersionLabel } from "@platform/lib/appVersionLabel";
+import type { ResolvedSnapshot } from "@platform/lib/snapshot-param";
+import { MenuIcons } from "@platform/ui/MenuIcons";
+import { OverflowMenu, type OverflowEntry } from "@apps/explorer/BarMenu";
+
+// lucide at MenuIcons' own weight (1.5 on a 24 grid, 16px) so the two rows that
+// have no MenuIcons glyph sit in the list at the same stroke as the rest.
+const LUCIDE = { size: 16, strokeWidth: 1.5, "aria-hidden": true } as const;
+
+// The server answers os.path.abspath (backslashes on Windows) while fsPath is
+// the shell's canonical forward-slash form — same drive-letter-only
+// normalization rule as the URL codec (a backslash in a POSIX filename must not
+// be rewritten).
+const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
+
+export interface EntryActionsMenuProps {
+  fsPath: string;
+  // The pane's own `_snapshot` resolution (`usePreviewSnapshot`, hoisted in the
+  // parent so the picker and Export agree on what "the previewed version" means)
+  // — mirrors AppPage.tsx's `snapshot` and its Export control's use of it: export
+  // the snapshot's OWN extracted tree, never the live folder, while one is
+  // previewed.
+  snapshotSha: string | null;
+  snapshotResolved: ResolvedSnapshot | null;
+  snapshotPending: boolean;
+  snapshotError: boolean;
+  // Opens this page under the chrome-free embed prefix in a new tab. The URL
+  // (and its `_mode` stamp) is Preview.tsx's rule, so it builds it.
+  onOpenEmbed: () => void;
+  // The MCP row: `null` when the parent folder offers no MCP companion (not an
+  // app, a mount) — the row is then listed disabled, since a menu that changes
+  // shape per file reads as broken; `pending` while the parent's probe is out.
+  mcp: { available: boolean; pending: boolean; reason?: string };
+  onOpenMcp: () => void;
+}
+
+export function EntryActionsMenu({
+  fsPath,
+  snapshotSha,
+  snapshotResolved,
+  snapshotPending,
+  snapshotError,
+  onOpenEmbed,
+  mcp,
+  onOpenMcp,
+}: EntryActionsMenuProps) {
+  const dir = fsPath.slice(0, fsPath.lastIndexOf("/")) || "/";
+  const name = basename(dir);
+  const [isEntry, setIsEntry] = useState(false);
+  const [doctorOpen, setDoctorOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    setIsEntry(false);
+    setDoctorOpen(false);
+    getAppEntry(dir)
+      .then((r) => {
+        if (alive) setIsEntry(r.entry != null && canon(r.entry) === fsPath);
+      })
+      .catch(() => {
+        /* indeterminate reads as "not an entry" — no rows for nothing */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [fsPath, dir]);
+  // Fetched after first paint, never blocking it — see useAppDoctorChecks.
+  // Opening the modal re-fetches its own copy; this one is only for the dot and
+  // is never reused to seed the dialog.
+  const doctorChecks = useAppDoctorChecks(isEntry ? dir : null);
+  const versionLabel = useAppVersionLabel(dir, snapshotSha);
+
+  // Mirrors AppPage.tsx's `exportDisabled`: a click landing mid-resolve, before
+  // `snapshotResolved.dir` exists, must not fall through to exporting the LIVE
+  // folder while the pane still shows the version being resolved.
+  const exportDisabled = exporting || snapshotPending || snapshotError;
+  const doExport = async () => {
+    if (exportDisabled) return;
+    setExporting(true);
+    try {
+      const isLive = snapshotSha === null;
+      // The snapshot's OWN extracted tree (`snap.dir`), never `snap.app_dir`
+      // (the LIVE folder the sha resolved from) — exporting that would silently
+      // ship the live app labelled as the picked commit.
+      const exportPath = snapshotResolved ? snapshotResolved.dir : dir;
+      // The filename carries the version so a v7 export sitting beside a live
+      // export in Downloads is never ambiguous about which is which.
+      const exportName = isLive ? name : `${name}-${versionLabel}`;
+      // Same capture-on-export as the /apps card (appShot, D396): the shown
+      // preview frame IS the app rendering, so it is the crop source — no
+      // navigation, no flash. exportAppFile itself skips capture when the folder
+      // carries an authored preview.png; the probe below is only so a pointless
+      // native shot (and, on a Mac that has not granted Screen Recording, its
+      // permission dialog) isn't taken for a capture the server would discard
+      // anyway (stat failure reads as "no authored still" — worst case is that
+      // redundant shot, never a lost export).
+      //
+      // `.is-shown` satisfies appShot's crop-source contract (pixels that ARE
+      // the app, not a box it may fill): the class rides `shown`, which the
+      // frame swap only sets once that frame paints. Only checked for a LIVE
+      // export: a snapshot's preview.png (if any) lives under the extracted
+      // tree, and `entry_html` is omitted below for a snapshot anyway.
+      const authored = isLive
+        ? await statPath(dir + "/preview.png").then(
+            (s) => !s.is_dir,
+            () => false,
+          )
+        : false;
+      await exportAppFile(
+        {
+          path: exportPath,
+          name: exportName,
+          // Omitted for a snapshot export: with no on-screen capture element
+          // threaded to this target folder, `exportAppFile`'s stage fallback
+          // would reload the ENTRY PAGE'S LIVE copy to shoot it — a present-day
+          // screenshot baked into a file labelled as the old commit.
+          entry_html: isLive ? fsPath : undefined,
+          preview_image: isLive && authored ? dir + "/preview.png" : null,
+        },
+        isLive ? document.querySelector(".preview-frame.is-shown") : null,
+      );
+    } catch (e) {
+      pushToast({ msg: "Could not export " + name + ": " + (e as Error).message, tone: "error" });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  // Put the folder on the sidebar's desk (POST /api/current-apps/add, a no-op
+  // when the row is there already, which then reads as the active row) and open
+  // the folder's app page, `/apps/<folder>`, in THIS tab.
+  const openProject = async () => {
+    try {
+      await addCurrentApp(dir);
+      announceCurrentAppsChanged();
+    } catch {
+      /* the page still opens; the row shows up on the next task under it */
+    }
+    navigateUrl("/apps/" + encodeFsPathSegments(dir));
+  };
+
+  const entryRows: OverflowEntry[] = isEntry
+    ? [
+        {
+          label: "App Doctor",
+          icon: <Stethoscope {...LUCIDE} />,
+          title:
+            "Check " + name +
+            " before you share it: leaked credentials, paths tied to this machine, " +
+            "stray generated files, uncommitted work, a stale fused API version",
+          trailing: <AppDoctorStatusDot checks={doctorChecks} />,
+          onClick: () => setDoctorOpen(true),
+        },
+        {
+          label: exporting ? "Exporting…" : "Download app",
+          icon: exporting ? <span className="mode-icon-spinner" /> : MenuIcons.download,
+          title: "Export " + name + " as a single .fused app file",
+          disabled: exportDisabled,
+          onClick: () => void doExport(),
+        },
+        {
+          label: "Open as project",
+          icon: MenuIcons.open,
+          title: "Open " + name + " as a project",
+          onClick: () => void openProject(),
+        },
+        "separator",
+      ]
+    : [];
+
+  const items: OverflowEntry[] = [
+    ...entryRows,
+    {
+      label: "Open in embed",
+      icon: MenuIcons.newTab,
+      title: "Open this page in a new tab, without the sidebar and toolbar",
+      onClick: onOpenEmbed,
+    },
+    {
+      label: "MCP config",
+      icon: mcp.pending ? <span className="mode-icon-spinner" /> : <Plug {...LUCIDE} />,
+      title: mcp.pending
+        ? "Checking if this folder publishes MCP tools…"
+        : mcp.available
+          ? "The MCP tools " + name + " publishes"
+          : mcp.reason ?? "This folder publishes no MCP tools",
+      disabled: mcp.pending || !mcp.available,
+      onClick: onOpenMcp,
+    },
+  ];
+
+  return (
+    <>
+      <OverflowMenu
+        items={items}
+        title="App actions"
+        badge={isEntry ? <AppDoctorStatusDot checks={doctorChecks} /> : undefined}
+      />
+      {doctorOpen && <AppDoctorModal dir={dir} onClose={() => setDoctorOpen(false)} />}
+    </>
+  );
+}
+
+export default EntryActionsMenu;

--- a/frontend/src/apps/explorer/EntryActionsMenu.tsx
+++ b/frontend/src/apps/explorer/EntryActionsMenu.tsx
@@ -1,4 +1,5 @@
-// THE CRUMB BAR'S KEBAB over a file preview: every app-level action that used to
+// THE BAR'S KEBAB — the file preview's crumb bar, and the folder listing's
+// search row (which IS the bar over a folder): every app-level action that used to
 // stand in that bar as its own bordered button — App Doctor, Export App, Open in
 // project — plus the fullscreen glyph and the MCP companion, in one `⋮`
 // (BarMenu's OverflowMenu). Four labelled buttons and two glyphs in a 28px strip
@@ -60,19 +61,30 @@ const LUCIDE = { size: 16, strokeWidth: 1.5, "aria-hidden": true } as const;
 const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
 
 export interface EntryActionsMenuProps {
+  // The app's ENTRY PAGE, or the page that might be one. Over a file preview
+  // this is the previewed file and the component asks the server whether it is
+  // the entry; over a folder listing the caller has already asked (Listing's
+  // `appEntryPath`) and passes the answer as `isEntry`, with `fsPath` the entry
+  // page it found — or `<folder>/index.html` as a stand-in when there is none,
+  // so the folder is still what `dir` resolves to.
   fsPath: string;
+  // Skip the probe: the caller knows. Undefined means "ask /api/apps/entry".
+  isEntry?: boolean;
   // The pane's own `_snapshot` resolution (`usePreviewSnapshot`, hoisted in the
   // parent so the picker and Export agree on what "the previewed version" means)
   // — mirrors AppPage.tsx's `snapshot` and its Export control's use of it: export
   // the snapshot's OWN extracted tree, never the live folder, while one is
-  // previewed.
-  snapshotSha: string | null;
-  snapshotResolved: ResolvedSnapshot | null;
-  snapshotPending: boolean;
-  snapshotError: boolean;
+  // previewed. Absent on a surface with no snapshot machinery (the folder
+  // listing, whose snapshot view never renders this menu — `paneEnabled`), where
+  // the export is the live folder.
+  snapshotSha?: string | null;
+  snapshotResolved?: ResolvedSnapshot | null;
+  snapshotPending?: boolean;
+  snapshotError?: boolean;
   // Opens this page under the chrome-free embed prefix in a new tab. The URL
-  // (and its `_mode` stamp) is Preview.tsx's rule, so it builds it.
-  onOpenEmbed: () => void;
+  // (and its `_mode` stamp) is Preview.tsx's rule, so it builds it. Omitted by
+  // a surface with no embed of its own (the folder listing), and the row with it.
+  onOpenEmbed?: () => void;
   // The MCP row. `available: false` when the parent folder offers no MCP
   // companion (not an app, a mount) — the row is then listed disabled with the
   // reason, since a menu that changes shape per file reads as broken; `pending`
@@ -86,23 +98,26 @@ export interface EntryActionsMenuProps {
 
 export function EntryActionsMenu({
   fsPath,
-  snapshotSha,
-  snapshotResolved,
-  snapshotPending,
-  snapshotError,
+  isEntry: isEntryKnown,
+  snapshotSha = null,
+  snapshotResolved = null,
+  snapshotPending = false,
+  snapshotError = false,
   onOpenEmbed,
   mcp,
   onOpenMcp,
 }: EntryActionsMenuProps) {
   const dir = fsPath.slice(0, fsPath.lastIndexOf("/")) || "/";
   const name = basename(dir);
-  const [isEntry, setIsEntry] = useState(false);
+  const [isEntryProbed, setIsEntry] = useState(false);
+  const isEntry = isEntryKnown ?? isEntryProbed;
   const [doctorOpen, setDoctorOpen] = useState(false);
   const [exporting, setExporting] = useState(false);
   useEffect(() => {
     let alive = true;
     setIsEntry(false);
     setDoctorOpen(false);
+    if (isEntryKnown !== undefined) return; // the caller answered; nothing to ask
     getAppEntry(dir)
       .then((r) => {
         if (alive) setIsEntry(r.entry != null && canon(r.entry) === fsPath);
@@ -113,7 +128,7 @@ export function EntryActionsMenu({
     return () => {
       alive = false;
     };
-  }, [fsPath, dir]);
+  }, [fsPath, dir, isEntryKnown]);
   // Fetched after first paint, never blocking it — see useAppDoctorChecks.
   // Opening the modal re-fetches its own copy; this one is only for the dot and
   // is never reused to seed the dialog.
@@ -220,12 +235,16 @@ export function EntryActionsMenu({
 
   const items: OverflowEntry[] = [
     ...entryRows,
-    {
-      label: "Open in embed",
-      icon: MenuIcons.newTab,
-      title: "Open this page in a new tab, without the sidebar and toolbar",
-      onClick: onOpenEmbed,
-    },
+    ...(onOpenEmbed
+      ? [
+          {
+            label: "Open in embed",
+            icon: MenuIcons.newTab,
+            title: "Open this page in a new tab, without the sidebar and toolbar",
+            onClick: onOpenEmbed,
+          } satisfies OverflowEntry,
+        ]
+      : []),
     ...(mcp
       ? [
           {
@@ -243,6 +262,13 @@ export function EntryActionsMenu({
       : []),
   ];
 
+  // A trailing separator with nothing after it (an entry page over a surface
+  // with neither embed nor MCP) would draw a rule under the last row.
+  while (items.length && items[items.length - 1] === "separator") items.pop();
+
+  // NOTHING QUALIFIES, NO KEBAB: OverflowMenu already renders nothing for an
+  // empty list, so a plain folder that is not an app and publishes no MCP gets
+  // no `⋮` at all rather than a menu that opens on nothing.
   return (
     <>
       <OverflowMenu

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -381,8 +381,8 @@ export default function Listing({
   const folderClaude = useDirMode(paneEnabled ? fsPath : null, "claude");
   const folderGit = useDirMode(paneEnabled ? fsPath : null, "git");
   // `mcp` for the same reason as `git`: the manifest it curates covers the FOLDER
-  // (templates/mcp/condition.py), so a folder that is not an app shows the pill
-  // disabled rather than not at all.
+  // (templates/mcp/condition.py). Not a pane mode — it gates the kebab's "MCP
+  // config" row (below) and the dialog behind it.
   const folderMcp = useDirMode(paneEnabled ? fsPath : null, "mcp");
   // While the probe is in flight the entries are PLACEHOLDERS with no template
   // path (lib/dir-mode), which would build a `path=null` iframe URL — so a
@@ -399,23 +399,18 @@ export default function Listing({
   // Git row is the Git glyph dimmed instead of a boxed "G". Nothing else reads
   // either; what the pane may BE is still `claude`/`git` alone.
   //
-  // MCP IS NOT A PANE MODE ANY MORE: the pane's switcher is a two-tab strip over
-  // Claude and Git (SideChrome's SideTabs), and the MCP companion opens as a
-  // dialog off the search row's kebab (EntryActionsMenu → McpDialog, the same
-  // arrangement the file preview has). So `mcp` is handed to the pane machinery
-  // as "never offered, never pending" — `paneSideList` then cannot put the pane
-  // on it, and a `?_side=mcp` deep link lands on the leading companion like any
-  // other unknown value — while the `folderMcp` probe itself feeds `mcpSrc` below.
+  // MCP IS NOT A PANE MODE (listing/pane-side's PANE_SIDE_COMPANIONS): the
+  // pane's switcher is a two-tab strip over Claude and Git (SideChrome's
+  // SideTabs), and the MCP companion opens as a dialog off the search row's
+  // kebab (EntryActionsMenu → McpDialog, the same arrangement the file preview
+  // has). The `folderMcp` probe above feeds that row alone, through `mcpSrc`.
   const sideEntries = {
     claude: folderClaude.pending ? null : folderClaude.entry,
     git: folderGit.pending ? null : folderGit.entry,
-    mcp: null,
     claudePending: folderClaude.pending,
     gitPending: folderGit.pending,
-    mcpPending: false,
     claudeBound: folderClaude.bound,
     gitBound: folderGit.bound,
-    mcpBound: null,
   };
   // The MCP dialog's document — the URL ListingPreviewPane built for the mcp
   // pane (`_file` is the folder, `_noopen=1` so the render is not recorded as an

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -101,7 +101,7 @@ import {
   subscribePendingClaudeAsk,
   takePendingClaudeAsk,
 } from "@apps/explorer/lib/pending-claude-ask";
-import { SideToggleButton, paneSideIcon } from "@apps/explorer/SideChrome";
+import { SideToggleButton } from "@apps/explorer/SideChrome";
 import { modeTitle } from "@platform/lib/mode-name";
 import { passedDragSlop } from "@apps/explorer/listing/marquee";
 import {
@@ -1981,11 +1981,7 @@ export default function Listing({
                 </button>
               )}
               {pane.on && !sideState.open && (
-                <SideToggleButton
-                  what={modeTitle(paneSide)}
-                  icon={paneSideIcon(paneSide, sideEntries)}
-                  onClick={openSide}
-                />
+                <SideToggleButton what={modeTitle(paneSide)} onClick={openSide} />
               )}
               {/* The path `···` is not here any more: it rides the crumb strip
                   now (Breadcrumb.tsx), immediately right of the folder name it

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -39,6 +39,7 @@ import { createPortal } from "react-dom";
 import {
   IS_PANEL_PANE,
   IS_SNAPSHOT,
+  embedUrlForFsPath,
   navigate,
   replaceSearch,
 } from "@platform/lib/router";
@@ -55,7 +56,7 @@ import { getViewState, setViewState } from "@platform/lib/viewstate";
 import { useFlip, FLIP_KEY_ATTR } from "@platform/lib/flip";
 import { useClipboard } from "@apps/explorer/lib/fs-clipboard";
 import ContextMenu from "@platform/ui/ContextMenu";
-import { EllipsisIcon } from "@apps/explorer/BarMenu";
+import type { OverflowEntry } from "@apps/explorer/BarMenu";
 import { PromptDialog, ConfirmDialog } from "@apps/explorer/FsDialogs";
 import ListingPreviewPane from "@apps/explorer/ListingPreviewPane";
 import { AccessDenied, isAccessDenied } from "@apps/explorer/AccessDenied";
@@ -1372,64 +1373,12 @@ export default function Listing({
     setMenu({ x: e.clientX, y: e.clientY, items: backgroundMenu() });
   };
 
-  // The header `⋮` (right end of the MODIFIED column). Everything here is about
-  // THIS FOLDER, which is what the crumb bar's own `⋮` used to be for over a
-  // listing — that one is gone (Breadcrumb.tsx) and its two unique items moved
-  // in below the background menu's set, so there is one place to look instead
-  // of a path menu and a right-click each holding half the folder's actions.
-  //
-  // Discoverability is the whole point of the button: the same items were
-  // already a right-click on the background, which nobody finds, and which an
-  // empty folder gives you no obvious surface to try.
-  //
-  // `barMenu()` (useFileOps -> lib/bar-menus) is the list, not an array built
-  // here: a right-click anywhere on the crumb bar opens the same one, and two
-  // copies of "the folder's actions plus the splits" is how the two surfaces
-  // would end up disagreeing about what the folder can do.
-  const openHeaderMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation(); // never sorts — the th around it is a sort control
-    const r = e.currentTarget.getBoundingClientRect();
-    setMenu({
-      // Right-ish alignment by hand: ContextMenu only clamps at the VIEWPORT
-      // edge, and with a preview pane open this button is nowhere near it, so
-      // an unbiased x would hang the popup off to the right of the column.
-      // 220 is the menu's own min-width (context-menu.css).
-      x: Math.max(4, r.right - 220),
-      y: r.bottom + 2,
-      items: barMenu(),
-    });
-  };
-
-  // The folder's `⋮`, absolutely positioned against the LAST header cell's
-  // right edge (the th is sticky, so it is already the positioned ancestor) —
-  // NOT a fourth column: rows have three cells, and a column they don't render
-  // breaks their backgrounds. It overlays the header's own padding, which is
-  // why .col-mtime reserves room for it (explorer.css) rather than letting it
-  // land on the sort arrow.
-  // Both handlers stop propagation: the normal header's th sorts on click, and
-  // a press that re-sorts the listing under the menu about to open is not what
-  // the button says it does. One element, three homes — the mtime th, the
-  // search header's Path th, and (labels hidden) the empty folder's strip —
-  // because the actions act on the current folder in every one of them.
-  //
-  // Only where this listing OWNS the bar chrome: the menu replaces the crumb
-  // bar's path `⋮`, so it belongs to the same view that dropped it. A
-  // snapshot's or a panel pane's listing never had that menu — and its "Split
-  // right" would rewrite the SHELL's URL from inside a nested surface.
-  const headerMenuBtn = !ownsBarChrome ? null : (
-    <button
-      type="button"
-      className="listing-head-menu"
-      aria-haspopup="menu"
-      aria-label="Folder actions"
-      title="Folder actions"
-      onPointerDown={(e) => e.stopPropagation()}
-      onClick={openHeaderMenu}
-    >
-      <EllipsisIcon />
-    </button>
-  );
+  // The folder's `⋮` used to sit on the MODIFIED column header (and on the
+  // search view's Path header, and on an empty folder's bare strip), opening
+  // `barMenu()`. It is gone: the bar's kebab (EntryActionsMenu, in the search
+  // row) carries that same list under the app rows, so a folder has ONE `⋮`.
+  // `barMenu()` itself stays the single source — the crumb bar's right-click
+  // opens it too (publishTopbarMenu).
 
   // --- table body -----------------------------------------------------------
 
@@ -1969,20 +1918,62 @@ export default function Listing({
                   The entry page is what the rows act on (export's `entry_html`),
                   with `<folder>/index.html` as a stand-in when there is none so
                   the folder is still what the menu resolves. */}
-              {paneEnabled && (
+              {(paneEnabled || ownsBarChrome) && (
                 <EntryActionsMenu
                   /* The server's answer is os.path.abspath — backslashes on
                      Windows — and the menu derives the folder with a "/" split,
                      so it goes through the same drive-letter-only normalisation
                      the file surface applies before comparing. */
                   fsPath={appEntryPath ? canonEntryPath(appEntryPath) : fsPath + "/index.html"}
-                  isEntry={appEntryPath !== null}
-                  mcp={{
-                    available: mcpSrc !== null,
-                    pending: folderMcp.pending,
-                    reason: unavailableReason("mcp"),
-                  }}
+                  isEntry={paneEnabled && appEntryPath !== null}
+                  mcp={
+                    paneEnabled
+                      ? {
+                          available: mcpSrc !== null,
+                          pending: folderMcp.pending,
+                          reason: unavailableReason("mcp"),
+                        }
+                      : undefined
+                  }
                   onOpenMcp={() => setMcpOpen(true)}
+                  /* Open in embed — this listing under the chrome-free embed
+                     prefix, in a new tab, `_mode=_listing` stamped so the embed
+                     shows the LISTING rather than hopping to the folder's app
+                     entry (the same stamp the file preview's row writes). Only
+                     where this listing owns the bar: a panel pane or a snapshot
+                     is not a page of its own to open. */
+                  onOpenEmbed={
+                    ownsBarChrome
+                      ? () => {
+                          const search = location.search;
+                          const stamped = new URLSearchParams(search).has("_mode")
+                            ? search
+                            : (search ? search + "&" : "?") + "_mode=_listing";
+                          window.open(embedUrlForFsPath(fsPath, stamped), "_blank", "noopener");
+                        }
+                      : undefined
+                  }
+                  /* The folder's own actions (lib/bar-menus' folderBarMenu via
+                     `barMenu()`) — what the column header's `⋮` used to open.
+                     Rebuilt per render, which is how Paste's enabled state
+                     tracks the clipboard. Submenu rows have no home in this
+                     flat menu; the folder menu has none. */
+                  extraItems={
+                    ownsBarChrome
+                      ? barMenu().flatMap((e): OverflowEntry[] =>
+                          e === "separator"
+                            ? [e]
+                            : e.submenu
+                              ? []
+                              : [{
+                                  label: e.label,
+                                  icon: e.icon,
+                                  disabled: e.disabled,
+                                  onClick: e.onClick ?? (() => {}),
+                                }]
+                        )
+                      : undefined
+                  }
                 />
               )}
               {pane.on && !sideState.open && (
@@ -2029,9 +2020,8 @@ export default function Listing({
           >
             <table className="listing-table">
               {/* Over an empty folder the column LABELS hide (visibility, see
-                  .listing-head-empty) but the strip stays: the folder `⋮`
-                  lives on it, and an empty folder is where that menu matters
-                  most. */}
+                  .listing-head-empty); the strip itself stays so the table
+                  keeps its shape under the "Empty directory" message. */}
               <thead className={emptyDir ? "listing-head-empty" : undefined}>
                 <tr>
                   {searching ? (
@@ -2041,14 +2031,7 @@ export default function Listing({
                     // that by name or date presents it as an answer it isn't,
                     // and the search box already says the coverage is
                     // approximate (listing/index-caveat).
-                    // The folder `⋮` stays through a search: its actions act on
-                    // the CURRENT folder either way, and search replacing the
-                    // one header that carried it would make the control come
-                    // and go with the query.
-                    <th className="col-name">
-                      Path
-                      {headerMenuBtn}
-                    </th>
+                    <th className="col-name">Path</th>
                   ) : (
                     (Object.entries(SORT_KEYS) as [SortKey, string][]).map(
                       ([key, label]) => (
@@ -2064,8 +2047,7 @@ export default function Listing({
                           }}
                         >
                           {/* Wrapped so the empty-folder state can hide the
-                              LABEL without unmounting the strip — the `⋮` on
-                              this row must survive it (explorer.css,
+                              LABEL without unmounting the strip (explorer.css,
                               .listing-head-empty). */}
                           <span className="col-label">{label}</span>
                           {/* One glyph that ROTATES for desc (see .sort-arrow):
@@ -2080,7 +2062,6 @@ export default function Listing({
                               ▲
                             </span>
                           )}
-                          {key === "mtime" && headerMenuBtn}
                         </th>
                       ),
                     )

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -39,17 +39,14 @@ import { createPortal } from "react-dom";
 import {
   IS_PANEL_PANE,
   IS_SNAPSHOT,
-  encodeFsPathSegments,
   navigate,
-  navigateUrl,
   replaceSearch,
 } from "@platform/lib/router";
 import { dirname, normDir } from "@apps/explorer/lib/fs-actions";
 import { useUrlVersion } from "@platform/lib/hooks";
-import { addCurrentApp, getAppEntry } from "@platform/lib/api";
+import { getAppEntry } from "@platform/lib/api";
 import { shortSha, snapshotListing } from "@platform/lib/snapshot-param";
 import { useSnapshotForFolder } from "@apps/explorer/listing/useSnapshotForFolder";
-import { announceCurrentAppsChanged } from "@platform/lib/tasksChanged";
 import { acquireOverlay, releaseOverlay } from "@platform/lib/ui-overlay";
 import { isMod } from "@platform/lib/platform";
 import { basename, formatSize, formatMtime, formatMtimeFull } from "@platform/lib/format";
@@ -102,6 +99,10 @@ import {
   takePendingClaudeAsk,
 } from "@apps/explorer/lib/pending-claude-ask";
 import { SideToggleButton } from "@apps/explorer/SideChrome";
+import { EntryActionsMenu } from "@apps/explorer/EntryActionsMenu";
+import { McpDialog } from "@apps/explorer/McpDialog";
+import { withNoFocus } from "@platform/lib/frame-focus";
+import { unavailableReason } from "@platform/lib/mode-visibility";
 import { modeTitle } from "@platform/lib/mode-name";
 import { passedDragSlop } from "@apps/explorer/listing/marquee";
 import {
@@ -397,17 +398,39 @@ export default function Listing({
   // mode's REAL icon — lib/dir-mode keeps a denied entry for exactly that, so the
   // Git row is the Git glyph dimmed instead of a boxed "G". Nothing else reads
   // either; what the pane may BE is still `claude`/`git` alone.
+  //
+  // MCP IS NOT A PANE MODE ANY MORE: the pane's switcher is a two-tab strip over
+  // Claude and Git (SideChrome's SideTabs), and the MCP companion opens as a
+  // dialog off the search row's kebab (EntryActionsMenu → McpDialog, the same
+  // arrangement the file preview has). So `mcp` is handed to the pane machinery
+  // as "never offered, never pending" — `paneSideList` then cannot put the pane
+  // on it, and a `?_side=mcp` deep link lands on the leading companion like any
+  // other unknown value — while the `folderMcp` probe itself feeds `mcpSrc` below.
   const sideEntries = {
     claude: folderClaude.pending ? null : folderClaude.entry,
     git: folderGit.pending ? null : folderGit.entry,
-    mcp: folderMcp.pending ? null : folderMcp.entry,
+    mcp: null,
     claudePending: folderClaude.pending,
     gitPending: folderGit.pending,
-    mcpPending: folderMcp.pending,
+    mcpPending: false,
     claudeBound: folderClaude.bound,
     gitBound: folderGit.bound,
-    mcpBound: folderMcp.bound,
+    mcpBound: null,
   };
+  // The MCP dialog's document — the URL ListingPreviewPane built for the mcp
+  // pane (`_file` is the folder, `_noopen=1` so the render is not recorded as an
+  // app open), or null while the probe is out or where the folder is not an app.
+  const mcpSrc =
+    !folderMcp.pending && folderMcp.entry && folderMcp.entry.path !== null
+      ? withNoFocus(
+          `/render?path=${encodeURIComponent(folderMcp.entry.path)}` +
+            `&_file=${encodeURIComponent(fsPath)}&_noopen=1`
+        )
+      : null;
+  const [mcpOpen, setMcpOpen] = useState(false);
+  useEffect(() => {
+    setMcpOpen(false);
+  }, [fsPath]);
   const paneOpen = pane.on && sideState.open;
   // One writer for both halves of the state, and it writes the URL only where the
   // listing owns one: a frozen-tree snapshot and a panel pane are each a whole
@@ -938,27 +961,8 @@ export default function Listing({
     };
   }, [base]);
 
-  // The ONE "Open in project" click, shared by the pane strip's button and its
-  // shut-pane fallback in the bar so they can't drift. Gated on the folder
-  // having an entry page (it IS an app), it puts the folder on the sidebar's
-  // desk (POST /api/current-apps/add — a no-op when the row is already there,
-  // which then simply reads as the active row) and hops to the folder's app
-  // page, `/apps/<folder>` — spelled here rather than imported from
-  // shell/current-apps-lib's appPageUrl because an app may not import the
-  // shell (Preview.tsx's Migrate button does the same). The add is awaited
-  // and announced before the hop so the row is on top the moment the page
-  // paints; a failed add still opens the page — the desk is a convenience,
-  // the page is the point.
-  const openAppEntry = async () => {
-    if (!appEntryPath) return;
-    try {
-      await addCurrentApp(base);
-      announceCurrentAppsChanged();
-    } catch {
-      /* the page still opens; the row shows up on the next task under it */
-    }
-    navigateUrl("/apps/" + encodeFsPathSegments(base));
-  };
+  // "Open in project" itself — desk add, then `/apps/<folder>` — is
+  // EntryActionsMenu's row now, on the search row's kebab, gated on this answer.
 
   const paneSides = paneSideList(sideEntries);
   // UNDECIDED — this folder's companion probes have not answered yet (pane-side's
@@ -1954,31 +1958,33 @@ export default function Listing({
                   Here rather than in the crumb bar because over a folder THIS ROW
                   is the bar (it portals into it — search-slot.ts), and this is the
                   folder's own chrome, beside the folder's own search box. */}
-              {/* OPEN IN PROJECT, the SHUT-PANE FALLBACK. Its home is the pane's own
-                  strip, beside the chevron and the pill (ListingPreviewPane) — the
-                  button is about the pane's SUBJECT, so it belongs to the pane. With
-                  the pane shut there is no strip to live in, and this row is the
-                  folder's own chrome, so it lands here instead of vanishing with the
-                  column.
+              {/* THE KEBAB (EntryActionsMenu), the folder's app-level one-shots:
+                  App Doctor, Download app, Open as project — gated on the folder
+                  having an entry page (`appEntryPath`: it IS an app) — and MCP
+                  config, gated on the folder publishing a manifest. Whether or not
+                  the pane is open: this row is the folder's own chrome, and the
+                  pane's strip is the tab strip alone. "Open in project" used to
+                  stand here as a bordered button while the pane was shut and in the
+                  pane's strip while it was open; one kebab in one place replaces
+                  both copies. A folder that qualifies for none of the rows gets no
+                  `⋮` at all (the menu renders nothing on an empty list). Not on a
+                  snapshot or a panel pane (`paneEnabled`), where the companions are
+                  off too.
 
-                  `!paneOpen` and not `!pane.on`: a pane the user has closed
-                  (`_side=off`) is the case this exists for. When the pane is open the
-                  strip has it and a second copy here would be two buttons for one
-                  action a few pixels apart, which reads as a rendering fault.
-
-                  It hops to the folder's app page (`/apps/<folder>`) and puts the
-                  folder on the sidebar's desk on the way — `openAppEntry`, above.
-                  It used to open the entry page itself ("Open app"); the app page's
-                  Overview tab frames that page, so nothing is lost. */}
-              {!paneOpen && appEntryPath && (
-                <button
-                  type="button"
-                  className="bar-ctl bar-ctl-bordered"
-                  title={"Open " + basename(base) + " as a project"}
-                  onClick={openAppEntry}
-                >
-                  Open in project
-                </button>
+                  The entry page is what the rows act on (export's `entry_html`),
+                  with `<folder>/index.html` as a stand-in when there is none so
+                  the folder is still what the menu resolves. */}
+              {paneEnabled && (
+                <EntryActionsMenu
+                  fsPath={appEntryPath ?? fsPath + "/index.html"}
+                  isEntry={appEntryPath !== null}
+                  mcp={{
+                    available: mcpSrc !== null,
+                    pending: folderMcp.pending,
+                    reason: unavailableReason("mcp"),
+                  }}
+                  onOpenMcp={() => setMcpOpen(true)}
+                />
               )}
               {pane.on && !sideState.open && (
                 <SideToggleButton what={modeTitle(paneSide)} onClick={openSide} />
@@ -2125,8 +2131,6 @@ export default function Listing({
                   ? `${paneKey(paneSide, fsPath)}:${claudeAskInstance}`
                   : paneKey(paneSide, fsPath)}
                 undecided={paneUndecided}
-                appEntry={appEntryPath}
-                onOpenApp={openAppEntry}
                 folder={fsPath}
                 side={paneSide}
                 sideEntries={sideEntries}
@@ -2138,6 +2142,11 @@ export default function Listing({
         )}
       </div>
 
+      {/* The MCP companion's dialog, off the kebab (McpDialog). `mcpSrc` is
+          re-read here rather than trusted from the click. */}
+      {mcpOpen && mcpSrc && (
+        <McpDialog src={mcpSrc} folderName={basename(base)} onClose={() => setMcpOpen(false)} />
+      )}
       {menu && (
         <ContextMenu
           x={menu.x}

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -99,7 +99,7 @@ import {
   takePendingClaudeAsk,
 } from "@apps/explorer/lib/pending-claude-ask";
 import { SideToggleButton } from "@apps/explorer/SideChrome";
-import { EntryActionsMenu } from "@apps/explorer/EntryActionsMenu";
+import { EntryActionsMenu, canonEntryPath } from "@apps/explorer/EntryActionsMenu";
 import { McpDialog } from "@apps/explorer/McpDialog";
 import { withNoFocus } from "@platform/lib/frame-focus";
 import { unavailableReason } from "@platform/lib/mode-visibility";
@@ -1971,7 +1971,11 @@ export default function Listing({
                   the folder is still what the menu resolves. */}
               {paneEnabled && (
                 <EntryActionsMenu
-                  fsPath={appEntryPath ?? fsPath + "/index.html"}
+                  /* The server's answer is os.path.abspath — backslashes on
+                     Windows — and the menu derives the folder with a "/" split,
+                     so it goes through the same drive-letter-only normalisation
+                     the file surface applies before comparing. */
+                  fsPath={appEntryPath ? canonEntryPath(appEntryPath) : fsPath + "/index.html"}
                   isEntry={appEntryPath !== null}
                   mcp={{
                     available: mcpSrc !== null,

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -30,8 +30,7 @@ import { modeTitle } from "@platform/lib/mode-name";
 import { withNoFocus } from "@platform/lib/frame-focus";
 import { ChatFrame } from "@platform/ui/ChatFrame";
 import { usePaneFocusGuard } from "@apps/explorer/listing/usePaneFocusGuard";
-import { SideCloseButton, paneSideIcon } from "@apps/explorer/SideChrome";
-import { ModeMenu } from "@apps/explorer/BarMenu";
+import { SideCloseButton, SideTabs, paneSideIcon } from "@apps/explorer/SideChrome";
 import { paneChatOnly } from "@apps/explorer/listing/pane-modes";
 import {
   paneSideMenu,
@@ -50,8 +49,6 @@ export default function ListingPreviewPane({
   folder,
   side,
   sideEntries,
-  appEntry,
-  onOpenApp,
   onSelectSide,
   onClose,
 }: {
@@ -73,14 +70,6 @@ export default function ListingPreviewPane({
   // per selection — see the module comment.
   sideEntries: PaneSideEntries;
   onSelectSide: (side: PaneSideChoice) => void;
-  // The FOLDER's entry page (`index.html`), or null when it has none — the
-  // "Open in project" button in the strip (gates it: an app, not any folder).
-  appEntry: string | null;
-  // Opens the folder as a project (its /apps page). The caller's own
-  // navigation, for the reason the whole button lives in Listing: an EMBEDDED
-  // pane may not move the host view, and the way that stays true is that this
-  // component never navigates.
-  onOpenApp: () => void;
   // Shuts the pane (`_side=off`). The listing's search row grows the reopening
   // half of the affordance while the pane is down — SideChrome writes the split
   // between the two down.
@@ -91,22 +80,24 @@ export default function ListingPreviewPane({
   const { rootRef, guardProps } = usePaneFocusGuard<HTMLDivElement>();
 
   // --- the pane's modes (listing/pane-side.ts) --------------------------------
-  // EVERY MODE THE PANE MAY BE ON, and never fewer: an unofferable COMPANION is
-  // drawn disabled with its reason, or spinning while its probe is out
-  // (paneSideMenu), rather than dropped — a menu that shrinks to one row hides
-  // itself, which once left a mount-backed folder's pane header a lone chevron.
+  // A TAB STRIP over the two companions the pane may be on (SideChrome's
+  // SideTabs — the same control the file sidebar's header wears), and never
+  // fewer: an unofferable companion is drawn disabled with its reason, or
+  // spinning while its probe is out (paneSideMenu), rather than dropped, so a
+  // mount-backed folder's pane header still says what it cannot show.
+  //
+  // `mcp` is filtered out of the rows paneSideMenu lays: it is no longer a pane
+  // mode (Listing hands it in as never offered) but a dialog off the search
+  // row's kebab (EntryActionsMenu → McpDialog). The row stays in
+  // PANE_SIDE_COMPANIONS because the parser and the tests speak that list.
   //
   // Unlike before D460 this list HOLDS STILL as the selection moves, because
-  // nothing here ever read the selection: walking from a repository into a
-  // folder outside one still dims the Git row exactly as it always did, but no
-  // row-driven `preview` mode ever widened or narrowed the pill to make room
-  // for a fourth option.
-  const sideMenu = (
-    <ModeMenu
-      entries={paneSideMenu(sideEntries).map((e) => ({
-        ...e,
-        icon: paneSideIcon(e.mode, sideEntries),
-      }))}
+  // nothing here ever read the selection.
+  const sideTabs = (
+    <SideTabs
+      tabs={paneSideMenu(sideEntries)
+        .filter((e) => e.mode !== "mcp")
+        .map((e) => ({ ...e, icon: paneSideIcon(e.mode, sideEntries) }))}
       active={side}
       onSelect={(m) => onSelectSide(m as PaneSideChoice)}
     />
@@ -118,28 +109,15 @@ export default function ListingPreviewPane({
   // its height in every state or the seam it shares with the crumb bar on the
   // left breaks (see .pane-header).
   //
-  // It opens with the way OUT of the column and it ends with the mode pill,
+  // It opens with the way OUT of the column and it ends with the tab strip,
   // which is the file sidebar's header exactly (SideChrome, PreviewSidebar) —
   // the two columns are the same column over a folder and over a file, so they
-  // wear the same bar. "Open in project" rides in here too, ahead of the pill, in
-  // every state including the skeleton — the subject (the open folder) is
-  // known long before the pane has resolved what to show about it.
+  // wear the same bar. "Open in project" no longer rides in here: it is a row of
+  // the search row's kebab, which is there whether or not this column is.
   const strip = () => (
     <div className="pane-header">
       <SideCloseButton what={modeTitle(side)} onClick={onClose} />
-      <div className="side-header-tail">
-        {appEntry && (
-          <button
-            type="button"
-            className="bar-ctl bar-ctl-bordered"
-            title={"Open " + folder.slice(folder.lastIndexOf("/") + 1) + " as a project"}
-            onClick={onOpenApp}
-          >
-            Open in project
-          </button>
-        )}
-        {sideMenu}
-      </div>
+      <div className="side-header-tail">{sideTabs}</div>
     </div>
   );
 

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -1,6 +1,7 @@
 // Right-hand preview pane for the directory listing (views/Listing.tsx): the
-// OPEN FOLDER's companions — `claude` (chat about the folder), `git` (its
-// working tree) and `mcp` (its MCP tools) — never the selection.
+// OPEN FOLDER's companions — `claude` (chat about the folder) and `git` (its
+// working tree) — never the selection. (`mcp`, its MCP tools, is a dialog off the
+// search row's kebab rather than a pane mode.)
 // listing/pane-side.ts owns the list and the `_side` param that records which.
 //
 // **THE PANE NO LONGER FOLLOWS THE SELECTION AT ALL** (D460, superseding
@@ -86,18 +87,17 @@ export default function ListingPreviewPane({
   // spinning while its probe is out (paneSideMenu), rather than dropped, so a
   // mount-backed folder's pane header still says what it cannot show.
   //
-  // `mcp` is filtered out of the rows paneSideMenu lays: it is no longer a pane
-  // mode (Listing hands it in as never offered) but a dialog off the search
-  // row's kebab (EntryActionsMenu → McpDialog). The row stays in
-  // PANE_SIDE_COMPANIONS because the parser and the tests speak that list.
+  // (`mcp` is not a pane mode — PANE_SIDE_COMPANIONS is the pair — but a dialog
+  // off the search row's kebab, EntryActionsMenu → McpDialog.)
   //
   // Unlike before D460 this list HOLDS STILL as the selection moves, because
   // nothing here ever read the selection.
   const sideTabs = (
     <SideTabs
-      tabs={paneSideMenu(sideEntries)
-        .filter((e) => e.mode !== "mcp")
-        .map((e) => ({ ...e, icon: paneSideIcon(e.mode, sideEntries) }))}
+      tabs={paneSideMenu(sideEntries).map((e) => ({
+        ...e,
+        icon: paneSideIcon(e.mode, sideEntries),
+      }))}
       active={side}
       onSelect={(m) => onSelectSide(m as PaneSideChoice)}
     />

--- a/frontend/src/apps/explorer/McpDialog.tsx
+++ b/frontend/src/apps/explorer/McpDialog.tsx
@@ -1,0 +1,78 @@
+// THE MCP COMPANION AS A DIALOG. `mcp` (the folder's MCP manifest and tools,
+// templates/mcp) was the third companion in the file preview's sidebar beside
+// Claude and Git. It left that column when the column's switcher became a tab
+// strip (SideChrome's SideTabs): two tabs read at a glance, three start to crowd
+// a column that is often 380px wide, and of the three MCP is the one you CONFIGURE
+// rather than work alongside — you set the manifest up, you check what it
+// publishes, you leave. That is a dialog's shape, and it is the shape App Doctor
+// already has on the same kebab (EntryActionsMenu), so the two app-level tools
+// open the same way from the same menu.
+//
+// The content is the same document the sidebar framed: the template rendered
+// through /render with `_file` aimed at the FOLDER (the manifest covers the app,
+// not the previewed page — lib/dir-mode's whole argument). Preview.tsx builds the
+// `src` because it owns the URL shape (`_noopen`, thumb flags); this component
+// is the box. A plain iframe, not ChatFrame: only the chat template stamps
+// `data-chat-ready`, and a cover revealed by the 8s fallback would be a new wait.
+//
+// The folder listing's pane still lists MCP as a pane mode — that surface kept
+// its dropdown and its three companions — so the template is framed two ways.
+import { X } from "lucide-react";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@platform/shadcn/ui/dialog";
+import { Button } from "@platform/shadcn/ui/button";
+
+export function McpDialog({
+  src,
+  folderName,
+  onClose,
+}: {
+  // The mcp template's /render URL, aimed at the app folder.
+  src: string;
+  folderName: string;
+  onClose: () => void;
+}) {
+  return (
+    // Always open while mounted: the caller renders this behind `{open && …}`,
+    // exactly as AppDoctorModal is, so the only close it can report is the user's.
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent
+        // An explicit height, or the iframe (a replaced element with no intrinsic
+        // size) collapses the grid row it sits in to nothing.
+        className="grid-rows-[auto_minmax(0,1fr)] gap-3 overflow-hidden p-4 sm:max-w-[760px] h-[80vh]"
+        showCloseButton={false}
+      >
+        <DialogHeader className="gap-1">
+          <div className="flex items-start justify-between gap-2">
+            <DialogTitle className="font-semibold">MCP config</DialogTitle>
+            <DialogClose render={<Button variant="ghost" size="icon-sm" className="-mt-1 -mr-1" />}>
+              <X />
+              <span className="sr-only">Close</span>
+            </DialogClose>
+          </div>
+          <DialogDescription>
+            The MCP tools {folderName} publishes, and how a client connects to them.
+          </DialogDescription>
+        </DialogHeader>
+        <iframe
+          className="mcp-dialog-frame"
+          src={src}
+          title="MCP"
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default McpDialog;

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -1840,10 +1840,15 @@ function TemplatePreview({
           init (router.ts), so it is a new document either way, and the old
           button's `location.assign` left this tab with no way back but
           EmbedStrip's "Open in explorer". The explorer stays put now; the
-          embed's strip still carries the query back for anyone who wants it. */}
-      {!stat.is_dir && (
-        <EntryActionsMenu
+          embed's strip still carries the query back for anyone who wants it.
+
+          Over a DIRECTORY previewed by this view (a folder opened in one of its
+          non-listing modes) the kebab carries that one row alone: `isEntry`
+          is answered `false` up front — the folder is not a page — so none of
+          the app rows are asked for, and nothing probes the parent for MCP. */}
+      <EntryActionsMenu
           fsPath={fsPath}
+          isEntry={stat.is_dir ? false : undefined}
           snapshotSha={snapshotSha}
           snapshotResolved={snapshotResolved}
           snapshotPending={snapshotPending}
@@ -1873,7 +1878,6 @@ function TemplatePreview({
           }
           onOpenMcp={() => setMcpOpen(true)}
         />
-      )}
       {/* The sidebar's OPENER, LAST in the bar — the shared control (SideChrome),
           which is where the "one affordance, two places, chosen by state" split
           between this button and the column's own close button is written down,

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -733,17 +733,19 @@ function TemplatePreview({
   const splitCapable = !!actionsInTopbar && !stat.is_dir && !IS_EMBED;
   const parts = partitionModes(templates);
 
-  // --- the BORROWED companions: `git` and `mcp`, from this file's parent folder -
+  // --- the BORROWED companion `git`, and the parent's `mcp`, from this file's parent folder -
   // A working tree belongs to the FOLDER (templates/git/condition.py), and so does
   // an app's MCP manifest (templates/mcp/condition.py), so the registry keeps both
   // on the universal "/" key alone and this file's own template list will never
   // carry either. "What has changed in here" and "what tools does this app
-  // publish" are worth just as much while reading one of its files, so the sidebar
+  // publish" are worth just as much while reading one of its files, so this view
   // asks the PARENT DIRECTORY for its entries through the ordinary stat +
   // condition machinery every mode surface uses (lib/dir-mode — which is also
   // where the caching lives, so walking a folder file by file costs one probe per
   // mode rather than one per file). A parent outside a repository, or one that is
   // not an app, or one on a mount, denies the gate and there is simply no pill.
+  // Only `git` is a SIDEBAR companion; the `mcp` probe feeds the crumb bar's
+  // kebab and its dialog instead (`mcpSrc`, below).
   //
   // Unless the file HAS one of its own: a user registry may bind either mode to a
   // file extension, and then the entry is the file's, aimed at the file, and there
@@ -1871,11 +1873,18 @@ function TemplatePreview({
               : (search ? search + "&" : "?") + "_mode=" + encodeURIComponent(entry.mode);
             window.open(embedUrlForFsPath(fsPath, stamped), "_blank", "noopener");
           }}
-          mcp={{
-            available: mcpSrc !== null,
-            pending: !parts.sidebar.some((e) => e.mode === "mcp") && parentMcp.pending,
-            reason: unavailableReason("mcp"),
-          }}
+          /* No MCP row on a surface that never probed the parent (a panel/tab
+             pane): the prop's own comment says why silence beats a wrong
+             reason there. */
+          mcp={
+            splitCapable
+              ? {
+                  available: mcpSrc !== null,
+                  pending: !parts.sidebar.some((e) => e.mode === "mcp") && parentMcp.pending,
+                  reason: unavailableReason("mcp"),
+                }
+              : undefined
+          }
           onOpenMcp={() => setMcpOpen(true)}
         />
       )}

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -6,7 +6,6 @@
 import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
-  addCurrentApp,
   getAppEntry,
   setAppPreview,
   getAppFileCloneTarget,
@@ -24,12 +23,8 @@ import {
   getGitSnapshot,
 } from "@platform/lib/api";
 import type { StatResult, TemplateEntry, RegistryEntryForPath } from "@platform/lib/api";
-import { captureAppPreview, cropRect, exportAppFile } from "@platform/lib/appShot";
-import { AppDoctorModal } from "@platform/ui/AppDoctorModal";
-import { AppDoctorStatusDot } from "@platform/ui/AppDoctorStatusDot";
-import { useAppDoctorChecks } from "@platform/ui/useAppDoctorChecks";
-import { announceCurrentAppsChanged } from "@platform/lib/tasksChanged";
-import { navigate, navigateUrl, urlForFsPath, viewUrlForFsPath, embedUrlForFsPath, replaceSearch, encodeFsPathSegments, IS_EMBED, IS_FOREIGN_EMBED, IS_PREVIEW } from "@platform/lib/router";
+import { captureAppPreview, cropRect } from "@platform/lib/appShot";
+import { navigate, navigateUrl, urlForFsPath, viewUrlForFsPath, embedUrlForFsPath, replaceSearch, IS_EMBED, IS_FOREIGN_EMBED, IS_PREVIEW } from "@platform/lib/router";
 import { useUrlVersion } from "@platform/lib/hooks";
 import { formatSize, formatMtimeFull, basename } from "@platform/lib/format";
 import {
@@ -57,6 +52,7 @@ import {
   isModePending,
   isSidebarMode,
   partitionModes,
+  unavailableReason,
   visibleModes,
   defaultMode,
   effectiveActive,
@@ -85,13 +81,13 @@ import {
   setResolvedSnapshot,
   shortSha,
   snapshotFrameSrc,
-  type ResolvedSnapshot,
 } from "@platform/lib/snapshot-param";
 import { disarmSidebarOnFailedSelect } from "@apps/explorer/lib/snapshot-clear";
 import { usePreviewSnapshot } from "@apps/explorer/lib/usePreviewSnapshot";
-import { useAppVersionLabel } from "@platform/lib/appVersionLabel";
 import { ModeMenu } from "@apps/explorer/BarMenu";
 import { SideReopenEdge, SideToggleButton } from "@apps/explorer/SideChrome";
+import { EntryActionsMenu } from "@apps/explorer/EntryActionsMenu";
+import { McpDialog } from "@apps/explorer/McpDialog";
 import PreviewSidebar from "@apps/explorer/PreviewSidebar";
 import { subscribePreviewSideSlot, previewSideSlot } from "@apps/explorer/preview-side-slot";
 import { subscribeTopbarSlot, topbarSlot } from "@apps/explorer/topbar-slot";
@@ -187,7 +183,7 @@ function usePreviewSideSlot(): HTMLElement | null {
 // which is why this probes on mount and re-probes per file rather than trusting
 // anything cached.
 //
-// Lives in the header, like ExportAppButton beside it — which embed mode
+// Lives in the header, like the kebab (EntryActionsMenu) beside it — which embed mode
 // hides, so a `.fused` opened by double-click used to show no Clone at all
 // (D390's chrome-free posture, accepted in D397). The top-level embed's
 // EmbedStrip now renders this same button (one control, one label rule) with
@@ -264,235 +260,6 @@ export function CloneAppFileButton({ fsPath, toView }: { fsPath: string; toView?
         MenuIcons.duplicate
       )}
       {busy ? "Cloning…" : target.cloned ? "Go to local version" : "Clone"}
-    </button>
-  );
-}
-
-// The App Doctor button, on the explorer topbar: shown whenever the previewed
-// page IS its folder's app entry (the server's own entry rule, asked of
-// /api/apps/entry — same gate as ExportAppButton beside it, same reason: the
-// filename says nothing). One click opens the checklist dialog, which runs the
-// deterministic checks and offers the one task that explains and fixes them
-// (platform/ui/AppDoctorModal).
-//
-// It REPLACES the "Migrate to new version" button that stood here: a stale
-// `fused-api-version` tag is one row of that checklist now, alongside the
-// things it never covered — a leaked key, a device path, stray generated
-// files, an uncommitted tree. That is also why the gate widened: migrate had
-// nothing to say about an app that was already current, and the doctor does.
-function AppDoctorButton({ fsPath }: { fsPath: string }) {
-  const [isEntry, setIsEntry] = useState(false);
-  const [open, setOpen] = useState(false);
-  const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
-  const dir = fsPath.slice(0, fsPath.lastIndexOf("/")) || "/";
-  useEffect(() => {
-    let alive = true;
-    setIsEntry(false);
-    setOpen(false);
-    getAppEntry(dir)
-      .then((r) => {
-        if (!alive) return;
-        setIsEntry(r.entry != null && canon(r.entry) === fsPath);
-      })
-      .catch(() => {
-        /* indeterminate reads as "not an entry" — no button for nothing */
-      });
-    return () => {
-      alive = false;
-    };
-  }, [fsPath, dir]);
-  // Fetched after first paint, never blocking it — see useAppDoctorChecks.
-  // Opening the modal re-fetches its own copy; this one is only for the
-  // header dot and is never reused to seed the dialog.
-  const doctorChecks = useAppDoctorChecks(isEntry ? dir : null);
-  if (!isEntry) return null;
-  return (
-    <>
-      <button
-        type="button"
-        className="bar-ctl bar-ctl-bordered"
-        title={
-          "Check " + basename(dir) +
-          " before you share it: leaked credentials, paths tied to this machine, " +
-          "stray generated files, uncommitted work, a stale fused API version"
-        }
-        onClick={() => setOpen(true)}
-      >
-        App Doctor
-        <AppDoctorStatusDot checks={doctorChecks} />
-      </button>
-      {open && <AppDoctorModal dir={dir} onClose={() => setOpen(false)} />}
-    </>
-  );
-}
-
-// The explorer folder view's "Open in project" (Listing.tsx openAppEntry),
-// here on the ENTRY PAGE's own header: viewing an app's index.html is the
-// other place one is standing in an app, so the same hop is offered — put the
-// folder on the sidebar's desk (POST /api/current-apps/add, a no-op when the
-// row is there already, which then reads as the active row) and open the
-// folder's app page, `/apps/<folder>`, spelled as the Migrate button spells it
-// since an app may not import shell/current-apps-lib. Same gate as
-// ExportAppButton beside it: the server's entry rule, never the filename.
-function OpenInProjectButton({ fsPath }: { fsPath: string }) {
-  const [isEntry, setIsEntry] = useState(false);
-  const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
-  const dir = fsPath.slice(0, fsPath.lastIndexOf("/")) || "/";
-  useEffect(() => {
-    let alive = true;
-    setIsEntry(false);
-    getAppEntry(dir)
-      .then((r) => {
-        if (alive) setIsEntry(r.entry != null && canon(r.entry) === fsPath);
-      })
-      .catch(() => {
-        /* indeterminate reads as "not an entry" — no button for nothing */
-      });
-    return () => {
-      alive = false;
-    };
-  }, [fsPath, dir]);
-  if (!isEntry) return null;
-  const open = async () => {
-    try {
-      await addCurrentApp(dir);
-      announceCurrentAppsChanged();
-    } catch {
-      /* the page still opens; the row shows up on the next task under it */
-    }
-    navigateUrl("/apps/" + encodeFsPathSegments(dir));
-  };
-  return (
-    <button
-      type="button"
-      className="bar-ctl bar-ctl-bordered"
-      title={"Open " + basename(dir) + " as a project"}
-      onClick={open}
-    >
-      Open in project
-    </button>
-  );
-}
-
-// Export the containing app as a .fused file (SPEC §43 AF-4), shown only when
-// the previewed page IS its folder's app entry — asked of the server (the one
-// shared entry rule, /api/apps/entry) rather than guessed from the filename.
-// You export from the app you're looking at; a plain html file gets nothing.
-function ExportAppButton({
-  fsPath,
-  snapshotSha,
-  snapshotResolved,
-  snapshotPending,
-  snapshotError,
-}: {
-  fsPath: string;
-  // The pane's own `_snapshot` resolution (`usePreviewSnapshot`, hoisted in
-  // the parent so the picker and this button agree on what "the previewed
-  // version" means) — mirrors AppPage.tsx's `snapshot` (`useAppPageSnapshot`)
-  // and its Export control's use of it, point for point: export the
-  // snapshot's OWN extracted tree, never the live folder, while one is
-  // previewed.
-  snapshotSha: string | null;
-  snapshotResolved: ResolvedSnapshot | null;
-  snapshotPending: boolean;
-  snapshotError: boolean;
-}) {
-  const [isEntry, setIsEntry] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const dir = fsPath.slice(0, fsPath.lastIndexOf("/")) || "/";
-  const name = basename(dir);
-  // Rules-of-hooks: called on every render, before the `!isEntry` early
-  // return below, exactly like every other hook in this component.
-  const versionLabel = useAppVersionLabel(dir, snapshotSha);
-  // The server answers os.path.abspath (backslashes on Windows) while fsPath
-  // is the shell's canonical forward-slash form — same drive-letter-only
-  // normalization rule as the URL codec (a backslash in a POSIX filename must
-  // not be rewritten).
-  const canon = (p: string) => (/^[A-Za-z]:[\\/]/.test(p) ? p.replace(/\\/g, "/") : p);
-  useEffect(() => {
-    let alive = true;
-    setIsEntry(false);
-    getAppEntry(dir)
-      .then((r) => {
-        if (alive) setIsEntry(r.entry != null && canon(r.entry) === fsPath);
-      })
-      .catch(() => {
-        /* indeterminate reads as "not an entry" — no button for nothing */
-      });
-    return () => {
-      alive = false;
-    };
-  }, [fsPath]);
-  if (!isEntry) return null;
-  // Mirrors AppPage.tsx's `exportDisabled`: a click landing mid-resolve, before
-  // `snapshotResolved.dir` exists, must not fall through to exporting the LIVE
-  // folder while the pane still shows the version being resolved.
-  const exportDisabled = busy || snapshotPending || snapshotError;
-  const doExport = async () => {
-    if (exportDisabled) return;
-    setBusy(true);
-    try {
-      const isLive = snapshotSha === null;
-      // The snapshot's OWN extracted tree (`snap.dir`), never `snap.app_dir`
-      // (the LIVE folder the sha resolved from) — exporting that would
-      // silently ship the live app labelled as the picked commit. See
-      // AppPage.tsx's Export control, which this mirrors.
-      const exportPath = snapshotResolved ? snapshotResolved.dir : dir;
-      // The filename carries the version so a v7 export sitting beside a
-      // live export in Downloads is never ambiguous about which is which.
-      const exportName = isLive ? name : `${name}-${versionLabel}`;
-      // Same capture-on-export as the /apps card (appShot, D396): the shown
-      // preview frame IS the app rendering, so it is the crop source — no
-      // navigation, no flash. exportAppFile itself skips capture when the
-      // folder carries an authored preview.png; the probe below is only so a
-      // pointless native shot (and, on a Mac that has not granted Screen
-      // Recording, its permission dialog) isn't taken for a capture the
-      // server would discard anyway (stat failure reads as "no authored
-      // still" — worst case is that redundant shot, never a lost export).
-      //
-      // `.is-shown` satisfies appShot's crop-source contract (pixels that ARE
-      // the app, not a box it may fill): the class rides `shown`, which the
-      // frame swap only sets once that frame paints — the same guarantee
-      // `data-fused-annotate-target` below relies on. Only checked for a LIVE
-      // export: a snapshot's preview.png (if any) lives under the extracted
-      // tree, and `entry_html` is omitted below for a snapshot anyway, so
-      // there is no on-screen capture source for it to matter.
-      const authored = isLive
-        ? await statPath(dir + "/preview.png").then(
-            (s) => !s.is_dir,
-            () => false,
-          )
-        : false;
-      await exportAppFile(
-        {
-          path: exportPath,
-          name: exportName,
-          // Omitted for a snapshot export: with no on-screen capture element
-          // threaded to this button's target folder, `exportAppFile`'s stage
-          // fallback would reload the ENTRY PAGE'S LIVE copy to shoot it — a
-          // present-day screenshot baked into a file labelled as the old
-          // commit. See AppPage.tsx's Export control for the same rule.
-          entry_html: isLive ? fsPath : undefined,
-          preview_image: isLive && authored ? dir + "/preview.png" : null,
-        },
-        isLive ? document.querySelector(".preview-frame.is-shown") : null,
-      );
-    } catch (e) {
-      pushToast({ msg: "Could not export " + name + ": " + (e as Error).message, tone: "error" });
-    } finally {
-      setBusy(false);
-    }
-  };
-  return (
-    <button
-      type="button"
-      className="bar-ctl bar-ctl-bordered"
-      title={"Export " + name + " as a single .fused app file"}
-      onClick={doExport}
-      disabled={exportDisabled}
-    >
-      {busy && <span className="mode-icon-spinner" />}
-      {busy ? "Exporting…" : "Export App"}
     </button>
   );
 }
@@ -687,7 +454,7 @@ function usePreviewFileMenu(
   };
 
   // IS THIS FILE AN APP'S FACE? The one shared entry rule, asked of the server
-  // (/api/apps/entry) exactly as ExportAppButton asks it — under the marker
+  // (/api/apps/entry) exactly as EntryActionsMenu asks it — under the marker
   // rule a filename says nothing. Only an entry gets "Set Current View as
   // Preview": a preview.png beside a plain html file has no card to show it.
   const [isAppEntry, setIsAppEntry] = useState(false);
@@ -986,17 +753,23 @@ function TemplatePreview({
   const ownMcp = parts.sidebar.some((e) => e.mode === "mcp");
   const parentGit = useDirMode(splitCapable && !ownGit ? parentDir : null, "git");
   const parentMcp = useDirMode(splitCapable && !ownMcp ? parentDir : null, "mcp");
-  // One list, because `sideSplit` ranks the assembled set and the probes are
-  // independent — which is also why the pending half names MODES rather than
-  // being a flag: `git` answering before `mcp` is ordinary.
-  const borrowedEntries = [
-    !ownGit ? parentGit.entry : null,
-    !ownMcp ? parentMcp.entry : null,
-  ].filter((e): e is TemplateEntry => !!e);
-  const borrowedPendingModes = [
-    ...(!ownGit && parentGit.pending ? ["git"] : []),
-    ...(!ownMcp && parentMcp.pending ? ["mcp"] : []),
-  ];
+  // MCP IS NOT A SIDEBAR COMPANION ANY MORE — the column holds Claude and Git as
+  // two tabs (SideChrome's SideTabs), and MCP opens as a dialog off the crumb
+  // bar's kebab (EntryActionsMenu → McpDialog; the argument is on McpDialog).
+  // So the `mcp` entry — the parent's, or the file's own if a registry bound it
+  // there — is kept OUT of everything `sideSplit` sees (`own`, `borrowed`,
+  // `bound`) and out of the switcher's rows, and is read only by `mcpSrc` below.
+  // The parent probe stays: it is what tells the kebab's row whether there is an
+  // MCP manifest to show. A `?_side=mcp` deep link now resolves to the default
+  // companion, which is the same thing an unknown `_side` always did.
+  //
+  // One list still, because `sideSplit` ranks the assembled set; the pending
+  // half names MODES rather than being a flag for the same reason it did when
+  // two probes fed it.
+  const borrowedEntries = [!ownGit ? parentGit.entry : null].filter(
+    (e): e is TemplateEntry => !!e
+  );
+  const borrowedPendingModes = [...(!ownGit && parentGit.pending ? ["git"] : [])];
   // Is THIS mode one the sidebar took from the parent? Asked in three places
   // downstream (the pending predicate, the iframe's target, the `_remote` flag),
   // and a predicate rather than three `m === "git" && !ownGit` because a file that
@@ -1024,7 +797,7 @@ function TemplatePreview({
   const split = sideSplit({
     splitCapable,
     content: parts.content,
-    own: parts.sidebar,
+    own: parts.sidebar.filter((e) => e.mode !== "mcp"),
     borrowed: borrowedEntries,
     borrowedPending: borrowedPendingModes,
     // This file's own gates, for `defaultSide` alone: an absent `_side` must not
@@ -1033,9 +806,8 @@ function TemplatePreview({
     // mount-backed file the answer is no (lib/preview-side's `defaultSide`).
     conditionsPending: conditions === null,
     bound: [
-      ...partitionModes(stat.templates).sidebar,
+      ...partitionModes(stat.templates).sidebar.filter((e) => e.mode !== "mcp"),
       ...(parentGit.bound ? [parentGit.bound] : []),
-      ...(parentMcp.bound ? [parentMcp.bound] : []),
     ],
   });
   const sideOn = split.on;
@@ -1053,7 +825,11 @@ function TemplatePreview({
   // every decision below (`sideEntry`, `activeSide`, the toggle, the reconcile)
   // reads the short list, so a disabled row can be rendered without becoming
   // something the URL or the split can land on.
-  const sidebarMenu = split.offered ? split.menu : [];
+  // Minus the `mcp` row `sidebarMenu` (lib/preview-side) still lays for every
+  // SIDEBAR_MODES member: that constant is shared with the folder pane, where MCP
+  // is still a pane mode, so the file sidebar drops the row here rather than
+  // there.
+  const sidebarMenu = split.offered ? split.menu.filter((e) => e.mode !== "mcp") : [];
   // Pending, for a SIDEBAR entry. A borrowed entry is gated on the PARENT's
   // verdicts, resolved by lib/dir-mode — not on any of this file's, so it cannot
   // go through `isPending` (which reads `conditions`, this file's map, and would
@@ -1151,6 +927,14 @@ function TemplatePreview({
   useEffect(() => {
     if (activeSide) setLastSide(activeSide);
   }, [activeSide]);
+  // The MCP dialog (McpDialog), opened from the kebab's row or from Open With →
+  // MCP. State here rather than in the kebab because Open With (`openMode`) has
+  // to reach it. Shut on every file hop: the dialog is about ONE folder's
+  // manifest, and a hop may leave the folder.
+  const [mcpOpen, setMcpOpen] = useState(false);
+  useEffect(() => {
+    setMcpOpen(false);
+  }, [fsPath]);
   // What the toggle acts on, and so what it looks like (lib/preview-side). Over
   // the SETTLED companions only: a placeholder whose probe may yet say "no
   // repository here" must not put a button in the bar for the length of that
@@ -1830,6 +1614,19 @@ function TemplatePreview({
       `&_file=${encodeURIComponent(target)}${rem}${chatOnly}${thumbFlags}`
     );
   };
+  // The MCP dialog's document: the same URL shape `sideSrcFor` builds, for the
+  // one companion that is no longer in `sidebarModes` (see the borrowed-entries
+  // comment). The file's own `mcp` binding wins over the parent's, as it did in
+  // the sidebar; `null` while the parent's probe is out or when nothing offers
+  // the mode, which is what the kebab's row reads to disable itself.
+  const mcpEntry =
+    parts.sidebar.find((e) => e.mode === "mcp") ?? (parentMcp.pending ? null : parentMcp.entry);
+  const mcpSrc =
+    mcpEntry && mcpEntry.path !== null
+      ? `/render?path=${encodeURIComponent(mcpEntry.path)}` +
+        `&_file=${encodeURIComponent(isBorrowedMode("mcp") ? parentDir : fsPath)}` +
+        `${isBorrowedMode("mcp") ? "" : remote}${thumbFlags}`
+      : null;
   // The claude iframe's REMOUNT key, distinct from the mode name `active`
   // everything else keys off of (the switcher's highlighted row, the title).
   // Ordinarily the mode alone is the right key — switching to a DIFFERENT
@@ -1958,8 +1755,14 @@ function TemplatePreview({
   // the menu's. On a splitting surface that request opens the sidebar instead of
   // replacing the content pane, which is the same answer the mode partition
   // gives everywhere else.
+  //
+  // MCP is the one companion with a third home: "Open With → MCP" opens the
+  // dialog (McpDialog) the kebab's row opens, since the sidebar no longer lists
+  // it. Only when there is a manifest to show; otherwise the request falls
+  // through to the content pane as any unsplit surface would take it.
   const openMode = (m: string) => {
-    if (sideOn && isSidebarMode(m)) setSide(m);
+    if (m === "mcp" && mcpSrc) setMcpOpen(true);
+    else if (sideOn && isSidebarMode(m)) setSide(m);
     else void setMode(m);
   };
   const loadOpenWith = () => Promise.resolve(buildOpenWithItems(templates, openMode));
@@ -1980,28 +1783,11 @@ function TemplatePreview({
       {!stat.is_dir && fsPath.toLowerCase().endsWith(".fused") && (
         <CloneAppFileButton fsPath={fsPath} />
       )}
-      {/* The containing app as one .fused file (SPEC §43 AF-4) — rendered only
-          when this page is its folder's app entry (the component asks the
-          server). Embed mode hides the whole header/topbar, so an opened
-          .fused app never shows it. */}
-      {!stat.is_dir && <AppDoctorButton fsPath={fsPath} />}
-      {!stat.is_dir && (
-        <ExportAppButton
-          fsPath={fsPath}
-          snapshotSha={snapshotSha}
-          snapshotResolved={snapshotResolved}
-          snapshotPending={snapshotPending}
-          snapshotError={snapshotError}
-        />
-      )}
-      {/* The folder view's "Open in project", offered on the app's entry page
-          too (same server-side entry gate), wearing the same bordered look as
-          Export App. Its HOME is the sidebar's header, right before the mode
-          pill — exactly where the folder pane's strip puts it — so the two
-          views agree on where the hop lives. This copy is the SHUT-SIDEBAR
-          fallback (`!activeSide`, Listing's `!paneOpen` rule): with the column
-          down there is no strip, and the button must not vanish with it. */}
-      {!stat.is_dir && !activeSide && <OpenInProjectButton fsPath={fsPath} />}
+      {/* The app-level actions — App Doctor, Download app (the .fused export,
+          SPEC §43 AF-4), Open as project, Open in embed, MCP config — are the
+          kebab AFTER the mode control (EntryActionsMenu, below). They stood here
+          as bordered buttons of their own for a while; the argument for the
+          menu is on that component. */}
       {/* One mode control per view, and for an explorer FOLDER it is the
           preview pane's, not this one. The pane header carries a ModeMenu of
           its own beside the previewed row (ListingPreviewPane), so a folder
@@ -2057,54 +1843,58 @@ function TemplatePreview({
           onSelect={setMode}
         />
       )}
-      {/* The sidebar's OPENER, immediately right of the mode control it
-          partitions with — the shared control (SideChrome), which is where the
-          "one affordance, two places, chosen by state" split between this button
-          and the column's own close chevron is written down. It renders only
-          while the column is SHUT, and it wears the COMPANION'S OWN ICON, so a
-          closed sidebar that last showed Git shows the Git glyph.
+      {/* THE KEBAB (EntryActionsMenu): the app-level one-shots, and the
+          fullscreen glyph that stood here as its "Open in embed" row. That row
+          opens this same page under the chrome-free embed prefix — no sidebar,
+          no crumb, no header — with the current query carried over and `_mode`
+          stamped explicitly even when the view is on its default (the URL omits
+          it then). In a NEW TAB: the view/embed prefix is read once at module
+          init (router.ts), so it is a new document either way, and the old
+          button's `location.assign` left this tab with no way back but
+          EmbedStrip's "Open in explorer". The explorer stays put now; the
+          embed's strip still carries the query back for anyone who wants it. */}
+      {!stat.is_dir && (
+        <EntryActionsMenu
+          fsPath={fsPath}
+          snapshotSha={snapshotSha}
+          snapshotResolved={snapshotResolved}
+          snapshotPending={snapshotPending}
+          snapshotError={snapshotError}
+          onOpenEmbed={() => {
+            // The existing query goes across BYTE FOR BYTE — no URLSearchParams
+            // round trip, which would re-encode every value on the way. Only the
+            // `_mode` stamp is appended, and only when the URL omits it (the
+            // default mode; setMode deletes the param for clean URLs).
+            const search = location.search;
+            const stamped = new URLSearchParams(search).has("_mode")
+              ? search
+              : (search ? search + "&" : "?") + "_mode=" + encodeURIComponent(entry.mode);
+            window.open(embedUrlForFsPath(fsPath, stamped), "_blank", "noopener");
+          }}
+          mcp={{
+            available: mcpSrc !== null,
+            pending: !parts.sidebar.some((e) => e.mode === "mcp") && parentMcp.pending,
+            reason: unavailableReason("mcp"),
+          }}
+          onOpenMcp={() => setMcpOpen(true)}
+        />
+      )}
+      {/* The sidebar's OPENER, LAST in the bar — the shared control (SideChrome),
+          which is where the "one affordance, two places, chosen by state" split
+          between this button and the column's own close button is written down,
+          and why the two wear one panel glyph. It renders only while the column
+          is SHUT; the tooltip names the companion it would reopen (the last one
+          open on this file).
+
+          Rightmost on purpose: it is the control for the right-hand column, so it
+          sits on the window's right edge, where that column appears.
 
           Absent entirely when this file has no companion at all (no `claude`, no
           `git` in the parent, or a gate denied them): a control for
           nothing is worse than no control. */}
       {sideTargetEntry && !activeSide && (
-        <SideToggleButton
-          what={modeTitle(sideTargetEntry.mode)}
-          icon={templateModeIcon(sideTargetEntry)}
-          onClick={toggleSide}
-        />
+        <SideToggleButton what={modeTitle(sideTargetEntry.mode)} onClick={toggleSide} />
       )}
-      {/* Fullscreen: this same page under the chrome-free embed prefix — no
-          sidebar, no crumb, no header — with the current query carried over,
-          and `_mode` stamped explicitly even when the view is on its default
-          (the URL omits it then). A FULL page load rather than `navigate`:
-          the view/embed prefix is read once at module init (router.ts), so
-          switching it is a new document. The way back is EmbedStrip's "Open
-          in explorer", which the top-level embed shows: it carries the query
-          back, and reads the `_mode` stamp as "return to THIS page" rather
-          than hopping a folder to its app entry. */}
-      <button
-        type="button"
-        className="bar-ctl bar-ctl-icon"
-        title="Open fullscreen, without the sidebar and toolbar"
-        aria-label="Open fullscreen, without the sidebar and toolbar"
-        onClick={() => {
-          // The existing query goes across BYTE FOR BYTE — no URLSearchParams
-          // round trip, which would re-encode every value on the way. Only the
-          // `_mode` stamp is appended, and only when the URL omits it (the
-          // default mode; setMode deletes the param for clean URLs).
-          const search = location.search;
-          const stamped = new URLSearchParams(search).has("_mode")
-            ? search
-            : (search ? search + "&" : "?") + "_mode=" + encodeURIComponent(entry.mode);
-          location.assign(embedUrlForFsPath(fsPath, stamped));
-        }}
-      >
-        <span className="mode-menu-icon">{MenuIcons.fullscreen}</span>
-      </button>
-      {/* The app view's overflow lived here — one "Open in explorer" entry,
-          jumping from the app's own route back to the folder. The route went
-          with D262 and the app view itself with D264. */}
     </>
   );
 
@@ -2371,10 +2161,15 @@ function TemplatePreview({
             src={sideEntry && isSidePending(sideEntry) ? null : sideSrcFor(activeSide)}
             onSelect={setSide}
             onClose={() => setSide(null)}
-            lead={<OpenInProjectButton fsPath={fsPath} />}
           />,
           sideSlot
         )}
+      {/* The MCP companion's dialog — the kebab's row and Open With → MCP both
+          open it (McpDialog). `mcpSrc` is re-checked here rather than trusted
+          from the click: the parent's verdict can change under an open dialog. */}
+      {mcpOpen && mcpSrc && (
+        <McpDialog src={mcpSrc} folderName={basename(parentDir)} onClose={() => setMcpOpen(false)} />
+      )}
       {/* And when it is SHUT, the seam it left behind, into the same slot: drag
           the split's right edge to pull the column back (SideChrome's
           SideReopenEdge, which argues why a gesture is allowed here when a second

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -1842,11 +1842,15 @@ function TemplatePreview({
           EmbedStrip's "Open in explorer". The explorer stays put now; the
           embed's strip still carries the query back for anyone who wants it.
 
-          Over a DIRECTORY previewed by this view (a folder opened in one of its
-          non-listing modes) the kebab carries that one row alone: `isEntry`
-          is answered `false` up front — the folder is not a page — so none of
-          the app rows are asked for, and nothing probes the parent for MCP. */}
-      <EntryActionsMenu
+          Over a DIRECTORY previewed by this view in one of its NON-LISTING
+          modes the kebab carries that one row alone: `isEntry` is answered
+          `false` up front — the folder is not a page — so none of the app rows
+          are asked for, and nothing probes the parent for MCP. In LISTING mode
+          the listing owns the bar's kebab (Listing.tsx's EntryActionsMenu, with
+          its own Open in embed row), so this one stands down — two `⋮` in one
+          bar was the bug. */}
+      {!(stat.is_dir && isListing) && (
+        <EntryActionsMenu
           fsPath={fsPath}
           isEntry={stat.is_dir ? false : undefined}
           snapshotSha={snapshotSha}
@@ -1878,6 +1882,7 @@ function TemplatePreview({
           }
           onOpenMcp={() => setMcpOpen(true)}
         />
+      )}
       {/* The sidebar's OPENER, LAST in the bar — the shared control (SideChrome),
           which is where the "one affordance, two places, chosen by state" split
           between this button and the column's own close button is written down,

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -752,22 +752,16 @@ function TemplatePreview({
   // is nothing to borrow — offering both would draw the same mode twice.
   const parentDir = dirname(fsPath);
   const ownGit = parts.sidebar.some((e) => e.mode === "git");
-  const ownMcp = parts.sidebar.some((e) => e.mode === "mcp");
   const parentGit = useDirMode(splitCapable && !ownGit ? parentDir : null, "git");
-  const parentMcp = useDirMode(splitCapable && !ownMcp ? parentDir : null, "mcp");
-  // MCP IS NOT A SIDEBAR COMPANION ANY MORE — the column holds Claude and Git as
-  // two tabs (SideChrome's SideTabs), and MCP opens as a dialog off the crumb
-  // bar's kebab (EntryActionsMenu → McpDialog; the argument is on McpDialog).
-  // So the `mcp` entry — the parent's, or the file's own if a registry bound it
-  // there — is kept OUT of everything `sideSplit` sees (`own`, `borrowed`,
-  // `bound`) and out of the switcher's rows, and is read only by `mcpSrc` below.
-  // The parent probe stays: it is what tells the kebab's row whether there is an
-  // MCP manifest to show. A `?_side=mcp` deep link now resolves to the default
-  // companion, which is the same thing an unknown `_side` always did.
-  //
-  // One list still, because `sideSplit` ranks the assembled set; the pending
-  // half names MODES rather than being a flag for the same reason it did when
-  // two probes fed it.
+  // The parent's MCP manifest, probed the same way — but never a sidebar entry
+  // (mode-visibility's SIDEBAR_MODES is Claude and Git): it feeds the kebab's
+  // "MCP config" row and the dialog behind it (`mcpSrc`, below).
+  const parentMcp = useDirMode(splitCapable ? parentDir : null, "mcp");
+  // One list, though `git` is the only borrowed companion (`mcp` was the second
+  // and is a dialog now — McpDialog), because `sideSplit` ranks the assembled
+  // set; the pending half names MODES rather than being a flag for the same
+  // reason. A `?_side=mcp` deep link resolves to the default companion, as any
+  // unknown `_side` does.
   const borrowedEntries = [!ownGit ? parentGit.entry : null].filter(
     (e): e is TemplateEntry => !!e
   );
@@ -777,8 +771,7 @@ function TemplatePreview({
   // and a predicate rather than three `m === "git" && !ownGit` because a file that
   // binds the mode itself must answer no at every one of them or the sidebar aims
   // a file-scoped view at the parent directory.
-  const isBorrowedMode = (m: string): boolean =>
-    (m === "git" && !ownGit) || (m === "mcp" && !ownMcp);
+  const isBorrowedMode = (m: string): boolean => m === "git" && !ownGit;
   // Registry order for the file's own companions, then SIDEBAR_MODES order over
   // the assembled list — Claude / Git, whatever the registry ranked
   // (see orderSidebarModes). `on` vs `offered` is the pending placeholder's whole
@@ -799,7 +792,7 @@ function TemplatePreview({
   const split = sideSplit({
     splitCapable,
     content: parts.content,
-    own: parts.sidebar.filter((e) => e.mode !== "mcp"),
+    own: parts.sidebar,
     borrowed: borrowedEntries,
     borrowedPending: borrowedPendingModes,
     // This file's own gates, for `defaultSide` alone: an absent `_side` must not
@@ -808,7 +801,7 @@ function TemplatePreview({
     // mount-backed file the answer is no (lib/preview-side's `defaultSide`).
     conditionsPending: conditions === null,
     bound: [
-      ...partitionModes(stat.templates).sidebar.filter((e) => e.mode !== "mcp"),
+      ...partitionModes(stat.templates).sidebar,
       ...(parentGit.bound ? [parentGit.bound] : []),
     ],
   });
@@ -827,11 +820,7 @@ function TemplatePreview({
   // every decision below (`sideEntry`, `activeSide`, the toggle, the reconcile)
   // reads the short list, so a disabled row can be rendered without becoming
   // something the URL or the split can land on.
-  // Minus the `mcp` row `sidebarMenu` (lib/preview-side) still lays for every
-  // SIDEBAR_MODES member: that constant is shared with the folder pane, where MCP
-  // is still a pane mode, so the file sidebar drops the row here rather than
-  // there.
-  const sidebarMenu = split.offered ? split.menu.filter((e) => e.mode !== "mcp") : [];
+  const sidebarMenu = split.offered ? split.menu : [];
   // Pending, for a SIDEBAR entry. A borrowed entry is gated on the PARENT's
   // verdicts, resolved by lib/dir-mode — not on any of this file's, so it cannot
   // go through `isPending` (which reads `conditions`, this file's map, and would
@@ -1616,18 +1605,15 @@ function TemplatePreview({
       `&_file=${encodeURIComponent(target)}${rem}${chatOnly}${thumbFlags}`
     );
   };
-  // The MCP dialog's document: the same URL shape `sideSrcFor` builds, for the
-  // one companion that is no longer in `sidebarModes` (see the borrowed-entries
-  // comment). The file's own `mcp` binding wins over the parent's, as it did in
-  // the sidebar; `null` while the parent's probe is out or when nothing offers
-  // the mode, which is what the kebab's row reads to disable itself.
-  const mcpEntry =
-    parts.sidebar.find((e) => e.mode === "mcp") ?? (parentMcp.pending ? null : parentMcp.entry);
+  // The MCP dialog's document: the same URL shape `sideSrcFor` builds for a
+  // borrowed companion, aimed at the PARENT folder (the manifest is the app's).
+  // `null` while the parent's probe is out or when the folder is not an app,
+  // which is what the kebab's row reads to disable itself.
+  const mcpEntry = parentMcp.pending ? null : parentMcp.entry;
   const mcpSrc =
     mcpEntry && mcpEntry.path !== null
       ? `/render?path=${encodeURIComponent(mcpEntry.path)}` +
-        `&_file=${encodeURIComponent(isBorrowedMode("mcp") ? parentDir : fsPath)}` +
-        `${isBorrowedMode("mcp") ? "" : remote}${thumbFlags}`
+        `&_file=${encodeURIComponent(parentDir)}${thumbFlags}`
       : null;
   // The claude iframe's REMOUNT key, distinct from the mode name `active`
   // everything else keys off of (the switcher's highlighted row, the title).
@@ -1880,7 +1866,7 @@ function TemplatePreview({
             splitCapable
               ? {
                   available: mcpSrc !== null,
-                  pending: !parts.sidebar.some((e) => e.mode === "mcp") && parentMcp.pending,
+                  pending: parentMcp.pending,
                   reason: unavailableReason("mcp"),
                 }
               : undefined

--- a/frontend/src/apps/explorer/PreviewSidebar.tsx
+++ b/frontend/src/apps/explorer/PreviewSidebar.tsx
@@ -36,8 +36,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { modeTitle } from "@platform/lib/mode-name";
 import { ChatFrame } from "@platform/ui/ChatFrame";
-import { ModeMenu } from "@apps/explorer/BarMenu";
-import { SideCloseButton } from "@apps/explorer/SideChrome";
+import { SideCloseButton, SideTabs } from "@apps/explorer/SideChrome";
 import {
   publishPreviewSideSlot,
   retractPreviewSideSlot,
@@ -110,7 +109,6 @@ export default function PreviewSidebar({
   src,
   onSelect,
   onClose,
-  lead,
 }: {
   // The switcher's whole list: every companion, in SIDEBAR_MODES order, the ones
   // this file cannot show disabled and carrying their reason.
@@ -132,11 +130,6 @@ export default function PreviewSidebar({
   // Clears `_side`. The title bar's opener is hidden while this column is up
   // (SideChrome writes the split down), so this is the only way out of it.
   onClose: () => void;
-  // What rides in the header's tail AHEAD of the mode pill — the entry page's
-  // "Open in project" button (Preview.tsx), in the slot the folder pane's
-  // strip gives the same button (ListingPreviewPane). Rendered as given: the
-  // caller gates it, this header only places it.
-  lead?: ReactNode;
 }) {
   // A width the user DRAGGED earlier in this document leads (lib/side-store) — that
   // is what makes the divider hold still while you walk from file to file, since
@@ -313,21 +306,18 @@ export default function PreviewSidebar({
               while it is up, the only one — the title bar's opener is not
               rendered. The listing pane's header opens with the same button. */}
           <SideCloseButton what={modeTitle(active)} onClick={onClose} />
-          {/* The shared mode control, over the companions, at the strip's far end
-              (the tail's auto margin packs it there — .side-header-tail, the same
-              wrapper the listing pane's header uses).
-
-              ALWAYS a menu now. This used to fall back to a flat, unclickable
-              label whenever `entries` was down to one, because BarMenu hides a
-              one-row menu and the strip would otherwise have been a lone chevron
-              over an unlabelled document. The list no longer shrinks: `entries`
-              is all three companions on every file, the unavailable ones disabled
-              and carrying the reason (lib/preview-side's `menu`), so there is
-              always a menu to draw and always more in it than the mode you are
-              looking at. */}
+          {/* The switcher, at the strip's far end (the tail's auto margin packs
+              it there — .side-header-tail, the same wrapper the listing pane's
+              header uses). A TAB STRIP over the two companions (SideChrome's
+              SideTabs), where the folder pane keeps a dropdown over its three:
+              the argument is on SideTabs. `entries` is both companions on every
+              file, the unavailable one disabled and carrying its reason
+              (lib/preview-side's `menu`), so the strip never shrinks to one tab.
+              "Open in project" no longer rides ahead of it: the crumb bar's
+              kebab (EntryActionsMenu) offers the hop whether or not this column
+              is up, so the column has nothing to fall back for. */}
           <div className="side-header-tail">
-            {lead}
-            <ModeMenu entries={entries} active={active} onSelect={onSelect} />
+            <SideTabs tabs={entries} active={active} onSelect={onSelect} />
           </div>
         </div>
         {src === null ? (

--- a/frontend/src/apps/explorer/SideChrome.tsx
+++ b/frontend/src/apps/explorer/SideChrome.tsx
@@ -27,6 +27,7 @@
 import { useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
 import PanelIcon from "@platform/ui/PanelIcon";
 import { modeTitle } from "@platform/lib/mode-name";
+import { Tabs, TabsList, TabsTrigger } from "@platform/shadcn/ui/tabs";
 import { reopenWidth } from "@platform/lib/panel-drag";
 import { templateModeIcon } from "@apps/explorer/ModeSwitcher";
 import { CONTENT_MIN_W, MIN_W } from "@apps/explorer/lib/side-width";
@@ -96,9 +97,9 @@ export interface SideTab {
 // THE FILE SIDEBAR'S SWITCHER IS A TAB STRIP, not a dropdown. With the column
 // down to two companions (Claude, Git — MCP left it for the crumb bar's kebab,
 // EntryActionsMenu) a menu that opens to show two rows costs a click to reveal
-// what a strip shows standing still. UNDERLINE tabs, the app page's own idiom
-// (.app-page-tabs): icon + label, the active one in full ink with a bar on the
-// header's bottom rule, the rest muted (.side-tab, explorer.css). Not the mode
+// what a strip shows standing still. shadcn Tabs in the line variant — the app
+// page's own tab bar (shell/AppPage.tsx): icon + label, the active one in full
+// ink with a bar on the header's bottom rule, the rest muted. Not the mode
 // control's bordered plate — in these bars a plate means "menu".
 //
 // Unlike ModeMenu it NEVER hides itself at one selectable row: an unavailable
@@ -116,31 +117,40 @@ export function SideTabs({
   onSelect: (mode: string) => void;
 }) {
   return (
-    <div className="side-tabs" role="tablist" aria-label="Sidebar panel">
-      {tabs.map((t) => {
-        const title = modeTitle(t.mode);
-        const on = t.mode === active;
-        return (
-          <button
+    // shadcn's Tabs, line variant — the SAME control the app page's tab bar is
+    // (shell/AppPage.tsx), so the two strips are one idiom rather than a
+    // hand-rolled lookalike. Controlled: `value` is the mode Preview/Listing
+    // resolved, and a click reports up through onSelect (the `_side` writer).
+    // The strip stretches to the header's height (.side-tabs, explorer.css) so
+    // the active bar lands on the header's own bottom rule.
+    <Tabs
+      value={active}
+      onValueChange={(v) => {
+        if (typeof v === "string" && v !== active) onSelect(v);
+      }}
+      className="side-tabs self-stretch"
+    >
+      <TabsList
+        variant="line"
+        aria-label="Sidebar panel"
+        className="h-full justify-start rounded-none border-b-0 p-0"
+      >
+        {tabs.map((t) => (
+          <TabsTrigger
             key={t.mode}
-            type="button"
-            role="tab"
-            aria-selected={on}
-            className={"bar-ctl side-tab" + (on ? " active" : "")}
+            value={t.mode}
+            className="flex-none px-2.5 text-[13px]"
             disabled={t.pending || !!t.disabledReason}
-            title={t.pending ? "Checking if this view applies…" : t.disabledReason ?? title}
-            onClick={() => {
-              if (!on) onSelect(t.mode);
-            }}
+            title={t.pending ? "Checking if this view applies…" : t.disabledReason}
           >
-            <span className="mode-menu-icon">
+            <span className="mode-menu-icon" data-icon="inline-start">
               {t.pending ? <span className="mode-icon-spinner" /> : t.icon}
             </span>
-            <span className="side-tab-label">{title}</span>
-          </button>
-        );
-      })}
-    </div>
+            {modeTitle(t.mode)}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
   );
 }
 

--- a/frontend/src/apps/explorer/SideChrome.tsx
+++ b/frontend/src/apps/explorer/SideChrome.tsx
@@ -26,6 +26,7 @@
 // any moment, and each sits where its own action makes sense.
 import { useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
 import PanelIcon from "@platform/ui/PanelIcon";
+import { modeTitle } from "@platform/lib/mode-name";
 import { reopenWidth } from "@platform/lib/panel-drag";
 import { templateModeIcon } from "@apps/explorer/ModeSwitcher";
 import { CONTENT_MIN_W, MIN_W } from "@apps/explorer/lib/side-width";
@@ -58,20 +59,16 @@ export function SideCloseButton({ what, onClick }: { what: string; onClick: () =
   );
 }
 
-// The opener, and it wears the COMPANION'S OWN ICON rather than a chevron: a
-// chevron only ever said "a panel goes here", while the icon says WHICH panel, so
-// the button announces what the click will get you with no hover needed. Which
-// icon that is, is the caller's business — the mode it would reopen is the one
-// last open on that surface.
-export function SideToggleButton({
-  what,
-  icon,
-  onClick,
-}: {
-  what: string;
-  icon: ReactNode;
-  onClick: () => void;
-}) {
+// The opener, and it wears the SAME PANEL GLYPH the close button does. It wore
+// the companion's own icon for a while (a Claude glyph for "reopen Claude"),
+// which said WHICH panel but not that it was a panel at all — in the crumb bar it
+// read as a fourth mode button beside the mode switcher rather than as the other
+// half of the column's close control. PanelIcon's own argument applies: the
+// collapse and expand controls of one panel share one picture, and the user reads
+// the SCREEN for the state. `what` still names the companion in the tooltip. It is
+// the LAST control in its bar (Preview.tsx's headerActions, Listing's search row):
+// the thing on the window's right edge is the button for the right-hand column.
+export function SideToggleButton({ what, onClick }: { what: string; onClick: () => void }) {
   const label = "Show the " + what + " panel";
   return (
     <button
@@ -82,8 +79,68 @@ export function SideToggleButton({
       aria-expanded={false}
       onClick={onClick}
     >
-      <span className="mode-menu-icon">{icon}</span>
+      <PanelIcon side="right" />
     </button>
+  );
+}
+
+// One tab of the file sidebar's header (SideTabs below): the companion, its
+// icon, and why it cannot be picked if it cannot.
+export interface SideTab {
+  mode: string;
+  icon: ReactNode;
+  pending?: boolean;
+  disabledReason?: string;
+}
+
+// THE FILE SIDEBAR'S SWITCHER IS A TAB STRIP, not a dropdown. With the column
+// down to two companions (Claude, Git — MCP left it for the crumb bar's kebab,
+// EntryActionsMenu) a menu that opens to show two rows costs a click to reveal
+// what a strip shows standing still. Same recipe as every control in these bars
+// (.bar-ctl, 28px, 16px glyph); the active tab wears the bordered plate the mode
+// control wears (.side-tab.active, explorer.css), which is the one piece of
+// chrome these rows allow and here says "this is the one you are on".
+//
+// Unlike ModeMenu it NEVER hides itself at one selectable row: an unavailable
+// companion is drawn disabled with its reason in the tooltip, a pending one
+// spins, so the strip always shows the whole closed set (lib/preview-side's
+// `menu` is where that policy is argued). The folder listing's pane keeps the
+// dropdown — it still carries three modes.
+export function SideTabs({
+  tabs,
+  active,
+  onSelect,
+}: {
+  tabs: SideTab[];
+  active: string;
+  onSelect: (mode: string) => void;
+}) {
+  return (
+    <div className="side-tabs" role="tablist" aria-label="Sidebar panel">
+      {tabs.map((t) => {
+        const title = modeTitle(t.mode);
+        const on = t.mode === active;
+        return (
+          <button
+            key={t.mode}
+            type="button"
+            role="tab"
+            aria-selected={on}
+            className={"bar-ctl side-tab" + (on ? " active" : "")}
+            disabled={t.pending || !!t.disabledReason}
+            title={t.pending ? "Checking if this view applies…" : t.disabledReason ?? title}
+            onClick={() => {
+              if (!on) onSelect(t.mode);
+            }}
+          >
+            <span className="mode-menu-icon">
+              {t.pending ? <span className="mode-icon-spinner" /> : t.icon}
+            </span>
+            <span className="side-tab-label">{title}</span>
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/frontend/src/apps/explorer/SideChrome.tsx
+++ b/frontend/src/apps/explorer/SideChrome.tsx
@@ -133,13 +133,16 @@ export function SideTabs({
       <TabsList
         variant="line"
         aria-label="Sidebar panel"
-        className="h-full justify-start rounded-none border-b-0 p-0"
+        className="h-full justify-start gap-3 rounded-none border-b-0 p-0"
       >
         {tabs.map((t) => (
           <TabsTrigger
             key={t.mode}
             value={t.mode}
-            className="flex-none px-2.5 text-[13px]"
+            /* 12px, the bar's own type size (.bar-ctl / the mode control's
+               label), so the strip reads at the same weight as the mode
+               dropdown across the seam. */
+            className="flex-none px-2 text-[12px]"
             disabled={t.pending || !!t.disabledReason}
             title={t.pending ? "Checking if this view applies…" : t.disabledReason}
           >

--- a/frontend/src/apps/explorer/SideChrome.tsx
+++ b/frontend/src/apps/explorer/SideChrome.tsx
@@ -96,10 +96,10 @@ export interface SideTab {
 // THE FILE SIDEBAR'S SWITCHER IS A TAB STRIP, not a dropdown. With the column
 // down to two companions (Claude, Git — MCP left it for the crumb bar's kebab,
 // EntryActionsMenu) a menu that opens to show two rows costs a click to reveal
-// what a strip shows standing still. Same recipe as every control in these bars
-// (.bar-ctl, 28px, 16px glyph); the active tab wears the bordered plate the mode
-// control wears (.side-tab.active, explorer.css), which is the one piece of
-// chrome these rows allow and here says "this is the one you are on".
+// what a strip shows standing still. UNDERLINE tabs, the app page's own idiom
+// (.app-page-tabs): icon + label, the active one in full ink with a bar on the
+// header's bottom rule, the rest muted (.side-tab, explorer.css). Not the mode
+// control's bordered plate — in these bars a plate means "menu".
 //
 // Unlike ModeMenu it NEVER hides itself at one selectable row: an unavailable
 // companion is drawn disabled with its reason in the tooltip, a pending one

--- a/frontend/src/apps/explorer/lib/dir-mode.ts
+++ b/frontend/src/apps/explorer/lib/dir-mode.ts
@@ -8,9 +8,10 @@
 // `stat.templates` therefore never mentions git, and yet "what has changed in
 // here" is exactly as useful while reading one file as while browsing its folder.
 //
-// `mcp` needs it for the same shape of reason and is borrowed the same way: the
+// `mcp` needs it for the same shape of reason and is probed the same way (though
+// it opens as a dialog off the bar's kebab now, not as a sidebar entry): the
 // `mcp.toml` manifest it curates covers the app FOLDER, so it too is bound to "/"
-// alone (templates/mcp/condition.py) and a file's sidebar takes the entry from its
+// alone (templates/mcp/condition.py) and a file's view takes the entry from its
 // parent app folder. Nothing here is git-specific — `useDirMode(dir, mode)` takes
 // the mode as a parameter, which is why a second folder-bound companion needed a
 // new CALLER and not a new module.

--- a/frontend/src/apps/explorer/lib/preview-side.test.ts
+++ b/frontend/src/apps/explorer/lib/preview-side.test.ts
@@ -25,7 +25,6 @@ const openedAt = (search: string, split: Parameters<typeof resolveSide>[1]) =>
 // with any rewording, silently, including a bad one.
 const NO_REPO = "Not inside a git repository";
 const NO_CLAUDE = "Claude is not available for this file";
-const NO_APP = "Not a fused app folder (needs index.html and a main())";
 
 // A registered template, icon and all — the icon matters here because a disabled
 // switcher row has to be able to find it.
@@ -40,8 +39,6 @@ const iconOf = (mode: string) => `/tpl/${mode}/icon.svg`;
 // flight: the mode name and nothing else.
 const GIT_PLACEHOLDER: TemplateEntry = { mode: "git", path: null, icon: null };
 const GIT: TemplateEntry = t("git");
-// The second folder-bound companion, borrowed exactly the same way.
-const MCP: TemplateEntry = t("mcp");
 
 const image = t("image");
 const claude = t("claude");
@@ -67,10 +64,9 @@ const file = (own: TemplateEntry[], git: "pending" | "yes" | "no"): SideSplitInp
   splitCapable: true,
   content: [image],
   own,
-  // A LIST since `mcp` joined `git` as a folder-bound companion (both are
-  // borrowed from the parent, each on its own probe). These cases are about the
-  // borrow MECHANISM, so one borrowed mode exercises it; `mcp`'s own row is
-  // covered where the menu is.
+  // A LIST, though `git` is the only folder-bound companion left (`mcp` was
+  // the second and is a dialog now): the borrow mechanism is per mode, each on
+  // its own probe, and the shape stays for the next one.
   borrowed: git === "no" ? [] : [git === "yes" ? GIT : GIT_PLACEHOLDER],
   borrowedPending: git === "pending" ? ["git"] : [],
 });
@@ -160,7 +156,6 @@ describe("sideSplit's menu", () => {
     expect(rows(sideSplit(file([], "no")).menu)).toEqual([
       ["claude", NO_CLAUDE],
       ["git", NO_REPO],
-      ["mcp", NO_APP],
     ]);
   });
 
@@ -168,37 +163,24 @@ describe("sideSplit's menu", () => {
     expect(rows(sideSplit(file([], "yes")).menu)).toEqual([
       ["claude", NO_CLAUDE],
       ["git", null],
-      ["mcp", NO_APP],
     ]);
   });
 
-  // BOTH folder-bound companions are borrowed, independently: a file inside an app
-  // that is not a repository gets a real MCP row beside a disabled Git one, which
-  // is the case a single borrowed slot could not represent at all.
-  it("borrows each folder-bound companion on its own verdict", () => {
-    const s = sideSplit({ ...file([claude], "no"), borrowed: [MCP] });
+  // `mcp` is not a companion (it is a dialog off the kebab), so a caller that
+  // still hands one in — a stale registry binding — gets it listed as an UNKNOWN
+  // companion at the end, never as a ranked row with a canned reason.
+  it("does not know mcp as a companion any more", () => {
+    const mcp = t("mcp");
+    const s = sideSplit({ ...file([claude], "no"), borrowed: [mcp] });
     expect(rows(s.menu)).toEqual([
       ["claude", null],
       ["git", NO_REPO],
       ["mcp", null],
     ]);
-    expect(names(s.settled)).toEqual(["claude", "mcp"]);
-    expect(s.on).toBe(true);
-  });
-
-  it("holds a pending MCP borrow the same way it holds a pending git one", () => {
-    const placeholder: TemplateEntry = { mode: "mcp", path: null, icon: null };
-    const s = sideSplit({
-      ...file([], "no"),
-      borrowed: [placeholder],
-      borrowedPending: ["mcp"],
-    });
-    // Listed (so `?_side=mcp` survives the wait) but settling nothing, exactly as
-    // the git case above: one probe out is one mode undecided.
-    expect(names(s.all)).toEqual(["mcp"]);
-    expect(names(s.settled)).toEqual([]);
-    expect(s.on).toBe(false);
-    expect(s.defaultSide).toBe(null);
+    expect(rows(sideSplit(file([claude], "no")).menu)).toEqual([
+      ["claude", null],
+      ["git", NO_REPO],
+    ]);
   });
 
   // A denied borrowed git is a listed, disabled Git row — the finding this
@@ -209,7 +191,6 @@ describe("sideSplit's menu", () => {
     expect(rows(menu)).toEqual([
       ["claude", null],
       ["git", NO_REPO],
-      ["mcp", NO_APP],
     ]);
     // A placeholder is a row, not a template: nothing to frame.
     expect(menu.find((e) => e.mode === "git")!.path).toBe(null);
@@ -222,7 +203,6 @@ describe("sideSplit's menu", () => {
     expect(rows(menu)).toEqual([
       ["claude", null],
       ["git", null],
-      ["mcp", NO_APP],
     ]);
     expect(menu.find((e) => e.mode === "git")).toBe(GIT_PLACEHOLDER);
   });
@@ -231,7 +211,7 @@ describe("sideSplit's menu", () => {
   // is the whole reason `menu` is a third list rather than a flag on `all`.
   it("decides nothing", () => {
     const s = sideSplit(file([], "no"));
-    expect(s.menu.length).toBe(3);
+    expect(s.menu.length).toBe(2);
     expect(s.on).toBe(false);
     expect(s.offered).toBe(false);
     expect(names(s.settled)).toEqual([]);
@@ -253,18 +233,16 @@ describe("sideSplit's menu", () => {
     // The file BINDS claude — the gate is what denied it, and the
     // filter that dropped it took the icon with it (Preview re-supplies them
     // from the raw stat).
-    const s = sideSplit({ ...file([], "no"), bound: [claude, GIT, MCP] });
+    const s = sideSplit({ ...file([], "no"), bound: [claude, GIT] });
     expect(s.menu.map((e) => [e.mode, e.icon])).toEqual([
       ["claude", iconOf("claude")],
       ["git", iconOf("git")],
-      ["mcp", iconOf("mcp")],
     ]);
     // ...and they are still disabled rows, not entries: no path, and the reason
     // is what makes them unselectable.
     expect(rows(s.menu)).toEqual([
       ["claude", NO_CLAUDE],
       ["git", NO_REPO],
-      ["mcp", NO_APP],
     ]);
     expect(s.menu.every((e) => e.path === null)).toBe(true);
   });
@@ -294,7 +272,6 @@ describe("sideSplit's menu", () => {
     expect(rows(s.menu)).toEqual([
       ["claude", null],
       ["git", null],
-      ["mcp", NO_APP],
       ["notes", null],
     ]);
   });

--- a/frontend/src/apps/explorer/lib/preview-side.ts
+++ b/frontend/src/apps/explorer/lib/preview-side.ts
@@ -105,7 +105,8 @@ export interface SideSplitInput {
   // The file's own modes, already partitioned (lib/mode-visibility).
   content: TemplateEntry[];
   own: TemplateEntry[];
-  // The parent folder's FOLDER-BOUND companion entries (`git`, `mcp`) — the ones
+  // The parent folder's FOLDER-BOUND companion entries (`git`; `mcp` was one
+  // until it became a dialog off the kebab) — the ones
   // no file's own template list can contain, so a file sidebar has them only by
   // borrowing (see the header and lib/dir-mode). Empty when the parent offers
   // none, and a mode is absent here when the file has one of its own.

--- a/frontend/src/apps/explorer/listing/column-shedding.test.ts
+++ b/frontend/src/apps/explorer/listing/column-shedding.test.ts
@@ -88,12 +88,10 @@ test("a shed column's header collapses to a zero px width with no box", () => {
       // Nothing else lives in this cell, so one clip covers the rest of it.
       expect(decls).toMatch(/overflow:\s*hidden/);
     } else {
-      // MODIFIED is the last column, so its right edge is the TABLE's — which
-      // is where the folder `⋮` is pinned (.listing-head-menu, Listing.tsx),
-      // and it has to survive the collapse or the folder's menu disappears
-      // whenever the listing is narrow. So this cell must NOT clip, and the one
-      // piece of content that font-size:0 cannot silence — the sort arrow,
-      // which sets its own 9px — is hidden by a rule of its own instead.
+      // MODIFIED is the last column and does not clip: the one piece of
+      // content that font-size:0 cannot silence — the sort arrow, which sets
+      // its own 9px — is hidden by a rule of its own instead. (The folder `⋮`
+      // that once rode this cell's right edge is the search row's kebab now.)
       expect(decls).not.toMatch(/overflow:\s*hidden/);
       const block = shedding.find((b) => b.body.includes(`th.${col}`))!;
       expect(ruleFor(block.body, `th.${col} .sort-arrow`)).toMatch(/display:\s*none/);
@@ -101,19 +99,9 @@ test("a shed column's header collapses to a zero px width with no box", () => {
   }
 });
 
-test("SIZE's header reserves berth for the folder ⋮ while MODIFIED is shed", () => {
-  // With MODIFIED collapsed, the absolutely-positioned `⋮` rides the table's
-  // right edge — which is inside SIZE's header until SIZE itself sheds. The
-  // header cell (and only the header cell — the column keeps its px width
-  // under border-box, and the body figures keep the full cell) stops its
-  // content short of the button. Dropping this repaints the label under the
-  // `⋮` between the two shed steps.
-  const wide = shedding.find((b) => /th\.col-mtime[^{]*\{[^}]*width:\s*0/s.test(b.body));
-  expect(wide).toBeDefined();
-  const berth = ruleFor(wide!.body, "th.col-size");
-  expect(berth).toMatch(/padding-right:\s*\d+px/);
-  expect(berth).not.toMatch(/width:/);
-});
+// The "SIZE reserves berth for the folder `⋮`" case is gone with the button:
+// the folder's actions live in the search row's kebab now (EntryActionsMenu),
+// so no header cell has a control to stop short of.
 
 test("the collapse rules outrank the default widths further down the file", () => {
   // The defaults (`table.listing-table th.col-size { width: 96px }`) sit AFTER

--- a/frontend/src/apps/explorer/listing/pane-side.test.ts
+++ b/frontend/src/apps/explorer/listing/pane-side.test.ts
@@ -23,12 +23,13 @@ const entry = (mode: string): TemplateEntry => ({
   conditional: true,
 });
 
-const NONE = { claude: null, git: null, mcp: null };
-// Every companion offered. Named ALL rather than BOTH since `mcp` joined the pair.
-const ALL = { claude: entry("claude"), git: entry("git"), mcp: entry("mcp") };
-// The two folder-bound companions with nothing to offer — the ordinary shape for a
-// folder that is neither a repository nor an app.
-const CLAUDE_ONLY = { claude: entry("claude"), git: null, mcp: null };
+const NONE = { claude: null, git: null };
+// Every companion offered. (`mcp` was a third for a while; it is a dialog off
+// the search row's kebab now — EntryActionsMenu → McpDialog — so ALL is the pair.)
+const ALL = { claude: entry("claude"), git: entry("git") };
+// The folder-bound companion with nothing to offer — the ordinary shape for a
+// folder outside a repository.
+const CLAUDE_ONLY = { claude: entry("claude"), git: null };
 
 test("the companions in switcher order, and a fallback that is not one of them", () => {
   // D285: the pane is a companion column. `PANE_SIDE_MODES` still carries `preview`
@@ -36,8 +37,8 @@ test("the companions in switcher order, and a fallback that is not one of them",
   // fallback — `PANE_SIDE_COMPANIONS` is what a user can choose and what the URL can
   // carry, and the old `DEFAULT_PANE_SIDE` is gone with the idea that `preview` was
   // anything's default.
-  expect(PANE_SIDE_MODES).toEqual(["preview", "claude", "git", "mcp"]);
-  expect(PANE_SIDE_COMPANIONS).toEqual(["claude", "git", "mcp"]);
+  expect(PANE_SIDE_MODES).toEqual(["preview", "claude", "git"]);
+  expect(PANE_SIDE_COMPANIONS).toEqual(["claude", "git"]);
   expect(PANE_SIDE_FALLBACK).toBe("preview");
 });
 
@@ -167,7 +168,7 @@ describe("paneSideParam", () => {
 // full-screen file sidebar has had all along.
 describe("paneSideList", () => {
   test("the companions alone, whatever the subject, and Claude is what it lands on", () => {
-    expect(paneSideList(ALL)).toEqual(["claude", "git", "mcp"]);
+    expect(paneSideList(ALL)).toEqual(["claude", "git"]);
     // An absent `_side` parses as no choice (`null`), and the resolve lands on the
     // first offered side.
     expect(activePaneSide(paneSideList(ALL), null)).toBe("claude");
@@ -176,7 +177,6 @@ describe("paneSideList", () => {
   test("an explicit Git choice still wins", () => {
     // The user's own `?_side=git` is a choice, not a default.
     expect(activePaneSide(paneSideList(ALL), "git")).toBe("git");
-    expect(activePaneSide(paneSideList(ALL), "mcp")).toBe("mcp");
   });
 
   test("a folder outside a repository lands on Claude with Git gone", () => {
@@ -184,12 +184,9 @@ describe("paneSideList", () => {
     expect(activePaneSide(paneSideList(CLAUDE_ONLY), "git")).toBe("claude");
   });
 
-  test("an app folder outside a repository offers MCP without Git", () => {
-    // The two folder-bound companions are independent gates: being an app says
-    // nothing about being a work tree, and the pane must not treat them as a pair.
-    const app = { claude: entry("claude"), git: null, mcp: entry("mcp") };
-    expect(paneSideList(app)).toEqual(["claude", "mcp"]);
-    expect(activePaneSide(paneSideList(app), "git")).toBe("claude");
+  test("`_side=mcp` is an unknown value now — it parses as no choice", () => {
+    // MCP left the pane for a dialog; a stale deep link lands on the leader.
+    expect(parsePaneSide("mcp")).toEqual({ open: true, mode: null });
   });
 
   // A PROBE STILL OUT IS NOT A DENIAL, and conflating the two put the reported bug
@@ -203,10 +200,8 @@ describe("paneSideList", () => {
   const PENDING = {
     claude: null,
     git: null,
-    mcp: null,
     claudePending: true,
     gitPending: true,
-    mcpPending: true,
   };
 
   test("probes still out offers nothing yet — for every row type now", () => {
@@ -227,7 +222,6 @@ describe("paneSideList", () => {
       git: entry("git"),
       gitPending: false,
       claudePending: false,
-      mcpPending: false,
     })).toEqual(["git"]);
   });
 
@@ -238,7 +232,7 @@ describe("paneSideList", () => {
   // file sidebar's (lib/preview-side's `defaultSide`) and fixed by the same rule —
   // the LEADER decides, and while the leader is undecided so is the pane.
   test("Git landing first does not open a pane that Claude would then displace", () => {
-    const gitFirst = { ...PENDING, git: entry("git"), gitPending: false, mcpPending: false };
+    const gitFirst = { ...PENDING, git: entry("git"), gitPending: false };
     expect(paneSideList(gitFirst)).toEqual([]);
     // ...so there is nothing on screen to move: the caller holds its skeleton on an
     // empty list, and `activePaneSide`'s answer is only the pill's placeholder.
@@ -257,7 +251,7 @@ describe("paneSideList", () => {
     // The undecided list is about what an ABSENT `_side` resolves to; a `?_side=git`
     // deep link is the user's own choice and `activePaneSide` keeps it (the param is
     // deliberately never reconciled away here).
-    const gitFirst = { ...PENDING, git: entry("git"), gitPending: false, mcpPending: false };
+    const gitFirst = { ...PENDING, git: entry("git"), gitPending: false };
     expect(activePaneSide(paneSideList(gitFirst), "git")).toBe(PANE_SIDE_FALLBACK);
     expect(activePaneSide(paneSideList({ ...gitFirst, claudePending: false }), "git")).toBe("git");
   });
@@ -273,10 +267,9 @@ describe("paneSideList", () => {
   });
 
   test("a follower still out is undecided too, not the fallback", () => {
-    // Claude denied, Git denied, MCP's probe still in flight: falling through to
-    // `preview` here would put the pane on the fallback and then move it the moment
-    // the verdict landed. Every follower has to be waited on, not just the first.
-    expect(paneSideList({ ...NONE, mcpPending: true })).toEqual([]);
+    // Claude denied, Git's probe still in flight: falling through to `preview`
+    // here would put the pane on the fallback and then move it the moment the
+    // verdict landed. The follower has to be waited on, not just the leader.
     expect(paneSideList({ ...NONE, gitPending: true })).toEqual([]);
   });
 
@@ -292,7 +285,7 @@ describe("paneSideList", () => {
   });
 });
 
-// WHAT THE SWITCHER DRAWS, which is all three whatever the folder offers — the
+// WHAT THE SWITCHER DRAWS, which is both companions whatever the folder offers — the
 // folder half of the file sidebar's rule. An unofferable mode is a disabled row
 // carrying its reason, so the header holds still as the user walks from a
 // repository into a folder outside one instead of shedding pills (and, at one
@@ -303,13 +296,11 @@ describe("paneSideMenu", () => {
     ...NONE,
     claudePending: true,
     gitPending: true,
-    mcpPending: true,
   };
   // Copy the user reads, so it is written out here rather than re-derived from
   // the constant it is testing.
   const NO_REPO = "Not inside a git repository";
   const NO_CLAUDE = "Claude is not available for this file";
-  const NO_APP = "Not a fused app folder (needs index.html and a main())";
   const rows = (e: Parameters<typeof paneSideMenu>[0]) =>
     paneSideMenu(e).map((r) => [r.mode, r.disabledReason ?? (r.pending ? "…" : null)]);
 
@@ -317,7 +308,6 @@ describe("paneSideMenu", () => {
     expect(rows(ALL)).toEqual([
       ["claude", null],
       ["git", null],
-      ["mcp", null],
     ]);
   });
 
@@ -325,7 +315,6 @@ describe("paneSideMenu", () => {
     expect(rows(CLAUDE_ONLY)).toEqual([
       ["claude", null],
       ["git", NO_REPO],
-      ["mcp", NO_APP],
     ]);
   });
 
@@ -338,7 +327,6 @@ describe("paneSideMenu", () => {
     expect(rows(NONE)).toEqual([
       ["claude", NO_CLAUDE],
       ["git", NO_REPO],
-      ["mcp", NO_APP],
     ]);
   });
 
@@ -348,7 +336,6 @@ describe("paneSideMenu", () => {
     expect(paneSideMenu(PENDING_MENU)).toEqual([
       { mode: "claude", pending: true },
       { mode: "git", pending: true },
-      { mode: "mcp", pending: true },
     ]);
   });
 
@@ -357,18 +344,17 @@ describe("paneSideMenu", () => {
     // everywhere: it is a state the pane falls into, so a row for it would be a
     // control that cannot be honoured, and it carries no `disabledReason` either
     // (it is not unavailable for a reason — it is not a mode).
-    expect(paneSideMenu(ALL).map((r) => r.mode)).toEqual(["claude", "git", "mcp"]);
+    expect(paneSideMenu(ALL).map((r) => r.mode)).toEqual(["claude", "git"]);
     // Unavailable COMPANIONS are still drawn and still explained — that rule is
     // untouched, and it is why the pill never shrinks to one row and hides.
     expect(paneSideMenu(CLAUDE_ONLY)).toEqual([
       { mode: "claude" },
       { mode: "git", disabledReason: NO_REPO },
-      { mode: "mcp", disabledReason: NO_APP },
     ]);
     // Even where the pane IS on `preview` — neither companion offered — the menu
     // shows the two companions and nothing else. This case used to assert the row
     // came back here.
-    expect(paneSideMenu(NONE).map((r) => r.mode)).toEqual(["claude", "git", "mcp"]);
+    expect(paneSideMenu(NONE).map((r) => r.mode)).toEqual(["claude", "git"]);
   });
 
   test("an undecided probe spins rather than claiming a reason", () => {
@@ -377,14 +363,12 @@ describe("paneSideMenu", () => {
     expect(rows(PENDING_MENU)).toEqual([
       ["claude", "…"],
       ["git", "…"],
-      ["mcp", "…"],
     ]);
     // The probes land independently: a settled denial beside an open probe is the
     // usual frame, and each row says only what is known of IT.
     expect(rows({ ...NONE, gitPending: true })).toEqual([
       ["claude", NO_CLAUDE],
       ["git", "…"],
-      ["mcp", NO_APP],
     ]);
   });
 
@@ -394,14 +378,14 @@ describe("paneSideMenu", () => {
     // now, so the menu never mentions it; what it cannot do is carry a reason, since
     // the reasons belong to companions that are unavailable.
     for (const e of [NONE, ALL, { ...NONE, gitPending: true }]) {
-      expect(paneSideMenu(e).map((r) => r.mode)).toEqual(["claude", "git", "mcp"]);
+      expect(paneSideMenu(e).map((r) => r.mode)).toEqual(["claude", "git"]);
     }
   });
 
   test("the rows decide nothing", () => {
     // What the pane may BE is still paneSideList's answer: a disabled row must
     // not become a mode the pane can land on.
-    expect(paneSideMenu(CLAUDE_ONLY).length).toBe(3);
+    expect(paneSideMenu(CLAUDE_ONLY).length).toBe(2);
     expect(paneSideList(CLAUDE_ONLY)).toEqual(["claude"]);
     // A denied request lands on the first mode ON OFFER — which is a companion now,
     // not the fallback. This asserted `"preview"` while `preview` led every list.
@@ -418,22 +402,18 @@ describe("paneSideIconEntry", () => {
   test("an offered mode uses its own entry", () => {
     expect(paneSideIconEntry("git", ALL)).toBe(ALL.git);
     expect(paneSideIconEntry("claude", ALL)).toBe(ALL.claude);
-    expect(paneSideIconEntry("mcp", ALL)).toBe(ALL.mcp);
   });
 
   test("a disabled mode falls back to the binding the gate refused", () => {
     // A folder outside a repository: nothing to frame, but `git` is bound and its
     // icon exists — dir-mode keeps the entry through the denial for this.
     expect(paneSideIconEntry("git", { ...NONE, gitBound: git })).toBe(git);
-    const mcp = entry("mcp");
-    expect(paneSideIconEntry("mcp", { ...NONE, mcpBound: mcp })).toBe(mcp);
   });
 
   test("a mode bound nowhere has no icon to offer", () => {
     // The caller's last resort, and only here.
     expect(paneSideIconEntry("git", NONE)).toBe(null);
     expect(paneSideIconEntry("claude", NONE)).toBe(null);
-    expect(paneSideIconEntry("mcp", NONE)).toBe(null);
   });
 
   test("the offered entry always outranks the binding", () => {
@@ -448,7 +428,6 @@ describe("activePaneSide", () => {
   test("an offered request wins", () => {
     expect(activePaneSide(paneSideList(ALL), "git")).toBe("git");
     expect(activePaneSide(paneSideList(ALL), "claude")).toBe("claude");
-    expect(activePaneSide(paneSideList(ALL), "mcp")).toBe("mcp");
   });
 
   test("an unavailable request lands on the first mode ON OFFER", () => {
@@ -457,7 +436,6 @@ describe("activePaneSide", () => {
     // folder that offers the chat lands on Claude, and only a folder offering neither
     // lands on `preview`.
     expect(activePaneSide(paneSideList(CLAUDE_ONLY), "git")).toBe("claude");
-    expect(activePaneSide(paneSideList(CLAUDE_ONLY), "mcp")).toBe("claude");
     expect(activePaneSide(paneSideList(NONE), "git")).toBe("preview");
   });
 });

--- a/frontend/src/apps/explorer/listing/pane-side.ts
+++ b/frontend/src/apps/explorer/listing/pane-side.ts
@@ -15,7 +15,7 @@
 //
 // **This makes the pane agree with the full-screen file sidebar, which was
 // companions-only from the start** (`lib/preview-side.ts` over
-// `mode-visibility.SIDEBAR_MODES` = `["claude", "git", "mcp"]` — no `preview`
+// `mode-visibility.SIDEBAR_MODES` = `["claude", "git"]` — no `preview`
 // side, ever).
 // The listing pane was the odd one out, and the four decisions above are it
 // converging on the shape the other half of the app already had.
@@ -26,9 +26,10 @@
 //   git      the OPEN FOLDER's working tree — not the row's. See dir-mode.ts:
 //            a working tree belongs to the folder, so `git` is bound to the
 //            universal "/" key alone and the pane borrows the folder's entry.
-//   mcp      the OPEN FOLDER's MCP tools — the curation panel over the app's
-//            Python entrypoints. Folder-bound for the same shape of reason: the
-//            `mcp.toml` manifest it writes covers the folder, not a row in it.
+//   (mcp     the OPEN FOLDER's MCP tools was a third mode here for a while.
+//            Folder-bound for the same shape of reason as `git`, but it is a
+//            DIALOG off the search row's kebab now — EntryActionsMenu →
+//            McpDialog — not a pane mode.)
 //
 //   preview  **NOT SELECTABLE, and not in the switcher.** It survives as the
 //            pane's internal FALLBACK for one state: neither companion offered (a
@@ -62,7 +63,7 @@ import { unavailableReason } from "@platform/lib/mode-visibility";
 
 // Every state the pane can BE IN. `preview` is here because the fallback needs
 // the type, not because anything offers it (see the header).
-export const PANE_SIDE_MODES = ["preview", "claude", "git", "mcp"] as const;
+export const PANE_SIDE_MODES = ["preview", "claude", "git"] as const;
 
 export type PaneSide = (typeof PANE_SIDE_MODES)[number];
 
@@ -70,7 +71,10 @@ export type PaneSide = (typeof PANE_SIDE_MODES)[number];
 // else. Splitting this out of `PaneSide` is what makes "the pane fell back to
 // preview" un-writable and un-requestable at the type level rather than by
 // convention — a `_side=preview` cannot round-trip because it cannot be held.
-export const PANE_SIDE_COMPANIONS = ["claude", "git", "mcp"] as const;
+// `mcp` was the third companion here; it left for a dialog off the search
+// row's kebab (EntryActionsMenu → McpDialog), so a `_side=mcp` is an unknown
+// value now and parses as no choice.
+export const PANE_SIDE_COMPANIONS = ["claude", "git"] as const;
 
 export type PaneSideChoice = (typeof PANE_SIDE_COMPANIONS)[number];
 
@@ -189,12 +193,11 @@ export function paneSideParam(state: PaneSideState): string | null {
 //
 // Order is by construction, not by sorting: this list IS the switcher's order.
 export interface PaneSideEntries {
-  // The OPEN FOLDER's `claude` / `git` / `mcp` template entries, or null when the
+  // The OPEN FOLDER's `claude` / `git` template entries, or null when the
   // folder does not offer the mode. `preview` needs no entry — it is the selected
   // row's own default template, resolved from the row's stat by pane-modes.ts.
   claude: TemplateEntry | null;
   git: TemplateEntry | null;
-  mcp: TemplateEntry | null;
   // The dir-mode probe behind that null has not answered yet (Listing passes the
   // flag alongside; the entry stays null because a placeholder has no template
   // path to frame). Only the MENU reads these — an undecided mode is neither
@@ -202,14 +205,12 @@ export interface PaneSideEntries {
   // disabled one asserting a reason nobody has established.
   claudePending?: boolean;
   gitPending?: boolean;
-  mcpPending?: boolean;
   // The folder's entry for a mode it will not SHOW: the binding as the stat
   // reported it, gate verdict or not (lib/dir-mode's `bound`). Read for one thing
   // only — see `paneSideIconEntry` — and never as an offer: a mode is on offer
   // when `claude`/`git` above is non-null, and nowhere else.
   claudeBound?: TemplateEntry | null;
   gitBound?: TemplateEntry | null;
-  mcpBound?: TemplateEntry | null;
 }
 
 // `isFolderBoundSide` and the `FOLDER_BOUND_SIDES` set it read used to separate
@@ -276,13 +277,12 @@ export function paneSideList(entries: PaneSideEntries): PaneSide[] {
   const companions: PaneSide[] = [];
   if (entries.claude) companions.push("claude");
   if (entries.git) companions.push("git");
-  if (entries.mcp) companions.push("mcp");
   if (companions.length > 0) return companions;
   // Nothing offered yet AND a follower still out is still undecided: falling
   // through to the fallback here would put the pane on `preview` and then move it
   // the moment the verdict landed, which is the jump the leader wait above exists
   // to prevent.
-  if (entries.gitPending || entries.mcpPending) return [];
+  if (entries.gitPending) return [];
   return [PANE_SIDE_FALLBACK];
 }
 
@@ -321,7 +321,6 @@ export function paneSideMenu(entries: PaneSideEntries): PaneSideMenuEntry[] {
   const pendingOf: Record<PaneSideChoice, boolean | undefined> = {
     claude: entries.claudePending,
     git: entries.gitPending,
-    mcp: entries.mcpPending,
   };
   const companion = (mode: PaneSideChoice): PaneSideMenuEntry => {
     if (entries[mode]) return { mode };
@@ -358,7 +357,6 @@ export function paneSideIconEntry(
   const bound: Record<PaneSideChoice, TemplateEntry | null | undefined> = {
     claude: entries.claudeBound,
     git: entries.gitBound,
-    mcp: entries.mcpBound,
   };
   return entries[side] ?? bound[side] ?? null;
 }

--- a/frontend/src/platform/lib/mode-visibility.test.ts
+++ b/frontend/src/platform/lib/mode-visibility.test.ts
@@ -81,16 +81,18 @@ describe("partitionModes", () => {
   it("agrees with isSidebarMode", () => {
     expect(isSidebarMode("claude")).toBe(true);
     expect(isSidebarMode("git")).toBe(true);
-    expect(isSidebarMode("mcp")).toBe(true);
+    // MCP is a dialog off the bar's kebab now, not a companion.
+    expect(isSidebarMode("mcp")).toBe(false);
     expect(isSidebarMode("claude_split")).toBe(false);
     expect(isSidebarMode("_render")).toBe(false);
   });
 
-  // `mcp` is the second FOLDER-BOUND companion, and it is on this list for the
-  // same reason `git` is: bound to "/" alone, so no file's own template list can
-  // contain it, and borrowed from the parent app folder instead.
-  it("ranks the companions chat, working tree, tools", () => {
-    expect(SIDEBAR_MODES).toEqual(["claude", "git", "mcp"]);
+  // `git` is the FOLDER-BOUND companion: bound to "/" alone, so no file's own
+  // template list can contain it, and borrowed from the parent folder instead.
+  // `mcp` used to follow it here and is a dialog now (McpDialog); an unknown
+  // mode in the input lands after the ranked ones.
+  it("ranks the companions chat, working tree", () => {
+    expect(SIDEBAR_MODES).toEqual(["claude", "git"]);
     expect(names(orderSidebarModes([t("mcp"), git, claude]))).toEqual([
       "claude",
       "git",

--- a/frontend/src/platform/lib/mode-visibility.ts
+++ b/frontend/src/platform/lib/mode-visibility.ts
@@ -69,17 +69,22 @@ export function isModeVisible(entry: TemplateEntry, verdicts: ConditionVerdicts)
 // must keep offering them as ordinary modes, which is only safe while "is this a
 // sidebar mode?" has one definition.
 //
-// `git` AND `mcp` ARE ON THIS LIST AND ARE IN NO FILE'S TEMPLATE LIST, and both
-// halves of that are deliberate. The registry binds each to the universal "/"
-// DIRECTORY key alone and both gates refuse anything that is not a directory
+// `git` IS ON THIS LIST AND IS IN NO FILE'S TEMPLATE LIST, and both halves of
+// that are deliberate. The registry binds it to the universal "/" DIRECTORY key
+// alone and its gate refuses anything that is not a directory
 // (templates/git/condition.py: a working tree belongs to the folder, since you
-// stash a tree and not a file; templates/mcp/condition.py: the tool manifest
-// belongs to the app folder it sits in), so `partitionModes` will never pull
-// either entry out of a file's own modes. The file sidebar BORROWS them from the
-// file's parent folder instead (apps/explorer/lib/dir-mode.ts) and inserts them
-// here — which is why the ordering below is a rule of its own rather than the
-// registry's.
-export const SIDEBAR_MODES = ["claude", "git", "mcp"] as const;
+// stash a tree and not a file), so `partitionModes` will never pull the entry
+// out of a file's own modes. The file sidebar BORROWS it from the file's parent
+// folder instead (apps/explorer/lib/dir-mode.ts) and inserts it here — which is
+// why the ordering below is a rule of its own rather than the registry's.
+//
+// `mcp` IS NOT A COMPANION. It was the third row here for a while; it is a
+// DIALOG now (apps/explorer/McpDialog, off the bar's kebab), on both the file
+// preview and the folder listing, because a manifest is something you configure
+// and leave rather than work beside. Its `unavailableReason` below survives for
+// that kebab row's tooltip; `isSidebarMode("mcp")` is false, so a registry that
+// bound the template to a file would list it as an ordinary content mode.
+export const SIDEBAR_MODES = ["claude", "git"] as const;
 
 const SIDEBAR_MODE_SET: ReadonlySet<string> = new Set(SIDEBAR_MODES);
 

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -548,9 +548,9 @@
    the layout half of that sharing.
 
    NO RULE FOR THE BUTTONS THEMSELVES (.side-close, .side-toggle): both ride the
-   plain .bar-ctl-icon recipe above, and their glyphs are the 16px right-hand
-   panel icon (platform/ui/PanelIcon) / the companion's own mode icon, in
-   currentColor like everything else in these rows.
+   plain .bar-ctl-icon recipe above, and both wear the same 16px right-hand
+   panel icon (platform/ui/PanelIcon), in currentColor like everything else in
+   these rows.
    A `.side-toggle.active` pressed look lived here for one round, while the opener
    stayed on screen with the panel open and the column carried a close button of
    its own. Exactly one of the two buttons is ever rendered now (SideChrome
@@ -576,6 +576,63 @@
    expand button to put here.) */
 .side-header-tail:empty {
   display: none;
+}
+
+/* ---- The file sidebar's tab strip (SideChrome's SideTabs) -----------------
+   Two .bar-ctl tabs side by side; the ACTIVE one wears the mode control's
+   bordered plate, so "which panel am I on" is answered by the same chrome that
+   answers "which mode is this" one bar over. The inactive tab is a plain ghost
+   control, and a disabled one dims exactly as any .bar-ctl does. */
+.side-tabs {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.side-tab.active {
+  border: 1px solid var(--border);
+  background: var(--ctl-plate-bg);
+  color: var(--fg);
+  cursor: default;
+}
+
+.side-tab-label {
+  font-weight: 500;
+}
+
+/* The kebab trigger's corner badge — the App Doctor's status dot, visible
+   with the menu shut (BarMenu's OverflowMenu `badge`). Positioned off the
+   28px square; the dot's own size and hue are app-doctor.css's. */
+.bar-overflow .bar-ctl {
+  position: relative;
+}
+
+.bar-overflow-badge {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  display: inline-flex;
+  pointer-events: none;
+}
+
+.bar-menu-item-trailing {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* The MCP dialog's document (McpDialog.tsx): fills the dialog's second grid
+   row, which the dialog sizes explicitly — a replaced element has no height
+   of its own to give. */
+.mcp-dialog-frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
 }
 
 /* ---- The mode control ---------------------------------------------------

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -579,14 +579,15 @@
 }
 
 /* ---- The side column's tab strip (SideChrome's SideTabs) ------------------
-   UNDERLINE TABS, the app page's idiom (.app-page-tabs, shadcn's line
-   variant): icon + label, the active one in full ink with a 2px bar sitting ON
-   the header's bottom rule, the rest muted. Not the bordered plate — a plate
-   says "this is a menu" everywhere else in these bars (.bar-ctl-bordered), and
-   a tab is not one. The strip stretches to the header's height so the bar
-   lands exactly on the rule: the tail wrapper stretches too (its own
-   align-items still centres the rest of what it holds), and the bar hangs the
-   header's vertical padding plus its 1px border below the tab's box. */
+   shadcn Tabs, line variant — the app page's tab bar (.app-page-tabs) in the
+   column header. The utilities own the look (muted text, active in full ink,
+   the 2px after-bar); the two things this file adds are GEOMETRY the utilities
+   cannot know: the strip stretches to the header's height (the tail wrapper
+   stretches too — its own align-items still centres the rest of what it
+   holds), and the active bar is moved down by the header's vertical padding
+   plus its 1px border so it sits ON the header's bottom rule rather than
+   floating 5px under the label. Unlayered, so these beat the layered
+   utilities without !important. */
 .side-header-tail:has(.side-tabs) {
   align-self: stretch;
 }
@@ -594,42 +595,15 @@
 .side-tabs {
   flex: 0 0 auto;
   align-self: stretch;
-  display: inline-flex;
-  align-items: stretch;
-  gap: 4px;
+  display: flex;
 }
 
-.side-tab {
-  position: relative;
-  height: auto;
-  padding: 0 6px;
-  border-radius: 0;
-  font-size: 13px;
-  color: var(--fg-muted);
+.side-tabs [data-slot="tabs-list"] {
+  height: 100%;
 }
 
-.side-tab:hover:not(:disabled) {
-  background: none;
-  color: var(--fg);
-}
-
-.side-tab.active {
-  color: var(--fg);
-  cursor: default;
-}
-
-.side-tab.active::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
+.side-tabs [data-slot="tabs-trigger"]::after {
   bottom: calc(-1 * var(--topbar-pad-y) - 1px);
-  height: 2px;
-  background: var(--fg);
-}
-
-.side-tab-label {
-  font-weight: 500;
 }
 
 /* The kebab trigger's corner badge — the App Doctor's status dot, visible

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -578,23 +578,54 @@
   display: none;
 }
 
-/* ---- The file sidebar's tab strip (SideChrome's SideTabs) -----------------
-   Two .bar-ctl tabs side by side; the ACTIVE one wears the mode control's
-   bordered plate, so "which panel am I on" is answered by the same chrome that
-   answers "which mode is this" one bar over. The inactive tab is a plain ghost
-   control, and a disabled one dims exactly as any .bar-ctl does. */
+/* ---- The side column's tab strip (SideChrome's SideTabs) ------------------
+   UNDERLINE TABS, the app page's idiom (.app-page-tabs, shadcn's line
+   variant): icon + label, the active one in full ink with a 2px bar sitting ON
+   the header's bottom rule, the rest muted. Not the bordered plate — a plate
+   says "this is a menu" everywhere else in these bars (.bar-ctl-bordered), and
+   a tab is not one. The strip stretches to the header's height so the bar
+   lands exactly on the rule: the tail wrapper stretches too (its own
+   align-items still centres the rest of what it holds), and the bar hangs the
+   header's vertical padding plus its 1px border below the tab's box. */
+.side-header-tail:has(.side-tabs) {
+  align-self: stretch;
+}
+
 .side-tabs {
   flex: 0 0 auto;
+  align-self: stretch;
   display: inline-flex;
-  align-items: center;
-  gap: 2px;
+  align-items: stretch;
+  gap: 4px;
+}
+
+.side-tab {
+  position: relative;
+  height: auto;
+  padding: 0 6px;
+  border-radius: 0;
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+
+.side-tab:hover:not(:disabled) {
+  background: none;
+  color: var(--fg);
 }
 
 .side-tab.active {
-  border: 1px solid var(--border);
-  background: var(--ctl-plate-bg);
   color: var(--fg);
   cursor: default;
+}
+
+.side-tab.active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(-1 * var(--topbar-pad-y) - 1px);
+  height: 2px;
+  background: var(--fg);
 }
 
 .side-tab-label {

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -997,14 +997,6 @@
   table.listing-table thead th.col-mtime .sort-arrow {
     display: none;
   }
-  /* With MODIFIED collapsed, that table-edge `⋮` falls inside SIZE's header
-     (SIZE holds out until 300px). Pad the HEADER cell only, so the label stops
-     short of the button; border-box keeps the column at its 96px, and the body
-     figures don't share the cell with the button, so they keep the full
-     width. */
-  table.listing-table thead th.col-size {
-    padding-right: 34px;
-  }
 }
 
 @container (max-width: 300px) {
@@ -1801,12 +1793,8 @@ table.listing-table th.col-size {
   width: 96px;
 }
 
-/* The extra right padding is the folder `⋮`'s berth: that button overlays this
-   cell rather than taking a column of its own (see .listing-head-menu below),
-   so the label and its sort arrow have to stop short of it. */
 table.listing-table th.col-mtime {
   width: 172px;
-  padding-right: 34px;
 }
 
 table.listing-table th {
@@ -1826,38 +1814,6 @@ table.listing-table th {
      rides with the header instead. */
   box-shadow: inset 0 -1px 0 var(--border);
   user-select: none;
-}
-
-/* The folder's `⋮` — the listing's own menu of what the crumb bar's path menu
-   used to offer over a folder, plus the background right-click's set. Pinned to
-   the last header cell's right edge; the sticky th is the positioned ancestor,
-   so this needs no wrapper. Vertically centred against a header whose height is
-   set by its text, hence the translate rather than a matching height.
-   Left as --fg-muted with the labels beside it: it is chrome for the folder,
-   not a fourth column heading, and it should not out-weigh the sorted column. */
-table.listing-table .listing-head-menu {
-  position: absolute;
-  right: 6px;
-  top: 50%;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  border: none;
-  border-radius: 5px;
-  background: transparent;
-  color: var(--fg-muted);
-  cursor: pointer;
-  transition: background 90ms var(--ease-out), color 90ms var(--ease-out);
-}
-
-/* The same wash every other quiet icon button in the chrome uses (.bar-ctl). */
-table.listing-table .listing-head-menu:hover {
-  background: rgba(var(--tint), 0.08);
-  color: var(--fg);
 }
 
 /* Only a header that sorts something gets the affordance. Search mode's single


### PR DESCRIPTION
## What

The explorer's bars — the file preview's crumb bar AND the folder listing's search row — are refactored the same way:

1. **Kebab dropdown** (`EntryActionsMenu.tsx`, new) replaces the bordered App Doctor / Export App / Open in project buttons and the fullscreen glyph:
   - App Doctor (opens the existing modal; status dot rides the kebab trigger's corner and repeats on the row)
   - Download app (the `.fused` export, same snapshot guards and capture source as before)
   - Open as project (same tab, desk add + `/apps/<folder>`)
   - Open in embed (**new tab** via `window.open`; the old button replaced the explorer document) — file preview only
   - MCP config (see 3)

   Entry-only rows are gated on one entry answer (the file surface probes once; the folder passes `appEntryPath`). **Nothing qualifies → no kebab** (a plain non-app folder shows no `⋮`).
2. **Sidebar collapsed icon** is now the panel glyph (`PanelIcon side="right"`, same as the close button) and is the rightmost control in the bar, on both surfaces.
3. **MCP moves out of the side column** into `McpDialog.tsx` (new), a shadcn Dialog framing the `mcp` template aimed at the folder — same shape as App Doctor, opened from the kebab (and from Open With → MCP on a file). `?_side=mcp` deep links now resolve to the leading companion on both surfaces.
4. **Side column dropdown → tabs** (`SideTabs` in `SideChrome.tsx`): Claude and Git as a two-tab strip in the column header, for the file sidebar and the folder pane alike; an unavailable tab is disabled with its reason, a pending one spins. Both "Open in project" copies that lived in those headers / the shut-pane fallback are gone (the kebab is always there).

`OverflowMenu` gained `disabled` / `title` / `trailing` per row and a trigger `badge`. `mcp` is removed from `SIDEBAR_MODES` and `PANE_SIDE_COMPANIONS` (constants are the source of truth; `unavailableReason("mcp")` stays for the kebab tooltip); the three lib test files are updated and pass.

## Verification

- `tsc --noEmit` clean. No tests run or added, no D row (owner rules). Visual smoke pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches export/snapshot guards, navigation (embed new tab, Open as project), and sidebar URL semantics (`mcp` no longer a pane mode); behavior is largely moved not rewritten but regressions could show in bar visibility gating and deep links.
> 
> **Overview**
> **Consolidates explorer bar chrome** so app-level actions live in one kebab (`EntryActionsMenu`) on the file preview crumb bar and the folder listing search row, instead of multiple bordered buttons plus a separate fullscreen control.
> 
> The new menu centralizes a **single** `/api/apps/entry` probe and exposes App Doctor (status dot on the trigger via `OverflowMenu` `badge`), Download app, Open as project, Open in embed (**new tab** with `window.open`), and MCP config. Folder listings merge prior header `⋮` actions via `extraItems` from `barMenu()`. **MCP leaves the side column** — `McpDialog` frames the same `/render` document; `mcp` is dropped from `SIDEBAR_MODES` and `PANE_SIDE_COMPANIONS`, so stale `?_side=mcp` links fall back like other unknown sides.
> 
> **Sidebar UX changes:** file preview and folder pane headers switch from `ModeMenu` to **`SideTabs`** (Claude + Git only). The reopen control uses **`PanelIcon`** (rightmost in the bar) instead of the companion glyph. `OverflowMenu` rows gain `disabled` / `title` / `trailing`.
> 
> Removed listing column-header menu CSS and related column-shedding test expectations; lib tests updated for the two-companion model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1807fded10ca12ac9c68e615150ff47dc2024c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->