### PR TITLE
Skip non-UTF-8-filename porcelain test on Windows

### DIFF
--- a/tests/test_git_status_listing.py
+++ b/tests/test_git_status_listing.py
@@ -15,6 +15,7 @@ are pinned here and they need different kinds of test:
   doubting.
 """
 import os
+import sys
 
 import pytest
 
@@ -77,6 +78,17 @@ def test_parse_porcelain_skips_malformed_chunks():
     assert git_status.parse_porcelain(out) == [("??", "ok.txt")]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="a raw non-UTF-8 filename is a POSIX-only possibility — Windows "
+    "filenames are UTF-16, so git-for-Windows only ever emits well-formed "
+    "UTF-8 for a real path. os.fsdecode's error handler there is "
+    "'surrogatepass', not POSIX's 'surrogateescape', and surrogatepass can't "
+    "decode an arbitrary invalid byte at all — the expected value on the "
+    "line below, os.fsdecode(raw), would raise the exact same "
+    "UnicodeDecodeError this test is otherwise checking parse_porcelain does "
+    "NOT raise, so there is no platform-appropriate assertion left to make.",
+)
 def test_parse_porcelain_decodes_a_non_utf8_name_like_scandir_would():
     """A name git can't render as UTF-8 (a latin-1 checkout, say) must decode
     the same way `os.scandir` decodes the identical bytes off disk —


### PR DESCRIPTION
## Summary
- `tests/test_git_status_listing.py::test_parse_porcelain_decodes_a_non_utf8_name_like_scandir_would` has been failing on `test-python-windows`, independent of any recent change — it reproduces identically on `main` at `3adf9215` (confirmed via that commit's own CI run), so this isn't a regression, just a test that was never actually valid on that platform.
- Root cause: the test manufactures a raw byte sequence that isn't valid UTF-8 (`b"caf\xe9.txt"`) to simulate a non-UTF-8 filename — e.g. one written under a latin-1 locale on a POSIX filesystem, which permits arbitrary bytes as a name. That's a POSIX-only scenario: NTFS filenames are UTF-16, so git-for-Windows only ever emits well-formed UTF-8 for a real path, and `os.fsdecode`'s error handler on Windows is `'surrogatepass'` (not POSIX's `'surrogateescape'`), which can't decode an arbitrary invalid byte at all. The test's own expected value (`os.fsdecode(raw)`, in its own assert) would raise the identical `UnicodeDecodeError` if reached — so there's no platform-appropriate assertion left to make on Windows.
- Fix: skip the test on `sys.platform == "win32"` with a reason explaining why, matching the pattern already used throughout this test suite for POSIX-only behavior. `parse_porcelain` itself is untouched — `os.fsdecode` is still the correct call on every platform it actually runs on, matching whatever `os.scandir` would produce for the same real filename there.

## Test plan
- [x] `tests/test_git_status_listing.py` passes locally (Linux) with the target test still running, not skipped
- [x] Full suite (`pytest tests/`) passes: 11917 passed, 194 skipped
- [ ] `test-python-windows` goes green in CI on this PR (can't run Windows locally to confirm directly, but the skip condition mirrors dozens of existing `sys.platform == "win32"` skips elsewhere in this suite)

https://claude.ai/code/session_01J7QX3Xg5MnSzdav9RuDCx9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7QX3Xg5MnSzdav9RuDCx9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only skip with no application code changes; fixes flaky/failing Windows CI without altering runtime git status behavior.
> 
> **Overview**
> **Skips** `test_parse_porcelain_decodes_a_non_utf8_name_like_scandir_would` on Windows via `@pytest.mark.skipif(sys.platform == "win32", …)` and adds `import sys` for that guard.
> 
> The test fabricates invalid UTF-8 path bytes to assert `parse_porcelain` decodes like `os.fsdecode` / `os.scandir` on POSIX; that scenario does not exist on NTFS/git-for-Windows, and the test’s own expected value (`os.fsdecode(raw)`) would fail the same way on win32. **Production `parse_porcelain` is unchanged**—only CI behavior for an invalid-on-Windows test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de7a874b19b1a1802893fa6d0b8d9f36e917045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->