### PR TITLE
Native chat: drop the topbar plan-window pill

### DIFF
--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -2855,7 +2855,6 @@ function ChatBody(props: ChatBodyProps) {
                 subtitle={name}
                 {...(taskId ? { taskId } : {})}
                 running={running}
-                quota={state.quota}
               />
             ) : null}
             <Transcript

--- a/frontend/src/apps/claude/protocol/controller-api.ts
+++ b/frontend/src/apps/claude/protocol/controller-api.ts
@@ -184,12 +184,6 @@ export interface ChatState {
   working: Working | null;
   trouble: Trouble | null;
   /**
-   * The plan window as of the newest poll (`PollResponse.quota`), kept across
-   * the run's end so the topbar's warning pill outlives the turn that raised
-   * it. Null until a poll carries one.
-   */
-  quota: import("./types").Quota | null;
-  /**
    * The permission mode the RUN is actually in — never the picker's param, which
    * applies to the next spawn (T:13884-13886). Seeded from the mode the run was
    * started with, replaced by `poll`'s own `mode`, and moved forward by the two

--- a/frontend/src/apps/claude/protocol/quota.test.ts
+++ b/frontend/src/apps/claude/protocol/quota.test.ts
@@ -7,8 +7,6 @@ import {
   continueNote,
   limitExplain,
   limitHit,
-  quotaPill,
-  quotaTitle,
   untilText,
 } from "./quota";
 import type { Quota } from "./types";
@@ -95,33 +93,5 @@ describe("continueNote", () => {
     expect(continueNote(q())).toBe(
       "Usage limit reached · continuing automatically at " + clockText(RESET),
     );
-  });
-});
-
-describe("quotaPill", () => {
-  test("nothing on an ordinary or a rejected window — the pill is the CLI's warning only", () => {
-    expect(quotaPill(q())).toBe("");
-    expect(quotaPill(q({ status: "rejected" }))).toBe("");
-    expect(quotaPill(null)).toBe("");
-  });
-  test("the warning's own utilization, rounded, with the window's short name", () => {
-    expect(quotaPill(q({ status: "allowed_warning", utilization: 0.934 }))).toBe(
-      "5h 93% · resets " + clockText(RESET),
-    );
-    expect(
-      quotaPill(q({ status: "allowed_warning", type: "seven_day", utilization: 0.52 })),
-    ).toBe("7d 52% · resets " + clockText(RESET));
-  });
-  test("falls back to the window's utilization when the top-level one is missing", () => {
-    expect(quotaPill(q({ status: "allowed_warning" }))).toBe("5h 17% · resets " + clockText(RESET));
-  });
-});
-
-describe("quotaTitle", () => {
-  test("one line per window", () => {
-    const lines = quotaTitle(q()).split("\n");
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toBe("5h window: 17% used · resets " + clockText(RESET));
-    expect(lines[1]).toStartWith("7d window: 6% used · resets ");
   });
 });

--- a/frontend/src/apps/claude/protocol/quota.ts
+++ b/frontend/src/apps/claude/protocol/quota.ts
@@ -78,35 +78,3 @@ export function limitExplain(quota: Quota, nowMs: number, scheduled: boolean): s
 export function continueNote(quota: Quota): string {
   return "Usage limit reached · continuing automatically at " + clockText(quota.resets_at);
 }
-
-/** "5h" / "7d" — a window's short name for the pill. Unknown names pass through. */
-export function windowShort(name: string): string {
-  if (name === "five_hour") return "5h";
-  if (name === "seven_day") return "7d";
-  return name;
-}
-
-/**
- * The topbar pill, or "" when there is nothing to say. Shown ONLY on the CLI's
- * own `allowed_warning` — its threshold, not ours — so the header stays empty
- * for every ordinary turn. "5h 93% · resets 3:45pm".
- */
-export function quotaPill(quota: Quota | null | undefined): string {
-  if (!quota || quota.status !== "allowed_warning") return "";
-  const win = quota.windows[quota.type];
-  const util = quota.utilization ?? win?.utilization ?? null;
-  if (util === null) return "";
-  return (
-    windowShort(quota.type) + " " + Math.round(util * 100) + "% · resets " + clockText(quota.resets_at)
-  );
-}
-
-/** The pill's hover: every window the CLI reported, one per line. */
-export function quotaTitle(quota: Quota): string {
-  return Object.entries(quota.windows)
-    .map(
-      ([name, w]) =>
-        windowShort(name) + " window: " + Math.round(w.utilization * 100) + "% used · resets " + clockText(w.resets_at),
-    )
-    .join("\n");
-}

--- a/frontend/src/apps/claude/protocol/run-controller.quota.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.quota.test.ts
@@ -85,18 +85,6 @@ function make(handlers: Record<string, Handler>, schedule?: (body: unknown) => P
 
 const flush = () => new Promise<void>((r) => setTimeout(r, 0));
 
-describe("the plan window on the poll", () => {
-  test("rides into state and survives a poll without one", async () => {
-    const warn: Quota = { ...rejected(), status: "allowed_warning", utilization: 0.93 };
-    const c = make({
-      start: () => ({ run_id: "r1" }),
-      poll: (_f, n) => (n === 0 ? poll({ quota: warn }) : poll({ done: true, text: "ok" })),
-    });
-    await c.sendMessage("hi");
-    expect(c.getState().quota).toEqual(warn);
-  });
-});
-
 describe("a limit hit", () => {
   test("schedules the comeback on the session at the reset, and notes it", async () => {
     const posted: unknown[] = [];
@@ -220,13 +208,3 @@ describe("a limit hit", () => {
   });
 });
 
-describe("a run repaired after the fact", () => {
-  test("still hands its plan window to state — the pill for a comeback that finished off-frame", async () => {
-    const warn: Quota = { ...rejected(), status: "allowed_warning", utilization: 0.93 };
-    const c = make({
-      poll: () => poll({ done: true, message: "continue", text: "back at it", quota: warn }),
-    });
-    await c.resumeRun("r1");
-    expect(c.getState().quota).toEqual(warn);
-  });
-});

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -199,7 +199,6 @@ function emptyState(file: string | null): ChatState {
     skills: [],
     working: null,
     trouble: null,
-    quota: null,
     permissionMode: DEFAULT_PERMISSION,
     queued: [],
     historyLoading: false,
@@ -1090,10 +1089,6 @@ export function createChatController(deps: ControllerDeps): ChatController {
         // usage arrives only at message end; estimate from streamed text meanwhile
         const tokens = Math.max(poll.tokens || 0, Math.round((poll.text || "").length / 4));
         setStats(tokens, poll.phase || "thinking", poll.retry ?? null, poll.activity ?? null);
-        // The plan window rides on every poll that saw a `rate_limit_event`;
-        // a poll without one (the turn's first, an older agent.py) keeps the
-        // last known rather than blanking the pill.
-        if (poll.quota && poll.quota !== state.quota) emit({ quota: poll.quota });
         noteSkills(poll.skills);
         surfaceAppState(poll.app_state, runId);
 
@@ -2533,11 +2528,6 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // road can be added later that forgets to.
       if (runId) shownRuns.add(runId);
       const poll = probe as PollResponse;
-      // THE PLAN WINDOW OFF A PROBE TOO. A scheduled comeback that finishes
-      // before the 15 s watch attaches never reaches `pollLoop` — the repair
-      // branch below appends its turns and returns — so the warning the CLI
-      // raised on that turn has to be taken here or the pill never shows.
-      if (poll.quota && poll.quota !== state.quota) emit({ quota: poll.quota });
       if (poll.session_id) noteSessionId(String(poll.session_id));
       const probeMsg = stripBlocks(poll.message || "");
       const users = state.turns.filter((t): t is UserTurn => t.role === "user");

--- a/frontend/src/apps/claude/styles/composer.css
+++ b/frontend/src/apps/claude/styles/composer.css
@@ -89,20 +89,6 @@
      rather than one more site at a time. */
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, monospace;
 }
-/* The plan-window pill before "running": the CLI's own warning, quiet and
-   monospace like the task number beside it, coloured as a caution, never as an
-   error — nothing has failed yet. */
-.c-tb-quota {
-  flex: 0 0 auto;
-  font-size: 10.5px;
-  line-height: 1.6;
-  padding: 0 6px;
-  border-radius: 999px;
-  color: var(--c-status-progress);
-  background: color-mix(in srgb, var(--c-status-progress) 12%, transparent);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
 /* "running" at the end of the chat's name — a shimmer through the WORD, not a
    spinner, and the same mark every "running" in this app wears (T:1342-1372).
    The travel stays inside 100% -> 0% over a 300%-wide image so no frame can

--- a/frontend/src/apps/claude/ui/Topbar.tsx
+++ b/frontend/src/apps/claude/ui/Topbar.tsx
@@ -16,8 +16,6 @@
 // TASK-023 is the identifier every other surface in this app prints, so a
 // reader can carry it to the Tasks page and quote it to someone (T:12660-12672).
 import "../styles/composer.css";
-import { quotaPill, quotaTitle } from "../protocol/quota";
-import type { Quota } from "../protocol/types";
 import { ClaudeMark } from "./ClaudeMark";
 import { knownTaskId } from "./Kebab";
 
@@ -30,13 +28,9 @@ export interface TopbarProps {
   /** A turn is live: one source of truth for the mark and the composer's stop
    *  square (T:1342-1349). */
   running: boolean;
-  /** The plan window off the newest poll. Draws a pill ONLY when the CLI
-   *  itself flagged `allowed_warning`; every ordinary turn draws nothing. */
-  quota?: Quota | null;
 }
 
-export function Topbar({ sessionId, subtitle, taskId, running, quota }: TopbarProps) {
-  const pill = quotaPill(quota);
+export function Topbar({ sessionId, subtitle, taskId, running }: TopbarProps) {
   // The number, or the session hash until it lands (T:12698 — the answer to a
   // slow listing is the old label, never a gap).
   const label =
@@ -62,13 +56,6 @@ export function Topbar({ sessionId, subtitle, taskId, running, quota }: TopbarPr
       {/* `aria-live="polite"`, not assertive: this is an ambient state, and a
           reader that interrupts to announce the start of every turn is worse
           than one that mentions it when it next comes up for air (T:4078). */}
-      {pill && quota ? (
-        // The CLI's own threshold, in its own words: "5h 93% · resets 3:45pm".
-        // A reader who knows /usage reads it without a legend.
-        <span className="c-tb-quota" title={quotaTitle(quota)}>
-          {pill}
-        </span>
-      ) : null}
       {running ? (
         <span className="c-tb-run" aria-live="polite">
           running

--- a/frontend/src/apps/claude/ui/follow.test.tsx
+++ b/frontend/src/apps/claude/ui/follow.test.tsx
@@ -61,7 +61,6 @@ function state(over: Partial<ChatState> = {}): ChatState {
     skills: [],
     working: null,
     trouble: null,
-    quota: null,
     permissionMode: "prompt",
     queued: [],
     historyLoading: false,

--- a/frontend/src/apps/claude/ui/placement.test.tsx
+++ b/frontend/src/apps/claude/ui/placement.test.tsx
@@ -105,7 +105,6 @@ function state(over: Partial<ChatState> = {}): ChatState {
     skills: [],
     working: null,
     trouble: null,
-    quota: null,
     permissionMode: "prompt",
     queued: [],
     historyLoading: false,


### PR DESCRIPTION
Follow-up to #1107, which shipped one thing more than was asked for.

Beside TASK-nnn in the chat header, #1107 drew a pill — `5h 93% · resets 4:15pm` — whenever Claude Code's `rate_limit_event` reported `allowed_warning`. The request was a **card when the session limit is hit**. An always-on chip in the header on every heavy session is a second surface nobody asked for, so it goes.

## Removed

- the pill and its hover title in `ui/Topbar.tsx`, plus the `quota` prop and the `quota={state.quota}` at its one call site
- `quotaPill` / `quotaTitle` / `windowShort` in `protocol/quota.ts` and their tests
- the `.c-tb-quota` rule in `styles/composer.css`
- `ChatState.quota` and the two poll sites that wrote it — the pill was its only reader, so it was dead state once the pill went

## Kept

- the limit card with its reset time and countdown (reads `Trouble.quota`)
- the scheduled comeback (reads `poll.quota` straight off the payload)
- `agent.py`'s `rate_limit_event` → `quota` parsing and `tests/test_claude_quota.py`

Pure deletion: 131 lines out, 1 in. No Python touched.

`bun test` 5269 pass, `tsc` clean, `check:boundaries` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only deletion of header UI and unused chat state; usage-limit behavior still flows through trouble cards and schedule comeback on poll quota.
> 
> **Overview**
> Removes the **chat header usage-warning pill** (`5h 93% · resets …`) that appeared beside TASK-nnn when polls reported `allowed_warning`. That chip was extra surface beyond the intended **limit-hit card**; this PR deletes it and the plumbing that only fed it.
> 
> **Removed:** `Topbar` quota prop and pill UI; `quotaPill` / `quotaTitle` / `windowShort` in `protocol/quota.ts` and their tests; `.c-tb-quota` styles; `ChatState.quota` and the poll/probe paths that copied `PollResponse.quota` into chat state.
> 
> **Unchanged:** limit trouble card and countdown (`Trouble.quota` on error rows), scheduled comeback after a rejected window, and backend `quota` on poll payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680b0c22d15ed75649b5562eecd6616dab96daf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->