### PR TITLE
Recheck for newer versions before installing updates

### DIFF
--- a/.claude/skills/making-a-release/SKILL.md
+++ b/.claude/skills/making-a-release/SKILL.md
@@ -29,8 +29,11 @@ A release is: bump `__version__`, land that bump on `main` **through a PR**, the
    before continuing. If `git status --porcelain` prints anything, stop and
    resolve it first.
 
-2. **Pick the new version.** Read the current value and the latest tag; choose the next semver:
+2. **Pick the new version.** Fetch tags first — a stale local tag list can hide a
+   version someone else already published since your last fetch. Then read the
+   current value and the latest tag and choose the next semver:
    ```bash
+   git fetch origin --tags
    grep __version__ fused_render/__init__.py
    git tag --sort=-creatordate | head -1
    ```
@@ -68,21 +71,35 @@ A release is: bump `__version__`, land that bump on `main` **through a PR**, the
    grep __version__ fused_render/__init__.py   # confirm it reads X.Y.Z
    ```
 
-7. **Tag** — annotated, name is `v` + the exact version:
+7. **Re-verify the version right before tagging.** Steps 2-6 take real time (PR
+   review, CI, the merge itself) — long enough for someone else to have published
+   a release in the meantime. The version you picked in step 2 may no longer be
+   the next version, or its tag may already exist. Re-fetch and check again,
+   immediately before creating the tag — do not rely on the step-2 check alone:
+   ```bash
+   git fetch origin --tags
+   git tag --sort=-creatordate | head -1   # must still be older than vX.Y.Z
+   git rev-parse vX.Y.Z 2>/dev/null && echo "TAG ALREADY EXISTS — STOP, do not reuse it"
+   ```
+   If the latest tag is now `vX.Y.Z` or newer, or `vX.Y.Z` already exists, someone
+   else released first: do not tag. Pick a fresh next version, bump it (new
+   branch + PR, back to step 3), and only tag once this check comes back clean.
+
+8. **Tag** — annotated, name is `v` + the exact version:
    ```bash
    git tag -a vX.Y.Z -m "vX.Y.Z"
    ```
 
-8. **Push the tag.** This is the release trigger:
+9. **Push the tag.** This is the release trigger:
    ```bash
    git push origin vX.Y.Z
    ```
 
-9. **Verify** the release workflow started, then clean up the branch:
-   ```bash
-   gh run list --workflow=release.yml --limit 3
-   git branch -d bump-X.Y.Z && git push origin --delete bump-X.Y.Z
-   ```
+10. **Verify** the release workflow started, then clean up the branch:
+    ```bash
+    gh run list --workflow=release.yml --limit 3
+    git branch -d bump-X.Y.Z && git push origin --delete bump-X.Y.Z
+    ```
 
 ## Quick Reference
 
@@ -112,3 +129,8 @@ A release is: bump `__version__`, land that bump on `main` **through a PR**, the
 - **Reusing an existing tag.** Tags are immutable releases; pick an unused version. Check `git tag` first.
 - **Skipping `git pull`.** Tagging a stale local `main` builds and ships an old
   commit. Always pull (steps 1 and 6) so the tag points at the true latest.
+- **Trusting the step-2 version check all the way to tag time.** The version was
+  "next" when you picked it, but PR review + CI take time — another release can
+  land in that window, making your chosen version stale or its tag already taken.
+  Re-fetch tags and re-check immediately before tagging (step 7), not just once
+  at the start.

--- a/.claude/skills/making-a-release/SKILL.md
+++ b/.claude/skills/making-a-release/SKILL.md
@@ -29,11 +29,8 @@ A release is: bump `__version__`, land that bump on `main` **through a PR**, the
    before continuing. If `git status --porcelain` prints anything, stop and
    resolve it first.
 
-2. **Pick the new version.** Fetch tags first — a stale local tag list can hide a
-   version someone else already published since your last fetch. Then read the
-   current value and the latest tag and choose the next semver:
+2. **Pick the new version.** Read the current value and the latest tag; choose the next semver:
    ```bash
-   git fetch origin --tags
    grep __version__ fused_render/__init__.py
    git tag --sort=-creatordate | head -1
    ```
@@ -71,35 +68,21 @@ A release is: bump `__version__`, land that bump on `main` **through a PR**, the
    grep __version__ fused_render/__init__.py   # confirm it reads X.Y.Z
    ```
 
-7. **Re-verify the version right before tagging.** Steps 2-6 take real time (PR
-   review, CI, the merge itself) — long enough for someone else to have published
-   a release in the meantime. The version you picked in step 2 may no longer be
-   the next version, or its tag may already exist. Re-fetch and check again,
-   immediately before creating the tag — do not rely on the step-2 check alone:
-   ```bash
-   git fetch origin --tags
-   git tag --sort=-creatordate | head -1   # must still be older than vX.Y.Z
-   git rev-parse vX.Y.Z 2>/dev/null && echo "TAG ALREADY EXISTS — STOP, do not reuse it"
-   ```
-   If the latest tag is now `vX.Y.Z` or newer, or `vX.Y.Z` already exists, someone
-   else released first: do not tag. Pick a fresh next version, bump it (new
-   branch + PR, back to step 3), and only tag once this check comes back clean.
-
-8. **Tag** — annotated, name is `v` + the exact version:
+7. **Tag** — annotated, name is `v` + the exact version:
    ```bash
    git tag -a vX.Y.Z -m "vX.Y.Z"
    ```
 
-9. **Push the tag.** This is the release trigger:
+8. **Push the tag.** This is the release trigger:
    ```bash
    git push origin vX.Y.Z
    ```
 
-10. **Verify** the release workflow started, then clean up the branch:
-    ```bash
-    gh run list --workflow=release.yml --limit 3
-    git branch -d bump-X.Y.Z && git push origin --delete bump-X.Y.Z
-    ```
+9. **Verify** the release workflow started, then clean up the branch:
+   ```bash
+   gh run list --workflow=release.yml --limit 3
+   git branch -d bump-X.Y.Z && git push origin --delete bump-X.Y.Z
+   ```
 
 ## Quick Reference
 
@@ -129,8 +112,3 @@ A release is: bump `__version__`, land that bump on `main` **through a PR**, the
 - **Reusing an existing tag.** Tags are immutable releases; pick an unused version. Check `git tag` first.
 - **Skipping `git pull`.** Tagging a stale local `main` builds and ships an old
   commit. Always pull (steps 1 and 6) so the tag points at the true latest.
-- **Trusting the step-2 version check all the way to tag time.** The version was
-  "next" when you picked it, but PR review + CI take time — another release can
-  land in that window, making your chosen version stale or its tag already taken.
-  Re-fetch tags and re-check immediately before tagging (step 7), not just once
-  at the start.

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -491,8 +491,15 @@ export function updateCheck(): Promise<UpdateStatus> {
   return postJson<UpdateStatus>("/api/update/check", {});
 }
 
-export function updateInstall(): Promise<UpdateStatus> {
-  return postJson<UpdateStatus>("/api/update/install", {});
+// `expectedVersion`: the `latest_version` the caller had on screen — the
+// server compares it against what its own pre-install recheck confirms is
+// actually current and defers instead of installing on a mismatch, so a
+// stale button can never land a different version than the one the user
+// saw and clicked (fused_render/update/mac.py's UpdateManager.install).
+export function updateInstall(expectedVersion?: string | null): Promise<UpdateStatus> {
+  return postJson<UpdateStatus>("/api/update/install", {
+    expected_version: expectedVersion ?? null,
+  });
 }
 
 export function listDir(fsPath: string, cursor?: string | null): Promise<ListResult> {

--- a/frontend/src/platform/ui/UpdateBadge.tsx
+++ b/frontend/src/platform/ui/UpdateBadge.tsx
@@ -172,7 +172,12 @@ export default function UpdateBadge({ version = null }: { version?: string | nul
   const install = async () => {
     setOpen(true);
     try {
-      setUpdateStatus(await updateInstall());
+      // Send what THIS render actually shows — `status.latest_version` —
+      // not just "install whatever's latest": the server's own background
+      // loop can move `_latest` on its own five-minute cadence, so without
+      // this the button could silently install a version the user never
+      // saw on screen (see UpdateManager.install's docstring).
+      setUpdateStatus(await updateInstall(status.latest_version));
     } catch {
       // Fall through — the re-armed poll picks up the real state.
     }

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -495,7 +495,11 @@ export default function GlobalSidebar({ config }: { config: Config }) {
     // answers, so the poll it arms sees "installing" and runs at the busy
     // interval — poked first it would still read "available" and arm the 60s
     // idle timer, leaving the rail dot behind for a minute (bugbot, PR #1049).
-    void updateInstall()
+    // Send what THIS row actually shows — `updateStatus.latest_version` —
+    // not just "install whatever's latest": see UpdateBadge.install and
+    // UpdateManager.install's docstring for why a version the caller didn't
+    // pass can't be trusted to match what was on screen.
+    void updateInstall(updateStatus.latest_version)
       .then(setUpdateStatus)
       .catch(() => {
         // Fall through — the re-armed poll picks up the real state.

--- a/fused_render/server/routers/update.py
+++ b/fused_render/server/routers/update.py
@@ -4,6 +4,7 @@ trigger work. Both mutate (network + a bundle swap), so they carry the D3
 X-Fused guard; they 404 when no update manager is running (dev server, CLI,
 Windows/Linux packages — those update through the supervisor's own path)."""
 from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel
 
 from fused_render.server.common import _require_fused
 from fused_render.update import mac as mac_update
@@ -28,8 +29,20 @@ def api_update_check(x_fused: str | None = Header(default=None)):
     return _manager().check()
 
 
+class InstallRequest(BaseModel):
+    # The `latest_version` the client's own status had on screen when the
+    # button was pressed. UpdateManager.install() compares this against
+    # what its pre-install recheck confirms is actually current, and defers
+    # rather than installs on a mismatch — see its docstring for why a
+    # server-side snapshot alone can't catch that race. Optional so an
+    # older client build (with no such field) still gets the previous,
+    # looser behavior instead of a hard validation error.
+    expected_version: str | None = None
+
+
 @router.post("/api/update/install")
-def api_update_install(x_fused: str | None = Header(default=None)):
+def api_update_install(body: InstallRequest | None = None,
+                       x_fused: str | None = Header(default=None)):
     if (error := _require_fused(x_fused)) is not None:
         return error
-    return _manager().install()
+    return _manager().install(expected_version=body.expected_version if body else None)

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -462,14 +462,27 @@ class UpdateManager:
 
         `_latest` can be up to CHECK_INTERVAL_S (5 min) stale — it was set by
         whichever periodic check last ran, and a newer version can have been
-        published since. Force a fresh check first so an install always
-        starts from the actual latest manifest, not a cached one: a failed
-        fetch here falls back to the last known-good `_latest` (see check()),
-        so this never makes an install worse, only fresher when it can be.
-        Only worth the round trip when there is something to install at all —
+        published since. Force a fresh check first so an install never runs
+        against a version that has already been superseded: a failed fetch
+        here falls back to the last known-good `_latest` (see check()), so
+        this never makes an install worse, only fresher when it can be. Only
+        worth the round trip when there is something to install at all —
         skipped from "idle"/"checking"/"installing", which refuse below
-        regardless of what a re-check would say."""
+        regardless of what a re-check would say.
+
+        If that re-check turns up a DIFFERENT version from the one that was
+        on screen the moment this was called, do not install it out from
+        under the click: the button the user pressed said "Update to
+        v<requested>", and quietly swapping in v<something else> — even a
+        newer one — is its own kind of dishonest wire status, the same
+        family of bug the manager otherwise goes out of its way to avoid
+        (`_check_error`, `check_only`, etc. all exist so this state machine
+        never tells the UI something that isn't true). Instead this leaves
+        `_latest`/state exactly as the re-check just set them ("available"
+        with the refreshed version) and returns without installing — the
+        badge now shows the new version, and a second click commits to it."""
         with self._lock:
+            requested_version = self._latest["version"] if self._latest else None
             worth_rechecking = (self._latest is not None
                                and self._state in ("available", "error"))
         if worth_rechecking:
@@ -478,6 +491,12 @@ class UpdateManager:
             if self._state == "installing":
                 return self.status()
             if self._latest is None or self._state not in ("available", "error"):
+                return self.status()
+            if self._latest["version"] != requested_version:
+                logger.info(
+                    "update install deferred: re-check found v%s, not the v%s "
+                    "that was on screen when install() was called",
+                    self._latest["version"], requested_version)
                 return self.status()
             # The dev-run manager (DEV_MANAGER_ENV) has no bundle to swap.
             # Refused here rather than left to fail inside the worker thread,

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -458,7 +458,22 @@ class UpdateManager:
     def install(self) -> dict:
         """Kick the install on a worker thread. One at a time; re-POSTing
         while installing just reports current state. Allowed from "available"
-        and from "error" (retry)."""
+        and from "error" (retry).
+
+        `_latest` can be up to CHECK_INTERVAL_S (5 min) stale — it was set by
+        whichever periodic check last ran, and a newer version can have been
+        published since. Force a fresh check first so an install always
+        starts from the actual latest manifest, not a cached one: a failed
+        fetch here falls back to the last known-good `_latest` (see check()),
+        so this never makes an install worse, only fresher when it can be.
+        Only worth the round trip when there is something to install at all —
+        skipped from "idle"/"checking"/"installing", which refuse below
+        regardless of what a re-check would say."""
+        with self._lock:
+            worth_rechecking = (self._latest is not None
+                               and self._state in ("available", "error"))
+        if worth_rechecking:
+            self.check(force=True)
         with self._lock:
             if self._state == "installing":
                 return self.status()

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -455,34 +455,46 @@ class UpdateManager:
 
     # -- installing -----------------------------------------------------------
 
-    def install(self) -> dict:
+    def install(self, expected_version: str | None = None) -> dict:
         """Kick the install on a worker thread. One at a time; re-POSTing
         while installing just reports current state. Allowed from "available"
         and from "error" (retry).
 
-        `_latest` can be up to CHECK_INTERVAL_S (5 min) stale — it was set by
-        whichever periodic check last ran, and a newer version can have been
-        published since. Force a fresh check first so an install never runs
-        against a version that has already been superseded: a failed fetch
-        here falls back to the last known-good `_latest` (see check()), so
-        this never makes an install worse, only fresher when it can be. Only
+        `expected_version` is what the CALLER had on screen — the client
+        sends the `latest_version` its last poll showed. That is not the
+        same thing as this manager's own `_latest` at the moment install()
+        starts: the background loop force-checks every CHECK_INTERVAL_S (5
+        min) independent of any click, so `_latest` can already have moved
+        — silently, from the caller's point of view — before the click even
+        lands. Comparing against a snapshot of `_latest` taken at call-start
+        would miss exactly that race, since both the snapshot and the
+        post-recheck value would already agree on the NEW version while the
+        screen the user clicked on still showed the old one. `expected_version`
+        is the only thing that actually pins down what the user saw.
+
+        Also force a fresh check before proceeding, so a version published
+        between the caller's last poll and this call — but not yet picked up
+        by the background loop either — still gets caught: a failed fetch
+        falls back to the last known-good `_latest` (see check()), so this
+        never makes an install worse, only fresher when it can be. Only
         worth the round trip when there is something to install at all —
         skipped from "idle"/"checking"/"installing", which refuse below
         regardless of what a re-check would say.
 
-        If that re-check turns up a DIFFERENT version from the one that was
-        on screen the moment this was called, do not install it out from
-        under the click: the button the user pressed said "Update to
-        v<requested>", and quietly swapping in v<something else> — even a
-        newer one — is its own kind of dishonest wire status, the same
-        family of bug the manager otherwise goes out of its way to avoid
-        (`_check_error`, `check_only`, etc. all exist so this state machine
-        never tells the UI something that isn't true). Instead this leaves
-        `_latest`/state exactly as the re-check just set them ("available"
-        with the refreshed version) and returns without installing — the
-        badge now shows the new version, and a second click commits to it."""
+        If `_latest` (after that recheck) does not match `expected_version`,
+        do not install it out from under the click: the button the user
+        pressed said "Update to v<expected>", and quietly swapping in a
+        different version — even a newer one — is its own kind of dishonest
+        wire status, the same family of bug the manager otherwise goes out
+        of its way to avoid (`_check_error`, `check_only`, etc. all exist so
+        this state machine never tells the UI something that isn't true).
+        Instead this leaves `_latest`/state exactly as they are ("available"
+        with whatever is actually current) and returns without installing —
+        the badge now shows that version, and a second click commits to it.
+        `expected_version=None` (an older client with no such field, or a
+        direct caller) skips this check entirely and trusts `_latest`
+        as-is, same as before this parameter existed."""
         with self._lock:
-            requested_version = self._latest["version"] if self._latest else None
             worth_rechecking = (self._latest is not None
                                and self._state in ("available", "error"))
         if worth_rechecking:
@@ -492,11 +504,12 @@ class UpdateManager:
                 return self.status()
             if self._latest is None or self._state not in ("available", "error"):
                 return self.status()
-            if self._latest["version"] != requested_version:
+            if (expected_version is not None
+                    and self._latest["version"] != expected_version):
                 logger.info(
-                    "update install deferred: re-check found v%s, not the v%s "
-                    "that was on screen when install() was called",
-                    self._latest["version"], requested_version)
+                    "update install deferred: v%s is current, not the v%s "
+                    "the caller had on screen",
+                    self._latest["version"], expected_version)
                 return self.status()
             # The dev-run manager (DEV_MANAGER_ENV) has no bundle to swap.
             # Refused here rather than left to fail inside the worker thread,

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -169,6 +169,68 @@ def test_install_retry_allowed_from_error(monkeypatch):
     assert manager.status()["state"] == "installed"
 
 
+def test_install_rechecks_and_installs_a_version_published_since_the_last_check(monkeypatch):
+    """`_latest` is set by whichever periodic check last ran and can be up to
+    CHECK_INTERVAL_S (5 min) stale. If a newer release was published in that
+    window, install() must hand _install_dmg the fresh manifest, not the
+    cached one from the last check()."""
+    manager = mac.UpdateManager(bundle="/nonexistent/FusedRender.app", method="dmg")
+    monkeypatch.setattr(mac, "__version__", "0.4.10")
+    versions = iter(["9.9.9", "9.9.10"])
+
+    def fetch(url, **kwargs):
+        return {"schema": 1, "version": next(versions), "url": "https://x/y.dmg",
+                "sha256": "s", "signature": "g"}
+
+    monkeypatch.setattr(common, "fetch_manifest", fetch)
+    manager.check()
+    assert manager.status()["latest_version"] == "9.9.9"
+
+    done = []
+    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: done.append(manifest))
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    assert done and done[0]["version"] == "9.9.10"
+    assert manager.status()["latest_version"] == "9.9.10"
+
+
+def test_install_rechecks_even_when_the_next_auto_tick_is_long_overdue(monkeypatch):
+    """The app can sit open with nothing happening for a while (backgrounded,
+    machine asleep) between one check finding an update and the user actually
+    clicking Install — long enough that the 5-minute auto loop should have
+    ticked again but, for whatever reason, hasn't. install()'s recheck must
+    not depend on that next tick ever landing: it forces its own fetch, which
+    ignores both the "only recheck from idle" rule and the MIN_CHECK_GAP_S
+    throttle that a plain check() would respect."""
+    manager = mac.UpdateManager(bundle="/nonexistent/FusedRender.app", method="dmg")
+    monkeypatch.setattr(mac, "__version__", "0.4.10")
+    versions = iter(["9.9.9", "9.9.10"])
+
+    def fetch(url, **kwargs):
+        return {"schema": 1, "version": next(versions), "url": "https://x/y.dmg",
+                "sha256": "s", "signature": "g"}
+
+    monkeypatch.setattr(common, "fetch_manifest", fetch)
+    manager.check()
+    assert manager.status()["latest_version"] == "9.9.9"
+    # No auto-tick has actually happened since — back-date the throttle clock
+    # well past both gaps so a non-forced check would have refused to fetch.
+    manager._last_check_at = time.monotonic() - 10 * common.CHECK_INTERVAL_S
+
+    done = []
+    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: done.append(manifest))
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    assert done and done[0]["version"] == "9.9.10"
+
+
+def test_install_does_not_hit_the_network_when_there_is_nothing_to_install(monkeypatch):
+    """The re-check in install() is only worth it when an install might
+    actually proceed — an idle manager (no known update) must not fetch."""
+    manager = _manager(monkeypatch)  # no `available`: common.fetch_manifest is left unpatched
+    assert manager.install()["state"] == "idle"
+
+
 # ---- brew path: one install path, and never a brew command anywhere ----------
 
 

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -169,14 +169,17 @@ def test_install_retry_allowed_from_error(monkeypatch):
     assert manager.status()["state"] == "installed"
 
 
-def test_install_rechecks_and_installs_a_version_published_since_the_last_check(monkeypatch):
+def test_install_defers_when_a_newer_version_appears_during_the_recheck(monkeypatch):
     """`_latest` is set by whichever periodic check last ran and can be up to
     CHECK_INTERVAL_S (5 min) stale. If a newer release was published in that
-    window, install() must hand _install_dmg the fresh manifest, not the
-    cached one from the last check()."""
+    window, silently installing it instead of the version that was on
+    screen when Install was clicked would retarget the button out from
+    under the user — its own kind of dishonest wire status. install() must
+    instead surface the refreshed version and wait for a fresh click before
+    starting anything."""
     manager = mac.UpdateManager(bundle="/nonexistent/FusedRender.app", method="dmg")
     monkeypatch.setattr(mac, "__version__", "0.4.10")
-    versions = iter(["9.9.9", "9.9.10"])
+    versions = iter(["9.9.9", "9.9.10", "9.9.10"])
 
     def fetch(url, **kwargs):
         return {"schema": 1, "version": next(versions), "url": "https://x/y.dmg",
@@ -188,10 +191,17 @@ def test_install_rechecks_and_installs_a_version_published_since_the_last_check(
 
     done = []
     monkeypatch.setattr(manager, "_install_dmg", lambda manifest: done.append(manifest))
+    status = manager.install()
+    assert manager._install_thread is None
+    assert done == []
+    assert status["state"] == "available"
+    assert status["latest_version"] == "9.9.10"
+
+    # The refreshed version is what a second click commits to — it matches
+    # what the recheck now finds, so this one proceeds.
     manager.install()
     manager._install_thread.join(timeout=5)
     assert done and done[0]["version"] == "9.9.10"
-    assert manager.status()["latest_version"] == "9.9.10"
 
 
 def test_install_rechecks_even_when_the_next_auto_tick_is_long_overdue(monkeypatch):
@@ -217,11 +227,12 @@ def test_install_rechecks_even_when_the_next_auto_tick_is_long_overdue(monkeypat
     # well past both gaps so a non-forced check would have refused to fetch.
     manager._last_check_at = time.monotonic() - 10 * common.CHECK_INTERVAL_S
 
-    done = []
-    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: done.append(manifest))
-    manager.install()
-    manager._install_thread.join(timeout=5)
-    assert done and done[0]["version"] == "9.9.10"
+    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: None)
+    status = manager.install()
+    # The overdue recheck still ran and found a newer version — surfaced,
+    # not installed outright, same as the deferred case above.
+    assert manager._install_thread is None
+    assert status["latest_version"] == "9.9.10"
 
 
 def test_install_does_not_hit_the_network_when_there_is_nothing_to_install(monkeypatch):

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -176,7 +176,8 @@ def test_install_defers_when_a_newer_version_appears_during_the_recheck(monkeypa
     screen when Install was clicked would retarget the button out from
     under the user — its own kind of dishonest wire status. install() must
     instead surface the refreshed version and wait for a fresh click before
-    starting anything."""
+    starting anything. `expected_version` is what the caller (the client)
+    had on screen — here, "9.9.9", the version found by the check() below."""
     manager = mac.UpdateManager(bundle="/nonexistent/FusedRender.app", method="dmg")
     monkeypatch.setattr(mac, "__version__", "0.4.10")
     versions = iter(["9.9.9", "9.9.10", "9.9.10"])
@@ -191,15 +192,15 @@ def test_install_defers_when_a_newer_version_appears_during_the_recheck(monkeypa
 
     done = []
     monkeypatch.setattr(manager, "_install_dmg", lambda manifest: done.append(manifest))
-    status = manager.install()
+    status = manager.install(expected_version="9.9.9")
     assert manager._install_thread is None
     assert done == []
     assert status["state"] == "available"
     assert status["latest_version"] == "9.9.10"
 
-    # The refreshed version is what a second click commits to — it matches
-    # what the recheck now finds, so this one proceeds.
-    manager.install()
+    # The refreshed version is what a second click (now expecting "9.9.10")
+    # commits to — it matches what the recheck now finds, so this proceeds.
+    manager.install(expected_version="9.9.10")
     manager._install_thread.join(timeout=5)
     assert done and done[0]["version"] == "9.9.10"
 
@@ -228,10 +229,47 @@ def test_install_rechecks_even_when_the_next_auto_tick_is_long_overdue(monkeypat
     manager._last_check_at = time.monotonic() - 10 * common.CHECK_INTERVAL_S
 
     monkeypatch.setattr(manager, "_install_dmg", lambda manifest: None)
-    status = manager.install()
+    status = manager.install(expected_version="9.9.9")
     # The overdue recheck still ran and found a newer version — surfaced,
     # not installed outright, same as the deferred case above.
     assert manager._install_thread is None
+    assert status["latest_version"] == "9.9.10"
+
+
+def test_install_defers_when_the_background_loop_already_moved_past_what_the_client_saw(
+        monkeypatch):
+    """The background loop force-checks on its own five-minute cadence,
+    independent of any click. If it already advanced `_latest` to a newer
+    version before the client's last poll caught up, the screen the user
+    clicked on still names the OLD version — and install()'s own recheck
+    finds nothing new, because the server had already moved before this
+    call even started. A snapshot of `_latest` taken at call-start would
+    equal the post-recheck value in this case (both already "9.9.10") and
+    miss the mismatch entirely; only comparing against what the CLIENT says
+    it saw (`expected_version`) catches it."""
+    manager = mac.UpdateManager(bundle="/nonexistent/FusedRender.app", method="dmg")
+    monkeypatch.setattr(mac, "__version__", "0.4.10")
+    manifest_version = {"v": "9.9.9"}
+
+    def fetch(url, **kwargs):
+        return {"schema": 1, "version": manifest_version["v"], "url": "https://x/y.dmg",
+                "sha256": "s", "signature": "g"}
+
+    monkeypatch.setattr(common, "fetch_manifest", fetch)
+    manager.check()
+    assert manager.status()["latest_version"] == "9.9.9"
+
+    # The background loop ticks on its own, finds a newer release. The
+    # client hasn't polled again yet, so its screen still says "9.9.9".
+    manifest_version["v"] = "9.9.10"
+    manager.check(force=True)
+    assert manager.status()["latest_version"] == "9.9.10"
+
+    done = []
+    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: done.append(manifest))
+    status = manager.install(expected_version="9.9.9")  # what the client's screen said
+    assert manager._install_thread is None
+    assert done == []
     assert status["latest_version"] == "9.9.10"
 
 
@@ -531,6 +569,33 @@ def test_config_carries_update_with_manager(client, monkeypatch):
     body = client.get("/api/config").json()
     assert body["update"]["state"] == "idle"
     assert body["update"]["method"] == "dmg"
+
+
+def test_install_endpoint_passes_expected_version_through(client, monkeypatch):
+    """The router forwards the request body's `expected_version` straight to
+    UpdateManager.install() — the whole point of the endpoint change: the
+    client tells the server what it had on screen. A request with no body
+    at all (an older client, or a direct caller) must still be valid,
+    falling back to None."""
+    manager = mac.UpdateManager(bundle="/x.app", method="dmg")
+    monkeypatch.setattr(mac, "_manager", manager)
+    recorded: dict = {}
+
+    def fake_install(expected_version=None):
+        recorded["expected_version"] = expected_version
+        return {"state": "idle"}
+
+    monkeypatch.setattr(manager, "install", fake_install)
+
+    resp = client.post("/api/update/install", headers={"X-Fused": "1"},
+                       json={"expected_version": "9.9.9"})
+    assert resp.status_code == 200
+    assert recorded["expected_version"] == "9.9.9"
+
+    recorded.clear()
+    resp = client.post("/api/update/install", headers={"X-Fused": "1"})
+    assert resp.status_code == 200
+    assert recorded["expected_version"] is None
 
 
 def test_start_noop_when_unbundled(monkeypatch):


### PR DESCRIPTION
## Summary
This change adds a version freshness check to the `install()` method to prevent installing outdated versions and to detect version changes between when the user clicks Install and when the installation actually begins.

## Key Changes
- **Added forced recheck in `install()`**: Before starting an installation, the method now calls `check(force=True)` to fetch the latest version information, bypassing the normal throttle and idle-only restrictions.

- **Deferred installation on version mismatch**: If the recheck discovers a different version than what was displayed when the user clicked Install, the installation is deferred. The UI is updated with the new version and the user must click Install again to proceed, ensuring honest state representation.

- **Skipped recheck when idle**: The recheck only runs when there's actually something to install (state is "available" or "error"), avoiding unnecessary network calls from idle state.

- **Graceful fallback**: If the recheck fails to fetch, it falls back to the last known-good version, ensuring the install never becomes worse than before the recheck attempt.

## Implementation Details
- The recheck respects the `CHECK_INTERVAL_S` (5 minute) staleness window that can exist in `_latest` from the periodic check loop.
- The version comparison happens after acquiring the lock to ensure thread-safe state inspection.
- Added comprehensive logging when an install is deferred due to version mismatch.
- Three new test cases validate: deferred installs on version changes, forced rechecks even when auto-ticks are overdue, and skipped rechecks when idle.

https://claude.ai/code/session_01J7QX3Xg5MnSzdav9RuDCx9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the mac self-update install path and API contract, but behavior is backward compatible and adds guards so installs align with what the UI showed.
> 
> **Overview**
> Self-update **Install** now pins what the user actually saw: the client sends **`latest_version` from its on-screen status** as `expected_version`, and macOS **`UpdateManager.install`** force-rechecks the manifest (when an install could proceed) then **defers** if the current `_latest` does not match that value—so a stale label or a background five-minute tick cannot silently install a different build than the one the user clicked.
> 
> **`updateInstall`** in the API layer posts optional `expected_version`; **UpdateBadge** and the sidebar settings update row pass their displayed version. The **`/api/update/install`** router accepts an optional JSON body (older clients with no body keep prior behavior). New tests cover defer-on-newer-version, background-loop race, forced recheck past throttle, idle skip, and router forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ba6dc167539faabd58715e477b80f2f82a42e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->