### PR TITLE
A task made from inside an app targets the app's page, not the folder around it

### DIFF
--- a/frontend/src/shell/AppPage.tsx
+++ b/frontend/src/shell/AppPage.tsx
@@ -209,7 +209,11 @@ const TAB_DEFS: Record<AppPageTab, TabDef> = {
   tasks: {
     label: "Tasks",
     Icon: ListTodo, // the sidebar's Tasks icon too (GlobalSidebar SCHEDULED_ICON)
-    render: ({ dir }) => <Scheduled scope={{ project: dir }} />,
+    // `entry` is this page's ALREADY-RESOLVED entry page (the Overview frames
+    // it), handed down so a new task opens on the app's page rather than the
+    // folder — a prefill in a field the user can still edit, not a rewrite.
+    // The filter stays on `dir`: the tab lists every task in the folder.
+    render: ({ dir, entry }) => <Scheduled scope={{ project: dir, entry }} />,
   },
   files: {
     label: "Files",

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -120,6 +120,11 @@ import { isUnderDir } from "./current-apps-lib";
 export interface TasksScope {
   /** The app folder, canonical forward-slash — the value `Task.project` carries. */
   project: string;
+  /** That folder's entry page when it has one, already resolved by the app page
+   *  (AppPage asks `getAppEntry` to frame the Overview). PREFILLS a new task's
+   *  target and nothing else — never the filter, which stays on `project` so
+   *  the tab keeps listing every task in the folder. */
+  entry?: string | null;
 }
 
 // How often the page re-reads itself. A `pending` message becomes `sent` on the
@@ -797,10 +802,14 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           // `openSeq` above.
           key={`${editing ? `edit:${editing.id}` : "new"}#${openSeq}`}
           initialTime={creating instanceof Date ? creating : null}
-          // Scoped, a new task is a task FOR THIS APP: the folder is prefilled
-          // so the modal opens ready to type. A deep link's own target still
-          // wins — it named a folder on purpose.
-          initialTarget={newTarget ?? scope?.project ?? null}
+          // Scoped, a new task is a task FOR THIS APP: the entry page is
+          // prefilled so the modal opens ready to type, because a task made
+          // from inside an app is nearly always about the page, not the folder
+          // around it. The folder is the fallback when the app has no entry.
+          // Prefill only — the field shows exactly what will be saved, and
+          // deleting the filename back to the folder is the user's to make. A
+          // deep link's own target still wins: it named a path on purpose.
+          initialTarget={newTarget ?? scope?.entry ?? scope?.project ?? null}
           initialMessage={newMessage}
           initialAttachments={newAttachments}
           chatSessionId={newSession}

--- a/frontend/src/shell/schedule-lib.test.ts
+++ b/frontend/src/shell/schedule-lib.test.ts
@@ -10,6 +10,7 @@ import {
   taskRunLabel,
   taskRunOptions,
 } from "./schedule-lib";
+import { taskFolder } from "./useMissingFolders";
 
 describe("describeRepeats", () => {
   it("reads the form's own presets", () => {
@@ -1350,17 +1351,53 @@ describe("folderHref", () => {
     // the watcher has not yet reported which session it opened. taskHref is null
     // for the whole of it, which is exactly when a run parked on a permission
     // prompt needs a way in.
-    expect(folderHref(task({ key: "pending:t1", session_id: "", target: "/Users/me/proj" })))
+    expect(folderHref(task({
+      key: "pending:t1", session_id: "",
+      project: "/Users/me/proj", target: "/Users/me/proj",
+    }))).toBe("/explorer/view/Users/me/proj?_side=claude&session_id=");
+  });
+
+  it("opens the FOLDER of a task that targets a file, not the file", () => {
+    // A task made from inside an app targets that app's entry page, and this
+    // door is the folder's sessions — a file preview has none of them on it.
+    // `project` is already that folder (routers/tasks.py:_place), so it is a
+    // field away and never a path to chop.
+    expect(folderHref(task({
+      key: "pending:t2", session_id: "",
+      project: "/Users/me/app", target: "/Users/me/app/index.html",
+    }))).toBe("/explorer/view/Users/me/app?_side=claude&session_id=");
+  });
+
+  it("falls back to the target when a row carries no project", () => {
+    expect(folderHref(task({ key: "k", project: "", target: "/Users/me/proj" })))
       .toBe("/explorer/view/Users/me/proj?_side=claude&session_id=");
   });
 
-  it("falls back to the project when the task points at no target", () => {
+  it("reads the project when the task points at no target", () => {
     expect(folderHref(task({ key: "k", target: "", project: "/Users/me" })))
       .toBe("/explorer/view/Users/me?_side=claude&session_id=");
   });
 
   it("says nothing rather than minting a url to nowhere", () => {
     expect(folderHref(task({ key: "k", target: "", project: "" }))).toBe(null);
+  });
+
+  // ONE reading of "which folder is this task's", shared by the door and the
+  // is-it-still-there stat. They disagreed once — `folderHref` read the project
+  // and `taskFolder` the target — and the cost was a live folder whose tasks all
+  // wore "Folder missing" because the entry page had been renamed.
+  it("names the same folder useMissingFolders stats", () => {
+    const t = task({
+      key: "pending:t3", session_id: "",
+      project: "/Users/me/app", target: "/Users/me/app/index.html",
+    });
+    expect(taskFolder(t)).toBe("/Users/me/app");
+    expect(folderHref(t)).toBe(`/explorer/view/Users/me/app?_side=claude&session_id=`);
+
+    const noProject = task({ key: "k", project: "", target: "/Users/me/proj" });
+    expect(taskFolder(noProject)).toBe("/Users/me/proj");
+
+    expect(taskFolder(task({ key: "k", project: "", target: "" }))).toBe("");
   });
 });
 

--- a/frontend/src/shell/schedule-lib.ts
+++ b/frontend/src/shell/schedule-lib.ts
@@ -544,7 +544,18 @@ export function explorerUrl(target: string, sessionId: string): string {
 // caller now, and this fallback is exactly what a run with no session yet needs
 // — a state the Notifications section's rows meet as often as the popover does.
 export function folderHref(task: Pick<Task, "target" | "project">): string | null {
-  const target = task.target || task.project;
+  // `project` FIRST, deliberately: this door is the run's FOLDER, and `project`
+  // is a folder by construction — `routers/tasks.py:_place` fills it from the
+  // transcript's own `cwd`, falling back to `_workdir(target)` (the target
+  // itself when it is a directory, its parent when it is a file) and, last, to
+  // the decoded project dir. Reading `target` first was the same answer for as
+  // long as a task's target was nearly always a folder; now that a task made
+  // from inside an app targets the app's ENTRY PAGE, target-first sent this to
+  // a file preview — which has none of the sessions this door promises — and
+  // this is reached only when `taskHref` declined, i.e. `session_id` is "",
+  // i.e. there is no transcript to open instead. `target` stays the fallback
+  // for a row whose project never got filled in.
+  const target = task.project || task.target;
   return target ? explorerUrl(target, "") : null;
 }
 

--- a/frontend/src/shell/useMissingFolders.ts
+++ b/frontend/src/shell/useMissingFolders.ts
@@ -20,10 +20,21 @@ import { statPath } from "@platform/lib/api";
 import { getRetainedNotifications, notify } from "@platform/lib/notifications";
 import type { HttpError, Task } from "@platform/lib/api";
 
-/** The folder a task's conversation lives in — the same field every href on
- *  this page opens (schedule-lib.folderHref, tasks-lib.taskHref). */
+/** The folder a task's conversation lives in — the same field, in the same
+ *  order, as the folder door this page opens (schedule-lib.folderHref).
+ *
+ *  `project` FIRST, because this asks "is the FOLDER still there": a task made
+ *  from inside an app targets the app's entry page, and target-first stat'd
+ *  that FILE — so renaming index.html while the folder sat right there marked
+ *  every one of the folder's tasks "Folder missing", disabled their Explorer
+ *  door and toasted "This task's folder was deleted". It also split the
+ *  one-stat-per-folder dedup below into one stat per entry file. `target` stays
+ *  the fallback for a row carrying no project.
+ *
+ *  `tasks-lib.taskHref` deliberately still reads `target` first — it wants the
+ *  file, and opens it with `_file=`. This one wants the place. */
 export function taskFolder(task: Pick<Task, "target" | "project">): string {
-  return task.target || task.project || "";
+  return task.project || task.target || "";
 }
 
 /** The hover caption on the "Folder missing" mark: the one place the path is


### PR DESCRIPTION
## The problem

The app page's Tasks tab prefilled a new task with the app **folder**, so a task written to change the app pointed at a directory listing instead of the page. Making a task from inside an app nearly always means "change this app", and the app is its entry page.

## What changes

The Tasks tab prefills that folder's **entry page** — the same page the Overview frames, resolved by the same rule every other surface asks (`app_listing.app_entry`, D301's `<meta name="fused-app">` marker). `AppPage` already has it in hand for the Overview, so the tab costs no extra call.

A prefill and nothing more: the field shows exactly what will be saved, and deleting the filename back to the folder is an ordinary edit that sticks.

The global `/tasks` picker is **deliberately untouched** — `NewJobModal.tsx` is byte-identical to main. It still hands over whatever was picked, verbatim.

`TasksScope` gains `entry` beside `project`, and the two keep separate jobs on purpose: `project` is what the list filters on, so the tab still shows every task in the folder, subfolders included.

No server change. `schedule.create` already accepted a file target, and `routers/tasks.py:_place` keeps `project` a folder — which is what files the new task under its own app.

## Two readers had to agree

A task targeting a file made a latent disagreement load-bearing:

- **`folderHref`** — the way into a run that has no session yet — read `target` first, so it would have opened a preview of the entry page, which has none of the sessions that door promises. Reads `project` first now.
- **`taskFolder`**, which the is-it-still-there stat uses, read `target` first too. Renaming an app's entry page while the folder sat right there would have marked every task in it "Folder missing", disabled its Explorer door, and toasted that the folder was deleted. It also split the one-stat-per-folder dedup into one stat per entry file.

A test pins the two to one answer, since their disagreeing is the whole failure. `tasks-lib.taskHref` still reads `target` first, deliberately — it wants the file, and opens it with `_file=`.

## Verification

- `npm run build` (boundaries + `tsc --noEmit` + vite) clean; `bun test` **5291 pass, 0 fail**.
- Browser pass on the prefill paths: entry app prefills the page, entry-less app keeps the folder, a manual edit survives and is what `/api/tasks` stores.
- No Python touched.

Reviewer note: worth a look at the two flipped call sites — every `folderHref` caller was audited (`tasks-lib`, `ScheduleCalendar`, `TaskCards` ×2, the pulse rows) and no case was found where target-first was the right answer, since `folderHref` is only reached when `session_id` is empty and there is no transcript to open instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task navigation and missing-folder detection for file targets; behavior change is intentional but affects every `folderHref` path when `session_id` is empty.
> 
> **Overview**
> **App Tasks tab** now prefills new tasks with the app’s **entry page** (passed from `AppPage` as `TasksScope.entry`) instead of only the folder, while list filtering still uses `project`. Deep-link `target` still wins; users can edit the prefilled path.
> 
> **Folder resolution** for in-flight runs (`folderHref`) and “folder missing” checks (`taskFolder`) now prefers **`project` over `target`**, so file-targeted app tasks open the folder’s Claude sessions and don’t false-flag missing folders when the entry file is renamed. Tests lock `folderHref` and `taskFolder` to the same rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17ebc3c8f4a3529d7c6f5ae556ddfd4443b17e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->