### PR TITLE
Tasks: tab colours, blocked count, repeat chip, popover stacking, hosted comments, Blocked re-run

### DIFF
--- a/frontend/src/apps/claude/ann/mode.test.ts
+++ b/frontend/src/apps/claude/ann/mode.test.ts
@@ -162,6 +162,28 @@ describe("§D — off → comment", () => {
     expect(modeOf(off)).toBe("off");
   });
 
+  test("the boot arm CONTINUES the round the URL's notes belong to (Akshil, 2026-09-11)", () => {
+    // Pins are gated on `roundStart`; a boot that stamped `now` hid every pin
+    // the reload had just restored while their chips still showed.
+    const seed = JSON.stringify([
+      { id: "a", content: "first", anchorPath: "div:nth-of-type(1)", createdAt: 42 },
+      { id: "b", content: "second", anchorPath: "div:nth-of-type(2)", createdAt: 77 },
+    ]);
+    const r = rig({ params: { annmode: "1", annotations: seed } });
+    r.machine.bootFromParam();
+    expect(modeOf(r)).toBe("comment");
+    expect(r.store.roundStart()).toBe(42);
+    // With nothing to restore, the round is simply now — the old behaviour.
+    const fresh = rig({ params: { annmode: "1" } });
+    fresh.machine.bootFromParam();
+    expect(fresh.store.roundStart()).toBe(5000);
+    // And a user re-arming later still starts a NEW round, so a finished
+    // round's pins do not follow into the next.
+    r.machine.set(false);
+    r.machine.set(true);
+    expect(r.store.roundStart()).toBeGreaterThan(42);
+  });
+
   test('§D last row — `annmode=2` on boot ENDS the walkthrough, it does not resume it', () => {
     const r = rig({ params: { annmode: "2" } });
     r.machine.bootFromParam();

--- a/frontend/src/apps/claude/ann/mode.ts
+++ b/frontend/src/apps/claude/ann/mode.ts
@@ -327,6 +327,21 @@ export function createAnnMode(deps: AnnModeDeps): AnnModeMachine {
       // that races the hosted pane's arrival. The audio was already stopped and
       // KEPT on `pagehide`, so nothing spoken is lost.
       set(deps.store.modeParam() === "1");
+      // A RELOAD CONTINUES THE ROUND, IT DOES NOT START ONE (Akshil, 2026-09-11:
+      // "on reload it remembers the content, but not the pin or the element").
+      // `set(true)` stamps the round at `now`, which is the pin gate — a note
+      // older than the round draws a chip and no pin, by design, so the pins of
+      // a finished round do not litter the next one. But the notes the URL just
+      // handed back are THIS round's: unsent, and the reader is mid-thought. So
+      // the round opens where the oldest of them was made, and the pins come
+      // back with the chips. Only when armed: an unarmed boot paints no pins.
+      if (on) {
+        const pending = deps.store.pending();
+        if (pending.length) {
+          deps.store.startRound(Math.min(...pending.map((c) => c.createdAt || 0)));
+          deps.render();
+        }
+      }
     },
     async done() {
       // NOT THE WALKTHROUGH'S TO FINISH (Bugbot, PR #1074). Done is Comment

--- a/frontend/src/apps/claude/ann/store.test.ts
+++ b/frontend/src/apps/claude/ann/store.test.ts
@@ -87,10 +87,15 @@ describe("the param's shape is T's, verbatim (T:6600, 6612)", () => {
     expect(store.list()).toHaveLength(1);
   });
 
-  test("HOSTED boots empty (T:6606): a sidebar teardown is a mode switch as often as a reload", () => {
+  test("HOSTED reads the param too (Akshil, 2026-09-11): a reload keeps the comments", () => {
+    // T:6606 booted the hosted layout empty, on the argument that a sidebar
+    // teardown is a mode switch as often as a reload. The reload was the case
+    // people actually hit — comment, reload, mode restored, notes gone — and
+    // leaving the pane clears nothing from the URL either way.
     const seed = JSON.stringify([{ id: "a", content: "hi", createdAt: 1 }]);
     const { store } = make({ [ANN_PARAM]: seed }, true);
-    expect(store.list()).toEqual([]);
+    expect(store.list()).toHaveLength(1);
+    expect(store.list()[0].content).toBe("hi");
   });
 });
 

--- a/frontend/src/apps/claude/ann/store.ts
+++ b/frontend/src/apps/claude/ann/store.ts
@@ -89,9 +89,14 @@ export function isSendableNow(
 export interface AnnStoreOptions {
   params: ParamsStore;
   /**
-   * T:6606 — the HOSTED layout boots EMPTY. A sidebar teardown is a mode switch
-   * as often as it is a reload and the param cannot say which, so re-hydrating
-   * would resurrect notes anchored to a pane the reader has since left.
+   * T:6606 had the HOSTED layout boot EMPTY, on the argument that a sidebar
+   * teardown is a mode switch as often as a reload. That cost the reload case
+   * every time (Akshil, 2026-09-11: "when I comment … and reload the page, the
+   * comments should stay because they are in url — the comment mode stays but
+   * the comments also should stay"), and the mode-switch case was never the
+   * one people hit: leaving the pane clears nothing from the URL either way.
+   * So both layouts now read the param at boot; `hosted` is kept for the
+   * target machinery and no longer decides this.
    */
   hosted?: boolean;
   /** Injected in tests. */
@@ -175,7 +180,7 @@ export function createAnnStore(opts: AnnStoreOptions): AnnStore {
         ? crypto.randomUUID()
         : "ann-" + now().toString(36) + "-" + Math.random().toString(36).slice(2, 8));
 
-  let list: Annotation[] = opts.hosted ? [] : parseAnnotations(params.get(ANN_PARAM));
+  let list: Annotation[] = parseAnnotations(params.get(ANN_PARAM));
   let round = 0;
   const subs = new Set<(list: readonly Annotation[]) => void>();
 

--- a/frontend/src/apps/claude/styles/transcript.css
+++ b/frontend/src/apps/claude/styles/transcript.css
@@ -597,7 +597,9 @@
 }
 .chat-root .perm .perm-head {
   font-size: 13px;
-  color: var(--c-dim);
+  /* A notch above `--c-dim` (Akshil, 2026-09-11: contrast): this line says
+     WHO is asking, and it read as a caption nobody was meant to see. */
+  color: color-mix(in srgb, var(--c-fg) 45%, var(--c-dim));
 }
 .chat-root .perm .perm-head .tool {
   color: var(--c-accent-text);
@@ -796,10 +798,22 @@
   flex: 1 1 auto;
   min-width: 0;
 }
-.chat-root .perm .qopt + .qopt {
-  /* A hairline between rows, drawn as a shadow so the radius on hover is not
-     cut through by a border. */
-  box-shadow: inset 0 1px 0 var(--c-border);
+/* A HAIRLINE BETWEEN ROWS, STRAIGHT (Akshil, 2026-09-11: "separator between
+   options is curved, it shouldn't be"). It was an inset box-shadow on the row,
+   and an inset shadow follows the row's 8px radius — each line ended in two
+   little arcs. A pseudo-element is a flat 1px box of its own, so it stays a
+   line whatever the row's corners do; inset by the row's padding on both ends
+   so it spans the words, not the hover fill. `--c-border-strong`, because the
+   plain border was too close to the card to be seen as a divider at all. */
+.chat-root .perm .qopt + .qopt::before {
+  content: "";
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  top: 0;
+  height: 1px;
+  background: var(--c-border-strong);
+  pointer-events: none;
 }
 .chat-root .perm .qopt:hover:not(:disabled) {
   background: var(--c-card-bg-2);
@@ -817,7 +831,9 @@
   height: 22px;
   border-radius: 6px;
   background: var(--c-card-bg-2);
-  color: var(--c-dim);
+  /* The row's own text colour, not `--c-dim`: a number one cannot read is not a
+     label (Akshil, 2026-09-11: "make sure contrast is better in this ui"). */
+  color: var(--c-fg);
   font-size: 12px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
@@ -862,13 +878,16 @@
   font-weight: 500;
   display: inline;
 }
-/* In line after the label, dim, so a row is one line unless the words need
-   two. */
+/* In line after the label, quieter than the label but READABLE (Akshil,
+   2026-09-11: contrast): `--c-dim` at 12px on the card fell under the line most
+   people can read at a glance, so the description takes a colour two-thirds of
+   the way from dim to the row's own text, at the row's size. Still a step
+   under the 500-weight label, which is what keeps the two apart. */
 .chat-root .perm .qopt .desc {
   display: inline;
   margin-left: 8px;
-  color: var(--c-dim);
-  font-size: 12px;
+  color: color-mix(in srgb, var(--c-fg) 65%, var(--c-dim));
+  font-size: 13px;
   line-height: 1.4;
   word-break: break-word;
 }

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -3066,6 +3066,10 @@ export interface Task {
   // same (bounded) answer they gave before these existed.
   next_run?: number;
   next_run_entry?: string;
+  // Whether that run is an occurrence of a repeating template (tasks.py
+  // `_next_run`, 2026-09-11) — the next-run chip's repeat glyph. Absent on an
+  // older server; tasks-lib.nextRunRepeats then reads the window.
+  next_run_repeats?: boolean;
   // The three most recent, newest first. The rest need the endpoint below —
   // this list is built by a tail parse because it runs for every row, and a
   // full transcript parse per task would not survive a few hundred of them.
@@ -3104,6 +3108,7 @@ export type TaskPulseTask = Pick<
   | "session_id"
   | "next_run"
   | "next_run_entry"
+  | "next_run_repeats"
 >;
 
 export function getTasks(): Promise<{ tasks: Task[]; generation?: number }> {

--- a/frontend/src/platform/shadcn/ui/popover.tsx
+++ b/frontend/src/platform/shadcn/ui/popover.tsx
@@ -29,7 +29,15 @@ function PopoverContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
-        className="isolate z-50"
+        // ABOVE THE APP'S MODAL. The chassis (`platform/ui/modal`) sits at
+        // z-index 1000 (`styles/deploy.css`) and the screenshot viewer opened
+        // from inside one at 1100; a popover anchored to a control INSIDE a modal
+        // — the task popup's composer pills, its Schedule confirm — rendered at
+        // 50 and so painted behind the scrim it was opened from: the button
+        // looked dead (Akshil, 2026-09-11: "schedule button doesn't work, it
+        // doesn't open anything"). A popover is transient and anchored, so the
+        // one plane above every dialog is the honest place for all of them.
+        className="isolate z-[1200]"
       >
         <PopoverPrimitive.Popup
           data-slot="popover-content"

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -85,8 +85,7 @@ import {
   taskFile,
   threadTone,
   messageWhenTitle,
-  nextRunChip,
-  repeatMark,
+  scheduledMark,
   outcomeTag,
   openMessageHref,
   openThreadIntent,
@@ -224,18 +223,24 @@ const ICON_FILE = icon(
 // TASK row (2026-09-10, "this task has a run booked") followed it out the next
 // day (Akshil, 2026-09-11: "remove that icon").
 //
-/** A REPEATING task — circle arrows after the title (Akshil, 2026-09-11: "can
- *  we have circle arrows icons? … let's have it after the title field"). lucide
- *  `refresh-cw`, at the file mark's 12px and drawn beside it: the two are the
- *  same kind of caption on the title — what the task is about, and that it runs
- *  again by itself. Drawn only while a repeating run is ahead
- *  (tasks-lib.nextRunRepeats over scheduledMark's test); the chip beside the
- *  time says WHEN and stays words-only. */
+/** THE SCHEDULE MARK after the title (Akshil, 2026-09-11: "for done/blocked/
+ *  archive tasks with schedule message let's show a schedule icon [clock] after
+ *  the title rather than 'in 1h' … if it is repeating we show repeat icon, if
+ *  scheduled once we show clock icon, we don't show both"). One glyph, chosen
+ *  by tasks-lib.scheduledMark: circle arrows (lucide `refresh-cw`) for an
+ *  occurrence of a template, a clock (lucide `clock`) for a one-off. Both at
+ *  the file mark's 12px and drawn beside it — the same kind of caption on the
+ *  title: what the task is about, and that it runs by itself. The instant is
+ *  in the tooltip; the row's one time column stays the row's. */
 const ICON_REPEAT = icon(
   <><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
     <path d="M21 3v5h-5" />
     <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
     <path d="M8 16H3v5" /></>,
+  12,
+);
+const ICON_CLOCK = icon(
+  <><circle cx="12" cy="12" r="9" /><polyline points="12 7 12 12 16 14" /></>,
   12,
 );
 const ICON_OPEN = icon(
@@ -1714,11 +1719,10 @@ function TaskNode({
   // reads LANE_SORTS, the same map the Board's lanes are ordered by), and null when
   // the task has neither, in which case nothing is drawn.
   const when = taskWhen(task);
-  // The run still to come, when the row's own time is not already it.
-  const soon = nextRunChip(task);
-  // ...and whether the task REPEATS — the circle arrows after the title. Null
-  // unless a run is ahead AND it is a template's occurrence (tasks-lib.repeatMark).
-  const repeating = repeatMark(task);
+  // A run still ahead — the mark after the title, clock or circle arrows
+  // (tasks-lib.scheduledMark). No chip beside the time any more (Akshil,
+  // 2026-09-11: "we don't need to show time 2 times on the right side").
+  const sched = scheduledMark(task);
   // ...and the one word a settled lane cannot say: that the last run was
   // STOPPED rather than finished (tasks-lib.outcomeTag).
   const outcome = outcomeTag(task);
@@ -2348,17 +2352,18 @@ function TaskNode({
           </span>
         ) : null}
 
-        {/* THE REPEAT MARK, after the file mark and for the reason that one is
+        {/* THE SCHEDULE MARK, after the file mark and for the reason that one is
             there: both caption the title — what the task is about, and that it
-            runs again on its own (Akshil, 2026-09-11). Drawn while a repeating
-            run is ahead; the chip at the row's end says when. Same three press
-            handlers as the file mark: the mark sits over the stretched link and
-            would otherwise be a dead run of pixels (Akshil, 2026-08-27). */}
-        {repeating ? (
+            runs by itself (Akshil, 2026-09-11). Circle arrows for a repeat, a
+            clock for a one-off, never both; the instant is in the tooltip. Same
+            three press handlers as the file mark: the mark sits over the
+            stretched link and would otherwise be a dead run of pixels (Akshil,
+            2026-08-27). */}
+        {sched ? (
           <span
-            className="tasks-row-repeat"
-            data-hint={repeating.title}
-            aria-label={repeating.label}
+            className="tasks-row-sched"
+            data-hint={sched.title}
+            aria-label={sched.label}
             onClick={(e) => {
               if (!href) return;
               if (opensElsewhere(e)) {
@@ -2376,7 +2381,7 @@ function TaskNode({
               if (e.button === 1 && href) e.preventDefault();
             }}
           >
-            {ICON_REPEAT}
+            {sched.repeats ? ICON_REPEAT : ICON_CLOCK}
           </span>
         ) : null}
 
@@ -2636,25 +2641,6 @@ function TaskNode({
             dash belongs in exactly the register the times beside it are in — it IS
             one of the column's values, not a different kind of thing — and
             `.tasks-row-time` already sizes, colours and aligns it. */}
-        {/* AND THE RUN THAT IS STILL COMING, when the time beside it is not
-            already that (tasks-lib.nextRunChip).
-
-            A recurring task whose last run finished sits in DONE now, not
-            Upcoming — the output nobody has read is what needs eyes, and a
-            promise is not a verdict (server `_message_verdict`). That is the
-            right lane and it drops one true fact off the row: the task is not
-            over. So the row says it, once, in the vocabulary every other time
-            here speaks (relativeWhen, absolute instant in the tooltip).
-
-            A CHIP and not a second time column: `.tasks-row-time` is the row's
-            one time slot and this is a different question, so it is marked
-            rather than aligned. Nothing is drawn on an Upcoming row, where the
-            time IS the next run and the chip would say it twice. */}
-        {soon && (
-          <span className="tasks-row-next" data-hint={soon.title}>
-            {soon.text}
-          </span>
-        )}
         {/* A PROVISIONAL row's time is not this row's time. taskWhen reads the
             run off the three-message window, and pulse carries no window, so it
             falls through to `last_active` — the session's clock, which on a live
@@ -3041,18 +3027,22 @@ export function TaskBoard({
         const said = await performRun({ kind: "resend", entryId: action.entryId });
         if (said) setNote(said);
       } else if (action.kind === "resay") {
-        // Same drop, typed message: no entry to copy, so the words travel as an
-        // immediate message into the session. `delay_seconds: 1` because the
-        // endpoint wants exactly one of due/delay and "now" is the smallest
-        // positive delay it takes; `immediate` keeps it off the calendar
-        // (schedule-lib.taskChips) — nobody planned this for a time.
-        await scheduleMessage({
+        // Same drop, typed message: no entry to copy, so the words travel as a
+        // message into the session — created, then FIRED (Akshil, 2026-09-11:
+        // "it shouldn't schedule it, it should rerun instantly"). run-now
+        // spawns before it answers, the same road `resend` takes, so the
+        // reload below already finds the task In progress. `delay_seconds: 1`
+        // only because the endpoint wants exactly one of due/delay; `immediate`
+        // keeps it off the calendar (schedule-lib.taskChips) — nobody planned
+        // this for a time.
+        const made = await scheduleMessage({
           target: action.target,
           message: action.body,
           session_id: action.sessionId,
           delay_seconds: 1,
           immediate: true,
         });
+        await performRun({ kind: "run-now", entryId: made.entry.id });
       } else if (action.kind === "unarchive") {
         // Archive → anywhere else. ONE meaning whatever `lane` is: the filing is
         // dropped and the task lands in whatever lane it DERIVES to, which is
@@ -3453,7 +3443,9 @@ function TaskCard({
   // still in Archive, so Unarchive is the only button it grows.
   const run = showsRowActions(task) ? taskRunIntent(task) : null;
   // The run still to come, when this card's lane does not already order by it.
-  const soon = nextRunChip(task);
+  // The mark after the title — clock or circle arrows (tasks-lib.scheduledMark),
+  // the List row's own, so the two views say "this runs by itself" alike.
+  const sched = scheduledMark(task);
   // ...and the one word the Done lane cannot say on its own: that this card's
   // last run was STOPPED rather than finished (tasks-lib.outcomeTag). Same
   // function the List row asks, so the two views cannot describe one run
@@ -3639,11 +3631,16 @@ function TaskCard({
             <span className="tasks-said">{`, ${taskUnreadLabel(unread)}`}</span>
           )}
         </span>
+        {sched && (
+          <span className="tasks-card-sched" title={sched.title} aria-label={sched.label}>
+            {sched.repeats ? ICON_REPEAT : ICON_CLOCK}
+          </span>
+        )}
         {/* The foot is the folder and the run ahead, so when neither says
             anything (spansProjects — every card in a board filtered to one
             project repeats it — and a card with no run coming) the whole line
             goes rather than leaving an empty row of padding. */}
-        {(showProject || soon || folderMissing) && (
+        {(showProject || folderMissing) && (
           <span className="schedule-tv-card-foot">
             {/* The List row's own mark, same words, same colour (see the row). */}
             {folderMissing && (
@@ -3656,14 +3653,6 @@ function TaskCard({
             )}
             {showProject && (
               <IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />
-            )}
-            {/* Same fact, same function, same words as the List row's
-                (tasks-lib.nextRunChip): a settled card whose task is due again
-                would otherwise show nothing about the run ahead. */}
-            {soon && (
-              <span className="tasks-row-next" title={soon.title}>
-                {soon.text}
-              </span>
             )}
           </span>
         )}

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -97,6 +97,7 @@ import {
   relativeWhen,
   settleMarkAllRead,
   spansProjects,
+  ringFailed,
   taskColumn,
   taskRunIntent,
   taskUnread,
@@ -2211,7 +2212,7 @@ function TaskNode({
         <span className="tasks-rowmark">
           <StatusIcon
             status={taskColumn(task)}
-            failed={task.failed}
+            failed={ringFailed(task)}
             unread={unread > 0}
             count={unread}
           />

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -3630,12 +3630,16 @@ function TaskCard({
           {unread > 0 && (
             <span className="tasks-said">{`, ${taskUnreadLabel(unread)}`}</span>
           )}
+          {/* INSIDE the title, not beside it: the card is a column flex box, so a
+              sibling is a row of its own and a lone glyph grew every scheduled
+              card by one line (Bugbot, PR #1105). Inline here it follows the
+              last word, which is where a caption on the title belongs. */}
+          {sched && (
+            <span className="tasks-card-sched" title={sched.title} aria-label={sched.label}>
+              {sched.repeats ? ICON_REPEAT : ICON_CLOCK}
+            </span>
+          )}
         </span>
-        {sched && (
-          <span className="tasks-card-sched" title={sched.title} aria-label={sched.label}>
-            {sched.repeats ? ICON_REPEAT : ICON_CLOCK}
-          </span>
-        )}
         {/* The foot is the folder and the run ahead, so when neither says
             anything (spansProjects — every card in a board filtered to one
             project repeats it — and a card with no run coming) the whole line

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -39,6 +39,7 @@ import {
   markWholeTaskRead,
   resendScheduledMessage,
   runScheduledNow,
+  scheduleMessage,
   archiveTask,
   unarchiveTask,
 } from "@platform/lib/api";
@@ -93,7 +94,6 @@ import {
   parseListMemory,
   projectOptions,
   relativeWhen,
-  scheduledMark,
   settleMarkAllRead,
   spansProjects,
   taskColumn,
@@ -179,13 +179,6 @@ export type { TaskFilters };
  * change rather than a value change.
  */
 const SHOW_ROW_ACTIONS: boolean = false;
-// THE SCHEDULE MARK IS BUILT AND HIDDEN (Akshil, 2026-09-11: "quick can we hide
-// the task list icon we just added"). Same arrangement as the strip above: the
-// glyph, its handlers, its CSS and tests all stay, and one flag decides whether
-// the row wears it. tasks-lib.scheduledMark is still computed — the tooltip
-// text and the predicate are the part worth keeping warm — so turning it back
-// on is this one line.
-const SHOW_SCHEDULE_MARK: boolean = false;
 
 
 // ---- icons -------------------------------------------------------------------
@@ -225,25 +218,19 @@ const ICON_FILE = icon(
 // status ring and MSG-003 on every thread row, saying where the message came
 // from. Removed at Akshil's request: it is a third glyph on a 12.5px line whose
 // first two already carry the state and the id, and nothing on the page acts on
-// the distinction. `.tasks-msg-kind` went from tasks.css with it.
+// the distinction. `.tasks-msg-kind` went from tasks.css with it. A clock on the
+// TASK row (2026-09-10, "this task has a run booked") followed it out the next
+// day (Akshil, 2026-09-11: "remove that icon").
 //
-// THE CLOCK BELOW IS NOT THAT CLOCK, and the difference is the whole reason it is
-// allowed back on the page. That one sat on every MESSAGE row and said which kind
-// each message was — a distinction the row's other two glyphs already carried.
-// This one sits on the TASK row and says the task has a run booked
-// (tasks-lib.scheduledMark), which nothing else on that line states: the "next
-// 2h" chip is absent on exactly the rows whose own time already IS the next run,
-// and a time in the last column is not a mark a list can be scanned by.
-/** A schedule, for a task with a run ahead of it.
- *
- *  lucide `clock`, at the file mark's 12px and drawn beside it: the two are the
- *  same kind of statement about the task — what it is about, and that it runs by
- *  itself — so they read as one pair of captions on the title rather than as two
- *  unrelated symbols. Boxy is not on offer here (a clock is a circle), but the
- *  stroke, the size and the muted register are the file mark's exactly. */
-const ICON_CLOCK = icon(
-  <><circle cx="12" cy="12" r="9" /><polyline points="12 7 12 12 16 14" /></>,
-  12,
+/** A REPEATING run, inside the next-run chip (Akshil, 2026-09-11: "for repeating
+ *  tasks we say 'in 1h [repeat icon, arrow circle]'"). lucide `repeat`, at the
+ *  chip's own 11px type so it reads as part of the word rather than as a mark
+ *  beside it. Drawn only when tasks-lib.nextRunChip says the run ahead is an
+ *  occurrence of a template; a one-off says the time alone. */
+const ICON_REPEAT = icon(
+  <><path d="m17 2 4 4-4 4" /><path d="M3 11v-1a4 4 0 0 1 4-4h14" />
+    <path d="m7 22-4-4 4-4" /><path d="M21 13v1a4 4 0 0 1-4 4H3" /></>,
+  11,
 );
 const ICON_OPEN = icon(
   <><path d="M15 3h6v6" /><path d="M10 14 21 3" />
@@ -1016,7 +1003,7 @@ interface ReadMarks {
  * own note when a re-send was queued rather than sent, "" when there is nothing
  * to say. Refusals THROW, so each caller can put them in its own note line.
  */
-async function performRun(intent: TaskRunIntent): Promise<string> {
+async function performRun(intent: Pick<TaskRunIntent, "kind" | "entryId">): Promise<string> {
   if (intent.kind === "resend") {
     const res = await resendScheduledMessage(intent.entryId);
     return res.note ?? "";
@@ -1723,10 +1710,6 @@ function TaskNode({
   const when = taskWhen(task);
   // The run still to come, when the row's own time is not already it.
   const soon = nextRunChip(task);
-  // ...and that there IS one at all — the mark beside the file glyph, drawn on
-  // every row with a run ahead of it including the Upcoming ones the chip stays
-  // quiet on. tasks-lib.scheduledMark owns the test and the tooltip.
-  const sched = scheduledMark(task);
   // ...and the one word a settled lane cannot say: that the last run was
   // STOPPED rather than finished (tasks-lib.outcomeTag).
   const outcome = outcomeTag(task);
@@ -2356,45 +2339,6 @@ function TaskNode({
           </span>
         ) : null}
 
-        {/* THE SCHEDULE MARK, next to the file mark and for the reason that one
-            is there: both answer "what kind of task is this" about the title
-            they sit against, so they belong in one pair of captions rather than
-            at opposite ends of the row (Akshil, 2026-09-10, on the List view).
-            tasks-lib.scheduledMark decides it — a run strictly ahead, the same
-            test nextRunChip applies, so the glyph and the chip cannot disagree
-            about whether one is coming.
-
-            A PRESS HERE IS A PRESS ON THE ROW, exactly as on the file mark
-            above: the mark sits over the stretched link (`z-index: 2`, for its
-            tooltip) and would otherwise be a second dead pixel-run on the row
-            (Akshil, 2026-08-27, about the file icon — same bug, so the same
-            three handlers rather than a second answer to it). */}
-        {SHOW_SCHEDULE_MARK && sched ? (
-          <span
-            className="tasks-row-sched"
-            data-hint={sched.title}
-            aria-label={sched.label}
-            onClick={(e) => {
-              if (!href) return;
-              if (opensElsewhere(e)) {
-                window.open(href, "_blank", "noopener");
-                return;
-              }
-              activate();
-            }}
-            onAuxClick={(e) => {
-              if (e.button !== 1 || !href) return;
-              e.preventDefault();
-              window.open(href, "_blank", "noopener");
-            }}
-            onMouseDown={(e) => {
-              if (e.button === 1 && href) e.preventDefault();
-            }}
-          >
-            {ICON_CLOCK}
-          </span>
-        ) : null}
-
         {/* Exactly ONE auto margin in this row: flex distributes free space
             equally across every auto margin, so a second one would park the
             right-hand group in the middle of the row instead of at its end. */}
@@ -2668,6 +2612,7 @@ function TaskNode({
         {soon && (
           <span className="tasks-row-next" data-hint={soon.title}>
             {soon.text}
+            {soon.repeats && ICON_REPEAT}
           </span>
         )}
         {/* A PROVISIONAL row's time is not this row's time. taskWhen reads the
@@ -3035,6 +2980,26 @@ export function TaskBoard({
         // left alone, so the thread reads as a run that happened early rather
         // than a schedule that was quietly rewritten.
         await runScheduledNow(action.entryId);
+      } else if (action.kind === "resend") {
+        // Blocked → In Progress, nothing pending: the scheduled message whose
+        // run broke goes again as a NEW message in the same thread
+        // (tasks-lib.rerunAction). The server's note rides along when the
+        // conversation was mid-turn and the message queued instead.
+        const said = await performRun({ kind: "resend", entryId: action.entryId });
+        if (said) setNote(said);
+      } else if (action.kind === "resay") {
+        // Same drop, typed message: no entry to copy, so the words travel as an
+        // immediate message into the session. `delay_seconds: 1` because the
+        // endpoint wants exactly one of due/delay and "now" is the smallest
+        // positive delay it takes; `immediate` keeps it off the calendar
+        // (schedule-lib.taskChips) — nobody planned this for a time.
+        await scheduleMessage({
+          target: action.target,
+          message: action.body,
+          session_id: action.sessionId,
+          delay_seconds: 1,
+          immediate: true,
+        });
       } else if (action.kind === "unarchive") {
         // Archive → anywhere else. ONE meaning whatever `lane` is: the filing is
         // dropped and the task lands in whatever lane it DERIVES to, which is
@@ -3645,6 +3610,7 @@ function TaskCard({
             {soon && (
               <span className="tasks-row-next" title={soon.title}>
                 {soon.text}
+                {soon.repeats && ICON_REPEAT}
               </span>
             )}
           </span>

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -86,6 +86,7 @@ import {
   threadTone,
   messageWhenTitle,
   nextRunChip,
+  repeatMark,
   outcomeTag,
   openMessageHref,
   openThreadIntent,
@@ -222,15 +223,19 @@ const ICON_FILE = icon(
 // TASK row (2026-09-10, "this task has a run booked") followed it out the next
 // day (Akshil, 2026-09-11: "remove that icon").
 //
-/** A REPEATING run, inside the next-run chip (Akshil, 2026-09-11: "for repeating
- *  tasks we say 'in 1h [repeat icon, arrow circle]'"). lucide `repeat`, at the
- *  chip's own 11px type so it reads as part of the word rather than as a mark
- *  beside it. Drawn only when tasks-lib.nextRunChip says the run ahead is an
- *  occurrence of a template; a one-off says the time alone. */
+/** A REPEATING task — circle arrows after the title (Akshil, 2026-09-11: "can
+ *  we have circle arrows icons? … let's have it after the title field"). lucide
+ *  `refresh-cw`, at the file mark's 12px and drawn beside it: the two are the
+ *  same kind of caption on the title — what the task is about, and that it runs
+ *  again by itself. Drawn only while a repeating run is ahead
+ *  (tasks-lib.nextRunRepeats over scheduledMark's test); the chip beside the
+ *  time says WHEN and stays words-only. */
 const ICON_REPEAT = icon(
-  <><path d="m17 2 4 4-4 4" /><path d="M3 11v-1a4 4 0 0 1 4-4h14" />
-    <path d="m7 22-4-4 4-4" /><path d="M21 13v1a4 4 0 0 1-4 4H3" /></>,
-  11,
+  <><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+    <path d="M21 3v5h-5" />
+    <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+    <path d="M8 16H3v5" /></>,
+  12,
 );
 const ICON_OPEN = icon(
   <><path d="M15 3h6v6" /><path d="M10 14 21 3" />
@@ -1710,6 +1715,9 @@ function TaskNode({
   const when = taskWhen(task);
   // The run still to come, when the row's own time is not already it.
   const soon = nextRunChip(task);
+  // ...and whether the task REPEATS — the circle arrows after the title. Null
+  // unless a run is ahead AND it is a template's occurrence (tasks-lib.repeatMark).
+  const repeating = repeatMark(task);
   // ...and the one word a settled lane cannot say: that the last run was
   // STOPPED rather than finished (tasks-lib.outcomeTag).
   const outcome = outcomeTag(task);
@@ -2339,6 +2347,38 @@ function TaskNode({
           </span>
         ) : null}
 
+        {/* THE REPEAT MARK, after the file mark and for the reason that one is
+            there: both caption the title — what the task is about, and that it
+            runs again on its own (Akshil, 2026-09-11). Drawn while a repeating
+            run is ahead; the chip at the row's end says when. Same three press
+            handlers as the file mark: the mark sits over the stretched link and
+            would otherwise be a dead run of pixels (Akshil, 2026-08-27). */}
+        {repeating ? (
+          <span
+            className="tasks-row-repeat"
+            data-hint={repeating.title}
+            aria-label={repeating.label}
+            onClick={(e) => {
+              if (!href) return;
+              if (opensElsewhere(e)) {
+                window.open(href, "_blank", "noopener");
+                return;
+              }
+              activate();
+            }}
+            onAuxClick={(e) => {
+              if (e.button !== 1 || !href) return;
+              e.preventDefault();
+              window.open(href, "_blank", "noopener");
+            }}
+            onMouseDown={(e) => {
+              if (e.button === 1 && href) e.preventDefault();
+            }}
+          >
+            {ICON_REPEAT}
+          </span>
+        ) : null}
+
         {/* Exactly ONE auto margin in this row: flex distributes free space
             equally across every auto margin, so a second one would park the
             right-hand group in the middle of the row instead of at its end. */}
@@ -2612,7 +2652,6 @@ function TaskNode({
         {soon && (
           <span className="tasks-row-next" data-hint={soon.title}>
             {soon.text}
-            {soon.repeats && ICON_REPEAT}
           </span>
         )}
         {/* A PROVISIONAL row's time is not this row's time. taskWhen reads the
@@ -3623,7 +3662,6 @@ function TaskCard({
             {soon && (
               <span className="tasks-row-next" title={soon.title}>
                 {soon.text}
-                {soon.repeats && ICON_REPEAT}
               </span>
             )}
           </span>

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -2955,14 +2955,27 @@ export function TaskBoard({
 
   // The one lane whose drop is not a filing decision. It is named while the
   // card is still in the air because "run this now" is not undoable and the
-  // dashed legal-drop outline says nothing about which of the two it is.
-  const runLane = useMemo(() => {
+  // dashed legal-drop outline says nothing about which of the two it is. A
+  // Blocked card's re-run (`resend`/`resay`, tasks-lib.rerunAction) is the same
+  // kind of drop — a NEW message goes out — so it carries the same warning,
+  // worded for what it does: the last message again, not the next one early.
+  const runDrop = useMemo(() => {
     if (!dragging) return null;
     for (const col of BOARD_LANES) {
-      if (dropAction(dragging, col.key)?.kind === "run") return col.key;
+      const kind = dropAction(dragging, col.key)?.kind;
+      if (kind === "run" || kind === "resend" || kind === "resay") {
+        return { lane: col.key, rerun: kind !== "run" };
+      }
     }
     return null;
   }, [dragging]);
+  const runLane = runDrop?.lane ?? null;
+  const runTitle = runDrop?.rerun
+    ? "Send the last message again"
+    : "Run the next scheduled message now";
+  const runHint = runDrop?.rerun
+    ? "Re-run — the last message goes again"
+    : "Run now — the time stays put";
 
   const drop = async (lane: BoardLane) => {
     const task = dragging;
@@ -3218,7 +3231,7 @@ export function TaskBoard({
                 }
                 title={
                   runLane === col.key
-                    ? "Run the next scheduled message now"
+                    ? runTitle
                     : empty
                       ? `${col.label}: nothing yet`
                       : `${col.label}: ${lane.length}`
@@ -3266,7 +3279,7 @@ export function TaskBoard({
                 {...dropProps(col.key)}
               >
                 {runLane === col.key && (
-                  <p className="tasks-run-hint">Run now — the time stays put</p>
+                  <p className="tasks-run-hint">{runHint}</p>
                 )}
                 {cards.map((task) => (
                   <TaskCard

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -58,6 +58,7 @@ import {
   firstLine,
   opensElsewhere,
   spansProjects,
+  ringFailed,
   taskColumn,
   taskHref,
   taskWhen,
@@ -533,7 +534,7 @@ function TaskCard({
               view sits under no lane header, so nothing else on it says what
               state the run is in — the same argument that keeps the ring on
               every List row and every Calendar chip. */}
-          <StatusIcon status={taskColumn(task)} failed={task.failed} />
+          <StatusIcon status={taskColumn(task)} failed={ringFailed(task)} />
           <span className="tasks-id tasks-id--task">{task.task_id}</span>
           {/* The same relative unit every task row on this page prints, from the
               same function — so a card and its row agree about when this last
@@ -827,7 +828,7 @@ function TaskPeek({
     <Modal
       title={
         <span className="task-peek-title">
-          <StatusIcon status={taskColumn(task)} failed={task.failed} />
+          <StatusIcon status={taskColumn(task)} failed={ringFailed(task)} />
           <span className="tasks-id tasks-id--task">{task.task_id}</span>
           {/* Shrink-to-fit, so the hint rides the WORDS and not the empty run
               of head to their right (Akshil, 2026-09-05). */}

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -103,8 +103,8 @@ describe("the sidebar's tasks pulse", () => {
     // reader for something goes first. Singular at one, because one is the
     // common case and "1 tasks" reads as a broken string.
     expect(pulseTitle(tasksPulse(parked, {})))
-      .toBe("1 task needs input · 2 running");
-    expect(attentionLabel(2)).toBe("2 tasks need input");
+      .toBe("1 blocked · 2 running");
+    expect(attentionLabel(2)).toBe("2 blocked");
   });
 
   it("says it in WORDS and in RED, and still nothing that moves", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -8451,6 +8451,10 @@ describe("the schedule mark on a List row", () => {
     expect(VIEWS).not.toContain('className="tasks-row-next"');
     // …and the Board card wears the same mark after its title.
     expect(VIEWS).toContain('className="tasks-card-sched"');
+    // Inside the title span (the card is a column flex box; a sibling would be a
+    // row of its own — Bugbot, PR #1105).
+    const title = VIEWS.slice(VIEWS.indexOf('className={"schedule-tv-card-title"'));
+    expect(title.indexOf('className="tasks-card-sched"')).toBeLessThan(title.indexOf("</span>\n        {"));
     expect(TASKS_CSS).toContain(".tasks-card-sched {");
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -75,6 +75,7 @@ import {
   messageWhenTitle,
   nextRunChip,
   nextRunRepeats,
+  repeatMark,
   outcomeTag,
   nextRunAt,
   openMessageHref,
@@ -7691,8 +7692,17 @@ describe("nextRunChip", () => {
     expect(chip.text).toBe("in 1h");
     expect(chip.repeats).toBe(true);
     expect(chip.title).toContain("repeats");
-    // The list row and the board card both draw the glyph off the same flag.
-    expect((VIEWS.match(/\{soon\.repeats && ICON_REPEAT\}/g) ?? []).length).toBe(2);
+    // The chip stays words-only; the glyph is the title's (repeatMark, below).
+    expect(VIEWS).not.toContain("soon.repeats");
+    expect(repeatMark(t, NOW)?.at).toBe(AHEAD);
+    expect(repeatMark(t, NOW)?.title).toContain("Repeats");
+    expect(repeatMark(task({ status: "done", next_run: AHEAD, next_run_entry: "e2" }), NOW)).toBe(null);
+    // Drawn after the file mark, with the file mark's three press handlers.
+    const ROW = VIEWS.slice(VIEWS.indexOf('className={"tasks-row"'), VIEWS.indexOf("{open && (", VIEWS.indexOf('className={"tasks-row"')));
+    expect(ROW).toContain('className="tasks-row-repeat"');
+    expect(ROW.indexOf('className="tasks-row-file"')).toBeLessThan(ROW.indexOf('className="tasks-row-repeat"'));
+    expect(ROW.indexOf('className="tasks-row-repeat"')).toBeLessThan(ROW.indexOf('className="tasks-grow"'));
+    expect(TASKS_CSS).toContain(".tasks-row-file,\n.tasks-row-repeat {");
   });
 
   it("reads the repeat off the window when an older server names none", () => {
@@ -8250,7 +8260,7 @@ describe("the folder chip as a filter tag", () => {
     expect(body).toContain("margin-block: calc(var(--tasks-row-pad-y) * -1)");
     // The scope glyph carries it too, with its margin-left left alone — that is a
     // deliberate pull toward the title and a shorthand would drop it.
-    const file = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file {"));
+    const file = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-repeat {"));
     const fileBody = file.slice(0, file.indexOf("}"));
     expect(fileBody).toContain("align-self: stretch");
     expect(fileBody).toContain("margin-left: calc(var(--tasks-row-gap) * -1)");
@@ -8310,7 +8320,7 @@ describe("the file mark after a task's title", () => {
     // `.tasks-rowlink` is an <a> over the whole row at z-index 1. An element
     // that does not lift out of the way never receives the pointer — and this
     // one exists only to be pointed at. Same lesson as the folder tag.
-    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file {"));
+    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-repeat {"));
     const body = rest.slice(0, rest.indexOf("}"));
     expect(body).toContain("position: relative");
     expect(body).toContain("z-index: 2");
@@ -8324,7 +8334,7 @@ describe("the file mark after a task's title", () => {
     // cursor over one glyph inside it announces a different kind of thing to
     // press and looks broken beside the row's own pointer (Akshil,
     // 2026-08-23).
-    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file {"));
+    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-repeat {"));
     // Comments stripped first — the rule's own headstone names the property it
     // no longer sets, and a substring search would find that instead.
     const body = rest.slice(0, rest.indexOf("}")).replace(/\/\*[\s\S]*?\*\//g, "");
@@ -8335,7 +8345,7 @@ describe("the file mark after a task's title", () => {
     // The row's flex `gap` is 10px and applies between every pair of children,
     // so the mark shipped with 10px on both sides plus a margin of its own. It
     // belongs to the title, so the gap is pulled back on that side only.
-    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file {"));
+    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-repeat {"));
     const body = rest.slice(0, rest.indexOf("}"));
     expect(body).toContain("margin-left: calc(var(--tasks-row-gap) * -1");
   });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -75,7 +75,6 @@ import {
   messageWhenTitle,
   nextRunChip,
   nextRunRepeats,
-  repeatMark,
   ringFailed,
   outcomeTag,
   nextRunAt,
@@ -2370,7 +2369,6 @@ describe("the unread mark", () => {
     // ICON_CLOCK at all now.
     const msgRow = thread.slice(0, thread.indexOf("{why && <p"));
     expect(msgRow).not.toContain("{ICON_CLOCK}");
-    expect(VIEWS).not.toContain("const ICON_CLOCK");
     // The body is the row's ink and carries the row's caption (`data-hint`), so
     // the element opens with an attribute now rather than closing immediately.
     expect(thread).toMatch(
@@ -4563,7 +4561,7 @@ describe("the folder chip on a row and a card", () => {
     // the id, where marks about the task live — in the foot it read as part of
     // the folder's name (Akshil, 2026-08-21).
     expect(CARD).toMatch(
-      /\{\(showProject \|\| soon \|\| folderMissing\) && \(\s*<span className="schedule-tv-card-foot">/,
+      /\{\(showProject \|\| folderMissing\) && \(\s*<span className="schedule-tv-card-foot">/,
     );
     // The task's own name is still captioned — on the TITLE now, not the row
     // (Akshil: "the tooltip of title should only show up if I am on title
@@ -7716,17 +7714,10 @@ describe("nextRunChip", () => {
     expect(chip.text).toBe("in 1h");
     expect(chip.repeats).toBe(true);
     expect(chip.title).toContain("repeats");
-    // The chip stays words-only; the glyph is the title's (repeatMark, below).
+    // The chip itself is no longer drawn anywhere — the fact moved to the title
+    // mark (scheduledMark, tested below); this stays as the lib's own answer.
+    expect(VIEWS).not.toContain("nextRunChip(");
     expect(VIEWS).not.toContain("soon.repeats");
-    expect(repeatMark(t, NOW)?.at).toBe(AHEAD);
-    expect(repeatMark(t, NOW)?.title).toContain("Repeats");
-    expect(repeatMark(task({ status: "done", next_run: AHEAD, next_run_entry: "e2" }), NOW)).toBe(null);
-    // Drawn after the file mark, with the file mark's three press handlers.
-    const ROW = VIEWS.slice(VIEWS.indexOf('className={"tasks-row"'), VIEWS.indexOf("{open && (", VIEWS.indexOf('className={"tasks-row"')));
-    expect(ROW).toContain('className="tasks-row-repeat"');
-    expect(ROW.indexOf('className="tasks-row-file"')).toBeLessThan(ROW.indexOf('className="tasks-row-repeat"'));
-    expect(ROW.indexOf('className="tasks-row-repeat"')).toBeLessThan(ROW.indexOf('className="tasks-grow"'));
-    expect(TASKS_CSS).toContain(".tasks-row-file,\n.tasks-row-repeat {");
   });
 
   it("reads the repeat off the window when an older server names none", () => {
@@ -7761,8 +7752,8 @@ describe("nextRunChip", () => {
     expect(chip.title).toContain(messageStamp(AHEAD));
     // The row's own time is still the last run — the rank did not move.
     expect(taskWhen(t, NOW).kind).toBe("last");
-    // Every row that draws the chip draws it off this one function.
-    expect((VIEWS.match(/nextRunChip\(task\)/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    // The same sentence rides the title mark, which is what the row now draws.
+    expect(scheduledMark(t, NOW)?.title).toContain("stays Blocked until this runs");
   });
 
   it("says nothing on an Upcoming row, whose own time is already that run", () => {
@@ -8303,7 +8294,7 @@ describe("the folder chip as a filter tag", () => {
     expect(body).toContain("margin-block: calc(var(--tasks-row-pad-y) * -1)");
     // The scope glyph carries it too, with its margin-left left alone — that is a
     // deliberate pull toward the title and a shorthand would drop it.
-    const file = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-repeat {"));
+    const file = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-sched {"));
     const fileBody = file.slice(0, file.indexOf("}"));
     expect(fileBody).toContain("align-self: stretch");
     expect(fileBody).toContain("margin-left: calc(var(--tasks-row-gap) * -1)");
@@ -8363,7 +8354,7 @@ describe("the file mark after a task's title", () => {
     // `.tasks-rowlink` is an <a> over the whole row at z-index 1. An element
     // that does not lift out of the way never receives the pointer — and this
     // one exists only to be pointed at. Same lesson as the folder tag.
-    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-repeat {"));
+    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-sched {"));
     const body = rest.slice(0, rest.indexOf("}"));
     expect(body).toContain("position: relative");
     expect(body).toContain("z-index: 2");
@@ -8377,7 +8368,7 @@ describe("the file mark after a task's title", () => {
     // cursor over one glyph inside it announces a different kind of thing to
     // press and looks broken beside the row's own pointer (Akshil,
     // 2026-08-23).
-    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-repeat {"));
+    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-sched {"));
     // Comments stripped first — the rule's own headstone names the property it
     // no longer sets, and a substring search would find that instead.
     const body = rest.slice(0, rest.indexOf("}")).replace(/\/\*[\s\S]*?\*\//g, "");
@@ -8388,7 +8379,7 @@ describe("the file mark after a task's title", () => {
     // The row's flex `gap` is 10px and applies between every pair of children,
     // so the mark shipped with 10px on both sides plus a margin of its own. It
     // belongs to the title, so the gap is pulled back on that side only.
-    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-repeat {"));
+    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-file,\n.tasks-row-sched {"));
     const body = rest.slice(0, rest.indexOf("}"));
     expect(body).toContain("margin-left: calc(var(--tasks-row-gap) * -1");
   });
@@ -8396,28 +8387,32 @@ describe("the file mark after a task's title", () => {
 
 describe("the schedule mark on a List row", () => {
   const AHEAD = Math.floor(NOW / 1000) + 3600;
+  const ROW = VIEWS.slice(
+    VIEWS.indexOf('className={"tasks-row"'),
+    VIEWS.indexOf("{open && (", VIEWS.indexOf('className={"tasks-row"')),
+  );
 
-  // The glyph is GONE (Akshil, 2026-09-11: "we had a hidden icon after title for
-  // scheduled tasks, remove that icon"). It was built on 2026-09-10, hidden the
-  // next morning behind SHOW_SCHEDULE_MARK, and removed the same day — the row
-  // wears the file mark alone again, and the fact it carried ("a run is booked")
-  // is the next-run chip's, which now also says whether that run repeats.
-  it("is not drawn, and has no flag left to flip", () => {
+  // Third answer in a day (Akshil, 2026-09-11). A clock after the title, then
+  // hidden, then removed for a chip beside the time — and back, because "we
+  // don't need to show time 2 times on the right side": the glyph says a run is
+  // booked and the tooltip says when; the row's one time column stays the row's.
+  it("is ONE glyph: circle arrows for a repeat, a clock for a one-off", () => {
+    const once = task({ status: "done", next_run: AHEAD, next_run_entry: "e2" });
+    const mark = scheduledMark(once, NOW)!;
+    expect(mark.at).toBe(AHEAD);
+    expect(mark.repeats).toBe(false);
+    expect(mark.title).toBe(`Scheduled · next run ${messageStamp(AHEAD)}`);
+    expect(mark.label).toBe(`Scheduled, next run ${messageStamp(AHEAD)}`);
+    const again = task({ status: "done", next_run: AHEAD, next_run_entry: "occ", next_run_repeats: true });
+    expect(scheduledMark(again, NOW)).toMatchObject({ repeats: true });
+    expect(scheduledMark(again, NOW)?.title).toBe(`Repeats · next run ${messageStamp(AHEAD)}`);
+    // Never both: the row picks by the flag.
+    expect(ROW).toContain("{sched.repeats ? ICON_REPEAT : ICON_CLOCK}");
+    expect((ROW.match(/ICON_CLOCK/g) ?? []).length).toBe(1);
     expect(VIEWS).not.toContain("SHOW_SCHEDULE_MARK");
-    expect(VIEWS).not.toContain("tasks-row-sched");
-    expect(VIEWS).not.toContain("scheduledMark(");
-    expect(TASKS_CSS).not.toContain("tasks-row-sched");
   });
 
-  // The predicate stays, for the tooltip text and because nextRunChip's test is
-  // the same one: two answers to "is a run coming" must not drift apart.
-  it("still knows which tasks have a run ahead, and names the instant", () => {
-    const t = task({ status: "done", next_run: AHEAD, next_run_entry: "e2" });
-    const mark = scheduledMark(t, NOW)!;
-    expect(mark.at).toBe(AHEAD);
-    expect(mark.title).toContain("Scheduled");
-    expect(mark.title).toContain(messageStamp(AHEAD));
-    expect(mark.label).toBe(`Scheduled, next run ${messageStamp(AHEAD)}`);
+  it("says nothing about a task with no run ahead, or one already due", () => {
     expect(scheduledMark(task({ status: "done" }), NOW)).toBe(null);
     const past = task({
       status: "done",
@@ -8425,6 +8420,38 @@ describe("the schedule mark on a List row", () => {
       next_run_entry: "e2",
     });
     expect(scheduledMark(past, NOW)).toBe(null);
+  });
+
+  it("on a Blocked row, says the lane's rule in the tooltip", () => {
+    // Stays Blocked — a pending message has no verdict — and the mark is where
+    // the row says a retry is booked (Akshil, 2026-09-11).
+    const t = task({ status: FAILED, next_run: AHEAD, next_run_entry: "e2" });
+    expect(scheduledMark(t, NOW)?.title).toBe(
+      `Scheduled · stays Blocked until this runs · ${messageStamp(AHEAD)}`,
+    );
+    expect(scheduledMark(t, NOW)?.label).not.toContain("·");
+  });
+
+  it("sits after the file mark, in the file mark's box, spending the row's gesture", () => {
+    expect(ROW).toContain('className="tasks-row-sched"');
+    expect(ROW.indexOf('className="tasks-row-file"')).toBeLessThan(
+      ROW.indexOf('className="tasks-row-sched"'),
+    );
+    expect(ROW.indexOf('className="tasks-row-sched"')).toBeLessThan(
+      ROW.indexOf('className="tasks-grow"'),
+    );
+    const mark = ROW.slice(ROW.indexOf('className="tasks-row-sched"'));
+    const body = mark.slice(0, mark.indexOf("{sched.repeats"));
+    expect(body).toContain("if (opensElsewhere(e)) {");
+    expect(body).toContain("activate();");
+    expect(body).toContain("onAuxClick");
+    // One selector list, so the two captions cannot drift apart.
+    expect(TASKS_CSS).toContain(".tasks-row-file,\n.tasks-row-sched {");
+    // The chip beside the time is gone from both views.
+    expect(VIEWS).not.toContain('className="tasks-row-next"');
+    // …and the Board card wears the same mark after its title.
+    expect(VIEWS).toContain('className="tasks-card-sched"');
+    expect(TASKS_CSS).toContain(".tasks-card-sched {");
   });
 });
 

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -76,6 +76,7 @@ import {
   nextRunChip,
   nextRunRepeats,
   repeatMark,
+  ringFailed,
   outcomeTag,
   nextRunAt,
   openMessageHref,
@@ -2057,7 +2058,7 @@ describe("the unread mark", () => {
     // held thread), so the ring hollows on the row's own press rather than on the
     // next poll — the same number that used to feed the dot.
     expect(ROW).toMatch(
-      /<StatusIcon\s+status=\{taskColumn\(task\)\}\s+failed=\{task\.failed\}\s+unread=\{unread > 0\}\s+count=\{unread\}\s*\/>/,
+      /<StatusIcon\s+status=\{taskColumn\(task\)\}\s+failed=\{ringFailed\(task\)\}\s+unread=\{unread > 0\}\s+count=\{unread\}\s*\/>/,
     );
     // Nothing trails the title any more: the ring leads the row, the title
     // follows, and the next thing is the live ping.
@@ -2582,9 +2583,10 @@ describe("the board card's status ring", () => {
   it("stays UNconditional on a List row and in the Calendar, which have no lane", () => {
     const from = VIEWS.indexOf('className={"tasks-row"');
     const row = VIEWS.slice(from, VIEWS.indexOf("{open && (", from));
-    // Not gated on anything: a flat row and a day cell have no header above them, so
-    // the ring is the only thing that files them at all.
-    expect(row).toMatch(/<StatusIcon\s+status=\{taskColumn\(task\)\}\s+failed=\{task\.failed\}/);
+    // Not gated on the LANE: a flat row and a day cell have no header above them,
+    // so the ring is the only thing that files them at all. The `failed` half is
+    // gated on the row being SETTLED (ringFailed), which is a different question.
+    expect(row).toMatch(/<StatusIcon\s+status=\{taskColumn\(task\)\}\s+failed=\{ringFailed\(task\)\}/);
     expect(VIEWS.slice(VIEWS.indexOf('className={"tasks-msg"'))).toContain("<StatusIcon");
     expect(SCHEDULE_CSS).toContain(".schedule-cal-popover .schedule-ring");
   });
@@ -7353,8 +7355,9 @@ describe("the Cards view's frame", () => {
     // the exclusion was wrong in both halves.
     expect(LIB).toContain("if (isSettledLane(task.status))");
     expect(LIB).toContain("return !!task.failed && isSettledLane(task.status);");
-    // Both readings ask the same list: two call sites, one declaration.
-    expect(LIB.split("isSettledLane").length).toBe(4);
+    // Three readings ask the same list — the empty pane's two and the task
+    // ring's (ringFailed) — one declaration.
+    expect(LIB.split("isSettledLane").length).toBe(5);
   });
 
   it("says 'Folder missing' on the List row and the Board card, and its press prints the sentence instead of leaving", () => {
@@ -7659,6 +7662,27 @@ describe("outcomeTag: the word the Done lane cannot say", () => {
   });
 });
 
+describe("ringFailed", () => {
+  it("repaints SETTLED lanes only: a live row wears its status, not its history", () => {
+    // TASK-017 (Akshil, 2026-09-11): blocked, then spoken to. The new turn made
+    // it `in_progress` while `failed` stayed true off the last settled run, and
+    // the red ring captioned "Blocked" sat in the In progress rank — under every
+    // real Blocked row, looking mis-sorted. The rank was right; the ring lied.
+    expect(ringFailed({ status: "in_progress", failed: true })).toBe(false);
+    expect(ringFailed({ status: "upcoming", failed: true })).toBe(false);
+    expect(ringFailed({ status: "needs_attention", failed: true })).toBe(false);
+    expect(ringFailed({ status: "done", failed: true })).toBe(true);
+    expect(ringFailed({ status: "blocked", failed: true })).toBe(true);
+    expect(ringFailed({ status: "archived", failed: true })).toBe(true);
+    expect(ringFailed({ status: "done", failed: false })).toBe(false);
+    // The task-level rings all read it; message-level tones keep their own.
+    expect(VIEWS).toContain("failed={ringFailed(task)}");
+    expect(VIEWS).not.toContain("failed={task.failed}");
+    expect(CARDS).toContain("failed={ringFailed(task)}");
+    expect(CARDS).not.toContain("failed={task.failed}");
+  });
+});
+
 describe("nextRunChip", () => {
   const AHEAD = Math.floor(NOW / 1000) + 3600;
 
@@ -7725,6 +7749,20 @@ describe("nextRunChip", () => {
       ],
     });
     expect(nextRunChip(once, NOW)?.repeats).toBe(false);
+  });
+
+  it("says the WORD on a Blocked row, where the lane cannot (Akshil, 2026-09-11)", () => {
+    // A pending message has no verdict, so a blocked task with a retry booked
+    // stays Blocked — and the chip is where the row says the retry exists.
+    const t = task({ status: FAILED, next_run: AHEAD, next_run_entry: "e2" });
+    const chip = nextRunChip(t, NOW)!;
+    expect(chip.text).toBe("scheduled in 1h");
+    expect(chip.title).toContain("Stays Blocked until this runs");
+    expect(chip.title).toContain(messageStamp(AHEAD));
+    // The row's own time is still the last run — the rank did not move.
+    expect(taskWhen(t, NOW).kind).toBe("last");
+    // Every row that draws the chip draws it off this one function.
+    expect((VIEWS.match(/nextRunChip\(task\)/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
   it("says nothing on an Upcoming row, whose own time is already that run", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -8083,6 +8083,11 @@ describe("popoverPill", () => {
     // failed folds into the column, exactly as StatusIcon reads it...
     const f = task({ status: "done", failed: true });
     expect(popoverPill(f, false, false, f.messages, day, later).label).toBe("Blocked");
+    // ...but a LIVE one-off wears its status, not its history (ringFailed): the
+    // failed flag is the last settled run, and this one is running again.
+    const again = task({ status: "in_progress", failed: true });
+    expect(popoverPill(again, false, false, again.messages, day, later).label)
+      .toBe("In Progress");
     // ...and the day's contents cannot move a one-off's word: it IS its task.
     expect(popoverPill(t, false, false, [broke], day, later).label).toBe("Done");
   });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -74,6 +74,7 @@ import {
   threadTone,
   messageWhenTitle,
   nextRunChip,
+  nextRunRepeats,
   outcomeTag,
   nextRunAt,
   openMessageHref,
@@ -1209,11 +1210,62 @@ describe("dropLanes", () => {
   it("lets a failed task out to In Progress (re-run) and Archive", () => {
     const retryable = upcoming([T9], { status: FAILED });
     expect(dropLanes(retryable)).toEqual(["in_progress", "archived"]);
-    // With nothing pending there is nothing to re-run — but it can still be
-    // filed away.
+    // A pending message wins: bringing forward what was already asked for is
+    // the smaller action, and the drop is that rather than a re-send.
+    expect(dropAction(retryable, "in_progress")?.kind).toBe("run");
+    // With nothing pending the drop RE-RUNS the message whose run broke
+    // (Akshil, 2026-09-11): the factory's one message is a sent scheduled
+    // entry, so it goes again through the schedule's own re-send.
     const spent = task({ status: FAILED });
-    expect(dropLanes(spent)).toEqual(["archived"]);
+    expect(dropLanes(spent)).toEqual(["in_progress", "archived"]);
+    expect(dropAction(spent, "in_progress")).toEqual({
+      kind: "resend",
+      entryId: "e1",
+      messageId: "MSG-001",
+    });
     expect(isDraggable(spent)).toBe(true);
+  });
+
+  it("re-runs a TYPED message by saying it again into the same session", () => {
+    // No entry to copy, so the words travel (tasks-lib.rerunAction). The
+    // newest message that went is the one re-asked, whichever kind it is.
+    const chat = task({
+      status: FAILED,
+      session_id: "sess-1",
+      target: "/Users/me/proj/app.py",
+      messages: [
+        msg({ message_id: "MSG-002", kind: "chat", entry_id: "", body: "fix the bug", turn: "done" }),
+        msg({ message_id: "MSG-001" }),
+      ],
+    });
+    expect(dropLanes(chat)).toEqual(["in_progress", "archived"]);
+    expect(dropAction(chat, "in_progress")).toEqual({
+      kind: "resay",
+      body: "fix the bug",
+      sessionId: "sess-1",
+      target: "/Users/me/proj/app.py",
+      messageId: "MSG-002",
+    });
+    // A pending or cancelled message is skipped — it never went, so it is not
+    // what broke — and the one before it speaks.
+    const skipped = task({
+      status: FAILED,
+      messages: [
+        msg({ message_id: "MSG-003", state: "cancelled" }),
+        msg({ message_id: "MSG-002", kind: "chat", entry_id: "", body: "try again" }),
+        msg({ message_id: "MSG-001" }),
+      ],
+    });
+    expect(dropAction(skipped, "in_progress")?.kind).toBe("resay");
+    // Nothing that went at all: the card stays put, as before.
+    const nothing = task({
+      status: FAILED,
+      messages: [msg({ state: "cancelled" })],
+    });
+    expect(dropLanes(nothing)).toEqual(["archived"]);
+    // And Upcoming keeps the stricter rule — a task that has not run yet has
+    // nothing to run AGAIN.
+    expect(dropLanes(task({ status: "upcoming" }))).toEqual(["archived"]);
   });
 
   it("still refuses In Progress on a pending message with no entry id", () => {
@@ -1603,15 +1655,18 @@ describe("taskRunIntent", () => {
     ).toBe(null);
   });
 
-  it("leaves the DRAG on run-now only", () => {
-    // A drop on a lane says where the card belongs; it must not quietly create
-    // work that was never scheduled. So the failed task with nothing pending —
-    // the one case resend exists for — cannot be dragged into In Progress at
-    // all, exactly as before.
+  it("lets the DRAG out of Blocked re-run, and nowhere else", () => {
+    // The drag out of Blocked with nothing pending is the button's resend
+    // (Akshil, 2026-09-11: "allow moving from blocked to inprogress and trigger
+    // a rerun") — the same message, the same call, so the two gestures cannot
+    // re-ask different things.
     const spent = broke();
-    expect(dropLanes(spent)).toEqual(["archived"]);
-    expect(dropAction(spent, "in_progress")).toBe(null);
-    // And every legal drop is still a run or an archive, never a resend.
+    expect(dropLanes(spent)).toEqual(["in_progress", "archived"]);
+    const drop = dropAction(spent, "in_progress");
+    const button = taskRunIntent(spent)!;
+    expect(drop?.kind).toBe("resend");
+    expect(drop && "entryId" in drop ? drop.entryId : null).toBe(button.entryId);
+    // A pending message still wins on the same lane: run-now, never a resend.
     for (const lane of ["in_progress", "done", "archived"] as const) {
       const action = dropAction(upcoming([T9], { status: FAILED }), lane);
       if (action) expect(["run", "archive"]).toContain(action.kind);
@@ -2308,12 +2363,12 @@ describe("the unread mark", () => {
     // ICON_CHAT, the speech bubble it drew, is gone from the file as well rather
     // than left as an unused constant for the next reader to wonder about.
     expect(VIEWS).not.toContain("const ICON_CHAT");
-    // ICON_CLOCK IS BACK (2026-09-10) and this test still holds, because the
-    // fact above is about the MESSAGE row: the clock is drawn on the TASK row
-    // now, where it says the task has a run booked (tasks-lib.scheduledMark)
-    // and nothing else on the line states it. No message row wears it.
+    // A clock came back on the TASK row for a day (2026-09-10) and went again
+    // (2026-09-11); either way no message row wears one, and the file holds no
+    // ICON_CLOCK at all now.
     const msgRow = thread.slice(0, thread.indexOf("{why && <p"));
     expect(msgRow).not.toContain("{ICON_CLOCK}");
+    expect(VIEWS).not.toContain("const ICON_CLOCK");
     // The body is the row's ink and carries the row's caption (`data-hint`), so
     // the element opens with an attribute now rather than closing immediately.
     expect(thread).toMatch(
@@ -4222,6 +4277,9 @@ describe("the run action on a board card", () => {
     // about what "Re-run" does.
     expect(NODE).toContain("performRun(intent)");
     expect(BOARD).toContain("performRun(intent)");
+    // …and the DRAG out of Blocked spends the same function for its re-send
+    // (2026-09-11), so there is still exactly one call to the endpoint.
+    expect(BOARD).toContain('performRun({ kind: "resend", entryId: action.entryId })');
     expect((VIEWS.match(/resendScheduledMessage\(/g) ?? []).length).toBe(1);
   });
 
@@ -6456,12 +6514,14 @@ describe("the tasks toolbar", () => {
     for (const name of ["ICON_VIEW_LIST", "ICON_VIEW_BOARD", "ICON_VIEW_CALENDAR"]) {
       expect(CALENDAR).toContain(`export const ${name} = icon(`);
     }
-    // The marks are muted at rest and take the label's colour on the active half,
-    // so the icon reinforces the fill's statement rather than competing with it.
-    expect(block(SCHEDULE_CSS, ".schedule-view-btn > svg")).toContain("color: var(--fg-muted)");
-    expect(
-      block(SCHEDULE_CSS, ".schedule-view-btn.is-active > svg"),
-    ).toContain("color: inherit");
+    // ONE colour per half (Akshil, 2026-09-11): the inactive BUTTON is muted
+    // and its glyph inherits, so icon and word never read as two weights; the
+    // active half drops the rule and both take the label colour.
+    expect(block(SCHEDULE_CSS, ".schedule-view-btn:not(.is-active)")).toContain(
+      "color: var(--fg-muted)",
+    );
+    expect(block(SCHEDULE_CSS, ".schedule-view-btn > svg")).toContain("color: inherit");
+    expect(SCHEDULE_CSS).not.toContain(".schedule-view-btn.is-active > svg");
     // Only the VIEW switcher. `.schedule-form-seg` is shared with the New task
     // form's Once / On a schedule pair, which is a choice inside a form and stays
     // text-only — so the icon rules hang off a class of their own.
@@ -7607,10 +7667,54 @@ describe("nextRunChip", () => {
     const t = task({ status: "done", next_run: AHEAD, next_run_entry: "e2" });
     const chip = nextRunChip(t, NOW)!;
     expect(chip.at).toBe(AHEAD);
-    expect(chip.text).toBe(`next ${relativeWhen(AHEAD, NOW)}`);
-    expect(chip.text).toContain("in 1h");
+    // The time alone — "in 1h", not "next in 1h" (Akshil, 2026-09-11): the
+    // chip sits apart from the row's own stamp, and that is what says "next".
+    expect(chip.text).toBe(relativeWhen(AHEAD, NOW));
+    expect(chip.text).toBe("in 1h");
     // The exact instant is in the tooltip, like every other time on the page.
     expect(chip.title).toContain("Next run");
+    // A one-off: nothing repeats, so the chip wears no repeat glyph.
+    expect(chip.repeats).toBe(false);
+  });
+
+  it("says the run REPEATS when the server names an occurrence", () => {
+    // The same words, plus the glyph (Akshil, 2026-09-11: "in 1h [repeat icon,
+    // arrow circle]"). `next_run_repeats` is the server's, decided over every
+    // pending entry before the tail is cut — the window may not hold the run.
+    const t = task({
+      status: "done",
+      next_run: AHEAD,
+      next_run_entry: "occ-2",
+      next_run_repeats: true,
+    });
+    const chip = nextRunChip(t, NOW)!;
+    expect(chip.text).toBe("in 1h");
+    expect(chip.repeats).toBe(true);
+    expect(chip.title).toContain("repeats");
+    // The list row and the board card both draw the glyph off the same flag.
+    expect((VIEWS.match(/\{soon\.repeats && ICON_REPEAT\}/g) ?? []).length).toBe(2);
+  });
+
+  it("reads the repeat off the window when an older server names none", () => {
+    // Fallback for a server without `next_run_repeats`: the pending occurrence
+    // in the window carries its template's id, and that is what makes it a
+    // repeat. Same shape as nextRunAt's own window fallback.
+    const t = task({
+      status: "done",
+      messages: [
+        msg({ message_id: "MSG-002", state: "pending", at: AHEAD, entry_id: "occ-2", template_id: "tpl" }),
+        msg({ message_id: "MSG-001" }),
+      ],
+    });
+    expect(nextRunChip(t, NOW)?.repeats).toBe(true);
+    const once = task({
+      status: "done",
+      messages: [
+        msg({ message_id: "MSG-002", state: "pending", at: AHEAD, entry_id: "e2" }),
+        msg({ message_id: "MSG-001" }),
+      ],
+    });
+    expect(nextRunChip(once, NOW)?.repeats).toBe(false);
   });
 
   it("says nothing on an Upcoming row, whose own time is already that run", () => {
@@ -8239,34 +8343,28 @@ describe("the file mark after a task's title", () => {
 
 describe("the schedule mark on a List row", () => {
   const AHEAD = Math.floor(NOW / 1000) + 3600;
-  const ROW = VIEWS.slice(
-    VIEWS.indexOf('className={"tasks-row"'),
-    VIEWS.indexOf("{open && (", VIEWS.indexOf('className={"tasks-row"')),
-  );
 
-  it("marks a task with a run ahead of it, and names the instant", () => {
+  // The glyph is GONE (Akshil, 2026-09-11: "we had a hidden icon after title for
+  // scheduled tasks, remove that icon"). It was built on 2026-09-10, hidden the
+  // next morning behind SHOW_SCHEDULE_MARK, and removed the same day — the row
+  // wears the file mark alone again, and the fact it carried ("a run is booked")
+  // is the next-run chip's, which now also says whether that run repeats.
+  it("is not drawn, and has no flag left to flip", () => {
+    expect(VIEWS).not.toContain("SHOW_SCHEDULE_MARK");
+    expect(VIEWS).not.toContain("tasks-row-sched");
+    expect(VIEWS).not.toContain("scheduledMark(");
+    expect(TASKS_CSS).not.toContain("tasks-row-sched");
+  });
+
+  // The predicate stays, for the tooltip text and because nextRunChip's test is
+  // the same one: two answers to "is a run coming" must not drift apart.
+  it("still knows which tasks have a run ahead, and names the instant", () => {
     const t = task({ status: "done", next_run: AHEAD, next_run_entry: "e2" });
     const mark = scheduledMark(t, NOW)!;
     expect(mark.at).toBe(AHEAD);
-    // The word first, so a bare glyph is decodable by hovering it, then the
-    // exact instant — the shape every other tooltip on this row has.
     expect(mark.title).toContain("Scheduled");
     expect(mark.title).toContain(messageStamp(AHEAD));
-  });
-
-  it("marks an Upcoming row too — the row the next-run CHIP stays quiet on", () => {
-    // Which is the whole reason the mark is not drawn inside that chip:
-    // nextRunChip is null on Upcoming, whose own time already IS the next run,
-    // and those are the most scheduled rows on the page.
-    const t = upcoming([AHEAD]);
-    expect(nextRunChip(t, NOW)).toBe(null);
-    expect(scheduledMark(t, NOW)?.at).toBe(AHEAD);
-  });
-
-  it("says nothing about a task with no run ahead, or one already due", () => {
-    // The same test nextRunChip applies, deliberately: two marks on one row
-    // must not disagree about whether a run is coming. An overdue pending is
-    // not what the task does NEXT — it is work the Upcoming lane surfaces.
+    expect(mark.label).toBe(`Scheduled, next run ${messageStamp(AHEAD)}`);
     expect(scheduledMark(task({ status: "done" }), NOW)).toBe(null);
     const past = task({
       status: "done",
@@ -8274,66 +8372,6 @@ describe("the schedule mark on a List row", () => {
       next_run_entry: "e2",
     });
     expect(scheduledMark(past, NOW)).toBe(null);
-  });
-
-  it("is built, and hidden behind one flag (Akshil, 2026-09-11)", () => {
-    // Same arrangement as SHOW_ROW_ACTIONS: everything stays, one constant
-    // decides. Flip it and the row wears the mark again with no other change.
-    expect(VIEWS).toContain("const SHOW_SCHEDULE_MARK: boolean = false;");
-    expect(VIEWS).toContain("{SHOW_SCHEDULE_MARK && sched ? (");
-    expect((VIEWS.match(/SHOW_SCHEDULE_MARK &&/g) ?? []).length).toBe(1);
-  });
-
-  it("is a glyph beside the file mark, with the fact in the tooltip", () => {
-    const mark = scheduledMark(task({ status: "done", next_run: AHEAD, next_run_entry: "e2" }), NOW)!;
-    expect(VIEWS).toContain('className="tasks-row-sched"');
-    expect(VIEWS).toContain("{ICON_CLOCK}");
-    expect(VIEWS).toContain("data-hint={sched.title}");
-    // …and read out to anything that cannot see the clock — as prose, without
-    // the hint's middle dot, which AT either names or drops.
-    expect(VIEWS).toContain("aria-label={sched.label}");
-    expect(mark.label).toBe(`Scheduled, next run ${messageStamp(AHEAD)}`);
-    expect(mark.label).not.toContain("·");
-    // The pair's order: what the task is about, then how it is run.
-    expect(ROW.indexOf('className="tasks-row-file"')).toBeLessThan(
-      ROW.indexOf('className="tasks-row-sched"'),
-    );
-    expect(ROW.indexOf('className="tasks-row-sched"')).toBeLessThan(
-      ROW.indexOf('className="tasks-grow"'),
-    );
-  });
-
-  it("spends the row's own gesture, so it is not a dead run of pixels", () => {
-    // The mark sits above `.tasks-rowlink` for its tooltip, which is exactly
-    // what made the file icon unclickable (Akshil, 2026-08-27). Same three
-    // handlers here, not a second answer to the same bug.
-    const mark = ROW.slice(ROW.indexOf('className="tasks-row-sched"'));
-    const body = mark.slice(0, mark.indexOf("{ICON_CLOCK}"));
-    expect(body).toContain("if (opensElsewhere(e)) {");
-    expect(body).toContain("activate();");
-    expect(body).toContain("onAuxClick");
-    expect(body).toContain("if (e.button === 1 && href) e.preventDefault();");
-  });
-
-  it("wears the file mark's own box, declaration for declaration", () => {
-    // The two are one pair of captions on the title; a second set of numbers
-    // for the second glyph is how a pair drifts apart.
-    const rest = TASKS_CSS.slice(TASKS_CSS.indexOf(".tasks-row-sched {"));
-    const body = rest.slice(0, rest.indexOf("}"));
-    // Above the stretched link, or it never receives the pointer at all.
-    expect(body).toContain("position: relative");
-    expect(body).toContain("z-index: 2");
-    // Not what gives way when a long title runs out of room.
-    expect(body).toContain("flex: 0 0 auto");
-    // Full-height hit zone, every pixel of it given back.
-    expect(body).toContain("align-self: stretch");
-    expect(body).toContain("padding-block: var(--tasks-row-pad-y)");
-    expect(body).toContain("margin-block: calc(var(--tasks-row-pad-y) * -1)");
-    // Pulled toward the group it belongs to, by one full row gap.
-    expect(body).toContain("margin-left: calc(var(--tasks-row-gap) * -1)");
-    // And no cursor of its own: a mark that announces a press the row's press
-    // does not make looks broken (the file mark's rule, same argument).
-    expect(body).not.toContain("cursor:");
   });
 });
 
@@ -8521,6 +8559,12 @@ describe("provisionalTasks", () => {
     expect(t.next_run).toBe(1_700_100_000);
     expect(t.next_run_entry).toBe("e-9");
     expect(nextRunAt(t)).toBe(1_700_100_000);
+    // And whether it repeats, so the chip's glyph is right on the first paint.
+    const [r] = provisionalTasks([
+      row({ next_run: 1_700_100_000, next_run_entry: "occ-9", next_run_repeats: true }),
+    ]);
+    expect(r.next_run_repeats).toBe(true);
+    expect(nextRunRepeats(r)).toBe(true);
   });
 
   it("marks the row provisional, and is not expandable", () => {

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3319,6 +3319,23 @@ export function scheduledMark(task: Task, now: number = Date.now()): ScheduledMa
   };
 }
 
+/**
+ * The circle arrows after a title: this task has a REPEATING run ahead of it
+ * (Akshil, 2026-09-11). scheduledMark's test — a run strictly ahead — and then
+ * nextRunRepeats over the same run, so the mark cannot claim a repeat the chip
+ * is not timing. Null for a one-off, and for a repeat whose runs are all spent.
+ */
+export function repeatMark(task: Task, now: number = Date.now()): ScheduledMark | null {
+  const mark = scheduledMark(task, now);
+  if (!mark || !nextRunRepeats(task)) return null;
+  const stamp = messageStamp(mark.at);
+  return {
+    at: mark.at,
+    title: `Repeats · next run ${stamp}`,
+    label: `Repeats, next run ${stamp}`,
+  };
+}
+
 // ---- "and that one was stopped" ----------------------------------------------
 // A run the user STOPPED settles in Done, which is the right lane — the stop was
 // asked for, so it is an outcome and not a fault, and a red mark would ask the

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3633,7 +3633,10 @@ export function popoverPill(
   day: Date,
   now: Date,
 ): RunStatus {
-  if (!recurring) return taskStatus(taskColumn(task), task.failed);
+  // ringFailed, not the raw flag: the calendar has no lane header either, so a
+  // live one-off whose LAST settled run broke would otherwise still read
+  // "Blocked" here after the List ring stopped saying so (Bugbot, PR #1105).
+  if (!recurring) return taskStatus(taskColumn(task), ringFailed(task));
   return dayPill(dayMessages, day, now, live);
 }
 

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3058,6 +3058,23 @@ function isSettledLane(status: string): boolean {
   return SETTLED_LANES.has(status);
 }
 
+/**
+ * Whether the task's RING paints red off `failed`.
+ *
+ * `failed` is history — the newest SETTLED run broke — and `status` is now.
+ * They part in one direction: a blocked task the user just spoke to is
+ * `in_progress` with `failed` still true (the new turn has no verdict yet).
+ * Painting that row red and captioning it "Blocked" put a "just now" row under
+ * every real Blocked row — it sat in the In progress rank, where it belongs,
+ * wearing the wrong ring (Akshil, 2026-09-11, TASK-017). So the flag repaints
+ * SETTLED lanes only: a Done ring gone red says "finished badly", which is the
+ * one thing `status` alone cannot; a live ring says what is happening. Same
+ * gate `emptyPaneFailed` applies to the card's empty pane, for the same reason.
+ */
+export function ringFailed(task: Pick<Task, "status" | "failed">): boolean {
+  return !!task.failed && isSettledLane(task.status);
+}
+
 /** What the two empty-pane readings need of a row: its status, its verdict, and
  *  whether anything on it has yet to run. */
 type EmptyPaneTask = Pick<Task, "status" | "failed"> & Pick<Partial<Task>, "messages">;
@@ -3259,10 +3276,20 @@ export function nextRunChip(task: Task, now: number = Date.now()): NextRunChip |
   const at = nextRunAt(task);
   if (at === null || at * 1000 <= now) return null;
   const repeats = nextRunRepeats(task);
+  // ON A BLOCKED ROW THE CHIP SAYS THE WORD (Akshil, 2026-09-11: "it should
+  // remain blocked because we don't know why it is blocked, but we should show
+  // that there is a scheduled message here"). The task stays in Blocked — a
+  // pending message has no verdict, so the failure still speaks — and the chip
+  // is where the row says a retry is booked. Elsewhere the time alone is
+  // enough; the lane already says the task is not over.
+  const blocked = taskColumn(task) === "blocked";
+  const when = relativeWhen(at, now);
   return {
     at,
-    text: relativeWhen(at, now),
-    title: `Next run ${messageStamp(at)}${repeats ? " · repeats" : ""}`,
+    text: blocked ? `scheduled ${when}` : when,
+    title: blocked
+      ? `Stays Blocked until this runs · ${messageStamp(at)}${repeats ? " · repeats" : ""}`
+      : `Next run ${messageStamp(at)}${repeats ? " · repeats" : ""}`,
     repeats,
   };
 }

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3326,6 +3326,10 @@ export interface ScheduledMark {
    *  splits its two strings the same way (path in the hint, sentence in the
    *  label). */
   label: string;
+  /** Whether that run is a template's occurrence — circle arrows rather than a
+   *  clock (Akshil, 2026-09-11: "if it is repeating we show repeat icon, if
+   *  scheduled once we show clock icon, we don't show both"). */
+  repeats: boolean;
 }
 
 /**
@@ -3339,27 +3343,26 @@ export function scheduledMark(task: Task, now: number = Date.now()): ScheduledMa
   const at = nextRunAt(task);
   if (at === null || at * 1000 <= now) return null;
   const stamp = messageStamp(at);
+  const repeats = nextRunRepeats(task);
+  const word = repeats ? "Repeats" : "Scheduled";
+  // ON A BLOCKED ROW THE TOOLTIP SAYS THE LANE'S RULE (Akshil, 2026-09-11: "it
+  // should remain blocked because we don't know why it is blocked, but we
+  // should show that there is a scheduled message here"). The task stays in
+  // Blocked — a pending message has no verdict, so the failure still speaks —
+  // and this mark is where the row says a retry is booked.
+  if (taskColumn(task) === "blocked") {
+    return {
+      at,
+      title: `${word} · stays Blocked until this runs · ${stamp}`,
+      label: `${word}, stays Blocked until this runs, ${stamp}`,
+      repeats,
+    };
+  }
   return {
     at,
-    title: `Scheduled · next run ${stamp}`,
-    label: `Scheduled, next run ${stamp}`,
-  };
-}
-
-/**
- * The circle arrows after a title: this task has a REPEATING run ahead of it
- * (Akshil, 2026-09-11). scheduledMark's test — a run strictly ahead — and then
- * nextRunRepeats over the same run, so the mark cannot claim a repeat the chip
- * is not timing. Null for a one-off, and for a repeat whose runs are all spent.
- */
-export function repeatMark(task: Task, now: number = Date.now()): ScheduledMark | null {
-  const mark = scheduledMark(task, now);
-  if (!mark || !nextRunRepeats(task)) return null;
-  const stamp = messageStamp(mark.at);
-  return {
-    at: mark.at,
-    title: `Repeats · next run ${stamp}`,
-    label: `Repeats, next run ${stamp}`,
+    title: `${word} · next run ${stamp}`,
+    label: `${word}, next run ${stamp}`,
+    repeats,
   };
 }
 

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -1457,7 +1457,9 @@ const LANE_EXITS: Record<BoardColumn, BoardLane[]> = {
   // is still Claude's output, and the way out is answering the card in the
   // chat — a drag cannot say yes on somebody's behalf.
   needs_attention: [],
-  // Retry, or file it away.
+  // Retry, or file it away. The retry is a RE-RUN (Akshil, 2026-09-11: "allow
+  // moving from blocked to in progress and trigger a rerun"): laneAction picks
+  // what is sent again — see `rerunAction`.
   blocked: ["in_progress", "archived"],
   // Done only (Akshil, 2026-09-07 — "we don't allow dragging from archive to
   // done, enable that"). The drop is the Unarchive button as a gesture: it
@@ -1830,6 +1832,13 @@ export function isDraggable(task: Task): boolean {
  */
 export type DropAction =
   | { kind: "run"; entryId: string; messageId: string }
+  /** Send a scheduled message that already went again, as a new one in the
+   *  same thread (`api.resendScheduledMessage`). */
+  | { kind: "resend"; entryId: string; messageId: string }
+  /** Say a TYPED message again: the schedule has no entry to copy, so the words
+   *  travel — a new immediate message into the same session
+   *  (`api.scheduleMessage`). */
+  | { kind: "resay"; body: string; sessionId: string; target: string; messageId: string }
   | { kind: "archive" }
   | { kind: "unarchive" };
 
@@ -1864,7 +1873,55 @@ function laneAction(
   // a scheduled task that has never run may be dragged there and a pure-chat
   // task with nothing pending may not.
   const m = runNowTarget(task);
-  return m ? { kind: "run", entryId: m.entryId, messageId: m.messageId } : null;
+  if (m) return { kind: "run", entryId: m.entryId, messageId: m.messageId };
+  // OUT OF BLOCKED, WITH NOTHING PENDING, THE DROP IS A RE-RUN (Akshil,
+  // 2026-09-11). Upcoming keeps the stricter rule: a task that has not run yet
+  // has nothing to run AGAIN, and its drop means "now" or nothing.
+  return here === "blocked" ? rerunAction(task) : null;
+}
+
+/**
+ * WHAT A RE-RUN SENDS, for a Blocked card dropped on In Progress with nothing
+ * pending to bring forward (Akshil, 2026-09-11: "trigger a rerun when that
+ * happens [rerun what? … last message? a stored prompt, what?]").
+ *
+ * The answer is THE MESSAGE WHOSE RUN BROKE — the newest one that went out,
+ * which is the one the lane is red about — sent again into the same
+ * conversation, so the thread reads as a person asking once more rather than
+ * as history rewritten. Nothing is stored for this: the message is the prompt.
+ *
+ * Two shapes, because the schedule knows one of them and not the other:
+ *
+ *   * a SCHEDULED message has an entry the server can copy verbatim
+ *     (`resendTarget` → `/api/schedule/resend`, the List's own Re-run) —
+ *     attachments, model and permission mode travel with it;
+ *   * a TYPED message has no entry, so its words go as a new immediate message
+ *     into the session (`api.scheduleMessage` with `session_id`) — the same
+ *     road the New task form's "continue this conversation" takes.
+ *
+ * Newest first across BOTH kinds, by the window's order: re-asking means the
+ * last thing that was asked for, whichever way it was asked. Null when the
+ * window holds nothing that went — then the card stays where it is, exactly as
+ * before (dropLanes offers no In Progress).
+ */
+export function rerunAction(task: Task): DropAction | null {
+  for (const m of task.messages ?? []) {
+    if (m.state === "pending" || m.state === "sending") continue;
+    if (m.entry_id) {
+      if (m.state === "sent" || m.state === "error")
+        return { kind: "resend", entryId: m.entry_id, messageId: m.message_id };
+      continue;
+    }
+    if (m.kind === "chat" && m.body.trim() && task.session_id)
+      return {
+        kind: "resay",
+        body: m.body,
+        sessionId: task.session_id,
+        target: task.target || task.project,
+        messageId: m.message_id,
+      };
+  }
+  return null;
 }
 
 // ---- filing, without the drag ------------------------------------------------
@@ -3157,10 +3214,32 @@ export function cardsForTasks(
 export interface NextRunChip {
   /** Epoch seconds, so a caller can order or test by it. */
   at: number;
-  /** What the chip prints: "next in 2h". */
+  /** What the chip prints: "in 2h". The word "next" went (Akshil, 2026-09-11):
+   *  the chip sits apart from the row's own stamp, and that is what says it. */
   text: string;
   /** The tooltip: which run, and exactly when. */
   title: string;
+  /** Whether that run is an OCCURRENCE of a repeating template — the row draws
+   *  a repeat glyph after the time (Akshil, 2026-09-11: "for repeating tasks we
+   *  say 'in 1h [repeat icon, arrow circle]'"). The server's `next_run_repeats`
+   *  where it sends one; the window's pending occurrence (`template_id`) where
+   *  it does not. */
+  repeats: boolean;
+}
+
+/**
+ * Whether the run `nextRunAt` names repeats. The server decides it over every
+ * pending entry (tasks.py `_next_run`), which is the only place the answer is
+ * always in hand; the window is the fallback for an older server, and it can
+ * only say yes for an occurrence it happens to hold.
+ */
+export function nextRunRepeats(task: Task): boolean {
+  if (typeof task.next_run_repeats === "boolean") return task.next_run_repeats;
+  const at = nextRunAt(task);
+  if (at === null) return false;
+  return (task.messages ?? []).some(
+    (m) => m.state === "pending" && m.at === at && !!m.template_id,
+  );
 }
 
 /**
@@ -3179,10 +3258,12 @@ export function nextRunChip(task: Task, now: number = Date.now()): NextRunChip |
   if (taskWhen(task, now).kind === "next") return null;
   const at = nextRunAt(task);
   if (at === null || at * 1000 <= now) return null;
+  const repeats = nextRunRepeats(task);
   return {
     at,
-    text: `next ${relativeWhen(at, now)}`,
-    title: `Next run ${messageStamp(at)}`,
+    text: relativeWhen(at, now),
+    title: `Next run ${messageStamp(at)}${repeats ? " · repeats" : ""}`,
+    repeats,
   };
 }
 
@@ -3777,12 +3858,12 @@ export function runningLabel(n: number): string {
 
 /** The collapsed dot's tooltip, and the expanded chip's — the sidebar's ONE
  *  sentence about the page, so the two modes cannot describe it differently. */
-/** "2 tasks need input" — the attention half of the same readout. A separate
- *  sentence from `runningLabel` because it asks for something: "running" is a
- *  report, this is a request. Singular at one ("1 task needs input"), because
- *  one is the common case here and a rail that says "1 tasks" reads as broken. */
+/** "2 blocked" — the attention half of the same readout. The word is the
+ *  Blocked lane's own (Akshil, 2026-09-11: "instead just say 1 blocked"): the
+ *  rail and the board then name one state with one word, and a count with no
+ *  noun needs no singular/plural fork. */
 export function attentionLabel(n: number): string {
-  return n === 1 ? "1 task needs input" : `${n} tasks need input`;
+  return `${n} blocked`;
 }
 
 export function pulseTitle(pulse: TasksPulse): string {
@@ -3859,6 +3940,7 @@ export function provisionalTasks(rows: TaskPulseTask[]): Task[] {
     // is not sorted by — so the time alone changed nothing (Bugbot).
     next_run: row.next_run,
     next_run_entry: row.next_run_entry,
+    next_run_repeats: row.next_run_repeats,
     messages: [],
     provisional: true,
   }));

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -304,13 +304,19 @@
   gap: 6px;
 }
 
-.schedule-view-btn > svg {
-  flex: 0 0 auto;
+/* ONE COLOUR PER HALF (Akshil, 2026-09-11: "icon and text same color when
+   inactive and same color when active"). The glyph used to be muted on its own
+   while the word beside it kept the button's full colour, so an inactive half
+   read as two weights. The button carries the muted colour and the svg inherits
+   it — one declaration, one hue for both marks; the active half drops the rule
+   and both take the label colour the fill already pairs with. */
+.schedule-view-btn:not(.is-active),
+.prefs-section .schedule-view-btn:not(.is-active) {
   color: var(--fg-muted);
 }
 
-.schedule-view-btn.is-active > svg,
-.prefs-section .schedule-view-btn.is-active > svg {
+.schedule-view-btn > svg {
+  flex: 0 0 auto;
   color: inherit;
 }
 

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -697,7 +697,7 @@ button.tasks-caret,
    press does not make. The row's own hover is the only hover here. */
 
 /* OPTICALLY CENTRED ON THE WORDS, NOT THE BOX (Akshil, 2026-09-10: "make sure
-   the clock icon is center aligned with the text"). Both title marks are
+   the clock icon is center aligned with the text"). The title mark is
    centred on the row's 36px by flex, and the title's 16px line box is too — so
    glyph centre, box centre and row centre all measure 156px on the same row.
    But a 13px mixed-case title has its ink below the box's middle: ascenders
@@ -707,41 +707,8 @@ button.tasks-caret,
    pixel down puts the clock's face and the file's page on the words' own
    middle. `transform`, not margin: it moves the ink and nothing else — the hit
    zone, the row height and the flex maths are untouched. */
-.tasks-row-file svg,
-.tasks-row-sched svg {
+.tasks-row-file svg {
   transform: translateY(1px);
-}
-
-/* THE SCHEDULE MARK AFTER THE TITLE (2026-09-10). A task with a run ahead of it
-   wears a clock, and the instant lives in the `title` — the same hover habit the
-   file mark and the folder chip already answer.
-
-   EVERY DECLARATION HERE IS THE FILE MARK'S, deliberately: the two are one pair
-   of captions on the title (what this task is about, and that it runs by
-   itself), and a second set of numbers for the second glyph is how a pair starts
-   drifting apart. So the same `z-index: 2` over `.tasks-rowlink`, the same
-   `flex: 0 0 auto` so the mark is not what gives way to a long title, the same
-   full-height hit zone paid for with matching negative margins, the same muted
-   register, and the same one-gap pull toward the group it belongs to.
-
-   It FOLLOWS the file mark rather than leading it: the file is what the task is
-   about and the schedule is how it is run, and a row that reads title, subject,
-   then habit is the order the sentence is already in. */
-.tasks-row-sched {
-  position: relative;
-  z-index: 2;
-  display: inline-flex;
-  align-items: center;
-  flex: 0 0 auto;
-  margin-left: calc(var(--tasks-row-gap) * -1);
-  color: var(--fg-muted);
-  opacity: 0.75;
-  align-self: stretch;
-  padding-block: var(--tasks-row-pad-y);
-  margin-block: calc(var(--tasks-row-pad-y) * -1);
-  padding-right: 4px;
-  padding-left: 4px;
-  margin-right: -4px;
 }
 
 /* THE FOLDER CHIP AS A TAG (2026-08-23). A press filters the page to that
@@ -1740,11 +1707,20 @@ button.tasks-caret,
    same tabular figures, so the pair still reads as one register. */
 .tasks-row-next {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
   font-size: 11px;
   color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   opacity: 0.85;
+}
+/* The repeat glyph after a repeating run's time (ScheduleTaskViews ICON_REPEAT):
+   the chip's own colour, so "in 1h ⟳" reads as one caption. */
+.tasks-row-next svg {
+  flex: 0 0 auto;
+  color: inherit;
 }
 
 /* ---- "and that one was stopped" --------------------------------------------

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -653,7 +653,8 @@ button.tasks-caret,
    `flex: 0 0 auto` beside a title that is the row's only shrinking element:
    the mark must not be what disappears when a long title runs out of room,
    because then it would say "about a folder" by being absent. */
-.tasks-row-file {
+.tasks-row-file,
+.tasks-row-repeat {
   position: relative;
   z-index: 2;
   display: inline-flex;
@@ -697,7 +698,7 @@ button.tasks-caret,
    press does not make. The row's own hover is the only hover here. */
 
 /* OPTICALLY CENTRED ON THE WORDS, NOT THE BOX (Akshil, 2026-09-10: "make sure
-   the clock icon is center aligned with the text"). The title mark is
+   the clock icon is center aligned with the text"). Both title marks are
    centred on the row's 36px by flex, and the title's 16px line box is too — so
    glyph centre, box centre and row centre all measure 156px on the same row.
    But a 13px mixed-case title has its ink below the box's middle: ascenders
@@ -707,7 +708,8 @@ button.tasks-caret,
    pixel down puts the clock's face and the file's page on the words' own
    middle. `transform`, not margin: it moves the ink and nothing else — the hit
    zone, the row height and the flex maths are untouched. */
-.tasks-row-file svg {
+.tasks-row-file svg,
+.tasks-row-repeat svg {
   transform: translateY(1px);
 }
 
@@ -1715,12 +1717,6 @@ button.tasks-caret,
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   opacity: 0.85;
-}
-/* The repeat glyph after a repeating run's time (ScheduleTaskViews ICON_REPEAT):
-   the chip's own colour, so "in 1h ⟳" reads as one caption. */
-.tasks-row-next svg {
-  flex: 0 0 auto;
-  color: inherit;
 }
 
 /* ---- "and that one was stopped" --------------------------------------------

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -654,7 +654,7 @@ button.tasks-caret,
    the mark must not be what disappears when a long title runs out of room,
    because then it would say "about a folder" by being absent. */
 .tasks-row-file,
-.tasks-row-repeat {
+.tasks-row-sched {
   position: relative;
   z-index: 2;
   display: inline-flex;
@@ -709,7 +709,7 @@ button.tasks-caret,
    middle. `transform`, not margin: it moves the ink and nothing else — the hit
    zone, the row height and the flex maths are untouched. */
 .tasks-row-file svg,
-.tasks-row-repeat svg {
+.tasks-row-sched svg {
   transform: translateY(1px);
 }
 
@@ -1717,6 +1717,18 @@ button.tasks-caret,
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   opacity: 0.85;
+}
+/* THE CARD'S SCHEDULE MARK (Akshil, 2026-09-11): the List row's clock or circle
+   arrows, after the card's title in the same muted register. Inline with the
+   title's last line rather than a foot row of its own — the foot went with the
+   "in 1h" chip, and a glyph is a caption on the title, not a second fact. */
+.tasks-card-sched {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: -1px;
+  margin-left: 6px;
+  color: var(--fg-muted);
+  opacity: 0.75;
 }
 
 /* ---- "and that one was stopped" --------------------------------------------

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -1652,9 +1652,16 @@ def _live(path: str | None, now: float) -> tuple[bool, float]:
 # --------------------------------------------------------------- the endpoints
 
 
-def _next_run(entries: list[dict]) -> tuple[float, str]:
-    """When this task NEXT runs, and WHICH entry that run is — `(0.0, "")` for a
-    task with nothing pending.
+def _next_run(entries: list[dict]) -> tuple[float, str, bool]:
+    """When this task NEXT runs, WHICH entry that run is, and whether it REPEATS
+    — `(0.0, "", False)` for a task with nothing pending.
+
+    The third is the row's repeat glyph (Akshil, 2026-09-11: "for repeating
+    tasks we say 'in 1h [repeat icon]'"): an occurrence carries its template's
+    id, and that is the whole test. Decided here, over the same entry the time
+    and the id name, so the glyph cannot describe a different run than the one
+    the chip is timing — and here rather than on the client because the window
+    may not hold the run at all (the paragraph below).
 
     This exists because the three messages a row carries cannot answer it. The
     tail is the three newest by `at`, and on this branch an OVERDUE pending is an
@@ -1691,6 +1698,7 @@ def _next_run(entries: list[dict]) -> tuple[float, str]:
     """
     best_at = 0.0
     best_id = ""
+    best_repeats = False
     for entry in entries:
         if str(entry.get("state") or "") != schedule.PENDING:
             continue
@@ -1702,7 +1710,8 @@ def _next_run(entries: list[dict]) -> tuple[float, str]:
             continue
         if not best_at or at < best_at:
             best_at, best_id = at, entry_id
-    return best_at, best_id
+            best_repeats = bool(entry.get("template_id"))
+    return best_at, best_id, best_repeats
 
 
 def _row(task: dict, number: str, triage: dict, read: dict, now: float,
@@ -1758,7 +1767,7 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         live = False
     # BEFORE the cut, from the whole set: the one fact about the future that the
     # three-message window cannot be trusted to hold. See `_next_run`.
-    next_run, next_run_entry = _next_run(task["entries"])
+    next_run, next_run_entry, next_run_repeats = _next_run(task["entries"])
     tail = merged[-_LISTING_MESSAGES:]
     # The tail's dicts ARE the merged list's dicts (a slice shares them), so the
     # liveness this writes onto the newest chat message is visible to the status
@@ -1883,6 +1892,9 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # reads (`last_active`, a message's `ran_at`). See `_next_run`.
         "next_run": next_run,
         "next_run_entry": next_run_entry,
+        # ...and whether that run is an occurrence of a repeating template —
+        # the chip's repeat glyph. False when nothing is pending.
+        "next_run_repeats": next_run_repeats,
         # Newest first, which is how every list in this feature reads.
         "messages": list(reversed(tail)),
     }
@@ -2156,6 +2168,7 @@ _PULSE_FIELDS = (
     # entry is one nobody can fire, and is not sorted by.
     "next_run",
     "next_run_entry",
+    "next_run_repeats",
 )
 
 

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -5019,8 +5019,17 @@ def _sessions(file: str) -> dict:
     """
     file = os.path.abspath(file)
     sessions = _cli_sessions(file)
+    # RUNNING FIRST, THEN RECENCY — the Tasks list's own rule (shell/tasks-lib
+    # LIST_ORDER: the ranks that are still doing something sit above the ones
+    # that are over, and time orders WITHIN a rank). The clock here is the
+    # transcript's mtime, and a turn writes its records in one burst when it
+    # ENDS, so a chat ten minutes into a long turn carries an older stamp than
+    # one that finished four minutes ago — sorted by time alone it sat under it
+    # while saying "running" (Akshil, 2026-09-11). A stable sort, so two running
+    # chats still order by when each last wrote.
     sessions.sort(key=lambda s: s.get("last_used") or s.get("created_at") or 0,
                   reverse=True)
+    sessions.sort(key=lambda s: not s.get("running"))
     return {"sessions": sessions}
 
 

--- a/tests/test_claude_sessions_merged.py
+++ b/tests/test_claude_sessions_merged.py
@@ -107,6 +107,22 @@ def test_newest_activity_first(agent, target):
     assert [r["id"] for r in rows] == ["cli-new", "cli-mid", "cli-old"]
 
 
+def test_a_running_chat_sorts_above_a_newer_finished_one(agent, target, monkeypatch):
+    """The Tasks list's rule (LIST_ORDER): what is still doing something sits
+    above what is over, and time orders within. A transcript is written in one
+    burst when the turn ENDS, so a chat mid-turn carries an OLDER mtime than one
+    that finished after it started — by time alone it sat under a finished chat
+    while wearing "running" (Akshil, 2026-09-11)."""
+    _, workdir = target
+    rows = [{"id": "done-4m", "preview": "p", "last_used": 100.0, "running": False},
+            {"id": "running-old", "preview": "p", "last_used": 40.0, "running": True},
+            {"id": "done-1h", "preview": "p", "last_used": 10.0, "running": False},
+            {"id": "running-older", "preview": "p", "last_used": 30.0, "running": True}]
+    monkeypatch.setattr(agent, "_cli_sessions", lambda f: list(rows))
+    assert [r["id"] for r in agent._sessions(workdir)["sessions"]] == \
+        ["running-old", "running-older", "done-4m", "done-1h"]
+
+
 def test_a_null_last_used_does_not_crash_the_sort(agent, target, monkeypatch):
     """The sort reads `last_used or created_at or 0`; a row missing both — or
     carrying explicit nulls — must fall to 0, not into a None comparison."""

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -379,7 +379,7 @@ def test_sidebar_pulse_is_the_compact_projection_of_the_task_rows(
     pulse_fields = (
         "key", "status", "unread", "last_active", "project",
         "task_id", "title", "target", "session_id", "happened_at", "next_run",
-        "next_run_entry",
+        "next_run_entry", "next_run_repeats",
     )
     assert pulse == [
         {field: row[field] for field in pulse_fields}
@@ -1134,6 +1134,7 @@ def test_the_next_run_is_zero_with_nothing_pending(client, projects_dir):
     task = _by_key(client)["sess-a"]
     assert task["next_run"] == 0
     assert task["next_run_entry"] == ""
+    assert task["next_run_repeats"] is False
 
     # And a task with no schedule anywhere near it reads the same way.
     _write_transcript(projects_dir, "sess-b", "/p", [_user("typed", T10)])
@@ -1160,6 +1161,8 @@ def test_only_pending_entries_name_the_next_run(client, projects_dir):
     task = _by_key(client)["sess-a"]
     assert task["next_run"] == tasks_store.epoch(T11)
     assert task["next_run_entry"] == "waiting"
+    # A one-off: no template behind it, so no repeat glyph.
+    assert task["next_run_repeats"] is False
 
 
 def test_a_recurring_occurrence_can_be_the_next_run(client, projects_dir):
@@ -1175,6 +1178,9 @@ def test_a_recurring_occurrence_can_be_the_next_run(client, projects_dir):
     task = _by_key(client)["sess-a"]
     assert task["next_run"] == tasks_store.epoch(T12)
     assert task["next_run_entry"] == "occ"
+    # ...and the row says so: an occurrence carries its template's id, which is
+    # what puts the repeat glyph on the chip (2026-09-11).
+    assert task["next_run_repeats"] is True
 
 
 def test_a_pending_entry_with_no_id_or_no_due_names_nothing(client,


### PR DESCRIPTION
## What

- **Tab bar** — inactive List/Board/Cards/Calendar half: icon and word share one muted colour; active half both take the label colour.
- **Sidebar** — attention readout is now `1 blocked` / `N blocked`.
- **Scheduled tasks** — the hidden title mark is removed. The next-run chip prints `in 1h` (no `next`), and a repeating run adds a repeat glyph. New row/pulse field `next_run_repeats` from `_next_run`, with a client fallback to the window's `template_id` for older servers.
- **Cards popup Schedule button** — the shadcn Popover positioner was `z-50` under the modal overlay at `z-index: 1000`, so the Schedule confirm (and the composer's model/effort/approval pickers) rendered behind the popup. Positioner now sits at 1200, above the modal chassis and the shot viewer.
- **Comments survive reload (native chat)** — the hosted layout booted with an empty annotation list on purpose; it now hydrates from the `annotations` URL param like the split layout, so a reload keeps both the mode and the notes.
- **Board: Blocked → In progress** — allowed with nothing pending; the drop re-runs the message whose run broke: a scheduled entry goes through `/api/schedule/resend` (same call as the row's Re-run), a typed message is sent again as an immediate message into the same session.

## Verification

- `bun test`: 5211 pass. `tsc --noEmit` clean. `pytest tests/test_tasks_api.py`: 171 pass.
- Full pytest: 3 failures in `test_ai_metrics`, `test_ai_worker_base`, `test_calls` reproduce on an untouched `main` checkout on this machine; unrelated to this branch.
- Browser (dev server): inactive tab text and svg both `rgb(154,160,166)`; peek Schedule confirm on top (`elementFromPoint` inside the popover, positioner z 1200); chip on a done task with a pending occurrence reads `in 3mo` + glyph in List and Board; hosted chat opened with `annmode=1&annotations=[…]` shows the seeded note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task drag/drop rerun paths (resend/resay APIs), listing/pulse fields, and annotation boot hydration—user-visible scheduling and comment behavior with moderate integration surface.
> 
> **Overview**
> **Tasks and scheduling UI** get a clearer schedule story on list/board cards: the separate “next in 1h” chip beside the time is removed; a **clock or repeat icon** after the title (from `scheduledMark` / new `next_run_repeats` on the API) carries that fact, with tooltips tuned for blocked rows. Status rings use **`ringFailed`** so live in-progress tasks don’t still show a red “blocked” ring from an old failure. **Dragging Blocked → In progress** can **re-run** the last message (`resend` for scheduled entries, immediate `resay` for typed chat). Sidebar pulse copy becomes **“N blocked”**; schedule view tabs mute **icon and label together**; popover positioner **`z-[1200]`** fixes Schedule/composer pickers behind modals.
> 
> **Native comment mode** now **hydrates annotations from the URL in hosted layout** (not an empty boot), and on armed reload **`bootFromParam` continues the annotation round** from the oldest restored note’s `createdAt` so pins reappear with chips.
> 
> **Smaller fixes:** permission-question transcript CSS (contrast, straight option dividers); Claude session picker sorts **running chats above** newer finished ones; server **`_next_run`** returns whether the next pending run repeats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d6719d467755014e87218cae86f31dac2dbc51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->