### PR TITLE
Native chat: question card lands with the transcript, and Peek opens warm

### DIFF
--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -35,7 +35,7 @@ import { currentUrl, navigateUrl } from "@platform/lib/router";
 import { createUrlParamsStore, type ParamsStore } from "./params/store";
 import { useChatParam } from "./params/useChatParams";
 import { resolveAgentDir } from "./protocol/agent";
-import { fetchHistory } from "./protocol/history";
+import { fetchHistory, sharedHistoryCache } from "./protocol/history";
 import type { SendOptions, UserTurn } from "./protocol/controller-api";
 import { watchStreamTeardown, watchTopOrigin } from "./shots";
 import type { Attachment, Receipt } from "./shots/types";
@@ -825,6 +825,7 @@ function ChatBody(props: ChatBodyProps) {
         // `/api/claude-sessions/history`, with agent.py through `/api/run`
         // behind it. See `fetchHistory`.
         history: (f, s) => fetchHistory(agentDir, f, s),
+        historyCache: sharedHistoryCache,
         model: () => liveModel.current,
         effort: () => liveEffort.current,
         hasPane: () => paneAnswer.current(),

--- a/frontend/src/apps/claude/protocol/controller-api.ts
+++ b/frontend/src/apps/claude/protocol/controller-api.ts
@@ -483,6 +483,15 @@ export interface ControllerDeps {
     file: string,
     sessionId: string,
   ) => Promise<import("./types").HistoryResponse & { error?: string }>;
+  /** ADDED (Akshil 2026-09-11, Tasks cards → Peek): the last history answer
+   *  per conversation, shared across every controller on the page. `openSession`
+   *  paints from it synchronously — transcript AND cards — before the fetch
+   *  lands, so a modal opened on a card the wall already loaded is instant, and
+   *  the fetch that follows replaces it. Absent (tests): no cache. */
+  historyCache?: {
+    get(file: string, sessionId: string): import("./types").HistoryResponse | undefined;
+    set(file: string, sessionId: string, res: import("./types").HistoryResponse): void;
+  };
   /** ADDED: the comeback after a usage limit. Injectable so bun tests see the
    *  body without a server; defaults to `@platform/lib/api`'s `scheduleMessage`
    *  (POST /api/schedule). */

--- a/frontend/src/apps/claude/protocol/history.ts
+++ b/frontend/src/apps/claude/protocol/history.ts
@@ -187,6 +187,38 @@ export { ANN_TAG };
  * `/api/run` road, byte-for-byte the same answer, so the page never loses the
  * conversation to the optimisation.
  */
+/**
+ * THE LAST HISTORY ANSWER PER CONVERSATION, page-wide (controller-api
+ * `historyCache`). Keyed by target + session because the same session id can
+ * exist under several project dirs with divergent content (`_history`'s own
+ * rule). Small and bounded: a wall of 30 cards is 30 entries; the eldest goes
+ * when the cap is hit. Module state on purpose — the Tasks wall's tile and the
+ * Peek modal opened on it are two controllers that must see one cache.
+ */
+const HISTORY_CACHE_CAP = 64;
+const historyCache = new Map<string, HistoryResponse>();
+const historyKey = (file: string, sessionId: string) => `${file}\u0000${sessionId}`;
+
+export const sharedHistoryCache = {
+  get(file: string, sessionId: string): HistoryResponse | undefined {
+    return historyCache.get(historyKey(file, sessionId));
+  },
+  set(file: string, sessionId: string, res: HistoryResponse): void {
+    const key = historyKey(file, sessionId);
+    historyCache.delete(key); // re-insert so the Map's order is recency
+    historyCache.set(key, res);
+    while (historyCache.size > HISTORY_CACHE_CAP) {
+      const eldest = historyCache.keys().next().value;
+      if (eldest === undefined) break;
+      historyCache.delete(eldest);
+    }
+  },
+  /** Tests. */
+  clear(): void {
+    historyCache.clear();
+  },
+};
+
 export async function fetchHistory(
   agentDir: string,
   file: string,

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -3136,6 +3136,58 @@ describe("cards ride on the history answer (Akshil 2026-09-11, Tasks cards wall)
     expect(peek.controller.getState().historyLoading).toBe(false);
   });
 
+  test("the fetched answer replaces the warm paint's cards — a finished run leaves no ghost card (Bugbot)", async () => {
+    const store = new Map<string, HistoryResponse>();
+    const historyCache = {
+      get: (f: string, s: string) => store.get(f + "|" + s),
+      set: (f: string, s: string, r: HistoryResponse) => void store.set(f + "|" + s, r),
+    };
+    store.set("/proj/app.py|s-abc", liveHistory("q1") as unknown as HistoryResponse);
+    const made = makeController(
+      {
+        history: () => ({ ...liveHistory("q1"), live_run: "", permissions: [], mode: "" }),
+        live_run: () => ({ run_id: "" }),
+        poll: () => poll({ done: true }),
+      },
+      createMemoryParamsStore(),
+      { historyCache },
+    );
+    const seen: string[][] = [];
+    made.controller.subscribe(() => seen.push(made.controller.getState().permissions.map((p) => p.id)));
+    await made.controller.openSession("s-abc");
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(seen.some((ids) => ids.includes("q1"))).toBe(true); // the warm paint had it
+    expect(made.controller.getState().permissions).toEqual([]); // the fetch took it away
+  });
+
+  test("a new chat stops writing into the previous session's cache entry (Bugbot)", async () => {
+    const store = new Map<string, HistoryResponse>();
+    const historyCache = {
+      get: (f: string, s: string) => store.get(f + "|" + s),
+      set: (f: string, s: string, r: HistoryResponse) => void store.set(f + "|" + s, r),
+    };
+    const made = makeController(
+      {
+        history: () => ({ ...liveHistory("q1"), permissions: [] }),
+        live_run: () => ({ run_id: "" }),
+        start: () => ({ run_id: "r2" }),
+        poll: (_f, n) =>
+          n === 0
+            ? poll({ session_id: "s-new", permissions: [question("q9")] })
+            : poll({ done: true, session_id: "s-new", permissions: [question("q9")] }),
+      },
+      createMemoryParamsStore(),
+      { historyCache },
+    );
+    await made.controller.openSession("s-abc");
+    await new Promise<void>((r) => setTimeout(r, 0));
+    made.controller.newChat();
+    await made.controller.sendMessage("hello");
+    expect(made.controller.getState().permissions.map((p) => p.id)).toEqual(["q9"]);
+    const old = store.get("/proj/app.py|s-abc")!;
+    expect((old.permissions || []).map((p) => p.id)).toEqual([]);
+  });
+
   test("the cache follows the cards a polling tile publishes", async () => {
     const store = new Map<string, HistoryResponse>();
     const historyCache = {

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -13,7 +13,7 @@ const { MARKER_VIEW } = await import("./wire");
 
 import type { runAgent } from "./agent";
 import type { AssistantTurn, ChatController, NoteTurn, UserTurn } from "./controller-api";
-import type { PermissionRow, PollResponse, Segment } from "./types";
+import type { HistoryResponse, PermissionRow, PollResponse, Segment } from "./types";
 
 // ---- fake agent.py ---------------------------------------------------------
 
@@ -91,7 +91,13 @@ const bodyOf = (sg: Segment): string => (sg as { text?: string }).text || "";
 function makeController(
   handlers: Record<string, Handler>,
   params = createMemoryParamsStore(),
-  over: { appStateBlock?: () => Promise<string> } = {},
+  over: {
+    appStateBlock?: () => Promise<string>;
+    historyCache?: {
+      get(file: string, sessionId: string): HistoryResponse | undefined;
+      set(file: string, sessionId: string, res: HistoryResponse): void;
+    };
+  } = {},
 ) {
   const agent = fakeAgent(handlers);
   const activity: number[] = [];
@@ -3016,5 +3022,142 @@ describe("a follow-up that fails after Back stays quiet (D3, QA PR #1061)", () =
     expect(controller.getState().trouble).toBeNull();
     expect(controller.getState().turns).toEqual([]);
     expect(made.returned.length).toBe(0);
+  });
+});
+
+describe("cards ride on the history answer (Akshil 2026-09-11, Tasks cards wall)", () => {
+  const question = (id: string): PermissionRow => ({
+    id,
+    tool: "AskUserQuestion",
+    input: { questions: [{ question: "Which?", options: [{ label: "A" }] }] },
+    created_at: 0,
+    decision: "",
+    scope: "",
+    mode: "",
+    answers: {},
+  });
+  const liveHistory = (id: string) => ({
+    turns: [{ role: "user", text: "hi", uuid: "u1" }],
+    transcript: null,
+    live_run: "r9",
+    permissions: [question(id)],
+    mode: "prompt",
+  });
+
+  test("the card and the transcript land in ONE emit, gate down, before any live_run lookup", async () => {
+    const made = makeController({
+      history: () => liveHistory("q1"),
+      live_run: () => ({ run_id: "r9" }),
+      poll: () => poll({ done: true, permissions: [question("q1")] }),
+    });
+    const frames: { perms: string[]; turns: number; adopting: boolean }[] = [];
+    made.controller.subscribe(() => {
+      const st = made.controller.getState();
+      frames.push({
+        perms: st.permissions.map((p) => p.id),
+        turns: st.turns.length,
+        adopting: st.adopting,
+      });
+    });
+    await made.controller.openSession("s-abc");
+    const landed = frames.find((f) => f.turns === 1);
+    expect(landed).toEqual({ perms: ["q1"], turns: 1, adopting: false });
+    // The card knows its run, so it is answerable before any poll attaches.
+    expect(made.controller.getState().permissions[0]!.runId).toBe("r9");
+  });
+
+  test("the first poll replaying the same rows does not duplicate the card", async () => {
+    const made = makeController({
+      history: () => liveHistory("q1"),
+      live_run: () => ({ run_id: "r9" }),
+      poll: () => poll({ done: true, permissions: [question("q1")] }),
+    });
+    await made.controller.openSession("s-abc");
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(made.controller.getState().permissions.map((p) => p.id)).toEqual(["q1"]);
+  });
+
+  test("an answer without `live_run` (older server) keeps the gate up as before", async () => {
+    const made = makeController({
+      history: () => ({ turns: [], transcript: null }),
+      live_run: () => ({ run_id: "" }),
+      poll: () => poll({ done: true }),
+    });
+    const seen: boolean[] = [];
+    made.controller.subscribe(() => seen.push(made.controller.getState().adopting));
+    await made.controller.openSession("s-old");
+    // The history emit itself did not lower the gate; the watch's first lap does.
+    expect(seen.includes(true)).toBe(true);
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(made.controller.getState().adopting).toBe(false);
+  });
+
+  test("a second controller paints from the shared cache before its own fetch returns (Peek on a tile)", async () => {
+    const store = new Map<string, HistoryResponse>();
+    const historyCache = {
+      get: (f: string, s: string) => store.get(f + "|" + s),
+      set: (f: string, s: string, r: HistoryResponse) => void store.set(f + "|" + s, r),
+    };
+    const tile = makeController(
+      {
+        history: () => liveHistory("q1"),
+        live_run: () => ({ run_id: "r9" }),
+        poll: () => poll({ done: true, permissions: [question("q1")] }),
+      },
+      createMemoryParamsStore(),
+      { historyCache },
+    );
+    await tile.controller.openSession("s-abc");
+    expect(store.size).toBe(1);
+
+    let release: (() => void) | null = null;
+    const peek = makeController(
+      {
+        history: () =>
+          new Promise((r) => {
+            release = () => r(liveHistory("q1"));
+          }),
+        live_run: () => ({ run_id: "r9" }),
+        poll: () => poll({ done: true, permissions: [question("q1")] }),
+      },
+      createMemoryParamsStore(),
+      { historyCache },
+    );
+    const opening = peek.controller.openSession("s-abc");
+    await new Promise<void>((r) => setTimeout(r, 0));
+    // Fetch still out — yet transcript, card and an open gate are on screen.
+    const st = peek.controller.getState();
+    expect(st.turns.length).toBe(1);
+    expect(st.permissions.map((p) => p.id)).toEqual(["q1"]);
+    expect(st.adopting).toBe(false);
+    expect(st.historyLoading).toBe(true);
+    release!();
+    await opening;
+    expect(peek.controller.getState().historyLoading).toBe(false);
+  });
+
+  test("the cache follows the cards a polling tile publishes", async () => {
+    const store = new Map<string, HistoryResponse>();
+    const historyCache = {
+      get: (f: string, s: string) => store.get(f + "|" + s),
+      set: (f: string, s: string, r: HistoryResponse) => void store.set(f + "|" + s, r),
+    };
+    const made = makeController(
+      {
+        history: () => ({ ...liveHistory("q1"), permissions: [] }),
+        live_run: () => ({ run_id: "r9" }),
+        poll: (_f, n) =>
+          n === 0
+            ? poll({ permissions: [question("q2")] })
+            : poll({ done: true, permissions: [question("q2")] }),
+      },
+      createMemoryParamsStore(),
+      { historyCache },
+    );
+    await made.controller.openSession("s-abc");
+    await new Promise<void>((r) => setTimeout(r, 0));
+    const cached = [...store.values()][0]!;
+    expect((cached.permissions || []).map((p) => p.id)).toEqual(["q2"]);
+    expect(cached.live_run).toBe("r9");
   });
 });

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -3160,6 +3160,40 @@ describe("cards ride on the history answer (Akshil 2026-09-11, Tasks cards wall)
     expect(made.controller.getState().permissions).toEqual([]); // the fetch took it away
   });
 
+  test("a card answered on the warm paint keeps its verdict when the fetch lands (Bugbot round 2)", async () => {
+    const store = new Map<string, HistoryResponse>();
+    const historyCache = {
+      get: (f: string, s: string) => store.get(f + "|" + s),
+      set: (f: string, s: string, r: HistoryResponse) => void store.set(f + "|" + s, r),
+    };
+    store.set("/proj/app.py|s-abc", liveHistory("q1") as unknown as HistoryResponse);
+    let release: (() => void) | null = null;
+    const made = makeController(
+      {
+        // The answer was built BEFORE the click: q1 still open on the wire.
+        history: () =>
+          new Promise((r) => {
+            release = () => r(liveHistory("q1"));
+          }),
+        decide: () => ({ decision: "allow", scope: "once", answers: { Which: "A" } }),
+        live_run: () => ({ run_id: "r9" }),
+        poll: () => poll({ done: true, permissions: [question("q1")] }),
+      },
+      createMemoryParamsStore(),
+      { historyCache },
+    );
+    const opening = made.controller.openSession("s-abc");
+    await new Promise<void>((r) => setTimeout(r, 0));
+    expect(made.controller.getState().permissions[0]!.decision).toBe("");
+    await made.controller.answerQuestion("q1", { Which: ["A"] });
+    expect(made.controller.getState().permissions[0]!.decision).toBe("allow");
+    release!();
+    await opening;
+    const card = made.controller.getState().permissions.find((p) => p.id === "q1")!;
+    expect(card.decision).toBe("allow");
+    expect(card.placement).toBe("parked");
+  });
+
   test("a new chat stops writing into the previous session's cache entry (Bugbot)", async () => {
     const store = new Map<string, HistoryResponse>();
     const historyCache = {

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -2233,10 +2233,18 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // only adds and updates by id, so a cache paint's card would survive an
       // answer that says the run is over (`live_run: ""`, no rows) and sit
       // there answerable, posting `decide` to a run that has ended (Bugbot, PR
-      // #1112). Nothing else has written a card yet — `openSession` cleared
-      // them and holds `sending` until this lands — so this only drops the
-      // cache's own rows.
-      if (!fromCache) permCards.clear();
+      // #1112). Only the UNDECIDED cards the answer no longer names go: the
+      // warm paint's gate is down, so a click can land while the fetch is out,
+      // and a verdict that already reached the server must not come back as an
+      // open card because this answer was built a moment before it (Bugbot,
+      // round 2). `syncPermissions` keeps a landed decision over an incoming
+      // row without one, so the decided card survives either way.
+      if (!fromCache) {
+        const named = new Set((res.permissions || []).map((p) => p && p.id));
+        for (const [id, row] of permCards) {
+          if (!named.has(id) && !row.decision) permCards.delete(id);
+        }
+      }
       syncPermissions(
         res.permissions,
         res.live_run || "",

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -2229,6 +2229,14 @@ export function createChatController(deps: ControllerDeps): ChatController {
   function landHistory(res: HistoryResponse, fromCache: boolean): void {
     const live = typeof res.live_run === "string";
     if (live) {
+      // THE FETCH REPLACES THE WARM PAINT, cards included: `syncPermissions`
+      // only adds and updates by id, so a cache paint's card would survive an
+      // answer that says the run is over (`live_run: ""`, no rows) and sit
+      // there answerable, posting `decide` to a run that has ended (Bugbot, PR
+      // #1112). Nothing else has written a card yet — `openSession` cleared
+      // them and holds `sending` until this lands — so this only drops the
+      // cache's own rows.
+      if (!fromCache) permCards.clear();
       syncPermissions(
         res.permissions,
         res.live_run || "",
@@ -2977,6 +2985,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     activeSeat = 0;
     activeTurnKey = null;
     permCards.clear();
+    restoredSid = ""; // the cache key leaves with the transcript (Bugbot, PR #1112)
     notedSkills.clear();
     answeredStates.clear();
     notedStates.clear();

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -738,7 +738,8 @@ export function createChatController(deps: ControllerDeps): ChatController {
     list: PermissionRow[] | null | undefined,
     runId: string,
     liveMode: PermissionMode | undefined,
-  ) => {
+    publish = true,
+  ): boolean => {
     // `poll.mode` is agent.py's `_live_mode` — the authoritative read of the mode
     // the run is in, so it outranks whatever the start seeded (T:16325).
     setPermissionMode(liveMode);
@@ -786,7 +787,8 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // else: KEEP `prev`. Nothing the card draws has moved, and replacing the
       // row would re-emit the whole list for a replay of the same request.
     }
-    if (changed) publishPermissions();
+    if (changed && publish) publishPermissions();
+    return changed;
   };
 
   /** Whether two readings of one request say the same thing TO THE CARD. `input`
@@ -806,14 +808,42 @@ export function createChatController(deps: ControllerDeps): ChatController {
     a.runId === b.runId &&
     JSON.stringify(a.answers ?? {}) === JSON.stringify(b.answers ?? {});
 
-  const publishPermissions = () => {
+  const permissionRows = (): PermissionRow[] => {
     const rows: PermissionRow[] = [];
     for (const row of permCards.values()) rows.push(row);
     // Open cards pinned LAST, in request order, as one contiguous block: the run
     // is blocked on them (T:14680 pinOpenCards).
     rows.sort((a, b) => Number(a.placement === "open") - Number(b.placement === "open"));
-    emit({ permissions: rows });
+    return rows;
   };
+  const publishPermissions = () => {
+    const rows = permissionRows();
+    emit({ permissions: rows });
+    rememberCards(rows);
+  };
+  /** THE CACHE FOLLOWS THE CARDS. A Peek opened on a tile that has been
+   *  polling for a minute must open on the card the tile shows NOW, not the one
+   *  the tile's history fetch saw at boot — so every published change writes
+   *  the rows (with the run they belong to) back over the cached answer. */
+  const rememberCards = (rows: PermissionRow[]) => {
+    const cache = deps.historyCache;
+    if (!cache) return;
+    // Under the id the conversation was RESTORED with, not `state.sessionId`:
+    // the first poll can re-point that to the id the CLI minted
+    // (`--fork-session`, `noteSessionId`), while the wall's tile and the Peek
+    // opened on it both still name the task's original session. Mirrored under
+    // the live id as well when the two differ, so either spelling opens warm.
+    const runId = activeRun || rows.find((r) => r.runId)?.runId || "";
+    for (const sid of new Set([restoredSid, state.sessionId])) {
+      if (!sid) continue;
+      const had = cache.get(FILE || "", sid);
+      if (!had) continue;
+      cache.set(FILE || "", sid, { ...had, live_run: runId || had.live_run || "", permissions: rows });
+    }
+  };
+  /** The session id `openSession` last restored — the cache key `rememberCards`
+   *  writes back under (see there). */
+  let restoredSid = "";
 
   /** The reason `sendError` is cleared HERE and not by the card: the row is the
    *  controller's, and a retry has to disable the buttons again — which the card
@@ -2184,6 +2214,36 @@ export function createChatController(deps: ControllerDeps): ChatController {
 
   // ---- history / sessions -------------------------------------------------
 
+  /**
+   * ONE EMIT for a restored conversation: turns, and — when the answer names a
+   * live run (`_history_live`) — its cards and the mode it is running in, with
+   * the adoption gate DOWN in the same frame. The gate exists so the transcript
+   * never paints once without its card (see `openSession`); with the card in
+   * hand there is nothing left to hold it for. An answer without `live_run`
+   * (older server, tests) keeps the gate up and the adopt watch discovers as
+   * before. The first poll of the adopted run replays the same rows and
+   * `syncPermissions` dedupes them by id.
+   *
+   * `fromCache` keeps `historyLoading` up: the fetch is still out.
+   */
+  function landHistory(res: HistoryResponse, fromCache: boolean): void {
+    const live = typeof res.live_run === "string";
+    if (live) {
+      syncPermissions(
+        res.permissions,
+        res.live_run || "",
+        (res.mode || undefined) as PermissionMode | undefined,
+        false,
+      );
+    }
+    emit({
+      turns: historyToTurns(res),
+      transcript: res.transcript ?? null,
+      ...(fromCache ? {} : { historyLoading: false }),
+      ...(live ? { permissions: permissionRows(), adopting: false } : {}),
+    });
+  }
+
   async function openSession(sessionId: string): Promise<void> {
     if (disposed) return;
     // Reuse the `sending` gate: a message sent during the await would be
@@ -2241,15 +2301,19 @@ export function createChatController(deps: ControllerDeps): ChatController {
       // `emptyState`; this is the other way a transcript is replaced.
       ownRunEndedAt: 0,
     });
+    // WHAT THIS PAGE ALREADY KNOWS ABOUT THE CONVERSATION paints before the
+    // fetch is even sent: the Tasks wall loaded this chat into a tile, and the
+    // Peek opened on that tile is a second controller with nothing of its own.
+    // Transcript and cards together, gate down — the fetch below replaces it.
+    restoredSid = sessionId;
+    const cached = deps.historyCache?.get(FILE || "", sessionId);
+    if (cached) landHistory(cached, true);
     try {
       const res = await fetchHistoryVia(sessionId);
       if (logGen !== gen || disposed) return;
       if (res.error) throw new Error(res.error);
-      emit({
-        turns: historyToTurns(res),
-        transcript: res.transcript ?? null,
-        historyLoading: false,
-      });
+      deps.historyCache?.set(FILE || "", sessionId, res);
+      landHistory(res, false);
     } catch (err) {
       // A failed restore is not a trouble card in T either — it warns and leaves
       // an empty log (T:18057-18059).
@@ -2859,6 +2923,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
       if (activeRun || sending) return;
       if (state.ownRunEndedAt !== endBefore || state.transcriptGen !== tGen) return;
       if (res.error) throw new Error(res.error);
+      deps.historyCache?.set(FILE || "", sessionId, res);
       // NOTHING IS RECORDED IN `shownRuns` HERE: a `history` row is text plus a
       // transcript `uuid` (`HistoryUserTurn`) and carries no run id, so a
       // refresh cannot say WHICH runs it just rendered. The duplicate-attach

--- a/frontend/src/apps/claude/protocol/types.ts
+++ b/frontend/src/apps/claude/protocol/types.ts
@@ -547,6 +547,12 @@ export interface TranscriptStat {
 export interface HistoryResponse {
   turns: HistoryTurn[];
   transcript: TranscriptStat;
+  /** agent.py `_history_live`: the run still going for this chat, with its
+   *  cards, so transcript and card paint in one frame. `""` = nothing live (an
+   *  answer too); absent = an older server, and the page discovers as before. */
+  live_run?: string;
+  permissions?: PermissionRow[];
+  mode?: PermissionMode | "";
 }
 
 /** agent.py:904 / 868,883. */

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -757,7 +757,8 @@ def _recap_generate(agent, file: str, session_id: str) -> str:
          "--output-format", "json", "--system-prompt", _RECAP_SYSTEM,
          _RECAP_PROMPT % tail],
         cwd=workdir, env=agent._spawn_env(), stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+        encoding="utf-8", errors="replace")
     try:
         stdout, _ = proc.communicate(timeout=_RECAP_TIMEOUT)
     except subprocess.TimeoutExpired:

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -5396,7 +5396,9 @@ def _history(file: str, session_id: str, app_reads: bool = False) -> dict:
     # folder this chat is open on), and the endpoint refuses to do it.
     stat = _transcript_stat(path)
     if not os.path.isfile(path):
-        return {"turns": [], "transcript": stat}
+        # A run can be live before its transcript exists (the CLI writes the
+        # first row after `system/init`), and its card must not wait on that.
+        return {"turns": [], "transcript": stat, **_history_live(file, session_id)}
 
     turns = []
     stretch = []  # rows of the assistant reply being read, for its segments
@@ -5527,7 +5529,41 @@ def _history(file: str, session_id: str, app_reads: bool = False) -> dict:
     # `transcript` is the watermark the page's live watch compares against
     # (origin/main, D406) — the stat taken BEFORE this read, so a row appended
     # while we were parsing shows up as a change rather than being missed.
-    return {"turns": turns, "transcript": stat}
+    return {"turns": turns, "transcript": stat, **_history_live(file, session_id)}
+
+
+def _history_live(file: str, session_id: str) -> dict:
+    """The run still going for this chat, WITH its cards, riding on the
+    history response.
+
+    Until this existed a restored conversation learned about its live run in
+    three more round trips after the transcript landed: `live_run`, then the
+    re-attach probe, then the first poll — and only that poll carried the
+    permission rows a question card is built from. The page held the
+    transcript invisible (`adopting`) the whole way so it would not paint once
+    without its card, which on the Tasks cards wall read as "chat in 3 s, card
+    in 5". The same three answers are one `listdir` and a few small reads, so
+    the history call now returns them and the page paints transcript and card
+    in the same frame (Akshil, 2026-09-11).
+
+    Same rows `_poll` returns, through the same `_permissions` / `_live_mode`,
+    so the page's dedupe-by-id contract holds when the first poll replays them.
+    `live_run: ""` when nothing is going — an answer too, and the page drops
+    the gate on it the way the first adopt lap always has."""
+    run_id = str(_live_run(file, session_id).get("run_id") or "")
+    if not run_id:
+        return {"live_run": "", "permissions": [], "mode": ""}
+    run_dir = os.path.join(RUNS, run_id)
+    try:
+        with open(os.path.join(run_dir, "meta.json"), encoding="utf-8") as fh:
+            meta = json.load(fh)
+    except (OSError, ValueError):
+        meta = {}
+    if not isinstance(meta, dict):
+        meta = {}
+    permissions = _permissions(run_dir)
+    return {"live_run": run_id, "permissions": permissions,
+            "mode": _live_mode(meta, permissions)}
 
 
 def _cancel(run_id: str, interrupt_first: bool = True,

--- a/tests/test_claude_live_run.py
+++ b/tests/test_claude_live_run.py
@@ -978,3 +978,66 @@ def test_the_widening_needs_a_session_id(agent, target, tmp_path):
     _run_dir(agent, "20260908-120000-ccc", file=folder)
     assert agent._live_run(target) == {"run_id": ""}
     assert agent._live_run(folder) == {"run_id": "20260908-120000-ccc"}
+
+
+# ---------------------------------------------------------------------------
+# `_history_live`: the live run and its cards ride on the history answer, so a
+# restored conversation paints transcript and question card in ONE frame
+# instead of learning about the run three round trips later (Akshil,
+# 2026-09-11 — the Tasks cards wall showed the chat in ~3 s and the card in ~5).
+# ---------------------------------------------------------------------------
+
+def _park_question(run_dir, request_id="q1"):
+    perm = os.path.join(run_dir, "perm")
+    os.makedirs(perm, exist_ok=True)
+    with open(os.path.join(perm, request_id + ".req.json"), "w",
+              encoding="utf-8") as f:
+        json.dump({"id": request_id, "tool": "AskUserQuestion",
+                   "tool_use_id": "toolu_1",
+                   "input": {"questions": [{"question": "Which?",
+                                            "options": [{"label": "A"}]}]},
+                   "created_at": 1}, f)
+
+
+@pytest.fixture()
+def projects(agent, tmp_path, monkeypatch):
+    p = tmp_path / "projects"
+    p.mkdir()
+    monkeypatch.setattr(agent, "PROJECTS", str(p))
+    return p
+
+
+def test_history_carries_the_live_run_and_its_cards(agent, target, projects):
+    d = _run_dir(agent, "20260911-180000-aaa", file=target, resumed_from="sess-A")
+    _park_question(d)
+    out = agent._history(target, "sess-A")
+    assert out["live_run"] == "20260911-180000-aaa"
+    assert [p["id"] for p in out["permissions"]] == ["q1"]
+    assert out["permissions"][0]["tool"] == "AskUserQuestion"
+    assert out["permissions"][0]["decision"] == ""
+    # `_live_mode` off the run's meta — the picker is right on first paint.
+    assert out["mode"] == "prompt"
+    # A run can be live before its transcript exists: the card must not wait.
+    assert out["turns"] == []
+
+
+def test_history_says_nothing_is_live_as_an_answer(agent, target, projects):
+    """`""` is the page's cue to drop the adoption gate right away, exactly as
+    the first `live_run` lap always did."""
+    _run_dir(agent, "20260911-180000-aaa", file=target, resumed_from="sess-A",
+             alive=False)
+    out = agent._history(target, "sess-A")
+    assert out["live_run"] == ""
+    assert out["permissions"] == []
+    assert out["mode"] == ""
+
+
+def test_history_live_block_matches_what_poll_returns(agent, target, projects):
+    """Same rows through the same `_permissions`, so the first poll of the
+    adopted run replays them and the page's dedupe-by-id holds."""
+    d = _run_dir(agent, "20260911-180000-aaa", file=target, resumed_from="sess-A")
+    _park_question(d, "q7")
+    hist = agent._history(target, "sess-A")
+    polled = agent._poll("20260911-180000-aaa", target)
+    assert hist["permissions"] == polled["permissions"]
+    assert hist["mode"] == polled["mode"]


### PR DESCRIPTION
## What

**Tasks cards wall:** chat showed in ~3 s, question card in ~5 s. **Peek modal** on a card re-loaded everything from scratch.

Today a restored conversation learns about its live run in three round trips *after* the transcript: `live_run` → re-attach probe → first poll (the only payload carrying permission rows). The transcript is held invisible (`adopting` gate) the whole way so it never paints without its card.

## Change

- **Server** — `_history` ends with `_history_live`: the run still going for this chat, its permission rows (same `_permissions` / `_live_mode` as `_poll`), and its mode. One `listdir` of the newest run dirs, ~10 ms. The no-transcript-yet road carries it too.
- **Controller** — `landHistory` folds the cards into the *same emit* as the turns and lowers the gate in that frame. Answers without `live_run` (older server, tests) keep the old discovery path. First poll replays the rows; `syncPermissions` dedupes by id. Cards are answerable before any poll attaches (`decide()` reads the card's `runId`).
- **Peek** — page-wide `sharedHistoryCache` (target + session → last history answer). A second controller paints transcript + cards + open gate synchronously from it before its own fetch returns; the fetch then replaces it. `publishPermissions` writes a polling tile's live cards back under the id the conversation was restored with (the poll can re-point `state.sessionId` via `--fork-session`).

## Measured (dev, :2665)

Open `?session_id` with a pending AskUserQuestion: transcript and card now land in the same probe tick, one `history` request before paint (previously history → live_run → probe → poll).

## Tests

- pytest: `_history` carries `live_run` / `permissions` / `mode`; `""` when nothing live; live block byte-equal to `_poll`'s.
- bun: cards + turns in one emit with gate down; poll replay does not duplicate; old-shape answer keeps gate up; second controller paints from cache before fetch; cache follows the tile's published cards.
- `bun test` 5293 pass, targeted pytest 344 pass, `tsc` clean, `check:boundaries` OK, `npm run build` OK.

Follow-ups (not here): pass the row's live run id from the Tasks page into tiles to skip `live_run` laps; resolve the chat template once per wall instead of per dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session restore, permission-card lifecycle, and shared in-memory cache across controllers—core chat UX paths, though behavior is heavily covered by new bun/pytest cases.
> 
> **Overview**
> Restored chats no longer wait on **`live_run` → adopt → first poll** before showing permission cards. **`_history`** now appends **`_history_live`** (`live_run`, `permissions`, `mode` — same shape as poll), including when the transcript file does not exist yet. The controller **`landHistory`** emits turns and cards in one frame and drops **`adopting`** when `live_run` is present; older servers without that field keep the prior discovery path.
> 
> **Peek / Tasks wall:** a page-wide **`sharedHistoryCache`** (target + session, cap 64) lets a second controller paint transcript + cards synchronously before its fetch finishes; the fetch then replaces the warm paint (ghost cards cleared, local answers preserved). **`publishPermissions`** writes live card state back into the cache under the restored session id.
> 
> Minor: recap subprocess uses explicit UTF-8 encoding on the server router.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c18af2503735ff3f27d810c66f49e975a486a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->