### PR TITLE
Native chat: usage-limit comeback — read rate_limit_event, schedule the continuation, show reset time

### DIFF
--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -2855,11 +2855,13 @@ function ChatBody(props: ChatBodyProps) {
                 subtitle={name}
                 {...(taskId ? { taskId } : {})}
                 running={running}
+                quota={state.quota}
               />
             ) : null}
             <Transcript
               followRef={transcriptFollow}
               state={state}
+              comebackPending={sched.blocked}
               actions={actions}
               liveMode={state.permissionMode}
               tail={tail}

--- a/frontend/src/apps/claude/protocol/controller-api.ts
+++ b/frontend/src/apps/claude/protocol/controller-api.ts
@@ -115,6 +115,8 @@ export interface ErrorTurn {
   key: string;
   text: string;
   kind: TroubleKind;
+  /** The plan window the failure carried (kind `limit` only). */
+  quota?: import("./types").Quota;
 }
 
 export type Turn = UserTurn | AssistantTurn | NoteTurn | ErrorTurn;
@@ -145,6 +147,12 @@ export interface Trouble {
   message: string;
   /** Verbatim traceback / stderr when present. */
   detail?: string;
+  /** For `limit`: the window that refused the turn, so the card can say WHEN
+   *  it reopens (and that the comeback is already scheduled) instead of
+   *  pointing the reader at the CLI's own sentence for the time. */
+  quota?: import("./types").Quota;
+  /** For `limit`: the comeback is on the schedule (server confirmed). */
+  scheduled?: boolean;
 }
 
 /** Working-line input (T:14782-14943 activityVerb/activityDetail/retryVerb). */
@@ -175,6 +183,12 @@ export interface ChatState {
   skills: SkillRow[];
   working: Working | null;
   trouble: Trouble | null;
+  /**
+   * The plan window as of the newest poll (`PollResponse.quota`), kept across
+   * the run's end so the topbar's warning pill outlives the turn that raised
+   * it. Null until a poll carries one.
+   */
+  quota: import("./types").Quota | null;
   /**
    * The permission mode the RUN is actually in — never the picker's param, which
    * applies to the next spawn (T:13884-13886). Seeded from the mode the run was
@@ -475,6 +489,16 @@ export interface ControllerDeps {
     file: string,
     sessionId: string,
   ) => Promise<import("./types").HistoryResponse & { error?: string }>;
+  /** ADDED: the comeback after a usage limit. Injectable so bun tests see the
+   *  body without a server; defaults to `@platform/lib/api`'s `scheduleMessage`
+   *  (POST /api/schedule). */
+  schedule?: (body: {
+    target: string;
+    message: string;
+    due: string;
+    session_id: string;
+    title: string;
+  }) => Promise<unknown>;
   /** ADDED: `sleep` for the 400 ms poll cadence and the follow-up wait —
    *  injectable so a test runs the loop without real time (T:16377). */
   sleep?: (ms: number) => Promise<void>;

--- a/frontend/src/apps/claude/protocol/history.ts
+++ b/frontend/src/apps/claude/protocol/history.ts
@@ -78,6 +78,7 @@ export function historyToTurns(resp: HistoryResponse): Turn[] {
         key: "h:" + i,
         text: t.text || "",
         kind: troubleFromMessage(t.text || "", true).kind,
+        ...(t.quota ? { quota: t.quota } : {}),
       };
     }
     if (t.stopped && i !== last && typeof console !== "undefined") {

--- a/frontend/src/apps/claude/protocol/quota.test.ts
+++ b/frontend/src/apps/claude/protocol/quota.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CONTINUE_GRACE_S,
+  clockText,
+  continueDue,
+  continueNote,
+  limitExplain,
+  limitHit,
+  quotaPill,
+  quotaTitle,
+  untilText,
+} from "./quota";
+import type { Quota } from "./types";
+
+// 2026-09-10T18:30:00Z — the reset off the real 429 (run 20260910-195317).
+const RESET = 1789066800;
+
+function q(over: Partial<Quota> = {}): Quota {
+  return {
+    status: "allowed",
+    type: "five_hour",
+    resets_at: RESET,
+    utilization: null,
+    windows: {
+      five_hour: { utilization: 0.17, resets_at: RESET },
+      seven_day: { utilization: 0.06, resets_at: RESET + 6 * 86400 },
+    },
+    ...over,
+  };
+}
+
+describe("limitHit", () => {
+  test("only a rejected window with a reset counts", () => {
+    expect(limitHit(q({ status: "rejected" }))).toBe(true);
+    expect(limitHit(q({ status: "allowed_warning" }))).toBe(false);
+    expect(limitHit(q({ status: "rejected", resets_at: 0 }))).toBe(false);
+    expect(limitHit(null)).toBe(false);
+    expect(limitHit(undefined)).toBe(false);
+  });
+});
+
+describe("continueDue", () => {
+  test("is the reset plus the grace, as an ISO instant", () => {
+    expect(continueDue(q())).toBe(new Date((RESET + CONTINUE_GRACE_S) * 1000).toISOString());
+  });
+});
+
+describe("clockText", () => {
+  test("spells the CLI's own clock: h:mmam/pm, no leading zero, local zone", () => {
+    const d = new Date(RESET * 1000);
+    const h = d.getHours() % 12 || 12;
+    const mm = String(d.getMinutes()).padStart(2, "0");
+    const ap = d.getHours() >= 12 ? "pm" : "am";
+    expect(clockText(RESET)).toBe(`${h}:${mm}${ap}`);
+  });
+  test("a reset more than a day out carries its weekday", () => {
+    const now = RESET * 1000;
+    expect(clockText(RESET + 5 * 86400, now)).toMatch(/^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) \d{1,2}:\d{2}[ap]m$/);
+    expect(clockText(RESET + 3600, now)).toMatch(/^\d{1,2}:\d{2}[ap]m$/);
+  });
+  test("midnight is 12:xxam, noon 12:xxpm", () => {
+    const local = (h: number) => new Date(2026, 0, 1, h, 5).getTime() / 1000;
+    expect(clockText(local(0))).toBe("12:05am");
+    expect(clockText(local(12))).toBe("12:05pm");
+  });
+});
+
+describe("untilText", () => {
+  const now = RESET * 1000;
+  test("under a minute is 'any moment now'", () => {
+    expect(untilText(RESET, now - 30_000)).toBe("any moment now");
+    expect(untilText(RESET, now + 60_000)).toBe("any moment now");
+  });
+  test("minutes, then hours and minutes", () => {
+    expect(untilText(RESET, now - 3 * 60_000)).toBe("in 3m");
+    expect(untilText(RESET, now - (2 * 3600 + 14 * 60) * 1000)).toBe("in 2h 14m");
+    expect(untilText(RESET, now - 3 * 3600 * 1000)).toBe("in 3h");
+  });
+});
+
+describe("limitExplain", () => {
+  const now = RESET * 1000 - 3 * 60_000;
+  test("names the reset and, once scheduled, the follow-up row", () => {
+    const plain = limitExplain(q({ status: "rejected" }), now, false);
+    expect(plain).toContain("It resets at " + clockText(RESET) + " (in 3m).");
+    expect(plain).not.toContain("follow-up");
+    const scheduled = limitExplain(q({ status: "rejected" }), now, true);
+    expect(scheduled).toContain("A follow-up is scheduled to continue this task then");
+  });
+});
+
+describe("continueNote", () => {
+  test("is the CLI's wait line", () => {
+    expect(continueNote(q())).toBe(
+      "Usage limit reached · continuing automatically at " + clockText(RESET),
+    );
+  });
+});
+
+describe("quotaPill", () => {
+  test("nothing on an ordinary or a rejected window — the pill is the CLI's warning only", () => {
+    expect(quotaPill(q())).toBe("");
+    expect(quotaPill(q({ status: "rejected" }))).toBe("");
+    expect(quotaPill(null)).toBe("");
+  });
+  test("the warning's own utilization, rounded, with the window's short name", () => {
+    expect(quotaPill(q({ status: "allowed_warning", utilization: 0.934 }))).toBe(
+      "5h 93% · resets " + clockText(RESET),
+    );
+    expect(
+      quotaPill(q({ status: "allowed_warning", type: "seven_day", utilization: 0.52 })),
+    ).toBe("7d 52% · resets " + clockText(RESET));
+  });
+  test("falls back to the window's utilization when the top-level one is missing", () => {
+    expect(quotaPill(q({ status: "allowed_warning" }))).toBe("5h 17% · resets " + clockText(RESET));
+  });
+});
+
+describe("quotaTitle", () => {
+  test("one line per window", () => {
+    const lines = quotaTitle(q()).split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("5h window: 17% used · resets " + clockText(RESET));
+    expect(lines[1]).toStartWith("7d window: 6% used · resets ");
+  });
+});

--- a/frontend/src/apps/claude/protocol/quota.ts
+++ b/frontend/src/apps/claude/protocol/quota.ts
@@ -1,0 +1,112 @@
+// THE PLAN WINDOW, IN WORDS — what the card, the topbar pill and the comeback
+// note say about a `Quota` (protocol/types.ts). Pure functions over an epoch and
+// a clock, so the copy is pinned by tests rather than by a screenshot.
+//
+// The vocabulary is Claude Code's own: its TUI says "You've hit your session
+// limit · resets 12:30am" and, while it waits, "Usage limit reached ·
+// continuing automatically at 12:30am". A reader who has seen the CLI say it
+// should recognise the same sentence here (Jakob's law), so these do not
+// paraphrase it.
+import type { Quota } from "./types";
+
+/**
+ * The fixed prompt the comeback sends. NOT the user's last message: the CLI's
+ * own auto-continue "sends Claude a fixed prompt to pick the task up where it
+ * stopped. It doesn't resend your last message" — resending would redo work
+ * the turn had already done before the limit cut it off.
+ */
+export const CONTINUE_PROMPT =
+  "Your usage limit has reset. Continue the task you were working on where it " +
+  "stopped. Do not repeat steps that were already completed.";
+
+/** The scheduled task's name in the Tasks list. */
+export const CONTINUE_TITLE = "Continue after usage limit";
+
+/** Seconds past the reset the comeback fires: the window reopens on the minute
+ *  and a request landing exactly on it has been seen refused. */
+export const CONTINUE_GRACE_S = 60;
+
+/** Whether this poll ended on the plan limit — the one case the comeback is for. */
+export function limitHit(quota: Quota | null | undefined): quota is Quota {
+  return !!quota && quota.status === "rejected" && quota.resets_at > 0;
+}
+
+/** The ISO instant the comeback is due. */
+export function continueDue(quota: Quota): string {
+  return new Date((quota.resets_at + CONTINUE_GRACE_S) * 1000).toISOString();
+}
+
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/**
+ * "12:30am" / "3:45pm" — the CLI's own clock spelling, in the local zone. A
+ * reset more than a day out (the weekly window) gets its weekday in front —
+ * "Tue 3:11pm" — because a bare clock five days away reads as today.
+ */
+export function clockText(epochS: number, nowMs: number = Date.now()): string {
+  const d = new Date(epochS * 1000);
+  let h = d.getHours();
+  const m = d.getMinutes();
+  const suffix = h >= 12 ? "pm" : "am";
+  h = h % 12;
+  if (h === 0) h = 12;
+  const clock = h + ":" + (m < 10 ? "0" : "") + m + suffix;
+  return epochS * 1000 - nowMs > 24 * 3600 * 1000 ? DAYS[d.getDay()] + " " + clock : clock;
+}
+
+/** "in 2h 14m" / "in 3m" / "any moment now" — the distance to the reset. */
+export function untilText(epochS: number, nowMs: number): string {
+  const secs = epochS - nowMs / 1000;
+  if (secs < 60) return "any moment now";
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return "in " + mins + "m";
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return "in " + h + "h" + (m ? " " + m + "m" : "");
+}
+
+/** The card's explanation for a limit hit, with the reset the CLI reported. */
+export function limitExplain(quota: Quota, nowMs: number, scheduled: boolean): string {
+  const when = clockText(quota.resets_at) + " (" + untilText(quota.resets_at, nowMs) + ")";
+  const head = "Nothing is broken — your plan's usage is spent for now. It resets at " + when + ".";
+  return scheduled
+    ? head + " A follow-up is scheduled to continue this task then; cancel it from the row below."
+    : head;
+}
+
+/** The note row the comeback leaves in the log — the CLI's own wait line. */
+export function continueNote(quota: Quota): string {
+  return "Usage limit reached · continuing automatically at " + clockText(quota.resets_at);
+}
+
+/** "5h" / "7d" — a window's short name for the pill. Unknown names pass through. */
+export function windowShort(name: string): string {
+  if (name === "five_hour") return "5h";
+  if (name === "seven_day") return "7d";
+  return name;
+}
+
+/**
+ * The topbar pill, or "" when there is nothing to say. Shown ONLY on the CLI's
+ * own `allowed_warning` — its threshold, not ours — so the header stays empty
+ * for every ordinary turn. "5h 93% · resets 3:45pm".
+ */
+export function quotaPill(quota: Quota | null | undefined): string {
+  if (!quota || quota.status !== "allowed_warning") return "";
+  const win = quota.windows[quota.type];
+  const util = quota.utilization ?? win?.utilization ?? null;
+  if (util === null) return "";
+  return (
+    windowShort(quota.type) + " " + Math.round(util * 100) + "% · resets " + clockText(quota.resets_at)
+  );
+}
+
+/** The pill's hover: every window the CLI reported, one per line. */
+export function quotaTitle(quota: Quota): string {
+  return Object.entries(quota.windows)
+    .map(
+      ([name, w]) =>
+        windowShort(name) + " window: " + Math.round(w.utilization * 100) + "% used · resets " + clockText(w.resets_at),
+    )
+    .join("\n");
+}

--- a/frontend/src/apps/claude/protocol/run-controller.quota.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.quota.test.ts
@@ -1,0 +1,182 @@
+// THE COMEBACK AFTER A USAGE LIMIT (run-controller `scheduleComeback`).
+//
+// A headless `claude -p` run that hits the plan limit ends its turn with the
+// CLI's own sentence as `error` and `quota.status === "rejected"` beside it —
+// the CLI's TUI would now wait and continue on its own; `-p` does not. So the
+// controller schedules ONE message on the same session at the reset the CLI
+// reported, carrying the fixed continuation prompt, and says so in the log.
+import { installDomShim } from "@platform/lib/testDomShim";
+installDomShim();
+import { describe, expect, test } from "bun:test";
+
+const { createChatController } = await import("./run-controller");
+const { createMemoryParamsStore } = await import("../params/store");
+const { CONTINUE_GRACE_S, CONTINUE_PROMPT, CONTINUE_TITLE } = await import("./quota");
+
+import type { runAgent } from "./agent";
+import type { NoteTurn } from "./controller-api";
+import type { PollResponse, Quota } from "./types";
+
+const RESET = 1789066800;
+const LIMIT_TEXT = "You've hit your session limit · resets 12:30am (Asia/Calcutta)";
+
+const rejected = (): Quota => ({
+  status: "rejected",
+  type: "five_hour",
+  resets_at: RESET,
+  utilization: null,
+  windows: { five_hour: { utilization: 1, resets_at: RESET } },
+});
+
+function poll(over: Partial<PollResponse> = {}): PollResponse {
+  return {
+    text: "",
+    done: false,
+    session_id: "s1",
+    error: "",
+    tokens: 0,
+    phase: "composing",
+    message: "",
+    permissions: [],
+    app_state: [],
+    mode: "prompt",
+    skills: [],
+    retry: null,
+    retry_total: 0,
+    retry_status: 0,
+    cancelled: false,
+    tasks_pending: false,
+    activity: {
+      tool: null,
+      tools_open: 0,
+      tool_input_bytes: 0,
+      thinking_tokens: 0,
+      hook: "",
+      tasks: [],
+      agent_rows: 0,
+    },
+    segments: [],
+    ...over,
+  };
+}
+
+type Handler = (fields: Record<string, unknown>, call: number) => unknown;
+
+function make(handlers: Record<string, Handler>, schedule?: (body: unknown) => Promise<unknown>) {
+  const counts: Record<string, number> = {};
+  const run = ((_dir: string, action: string, fields: Record<string, unknown>) => {
+    const n = (counts[action] = (counts[action] || 0) + 1) - 1;
+    const h = handlers[action];
+    if (!h) throw new Error("no handler for " + action);
+    return Promise.resolve(h(fields, n));
+  }) as unknown as typeof runAgent;
+  const controller = createChatController({
+    file: "/proj/app.py",
+    agentDir: "/tpl/claude",
+    params: createMemoryParamsStore(),
+    run,
+    sleep: () => Promise.resolve(),
+    now: () => 1_000,
+    hasPane: () => true,
+    ...(schedule ? { schedule: schedule as never } : {}),
+  });
+  return controller;
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("the plan window on the poll", () => {
+  test("rides into state and survives a poll without one", async () => {
+    const warn: Quota = { ...rejected(), status: "allowed_warning", utilization: 0.93 };
+    const c = make({
+      start: () => ({ run_id: "r1" }),
+      poll: (_f, n) => (n === 0 ? poll({ quota: warn }) : poll({ done: true, text: "ok" })),
+    });
+    await c.sendMessage("hi");
+    expect(c.getState().quota).toEqual(warn);
+  });
+});
+
+describe("a limit hit", () => {
+  test("schedules the comeback on the session at the reset, and notes it", async () => {
+    const posted: unknown[] = [];
+    const c = make(
+      {
+        start: () => ({ run_id: "r1" }),
+        poll: () => poll({ done: true, error: LIMIT_TEXT, quota: rejected() }),
+      },
+      (body) => {
+        posted.push(body);
+        return Promise.resolve({ entry: { id: "e1" } });
+      },
+    );
+    await c.sendMessage("do the thing");
+    await flush();
+    expect(posted).toEqual([
+      {
+        target: "/proj/app.py",
+        message: CONTINUE_PROMPT,
+        due: new Date((RESET + CONTINUE_GRACE_S) * 1000).toISOString(),
+        session_id: "s1",
+        title: CONTINUE_TITLE,
+      },
+    ]);
+    const state = c.getState();
+    expect(state.trouble?.kind).toBe("limit");
+    expect(state.trouble?.quota?.resets_at).toBe(RESET);
+    expect(state.trouble?.scheduled).toBe(true);
+    const roles = state.turns.map((t) => t.role);
+    expect(roles).toEqual(["user", "error", "note"]);
+    const note = state.turns[2] as NoteTurn;
+    expect(note.glyph).toBe("◷");
+    expect(note.text).toStartWith("Usage limit reached · continuing automatically at ");
+    // The error row carries the window too, for a renderer that wants the time.
+    expect((state.turns[1] as { quota?: Quota }).quota?.status).toBe("rejected");
+  });
+
+  test("a refused POST leaves the limit card up and says the follow-up did not schedule", async () => {
+    const c = make(
+      {
+        start: () => ({ run_id: "r1" }),
+        poll: () => poll({ done: true, error: LIMIT_TEXT, quota: rejected() }),
+      },
+      () => Promise.reject(new Error("target: refused")),
+    );
+    await c.sendMessage("go");
+    await flush();
+    const errs = c.getState().turns.filter((t) => t.role === "error");
+    expect(errs.length).toBe(2);
+    expect((errs[1] as { text: string }).text).toContain("Could not schedule the follow-up");
+    expect(c.getState().turns.some((t) => t.role === "note")).toBe(false);
+  });
+
+  test("an error without a rejected window is an ordinary failure — nothing scheduled", async () => {
+    const posted: unknown[] = [];
+    const c = make(
+      {
+        start: () => ({ run_id: "r1" }),
+        poll: () =>
+          poll({ done: true, error: "API Error: 529 Overloaded", quota: { ...rejected(), status: "allowed" } }),
+      },
+      (body) => {
+        posted.push(body);
+        return Promise.resolve({});
+      },
+    );
+    await c.sendMessage("go");
+    await flush();
+    expect(posted).toEqual([]);
+    expect(c.getState().trouble?.quota).toBeUndefined();
+  });
+});
+
+describe("a run repaired after the fact", () => {
+  test("still hands its plan window to state — the pill for a comeback that finished off-frame", async () => {
+    const warn: Quota = { ...rejected(), status: "allowed_warning", utilization: 0.93 };
+    const c = make({
+      poll: () => poll({ done: true, message: "continue", text: "back at it", quota: warn }),
+    });
+    await c.resumeRun("r1");
+    expect(c.getState().quota).toEqual(warn);
+  });
+});

--- a/frontend/src/apps/claude/protocol/run-controller.quota.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.quota.test.ts
@@ -134,7 +134,7 @@ describe("a limit hit", () => {
     expect((state.turns[1] as { quota?: Quota }).quota?.status).toBe("rejected");
   });
 
-  test("a refused POST leaves the limit card up and says the follow-up did not schedule", async () => {
+  test("a refused POST keeps the limit card (with its reset) and notes the refusal", async () => {
     const c = make(
       {
         start: () => ({ run_id: "r1" }),
@@ -144,10 +144,60 @@ describe("a limit hit", () => {
     );
     await c.sendMessage("go");
     await flush();
-    const errs = c.getState().turns.filter((t) => t.role === "error");
-    expect(errs.length).toBe(2);
-    expect((errs[1] as { text: string }).text).toContain("Could not schedule the follow-up");
-    expect(c.getState().turns.some((t) => t.role === "note")).toBe(false);
+    const state = c.getState();
+    // ONE error row and the card still the limit's: the refusal must not
+    // replace the card that carries the reset time (Bugbot #1107).
+    expect(state.turns.filter((t) => t.role === "error").length).toBe(1);
+    expect(state.trouble?.kind).toBe("limit");
+    expect(state.trouble?.quota?.resets_at).toBe(RESET);
+    expect(state.trouble?.scheduled).toBeUndefined();
+    const notes = state.turns.filter((t): t is NoteTurn => t.role === "note");
+    expect(notes.length).toBe(1);
+    expect(notes[0]!.text).toContain("Could not schedule the follow-up");
+  });
+
+  test("a second end on the same run prints nothing and posts nothing", async () => {
+    const posted: unknown[] = [];
+    const c = make(
+      {
+        start: () => ({ run_id: "r1" }),
+        poll: () => poll({ done: true, error: LIMIT_TEXT, quota: rejected() }),
+      },
+      (body) => {
+        posted.push(body);
+        return Promise.resolve({});
+      },
+    );
+    await c.sendMessage("go");
+    await flush();
+    // Re-attach to the SAME run id: agent.py answers with the same ended poll.
+    await c.resumeRun("r1");
+    await flush();
+    expect(posted.length).toBe(1);
+    expect(c.getState().turns.filter((t) => t.role === "error").length).toBe(1);
+  });
+
+  test("a limit hit repaired off-frame gets the card and the comeback too", async () => {
+    const posted: unknown[] = [];
+    const c = make(
+      {
+        poll: () => poll({ done: true, message: "do it", error: LIMIT_TEXT, quota: rejected() }),
+      },
+      (body) => {
+        posted.push(body);
+        return Promise.resolve({});
+      },
+    );
+    await c.resumeRun("r9");
+    await flush();
+    expect(posted.length).toBe(1);
+    expect((posted[0] as { session_id: string }).session_id).toBe("s1");
+    const state = c.getState();
+    expect(state.trouble?.kind).toBe("limit");
+    expect(state.trouble?.quota?.resets_at).toBe(RESET);
+    // Empty transcript → the repair's own rule adds no user line (same as
+    // `addError` did); the card row and the comeback note are what matter.
+    expect(state.turns.map((t) => t.role)).toEqual(["error", "note"]);
   });
 
   test("an error without a rejected window is an ordinary failure — nothing scheduled", async () => {

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -31,6 +31,7 @@
 // 5. CARDS LAND BELOW THE PROSE THEY INTERRUPT. `syncPermissions` runs AFTER
 //    the segment render, every poll, and re-pins the open cards last
 //    (T:16305-16311, 14665-14775).
+import { scheduleMessage } from "@platform/lib/api";
 import { announceTasksChanged } from "@platform/lib/tasksChanged";
 
 import { runAgent } from "./agent";
@@ -51,6 +52,7 @@ import type {
   Working,
 } from "./controller-api";
 import { historyToTurns } from "./history";
+import { CONTINUE_PROMPT, CONTINUE_TITLE, continueDue, continueNote, limitHit } from "./quota";
 import { pollBody, type SegmentView } from "./segments";
 import { isUnknownRun, troubleFromError, troubleFromMessage, troubleOf } from "./trouble";
 import type {
@@ -67,6 +69,7 @@ import type {
   PermissionRow,
   Phase,
   PollResponse,
+  Quota,
   RetryInfo,
   RunIdResponse,
   SendResponse,
@@ -196,6 +199,7 @@ function emptyState(file: string | null): ChatState {
     skills: [],
     working: null,
     trouble: null,
+    quota: null,
     permissionMode: DEFAULT_PERMISSION,
     queued: [],
     historyLoading: false,
@@ -604,6 +608,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
       key: nextKey("e"),
       text: trouble.message,
       kind: trouble.kind,
+      ...(trouble.quota ? { quota: trouble.quota } : {}),
     };
     emit({ trouble, turns: [...state.turns, row] });
   };
@@ -611,6 +616,51 @@ export function createChatController(deps: ControllerDeps): ChatController {
   /** T:13698 `addError(message)` — classify, then report. */
   const addError = (message: string, fromAgent = false) =>
     reportTrouble(troubleFromMessage(message, fromAgent));
+
+  /**
+   * THE COMEBACK AFTER A USAGE LIMIT. Claude Code's own TUI waits in the open
+   * session and continues the task when the plan window reopens; a headless
+   * `-p` run gets no such wait — the turn ends on the limit and the process is
+   * reaped. So the chat does the same thing with the infrastructure it already
+   * has: one scheduled message on THIS session, due at the reset the CLI
+   * reported (+ a minute), carrying the CLI's own fixed continuation prompt.
+   * The schedule banner (`SchedBlock`) then shows the row with its time and
+   * its cancel, exactly like any other pending message, and the fired run
+   * resumes the conversation in place.
+   *
+   * Reported as trouble FIRST, with the window on it, so the card says when
+   * the reset is even if the POST fails; the note and the card's "scheduled"
+   * line land only once the server has the row. Once per run: `poll.done`
+   * repeats on a re-attached loop and a second row would fire twice.
+   */
+  const scheduledRuns = new Set<string>();
+  const scheduleComeback = (runId: string, error: string, quota: Quota) => {
+    const trouble: Trouble = { ...troubleFromMessage(error), quota };
+    reportTrouble(trouble);
+    const sessionId = state.sessionId;
+    if (!FILE || !sessionId || scheduledRuns.has(runId)) return;
+    scheduledRuns.add(runId);
+    const post = deps.schedule ?? scheduleMessage;
+    void post({
+      target: FILE,
+      message: CONTINUE_PROMPT,
+      due: continueDue(quota),
+      session_id: sessionId,
+      title: CONTINUE_TITLE,
+    })
+      .then(() => {
+        // The card's line about the scheduled follow-up, and the CLI's own
+        // wait sentence as a note in the log where the failure sits.
+        if (state.trouble === trouble) emit({ trouble: { ...trouble, scheduled: true } });
+        addNote(continueNote(quota), "\u25f7");
+        announceTasksChanged();
+      })
+      .catch((err: unknown) => {
+        addError(
+          "Could not schedule the follow-up: " + (err instanceof Error ? err.message : String(err)),
+        );
+      });
+  };
 
   // ---- skills / app_state (T:15771-15837) --------------------------------
 
@@ -1030,6 +1080,10 @@ export function createChatController(deps: ControllerDeps): ChatController {
         // usage arrives only at message end; estimate from streamed text meanwhile
         const tokens = Math.max(poll.tokens || 0, Math.round((poll.text || "").length / 4));
         setStats(tokens, poll.phase || "thinking", poll.retry ?? null, poll.activity ?? null);
+        // The plan window rides on every poll that saw a `rate_limit_event`;
+        // a poll without one (the turn's first, an older agent.py) keeps the
+        // last known rather than blanking the pill.
+        if (poll.quota && poll.quota !== state.quota) emit({ quota: poll.quota });
         noteSkills(poll.skills);
         surfaceAppState(poll.app_state, runId);
 
@@ -1316,7 +1370,8 @@ export function createChatController(deps: ControllerDeps): ChatController {
               });
             }
           }
-          if (end.error) addError(end.error);
+          if (end.error && limitHit(poll.quota)) scheduleComeback(runId, end.error, poll.quota);
+          else if (end.error) addError(end.error);
           // Same guard: a superseded loop's own "Stopped." must not land in the
           // log while the newer loop's turn is the one actually streaming.
           if (loopSeq === seat && end.note) addNote(end.note, "⏹");
@@ -2465,6 +2520,11 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // road can be added later that forgets to.
       if (runId) shownRuns.add(runId);
       const poll = probe as PollResponse;
+      // THE PLAN WINDOW OFF A PROBE TOO. A scheduled comeback that finishes
+      // before the 15 s watch attaches never reaches `pollLoop` — the repair
+      // branch below appends its turns and returns — so the warning the CLI
+      // raised on that turn has to be taken here or the pill never shows.
+      if (poll.quota && poll.quota !== state.quota) emit({ quota: poll.quota });
       if (poll.session_id) noteSessionId(String(poll.session_id));
       const probeMsg = stripBlocks(poll.message || "");
       const users = state.turns.filter((t): t is UserTurn => t.role === "user");

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -630,16 +630,24 @@ export function createChatController(deps: ControllerDeps): ChatController {
    *
    * Reported as trouble FIRST, with the window on it, so the card says when
    * the reset is even if the POST fails; the note and the card's "scheduled"
-   * line land only once the server has the row. Once per run: `poll.done`
-   * repeats on a re-attached loop and a second row would fire twice.
+   * line land only once the server has the row. A refused POST is a NOTE
+   * beside that card, never a second card: `reportTrouble` replaces the slot,
+   * and the reset time is the one fact the reader must not lose (Bugbot
+   * #1107). Once per run, and the guard comes BEFORE the row: `poll.done`
+   * repeats on a re-attached or superseded loop, and the second pass must
+   * print nothing and post nothing (Bugbot #1107).
+   *
+   * Returns whether it took the failure — false means the caller reports the
+   * error the ordinary way (no session to schedule on, or no target).
    */
   const scheduledRuns = new Set<string>();
-  const scheduleComeback = (runId: string, error: string, quota: Quota) => {
+  const scheduleComeback = (runId: string, error: string, quota: Quota): boolean => {
+    if (scheduledRuns.has(runId)) return true;
+    const sessionId = state.sessionId;
+    if (!FILE || !sessionId) return false;
+    scheduledRuns.add(runId);
     const trouble: Trouble = { ...troubleFromMessage(error), quota };
     reportTrouble(trouble);
-    const sessionId = state.sessionId;
-    if (!FILE || !sessionId || scheduledRuns.has(runId)) return;
-    scheduledRuns.add(runId);
     const post = deps.schedule ?? scheduleMessage;
     void post({
       target: FILE,
@@ -656,10 +664,12 @@ export function createChatController(deps: ControllerDeps): ChatController {
         announceTasksChanged();
       })
       .catch((err: unknown) => {
-        addError(
+        addNote(
           "Could not schedule the follow-up: " + (err instanceof Error ? err.message : String(err)),
+          "\u25f7",
         );
       });
+    return true;
   };
 
   // ---- skills / app_state (T:15771-15837) --------------------------------
@@ -1370,8 +1380,11 @@ export function createChatController(deps: ControllerDeps): ChatController {
               });
             }
           }
-          if (end.error && limitHit(poll.quota)) scheduleComeback(runId, end.error, poll.quota);
-          else if (end.error) addError(end.error);
+          // The comeback is gated on ownership like the stop note below: a
+          // superseded loop's end must not print or schedule anything.
+          if (end.error && limitHit(poll.quota) && loopSeq === seat) {
+            if (!scheduleComeback(runId, end.error, poll.quota)) addError(end.error);
+          } else if (end.error) addError(end.error);
           // Same guard: a superseded loop's own "Stopped." must not land in the
           // log while the newer loop's turn is the one actually streaming.
           if (loopSeq === seat && end.note) addNote(end.note, "⏹");
@@ -2678,9 +2691,18 @@ export function createChatController(deps: ControllerDeps): ChatController {
          * case, so this is parity with its behaviour rather than its spelling.
          */
         let appended = false;
+        // A LIMIT HIT REPAIRED OFF-FRAME IS STILL A LIMIT HIT (Bugbot #1107):
+        // the same card with the reset time, the same scheduled comeback. The
+        // three branches below only decide whether a user line is needed
+        // first; the error itself goes through here.
+        const probeQuota = poll.quota;
+        const reportProbeError = (message: string) => {
+          if (limitHit(probeQuota) && scheduleComeback(runId, message, probeQuota)) return;
+          addError(message);
+        };
         if (poll.error) {
           if (matches || !users.length) {
-            addError(poll.error);
+            reportProbeError(poll.error);
             appended = true;
           } else if (unseen) {
             // The turn is not on screen and never was, so the failure needs its
@@ -2698,7 +2720,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
             // transcript is already showing, so with none there is no turn to
             // append and neither flag has anything to be quiet about.
             addUser(probeMsg);
-            addError(poll.error);
+            reportProbeError(poll.error);
             appended = true;
           } else if (shownAlready && !errorShown(poll.error)) {
             // THE PROMPT IS UP AND THE FAILURE IS NOT (Bugbot PR #1075, third
@@ -2712,7 +2734,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
             // under the line that is already there, and only `errorShown`
             // stops it: if the transcript happened to carry the failure too,
             // the row is there and there is nothing to add.
-            addError(poll.error);
+            reportProbeError(poll.error);
             appended = true;
           }
           // A FAILED TURN IS NEWS TOO (Bugbot 3974939169): same nonce, same

--- a/frontend/src/apps/claude/protocol/types.ts
+++ b/frontend/src/apps/claude/protocol/types.ts
@@ -345,6 +345,22 @@ export interface RetryInfo {
   error: string;
 }
 
+/**
+ * The plan window as of the last API response (agent.py `_quota_info`, off the
+ * CLI's own `rate_limit_event` row — one per response). `status` is the CLI's
+ * word: `allowed`, `allowed_warning` (it crossed its own threshold; `utilization`
+ * says how far), `rejected` (the turn just died on the limit; `resets_at` is the
+ * epoch second the window reopens, and the comeback is scheduled on it).
+ * `windows` is every window at once, keyed `five_hour` / `seven_day`.
+ */
+export interface Quota {
+  status: "allowed" | "allowed_warning" | "rejected" | string;
+  type: "five_hour" | "seven_day" | string;
+  resets_at: number;
+  utilization: number | null;
+  windows: Record<string, { utilization: number; resets_at: number }>;
+}
+
 export interface ActivityTool {
   id: string;
   name: string;
@@ -385,6 +401,8 @@ export interface PollResponse {
   retry: RetryInfo | null;
   retry_total: number;
   retry_status: number;
+  /** Absent on an older agent.py. */
+  quota?: Quota | null;
   cancelled: boolean;
   tasks_pending: boolean;
   activity: Activity;
@@ -517,6 +535,8 @@ export interface HistoryAssistantTurn {
 export interface HistoryErrorTurn {
   role: "error";
   text: string;
+  /** The transcript's `quotaLimits` on a failed row — only a limit hit has it. */
+  quota?: Quota;
 }
 export type HistoryTurn = HistoryUserTurn | HistoryAssistantTurn | HistoryErrorTurn;
 export interface TranscriptStat {

--- a/frontend/src/apps/claude/styles/composer.css
+++ b/frontend/src/apps/claude/styles/composer.css
@@ -89,6 +89,20 @@
      rather than one more site at a time. */
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, monospace;
 }
+/* The plan-window pill before "running": the CLI's own warning, quiet and
+   monospace like the task number beside it, coloured as a caution, never as an
+   error — nothing has failed yet. */
+.c-tb-quota {
+  flex: 0 0 auto;
+  font-size: 10.5px;
+  line-height: 1.6;
+  padding: 0 6px;
+  border-radius: 999px;
+  color: var(--c-status-progress);
+  background: color-mix(in srgb, var(--c-status-progress) 12%, transparent);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
 /* "running" at the end of the chat's name — a shimmer through the WORD, not a
    spinner, and the same mark every "running" in this app wears (T:1342-1372).
    The travel stays inside 100% -> 0% over a 300%-wide image so no frame can

--- a/frontend/src/apps/claude/ui/Topbar.tsx
+++ b/frontend/src/apps/claude/ui/Topbar.tsx
@@ -16,6 +16,8 @@
 // TASK-023 is the identifier every other surface in this app prints, so a
 // reader can carry it to the Tasks page and quote it to someone (T:12660-12672).
 import "../styles/composer.css";
+import { quotaPill, quotaTitle } from "../protocol/quota";
+import type { Quota } from "../protocol/types";
 import { ClaudeMark } from "./ClaudeMark";
 import { knownTaskId } from "./Kebab";
 
@@ -28,9 +30,13 @@ export interface TopbarProps {
   /** A turn is live: one source of truth for the mark and the composer's stop
    *  square (T:1342-1349). */
   running: boolean;
+  /** The plan window off the newest poll. Draws a pill ONLY when the CLI
+   *  itself flagged `allowed_warning`; every ordinary turn draws nothing. */
+  quota?: Quota | null;
 }
 
-export function Topbar({ sessionId, subtitle, taskId, running }: TopbarProps) {
+export function Topbar({ sessionId, subtitle, taskId, running, quota }: TopbarProps) {
+  const pill = quotaPill(quota);
   // The number, or the session hash until it lands (T:12698 — the answer to a
   // slow listing is the old label, never a gap).
   const label =
@@ -56,6 +62,13 @@ export function Topbar({ sessionId, subtitle, taskId, running }: TopbarProps) {
       {/* `aria-live="polite"`, not assertive: this is an ambient state, and a
           reader that interrupts to announce the start of every turn is worse
           than one that mentions it when it next comes up for air (T:4078). */}
+      {pill && quota ? (
+        // The CLI's own threshold, in its own words: "5h 93% · resets 3:45pm".
+        // A reader who knows /usage reads it without a legend.
+        <span className="c-tb-quota" title={quotaTitle(quota)}>
+          {pill}
+        </span>
+      ) : null}
       {running ? (
         <span className="c-tb-run" aria-live="polite">
           running

--- a/frontend/src/apps/claude/ui/Transcript.tsx
+++ b/frontend/src/apps/claude/ui/Transcript.tsx
@@ -83,6 +83,10 @@ export interface TranscriptProps {
   paneNoun?: string;
   /** What the app was doing, for a trouble card's report. */
   what?: string;
+  /** Whether a scheduled message is still pending on this conversation
+   *  (`useSchedule.blocked`) — the limit card's "a follow-up is scheduled"
+   *  sentence is only true while it is. */
+  comebackPending?: boolean;
   /**
    * THE FOLLOW FLAG, LENT OUT (T:12758, T:17211-17213).
    *
@@ -113,6 +117,7 @@ export const Transcript = memo(function Transcript({
   onOpenShot,
   paneNoun,
   what,
+  comebackPending,
   followRef,
 }: TranscriptProps) {
   const port = useRef<HTMLDivElement>(null);
@@ -507,7 +512,11 @@ export const Transcript = memo(function Transcript({
                 turn had stopped — "last line = the error" is the request. The
                 row is the log entry, the card is what the user can act on. */}
             {state.trouble ? (
-              <TroubleView trouble={state.trouble} {...(what ? { what } : {})} />
+              <TroubleView
+                trouble={state.trouble}
+                {...(what ? { what } : {})}
+                {...(comebackPending !== undefined ? { comebackPending } : {})}
+              />
             ) : null}
             {/* THE TAIL PIN (#17). An OPEN card sticks to the bottom of the
                 scrollport for as long as it is open, because the run cannot

--- a/frontend/src/apps/claude/ui/TroubleView.tsx
+++ b/frontend/src/apps/claude/ui/TroubleView.tsx
@@ -12,6 +12,8 @@ import { useState } from "react";
 
 import { TroubleCard } from "@platform/ui/TroubleCard";
 
+import { limitExplain } from "../protocol/quota";
+
 import type { Trouble, TroubleKind } from "../protocol/controller-api";
 import { platformKindOf, splitTroubleMessage, troubleExplain } from "../protocol/trouble";
 
@@ -105,6 +107,11 @@ export interface TroubleViewProps {
   /** Words for a caller that knows more than the kind does — the boot failure's
    *  two shapes share one kind and differ only in these (P3R1-8). */
   said?: { title: string; explain: string };
+  /** For a `limit`: whether the comeback row is STILL on the schedule. The
+   *  trouble's own `scheduled` flag says the POST landed; this says the banner
+   *  is still up — false once the user cancels it, so the card stops promising
+   *  a follow-up that will not come. Absent = trust the flag. */
+  comebackPending?: boolean;
 }
 
 export function TroubleView({
@@ -113,6 +120,7 @@ export function TroubleView({
   onRetry,
   retryLabel,
   said: saidProp,
+  comebackPending,
 }: TroubleViewProps) {
   const said = saidProp ?? SAID[trouble.kind];
   const lines = splitTroubleMessage(trouble.message);
@@ -120,7 +128,16 @@ export function TroubleView({
   // message — which is a better description than the classifier's generic one
   // for exactly the messages that carry one. Neither present: the card's own
   // fallback copy stands, so nothing is passed at all.
-  const explain = said?.explain ?? troubleExplain(lines);
+  //
+  // A LIMIT WITH ITS WINDOW says when: the CLI reported the reset as an epoch
+  // beside the failure (`Trouble.quota`), so the card prints the clock and the
+  // distance itself — and, once the server holds the comeback row, that a
+  // follow-up is scheduled — instead of telling the reader to find the time
+  // in the CLI's sentence below.
+  const explain =
+    trouble.kind === "limit" && trouble.quota
+      ? limitExplain(trouble.quota, Date.now(), !!trouble.scheduled && comebackPending !== false)
+      : (said?.explain ?? troubleExplain(lines));
   return (
     <div className="turn trouble">
       <TroubleCard

--- a/frontend/src/apps/claude/ui/follow.test.tsx
+++ b/frontend/src/apps/claude/ui/follow.test.tsx
@@ -61,6 +61,7 @@ function state(over: Partial<ChatState> = {}): ChatState {
     skills: [],
     working: null,
     trouble: null,
+    quota: null,
     permissionMode: "prompt",
     queued: [],
     historyLoading: false,

--- a/frontend/src/apps/claude/ui/placement.test.tsx
+++ b/frontend/src/apps/claude/ui/placement.test.tsx
@@ -105,6 +105,7 @@ function state(over: Partial<ChatState> = {}): ChatState {
     skills: [],
     working: null,
     trouble: null,
+    quota: null,
     permissionMode: "prompt",
     queued: [],
     historyLoading: false,

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -3161,6 +3161,43 @@ def _retry_info(row: dict):
         return None
 
 
+def _quota_info(row: dict):
+    """One `rate_limit_event` row as the page's view of it, or None if unreadable.
+
+    The CLI emits one after EVERY API response (verified on CLI 2.1.267/268):
+    `rate_limit_info` carries the plan window that gated the request — its
+    `status` (`allowed`, `allowed_warning`, `rejected`), the epoch second the
+    window resets, which window it is (`five_hour`, `seven_day`), and under
+    `unifiedWindows` the utilization of every window at once. The page used to
+    throw all of it away and then parse "resets 12:30am" back out of the
+    failure TEXT, which is a worse copy of a number the CLI had just handed
+    over. `resets_at` is what a comeback is scheduled on; `windows` is what a
+    warning pill shows before it comes to that.
+
+    Field names are re-spelled to the payload's own snake_case so the TS type
+    reads like every other poll field; the CLI's camelCase stays on the wire."""
+    info = row.get("rate_limit_info")
+    if not isinstance(info, dict):
+        return None
+    try:
+        windows = {}
+        for name, win in (info.get("unifiedWindows") or {}).items():
+            if not isinstance(win, dict):
+                continue
+            windows[str(name)] = {
+                "utilization": float(win.get("utilization") or 0),
+                "resets_at": int(win.get("resetsAt") or 0)}
+        util = info.get("utilization")
+        return {"status": str(info.get("status") or ""),
+                "type": str(info.get("rateLimitType") or ""),
+                "resets_at": int(info.get("resetsAt") or 0),
+                "utilization": (float(util) if isinstance(util, (int, float))
+                                else None),
+                "windows": windows}
+    except (TypeError, ValueError):
+        return None
+
+
 def _overload_error(error: str, info) -> str:
     """`error` rewritten to say what actually happened, for a run that died with a
     retry still in flight.
@@ -4211,6 +4248,7 @@ def _poll(run_id: str, file: str = "", app_reads: bool = False) -> dict:
     retry_total = 0      # how many retries this run has seen at all
     retry_status = 0     # HTTP status of the last one (529 overloaded, 429 …)
     gave_up = None       # the retry still in flight when the run ended badly
+    quota = None         # the latest `rate_limit_event` — plan window + reset time
     # WHAT THE RUN IS DOING RIGHT NOW, beyond the verb. Every one of these is a
     # thing the CLI already writes to out.jsonl and the page used to ignore, so
     # a long quiet stretch — a minute of extended thinking, a Bash `sleep 30`,
@@ -4379,6 +4417,12 @@ def _poll(run_id: str, file: str = "", app_reads: bool = False) -> dict:
                         "id": tid, "name": str(cb.get("name") or "tool"),
                         "detail": _tool_detail(cb.get("name"), tool_inputs.get(tid, {}))}
                     tool_input_bytes = 0
+        elif t == "rate_limit_event":
+            # Latest wins: the CLI writes one per API response and the newest
+            # is the current state of the plan window, warning or not.
+            info = _quota_info(row)
+            if info is not None:
+                quota = info
         elif t == "result":
             saw_result = True
             idle = True
@@ -4651,6 +4695,11 @@ def _poll(run_id: str, file: str = "", app_reads: bool = False) -> dict:
             "app_state": app_state, "mode": _live_mode(meta, permissions),
             "skills": skills, "retry": retry, "retry_total": retry_total,
             "retry_status": retry_status,
+            # The plan window as of the last API response (`_quota_info`).
+            # Beside `error`, not folded into it: a `rejected` status with a
+            # `resets_at` is what lets the page schedule the comeback at the
+            # actual reset instead of telling the user to wait.
+            "quota": quota,
             # The page's own stop button sets a variable and can swallow the
             # resulting error itself, but a stop from anywhere else (the
             # tasks queue card's ✕, which goes through schedule.py) needs
@@ -5429,12 +5478,21 @@ def _history(file: str, session_id: str, app_reads: bool = False) -> dict:
                 # into a text segment and print the failure twice.
                 close_stretch()
                 message = text.strip() or "the API call failed"
-                turns.append({"role": "error",
-                              # The same rewrite the live path applies to
-                              # `_poll`'s `error` (see `_account_error`), so a
-                              # usage limit reads with the same help line
-                              # whether it is live or restored.
-                              "text": _account_error(message)})
+                err_turn = {"role": "error",
+                            # The same rewrite the live path applies to
+                            # `_poll`'s `error` (see `_account_error`), so a
+                            # usage limit reads with the same help line
+                            # whether it is live or restored.
+                            "text": _account_error(message)}
+                # The transcript's own copy of the plan window (`quotaLimits`,
+                # camelCase, only on the failed row) — so a restored limit
+                # card can still say when the window resets.
+                limits = row.get("quotaLimits")
+                if isinstance(limits, dict):
+                    info = _quota_info({"rate_limit_info": limits})
+                    if info is not None:
+                        err_turn["quota"] = info
+                turns.append(err_turn)
                 continue
             stretch.append(row)
             if text.strip():

--- a/tests/test_claude_quota.py
+++ b/tests/test_claude_quota.py
@@ -1,0 +1,167 @@
+"""The plan window the CLI reports beside every reply, and what `_poll` makes of it.
+
+Claude Code writes one `rate_limit_event` row after EVERY API response (CLI
+2.1.267/268, verified over 390 real `out.jsonl` files): the status of the plan
+window that gated the request, the epoch second it resets, which window it is,
+and the utilization of every window. The page used to drop the row and, on a
+limit hit, regex the reset time back out of the failure TEXT — so these pin the
+row's translation into `quota`, the one field the comeback is scheduled on.
+"""
+import importlib.util
+import json
+import os
+
+import pytest
+
+TEMPLATE_DIR = os.path.join("fused_render", "templates", "claude")
+
+
+def _load(name):
+    path = os.path.join(TEMPLATE_DIR, name + ".py")
+    spec = importlib.util.spec_from_file_location("claude_quota_" + name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def agent():
+    return _load("agent")
+
+
+@pytest.fixture
+def run_dir(tmp_path):
+    d = tmp_path / "runs" / "run"
+    (d / "perm").mkdir(parents=True)
+    (d / "appstate").mkdir(parents=True)
+    return d
+
+
+def _poll(agent, run_dir, rows, alive=True):
+    agent.RUNS = str(run_dir.parent)
+    agent._alive = lambda _run_dir: alive
+    body = "".join(json.dumps(r) + "\n" for r in rows)
+    (run_dir / "out.jsonl").write_text(body, encoding="utf-8")
+    return agent._poll("run")
+
+
+def _event(status="allowed", resets_at=1789066800, kind="five_hour", **extra):
+    """A `rate_limit_event` as CLI 2.1.267 writes it (captured verbatim, ids
+    trimmed)."""
+    info = {"status": status, "resetsAt": resets_at, "rateLimitType": kind,
+            "overageStatus": "rejected",
+            "overageDisabledReason": "member_zero_credit_limit",
+            "isUsingOverage": False,
+            "unifiedWindows": {
+                "five_hour": {"utilization": 0.17, "resetsAt": resets_at},
+                "seven_day": {"utilization": 0.06, "resetsAt": 1789614000}}}
+    info.update(extra)
+    return {"type": "rate_limit_event", "rate_limit_info": info,
+            "uuid": "u", "session_id": "s"}
+
+
+def _limit_hit(resets_at=1789066800):
+    """The three rows a headless run writes when the plan window is spent
+    (captured from run 20260910-195317-f9d26d)."""
+    text = "You've hit your session limit · resets 12:30am (Asia/Calcutta)"
+    return [
+        _event("rejected", resets_at,
+               unifiedWindows={"five_hour": {"utilization": 1,
+                                             "resetsAt": resets_at},
+                               "seven_day": {"utilization": 0.83,
+                                             "resetsAt": 1789376400}}),
+        {"type": "assistant", "session_id": "s", "is_api_error_message": True,
+         "error": "rate_limit",
+         "message": {"role": "assistant", "content": [
+             {"type": "text", "text": text}]}},
+        {"type": "result", "subtype": "success", "is_error": True,
+         "result": text, "session_id": "s"},
+    ]
+
+
+def test_no_event_means_no_quota(agent, run_dir):
+    data = _poll(agent, run_dir, [{"type": "system", "subtype": "init",
+                                   "session_id": "s"}])
+    assert data["quota"] is None
+
+
+def test_the_event_is_translated_to_snake_case(agent, run_dir):
+    data = _poll(agent, run_dir, [_event()])
+    assert data["quota"] == {
+        "status": "allowed", "type": "five_hour", "resets_at": 1789066800,
+        "utilization": None,
+        "windows": {"five_hour": {"utilization": 0.17,
+                                  "resets_at": 1789066800},
+                    "seven_day": {"utilization": 0.06,
+                                  "resets_at": 1789614000}}}
+
+
+def test_a_warning_carries_its_utilization(agent, run_dir):
+    """`allowed_warning` is the CLI's own threshold signal — the row grows a
+    top-level `utilization` and the page shows a pill off it."""
+    data = _poll(agent, run_dir, [_event("allowed_warning", utilization=0.93,
+                                         surpassedThreshold=0.9)])
+    assert data["quota"]["status"] == "allowed_warning"
+    assert data["quota"]["utilization"] == 0.93
+
+
+def test_the_latest_event_wins(agent, run_dir):
+    data = _poll(agent, run_dir, [_event("allowed", resets_at=1),
+                                  _event("allowed_warning", resets_at=2)])
+    assert data["quota"]["status"] == "allowed_warning"
+    assert data["quota"]["resets_at"] == 2
+
+
+def test_a_limit_hit_reports_rejected_beside_the_error(agent, run_dir):
+    """THE case the field exists for: the turn ends with the CLI's own limit
+    text as `error` (rewritten by `_account_error`, same as before) AND
+    `quota.status == rejected` with the epoch the window reopens — which is
+    what the page schedules the comeback on."""
+    data = _poll(agent, run_dir, _limit_hit(), alive=False)
+    assert data["done"] is True
+    assert "usage limit was reached" in data["error"]
+    assert "resets 12:30am" in data["error"]
+    assert data["quota"]["status"] == "rejected"
+    assert data["quota"]["resets_at"] == 1789066800
+    assert data["quota"]["windows"]["five_hour"]["utilization"] == 1
+
+
+def test_an_unreadable_event_is_ignored(agent, run_dir):
+    data = _poll(agent, run_dir, [
+        {"type": "rate_limit_event", "rate_limit_info": "nope"},
+        {"type": "rate_limit_event", "rate_limit_info": {"resetsAt": "soon"}},
+    ])
+    assert data["quota"] is None
+
+
+def test_history_carries_the_transcripts_quota_on_the_error_turn(agent, tmp_path,
+                                                                  monkeypatch):
+    """The persisted transcript spells the same facts `quotaLimits`, camelCase,
+    on the failed assistant row — a restored limit card gets the reset time
+    from there."""
+    file = tmp_path / "proj" / "index.html"
+    file.parent.mkdir()
+    file.write_text("<html></html>")
+    projects = tmp_path / "projects"
+    monkeypatch.setattr(agent, "PROJECTS", str(projects))
+    pdir = projects / agent._munge(agent._workdir(str(file)))
+    pdir.mkdir(parents=True)
+    rows = [
+        {"type": "user", "uuid": "u1",
+         "message": {"role": "user", "content": "go"}},
+        {"type": "assistant", "uuid": "a1", "isApiErrorMessage": True,
+         "apiErrorStatus": 429, "error": "rate_limit",
+         "quotaLimits": {"status": "rejected", "resetsAt": 1789066800,
+                         "rateLimitType": "five_hour"},
+         "message": {"role": "assistant", "content": [
+             {"type": "text",
+              "text": "You've hit your session limit · resets 12:30am"}]}},
+    ]
+    (pdir / "sess.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    data = agent._history(str(file), "sess")
+    err = [t for t in data["turns"] if t["role"] == "error"]
+    assert len(err) == 1
+    assert err[0]["quota"]["status"] == "rejected"
+    assert err[0]["quota"]["resets_at"] == 1789066800
+    assert err[0]["quota"]["windows"] == {}


### PR DESCRIPTION
## What

Claude Code's TUI waits out a plan usage limit and continues the task on its own. A headless `-p` run (what the chat spawns) gets no such wait — the turn ends on the limit and the host reaps the CLI. The native chat now does the same thing with the scheduler it already has.

- **agent.py**: parse the CLI's `rate_limit_event` row (one per API response, CLI ≥ 2.1.267) into `quota` on the poll payload — `status` (`allowed | allowed_warning | rejected`), window, `resets_at` epoch, per-window utilization. `_history` carries the transcript's `quotaLimits` on a restored error turn. This row was previously dropped and the reset time was regexed back out of the failure text.
- **run-controller**: a turn ending with `quota.status === "rejected"` posts one scheduled message on the same session at `resets_at + 60 s` with a fixed continuation prompt (not the user's last message — same as the CLI's own auto-continue), then leaves the CLI's wait line as a `◷` note. Also emitted from the probe/repair path so a comeback that finished off-frame still reports its window.
- **Limit card**: "Nothing is broken — your plan's usage is spent for now. It resets at 3:13pm (in 2m). A follow-up is scheduled to continue this task then; cancel it from the row below." Second sentence drops once the banner's Cancel lands.
- **Topbar pill** `5h 93% · resets 4:15pm` — only on the CLI's own `allowed_warning`; hover lists every window; resets > 24 h out carry a weekday.

The scheduled row is an ordinary scheduled message: it shows in the SchedBlock banner (with Cancel), the Tasks list, and fires with `--resume` into the same conversation.

## Verified

- Live via cmux browser against a stub `claude` that replays the real 429 rows (captured from run `20260910-195317`): limit hit → card/note/banner → comeback fires → reply lands in the same chat → pill renders; cancel path; geometry at 427/1000 px; console clean.
- `bun test` 1535 pass, `tsc` clean, `check:boundaries` OK, `pytest tests/test_claude_*.py` green (7 `test_claude_health` failures pre-exist on main, environmental).

## Tests added

- `tests/test_claude_quota.py` — poll/history shapes off captured CLI rows
- `frontend/.../protocol/quota.test.ts` — copy helpers
- `frontend/.../protocol/run-controller.quota.test.ts` — schedule body, note, refused POST, non-limit error, repair path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schedules automated follow-up messages and changes error/limit handling in the live poll and repair paths; scope is bounded to usage-limit cases with tests, but touches core run lifecycle and task scheduling.
> 
> **Overview**
> Headless Claude chat runs that hit a **plan usage limit** now mirror the CLI TUI: the backend reads each API response’s `rate_limit_event` into a **`quota`** field on poll (and on restored error turns in history), instead of parsing reset times from error text.
> 
> When a turn ends with **`quota.status === "rejected"`**, the run controller **schedules one continuation message** on the same session at reset + 60s with a fixed prompt (not the user’s last message), adds a **◷ note** and a **limit trouble card** with reset time and optional “follow-up scheduled” copy, and guards against duplicate scheduling on re-attach. Failed schedule POSTs keep the limit card and add a refusal note.
> 
> The **topbar** shows a warning pill only on **`allowed_warning`**; **`TroubleView`** uses quota-aware copy and respects whether a comeback is still pending in the schedule banner. New **`quota`** helpers and tests cover copy, controller behavior, and **`agent.py`** quota parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b74fe7075808c9219142b2c29d84062a33bf0402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->