### PR TITLE
App Doctor: prompts carry the rows diagnosis, git findings read plainly, fixes commit their own work

### DIFF
--- a/fused_render/app_doctor.py
+++ b/fused_render/app_doctor.py
@@ -717,18 +717,30 @@ def doctor_task_check_id(message: str) -> str | None:
 ALL = "all"
 
 
-def _findings_block(findings: list[dict]) -> str:
-    """`findings` as the lines a fix session reads, one per line: where it
-    is and what fired. Shared by `doctor_prompt` and `doctor_prompt_all` so
-    the two prompts describe a finding identically."""
-    if not findings:
-        return "- (no findings listed — the row's own detail already explains why it failed)"
-    return "\n".join(
+def _findings_block(detail: str, findings: list[dict]) -> str:
+    """`detail` and `findings` as the lines a fix session reads. Shared by
+    `doctor_prompt` and `doctor_prompt_all` so the two prompts describe a
+    row identically.
+
+    `detail` is the row's own one-line diagnosis (`_check`'s `detail`) — for
+    a `kind="fact"` row (`api-version`, `readme`, `git`, ...) it is the WHOLE
+    diagnosis, findings is always `[]` for those, and there used to be a
+    fallback line here pointing at a `detail` the prompt never actually
+    included. That fallback is gone: `detail` always goes in, first, so
+    there is no longer a row with nothing to say. For a `kind="candidate"`
+    row (`secrets`, `device-paths`) `detail` is a one-line count ("2 lines
+    to look at") and the findings below it are the substance — both go in,
+    detail first."""
+    lines = []
+    if detail:
+        lines.append(f"- {detail}")
+    lines.extend(
         "- " + (f"{f.get('path', '.')}:{f['line']}" if f.get("line") else
                 str(f.get('path', '.')))
         + f": {f.get('rule', '')}: {f.get('excerpt', '')}"
         for f in findings
     )
+    return "\n".join(lines)
 
 
 def _triage_ask(kind: str) -> str:
@@ -756,8 +768,40 @@ _CREDENTIAL_NOTE = (
     "ask about alone."
 )
 
+# R3: App Doctor itself never writes — the fix SESSION does, and until now no
+# prompt told it to leave its own edits committed, so a reopened report saw
+# the `git` row FAIL right after a fix landed, reading as if the fix broke
+# something. Two wordings, not one, because "fix all" makes ONE commit for
+# the whole run rather than one per row (`doctor_prompt_all` already says
+# "one row at a time in the order given" — this is the trailing step after
+# that, not a per-row addition).
+#
+# Both are deliberately conditional ("only if you changed something") so an
+# advisory-only outcome — every `secrets` row that follows `_CREDENTIAL_NOTE`
+# above: report the leak, don't touch the file — never produces an empty or
+# spurious commit. And neither says "commit the fix", which for `secrets`
+# could be misread as license to commit a value merely relocated rather than
+# left alone; the wording instead says plainly that a still-live or
+# relocated credential must never end up in the commit.
+_COMMIT_STEP = (
+    "If you edited any files to address this, commit them now in this repo — never "
+    "push. Say what changed in the commit message. If you made no edit at all (an "
+    "advisory-only outcome, including a secrets finding where the right move was "
+    "reporting it rather than touching the file), make no commit — not an empty one, "
+    "and never one that commits a still-live or merely relocated credential."
+)
 
-def doctor_prompt(entry_html: str, check_id: str, findings: list[dict]) -> str:
+_COMMIT_STEP_ALL = (
+    "When every row above is done: make ONE commit — not one per row — covering every "
+    "file you actually edited across the whole run. Never push. If nothing needed "
+    "changing anywhere (every row was advisory only, or already passed), make no "
+    "commit at all — and never commit a still-live or merely relocated credential from "
+    "a secrets row."
+)
+
+
+def doctor_prompt(entry_html: str, check_id: str, findings: list[dict],
+                  detail: str = "") -> str:
     """The fix task's text for ONE row: names the check, points at the
     skill's section for it by id (SKILL.md's section names match check ids
     exactly, see its own module note), and carries that row's findings
@@ -771,17 +815,22 @@ def doctor_prompt(entry_html: str, check_id: str, findings: list[dict]) -> str:
     direct `_CHECK_META` read would keep asking for a triage-first fix (or a
     fix-outright one) based on this module's fallback copy even after the
     engine reclassified an id — fix-outright where triage-first was needed
-    is exactly the failure the candidate/fact split exists to prevent."""
+    is exactly the failure the candidate/fact split exists to prevent.
+
+    `detail` is the row's own diagnosis (`report_one(...)["detail"]`) — R1:
+    every prompt has to carry it, not just the findings list, since most
+    checks (every `kind="fact"` row) never populate `findings` at all and
+    `detail` is their whole story."""
     entry_name = os.path.basename(entry_html)
     _section, _severity, kind = _meta(check_id)
-    lines = _findings_block(findings)
+    lines = _findings_block(detail, findings)
     ask = _triage_ask(kind)
 
     return (
         f"{DOCTOR_PROMPT_PREFIX} — check `{check_id}` (`{entry_name}` is its entry page). "
         f"Invoke the `{SKILL_QUALIFIED}` skill and read its `{check_id}` section end to "
         f"end. {ask} {_CREDENTIAL_NOTE}\n\n"
-        f"Findings for this row:\n{lines}"
+        f"Findings for this row:\n{lines}\n\n{_COMMIT_STEP}"
     )
 
 
@@ -793,24 +842,36 @@ def doctor_prompt_all(entry_html: str, checks: list[dict]) -> str:
     difference is how many rows are in the prompt and that this one names no
     single check by id (`ALL` fills that slot in the stored prompt instead,
     so `is_doctor_prompt` and the one-live-task-per-app gate still work
-    unchanged)."""
+    unchanged).
+
+    R1: each row's own `detail` is included alongside its findings, same as
+    `doctor_prompt` — every check dict already carries `detail` (`_check`),
+    so no re-derivation needed here. R3: ONE trailing commit step covers the
+    whole run, appended after every row's block — never one per row, and
+    only when there was at least one failing row to maybe act on."""
     entry_name = os.path.basename(entry_html)
     failing = [c for c in checks if c["state"] == FAIL]
     if not failing:
-        body = "Every check passed — say so and stop; there is nothing to fix."
-    else:
-        blocks = []
-        for c in failing:
-            blocks.append(
-                f"## `{c['id']}` — {c['label']}\n"
-                f"{_triage_ask(c['kind'])}\n"
-                f"{_findings_block(c['findings'])}"
-            )
-        body = "\n\n".join(blocks)
+        return (
+            f"{DOCTOR_PROMPT_PREFIX} — check `{ALL}` (`{entry_name}` is its entry page, "
+            f"covering every failing row). Invoke the `{SKILL_QUALIFIED}` skill and "
+            f"follow it end to end, one row at a time in the order given. "
+            f"{_CREDENTIAL_NOTE}\n\n"
+            "Every check passed — say so and stop; there is nothing to fix."
+        )
+
+    blocks = []
+    for c in failing:
+        blocks.append(
+            f"## `{c['id']}` — {c['label']}\n"
+            f"{_triage_ask(c['kind'])}\n"
+            f"{_findings_block(c['detail'], c['findings'])}"
+        )
+    body = "\n\n".join(blocks)
 
     return (
         f"{DOCTOR_PROMPT_PREFIX} — check `{ALL}` (`{entry_name}` is its entry page, "
         f"covering every failing row). Invoke the `{SKILL_QUALIFIED}` skill and follow "
         f"it end to end, one row at a time in the order given. {_CREDENTIAL_NOTE}\n\n"
-        f"{body}"
+        f"{body}\n\n{_COMMIT_STEP_ALL}"
     )

--- a/fused_render/app_doctor.py
+++ b/fused_render/app_doctor.py
@@ -267,16 +267,25 @@ def _git_pending(app_dir: str) -> tuple[str, list[tuple[str, str]]]:
     lines = [ln for ln in (r.stdout or "").splitlines() if ln.strip()]
     if not lines:
         return PASS, []
-    # `git status` reports paths relative to the REPO root, which for an app in
-    # the shared repo is one level up from the folder being reviewed. Strip that
-    # prefix so a row reads like every other finding's path — app-relative.
-    prefix = os.path.basename(app_dir.rstrip("/\\")) + "/"
+    # `git status` reports paths relative to the REPO root. For an app living
+    # in the shared `local` repo (D626) that root is one level up from the
+    # folder being reviewed, so a prefix strip is needed to read app-relative,
+    # the same as every other finding's path. But an app that IS its own repo
+    # root (`_repo_scope`'s other supported layout — an unmigrated app with
+    # its own `.git`) has paths already relative to app_dir with nothing to
+    # strip: stripping there would wrongly collapse a same-named untracked
+    # SUBdirectory (`?? demo/` inside app `demo/`) down to the empty string,
+    # over-claiming the whole app as untracked when only that subdirectory
+    # is (review finding: string-compare alone can't tell the two apart).
+    scope = app_git._repo_scope(app_dir)
+    is_own_repo_root = scope is not None and scope[1] == "."
+    prefix = "" if is_own_repo_root else os.path.basename(app_dir.rstrip("/\\")) + "/"
     out = []
     for ln in lines:
         code, _, rest = ln[:2], ln[2:3], ln[3:]
         rest = rest.strip().strip('"')
         code = code.strip() or "??"
-        if rest.startswith(prefix):
+        if prefix and rest.startswith(prefix):
             rest = rest[len(prefix):]
         # `(code, rest)` — NOT a formatted string. `rest` strips to "" when
         # the WHOLE app folder is untracked (git collapses that to one `??

--- a/fused_render/app_doctor.py
+++ b/fused_render/app_doctor.py
@@ -785,13 +785,23 @@ _CREDENTIAL_NOTE = (
 # "one row at a time in the order given" — this is the trailing step after
 # that, not a per-row addition).
 #
-# Both are deliberately conditional ("only if you changed something") so an
-# advisory-only outcome — every `secrets` row that follows `_CREDENTIAL_NOTE`
-# above: report the leak, don't touch the file — never produces an empty or
-# spurious commit. And neither says "commit the fix", which for `secrets`
-# could be misread as license to commit a value merely relocated rather than
-# left alone; the wording instead says plainly that a still-live or
-# relocated credential must never end up in the commit.
+# `_COMMIT_STEP` is deliberately conditional ("only if you changed something")
+# so an advisory-only outcome — every `secrets` row that follows
+# `_CREDENTIAL_NOTE` above: report the leak, don't touch the file — never
+# produces an empty or spurious commit. And it never says "commit the fix",
+# which for `secrets` could be misread as license to commit a value merely
+# relocated rather than left alone; the wording instead says plainly that a
+# still-live or relocated credential must never end up in the commit.
+#
+# Review findings 1 & 2, one root cause: `_COMMIT_STEP` is only right for a
+# row whose fix EDITS FILES. `git` and `pushed` don't — their fix IS a git
+# action, already spelled out in their own SKILL.md section ("Commit the
+# listed paths" / "Push the branch"). Appending `_COMMIT_STEP` on top of
+# those two contradicts them: its "never push" fights `pushed`'s only real
+# fix, and its "no edit at all -> no commit" fights `git`'s fix, which
+# commits paths that are already uncommitted with no edit required. So
+# `doctor_prompt` skips `_COMMIT_STEP` entirely for `git` and `pushed` —
+# those rows' own SKILL.md sections are the whole instruction, untouched.
 _COMMIT_STEP = (
     "If you edited any files to address this, commit them now in this repo — never "
     "push. Say what changed in the commit message. If you made no edit at all (an "
@@ -800,12 +810,29 @@ _COMMIT_STEP = (
     "and never one that commits a still-live or merely relocated credential."
 )
 
+# The `_COMMIT_STEP` per-row rows this trailing step must not be appended
+# after (see the note above `_COMMIT_STEP`) — their own SKILL.md sections
+# already cover committing/pushing, and a blanket "never push" or
+# edit-conditioned commit instruction here would contradict them exactly the
+# same way `_COMMIT_STEP` would on their own per-row prompts.
+_COMMIT_STEP_EXEMPT = frozenset({"git", "pushed"})
+
+# Fix-all's trailing step covers a run that may include a `git` and/or a
+# `pushed` row alongside ordinary file-editing rows, so — unlike
+# `_COMMIT_STEP` — it must not blanket-forbid push or restrict the commit to
+# only files edited THIS run: it explicitly defers to those two rows' own
+# sections above when one of them is present (review findings 1 & 2 applied
+# to the fix-all case).
 _COMMIT_STEP_ALL = (
     "When every row above is done: make ONE commit — not one per row — covering every "
-    "file you actually edited across the whole run. Never push. If nothing needed "
-    "changing anywhere (every row was advisory only, or already passed), make no "
-    "commit at all — and never commit a still-live or merely relocated credential from "
-    "a secrets row."
+    "file you actually edited across the whole run, plus any pre-existing uncommitted "
+    "paths a `git` row above asked you to commit even though you didn't edit them. This "
+    "step itself does not include pushing — except if a `pushed` row is one of the rows "
+    "above, in which case follow through on push exactly as that row's own section says; "
+    "this step does not forbid it. If nothing needed changing anywhere (every row was "
+    "advisory only, or already passed) and no row above asked for a commit or push of "
+    "its own, make no commit at all — and never commit a still-live or merely relocated "
+    "credential from a secrets row."
 )
 
 
@@ -829,18 +856,29 @@ def doctor_prompt(entry_html: str, check_id: str, findings: list[dict],
     `detail` is the row's own diagnosis (`report_one(...)["detail"]`) — R1:
     every prompt has to carry it, not just the findings list, since most
     checks (every `kind="fact"` row) never populate `findings` at all and
-    `detail` is their whole story."""
+    `detail` is their whole story.
+
+    Review finding 3: `router` (`apps.py`) passes `findings=[]`, `detail=""`
+    whenever `report_one()` returns `None` — `_findings_block` then returns
+    `""` and the "Findings for this row:" header is omitted rather than left
+    dangling over nothing.
+
+    Review findings 1 & 2: `git` and `pushed` are excluded from the trailing
+    `_COMMIT_STEP` (see the note above that constant) — their own SKILL.md
+    sections are the whole instruction for those two rows."""
     entry_name = os.path.basename(entry_html)
     _section, _severity, kind = _meta(check_id)
     lines = _findings_block(detail, findings)
     ask = _triage_ask(kind)
+    findings_section = f"Findings for this row:\n{lines}\n\n" if lines else ""
+    commit_step = "" if check_id in _COMMIT_STEP_EXEMPT else _COMMIT_STEP
 
     return (
         f"{DOCTOR_PROMPT_PREFIX} — check `{check_id}` (`{entry_name}` is its entry page). "
         f"Invoke the `{SKILL_QUALIFIED}` skill and read its `{check_id}` section end to "
         f"end. {ask} {_CREDENTIAL_NOTE}\n\n"
-        f"Findings for this row:\n{lines}\n\n{_COMMIT_STEP}"
-    )
+        f"{findings_section}{commit_step}"
+    ).rstrip()
 
 
 def doctor_prompt_all(entry_html: str, checks: list[dict]) -> str:

--- a/fused_render/app_doctor.py
+++ b/fused_render/app_doctor.py
@@ -243,10 +243,12 @@ def _generated_paths(app_dir: str) -> list[str]:
 # ------------------------------------------------------------------ git state
 
 
-def _git_pending(app_dir: str) -> tuple[str, list[str]]:
-    """`(state, paths)` for the folder's version control: FAIL with the
-    uncommitted paths, PASS when the folder is clean, SKIP when git cannot
-    answer (not a repo, git missing, a repo that will not read).
+def _git_pending(app_dir: str) -> tuple[str, list[tuple[str, str]]]:
+    """`(state, records)` for the folder's version control: FAIL with the
+    uncommitted `(code, rest)` porcelain records (app-relative, prefix
+    already stripped — see `_git_findings` for what each shape means), PASS
+    when the folder is clean, SKIP when git cannot answer (not a repo, git
+    missing, a repo that will not read).
 
     Status is scoped to the app folder itself — sibling apps share one `local`
     repo (D626), and a neighbour's work in progress is not this app's finding.
@@ -273,10 +275,54 @@ def _git_pending(app_dir: str) -> tuple[str, list[str]]:
     for ln in lines:
         code, _, rest = ln[:2], ln[2:3], ln[3:]
         rest = rest.strip().strip('"')
+        code = code.strip() or "??"
         if rest.startswith(prefix):
             rest = rest[len(prefix):]
-        out.append(f"{code.strip() or '??'} {rest}")
+        # `(code, rest)` — NOT a formatted string. `rest` strips to "" when
+        # the WHOLE app folder is untracked (git collapses that to one `??
+        # myapp/` line, and `rest == prefix` exactly), and stays non-empty
+        # but directory-shaped (`"sub/"`) for a nested untracked directory
+        # git also collapses. `_git_findings` below turns each shape into a
+        # readable finding — this function only parses porcelain output, it
+        # does not decide how a shape reads.
+        out.append((code, rest))
     return FAIL, out
+
+
+def _git_findings(pending: list[tuple[str, str]]) -> list[dict]:
+    """One finding per `(code, rest)` pair from `_git_pending`, in the shape
+    `_git_check` hands to the modal and the fix prompt.
+
+    Three shapes, by what `rest` looks like after `_git_pending`'s prefix
+    strip:
+
+    * EMPTY — the whole app folder is untracked (git's `?? myapp/` collapse,
+      stripped down to nothing). `path` is `.` (there is no more specific
+      path to give) and the excerpt says so in words, ending in a period so
+      the modal's `excerpt.includes(path)` dedup guard still fires on the
+      literal `.` — the same trick every other shape below relies on, just
+      earned differently.
+    * A DIRECTORY — `rest` still ends in `/` (git's `?? sub/` collapse for a
+      nested untracked directory: nothing inside was walked, so there is
+      nothing more specific to report). Reads as the directory itself, not
+      the bare porcelain line.
+    * ORDINARY — a real file entry (`M app.py`, `?? notes.txt`). Unchanged
+      from before this fix: `path` and `excerpt` are both `"{code} {rest}"`,
+      which is what existing tests pin and what the modal's dedup guard
+      already handles.
+    """
+    out = []
+    for code, rest in pending:
+        if not rest:
+            out.append({"rule": "git:uncommitted", "path": ".", "line": 0,
+                       "excerpt": "the whole app folder is untracked."})
+        elif rest.endswith("/"):
+            out.append({"rule": "git:uncommitted", "path": rest, "line": 0,
+                       "excerpt": f"{rest} (untracked directory)"})
+        else:
+            p = f"{code} {rest}"
+            out.append({"rule": "git:uncommitted", "path": p, "line": 0, "excerpt": p})
+    return out
 
 
 # `_pushed_pending`'s SKIP reasons — distinct enough that `_pushed_check` can
@@ -517,8 +563,7 @@ def _git_check(app_dir: str) -> dict:
         else f"{len(pending)} uncommitted path{'' if len(pending) == 1 else 's'} — "
              "commit them so what you share is what you tested" if state == FAIL
         else "the working tree is clean",
-        [{"rule": "git:uncommitted", "path": p, "line": 0, "excerpt": p}
-         for p in pending],
+        _git_findings(pending),
     )
 
 

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -741,7 +741,8 @@ def api_app_doctor_fix(body: dict = Body(...),
     else:
         row = app_doctor.report_one(folder, check_id)
         findings = row["findings"] if row else []
-        prompt = app_doctor.doctor_prompt(entry_html, check_id, findings)
+        detail = row["detail"] if row else ""
+        prompt = app_doctor.doctor_prompt(entry_html, check_id, findings, detail)
     task, task_error = _create_app_task(entry_html, prompt, model, effort)
     return {
         "path": folder,

--- a/skills/fused-render-app-doctor/SKILL.md
+++ b/skills/fused-render-app-doctor/SKILL.md
@@ -80,7 +80,7 @@ Real: a hardcoded `/Users/alex/data.csv` (or `/home/…`, `/Volumes/…`) the ap
 
 **fact** — `git status --porcelain`, scoped to the app folder. Skip means no readable git repo or no git; unanswerable, not failing.
 
-**Fix.** Commit the listed paths, or `.gitignore` them if they shouldn't be tracked — so what you share is what you tested.
+**Fix.** Commit the listed paths, or `.gitignore` them if they shouldn't be tracked — and commit that `.gitignore` edit too, or it is itself an uncommitted change and this row fails again — so what you share is what you tested.
 
 ## `pushed` — every commit is pushed
 

--- a/tests/test_app_doctor_report.py
+++ b/tests/test_app_doctor_report.py
@@ -301,6 +301,52 @@ def test_a_sibling_apps_uncommitted_work_is_not_this_apps_finding(workspace):
     assert _state(app_doctor.report(str(theirs)), "git") == "fail"
 
 
+@pytest.mark.skipif(not __import__("shutil").which("git"), reason="git not on PATH")
+def test_a_wholly_untracked_app_folder_reads_as_a_folder_finding_not_a_bare_code(
+    workspace,
+):
+    """git collapses a fully-untracked directory to one `?? demo/` line. After
+    the app-relative prefix strip, `rest` is exactly empty (D-defect-2) — the
+    finding must read as the app folder itself being untracked, never as a
+    bare `??` with nothing after it."""
+    d = _app(workspace)
+    repo = workspace / "local"
+    _git(repo, "init", "-q")
+    # Nothing committed at all: the whole app folder is untracked.
+
+    row = _rows(app_doctor.report(str(d)))["git"]
+    assert row["state"] == "fail"
+    assert len(row["findings"]) == 1
+    finding = row["findings"][0]
+    assert finding["path"] == "."
+    assert finding["excerpt"] != "??"
+    assert "?" not in finding["excerpt"]
+    assert "untracked" in finding["excerpt"]
+
+
+@pytest.mark.skipif(not __import__("shutil").which("git"), reason="git not on PATH")
+def test_a_nested_untracked_directory_reads_as_a_directory_not_a_bare_code(workspace):
+    """A subdirectory that is entirely new collapses to one `?? sub/` line —
+    unlike the whole-app case, `rest` is not empty here (D-defect-2's
+    variant), but it should still read as a directory, not a raw status
+    line."""
+    d = _app(workspace)
+    repo = workspace / "local"
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "in")
+    sub = d / "sub"
+    sub.mkdir()
+    (sub / "new.py").write_text("x = 1\n")
+
+    row = _rows(app_doctor.report(str(d)))["git"]
+    assert row["state"] == "fail"
+    assert len(row["findings"]) == 1
+    finding = row["findings"][0]
+    assert finding["path"] == "sub/"
+    assert finding["excerpt"] == "sub/ (untracked directory)"
+
+
 # --------------------------------------------------------------- pushed
 
 def test_a_folder_that_is_not_a_repo_skips_the_pushed_row_with_the_right_reason(

--- a/tests/test_app_doctor_report.py
+++ b/tests/test_app_doctor_report.py
@@ -694,3 +694,115 @@ def test_a_live_task_attaches_to_its_own_row_only(client, workspace, monkeypatch
     rows = {c["id"]: c for c in body["checks"]}
     assert rows["readme"]["task"] == {"id": "t1", "state": "sent", "run_id": "r1"}
     assert rows["icon"]["task"] is None
+
+
+# ----------------------------------------------------- R1: prompt carries detail
+
+
+def test_a_fact_rows_prompt_carries_its_own_detail_and_drops_the_fallback(workspace):
+    """`api-version` is a `kind="fact"` row and never carries findings — its
+    `detail` IS the diagnosis. The old fallback line pointed at a `detail`
+    the prompt never actually included; that string must be gone."""
+    current = app_doctor.fused_api_version.current_version()
+    if current <= 0:
+        pytest.skip("no migration docs resolve, so nothing is behind")
+    d = _app(workspace, version=0)
+    row = _rows(app_doctor.report(str(d)))["api-version"]
+    assert row["state"] == "fail"
+    prompt = app_doctor.doctor_prompt(str(d / "index.html"), "api-version",
+                                     row["findings"], row["detail"])
+    assert row["detail"] in prompt
+    assert "no findings listed" not in prompt
+
+
+def test_a_candidate_rows_prompt_carries_both_detail_and_findings(workspace):
+    """`secrets` is a `kind="candidate"` row: it DOES carry findings, and the
+    row's own `detail` (e.g. "1 line to look at") must show up alongside
+    them, not instead of them."""
+    d = _app(workspace)
+    (d / "app.py").write_text('AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+    row = _rows(app_doctor.report(str(d)))["secrets"]
+    assert row["state"] == "fail"
+    assert row["findings"]
+    prompt = app_doctor.doctor_prompt(str(d / "index.html"), "secrets",
+                                     row["findings"], row["detail"])
+    assert row["detail"] in prompt
+    for f in row["findings"]:
+        assert f["excerpt"] in prompt
+
+
+def test_report_one_returning_none_behaves_as_today(monkeypatch):
+    """No row (an unknown check id slipping past validation somehow) must not
+    crash `doctor_prompt` — the router already guards `check_id` against
+    `CHECK_ORDER`, but the prompt builder itself should not assume a detail
+    is always available."""
+    prompt = app_doctor.doctor_prompt("app/index.html", "readme", [], "")
+    assert "readme" in prompt
+
+
+# --------------------------------------------------- R1 grep: no dead fallback
+
+def test_the_deleted_fallback_string_is_gone_from_the_module():
+    """Defect 1's fallback line must not merely be unreachable — it must not
+    exist anywhere a session (or a future test) could still find it."""
+    src = open(app_doctor.__file__, encoding="utf-8").read()
+    assert "no findings listed" not in src
+
+
+# ------------------------------------------------------- R3: fix sessions commit
+
+
+def test_a_single_row_prompt_ends_with_a_conditional_commit_step_and_no_push(workspace):
+    d = _app(workspace)
+    prompt = app_doctor.doctor_prompt(str(d / "index.html"), "readme", [], "no README")
+    assert "commit" in prompt.lower()
+    # "push" only ever appears as an explicit PROHIBITION ("never push") —
+    # never as an instruction to actually push.
+    assert "never push" in prompt.lower()
+    assert "push the branch" not in prompt.lower()
+    assert "push it" not in prompt.lower()
+
+
+def test_fix_all_makes_one_trailing_commit_not_one_per_row(workspace):
+    d = _app(workspace, readme=False)
+    (d / "app.py").write_text('DATA = "/Users/alice/data.csv"\n')
+    checks = app_doctor.report(str(d))["checks"]
+    failing = [c for c in checks if c["state"] == "fail"]
+    assert len(failing) >= 2  # readme AND device-paths, so a per-row commit
+                              # step would show up more than once if present.
+    prompt = app_doctor.doctor_prompt_all(str(d / "index.html"), checks)
+    # The commit step is the block appended once, after every row — not
+    # something each row's own block asks for.
+    assert prompt.count(app_doctor._COMMIT_STEP_ALL) == 1
+    for c in failing:
+        row_block = (
+            f"## `{c['id']}` — {c['label']}\n"
+            f"{app_doctor._triage_ask(c['kind'])}\n"
+            f"{app_doctor._findings_block(c['detail'], c['findings'])}"
+        )
+        assert "commit" not in row_block.lower()
+    assert "push the branch" not in prompt.lower()
+    assert "push it" not in prompt.lower()
+
+
+def test_fix_all_with_nothing_failing_asks_for_no_commit(workspace):
+    d = _app(workspace)
+    checks = app_doctor.report(str(d))["checks"]
+    prompt = app_doctor.doctor_prompt_all(str(d / "index.html"), checks)
+    assert "commit" not in prompt.lower()
+
+
+def test_the_secrets_commit_step_cannot_be_read_as_commit_the_secret_fix(workspace):
+    """R3's sensitive case: the commit instruction must not be readable as
+    licence to commit a still-live or merely relocated credential. A session
+    following `_CREDENTIAL_NOTE` (report + say "rotate it", never move the
+    value) makes no file edit for `secrets`, so the wording must make clear
+    that no edit means no commit — and must never say "commit the fix" in a
+    way that could be misapplied to a relocated secret."""
+    d = _app(workspace)
+    (d / "app.py").write_text('AWS_KEY = "AKIAABCDEFGHIJKLMNOP"\n')
+    row = _rows(app_doctor.report(str(d)))["secrets"]
+    prompt = app_doctor.doctor_prompt(str(d / "index.html"), "secrets",
+                                     row["findings"], row["detail"])
+    assert "commit the fix" not in prompt.lower()
+    assert "live" in prompt.lower() or "relocat" in prompt.lower()

--- a/tests/test_app_doctor_report.py
+++ b/tests/test_app_doctor_report.py
@@ -772,6 +772,18 @@ def test_report_one_returning_none_behaves_as_today(monkeypatch):
     assert "readme" in prompt
 
 
+def test_empty_detail_and_findings_omit_the_dangling_header(workspace):
+    """Review finding 3: `apps.py`'s router passes `findings=[]`, `detail=""`
+    whenever `report_one` returns `None` (an unknown check id slipping past
+    validation). With no fallback line left, `_findings_block("", [])`
+    returns `""` — the "Findings for this row:" header must not be emitted
+    over nothing, or the prompt reads as a dangling, empty section."""
+    prompt = app_doctor.doctor_prompt(str(_app(workspace) / "index.html"),
+                                     "readme", [], "")
+    assert "Findings for this row:" not in prompt
+    assert "\n\n\n" not in prompt
+
+
 # --------------------------------------------------- R1 grep: no dead fallback
 
 def test_the_deleted_fallback_string_is_gone_from_the_module():
@@ -785,6 +797,16 @@ def test_the_deleted_fallback_string_is_gone_from_the_module():
 
 
 def test_a_single_row_prompt_ends_with_a_conditional_commit_step_and_no_push(workspace):
+    """This covers a row whose fix EDITS FILES (`readme`) — the shape
+    `_COMMIT_STEP` is right for. It deliberately does NOT stand in for every
+    row: `git` and `pushed` don't edit files, their fix IS a git action
+    spelled out in their own SKILL.md section, and appending this same
+    "never push" / edit-conditioned step to THOSE rows is exactly what
+    review findings 1 & 2 caught (a `pushed` row's only real fix is
+    forbidden by "never push"; a `git` row's fix needs no edit, so "no edit
+    -> no commit" disables it). Those two rows are covered separately below
+    by `test_the_pushed_rows_own_prompt_carries_no_never_push_step` and
+    `test_the_git_rows_own_prompt_carries_no_edit_conditioned_commit_step`."""
     d = _app(workspace)
     prompt = app_doctor.doctor_prompt(str(d / "index.html"), "readme", [], "no README")
     assert "commit" in prompt.lower()
@@ -793,6 +815,62 @@ def test_a_single_row_prompt_ends_with_a_conditional_commit_step_and_no_push(wor
     assert "never push" in prompt.lower()
     assert "push the branch" not in prompt.lower()
     assert "push it" not in prompt.lower()
+
+
+def test_the_pushed_rows_own_prompt_carries_no_never_push_step(workspace):
+    """Review finding 1: the trailing commit step's "never push" contradicts
+    SKILL.md's `pushed` section ("Push the branch") — the row's only real
+    fix. The `pushed` row's own prompt must not carry the generic commit/
+    no-push step at all; its own SKILL.md section is the whole instruction."""
+    d = _app(workspace)
+    prompt = app_doctor.doctor_prompt(str(d / "index.html"), "pushed", [],
+                                     "1 commit ahead of upstream")
+    assert "never push" not in prompt.lower()
+    assert app_doctor._COMMIT_STEP not in prompt
+
+
+def test_the_git_rows_own_prompt_carries_no_edit_conditioned_commit_step(workspace):
+    """Review finding 2: `_COMMIT_STEP`'s "if you made no edit at all ...
+    make no commit" disables the `git` row's own fix, which is exactly to
+    commit pre-existing uncommitted paths with no file edit required. The
+    `git` row's own prompt must not carry the generic commit step; SKILL.md's
+    `git` section ("Commit the listed paths, or .gitignore them") is the
+    whole instruction."""
+    d = _app(workspace)
+    prompt = app_doctor.doctor_prompt(str(d / "index.html"), "git",
+                                     [{"rule": "git:uncommitted", "path": "?? a.py",
+                                       "line": 0, "excerpt": "?? a.py"}],
+                                     "1 uncommitted path")
+    assert app_doctor._COMMIT_STEP not in prompt
+
+
+def test_fix_all_containing_a_pushed_row_can_still_push_for_that_row(workspace):
+    """Review finding 1 in `doctor_prompt_all`: a Fix-all run that includes a
+    `pushed` row must still be able to push for that row — the trailing
+    `_COMMIT_STEP_ALL` step must not be phrased as a blanket "never push"
+    that overrides the `pushed` row's own SKILL.md instruction."""
+    checks = [
+        {"id": "pushed", "label": "Every commit is pushed", "kind": "fact",
+         "state": "fail", "detail": "1 commit ahead of upstream", "findings": []},
+    ]
+    prompt = app_doctor.doctor_prompt_all(str(_app(workspace) / "index.html"), checks)
+    assert "never push" not in prompt.lower()
+
+
+def test_fix_all_containing_a_git_row_can_still_commit_pre_existing_paths(workspace):
+    """Review finding 2 in `doctor_prompt_all`: a Fix-all run that includes a
+    `git` row must still be able to commit paths that were already
+    uncommitted before the run — not only "files you actually edited"."""
+    checks = [
+        {"id": "git", "label": "Every change is committed", "kind": "fact",
+         "state": "fail", "detail": "1 uncommitted path",
+         "findings": [{"rule": "git:uncommitted", "path": "?? a.py", "line": 0,
+                       "excerpt": "?? a.py"}]},
+    ]
+    prompt = app_doctor.doctor_prompt_all(str(_app(workspace) / "index.html"), checks)
+    # The trailing step must not read as forbidding a commit of pre-existing
+    # uncommitted paths that the git row itself asked for.
+    assert "pre-existing" in prompt.lower()
 
 
 def test_fix_all_makes_one_trailing_commit_not_one_per_row(workspace):

--- a/tests/test_app_doctor_report.py
+++ b/tests/test_app_doctor_report.py
@@ -347,6 +347,38 @@ def test_a_nested_untracked_directory_reads_as_a_directory_not_a_bare_code(works
     assert finding["excerpt"] == "sub/ (untracked directory)"
 
 
+@pytest.mark.skipif(not __import__("shutil").which("git"), reason="git not on PATH")
+def test_an_app_that_is_its_own_repo_root_does_not_over_claim_the_whole_folder(
+    workspace,
+):
+    """Review finding 4: `rest` strips to empty for ANY porcelain line whose
+    path equals the app's own basename, not only the whole-app-folder
+    collapse. When the app folder IS the repo root (an unmigrated app with
+    its own `.git`, `app_git._repo_scope`'s other supported layout) git
+    already reports paths relative to the app dir itself — no prefix to
+    strip at all. An untracked subdirectory that happens to share the app's
+    own folder name (`?? demo/` inside app `demo/`) must read as that
+    subdirectory being untracked, not as the whole app being untracked."""
+    d = _app(workspace, name="demo")
+    _git(d, "init", "-q")
+    _git(d, "add", "-A")
+    _git(d, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "in")
+    sub = d / "demo"  # same basename as the app folder itself
+    sub.mkdir()
+    (sub / "new.py").write_text("x = 1\n")
+
+    row = _rows(app_doctor.report(str(d)))["git"]
+    assert row["state"] == "fail"
+    assert len(row["findings"]) == 1
+    finding = row["findings"][0]
+    # Must NOT read as "the whole app folder is untracked" — only one
+    # subdirectory is.
+    assert finding["path"] != "."
+    assert "whole app folder" not in finding["excerpt"]
+    assert finding["path"] == "demo/"
+    assert finding["excerpt"] == "demo/ (untracked directory)"
+
+
 # --------------------------------------------------------------- pushed
 
 def test_a_folder_that_is_not_a_repo_skips_the_pushed_row_with_the_right_reason(

--- a/tests/test_app_doctor_report.py
+++ b/tests/test_app_doctor_report.py
@@ -15,6 +15,7 @@ The spawn is stubbed at the same module seam the scaffolding tests use
 """
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -844,23 +845,61 @@ def test_the_git_rows_own_prompt_carries_no_edit_conditioned_commit_step(workspa
     assert app_doctor._COMMIT_STEP not in prompt
 
 
+def test_git_skill_section_tells_the_gitignore_branch_to_commit_its_own_edit():
+    """Re-review finding: `_COMMIT_STEP_EXEMPT` means the `git` row's prompt
+    carries NO commit instruction of its own — SKILL.md's `git` section is
+    the whole story (see the test above). That section offers two fixes:
+    "Commit the listed paths" (self-contained: committing IS the action) or
+    ".gitignore them" (NOT self-contained: writing/editing a `.gitignore` is
+    itself a file edit that then needs committing, or it shows up as its own
+    uncommitted change and the row fails again next time). Before the
+    `_COMMIT_STEP` exemption, the generic step caught this; now nothing does
+    unless the section itself says so. Assert the `.gitignore` branch is
+    followed by an explicit instruction to commit that edit."""
+    text = (Path(__file__).resolve().parents[1] / "skills" /
+            "fused-render-app-doctor" / "SKILL.md").read_text()
+    section = text.split("## `git`", 1)[1].split("\n## ", 1)[0]
+    assert ".gitignore" in section
+    gitignore_idx = section.index(".gitignore")
+    after = section[gitignore_idx:].lower()
+    assert "commit" in after, (
+        "the .gitignore branch of the git fix must say to commit that edit too"
+    )
+
+
 def test_fix_all_containing_a_pushed_row_can_still_push_for_that_row(workspace):
     """Review finding 1 in `doctor_prompt_all`: a Fix-all run that includes a
     `pushed` row must still be able to push for that row — the trailing
     `_COMMIT_STEP_ALL` step must not be phrased as a blanket "never push"
-    that overrides the `pushed` row's own SKILL.md instruction."""
+    that overrides the `pushed` row's own SKILL.md instruction.
+
+    Absence of "never push" alone would also pass if the step said nothing
+    about pushing at all — silence isn't permission. Assert the real
+    semantics: the step affirmatively defers to the `pushed` row's own
+    section rather than merely not-forbidding it."""
     checks = [
         {"id": "pushed", "label": "Every commit is pushed", "kind": "fact",
          "state": "fail", "detail": "1 commit ahead of upstream", "findings": []},
     ]
     prompt = app_doctor.doctor_prompt_all(str(_app(workspace) / "index.html"), checks)
     assert "never push" not in prompt.lower()
+    lower = prompt.lower()
+    # The trailing step must name the `pushed` row and instruct following
+    # through on push for it — not just avoid a blanket prohibition.
+    assert "pushed" in lower
+    assert "follow through on push" in lower
+    assert "does not forbid it" in lower
 
 
 def test_fix_all_containing_a_git_row_can_still_commit_pre_existing_paths(workspace):
     """Review finding 2 in `doctor_prompt_all`: a Fix-all run that includes a
     `git` row must still be able to commit paths that were already
-    uncommitted before the run — not only "files you actually edited"."""
+    uncommitted before the run — not only "files you actually edited".
+
+    A bare "pre-existing" substring would also pass if it appeared in some
+    unrelated disclaimer. Assert the real semantics: the step explicitly
+    scopes the commit to include paths a `git` row asked for, attributed to
+    that row, not just files edited this run."""
     checks = [
         {"id": "git", "label": "Every change is committed", "kind": "fact",
          "state": "fail", "detail": "1 uncommitted path",
@@ -868,9 +907,13 @@ def test_fix_all_containing_a_git_row_can_still_commit_pre_existing_paths(worksp
                        "excerpt": "?? a.py"}]},
     ]
     prompt = app_doctor.doctor_prompt_all(str(_app(workspace) / "index.html"), checks)
+    lower = prompt.lower()
     # The trailing step must not read as forbidding a commit of pre-existing
     # uncommitted paths that the git row itself asked for.
-    assert "pre-existing" in prompt.lower()
+    assert "pre-existing" in lower
+    assert "pre-existing uncommitted" in lower
+    assert "a `git` row" in lower or "a git row" in lower
+    assert "even though you didn't edit them" in lower
 
 
 def test_fix_all_makes_one_trailing_commit_not_one_per_row(workspace):


### PR DESCRIPTION
## Summary

Three App Doctor defects reported from real use, all in how a row explains itself:

- **Fix prompts carried no diagnosis.** The empty-findings fallback read *"the row's own detail already explains why it failed"* — but the prompt never included that detail. Only `secrets` and `device-paths` ever populate findings, so the other **nine** checks pasted that line and nothing else. Every prompt now leads with the row's own `detail`; findings-bearing rows get both, detail first. The fallback string is deleted, and the header is omitted entirely when there is nothing to put under it.
- **An untracked app folder rendered as `?? : git:uncommitted: ??`.** Git collapses a fully-untracked folder to one `?? myapp/` line; the app-relative prefix strip then consumed the entire path, leaving a bare status code used as both `path` and `excerpt`. Collapsed entries now read as what they are — the app folder, or a named untracked directory. The strip is scoped using `app_git._repo_scope`, so an app that is its own repo root no longer over-claims when a subdirectory happens to share its basename.
- **A fix left the tree dirty and the commit row failed next run.** App Doctor is read-only; "Fix" delegates to a session that edits files. No prompt told that session to commit, so a reopened report showed `git` FAIL right after a successful fix. Fix prompts now end with a commit step — commit only, never push, and only when an edit actually happened. The `git` and `pushed` rows are exempt, since their own fix *is* a git action and a generic step contradicted it.

## Visuals

The delta is in how one failing row becomes the text a fix session receives:

```mermaid
flowchart TD
    A[Failing check row] --> B{Has findings?}
    B -->|"No — 9 of 11 checks"| C["Before: fallback line<br/>pointing at absent text"]
    B -->|"Yes — secrets, device-paths"| D[Findings list only]
    C --> E["Now: row's own detail"]
    D --> E
    E --> F{git or pushed row?}
    F -->|no| G[Prompt + commit step]
    F -->|yes| H[Prompt, own git fix stands]
```

## Usage

Not separately invocable — this changes text App Doctor already produces. To see it:

1. Open App Doctor on an app with a stale `fused-api-version` tag.
2. Click **Fix** on that row. The pasted message now contains the diagnosis (`declares version 1; the runtime is on 3 — …`) instead of `(no findings listed — …)`, and ends with a commit instruction.
3. For the git row, run it on an app folder that is entirely untracked — the finding reads as the app folder being untracked rather than `??`.

## Test Plan

- [x] `tests/test_app_doctor_report.py` — cases covering: detail present for a fact row, detail **and** findings for a candidate row, the `no findings listed` string absent repo-wide, whole-folder-untracked, nested untracked directory, an app that is its own repo root, ordinary file entries unchanged, the empty-header guard, `git`/`pushed` exemption in both single-row and fix-all prompts, and the `.gitignore` branch being told to commit itself.
- [x] Scoped: `pytest tests/test_app_doctor.py tests/test_app_doctor_report.py` → **94 passed**.
- [x] `bun test frontend/src/platform/ui/appdoctor-lib.test.ts` → 27 passed; full `bun test` → **5213 passed, 0 failed**.
- [x] Full local suite run twice (once per fix round). Failure set matches `origin/main`'s known macOS baseline; **zero** failures in `test_app_doctor*`, `test_app_git`, `test_git_*`, `test_apps_api`.
- [x] Two code-review rounds. Round 1 found 4 issues (all fixed); round 2 found 1 remaining gap — the `git` row's `.gitignore` fix branch had no commit instruction after the exemption — now fixed in `SKILL.md`.
- [ ] **Known-red CI lane, not from this PR:** `test-python-windows` fails `test_git_status_listing.py::test_parse_porcelain_decodes_a_non_utf8_name_like_scandir_would` with a `UnicodeDecodeError`. Base commit `a93e3c35f` on `main` fails the identical test with the identical error (`1 failed, 11468 passed`); this branch shows the same single failure with more tests passing. That module is not touched by this diff.

**Reviewer's eye here:** no `.tsx` changed — `AppDoctorModal.tsx`'s existing `!f.excerpt.includes(f.path)` dedup guard renders all three git shapes correctly, verified by checking each string against the guard. For the whole-folder case it passes only because `path` is `"."` and the excerpt ends in a period. It works and it's commented, but it's worth an opinion on whether the guard should be explicit instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
