### PR TITLE
Native chat: E2E round-1 fixes — queue/Stop, cards, scheduler attachments, in-process history

### DIFF
--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -35,6 +35,7 @@ import { currentUrl, navigateUrl } from "@platform/lib/router";
 import { createUrlParamsStore, type ParamsStore } from "./params/store";
 import { useChatParam } from "./params/useChatParams";
 import { resolveAgentDir } from "./protocol/agent";
+import { fetchHistory } from "./protocol/history";
 import type { SendOptions, UserTurn } from "./protocol/controller-api";
 import { watchStreamTeardown, watchTopOrigin } from "./shots";
 import type { Attachment, Receipt } from "./shots/types";
@@ -801,6 +802,10 @@ function ChatBody(props: ChatBodyProps) {
         file,
         agentDir,
         params,
+        // The transcript restore takes the in-process road (owner E2E R1, F5):
+        // `/api/claude-sessions/history`, with agent.py through `/api/run`
+        // behind it. See `fetchHistory`.
+        history: (f, s) => fetchHistory(agentDir, f, s),
         model: () => liveModel.current,
         effort: () => liveEffort.current,
         hasPane: () => paneAnswer.current(),
@@ -2494,6 +2499,12 @@ function ChatBody(props: ChatBodyProps) {
       // typed meanwhile. Sending it there uploaded an empty note and the
       // transcript then wrote words onto it after it was stamped `sent`
       // (Bugbot, PR #1074).
+      // The scheduler handoff's two directions (owner E2E R1, F4): what the
+      // tray holds when Continue is pressed, and the paths that come back with
+      // "Back to chat" (task-shots copies, registered as real paths — no
+      // upload, `useAttachments.addPaths`).
+      attachments: () => attach.items,
+      onRestoreAttachments: (paths: string[]) => void attach.addPaths(paths),
       hasAttachments:
         attach.items.length > 0 ||
         ann.chips.some((c) => isSendableNow(c.note, walkthroughOwns(ann.mode))),

--- a/frontend/src/apps/claude/live/watch.ts
+++ b/frontend/src/apps/claude/live/watch.ts
@@ -203,6 +203,11 @@ export function createLiveWatch(deps: LiveWatchDeps): LiveWatch {
     // pre-read stat — never from this probe, which is older than the rows the
     // refetch brings.
     if (verdict.refresh) await deps.refreshHistory(sessionId);
+    // Re-read after the await too (Bugbot 3977975835): a run of this frame's
+    // that began and ended during the refresh has stamped `ownRunEndedAt`, and
+    // the verdict above was reached about a transcript that predates its rows —
+    // "running outside this app" over this page's own reply.
+    if (deps.ownRunEndedAt() !== ownEndBefore) return;
     const running = deps.hasActiveRun ? deps.hasActiveRun() : deps.busy();
     if (!stopped && deps.sessionId() === sessionId && !running) {
       deps.setExternalWorking(verdict.running);

--- a/frontend/src/apps/claude/protocol/controller-api.ts
+++ b/frontend/src/apps/claude/protocol/controller-api.ts
@@ -466,6 +466,15 @@ export interface ControllerDeps {
   /** ADDED: the transport, injectable so bun tests drive the loop with a fake
    *  agent.py. Defaults to `protocol/agent.ts`'s `runAgent`. */
   run?: typeof import("./agent").runAgent;
+  /** ADDED (owner E2E R1, F5): the transcript restore, as its own road. The
+   *  host passes `protocol/history.ts`'s `fetchHistory` — the in-process
+   *  `/api/claude-sessions/history` route, with `/api/run` behind it — so a
+   *  chat opens without waiting on a Python subprocess. Absent (tests), the
+   *  loop asks `run("history")` as before. */
+  history?: (
+    file: string,
+    sessionId: string,
+  ) => Promise<import("./types").HistoryResponse & { error?: string }>;
   /** ADDED: `sleep` for the 400 ms poll cadence and the follow-up wait —
    *  injectable so a test runs the loop without real time (T:16377). */
   sleep?: (ms: number) => Promise<void>;

--- a/frontend/src/apps/claude/protocol/history.ts
+++ b/frontend/src/apps/claude/protocol/history.ts
@@ -34,6 +34,8 @@
 //   * `uuid` is the transcript record's own id — the value the Tasks list
 //     carries as a message `anchor`, which is what makes `?msg=` resolvable
 //     (T:18030). Optional: a payload without it simply cannot be anchored to.
+import { getJson } from "@platform/lib/api";
+import { runAgent } from "./agent";
 import type { Turn } from "./controller-api";
 import { troubleFromMessage } from "./trouble";
 import type { HistoryResponse, HistoryTurn, SessionRow } from "./types";
@@ -173,3 +175,31 @@ export function rowPane(s: Pick<SessionRow, "pane"> | null | undefined, file: st
 /** The tag name of the annotations block, re-exported so a caller explaining a
  *  title does not have to import from two files. */
 export { ANN_TAG };
+
+/**
+ * The transcript restore, in process (owner E2E R1, F5). `/api/run` executes
+ * agent.py in a fresh Python subprocess per call — several hundred ms of
+ * interpreter start-up in front of a 30 ms read — and that spawn was most of
+ * the wait between opening a chat and seeing it. `/api/claude-sessions/history`
+ * runs the same `_history` on the server's own loaded agent module. Anything
+ * but a 200 (an older server, a module that did not load) falls back to the
+ * `/api/run` road, byte-for-byte the same answer, so the page never loses the
+ * conversation to the optimisation.
+ */
+export async function fetchHistory(
+  agentDir: string,
+  file: string,
+  sessionId: string,
+): Promise<HistoryResponse & { error?: string }> {
+  try {
+    const q = new URLSearchParams({ file, session_id: sessionId });
+    return await getJson<HistoryResponse>(`/api/claude-sessions/history?${q}`);
+  } catch {
+    return (await runAgent(
+      agentDir,
+      "history",
+      { file, session_id: sessionId },
+      { key: null },
+    )) as HistoryResponse & { error?: string };
+  }
+}

--- a/frontend/src/apps/claude/protocol/history.ts
+++ b/frontend/src/apps/claude/protocol/history.ts
@@ -192,13 +192,13 @@ export async function fetchHistory(
   sessionId: string,
 ): Promise<HistoryResponse & { error?: string }> {
   try {
-    const q = new URLSearchParams({ file, session_id: sessionId });
+    const q = new URLSearchParams({ file, session_id: sessionId, native: "1" });
     return await getJson<HistoryResponse>(`/api/claude-sessions/history?${q}`);
   } catch {
     return (await runAgent(
       agentDir,
       "history",
-      { file, session_id: sessionId },
+      { file, session_id: sessionId, native: "1" },
       { key: null },
     )) as HistoryResponse & { error?: string };
   }

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -769,6 +769,47 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply.map((t) => !!t.streaming)).toEqual([false, false, false]);
   });
 
+  // Owner E2E R1, F6 (2026-09-10). "I queued a message, it streamed the response
+  // for 1, then the response for 2, and the response for 1 vanished" — with
+  // reply 2 sitting ABOVE its own user bubble. Both replies were ONE short text
+  // segment, the echo and the `result` landed inside one poll gap, and
+  // agent.py reported no seam: seam count 0→0, segment count 1→1, so neither
+  // the lost-seam test nor the shrink test fired and reply 2 was written into
+  // reply 1's slot. The text is the remaining signal: a window only grows, so
+  // a payload that does not start with the last one is a window that moved.
+  test("a same-size unseamed step still opens its own bubble (continuity)", async () => {
+    let controller!: ChatController;
+    const A = text("Markdown was made by John Gruber.");
+    const B = text("Done again.");
+    const made = makeController({
+      start: () => ({ run_id: "r1" }),
+      send: () => ({ sent: true as const }),
+      poll: async (_f, n) => {
+        if (n === 0) return poll({ segments: [A], text: A.text });
+        if (n === 1) {
+          await controller.sendFollowUp("do it again");
+          return poll({ segments: [], text: "" });
+        }
+        // Echo and A's `result` both landed in the gap: B alone, no seam, same
+        // segment count, not shorter.
+        if (n === 2) return poll({ segments: [B], text: B.text });
+        return poll({ done: true, segments: [B], text: B.text });
+      },
+    });
+    controller = made.controller;
+    await controller.sendMessage("who is markdown made by");
+
+    expect(controller.getState().turns.map((t) => t.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    const reply = assistants(controller);
+    expect(reply.map((t) => (t.segments || []).map(bodyOf))).toEqual([[A.text], [B.text]]);
+    expect(reply.map((t) => !!t.streaming)).toEqual([false, false]);
+  });
+
   // ── owner feedback R4-3 ──────────────────────────────────────────────────
   //
   // "Sometimes when I reply, it re-streams the previous message's response, and

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -191,7 +191,8 @@ describe("start → poll → done", () => {
       read_dirs: "[]",
     });
     // The poll rides `file` so the agent can refuse another target's run.
-    expect(agent.of("poll")[0].fields).toEqual({ run_id: "r1", file: "/proj/app.py" });
+    // `native: "1"`: app-state reads come back as in-stream notices (agent.py `app_reads`).
+    expect(agent.of("poll")[0].fields).toEqual({ run_id: "r1", file: "/proj/app.py", native: "1" });
 
     const s = controller.getState();
     expect(users(controller).map((t) => t.text)).toEqual(["hi"]);
@@ -2238,7 +2239,9 @@ describe("skills and app_state rows (T:15771-15837)", () => {
       state: '{"url":"/x"}',
     });
     expect(controller.getState().appState).toEqual([]);
-    expect(notes(controller).map((n) => n.text)).toEqual(["read app state — check the console"]);
+    // The page writes NO line of its own any more: agent.py puts the read in
+    // the stream as a notice segment, where it happened (owner E2E R1).
+    expect(notes(controller).map((n) => n.text)).toEqual([]);
   });
 
   test("`waitedOut` flips once the pane has had ~2 s (5 polls) to answer", async () => {
@@ -2279,8 +2282,9 @@ describe("skills and app_state rows (T:15771-15837)", () => {
     controller = made.controller;
     await controller.sendMessage("go");
     expect(made.agent.of("app_state").length).toBe(2);
-    // …and only ONE note, however many attempts it took (T:15797).
-    expect(notes(controller).map((n) => n.text)).toEqual(["read app state"]);
+    // …and no note from the page, however many attempts it took: the read is
+    // agent.py's notice segment now, once, where it happened.
+    expect(notes(controller).map((n) => n.text)).toEqual([]);
   });
 });
 

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -810,6 +810,40 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply.map((t) => !!t.streaming)).toEqual([false, false]);
   });
 
+  // Bugbot #1099. The continuity read cannot see a follow-up reply that merely
+  // EXTENDS the previous one: "OK" then "OK, done" keeps the seam count, the
+  // segment count and the prefix. agent.py now reports where the window starts
+  // (`window`, the poll cursor); that offset moving is the step itself.
+  test("a follow-up reply that extends the previous text still opens its own bubble (window)", async () => {
+    let controller!: ChatController;
+    const A = text("OK");
+    const B = text("OK, done");
+    const made = makeController({
+      start: () => ({ run_id: "r1" }),
+      send: () => ({ sent: true as const }),
+      poll: async (_f, n) => {
+        if (n === 0) return poll({ segments: [A], text: A.text, window: 0 });
+        if (n === 1) {
+          await controller.sendFollowUp("do it again");
+          return poll({ segments: [], text: "", window: 0 });
+        }
+        // Echo and A's `result` landed in the gap; the cursor stepped to B.
+        if (n === 2) return poll({ segments: [B], text: B.text, window: 480 });
+        return poll({ done: true, segments: [B], text: B.text, window: 480 });
+      },
+    });
+    controller = made.controller;
+    await controller.sendMessage("say OK");
+    const reply = assistants(controller);
+    expect(reply.map((t) => (t.segments || []).map(bodyOf))).toEqual([[A.text], [B.text]]);
+    expect(controller.getState().turns.map((t) => t.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+  });
+
   // ── owner feedback R4-3 ──────────────────────────────────────────────────
   //
   // "Sometimes when I reply, it re-streams the previous message's response, and

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1543,29 +1543,28 @@ describe("stop (T:15901)", () => {
     expect(agent.calls.length).toBe(0);
   });
 
-  // QA round 3a, defect 2. The CLI answers `{"still_queued": []}` for anything
-  // fed through the held-open stdin — it echoes the follow-up into `out.jsonl`
-  // the moment the inbox drains, so by the time the interrupt lands it no longer
-  // counts the message as queued. T has nothing else to consult and drops the
-  // text; the controller keeps its own record and does not have to.
-  // ── feedback #11: WHEN a stop owes the composer the queued text back ────────
-  test("an empty `still_queued` means Claude read it — the bubble stays put", async () => {
-    // The measured behaviour of the held-open stdin: a follow-up is echoed into
-    // `out.jsonl` the moment the inbox drains, so an interrupt landing after
-    // that finds nothing queued and answers `{"still_queued": []}`. Claude READ
-    // the message (Surya's mid-response drain), so yanking it out of the
-    // transcript and back into the box would deny a turn the reader watched
-    // happen. This used to hand the whole queue back on exactly this response.
+  // Owner E2E R1, F7 (2026-09-10), reversing QA round 3a / feedback #11. The
+  // CLI answers `{"still_queued": []}` for a follow-up it has drained — and was
+  // then seen answering that very message AFTER the interrupt, with no poll
+  // loop watching (the live watch called it "Running outside this app…"). So an
+  // empty list is not "Claude read it": Stop hands EVERY queued entry back to
+  // the box, drops its bubble, and tells agent.py the turn had a queue so the
+  // session tree ends with the interrupt. Claude Code's own Esc does the same:
+  // the queue returns to the input, editable.
+  test("an empty `still_queued` still hands a queued follow-up back (Stop means stop)", async () => {
     let controller!: ChatController;
+    const cancels: Record<string, unknown>[] = [];
     const made = makeController({
       start: () => ({ run_id: "r1" }),
       send: () => ({ sent: true as const }),
-      cancel: () => ({ cancelled: "r1", still_queued: [] }),
+      cancel: (fields) => {
+        cancels.push(fields);
+        return { cancelled: "r1", still_queued: [] };
+      },
       poll: async (_f, n) => {
         if (n === 0) return poll({ segments: [text("working on it")] });
         if (n === 1) {
           await controller.sendFollowUp("Claude already read this");
-          // The bubble is up and the hint is showing, both BEFORE the stop.
           expect(users(controller).map((t) => t.text)).toEqual([
             "go",
             "Claude already read this",
@@ -1583,11 +1582,13 @@ describe("stop (T:15901)", () => {
     });
     controller = made.controller;
     await controller.sendMessage("go");
-    // Nothing owed back…
-    expect(made.stranded).toEqual([]);
-    // …and the bubble is still a turn of the conversation.
-    expect(users(controller).map((t) => t.text)).toEqual(["go", "Claude already read this"]);
-    // Nothing is "queued for this turn" once the turn is over, either way.
+    // The words come back to the box…
+    expect(made.stranded).toEqual([["Claude already read this"]]);
+    // …the bubble goes with them…
+    expect(users(controller).map((t) => t.text)).toEqual(["go"]);
+    // …agent.py was told the turn had a queue…
+    expect(cancels[0]?.queued).toBe("1");
+    // …and nothing is "queued for this turn" once the turn is over.
     expect(controller.getState().queued).toEqual([]);
     expect(notes(controller).map((n) => n.text)).toEqual(["Stopped."]);
   });

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -799,6 +799,33 @@ export function createChatController(deps: ControllerDeps): ChatController {
   // ---- working line (T:14774-14926 — the VERBS are the UI's) -------------
 
   let workingStartedAt = 0;
+  /** WHEN THIS TURN STARTED, kept across a reload (owner E2E R1, F10): the
+   *  working line's "(10s)" restarted from 0 on F5 because the start was a
+   *  controller-local `now()`. The frame that starts a turn stamps the run
+   *  in sessionStorage; a frame that re-attaches to the same run reads the
+   *  stamp back. Same tab only, which is the reload case; a new tab starts
+   *  its clock at attach, as before. Cleared when the loop ends so an
+   *  idle-time send into the same host does not inherit the last turn's
+   *  clock. */
+  const turnStartKey = (runId: string) => `fused-render:claude-turn-start:${runId}`;
+  const turnStartedAt = (runId: string): number => {
+    try {
+      const saved = Number(sessionStorage.getItem(turnStartKey(runId)) || 0);
+      if (saved > 0 && saved <= now()) return saved;
+      const at = now();
+      sessionStorage.setItem(turnStartKey(runId), String(at));
+      return at;
+    } catch {
+      return now();
+    }
+  };
+  const forgetTurnStart = (runId: string) => {
+    try {
+      sessionStorage.removeItem(turnStartKey(runId));
+    } catch {
+      /* storage refused; nothing to forget */
+    }
+  };
 
   const setStats = (
     tokens: number,
@@ -838,7 +865,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // the visible conversation WITHOUT bumping the generation (it holds the
     // `sending` gate instead), so this counter is the only thing that moves.
     const tGen = state.transcriptGen;
-    workingStartedAt = now();
+    workingStartedAt = turnStartedAt(runId);
     setRunningUi(true);
     setStats(0, "thinking", null, null);
     noteChatActivity();
@@ -1326,6 +1353,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // `followDecision`'s own-echo rule reads somebody else's rows in the NEW
       // chat as this page's own and suppresses the refresh they should trigger.
       if (logGen === gen && state.transcriptGen === tGen) emit({ ownRunEndedAt: now() });
+      forgetTurnStart(runId);
       // Nothing is "queued for this turn" once the turn is over: the CLI drains
       // its queue as part of the run, so whatever is still listed here has
       // either been answered above or died with the process. Guarded on
@@ -1792,7 +1820,12 @@ export function createChatController(deps: ControllerDeps): ChatController {
     stoppedSeat = seat;
     emit({ status: "stopping" });
     try {
-      const result = (await run(dir, "cancel", { run_id: runId as string }, { key: null })) as CancelResponse;
+      const result = (await run(
+        dir,
+        "cancel",
+        { run_id: runId as string, ...(queued.length ? { queued: "1" } : {}) },
+        { key: null },
+      )) as CancelResponse;
       // WHAT COMES BACK TO THE COMPOSER, and the rule is deliberately narrow
       // (feedback #11).
       //
@@ -1836,8 +1869,13 @@ export function createChatController(deps: ControllerDeps): ChatController {
         // the user owns and would edit — handing back the composed wire payload
         // would put the app-state and attachment markers into their box.
         const at = named.indexOf(entry.wire);
-        const back = at >= 0 || !entry.landed;
-        if (!back) continue;
+        // EVERY entry comes back (owner E2E R1, F7). A landed follow-up the
+        // CLI did not name used to keep its bubble and leave the queue hint
+        // — a message the reader apparently sent, with no reply, forever: the
+        // backend ends the session tree the moment anything was queued, so
+        // nothing was ever going to answer it. Claude Code's own Esc does the
+        // same thing — the queued messages return to the input, editable.
+        // Losing a bubble is recoverable; a bubble with no reply is not.
         stranded.push(entry.typed || entry.wire);
         // AND ITS PICTURES, but only for a send the inbox never confirmed. The
         // words go back through `onStranded`; the attachments are parked in
@@ -2716,6 +2754,14 @@ export function createChatController(deps: ControllerDeps): ChatController {
     if (disposed || !sessionId) return;
     if (activeRun || sending) return;
     const gen = logGen;
+    // WHAT THE LOG LOOKED LIKE WHEN THIS WAS ASKED (Bugbot 3977975835). A
+    // scheduled or adopted repair that starts AND finishes inside the round
+    // trip leaves `activeRun`/`sending` clear again — but it has drawn rows
+    // this payload predates, and stamped `ownRunEndedAt` doing so. Either
+    // stamp moving means the answer is about an older conversation than the
+    // one on screen: drop it, the watch will ask again.
+    const endBefore = state.ownRunEndedAt;
+    const tGen = state.transcriptGen;
     try {
       const res = (await run(
         dir,
@@ -2727,6 +2773,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // A run that attached across the await owns the log now; its stream is
       // fresher than this answer.
       if (activeRun || sending) return;
+      if (state.ownRunEndedAt !== endBefore || state.transcriptGen !== tGen) return;
       if (res.error) throw new Error(res.error);
       // NOTHING IS RECORDED IN `shownRuns` HERE: a `history` row is text plus a
       // transcript `uuid` (`HistoryUserTurn`) and carries no run id, so a

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -2170,12 +2170,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
       ownRunEndedAt: 0,
     });
     try {
-      const res = (await run(
-        dir,
-        "history",
-        { file: FILE || "", session_id: sessionId },
-        { key: null },
-      )) as HistoryResponse & { error?: string };
+      const res = await fetchHistoryVia(sessionId);
       if (logGen !== gen || disposed) return;
       if (res.error) throw new Error(res.error);
       emit({
@@ -2750,6 +2745,19 @@ export function createChatController(deps: ControllerDeps): ChatController {
    * Gated on the same two facts every follower read is: a live run owns the
    * transcript, and a send in flight is about to add to it.
    */
+  /** The transcript restore's transport: the host's in-process road when it
+   *  gave one (`deps.history`, owner E2E R1, F5), else agent.py through
+   *  `/api/run` — the tests' fake agent, and the pre-F5 behaviour. */
+  const fetchHistoryVia = (sessionId: string): Promise<HistoryResponse & { error?: string }> =>
+    deps.history
+      ? deps.history(FILE || "", sessionId)
+      : (run(
+          dir,
+          "history",
+          { file: FILE || "", session_id: sessionId },
+          { key: null },
+        ) as Promise<HistoryResponse & { error?: string }>);
+
   async function refreshHistory(sessionId: string): Promise<void> {
     if (disposed || !sessionId) return;
     if (activeRun || sending) return;
@@ -2763,12 +2771,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     const endBefore = state.ownRunEndedAt;
     const tGen = state.transcriptGen;
     try {
-      const res = (await run(
-        dir,
-        "history",
-        { file: FILE || "", session_id: sessionId },
-        { key: null },
-      )) as HistoryResponse & { error?: string };
+      const res = await fetchHistoryVia(sessionId);
       if (logGen !== gen || disposed) return;
       // A run that attached across the await owns the log now; its stream is
       // fresher than this answer.

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -903,6 +903,10 @@ export function createChatController(deps: ControllerDeps): ChatController {
     let prevSegLen = 0;
     let prevTextLen = 0;
     let prevBreaks = 0;
+    /** The previous non-blank poll's whole window text, for the continuity
+     *  test: a window only ever GROWS, so a payload that does not start with
+     *  the last one is a window that moved. */
+    let prevFullText = "";
     let seenFollowupSeq = followupSeq;
     /**
      * HOW MANY SEAMS ARE STILL OWED — a COUNT, not a flag (Bugbot PR #1061).
@@ -1046,7 +1050,19 @@ export function createChatController(deps: ControllerDeps): ChatController {
           const shrank = prevSegLen
             ? segs.length < prevSegLen
             : !poll.done && fullText.length < prevTextLen;
-          if (lost > 0 || shrank) {
+          // THE CONTINUITY READ (owner E2E R1, F6): two short single-segment
+          // replies leave the seam count AND the segment count unchanged
+          // across a step the loop never saw the seam for — reply 1 `[A]`,
+          // then reply 2 `[B]`, one segment each — so neither test above
+          // fires, slot 0 is re-used, and reply 1 is overwritten with reply 2
+          // (which then sits ABOVE its own user bubble). A window only ever
+          // grows in place, so a payload whose text does not continue the
+          // last one is the window having moved, whatever its size. Same
+          // trick `baseText` already relies on below. A false positive costs
+          // an extra bubble; a miss costs a reply.
+          const moved =
+            prevFullText.length > 0 && fullText.length > 0 && !fullText.startsWith(prevFullText);
+          if (lost > 0 || shrank || moved) {
             // A LOST seam count is how many steps happened, so it settles that
             // many of the outstanding ones; a bare shrink is one step, and the
             // rest stay owed. Never below zero: a shrink for an unrelated
@@ -1063,6 +1079,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
           prevSegLen = segs.length;
           prevTextLen = fullText.length;
           prevBreaks = reported.length;
+          prevFullText = fullText;
         }
 
         // THE SPANS THIS LOOP DID NOT SEND, taken as the base — see

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -934,6 +934,10 @@ export function createChatController(deps: ControllerDeps): ChatController {
      *  test: a window only ever GROWS, so a payload that does not start with
      *  the last one is a window that moved. */
     let prevFullText = "";
+    /** The previous non-blank poll's window start (`poll.window`), when the
+     *  agent reports one: the cursor itself, and the one read that needs no
+     *  inference. */
+    let prevWindow: number | null = null;
     let seenFollowupSeq = followupSeq;
     /**
      * HOW MANY SEAMS ARE STILL OWED — a COUNT, not a flag (Bugbot PR #1061).
@@ -1089,7 +1093,14 @@ export function createChatController(deps: ControllerDeps): ChatController {
           // an extra bubble; a miss costs a reply.
           const moved =
             prevFullText.length > 0 && fullText.length > 0 && !fullText.startsWith(prevFullText);
-          if (lost > 0 || shrank || moved) {
+          // THE CURSOR ITSELF, when agent.py says where the window starts
+          // (Bugbot #1099): a follow-up reply that merely EXTENDS the one
+          // before it ("OK" → "OK, done") keeps the seam count, the segment
+          // count AND the prefix, so none of the three reads above can see
+          // the step. The offset moving is the step, no inference needed.
+          const slid =
+            typeof poll.window === "number" && prevWindow !== null && poll.window !== prevWindow;
+          if (lost > 0 || shrank || moved || slid) {
             // A LOST seam count is how many steps happened, so it settles that
             // many of the outstanding ones; a bare shrink is one step, and the
             // rest stay owed. Never below zero: a shrink for an unrelated
@@ -1107,6 +1118,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
           prevTextLen = fullText.length;
           prevBreaks = reported.length;
           prevFullText = fullText;
+          if (typeof poll.window === "number") prevWindow = poll.window;
         }
 
         // THE SPANS THIS LOOP DID NOT SEND, taken as the base — see

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -996,7 +996,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
         const data = (await run(
           dir,
           "poll",
-          { run_id: runId, file: FILE || "" },
+          { run_id: runId, file: FILE || "", native: "1" },
           // The controller's own lifetime: `dispose` aborts, so an unmounted
           // chat's last poll does not run to completion on its own.
           { key: null, ...(life ? { signal: life.signal } : {}) },
@@ -2090,15 +2090,12 @@ export function createChatController(deps: ControllerDeps): ChatController {
     if (!runId || answeredStates.has(id)) return;
     answeredStates.add(id); // claimed before the await: polls overlap
     trim(answeredStates);
-    // Once per REQUEST, not once per attempt: the claim above is released again
-    // when an attempt fails, and a retry appending another line would make the
-    // log read as several reads of the app for one tool call.
-    if (!notedStates.has(id)) {
-      notedStates.add(id);
-      trim(notedStates);
-      const reason = state.appState.find((r) => r.id === id)?.reason || "";
-      addNote(reason ? "read app state — " + reason : "read app state", "◍");
-    }
+    // NO LINE OF THIS PAGE'S OWN (owner E2E R1, 2026-09-10). T appended a
+    // "read app state" note at the end of the log when it answered — and the
+    // reply kept streaming ABOVE it, so the note trailed the finished answer
+    // like a stuck status, and a reload lost it. agent.py now emits the read
+    // as a notice segment where it happened (`native=1` on poll/history →
+    // `app_reads`), so it streams and restores in place.
     emit({ appState: state.appState.filter((r) => r.id !== id) });
     let res: AppStateResponse | null = null;
     try {
@@ -2418,7 +2415,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // Tagged with this attach's seat so only this attach can let it go.
     if (runId) claimingRuns.set(runId, seat);
     try {
-      let probe = (await run(dir, "poll", { run_id: runId, file: FILE || "" }, { key: null })) as
+      let probe = (await run(dir, "poll", { run_id: runId, file: FILE || "", native: "1" }, { key: null })) as
         | PollResponse
         | { error: string; done: true };
       if (logGen !== gen || disposed) return;
@@ -2433,7 +2430,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
         i++
       ) {
         await sleep(UNKNOWN_RUN_RETRY_MS);
-        probe = (await run(dir, "poll", { run_id: runId, file: FILE || "" }, { key: null })) as
+        probe = (await run(dir, "poll", { run_id: runId, file: FILE || "", native: "1" }, { key: null })) as
           | PollResponse
           | { error: string; done: true };
         if (logGen !== gen || disposed) return;
@@ -2766,7 +2763,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
       : (run(
           dir,
           "history",
-          { file: FILE || "", session_id: sessionId },
+          { file: FILE || "", session_id: sessionId, native: "1" },
           { key: null },
         ) as Promise<HistoryResponse & { error?: string }>);
 

--- a/frontend/src/apps/claude/protocol/types.ts
+++ b/frontend/src/apps/claude/protocol/types.ts
@@ -383,6 +383,11 @@ export interface PollResponse {
   tasks_pending: boolean;
   activity: Activity;
   segments: Segment[];
+  /** Byte offset in out.jsonl where this payload's window starts — the poll
+   *  cursor. A change while a follow-up is outstanding IS the cursor stepping
+   *  past its seam (agent.py `_poll`, Bugbot #1099). Absent on an older
+   *  agent.py. */
+  window?: number;
   /**
    * Where a mid-stream follow-up was ABSORBED into the reply already streaming
    * (agent.py `_absorbed_turn_breaks`). One entry per seam, in file order,

--- a/frontend/src/apps/claude/protocol/types.ts
+++ b/frontend/src/apps/claude/protocol/types.ts
@@ -63,6 +63,9 @@ export interface PollRequest {
   run_id: string;
   /** Rides along so a poll can refuse another target's run (agent.py:5199-5203). */
   file: string;
+  /** `"1"` from the React page: app-state reads come back as in-stream
+   *  notice segments instead of being stripped (agent.py `app_reads`). */
+  native?: string;
 }
 
 /** `decide` for a permission card (T:13979-13996). */
@@ -125,6 +128,9 @@ export interface FileSessionRequest {
   file: string;
   /** Optional for `live_run` (target as a whole), required for the rest. */
   session_id: string;
+  /** `"1"` from the React page (history): app-state reads come back as
+   *  in-stream notice segments (agent.py `app_reads`). */
+  native?: string;
 }
 export interface RunIdRequest {
   run_id: string;

--- a/frontend/src/apps/claude/protocol/types.ts
+++ b/frontend/src/apps/claude/protocol/types.ts
@@ -129,6 +129,12 @@ export interface FileSessionRequest {
 export interface RunIdRequest {
   run_id: string;
 }
+/** `cancel` — `queued: "1"` when this page had a follow-up in flight for the
+ *  turn, so agent.py ends the session tree after the interrupt rather than
+ *  letting the CLI answer the queue with nobody watching. */
+export interface CancelRequest extends RunIdRequest {
+  queued?: string;
+}
 export interface SnapshotsRequest {
   file: string;
   /** "" | "0" = don't enrich (agent.py:5239-5250). */
@@ -166,7 +172,7 @@ export interface AgentRequests {
   shots_dir: Record<string, never>;
   image_to_png: ImageToPngRequest;
   terminal_command: FileSessionRequest;
-  cancel: RunIdRequest;
+  cancel: CancelRequest;
   live_host: FileSessionRequest;
   send: SendRequest;
 }

--- a/frontend/src/apps/claude/sched/scheduled.test.ts
+++ b/frontend/src/apps/claude/sched/scheduled.test.ts
@@ -6,7 +6,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   createScheduleWatcher,
-  NOTE_FOREIGN,
   NOTE_OURS,
   SB_STATES,
   SCHEDULE_IMMINENT_MS,
@@ -325,13 +324,14 @@ describe("pollScheduledRuns", () => {
     expect(h.resumed).toEqual(["r-new"]);
   });
 
-  test("a foreign run is noted ONCE and never marked attached", async () => {
+  test("a foreign run is SILENT here (owner E2E R1, F9) and never marked attached", async () => {
     const rows = [fired({ id: "theirs", session_id: "s2" })];
     const h = harness({ entries: [[], rows, rows] });
     await h.watcher.tick();
     await h.watcher.tick();
     await h.watcher.tick();
-    expect(h.notes).toEqual([NOTE_FOREIGN]);
+    // Another conversation's scheduled run is not this chat's business.
+    expect(h.notes).toEqual([]);
     expect(h.resumed).toEqual([]);
     // NOT in `attached`: switching to that session must still restore the turn
     // from history rather than being written off as already handled.

--- a/frontend/src/apps/claude/sched/scheduled.ts
+++ b/frontend/src/apps/claude/sched/scheduled.ts
@@ -566,10 +566,13 @@ export function createScheduleWatcher(deps: ScheduleWatcherDeps): ScheduleWatche
         continue;
       }
       if (!scheduledRunIsOurs(entry, mine)) {
-        if (!noted.has(runId)) {
-          noted.add(runId);
-          deps.addNote(NOTE_FOREIGN);
-        }
+        // SILENT (owner E2E R1, F9). T posted "a scheduled message for this
+        // folder just ran in another session" into EVERY open chat on the
+        // folder — a chat that never scheduled anything got a warning about
+        // work it has nothing to do with. The run is someone else's
+        // conversation; it shows up there, and on the tasks page. The id is
+        // still remembered so a later tick does not re-evaluate it.
+        noted.add(runId);
         continue;
       }
       // The live-turn guard sits HERE, adjacent to the call with nothing awaited

--- a/frontend/src/apps/claude/styles/transcript.css
+++ b/frontend/src/apps/claude/styles/transcript.css
@@ -791,7 +791,7 @@
 /* The label column, so a two-line description wraps inside the row instead of
    shoving the tick around. `.qbody` (the Other row) is the same box by another
    name; both are the row's one growing child. */
-.chat-root .perm .qopt > span:not(.qtick),
+.chat-root .perm .qopt > span:not(.qtick):not(.qnum),
 .chat-root .perm .qopt .qbody {
   flex: 1 1 auto;
   min-width: 0;
@@ -835,6 +835,12 @@
 }
 .chat-root .perm .qopt:hover:not(:disabled) .qnum {
   color: var(--c-fg);
+}
+/* THE KEYBOARD'S CUE lands on the row, since the control itself is unseen
+   (Bugbot #1099): the same ring the tick used to wear, drawn around the row. */
+.chat-root .perm .qopt:has(.qtick:focus-visible) {
+  outline: 2px solid color-mix(in srgb, var(--c-accent) 70%, transparent);
+  outline-offset: -2px;
 }
 .chat-root .perm .qopt:has(.qtick[data-checked]) .qnum,
 .chat-root .perm .qopt.qother.typing .qnum {

--- a/frontend/src/apps/claude/styles/transcript.css
+++ b/frontend/src/apps/claude/styles/transcript.css
@@ -704,7 +704,11 @@
   border-color: var(--c-border);
 }
 .chat-root .perm.ask .qscroll {
-  max-height: 46vh;
+  /* Owner E2E R1 (2026-09-10, screenshot): "too big … 70–80% max". Was 46vh,
+     which with the old 50px option rows meant a five-option card scrolled
+     inside itself on a laptop. The rows are half that height now (below), so
+     most cards never reach this; the cap is for the long tail. */
+  max-height: 75vh;
   overflow: auto;
 }
 /* While an "Other" row is open there is exactly ONE scroller inside the card,
@@ -732,14 +736,22 @@
 }
 .chat-root .perm .qtext {
   font-size: 14px;
-  line-height: 1.45;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--c-fg-strong);
   word-break: break-word;
 }
+/* THE LIST, not a stack of cards (owner E2E R1, 2026-09-10, reference: the
+   Claude desktop question sheet). Rows with no border of their own, a hairline
+   between them, a numbered badge at the left instead of a radio, the
+   description in line after the label. Half the height of the boxed rows this
+   replaced, so a five-option question is a glance and not a scroll. */
 .chat-root .perm .qopts {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 12px;
+  gap: 0;
+  margin-top: 8px;
+  counter-reset: qn;
 }
 /* AN OPTION ROW (#19/#21). It is a row of [tick | label over description],
    left-aligned, and every one of those words had to be said again here because
@@ -753,15 +765,17 @@
 .chat-root .perm .qopt {
   display: flex;
   justify-content: flex-start;
-  gap: 12px;
-  align-items: flex-start;
+  gap: 10px;
+  align-items: center;
   text-align: left;
   width: 100%;
   height: auto;
   min-height: 0;
-  padding: 10px 12px;
-  border: 1px solid var(--c-border);
-  border-radius: 10px;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 8px;
+  /* The hidden control below is positioned against the row. */
+  position: relative;
   background: transparent;
   color: var(--c-fg);
   font: inherit;
@@ -782,9 +796,50 @@
   flex: 1 1 auto;
   min-width: 0;
 }
+.chat-root .perm .qopt + .qopt {
+  /* A hairline between rows, drawn as a shadow so the radius on hover is not
+     cut through by a border. */
+  box-shadow: inset 0 1px 0 var(--c-border);
+}
 .chat-root .perm .qopt:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--c-accent) 60%, transparent);
   background: var(--c-card-bg-2);
+}
+/* THE BADGE: the row's number, in the place the radio stood. The reference
+   sheet reads its options by number; a radio said "pick one" and a checkbox
+   said "pick many" but neither said WHICH row this is. Checked = accent fill.
+   The Other row wears a pencil: it is written, not picked. */
+.chat-root .perm .qopt .qnum {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: var(--c-card-bg-2);
+  color: var(--c-dim);
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  transition:
+    background 0.12s ease-out,
+    color 0.12s ease-out;
+}
+.chat-root .perm .qopt:not(.qother) .qnum::before {
+  counter-increment: qn;
+  content: counter(qn);
+}
+.chat-root .perm .qopt.qother .qnum::before {
+  content: "✎";
+  font-size: 12px;
+}
+.chat-root .perm .qopt:hover:not(:disabled) .qnum {
+  color: var(--c-fg);
+}
+.chat-root .perm .qopt:has(.qtick[data-checked]) .qnum,
+.chat-root .perm .qopt.qother.typing .qnum {
+  background: var(--c-accent);
+  color: var(--c-on-accent);
 }
 /* THE SELECTED ROW, not just the selected tick. A 14px dot is not enough of an
    answer to "which one did I pick?" in a list of five; the row itself carries
@@ -792,19 +847,20 @@
    row is its parent — there is no class on the row to key off. */
 .chat-root .perm .qopt:has(.qtick[data-checked]),
 .chat-root .perm .qopt.qother.typing {
-  border-color: color-mix(in srgb, var(--c-accent) 70%, transparent);
   background: color-mix(in srgb, var(--c-accent) 12%, transparent);
 }
 .chat-root .perm .qopt:has(.qtick[data-checked]) .lbl {
   color: var(--c-fg-strong);
 }
 .chat-root .perm .qopt .lbl {
-  font-weight: 600;
-  display: block;
+  font-weight: 500;
+  display: inline;
 }
+/* In line after the label, dim, so a row is one line unless the words need
+   two. */
 .chat-root .perm .qopt .desc {
-  display: block;
-  margin-top: 2px;
+  display: inline;
+  margin-left: 8px;
   color: var(--c-dim);
   font-size: 12px;
   line-height: 1.4;
@@ -815,12 +871,18 @@
    middle out. Selected by TYPE, never as "any input in a .qopt" — the Other
    row puts a text field inside one. */
 .chat-root .perm .qopt .qtick {
+  /* The control stays for the keyboard, the screen reader and the `:has()`
+     rules above; the badge is its face. Sized to nothing rather than
+     `display: none`, which would take it out of the tab order. */
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
   appearance: none;
   -webkit-appearance: none;
-  width: 14px;
-  height: 14px;
-  min-width: 14px;
-  margin: 3px 0 0;
+  width: 1px;
+  height: 1px;
+  min-width: 1px;
+  margin: 0;
   flex-shrink: 0;
   border: 1.5px solid var(--c-border-strong);
   background: var(--c-bg);
@@ -882,8 +944,12 @@
   overflow: visible;
 }
 .chat-root .perm .qopt.qother.typing {
-  border-color: color-mix(in srgb, var(--c-accent) 60%, transparent);
+  /* The field grows under the caption; the badge stays on the first line. */
+  align-items: flex-start;
   cursor: default;
+}
+.chat-root .perm .qopt.qother.typing .qnum {
+  margin-top: 1px;
 }
 /* By CLASS only, never `textarea.qtype`, so it cannot lose a specificity race
    to a rule that selects on the row's contents. */
@@ -923,9 +989,9 @@
   border-color: color-mix(in srgb, var(--c-accent) 60%, transparent);
 }
 .chat-root .perm .qsend {
-  margin-top: 12px;
+  margin-top: 8px;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
 }
 /* Why Send is still off, said next to Send. A disabled primary button with no
    explanation is a dead end; "1 of 3 answered" is the instruction. */
@@ -962,7 +1028,7 @@
   display: flex;
   flex-wrap: nowrap;
   gap: 0;
-  margin: 10px 0 2px;
+  margin: 8px 0 2px;
   padding: 0;
   width: 100%;
   height: auto;
@@ -976,7 +1042,7 @@
   flex: 1 1 0;
   min-width: 0;
   height: auto;
-  padding: 5px 10px;
+  padding: 4px 10px;
   border: 0;
   border-radius: 0;
   margin: 0;

--- a/frontend/src/apps/claude/ui/Composer.tsx
+++ b/frontend/src/apps/claude/ui/Composer.tsx
@@ -16,6 +16,7 @@ import { useAutoGrow } from "@platform/lib/autoGrow";
 import "../styles/composer.css";
 import type { PermissionMode } from "../protocol/types";
 import type { RunStatus, SendOptions } from "../protocol/controller-api";
+import type { Attachment } from "../shots/types";
 import {
   applyLead2,
   fitFlags,
@@ -30,7 +31,7 @@ import { EffortSelect } from "./EffortSelect";
 import { ModelSelect } from "./ModelSelect";
 import { PermissionSelect } from "./PermissionSelect";
 import { SchedButton } from "./SchedButton";
-import { takeDraft } from "./sched-draft";
+import { takeAttachments, takeDraft } from "./sched-draft";
 
 /** T:4227 / T:4156 — the box's own placeholder, verbatim. The chat one names
  *  who is being replied to; the landing one names the errand. */
@@ -290,6 +291,21 @@ export interface ComposerCardProps {
   /** Chips above the box: attachments (PR2), annotations (PR3). */
   chips?: ReactNode;
   /**
+   * THE TRAY ITSELF, for the scheduler handoff's other half. `chips` is what it
+   * LOOKS like and `hasAttachments` is whether there is one; Schedule needs the
+   * list, because what travels to the task form is a copy of every file in it
+   * (owner E2E R1, F4 (2026-09-10)). A function, read at Continue time, for the
+   * reason `draft` is one.
+   */
+  attachments?(): readonly Attachment[];
+  /**
+   * …and the way back: the paths the task form was opened on, handed to the tray
+   * on the mount that follows "Back to chat". These are task-shots-resident real
+   * paths, so this is `addPaths`' errand — no upload, thumbnails through
+   * /api/fs/raw.
+   */
+  onRestoreAttachments?(paths: string[]): void;
+  /**
    * ⌘V of a picture or a file (T:11719 `shotPasteHandler`). The handler decides
    * whether the paste was an attachment — a paste of WORDS must reach the box,
    * and stealing an ordinary paste in a composer the user types in all day would
@@ -343,6 +359,8 @@ export function ComposerCard({
   sendBusy,
   columnRef,
   chips,
+  attachments,
+  onRestoreAttachments,
   onPaste,
   camera,
   fitRevision,
@@ -352,6 +370,29 @@ export function ComposerCard({
   // The other half of the scheduler round trip, put back into an EMPTY box
   // only, and the stash is spent either way (T:12105-12118).
   const [text, setText] = useState(() => takeDraft(file));
+  /**
+   * THE TRAY'S HALF OF THE SAME ROUND TRIP (owner E2E R1, F4 (2026-09-10)).
+   *
+   * Not a `useState` initialiser like the draft's, because the answer does not
+   * belong to this component: the tray lives in `ClaudeChat`, and the only thing
+   * to do with these paths is hand them up. In an EFFECT and not the render body
+   * for `attachBack`'s reason — a render React throws away (StrictMode's double
+   * invoke, a concurrent attempt that loses) must not have spent the stash.
+   *
+   * ONCE, latched on a ref: `takeAttachments` spends the row, so the second run
+   * of a StrictMode double-mount reads nothing anyway — but the handler is a
+   * prop whose identity changes, and re-running on it would re-add the tray's
+   * chips on every re-render that reshuffled it.
+   */
+  const tookAttachments = useRef(false);
+  const restoreAttachments = useRef(onRestoreAttachments);
+  restoreAttachments.current = onRestoreAttachments;
+  useEffect(() => {
+    if (tookAttachments.current) return;
+    tookAttachments.current = true;
+    const back = takeAttachments(file);
+    if (back.length) restoreAttachments.current?.(back.map((a) => a.path));
+  }, [file]);
   const { ref: boxRef, grow } = useAutoGrow(text);
   const rowRef = useRef<HTMLDivElement | null>(null);
   // The host's ref MIRRORS ours rather than replacing it: `useAutoGrow` owns the
@@ -582,6 +623,7 @@ export function ComposerCard({
             file={file}
             sessionId={sessionId}
             draft={draft}
+            {...(attachments ? { attachments } : {})}
             back={back}
             // TWO GUARDS WITH DIFFERENT SCOPES, which is what T:12075/12099 read
             // off `schedBlocked() || annNavLocked()` for every `.schedbtn`:

--- a/frontend/src/apps/claude/ui/QuestionCard.tsx
+++ b/frontend/src/apps/claude/ui/QuestionCard.tsx
@@ -378,10 +378,12 @@ export function QuestionCard({ row, onAnswer, onDismiss }: QuestionCardProps) {
                     disabled={posting || resolved}
                     onClick={() => void sendOne(q, option.label)}
                   >
+                    <span className="qnum" aria-hidden="true" />
                     <OptionText option={option} />
                   </Button>
                 ) : (
                   <label key={oi} className="qopt">
+                    <span className="qnum" aria-hidden="true" />
                     {multi ? (
                       <Checkbox
                         className="qtick"
@@ -414,6 +416,7 @@ export function QuestionCard({ row, onAnswer, onDismiss }: QuestionCardProps) {
               {oneShot ? (
                 otherOpen[i] ? (
                   <div className="qopt qother typing">
+                    <span className="qnum" aria-hidden="true" />
                     {/* The SAME body the button carries, not a bare field: an
                         unlabelled input left a grey box the user could not
                         tell what they were answering (T:14346-14351).
@@ -458,11 +461,13 @@ export function QuestionCard({ row, onAnswer, onDismiss }: QuestionCardProps) {
                     }}
                     onClick={() => openOther(i)}
                   >
+                    <span className="qnum" aria-hidden="true" />
                     <OptionText option={OTHER} />
                   </button>
                 )
               ) : (
                 <label className={cn("qopt", "qother", otherOpen[i] && "typing")}>
+                  <span className="qnum" aria-hidden="true" />
                   {multi ? (
                     <Checkbox
                       className="qtick"

--- a/frontend/src/apps/claude/ui/SchedButton.tsx
+++ b/frontend/src/apps/claude/ui/SchedButton.tsx
@@ -6,10 +6,23 @@
 // know and this composer always does: the FOLDER, the words already in the box,
 // and the conversation they were written in. What does NOT travel is how this
 // chat is configured — a task runs unattended and the page owns those answers.
-import { useCallback, useEffect, useState } from "react";
+//
+// …and, since owner E2E R1, F4 (2026-09-10), THE ATTACHMENTS: a draft that
+// carries three screenshots is one thing the user assembled, and arriving at the
+// task form with the words but not the pictures made them do the attaching
+// twice.
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Popover, PopoverTrigger } from "@platform/shadcn/ui/popover";
+import { rawUrl, uploadTaskShot } from "@platform/lib/api";
+import type { Attachment } from "../shots/types";
 import { SchedConfirm } from "./SchedConfirm";
-import { schedulerUrl, stashDraft } from "./sched-draft";
+import {
+  basenameOf,
+  schedulerUrl,
+  stashAttachments,
+  stashDraft,
+  type SchedAttachment,
+} from "./sched-draft";
 import { useDismissOnWindow } from "./useDismissOnWindow";
 
 export interface SchedButtonProps {
@@ -20,6 +33,10 @@ export interface SchedButtonProps {
   /** Read at CONTINUE time and not at open time, so a paste made with the
    *  confirm already up still travels (T:12094). */
   draft(): string;
+  /** The tray, read at CONTINUE time for the same reason `draft` is: a picture
+   *  attached while the confirm was up is part of what the user is scheduling
+   *  (owner E2E R1, F4 (2026-09-10)). Absent on a composer with no tray. */
+  attachments?(): readonly Attachment[];
   /** Where "Back to chat" has to land — the host's own path. */
   back: string;
   /** A pending scheduled message shuts this door as well as the composer's
@@ -76,10 +93,51 @@ function CalendarIcon() {
   );
 }
 
+/**
+ * THE CHAT'S ATTACHMENTS, COPIED INTO THE TASK-SHOTS DIR.
+ *
+ * The backend refuses any `attachments` path outside `schedule.shots_dir()`
+ * (~/.fused-render/task-shots), and a chat attachment lives in the claude
+ * template's tempdir-rooted shots dir on a 12 h TTL — so the path itself cannot
+ * travel. The bytes do: read the file back through /api/fs/raw (the same URL the
+ * chip's own thumbnail is drawn from) and put it up through the endpoint the
+ * task form's own drop and paste already use, which is what makes the two kinds
+ * of attachment indistinguishable once they are on the card.
+ *
+ * PENDING CHIPS ARE NOT PART OF THIS, for `take()`'s reason: their bytes are
+ * still on their way, so there is nothing to copy.
+ *
+ * ONE FAILURE COSTS ONE ATTACHMENT. `allSettled` and not `all`: a pruned file or
+ * a refused upload must not take the other two with it, and must never be the
+ * reason the button does nothing at all — the words and the folder are the
+ * handoff's point and they still travel (owner E2E R1, F4 (2026-09-10)).
+ */
+export async function copyToTaskShots(
+  items: readonly Attachment[],
+): Promise<SchedAttachment[]> {
+  const carry = items.filter((a) => !a.pending && !!a.view);
+  if (!carry.length) return [];
+  const done = await Promise.allSettled(
+    carry.map(async (att): Promise<SchedAttachment> => {
+      const view = att.view as string;
+      const name = att.name || basenameOf(view);
+      const res = await fetch(rawUrl(view));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const blob = await res.blob();
+      const up = await uploadTaskShot(new File([blob], name, { type: blob.type }));
+      return { path: up.path, name, kind: up.kind === "image" ? "image" : "file" };
+    }),
+  );
+  // IN THE TRAY'S OWN ORDER, which `allSettled` preserves: the chips on the task
+  // card then read left to right the way the chips in the composer did.
+  return done.flatMap((r) => (r.status === "fulfilled" ? [r.value] : []));
+}
+
 export function SchedButton({
   file,
   sessionId,
   draft,
+  attachments,
   back,
   disabled,
   disabledReason,
@@ -102,19 +160,59 @@ export function SchedButton({
     if (disabled) setOpen(false);
   }, [disabled]);
 
+  /**
+   * A HANDOFF IS ALREADY LEAVING. The copy below is a round trip per attachment,
+   * so Continue is no longer instantaneous, and a second Continue in that window
+   * would upload every file twice and navigate twice. A ref and not state, for
+   * `useAttachments`' `busy` reason: a boolean in state is only read as of the
+   * render that closed over it, and both presses of a double click are in one
+   * tick.
+   */
+  const leaving = useRef(false);
+
   const go = useCallback(() => {
     // The confirm can OUTLIVE the press that opened it — the schedule poll may
     // block this chat while the question is still on screen — so the last word
     // on whether a task may be made from here is read HERE (T:12091).
-    if (disabled) return;
+    if (disabled || leaving.current) return;
+    leaving.current = true;
     const text = draft().trim();
+    const tray = attachments?.() ?? [];
     setOpen(false);
     // The draft SURVIVES the trip: leaving unloads this view, and a rebuilt
     // composer used to come back empty (T:12011).
     stashDraft(file, text);
-    const url = schedulerUrl({ file, draft: text, sessionId, back });
-    onNavigate?.(url);
-  }, [disabled, draft, file, sessionId, back, onNavigate]);
+    const leave = (carried: SchedAttachment[]): void => {
+      // Both roads, for the two directions: the URL is how the task form opens
+      // on them, the stash is how the composer gets them back.
+      stashAttachments(file, carried);
+      onNavigate?.(
+        schedulerUrl({ file, draft: text, sessionId, back, attachments: carried }),
+      );
+    };
+    // AN EMPTY TRAY STILL LEAVES IN THIS TICK. The copy below is a round trip
+    // per file and there is nothing to round-trip here, so the overwhelmingly
+    // common handoff keeps the immediacy T:12019 built it for — a Continue that
+    // waits a microtask for an answer it already knows is a control that feels
+    // slower for no reason.
+    if (!tray.some((a) => !a.pending && !!a.view)) {
+      leaving.current = false;
+      leave([]);
+      return;
+    }
+    // THE TRAY IS NOT EMPTIED. `take()` is the send's gesture; this one is a
+    // handoff the user can walk back from with "Back to chat", and a tray
+    // cleared here would leave them with neither copy while the task form is
+    // open (owner E2E R1, F4 (2026-09-10)).
+    void copyToTaskShots(tray)
+      .catch((): SchedAttachment[] => [])
+      .then(leave)
+      .finally(() => {
+        // A refused navigation (no `onNavigate`, a host that declined) must not
+        // latch the button for the rest of the page's life.
+        leaving.current = false;
+      });
+  }, [disabled, draft, attachments, file, sessionId, back, onNavigate]);
 
   const cancel = useCallback(() => {
     setOpen(false);

--- a/frontend/src/apps/claude/ui/Transcript.tsx
+++ b/frontend/src/apps/claude/ui/Transcript.tsx
@@ -119,7 +119,10 @@ export const Transcript = memo(function Transcript({
   const log = useRef<HTMLDivElement>(null);
   const followTail = useRef(true);
   const [flare, setFlare] = useState<string | null>(null);
-  const anchorSpent = useRef(false);
+  // Keyed by the anchor it was spent on, not a boolean: the chat does not
+  // remount between two task-list clicks, and a latch that never re-armed made
+  // the second message link a no-op (owner E2E R1, F2).
+  const anchorSpent = useRef<string | null>(null);
   const stopSettle = useRef<(() => void) | null>(null);
 
   // ── the follow flag and the gestures that move it ────────────────────────
@@ -403,11 +406,21 @@ export const Transcript = memo(function Transcript({
   const spend = useRef(onAnchorSpent);
   spend.current = onAnchorSpent;
   useEffect(() => {
-    if (!msgAnchor || anchorSpent.current || state.historyLoading) return;
+    // `transcriptGen === 0` is a history load that has not STARTED yet — the
+    // first render, before the host's boot effect flips `historyLoading` on.
+    // Spending the anchor there landed it on an empty log every time a task
+    // page opened from a message link (owner E2E R1, F2).
+    if (
+      !msgAnchor ||
+      anchorSpent.current === msgAnchor ||
+      state.historyLoading ||
+      state.transcriptGen === 0
+    )
+      return;
     // Spent on the first transcript it is offered, landed or not: left armed, a
     // uuid that matched nothing here would flare whichever turn of a DIFFERENT
     // conversation happened to carry that id.
-    anchorSpent.current = true;
+    anchorSpent.current = msgAnchor;
     const wrap = port.current;
     const el = findTurn(log.current, msgAnchor);
     spend.current?.();

--- a/frontend/src/apps/claude/ui/Transcript.tsx
+++ b/frontend/src/apps/claude/ui/Transcript.tsx
@@ -406,15 +406,17 @@ export const Transcript = memo(function Transcript({
   const spend = useRef(onAnchorSpent);
   spend.current = onAnchorSpent;
   useEffect(() => {
-    // `transcriptGen === 0` is a history load that has not STARTED yet — the
-    // first render, before the host's boot effect flips `historyLoading` on.
-    // Spending the anchor there landed it on an empty log every time a task
-    // page opened from a message link (owner E2E R1, F2).
+    // AN EMPTY LOG THAT HAS NOT LOADED YET IS NOT A TRANSCRIPT TO SPEND ON.
+    // `transcriptGen === 0` with no turns is the first render, before the
+    // host's boot effect flips `historyLoading` on: spending the anchor there
+    // landed it on an empty log every time a task page opened from a message
+    // link (owner E2E R1, F2). A conversation started with Send never bumps
+    // the generation but HAS turns, so it is not held back (Bugbot #1099).
     if (
       !msgAnchor ||
       anchorSpent.current === msgAnchor ||
       state.historyLoading ||
-      state.transcriptGen === 0
+      (state.transcriptGen === 0 && state.turns.length === 0)
     )
       return;
     // Spent on the first transcript it is offered, landed or not: left armed, a
@@ -430,7 +432,7 @@ export const Transcript = memo(function Transcript({
     scrollToAnchor(el, still);
     stopSettle.current = settleAnchor(wrap, el, still);
     setFlare(msgAnchor);
-  }, [msgAnchor, state.historyLoading]);
+  }, [msgAnchor, state.historyLoading, state.transcriptGen, state.turns.length]);
   // The flare's own effect, keyed on the flare: one timer per halo, torn down
   // only when the halo it belongs to goes.
   useEffect(() => {

--- a/frontend/src/apps/claude/ui/cards.test.tsx
+++ b/frontend/src/apps/claude/ui/cards.test.tsx
@@ -696,8 +696,11 @@ test("the open Other row keeps its caption and field in a single .qbody column",
   expect(String((open.props as Props).className)).toContain("typing");
   // Exactly ONE flex item in the row, and it owns everything.
   const children = (open.children ?? []).filter((k) => typeof k !== "string") as Json[];
-  expect(children).toHaveLength(1);
-  const body = children[0]!;
+  // The badge (the row's number / pencil, owner E2E R1 2026-09-10) then ONE
+  // body column — never the field as a third sibling.
+  expect(children).toHaveLength(2);
+  expect(String((children[0]!.props as Props).className)).toBe("qnum");
+  const body = children[1]!;
   expect(String((body.props as Props).className)).toBe("qbody");
   // The caption is inside it, beside the label and the field — not a sibling of
   // the textarea in the flex row.

--- a/frontend/src/apps/claude/ui/sched-draft.test.ts
+++ b/frontend/src/apps/claude/ui/sched-draft.test.ts
@@ -1,0 +1,137 @@
+// The scheduler handoff's two round trips: the draft (T:12105-12118) and the
+// attachments beside it (owner E2E R1, F4 (2026-09-10)).
+//
+// `sessionStorage` is NOT in `testDomShim` — nothing else in the suite needs it,
+// and the shim's own note says to extend it only for `window`/`location`/
+// `history` members. A map-backed stand-in is installed here, before the module
+// under test is imported, for the same ordering reason: `??=` so a suite that
+// ran first in this process keeps its own.
+import { installDomShim } from "@platform/lib/testDomShim";
+installDomShim();
+import { expect, test } from "bun:test";
+
+interface Storeish {
+  sessionStorage?: unknown;
+}
+const rows = new Map<string, string>();
+(globalThis as Storeish).sessionStorage ??= {
+  getItem: (k: string) => (rows.has(k) ? rows.get(k)! : null),
+  setItem: (k: string, v: string) => void rows.set(k, String(v)),
+  removeItem: (k: string) => void rows.delete(k),
+  clear: () => rows.clear(),
+};
+
+const {
+  attachKey,
+  basenameOf,
+  draftKey,
+  parseAttachmentsParam,
+  schedulerUrl,
+  stashAttachments,
+  stashDraft,
+  takeAttachments,
+  takeDraft,
+} = await import("./sched-draft");
+
+type SchedAttachment = import("./sched-draft").SchedAttachment;
+
+const FILE = "/w/app/page.html";
+const LINK = { file: FILE, draft: "look at this", sessionId: "s1", back: "/w/app/page.html" };
+const SHOTS: SchedAttachment[] = [
+  { path: "/Users/a/.fused-render/task-shots/20260910-a.png", name: "shot.png", kind: "image" },
+  { path: "/Users/a/.fused-render/task-shots/20260910-b.csv", name: "rows.csv", kind: "file" },
+];
+
+test("the two stashes are DIFFERENT rows — each half of the handoff is spent on its own", () => {
+  expect(attachKey(FILE)).not.toBe(draftKey(FILE));
+  expect(attachKey(null)).toBe("fused:chatshots:");
+});
+
+test("the attachments round-trip, and the row is SPENT — a second mount gets nothing", () => {
+  stashAttachments(FILE, SHOTS);
+  expect(takeAttachments(FILE)).toEqual(SHOTS);
+  // Spent either way, exactly like the draft: re-filling the tray over what the
+  // user has attached since is the bug this rule exists for.
+  expect(takeAttachments(FILE)).toEqual([]);
+});
+
+test("the two halves do not read each other's row", () => {
+  stashDraft(FILE, "words");
+  stashAttachments(FILE, SHOTS);
+  expect(takeDraft(FILE)).toBe("words");
+  expect(takeAttachments(FILE)).toEqual(SHOTS);
+});
+
+test("an EMPTY list clears the row rather than storing []", () => {
+  stashAttachments(FILE, SHOTS);
+  stashAttachments(FILE, []);
+  expect(takeAttachments(FILE)).toEqual([]);
+});
+
+test("the stash is per FILE — a handoff from another folder is another errand", () => {
+  stashAttachments(FILE, SHOTS);
+  expect(takeAttachments("/w/other/page.html")).toEqual([]);
+  expect(takeAttachments(FILE)).toEqual(SHOTS);
+});
+
+test("schedulerUrl appends the attachments, decodably, and ONLY when there are some", () => {
+  expect(schedulerUrl(LINK)).not.toContain("attachments=");
+  const url = schedulerUrl({ ...LINK, attachments: SHOTS });
+  const raw = new URLSearchParams(url.slice(url.indexOf("?"))).get("attachments");
+  expect(JSON.parse(raw!)).toEqual(SHOTS);
+  // The rest of the link is untouched — the param is an addition, not a shape
+  // change (T:12019's `new=1` still opens the form).
+  expect(url.startsWith("/tasks?new=1")).toBe(true);
+  expect(url).toContain("&message=look%20at%20this");
+});
+
+test("an empty attachments list is the same URL as no attachments at all", () => {
+  expect(schedulerUrl({ ...LINK, attachments: [] })).toBe(schedulerUrl(LINK));
+});
+
+test("BAD JSON IS AN EMPTY LIST, never a throw — the effect that opens the form runs on it", () => {
+  expect(parseAttachmentsParam(null)).toEqual([]);
+  expect(parseAttachmentsParam("")).toEqual([]);
+  expect(parseAttachmentsParam("[{oops")).toEqual([]);
+  expect(parseAttachmentsParam('{"path":"/a.png"}')).toEqual([]);
+  expect(parseAttachmentsParam("[1,null,\"x\"]")).toEqual([]);
+});
+
+test("a row with no path is dropped, and everything else is floored", () => {
+  expect(
+    parseAttachmentsParam(
+      JSON.stringify([
+        { path: "", name: "gone", kind: "image" },
+        { name: "pathless", kind: "image" },
+        { path: "/shots/x.png", kind: "image" },
+        { path: "/shots/y.tif", name: "y.tif", kind: "wat" },
+      ]),
+    ),
+  ).toEqual([
+    // No name on the wire: the basename is the only name there is.
+    { path: "/shots/x.png", name: "x.png", kind: "image" },
+    // Anything that is not the word "image" wears the glyph — the same floor
+    // `restoredAttachments` applies to a stored entry.
+    { path: "/shots/y.tif", name: "y.tif", kind: "file" },
+  ]);
+});
+
+test("a stashed row from an older build is read by the same parser", () => {
+  // Written by hand rather than by `stashAttachments`, which is the case this
+  // shared parser exists for.
+  (globalThis as { sessionStorage: Storage }).sessionStorage.setItem(
+    attachKey(FILE),
+    '[{"path":"/shots/z.png"},"junk"]',
+  );
+  expect(takeAttachments(FILE)).toEqual([
+    { path: "/shots/z.png", name: "z.png", kind: "file" },
+  ]);
+});
+
+test("basenameOf survives both separators and a path that is only a name", () => {
+  expect(basenameOf("/shots/a/b.png")).toBe("b.png");
+  expect(basenameOf("C:\\shots\\b.png")).toBe("b.png");
+  expect(basenameOf("b.png")).toBe("b.png");
+  // Never the empty string: a chip with no name at all says nothing.
+  expect(basenameOf("/shots/")).toBe("/shots/");
+});

--- a/frontend/src/apps/claude/ui/sched-draft.ts
+++ b/frontend/src/apps/claude/ui/sched-draft.ts
@@ -33,6 +33,96 @@ export function takeDraft(file: string | null): string {
   }
 }
 
+/**
+ * ONE ATTACHMENT, AS THE TASK FORM STORES IT — the `attachments` row of POST
+ * /api/schedule, and the same three fields `restoredAttachments` reads back off
+ * a saved entry. `path` is always task-shots-resident: the chat's own copy lives
+ * in its tempdir shots dir on a 12 h TTL, which the backend will not accept, so
+ * the handoff re-uploads the bytes and carries the answer (owner E2E R1, F4
+ * (2026-09-10)).
+ */
+export interface SchedAttachment {
+  path: string;
+  name: string;
+  kind: "image" | "file";
+}
+
+/** The draft's key with a distinct suffix: the two halves of the handoff are
+ *  spent independently, so they cannot share one row (owner E2E R1, F4
+ *  (2026-09-10)). */
+export function attachKey(file: string | null): string {
+  return `fused:chatshots:${file ?? ""}`;
+}
+
+/** Same contract as `stashDraft`: a storage refusal costs the round trip, never
+ *  the navigation. */
+export function stashAttachments(
+  file: string | null,
+  list: readonly SchedAttachment[],
+): void {
+  try {
+    if (!list.length) {
+      sessionStorage.removeItem(attachKey(file));
+      return;
+    }
+    sessionStorage.setItem(attachKey(file), JSON.stringify(list));
+  } catch {
+    // Storage denied — the chips just don't come back with the draft.
+  }
+}
+
+/** SPENT on read, exactly like `takeDraft`: a second composer mount must not
+ *  re-fill the tray over what the user has attached since. */
+export function takeAttachments(file: string | null): SchedAttachment[] {
+  try {
+    const key = attachKey(file);
+    const saved = sessionStorage.getItem(key);
+    if (saved === null) return [];
+    sessionStorage.removeItem(key);
+    return parseAttachmentsParam(saved);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The `&attachments=` param, or the stashed row, turned into a list — and it is
+ * the same function for both because both are strings someone else wrote: a URL
+ * a user edited, a sessionStorage row from an older build. BAD JSON IS AN EMPTY
+ * LIST, never a throw: this runs inside the effect that opens the task form, and
+ * a parse error there cost the whole handoff (owner E2E R1, F4 (2026-09-10)).
+ */
+export function parseAttachmentsParam(raw: string | null): SchedAttachment[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const out: SchedAttachment[] = [];
+  for (const row of parsed) {
+    if (!row || typeof row !== "object") continue;
+    const a = row as Partial<SchedAttachment>;
+    if (typeof a.path !== "string" || !a.path) continue;
+    out.push({
+      path: a.path,
+      name: typeof a.name === "string" && a.name ? a.name : basenameOf(a.path),
+      // Anything that is not the word "image" is a glyph, which is the same
+      // floor `restoredAttachments` applies to a stored entry.
+      kind: a.kind === "image" ? "image" : "file",
+    });
+  }
+  return out;
+}
+
+/** The name a chip falls back to when the attachment carried none. */
+export function basenameOf(path: string): string {
+  const cut = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
+  return (cut === -1 ? path : path.slice(cut + 1)) || path;
+}
+
 /** `/tasks` (T:11968). */
 export const SCHEDULE_URL = "/tasks";
 
@@ -46,6 +136,10 @@ export interface SchedulerLink {
   /** The deep link's second errand; no caller in the template passes it any
    *  more, but it is the link's shape rather than a private argument (T:12007). */
   editId?: string;
+  /** What the composer's tray was holding, already copied into the task-shots
+   *  dir. In the URL as well as the stash because the form is opened FROM the
+   *  URL — the stash is the way back (owner E2E R1, F4 (2026-09-10)). */
+  attachments?: readonly SchedAttachment[];
 }
 
 /** `new=1` is what makes the hop feel like one control rather than two: the
@@ -59,6 +153,11 @@ export function schedulerUrl(link: SchedulerLink): string {
     `&target=${encodeURIComponent(link.file ?? "")}` +
     `&message=${encodeURIComponent(link.draft || "")}` +
     `&session_id=${encodeURIComponent(link.sessionId || "")}` +
-    `&back=${encodeURIComponent(link.back)}`
+    `&back=${encodeURIComponent(link.back)}` +
+    // ONLY WHEN THERE IS SOMETHING TO SAY: a `&attachments=%5B%5D` on every
+    // handoff is a URL that claims the trip carried files it did not.
+    (link.attachments && link.attachments.length
+      ? `&attachments=${encodeURIComponent(JSON.stringify(link.attachments))}`
+      : "")
   );
 }

--- a/frontend/src/apps/claude/ui/useFitStrip.ts
+++ b/frontend/src/apps/claude/ui/useFitStrip.ts
@@ -83,6 +83,35 @@ import { useCallback, useRef } from "react";
 
 import { measureRowNeed } from "./fit";
 
+/**
+ * THE STRIP'S NATURAL WIDTH, measured as the row's own `max-content` — every
+ * child at the width it asks for, growers included at THEIR content size.
+ *
+ * `measureRowNeed` sums the children's boxes as laid out, and one of this
+ * row's children grows (`.c-anncta` carries the slack, `flex: 1 1 auto`). Laid
+ * out, that child's box IS the slack, so the sum came out equal to the row's
+ * width at the moment it was read — and that moment was the first paint, at
+ * the widest the pane would ever be. Cached, "natural" then exceeded every
+ * narrower box by construction, and the strip folded on the first few pixels
+ * of shrink while the words still had a hundred to spare (owner E2E R1, F1,
+ * measured live: `tight` at a 379px box for a 373px labelled row).
+ *
+ * Read with the words ON (the caller strips `.tight` first). `max-content` on
+ * a flex row is the sum of its children's max-content, growers at their
+ * content width, gaps and padding included — the number the fold is about.
+ * The inline width is put back exactly as found, so a row that had none has
+ * none. Synchronous: one forced layout, on the same tick, invisible.
+ */
+export function measureStripNeed(row: HTMLElement): number {
+  const prev = row.style.width;
+  row.style.width = "max-content";
+  const w = row.getBoundingClientRect().width;
+  row.style.width = prev;
+  // A shim with no layout answers 0; fall back to the box sum so tests that
+  // drive `createStripFit` through a fake `need` keep meaning what they say.
+  return w > 0 ? Math.ceil(w) : measureRowNeed(row);
+}
+
 /** The px of overflow a strip is allowed to carry before it folds. Spent on the
  *  FOLD only — see the note above. */
 export const FIT_HYSTERESIS = 3;
@@ -102,7 +131,7 @@ export interface StripFit {
  * injected so a test can prove the verdict without a layout engine.
  */
 export function createStripFit(
-  need: (row: HTMLElement) => number = measureRowNeed,
+  need: (row: HTMLElement) => number = measureStripNeed,
 ): StripFit {
   let natural: number | null = null;
   return {
@@ -150,7 +179,7 @@ export function createStripFit(
 /** The one-shot verdict, for a caller with no generation to track. */
 export function fitStrip(
   row: HTMLElement | null | undefined,
-  need: (row: HTMLElement) => number = measureRowNeed,
+  need: (row: HTMLElement) => number = measureStripNeed,
 ): void {
   createStripFit(need).run(row);
 }

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -2224,6 +2224,7 @@ export default function NewJobModal({
   initialTime,
   initialTarget,
   initialMessage,
+  initialAttachments,
   chatSessionId,
   chatBack,
   editing,
@@ -2245,6 +2246,14 @@ export default function NewJobModal({
   // — first line to the title, the rest to the description (splitDraft), which
   // Save composes back into one message…
   initialMessage?: string | null;
+  // …and the chat's TRAY arrives as this card's chips (owner E2E R1, F4
+  // (2026-09-10)). Already copied into the task-shots dir by the composer's
+  // Schedule button — the chat's own copies live in a tempdir on a 12 h TTL and
+  // POST /api/schedule refuses any path outside the shots dir — so what lands
+  // here is the same three fields a saved entry's `attachments` carries, and it
+  // is seeded through the identical function an Edit uses. An Edit outranks it:
+  // that entry's own attachments are the ones being changed.
+  initialAttachments?: { path: string; name: string; kind: "image" | "file" }[];
   // …the open conversation arrives as a session to CONTINUE — but only a
   // one-off resumes it; a repeating task always opens fresh chats, because
   // resuming the same conversation every day compounds context forever.
@@ -2292,8 +2301,15 @@ export default function NewJobModal({
   // in this card's own chrome). An Edit opens on the entry's stored paths, kind
   // decided by extension since there is no File to ask; a fresh attach shows
   // its chip immediately and swaps in the uploaded path when the POST answers.
+  // …and a CHAT HANDOFF opens on the tray it came from, through the same
+  // function and therefore as the same chips: a restored path with no blob, its
+  // picture drawn through /api/fs/raw (owner E2E R1, F4 (2026-09-10)). Only when
+  // this is not an Edit — an entry being changed already has attachments of its
+  // own, and they are the ones on the card.
   const [images, setImages] = useState<TaskImage[]>(() =>
-    restoredAttachments(editing));
+    editing
+      ? restoredAttachments(editing)
+      : restoredAttachments({ images: [], attachments: initialAttachments ?? [] }));
   // THE REF IS THE AUTHORITY, the state is its mirror for rendering — and that
   // asymmetry is load-bearing twice (Bugbot, PR #865). Save awaits the uploads
   // and then has to read the paths they wrote; a `setImages` updater only

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -63,6 +63,14 @@ import type {
   Task,
 } from "@platform/lib/api";
 import { useRefreshOnReturn } from "@platform/lib/hooks";
+// The chat's own handoff module, not a second reading of its URL shape: the
+// param is written by `schedulerUrl` and there must be exactly one parser for it
+// (owner E2E R1, F4 (2026-09-10)). A leaf module with no imports of its own, so
+// this costs the shell chunk nothing but the function.
+import {
+  parseAttachmentsParam,
+  type SchedAttachment,
+} from "@apps/claude/ui/sched-draft";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
 import ScheduleCalendar, {
@@ -253,6 +261,11 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   const [newMessage, setNewMessage] = useState<string | null>(null);
   const [newSession, setNewSession] = useState<string | null>(null);
   const [newBack, setNewBack] = useState<string | null>(null);
+  // The chips the chat's tray was holding, already copied into the task-shots
+  // dir by the composer's Schedule button — so what arrives here is exactly the
+  // shape a saved entry's `attachments` has, and the card seeds from it the same
+  // way an Edit does (owner E2E R1, F4 (2026-09-10)).
+  const [newAttachments, setNewAttachments] = useState<SchedAttachment[]>([]);
   // Search, status and project, client-side only — nothing here is worth a URL
   // or a localStorage row: a filter is how you read the page this minute.
   const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS);
@@ -293,6 +306,11 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     setNewMessage(q.get("message"));
     setNewSession(q.get("session_id"));
     setNewBack(q.get("back"));
+    // Defensive by contract, not by suspicion: this is a URL a user can edit
+    // and a param an older build may not have written — `parseAttachmentsParam`
+    // answers [] for anything it cannot read, because a parse error here would
+    // cost the folder, the draft and the session as well as the files.
+    setNewAttachments(parseAttachmentsParam(q.get("attachments")));
     openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null);
     q.delete("new");
     q.delete("target");
@@ -300,6 +318,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     q.delete("session_id");
     q.delete("back");
     q.delete("edit");
+    q.delete("attachments");
     const rest = q.toString();
     history.replaceState(history.state, "", location.pathname + (rest ? `?${rest}` : ""));
   }, []);
@@ -783,6 +802,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           // wins — it named a folder on purpose.
           initialTarget={newTarget ?? scope?.project ?? null}
           initialMessage={newMessage}
+          initialAttachments={newAttachments}
           chatSessionId={newSession}
           chatBack={newBack}
           editing={editing}

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -483,7 +483,19 @@ function TaskCard({
   const resolving = !src && !folderMissing && !!task.session_id && template === undefined;
 
   return (
-    <section className="task-card" aria-label={`${task.task_id} ${title}`}>
+    <section
+      className="task-card task-card--door"
+      aria-label={`${task.task_id} ${title}`}
+      // THE WHOLE CARD IS THE DOOR (Akshil, 2026-09-10, E2E R1 F3): the body
+      // used to be the live chat with its own scroll and its own clicks —
+      // collapsible chips, thumbnails, links — and a wall of tiles each
+      // fighting for the wheel. Now the body is a picture (task-cards.css
+      // `.task-card--door .task-card-body`: no pointer events, no scroll) and a
+      // press anywhere on the card opens the same popup the head did. The head
+      // keeps its own handler for the keyboard; the doors strip inside it still
+      // stops its presses, so a door never also opens the popup.
+      onClick={() => onPeek(task)}
+    >
       {/* THE HEAD IS THE DOOR (Akshil, 2026-09-05: "when I click on the heading
           of the card ... it should open the preview"). The whole strip — ring,
           id, time, title — is one button that opens the task's popup; the body
@@ -495,7 +507,10 @@ function TaskCard({
         role="button"
         tabIndex={0}
         aria-label={`Preview ${task.task_id}`}
-        onClick={() => onPeek(task)}
+        onClick={(e) => {
+          e.stopPropagation();
+          onPeek(task);
+        }}
         onKeyDown={(e) => {
           // Only a key pressed ON THE HEAD. The folder chip inside it is a real
           // button of its own; its Enter and Space bubble here, and answering

--- a/frontend/src/shell/new-task-images.test.ts
+++ b/frontend/src/shell/new-task-images.test.ts
@@ -357,3 +357,45 @@ describe("the wiring the pure tests cannot see", () => {
     expect(MODAL).toContain('images.map((i) => i.path || "pending").join("\\n") !== initial.images');
   });
 });
+
+// ---- the chat's tray arrives as this card's chips --------------------------
+// owner E2E R1, F4 (2026-09-10): a draft carrying three screenshots is one thing
+// the user assembled, and the handoff used to bring the words without them.
+const SCHEDULED = readFileSync(join(HERE, "Scheduled.tsx"), "utf8");
+
+describe("the chat handoff's attachments", () => {
+  it("seed IDENTICAL chips to an edit's — one restore function, not two", () => {
+    const carried = [
+      { path: "/h/task-shots/20260910-a.png", name: "screenshot.png", kind: "image" as const },
+      { path: "/h/task-shots/20260910-b.csv", name: "rows.csv", kind: "file" as const },
+    ];
+    expect(restoredAttachments({ images: [], attachments: carried })).toEqual(
+      restoredAttachments({ attachments: carried }),
+    );
+    expect(restoredAttachments({ images: [], attachments: carried })
+      .map((c) => [c.name, c.kind, c.thumb]))
+      .toEqual([["screenshot.png", "image", null], ["rows.csv", "file", null]]);
+  });
+
+  it("an EDIT still outranks them — the entry's own attachments are the ones on the card", () => {
+    // Pinned to the source because it is a branch in a `useState` initialiser,
+    // which runs once and cannot be observed from a pure call.
+    expect(MODAL).toContain("editing\n      ? restoredAttachments(editing)");
+    expect(MODAL).toContain(
+      'restoredAttachments({ images: [], attachments: initialAttachments ?? [] })');
+  });
+
+  it("Save sends them, in the field the backend reads names off", () => {
+    // Already the case for a dropped file, and a seeded chip is the same chip:
+    // both are rows of `imagesRef`, so nothing about the payload changes.
+    expect(MODAL).toContain(".map((i) => ({ path: i.path, name: i.name, kind: i.kind }))");
+  });
+
+  it("the Tasks page parses the param through the chat's own parser and CONSUMES it", () => {
+    expect(SCHEDULED).toContain(
+      'setNewAttachments(parseAttachmentsParam(q.get("attachments")));');
+    // Deleted with the rest, or a reload reopens the modal forever.
+    expect(SCHEDULED).toContain('q.delete("attachments");');
+    expect(SCHEDULED).toContain("initialAttachments={newAttachments}");
+  });
+});

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -6794,7 +6794,9 @@ describe("cardsForTasks", () => {
     ];
     // "f" is OLDER than "a" and still comes first: the lane outranks the clock.
     // "e" — archived — is drawn too, in the bottom lane.
-    expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["f", "d", "c", "a", "b", "e"]);
+    // Upcoming ("c") is not a card (Akshil, 2026-09-10): a run that has not
+    // happened has no chat to show. It keeps its lane on the List and Calendar.
+    expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["f", "d", "a", "b", "e"]);
   });
 
   it("is the List's order, exactly — sortByLane, not a second opinion", () => {
@@ -6852,7 +6854,7 @@ describe("cardsForTasks", () => {
     expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["new", "mid", "old"]);
   });
 
-  it("runs Upcoming soonest first, overdue at the very top — the List's rule", () => {
+  it("does not draw Upcoming at all — a run that has not happened has no chat to show", () => {
     // The old clock ran every lane newest-created first, which on Upcoming put
     // the run due in ten minutes under one due in October if it was scheduled
     // later. The List sorts that lane by the run ahead, ascending; so does this.
@@ -6866,7 +6868,12 @@ describe("cardsForTasks", () => {
         messages: [msg({ at, ran_at: 0, state: "pending" })],
       });
     const rows = [soon("october", NOW_S + 30 * 86_400), soon("tenmin", NOW_S + 600), soon("late", NOW_S - 600)];
-    expect(cardsForTasks(rows, CARD_PAGE, NOW).cards.map((t) => t.key)).toEqual(["late", "tenmin", "october"]);
+    expect(cardsForTasks(rows, CARD_PAGE, NOW)).toEqual({ cards: [], hidden: 0 });
+    // Nor does a hidden Upcoming count toward "Show more".
+    expect(cardsForTasks([...rows, running("a", 100)], 1, NOW)).toEqual({
+      cards: [expect.objectContaining({ key: "a" })],
+      hidden: 0,
+    });
   });
 
   it("does not re-sort when a run merely writes", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -7370,7 +7370,17 @@ describe("the Cards view's frame", () => {
     // type into, with buttons for the List, the Explorer and Archive.
     const head = CARDS.slice(CARDS.indexOf("<header"), CARDS.indexOf("</header>"));
     expect(head).toContain('role="button"');
-    expect(head).toContain("onClick={() => onPeek(task)}");
+    // The head still opens the popup, and stops the press there — the CARD is
+    // the door now too (Akshil, 2026-09-10, E2E R1 F3), so a head press must
+    // not open it twice.
+    expect(head).toContain("e.stopPropagation();");
+    expect(head).toContain("onPeek(task);");
+    // THE WHOLE CARD IS THE DOOR: the body is a picture of the chat — no
+    // pointer events, no scroll — and any press on the card opens the popup.
+    expect(CARDS).toContain('className="task-card task-card--door"');
+    expect(CARDS).toContain("onClick={() => onPeek(task)}");
+    expect(block(CARDS_CSS, ".task-card--door .task-card-body")).toContain("pointer-events: none");
+    expect(block(CARDS_CSS, ".task-card--door .task-card-body")).toContain("overflow: hidden");
     expect(head).toContain('e.key === "Enter" || e.key === " "');
     // ...for keys pressed on the head itself: the folder chip inside it is a
     // button whose Enter/Space bubble up (Bugbot, #1011).

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3126,6 +3126,11 @@ export function cardsForTasks(
   const seen = new Set<string>();
   const all: Task[] = [];
   for (const task of sortByLane(tasks, now)) {
+    // NOT YET DUE IS NOT A CARD (Akshil, 2026-09-10, E2E R1): an upcoming
+    // task has no chat to show, so its tile was a sentence in a frame — the
+    // Calendar and the List are where a future run is read. The wall shows
+    // work that has happened or is happening.
+    if (task.status === "upcoming") continue;
     const id = cardKey(task);
     if (seen.has(id)) continue;
     seen.add(id);

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -375,6 +375,25 @@
    The head's hover doors are outside the body and keep working. */
 .task-card--door {
   cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    background-color 120ms ease;
+}
+/* SAY IT IS A DOOR (Akshil, 2026-09-10: "I don't know if the card is clickable
+   or not"). The same wash the head already wears on hover, over the whole
+   card, plus the border and shadow one step up — the row-hover language every
+   list on this page speaks, so a reader who has hovered a List row knows what
+   this means. The transition is 120ms, under the threshold reduced-motion
+   guidance treats as motion, so no media query is needed (this sheet keeps
+   to container queries by rule). */
+.task-card--door:hover {
+  background: color-mix(in srgb, var(--fg) 5%, var(--tasks-card-bg));
+  border-color: color-mix(in srgb, var(--fg) 22%, var(--border));
+  box-shadow: 0 2px 8px var(--shadow-sm);
+}
+.task-card--door:hover .task-card-body {
+  background: color-mix(in srgb, var(--fg) 3%, var(--bg));
 }
 .task-card--door .task-card-body {
   pointer-events: none;

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -367,6 +367,25 @@
   background: var(--bg);
 }
 
+/* THE CARD IS ONE DOOR (Akshil, 2026-09-10, E2E R1 F3). The body is a picture of
+   the chat, not the chat: nothing in it takes the pointer, and the transcript's
+   own scroller is clipped instead of scrolled — the live tail still pins to the
+   bottom, because that is a scrollTop the chat sets, not a wheel. Same size, same
+   type scale, same layout; only the mini scrollbar and the in-card clicks go.
+   The head's hover doors are outside the body and keep working. */
+.task-card--door {
+  cursor: pointer;
+}
+.task-card--door .task-card-body {
+  pointer-events: none;
+  overflow: hidden;
+}
+.task-card--door .task-card-body .chat-root .chat-logwrap,
+.task-card--door .task-card-body .chat-root .chat-log {
+  overflow: hidden;
+  scrollbar-width: none;
+}
+
 /* SCALED, not shrunk. Six cards across a laptop leave each frame ~380px wide,
    and the chat template lays itself out for a pane twice that: at 1:1 its text
    was too big to read as a wall (Akshil, 2026-09-04). The template's type is in

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -478,6 +478,31 @@ def api_claude_session_summaries():
     return {"sessions": sessions}
 
 
+@router.get("/api/claude-sessions/history")
+def api_claude_session_history(file: str, session_id: str):
+    """The chat's transcript restore, IN PROCESS (owner E2E R1, F5).
+
+    The chat used to ask for its history through `/api/run`, which executes
+    `templates/claude/agent.py` in a fresh Python subprocess per call: a cold
+    interpreter plus the module's imports, several hundred milliseconds, before
+    `_history` itself — which reads and parses a 300 KB transcript in about
+    30 ms. On the path between "click a chat" and "see the conversation" the
+    spawn WAS the wait. Here the same function runs on the agent module the
+    tasks listing already keeps loaded (`tasks._agent_module`, cached once), on
+    a worker thread because it reads a file. Same shape, same bytes: the page's
+    `historyToTurns` cannot tell the two roads apart, and `/api/run` stays the
+    fallback when this answers anything but 200."""
+    from fused_render.server.routers import tasks as _tasks
+
+    agent = _tasks._agent_module()
+    if agent is None:
+        raise HTTPException(status_code=503,
+                            detail="the claude agent module did not load")
+    if not file or not session_id:
+        raise HTTPException(status_code=400, detail="file and session_id are required")
+    return agent._history(file, session_id)
+
+
 @router.get("/api/claude-sessions/liveness")
 def api_claude_session_liveness(path: str):
     """`(mtime, size, running)` for ONE transcript file — the cheapest possible

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -479,7 +479,7 @@ def api_claude_session_summaries():
 
 
 @router.get("/api/claude-sessions/history")
-def api_claude_session_history(file: str, session_id: str):
+def api_claude_session_history(file: str, session_id: str, native: str = ""):
     """The chat's transcript restore, IN PROCESS (owner E2E R1, F5).
 
     The chat used to ask for its history through `/api/run`, which executes
@@ -500,7 +500,9 @@ def api_claude_session_history(file: str, session_id: str):
                             detail="the claude agent module did not load")
     if not file or not session_id:
         raise HTTPException(status_code=400, detail="file and session_id are required")
-    return agent._history(file, session_id)
+    # `native=1`: the React page wants the app-state reads on record as
+    # in-stream notices (agent.py `_segments_from_rows`, `app_reads`).
+    return agent._history(file, session_id, app_reads=native == "1")
 
 
 @router.get("/api/claude-sessions/liveness")

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -5425,7 +5425,8 @@ def _history(file: str, session_id: str) -> dict:
     return {"turns": turns, "transcript": stat}
 
 
-def _cancel(run_id: str, interrupt_first: bool = True) -> dict:
+def _cancel(run_id: str, interrupt_first: bool = True,
+            queued: bool = False) -> dict:
     """End a run — the STOP button's own action, and also `_send`'s way of
     ending a session it cannot hand a mid-session change to (a `read_dirs`
     that outgrew what was granted at spawn, or a changed `effort`).
@@ -5572,7 +5573,15 @@ def _cancel(run_id: str, interrupt_first: bool = True) -> dict:
             for item in list(response.get("still_queued") or []) + stranded:
                 if item and item not in still:
                     still.append(item)
-            if still:
+            # `queued` is the PAGE's knowledge: it had a follow-up in flight
+            # for this turn. The CLI does not reliably name a drained
+            # follow-up in `still_queued` — it answered `[]` and then went on
+            # to answer the message after the interrupt, with no poll loop
+            # watching (the page's live watch then called that turn "Running
+            # outside this app…"; owner E2E R1, F7/F8). Stop means stop
+            # everything, so a turn that had a queue ends the tree the same
+            # way a named remainder does.
+            if still or queued:
                 _kill_tree(run_dir)
             return {"cancelled": run_id, "still_queued": still}
         # No answer inside the timeout — the host may be stuck, or died
@@ -5641,7 +5650,7 @@ def main(action: str = "start", file: str = "", message: str = "",
          state: str = "", has_pane: str = "", enrich: str = "",
          deltas: str = "", version_id: str = "", confirm_unique: str = "",
          answers: str = "", note: str = "", custom: str = "",
-         read_dirs: str = "", path: str = "") -> dict:
+         read_dirs: str = "", path: str = "", queued: str = "") -> dict:
     if action == "start":
         if not file:
             return {"error": "missing target file (no _file param?)"}
@@ -5728,7 +5737,7 @@ def main(action: str = "start", file: str = "", message: str = "",
     if action == "terminal_command":
         return _terminal_command(file, session_id)
     if action == "cancel":
-        return _cancel(run_id)
+        return _cancel(run_id, queued=queued == "1")
     if action == "live_host":
         # "Is there a session I can hand a follow-up to?" — asked BEFORE
         # every send (see template.html's sendMessage): a host answering

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -4652,7 +4652,17 @@ def _poll(run_id: str, file: str = "") -> dict:
             # while `echo_pending` blanks the payload the offsets would index
             # into.
             "turn_breaks": [] if echo_pending
-            else _absorbed_turn_breaks(parsed)}
+            else _absorbed_turn_breaks(parsed),
+            # WHERE THIS WINDOW STARTS, as a byte offset into out.jsonl (the
+            # cursor `_read_current_turn` settled on). The page keeps one
+            # bubble per reply in the window and has to notice when the cursor
+            # steps past an absorbed follow-up, because the poll after that
+            # step carries only the newer reply with no seam left to place it.
+            # It used to infer the step from the payload (a seam lost, a size
+            # that shrank, text that no longer continues) — and a follow-up
+            # reply that merely EXTENDS the previous one ("OK" → "OK, done")
+            # defeats all three (Bugbot #1099). The offset is the fact itself.
+            "window": scan_cursor}
 
 
 # ------------------------------------------------------- sessions & history

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -3355,7 +3355,8 @@ def _thinking_delta_text(row) -> str:
     return str(delta.get("thinking") or "")
 
 
-def _segments_from_rows(rows: list, shape: tuple = ()) -> list:
+def _segments_from_rows(rows: list, shape: tuple = (),
+                        app_reads: bool = False) -> list:
     """The ordered transcript of a reply: text, thinking and tool segments.
 
     ONE reader with TWO callers — `_poll` over the live `out.jsonl` and
@@ -3560,6 +3561,26 @@ def _segments_from_rows(rows: list, shape: tuple = ()) -> list:
                     # name: every other MCP tool is a real call.
                     if tool_id:
                         stripped.add(tool_id)
+                    # THE NATIVE PAGE WANTS THE READ ON RECORD, IN PLACE
+                    # (`app_reads`; owner E2E R1, 2026-09-10). The legacy
+                    # template writes its own "read app state" line at answer
+                    # time, at the END of the log — so the reply that kept
+                    # streaming above it left the line trailing the finished
+                    # answer like a stuck status, and a reload lost it (the
+                    # line was never in the transcript). A notice segment here
+                    # sits where the read happened, streams and restores the
+                    # same, and the native page writes no line of its own.
+                    # Legacy callers leave the flag off and see no change.
+                    if app_reads:
+                        tool_input = block.get("input")
+                        reason = ""
+                        if isinstance(tool_input, dict):
+                            reason = str(tool_input.get("reason") or "").strip()
+                        segments.append({
+                            "kind": "notice",
+                            "text": ["read app state — " + reason
+                                     if reason else "read app state"],
+                            "status": "app_state"})
                     continue
                 if tool_id and tool_id in by_tool_id:
                     continue  # the same finalized message written twice
@@ -3760,7 +3781,7 @@ def _is_api_error_row(row: dict) -> bool:
     return isinstance(row, dict) and row.get("isApiErrorMessage") is True
 
 
-def _absorbed_turn_breaks(rows: list) -> list:
+def _absorbed_turn_breaks(rows: list, app_reads: bool = False) -> list:
     """Where a reply ENDED inside this row window because a follow-up had been
     folded into it, as payload offsets a page can slice on.
 
@@ -3830,7 +3851,7 @@ def _absorbed_turn_breaks(rows: list) -> list:
                 # seam — and one of the outstanding follow-ups is now the
                 # message the NEXT span answers.
                 outstanding -= 1
-                _seam(breaks, rows, i + 1, shape)
+                _seam(breaks, rows, i + 1, shape, app_reads)
                 last_result = None
             else:
                 # Not a seam YET. It becomes one if a new user turn shows up
@@ -3880,14 +3901,15 @@ def _absorbed_turn_breaks(rows: list) -> list:
                 # branch exists for (a follow-up the CLI drained straight after
                 # the reply's `result`) has no wake in it by construction.
                 if last_result is not None and prev_main == last_result:
-                    _seam(breaks, rows, i, shape)
+                    _seam(breaks, rows, i, shape, app_reads)
                     last_result = None
             else:
                 outstanding += 1
     return breaks
 
 
-def _seam(breaks: list, rows: list, end: int, shape: tuple) -> None:
+def _seam(breaks: list, rows: list, end: int, shape: tuple,
+          app_reads: bool = False) -> None:
     """Record a seam at `rows[:end]`, as payload offsets.
 
     `end` is EXCLUSIVE, and the two callers pass different things for good
@@ -3901,7 +3923,7 @@ def _seam(breaks: list, rows: list, end: int, shape: tuple) -> None:
     through `_segments_from_rows` with the WINDOW's own gates (`shape`) — so
     they are indices into the exact lists `_poll` returns. See
     `_segments_from_rows`'s note on why the gates travel."""
-    prefix = _segments_from_rows(rows[:end], shape)
+    prefix = _segments_from_rows(rows[:end], shape, app_reads)
     breaks.append({
         "segments": len(prefix),
         "text": sum(len(seg.get("text") or "")
@@ -4103,7 +4125,7 @@ def _cancelled_marker_state(run_dir: str, cursor: int) -> bool:
     return False
 
 
-def _poll(run_id: str, file: str = "") -> dict:
+def _poll(run_id: str, file: str = "", app_reads: bool = False) -> dict:
     run_dir = os.path.join(RUNS, run_id)
     if _bad_id(run_id) or not os.path.isdir(run_dir):
         return {"text": "", "done": True, "session_id": "", "error": "unknown run_id",
@@ -4645,14 +4667,15 @@ def _poll(run_id: str, file: str = "") -> dict:
                 "tasks": [{"id": k, "description": v} for k, v in bg_tasks.items()],
                 "agent_rows": agent_rows,
             },
-            "segments": [] if echo_pending else _segments_from_rows(parsed),
+            "segments": [] if echo_pending
+            else _segments_from_rows(parsed, app_reads=app_reads),
             # The seams inside this payload where a mid-stream follow-up was
             # absorbed into the reply already streaming — see
             # `_absorbed_turn_breaks`. Empty on every ordinary poll, and empty
             # while `echo_pending` blanks the payload the offsets would index
             # into.
             "turn_breaks": [] if echo_pending
-            else _absorbed_turn_breaks(parsed),
+            else _absorbed_turn_breaks(parsed, app_reads),
             # WHERE THIS WINDOW STARTS, as a byte offset into out.jsonl (the
             # cursor `_read_current_turn` settled on). The page keeps one
             # bubble per reply in the window and has to notice when the cursor
@@ -5269,7 +5292,7 @@ def _transcript_stat(path: str) -> dict:
         return {"path": path, "mtime": 0.0, "size": 0}
 
 
-def _history(file: str, session_id: str) -> dict:
+def _history(file: str, session_id: str, app_reads: bool = False) -> dict:
     """Rebuild the conversation from the Claude Code session transcript.
 
     Resolved ONLY at the target file's own project dir — with copied files
@@ -5329,7 +5352,7 @@ def _history(file: str, session_id: str) -> dict:
         """
         if not stretch:
             return
-        segments = _segments_from_rows(stretch)
+        segments = _segments_from_rows(stretch, app_reads=app_reads)
         del stretch[:]
         if not segments:
             return
@@ -5660,7 +5683,8 @@ def main(action: str = "start", file: str = "", message: str = "",
          state: str = "", has_pane: str = "", enrich: str = "",
          deltas: str = "", version_id: str = "", confirm_unique: str = "",
          answers: str = "", note: str = "", custom: str = "",
-         read_dirs: str = "", path: str = "", queued: str = "") -> dict:
+         read_dirs: str = "", path: str = "", queued: str = "",
+         native: str = "") -> dict:
     if action == "start":
         if not file:
             return {"error": "missing target file (no _file param?)"}
@@ -5677,7 +5701,7 @@ def main(action: str = "start", file: str = "", message: str = "",
         # `file` rides along so the poll can refuse a run that is not about
         # this page's target (see _poll) — optional, because not every caller
         # has a page (claude_spawn's record loop).
-        return _poll(run_id, file)
+        return _poll(run_id, file, app_reads=native == "1")
     if action == "decide":
         # `answers` arrives as a JSON string for the same reason `state` does
         # below — params cross into python string-shaped — and is only read for
@@ -5712,7 +5736,7 @@ def main(action: str = "start", file: str = "", message: str = "",
     if action == "history":
         if not file:
             return {"error": "missing target file (no _file param?)"}
-        return _history(file, session_id)
+        return _history(file, session_id, app_reads=native == "1")
     if action == "snapshots":
         # `enrich` arrives as a STRING like every other param (the binder is
         # str-shaped), so "" and "0" both mean don't — the boot call sends

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -3559,6 +3559,11 @@ def _segments_from_rows(rows: list, shape: tuple = (),
                     # showing. Nobody requested it and its answer is our JSON,
                     # so it is not part of the conversation. ONLY this exact
                     # name: every other MCP tool is a real call.
+                    # Once per CALL: a finalized assistant row can be written
+                    # twice (the `by_tool_id` guard below exists for that), and
+                    # the notice must not be (Bugbot #1099).
+                    if tool_id and tool_id in stripped:
+                        continue
                     if tool_id:
                         stripped.add(tool_id)
                     # THE NATIVE PAGE WANTS THE READ ON RECORD, IN PLACE

--- a/tests/test_claude_agent_segments.py
+++ b/tests/test_claude_agent_segments.py
@@ -922,3 +922,10 @@ def test_poll_and_history_pass_app_reads_from_the_native_flag(agent, tmp_path):
     assert not any(s["kind"] == "notice" for s in legacy["segments"])
     native = agent._poll("run", app_reads=True)
     assert any(s["kind"] == "notice" for s in native["segments"])
+
+
+def test_a_twice_written_app_state_call_is_one_notice(agent):
+    rows = _app_state_rows(agent)
+    rows.insert(1, rows[0])  # the finalized assistant row, written again
+    segs = agent._segments_from_rows(rows, app_reads=True)
+    assert [s["kind"] for s in segs].count("notice") == 1

--- a/tests/test_claude_agent_segments.py
+++ b/tests/test_claude_agent_segments.py
@@ -856,6 +856,69 @@ def test_the_watermark_is_stat_ed_before_the_rows_are_read(agent):
     the payload does not contain — a turn silently swallowed for good. Taken
     first, a write that lands mid-read costs one redundant re-render."""
     src = open(os.path.join(TEMPLATE_DIR, "agent.py"), encoding="utf-8").read()
-    body = src[src.index("def _history(file: str, session_id: str)"):]
+    body = src[src.index("def _history(file: str, session_id: str, app_reads: bool = False)"):]
     body = body[:body.index("\ndef ")]
     assert body.index("_transcript_stat(path)") < body.index("for line in open(path")
+
+
+def _app_state_rows(agent):
+    """A reply that reads the app once, mid-stream: text, the bridge's own
+    `app_state` tool call with a reason, its result, more text, `result`."""
+    plumbing = "mcp__%s__%s" % (agent.PERMISSION_SERVER, agent.APP_STATE_TOOL)
+    return [
+        {"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "text", "text": "Looking."},
+            {"type": "tool_use", "id": "t-app", "name": plumbing,
+             "input": {"reason": "Checking whether the banner cleared"}},
+        ]}},
+        {"type": "user", "message": {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t-app", "content": "{}"},
+        ]}},
+        {"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "text", "text": "It cleared."},
+        ]}},
+        {"type": "result", "subtype": "success", "result": "It cleared."},
+    ]
+
+
+def test_the_app_state_read_is_stripped_for_the_legacy_page(agent):
+    """The template writes its own "read app state" line at answer time, so
+    the bridge's call is not a segment (the pre-existing contract)."""
+    segs = agent._segments_from_rows(_app_state_rows(agent))
+    assert [s["kind"] for s in segs] == ["text", "text"] or \
+        [s["kind"] for s in segs] == ["text"]
+    assert not any(s["kind"] == "notice" for s in segs)
+    assert not any(s["kind"] == "tool" for s in segs)
+
+
+def test_the_app_state_read_is_a_notice_in_place_for_the_native_page(agent):
+    """Owner E2E R1 (2026-09-10): the native page's own end-of-log note trailed
+    the finished reply like a stuck status and was lost on reload. With
+    `app_reads` the read is a notice segment between the prose it interrupted,
+    carrying the tool's reason — same in a live poll and a restored history."""
+    segs = agent._segments_from_rows(_app_state_rows(agent), app_reads=True)
+    kinds = [s["kind"] for s in segs]
+    assert "notice" in kinds
+    note = segs[kinds.index("notice")]
+    assert note["text"] == "read app state — Checking whether the banner cleared"
+    assert note["status"] == "app_state"
+    # In PLACE: prose before it, prose after it, never a tool chip for it.
+    assert kinds.index("notice") > 0
+    assert kinds[-1] == "text"
+    assert "tool" not in kinds
+
+
+def test_the_app_state_read_without_a_reason_is_a_bare_notice(agent):
+    rows = _app_state_rows(agent)
+    rows[0]["message"]["content"][1]["input"] = {}
+    segs = agent._segments_from_rows(rows, app_reads=True)
+    note = next(s for s in segs if s["kind"] == "notice")
+    assert note["text"] == "read app state"
+
+
+def test_poll_and_history_pass_app_reads_from_the_native_flag(agent, tmp_path):
+    rows = _app_state_rows(agent)
+    legacy = _poll_rows(agent, tmp_path, rows)
+    assert not any(s["kind"] == "notice" for s in legacy["segments"])
+    native = agent._poll("run", app_reads=True)
+    assert any(s["kind"] == "notice" for s in native["segments"])


### PR DESCRIPTION
Follow-up to #1061 / #1064 / #1074 / #1075 from the owner's manual end-to-end pass (sections 0–D). Everything is behind the same `native_chat_enabled` flag except the tasks-card change and the new history route.

## What changed

- **A queued follow-up's reply no longer overwrites the reply before it.** Two short single-segment replies left both the seam count and the segment count unchanged across a cursor step the poll loop never saw the seam for, so reply 2 landed in reply 1's slot: reply 1 vanished and reply 2 sat above its own user bubble. The loop now also treats a payload whose text does not continue the previous one as the window having moved. Regression test added.
- **Stop means stop.** Every queued follow-up returns to the composer and its bubble goes, the way Claude Code's Esc returns the queue to the input. The CLI does not reliably name a drained follow-up in `still_queued` and was seen answering it after the interrupt with nobody watching (the live watch then labelled that turn "Running outside this app…"). The page now tells `agent.py` the turn had a queue (`cancel` with `queued=1`) and the session tree ends after the interrupt. This is the one `agent.py` change; the legacy template never sends the flag, so its behaviour is unchanged.
- **Message links from the tasks list land on their message.** The anchor was spent on the first render, before the history load had started, and was a one-shot latch.
- **The working line's clock survives a reload.** The turn start is stamped in `sessionStorage` per run id; a re-attaching frame reads it back.
- **A scheduled run for another conversation on the same folder no longer posts a note into this chat.**
- **Tasks cards: the whole card is the door.** The body is a picture of the chat (no pointer events, scroll clipped); a press anywhere opens the popup the head already opened. Hover doors unchanged.
- **Composer attachments ride along to the scheduler and back.** Continue copies the tray's files into the task-shots store, carries them to the New task card, and Back to chat puts them back in the tray.
- **History restores in process.** `/api/run` executes `agent.py` in a fresh Python subprocess per call. New `GET /api/claude-sessions/history` runs the same `_history` on the server's loaded agent module; the chat uses it with `/api/run` as the fallback. Same payload, byte for byte.

  | road | 310 KB transcript |
  |---|---|
  | `/api/run` (subprocess) | 125–230 ms |
  | `/api/claude-sessions/history` | 6 ms |

- **Bugbot 3977975835** (left open when #1075 merged): `refreshHistory` drops a payload when `ownRunEndedAt`/`transcriptGen` moved during the fetch; `followTranscript` re-checks the stamp after the refresh.

## Verified

- `tsc --noEmit` clean; `bun test` 2628 pass; boundaries OK.
- Python: `tests/test_claude_ask_lifecycle.py`, `tests/test_claude_agent_segments.py`, `tests/test_claude_sessions_api.py`, `tests/test_claude_sessions_merged.py` pass.
- Payload parity of the two history roads checked against a live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core poll/history bubble logic, Stop/cancel session semantics, and a new in-process history path—bugs could corrupt transcripts, lose queued messages, or desync live vs restored chat.
> 
> **Overview**
> **Native chat E2E fixes** across the run controller, agent, server, tasks UI, and scheduler handoff—mostly behind native chat; task-card behavior and the history route apply more broadly.
> 
> **Transcript / polling:** Follow-up replies no longer overwrite the previous assistant bubble when seams and segment counts stay flat—the loop also opens a new bubble when window text discontinues or when `poll.window` moves (extends like "OK" → "OK, done"). Polls and history send **`native=1`** so app-state reads appear as in-stream **notice** segments (the page stops appending its own "read app state" notes). **`refreshHistory`** and the live watcher drop stale results if `ownRunEndedAt` or `transcriptGen` changed during the fetch.
> 
> **Stop / queue:** **Stop** returns every queued follow-up to the composer (even when `still_queued` is empty), removes its bubble, and passes **`queued: "1"`** on cancel so the backend can end the session tree after interrupt.
> 
> **Restore / UX:** **`fetchHistory`** hits **`GET /api/claude-sessions/history`** (loaded agent in-process) with **`/api/run`** fallback. Working-line elapsed time survives F5 via **`sessionStorage`** per run id. Task **message anchors** wait for a loaded transcript and can fire again per anchor. Foreign scheduled runs on the same folder no longer inject notes into unrelated chats.
> 
> **Scheduler:** Composer **attachments** copy into task-shots on Schedule, travel via URL/stash, seed **New task**, and restore on "Back to chat".
> 
> **Tasks wall:** **Upcoming** tasks are omitted from the cards view; each card is a single **door** (body non-interactive preview, click opens peek). Permission **question** UI restyled (numbered rows, taller scroll cap). Composer strip fit uses **`max-content`** width so controls don’t fold too early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46445da5b68b23a6db822d77bb90485b3f8111e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->