### PR TITLE
Drafts: the chat composer and the New Task modal remember what you typed

### DIFF
--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -132,7 +132,7 @@ import { useChatRecapEnabled } from "./feature-flag";
 import { useSchedule } from "./sched/useSchedule";
 import { createLiveWatch } from "./live/watch";
 import { getClaudeSessionLiveness } from "@platform/lib/api";
-import { chatDraftKey, rekeyChatDraft } from "@platform/lib/drafts";
+import { chatDraftKey, rekeyChatDraft, takeSentWithoutSession } from "@platform/lib/drafts";
 import "./styles/ann.css";
 import "./styles/chat.css";
 import "./styles/hljs.css";
@@ -2460,42 +2460,35 @@ function ChatBody(props: ChatBodyProps) {
    * again. One POST moves both, the same way `pending:<entry>` is walked onto a
    * session when a scheduled run reports one.
    *
-   * ONCE, AND ONLY FOR A CHAT THAT STARTED WITHOUT ONE. `started` latches what
-   * the very first render saw: a chat opened ON a session (a recent row, a deep
-   * link, the Tasks page) never had a `new:<file>` key, and telling the server to
-   * rename one would at best be a no-op and at worst claim a key belonging to a
-   * different, still-unsent chat in the same folder.
+   * ONLY FOR THE SEND THAT MADE THIS SESSION, and the composer is what says so
+   * (Bugbot, PR #1118, 2026-09-12). This used to be inferred from what the
+   * effect itself saw: latch "started without a session" on the first pass with
+   * an empty `state.sessionId`, then rekey when an id turned up. But an empty id
+   * on the first pass is the ORDINARY case for every chat — the id arrives only
+   * when boot's `openSession` answers — so the latch caught chats that had been
+   * opened ON a session too, and opening one in a folder that already held a
+   * `new:<file>` draft silently moved that unsent row, words and TASK number,
+   * onto a conversation it had nothing to do with. `markSentWithoutSession` is
+   * written at the one moment the answer is certain — a Send from a composer
+   * with no session — and spent here.
+   *
+   * NO LATCHES LEFT TO GET WRONG. The fact is consumed on read and keyed on the
+   * file, so the move happens once however many times the effect re-runs, and a
+   * second session-less chat in the same `ChatBody` (which is not keyed on
+   * `file` — see the boot's `bootedFor`, Bugbot PR #1061) carries its own
+   * answer rather than inheriting the first one's.
    *
    * Fire and forget, like every other write in platform/lib/drafts: a refusal
    * costs the number's continuity and nothing the reader is doing — and the
    * draft this renames is one the send is about to delete anyway.
-   *
-   * BOTH LATCHES ARE PER CONTROLLER, not per mount — the same rule, and for the
-   * same reason, as the boot's `bootedFor` above (Bugbot, PR #1061). `ChatBody`
-   * is not keyed on `file`: switching to a target whose `agentDir` is already
-   * cached rebuilds the controller WITHOUT remounting this tree, so as bare
-   * per-mount refs these two carried chat A's answers into chat B. Chat A's
-   * first send sets `rekeyed`, and a later session-less chat B in the same
-   * `ChatBody` then never moved its `new:<fileB>` draft — and the TASK number
-   * and List row wearing that key — onto the session its own first send made.
    */
-  const rekeyedFor = useRef<object | null>(null);
-  const rekeyed = useRef(false);
-  const startedWithoutSession = useRef<boolean | null>(null);
   useEffect(() => {
-    // A NEW CONTROLLER IS A NEW CHAT, so both answers are asked again: whether
-    // THIS chat started without a session, and whether ITS draft has moved.
-    if (rekeyedFor.current !== controller) {
-      rekeyedFor.current = controller;
-      rekeyed.current = false;
-      startedWithoutSession.current = null;
-    }
     const id = state.sessionId ?? "";
-    if (startedWithoutSession.current === null) startedWithoutSession.current = !id;
-    if (!startedWithoutSession.current || rekeyed.current || !id) return;
-    rekeyed.current = true;
-    void rekeyChatDraft(chatDraftKey(null, file), id);
-  }, [controller, file, state.sessionId]);
+    if (!id) return;
+    if (takeSentWithoutSession(chatDraftKey(null, file))) {
+      void rekeyChatDraft(chatDraftKey(null, file), id);
+    }
+  }, [file, state.sessionId]);
 
   const card = useMemo(
     () => ({

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -2469,16 +2469,33 @@ function ChatBody(props: ChatBodyProps) {
    * Fire and forget, like every other write in platform/lib/drafts: a refusal
    * costs the number's continuity and nothing the reader is doing — and the
    * draft this renames is one the send is about to delete anyway.
+   *
+   * BOTH LATCHES ARE PER CONTROLLER, not per mount — the same rule, and for the
+   * same reason, as the boot's `bootedFor` above (Bugbot, PR #1061). `ChatBody`
+   * is not keyed on `file`: switching to a target whose `agentDir` is already
+   * cached rebuilds the controller WITHOUT remounting this tree, so as bare
+   * per-mount refs these two carried chat A's answers into chat B. Chat A's
+   * first send sets `rekeyed`, and a later session-less chat B in the same
+   * `ChatBody` then never moved its `new:<fileB>` draft — and the TASK number
+   * and List row wearing that key — onto the session its own first send made.
    */
+  const rekeyedFor = useRef<object | null>(null);
   const rekeyed = useRef(false);
   const startedWithoutSession = useRef<boolean | null>(null);
   useEffect(() => {
+    // A NEW CONTROLLER IS A NEW CHAT, so both answers are asked again: whether
+    // THIS chat started without a session, and whether ITS draft has moved.
+    if (rekeyedFor.current !== controller) {
+      rekeyedFor.current = controller;
+      rekeyed.current = false;
+      startedWithoutSession.current = null;
+    }
     const id = state.sessionId ?? "";
     if (startedWithoutSession.current === null) startedWithoutSession.current = !id;
     if (!startedWithoutSession.current || rekeyed.current || !id) return;
     rekeyed.current = true;
     void rekeyChatDraft(chatDraftKey(null, file), id);
-  }, [file, state.sessionId]);
+  }, [controller, file, state.sessionId]);
 
   const card = useMemo(
     () => ({

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -132,7 +132,7 @@ import { useChatRecapEnabled } from "./feature-flag";
 import { useSchedule } from "./sched/useSchedule";
 import { createLiveWatch } from "./live/watch";
 import { getClaudeSessionLiveness } from "@platform/lib/api";
-import { chatDraftKey, rekeyChatDraft, takeSentWithoutSession } from "@platform/lib/drafts";
+import { chatDraftKey, rekeyChatDraft } from "@platform/lib/drafts";
 import "./styles/ann.css";
 import "./styles/chat.css";
 import "./styles/hljs.css";
@@ -1959,6 +1959,29 @@ function ChatBody(props: ChatBodyProps) {
   );
 
   /**
+   * THE SEND THAT IS OWED A REKEY — set when a Send goes out of a chat that has
+   * no session yet, because that send is the one about to create one and the
+   * `new:<file>` draft's TASK number has to follow it (the rekey effect below
+   * spends this).
+   *
+   * BOUND TO THE RUN, not left lying in the module (Bugbot, PR #1118,
+   * 2026-09-12). `controller` and `file` together are the only thing that says
+   * which conversation a later `state.sessionId` belongs to: `ChatBody` is not
+   * keyed on `file`, so switching targets can swap the file, the controller, or
+   * both under this same tree. A note kept outside the component could be spent
+   * by whichever conversation happened to report an id next — another chat in
+   * the same folder, or a session opened rather than sent — and would walk the
+   * unsent row and its number onto it. `live` is how the run's END is told from
+   * its start: `RunStatus` spells both `idle`.
+   */
+  const pendingRekey = useRef<{
+    controller: ReturnType<typeof createChatController>;
+    file: string | null;
+    key: string;
+    live: boolean;
+  } | null>(null);
+
+  /**
    * THE SEND WINDOW, SERIALIZED — one road, both kinds of send.
    *
    * `beginSend` is AWAITED (a round of notes has its pane photographed before
@@ -1995,6 +2018,13 @@ function ChatBody(props: ChatBodyProps) {
       setSendLocked(true);
       const sendId = `s${++sendSeq.current}`;
       sendHolder.current = sendId;
+      // NO SESSION UNDER THIS SEND MEANS THIS SEND MAKES ONE, which is the one
+      // moment the answer is certain — read off the controller rather than off
+      // a render, so a poll that has not landed yet cannot make an opened
+      // session look like a new one (`pendingRekey` above).
+      if (!controller.getState().sessionId) {
+        pendingRekey.current = { controller, file, key: chatDraftKey(null, file), live: false };
+      }
       // A WORDLESS send (notes or pictures alone) posts no optimistic row: its
       // bubble is the markers `stripBlocks` builds out of the composed wire,
       // and only the controller can write those.
@@ -2041,7 +2071,7 @@ function ChatBody(props: ChatBodyProps) {
         }
       })();
     },
-    [controller, beginSend, releaseSend],
+    [controller, file, beginSend, releaseSend],
   );
 
   const onSend = useCallback(
@@ -2460,35 +2490,53 @@ function ChatBody(props: ChatBodyProps) {
    * again. One POST moves both, the same way `pending:<entry>` is walked onto a
    * session when a scheduled run reports one.
    *
-   * ONLY FOR THE SEND THAT MADE THIS SESSION, and the composer is what says so
-   * (Bugbot, PR #1118, 2026-09-12). This used to be inferred from what the
-   * effect itself saw: latch "started without a session" on the first pass with
-   * an empty `state.sessionId`, then rekey when an id turned up. But an empty id
-   * on the first pass is the ORDINARY case for every chat — the id arrives only
-   * when boot's `openSession` answers — so the latch caught chats that had been
-   * opened ON a session too, and opening one in a folder that already held a
-   * `new:<file>` draft silently moved that unsent row, words and TASK number,
-   * onto a conversation it had nothing to do with. `markSentWithoutSession` is
-   * written at the one moment the answer is certain — a Send from a composer
-   * with no session — and spent here.
+   * ONLY FOR THE SEND THAT MADE THIS SESSION. This used to be inferred from
+   * what the effect itself saw: latch "started without a session" on the first
+   * pass with an empty `state.sessionId`, then rekey when an id turned up. But
+   * an empty id on the first pass is the ORDINARY case for every chat — the id
+   * arrives only when boot's `openSession` answers — so the latch caught chats
+   * that had been opened ON a session too, and opening one in a folder that
+   * already held a `new:<file>` draft silently moved that unsent row, words and
+   * TASK number, onto a conversation it had nothing to do with. Its first
+   * replacement moved the answer into a module-level set the composer wrote at
+   * the send; that fixed the inference but not the OWNERSHIP — nothing said
+   * which session was allowed to spend the note, so switching conversations in
+   * the same folder before the first poll returned spent it on the wrong one
+   * (Bugbot, PR #1118, 2026-09-12).
    *
-   * NO LATCHES LEFT TO GET WRONG. The fact is consumed on read and keyed on the
-   * file, so the move happens once however many times the effect re-runs, and a
-   * second session-less chat in the same `ChatBody` (which is not keyed on
-   * `file` — see the boot's `bootedFor`, Bugbot PR #1061) carries its own
-   * answer rather than inheriting the first one's.
+   * SO THE NOTE CARRIES ITS RUN. `pendingRekey` is written where the send is
+   * dispatched and remembers the controller and file it was dispatched for; the
+   * three things that can happen to it are all answered here, in order:
+   *
+   *   * THIS IS NOT THAT CONVERSATION any more (a different controller, or the
+   *     same one now pointed at another file) — drop the note unspent, because
+   *     the id this chat is about to report was not made by our send;
+   *   * THE ID LANDED for the run we sent — move the draft, once, and drop it;
+   *   * THE RUN ENDED WITHOUT ONE — drop it. `RunStatus` has no separate
+   *     "ended", so an end is only an end after the run has been seen live;
+   *     a send refused before it ever ran leaves the note to the ownership
+   *     check, which is the next thing that touches it.
    *
    * Fire and forget, like every other write in platform/lib/drafts: a refusal
    * costs the number's continuity and nothing the reader is doing — and the
    * draft this renames is one the send is about to delete anyway.
    */
   useEffect(() => {
-    const id = state.sessionId ?? "";
-    if (!id) return;
-    if (takeSentWithoutSession(chatDraftKey(null, file))) {
-      void rekeyChatDraft(chatDraftKey(null, file), id);
+    const pending = pendingRekey.current;
+    if (!pending) return;
+    if (pending.controller !== controller || pending.file !== file) {
+      pendingRekey.current = null;
+      return;
     }
-  }, [file, state.sessionId]);
+    const id = state.sessionId ?? "";
+    if (id) {
+      pendingRekey.current = null;
+      void rekeyChatDraft(pending.key, id);
+      return;
+    }
+    if (state.status !== "idle") pending.live = true;
+    else if (pending.live) pendingRekey.current = null;
+  }, [controller, file, state.sessionId, state.status]);
 
   const card = useMemo(
     () => ({

--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -132,6 +132,7 @@ import { useChatRecapEnabled } from "./feature-flag";
 import { useSchedule } from "./sched/useSchedule";
 import { createLiveWatch } from "./live/watch";
 import { getClaudeSessionLiveness } from "@platform/lib/api";
+import { chatDraftKey, rekeyChatDraft } from "@platform/lib/drafts";
 import "./styles/ann.css";
 import "./styles/chat.css";
 import "./styles/hljs.css";
@@ -2446,6 +2447,38 @@ function ChatBody(props: ChatBodyProps) {
     });
     return watch.start();
   }, [controller, inChat, state.sessionId]);
+
+  /**
+   * THE DRAFT'S TASK NUMBER FOLLOWS THE SESSION THE CHAT TURNS OUT TO BE
+   * (design.md, Round 2: "Every draft has a TASK number").
+   *
+   * A brand-new conversation has no session id, so its composer autosaves under
+   * `new:<file>` and the server gives THAT key a TASK-NNN and a row on the List.
+   * The first send creates the session; from the next render the composer keys
+   * on the session id instead (Composer's `draftKey`), and without this the
+   * number — and the row wearing it — would be stranded on a key nothing reads
+   * again. One POST moves both, the same way `pending:<entry>` is walked onto a
+   * session when a scheduled run reports one.
+   *
+   * ONCE, AND ONLY FOR A CHAT THAT STARTED WITHOUT ONE. `started` latches what
+   * the very first render saw: a chat opened ON a session (a recent row, a deep
+   * link, the Tasks page) never had a `new:<file>` key, and telling the server to
+   * rename one would at best be a no-op and at worst claim a key belonging to a
+   * different, still-unsent chat in the same folder.
+   *
+   * Fire and forget, like every other write in platform/lib/drafts: a refusal
+   * costs the number's continuity and nothing the reader is doing — and the
+   * draft this renames is one the send is about to delete anyway.
+   */
+  const rekeyed = useRef(false);
+  const startedWithoutSession = useRef<boolean | null>(null);
+  useEffect(() => {
+    const id = state.sessionId ?? "";
+    if (startedWithoutSession.current === null) startedWithoutSession.current = !id;
+    if (!startedWithoutSession.current || rekeyed.current || !id) return;
+    rekeyed.current = true;
+    void rekeyChatDraft(chatDraftKey(null, file), id);
+  }, [file, state.sessionId]);
 
   const card = useMemo(
     () => ({

--- a/frontend/src/apps/claude/ui/Composer.test.tsx
+++ b/frontend/src/apps/claude/ui/Composer.test.tsx
@@ -1,12 +1,24 @@
 import { installDomShim } from "@platform/lib/testDomShim";
 installDomShim();
-import { expect, test } from "bun:test";
+import { afterEach, beforeEach, expect, test } from "bun:test";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 
 const { ComposerCard, BLOCKED_SEND_TITLE, CHAT_PLACEHOLDER, HOME_PLACEHOLDER } =
   await import("./Composer");
 const { DEFAULT_EFFORT, DEFAULT_MODEL, DEFAULT_PERMISSION } =
   await import("./composer-defaults");
+
+const realFetch = globalThis.fetch;
+beforeEach(() => {
+  (globalThis as { fetch: unknown }).fetch = () =>
+    Promise.resolve(new Response("{}", { status: 200 }));
+});
+
+const mounted: ReactTestRenderer[] = [];
+afterEach(() => {
+  for (const r of mounted.splice(0)) act(() => r.unmount());
+  (globalThis as { fetch: unknown }).fetch = realFetch;
+});
 
 const controls = {
   model: DEFAULT_MODEL,
@@ -45,6 +57,7 @@ function mount(over: Partial<Parameters<typeof ComposerCard>[0]> = {}) {
       />,
     );
   });
+  mounted.push(renderer!);
   const root = renderer!.root;
   const box = () => root.findByType("textarea");
   const type = (value: string) =>
@@ -509,6 +522,7 @@ test("clicking Send puts focus back in the textarea", () => {
       { createNodeMock: (el) => (el.type === "textarea" ? node : null) },
     );
   });
+  mounted.push(renderer);
   const root = renderer.root;
   act(() => {
     root.findByType("textarea").props.onChange({ currentTarget: { value: "hello" } });

--- a/frontend/src/apps/claude/ui/Composer.tsx
+++ b/frontend/src/apps/claude/ui/Composer.tsx
@@ -17,6 +17,7 @@ import {
   chatDraftKey,
   deleteChatDraft,
   fetchChatDraft,
+  markSentWithoutSession,
   saveChatDraft,
   useAutosave,
   type DraftAttachment,
@@ -586,6 +587,13 @@ export function ComposerCard({
     // whichever write is running, THEN the delete goes out; `submit` itself
     // does not wait on either (Akshil, 2026-09-11).
     autosaveRef.current.reset({ text: "", attachments: [] });
+    // AND IF THERE WAS NO SESSION UNDER IT, THIS IS THE SEND THAT CREATES ONE
+    // (Bugbot, PR #1118, 2026-09-12). The draft's TASK number and List row are
+    // sitting on `new:<file>` and have to follow that session, but only the
+    // composer can tell this send apart from the many renders in which a chat
+    // opened ON a session simply has not heard its id back yet. Recorded here,
+    // where the answer is certain; `ClaudeChat` spends it when the id lands.
+    if (!sessionId) markSentWithoutSession(draftKeyRef.current);
     void autosaveRef.current.settle().then(() => deleteChatDraft(draftKeyRef.current));
     // A live run gets this message DIRECTLY instead of parking it in a
     // page-side array (T:17889-17899).
@@ -606,7 +614,7 @@ export function ComposerCard({
     // that also scrolls fights it.
     boxRef.current?.focus({ preventScroll: true });
     return true;
-  }, [blocked, attaching, busyRef, sendBusy, text, hasAttachments, running, onFollowUp, onSend, controls, boxRef]);
+  }, [blocked, attaching, busyRef, sendBusy, text, hasAttachments, running, onFollowUp, onSend, controls, boxRef, sessionId]);
 
   // The seat for the programmatic send. In an EFFECT so a render React throws
   // away (StrictMode's double invoke, a concurrent attempt that loses) cannot

--- a/frontend/src/apps/claude/ui/Composer.tsx
+++ b/frontend/src/apps/claude/ui/Composer.tsx
@@ -17,7 +17,6 @@ import {
   chatDraftKey,
   deleteChatDraft,
   fetchChatDraft,
-  markSentWithoutSession,
   saveChatDraft,
   useAutosave,
   type DraftAttachment,
@@ -587,13 +586,6 @@ export function ComposerCard({
     // whichever write is running, THEN the delete goes out; `submit` itself
     // does not wait on either (Akshil, 2026-09-11).
     autosaveRef.current.reset({ text: "", attachments: [] });
-    // AND IF THERE WAS NO SESSION UNDER IT, THIS IS THE SEND THAT CREATES ONE
-    // (Bugbot, PR #1118, 2026-09-12). The draft's TASK number and List row are
-    // sitting on `new:<file>` and have to follow that session, but only the
-    // composer can tell this send apart from the many renders in which a chat
-    // opened ON a session simply has not heard its id back yet. Recorded here,
-    // where the answer is certain; `ClaudeChat` spends it when the id lands.
-    if (!sessionId) markSentWithoutSession(draftKeyRef.current);
     void autosaveRef.current.settle().then(() => deleteChatDraft(draftKeyRef.current));
     // A live run gets this message DIRECTLY instead of parking it in a
     // page-side array (T:17889-17899).
@@ -614,7 +606,7 @@ export function ComposerCard({
     // that also scrolls fights it.
     boxRef.current?.focus({ preventScroll: true });
     return true;
-  }, [blocked, attaching, busyRef, sendBusy, text, hasAttachments, running, onFollowUp, onSend, controls, boxRef, sessionId]);
+  }, [blocked, attaching, busyRef, sendBusy, text, hasAttachments, running, onFollowUp, onSend, controls, boxRef]);
 
   // The seat for the programmatic send. In an EFFECT so a render React throws
   // away (StrictMode's double invoke, a concurrent attempt that loses) cannot

--- a/frontend/src/apps/claude/ui/Composer.tsx
+++ b/frontend/src/apps/claude/ui/Composer.tsx
@@ -13,6 +13,14 @@ import {
   type ReactNode,
 } from "react";
 import { useAutoGrow } from "@platform/lib/autoGrow";
+import {
+  chatDraftKey,
+  deleteChatDraft,
+  fetchChatDraft,
+  saveChatDraft,
+  useAutosave,
+  type DraftAttachment,
+} from "@platform/lib/drafts";
 import "../styles/composer.css";
 import type { PermissionMode } from "../protocol/types";
 import type { RunStatus, SendOptions } from "../protocol/controller-api";
@@ -394,6 +402,95 @@ export function ComposerCard({
     if (back.length) restoreAttachments.current?.(back.map((a) => a.path));
   }, [file]);
   const { ref: boxRef, grow } = useAutoGrow(text);
+
+  // ---- THE SERVER-SIDE DRAFT (design.md, "Client behavior / Chat composer") --
+  //
+  // The stash above is the SCHEDULE HOP — one navigation, this tab, spent on
+  // read. This is the other lifetime: what the reader typed and did not send,
+  // kept on the server so it survives a reload, another window, and opening a
+  // different chat and coming back. Additive in one direction, exactly as the
+  // design says: the hop is untouched and wins, because it is the more specific
+  // fact (a draft that was on its way to the task form thirty seconds ago).
+  //
+  // The key is the session, or `new:<file>` while the chat has not got one yet
+  // (chatDraftKey). A brand-new chat's first send both creates the session and
+  // deletes the draft, so nothing is ever re-keyed under the reader.
+  const draftKey = chatDraftKey(sessionId, file);
+  // What the box holds RIGHT NOW, for the async seed below to check against —
+  // `text` inside that closure is the value from the render that started the
+  // fetch, which is precisely the one that may be stale by the time it answers.
+  const textRef = useRef(text);
+  textRef.current = text;
+  // ONCE PER KEY, and never killed by a cleanup. The first shape latched a
+  // single "seeded" ref AND flipped an `alive` flag in the effect's cleanup;
+  // the two together lost every draft (owner E2E flow D, 2026-09-11): the
+  // key changes once on most mounts (the session id lands a render after the
+  // box does, `new:<file>` → `<session>`), so the cleanup killed the fetch in
+  // flight and the latch refused the re-run. Now each key fetches once, a
+  // late answer is judged only by whether the box is still empty, and a
+  // StrictMode double mount costs one duplicate GET whose second answer is a
+  // no-op `setText` of the same words.
+  const seededKeys = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (seededKeys.current.has(draftKey)) return;
+    seededKeys.current.add(draftKey);
+    // The hop already filled the box: it is newer and more specific, and the
+    // server's copy is about to be overwritten by the first autosave anyway.
+    if (textRef.current) return;
+    void fetchChatDraft(draftKey).then((saved) => {
+      if (!saved) return;
+      // WORDS TYPED WHILE THE FETCH WAS IN FLIGHT outrank anything it can
+      // answer (design.md: "a composer that is focused ignores incoming draft
+      // updates"). The test is the words, NOT the caret: `autoFocus` below puts
+      // the caret in the box on mount, before any fetch can answer.
+      if (textRef.current) return;
+      if (saved.text) {
+        setText(saved.text);
+        // Restored words are already the server's words: tell the autosave so
+        // the box coming back does not cost a PUT of the same text.
+        autosaveRef.current.reset({ text: saved.text, attachments: saved.attachments ?? [] });
+        grow();
+      }
+      // The tray's half, through the same door "Back to chat" uses: these are
+      // real paths, so they are registered rather than uploaded.
+      if (saved.attachments?.length) {
+        restoreAttachments.current?.(saved.attachments.map((a) => a.path));
+      }
+    });
+  }, [draftKey, grow]);
+
+  // What the tray holds, in the draft's own three fields. Read during render
+  // because `attachments()` is a plain read of the host's state (ClaudeChat
+  // passes `() => attach.items`), and `pending`/`view`-less chips are left out
+  // for SchedButton's reason: a chip still uploading names no file yet.
+  const trayDraft: DraftAttachment[] = attachments
+    ? attachments()
+        .filter((a) => !a.pending && !!a.view)
+        .map((a) => ({
+          path: a.view as string,
+          name: a.name || (a.view as string),
+          // Anything that is not a picture wears the glyph, the same floor
+          // `parseAttachmentsParam` applies to a stash row.
+          kind: a.kind === "image" ? "image" : "file",
+        }))
+    : [];
+  // 600 ms after the last keystroke, plus blur / pagehide / unmount. Empty text
+  // with an empty tray is a DELETE server-side, so clearing the box by hand
+  // clears the draft too without this having to know the difference.
+  // Returns the write's own promise (rather than `void`-discarding it, like
+  // most fire-and-forget callers of `saveChatDraft`) so `autosave.settle()`
+  // below can tell when it actually lands (Akshil, 2026-09-11).
+  const autosave = useAutosave({ text, attachments: trayDraft }, (value, opts) =>
+    saveChatDraft(draftKey, value.text, value.attachments, opts),
+  );
+  // `submit` is a useCallback built below; it needs the autosave handle, and the
+  // handle's identity is stable, so it is read through the ref every other seat
+  // in this file uses for the same reason.
+  const autosaveRef = useRef(autosave);
+  autosaveRef.current = autosave;
+  const draftKeyRef = useRef(draftKey);
+  draftKeyRef.current = draftKey;
+
   const rowRef = useRef<HTMLDivElement | null>(null);
   // The host's ref MIRRORS ours rather than replacing it: `useAutoGrow` owns the
   // element it measures, and a modal's `initialFocus` only needs to be able to
@@ -480,6 +577,16 @@ export function ComposerCard({
     const message = extra ? (typed ? typed.replace(/\s*$/, "") + "\n\n" + extra : extra) : typed;
     if (!message && !hasAttachments) return false;
     setText("");
+    // THE DRAFT IS SPENT. `reset` first and with the value the box is ABOUT to
+    // have: a write debounced a keystroke ago would otherwise land after the
+    // DELETE and put the sent message back on the list as an unsent draft.
+    // `reset` only cancels that PENDING timer, though — a PUT already in
+    // flight (fired a keystroke before this one) cannot be cancelled and
+    // would still land after an immediate delete. `settle()` waits out
+    // whichever write is running, THEN the delete goes out; `submit` itself
+    // does not wait on either (Akshil, 2026-09-11).
+    autosaveRef.current.reset({ text: "", attachments: [] });
+    void autosaveRef.current.settle().then(() => deleteChatDraft(draftKeyRef.current));
     // A live run gets this message DIRECTLY instead of parking it in a
     // page-side array (T:17889-17899).
     if (running && onFollowUp) onFollowUp(message);

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -4818,6 +4818,17 @@ export function scheduleMessage(body: {
   // delete the client made separately could be the half that failed, leaving a
   // draft row beside the task it had already become.
   draft_id?: string;
+  // THE CHAT DRAFT THIS TASK WAS TYPED IN, when the card was opened from the
+  // composer's Schedule button (`new:<file>` for a chat with no session yet, a
+  // session id otherwise). The server deletes it as part of creating the task.
+  //
+  // NOT THE SAME THING AS `draft_id`, and not covered by `session_id` either:
+  // the hop's first autosave normally moves the chat draft onto the task draft,
+  // but Schedule pressed inside that 600 ms debounce mints no task draft at all
+  // — and a brand-new chat has no session id to travel in the other field. So
+  // the origin key rides here, and the composer's copy goes wherever this task
+  // came from (Bugbot, PR #1118).
+  from_chat_key?: string;
 }): Promise<{ entry: ScheduledMessage }> {
   return postJson<{ entry: ScheduledMessage }>("/api/schedule", body);
 }

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2996,7 +2996,10 @@ export interface Task {
   // merely SCHEDULED at the session (`entry`). The last two are named apart
   // because only `entry` can be the message a form is composing right now; see
   // sessionTitleOf and tasks.py `_title`.
-  title_source: "user" | "ai" | "message" | "entry";
+  // …plus `"draft"` on a draft row, whose name is the form's own Title field
+  // (or the first line of its description, or "Untitled draft") — there is no
+  // session or entry behind it to take one from.
+  title_source: "user" | "ai" | "message" | "entry" | "draft";
   description: string;
   // Decided by the SERVER, once, for every view — List, Board and Calendar all
   // read this rather than each deriving a column from the newest message.
@@ -3018,6 +3021,71 @@ export interface Task {
   // actually ran can fail.
   status: "upcoming" | "in_progress" | "needs_attention" | "blocked" | "done"
     | "archived";
+  /**
+   * WHICH KIND OF ROW THIS IS — and the one field that says a row is not a task
+   * at all.
+   *
+   * Absent (or "task") on every ordinary row. `"draft"` is an unfinished New
+   * task form the server is holding (fused_render/drafts.py), emitted as a row
+   * so the List and the Board can offer it back: no number, no session, no run,
+   * and no verb — run, archive, erase, drag — applies to it.
+   *
+   * A draft's `status` is `"upcoming"`, deliberately, so every existing lane
+   * switch on this page keeps working on it; `kind` is what tells the two apart
+   * where it matters (tasks-lib.isDraftTask, which taskColumn asks). It draws
+   * inside the Upcoming lane rather than in a lane of its own — an unfinished
+   * thing is the most upcoming thing, and six columns is already the width
+   * budget (design.md, Decisions, Akshil 2026-09-11).
+   */
+  kind?: "task" | "draft";
+  /** The same fact the server spells a second way on a draft row. Read `kind`;
+   *  this is here so the shape is describable, not so it is asked twice. */
+  state?: "draft";
+  /**
+   * WHICH KIND OF DRAFT (design.md, Round 2: "New-chat drafts are rows").
+   *
+   * Only on a `kind: "draft"` row, and only two answers. `"task"` is the
+   * unfinished New task form — it carries `draft_id` and `form`, and its row
+   * re-opens that card. `"chat"` is a conversation NOBODY HAS SENT YET: a
+   * composer holding words in a folder whose chat has no session, keyed
+   * `new:<file>` — it carries `file` and `draft`, no form, and its row opens
+   * that folder's chat with the composer already prefilled.
+   *
+   * The two are one mark to the reader (both wear the Draft chip, both sort to
+   * the top of the List) and two entirely different presses, which is the whole
+   * reason the server spells the difference out rather than leaving it to be
+   * inferred from which of `draft_id` / `file` happens to be set.
+   *
+   * Absent on a server that predates the second kind, where every draft row is
+   * a task draft — tasks-lib reads it that way round deliberately.
+   */
+  draft_kind?: "task" | "chat";
+  /**
+   * The chat's own `file` — the path its Claude pane is mounted on, and the
+   * `<file>` half of a `new:<file>` draft key (platform/lib/drafts.chatDraftKey
+   * carries the rule that keeps the four spellings of it in step).
+   *
+   * Only on a `draft_kind: "chat"` row. It is what the row's press turns into a
+   * URL, and it is deliberately NOT the same field as `target`: `target` is
+   * where a TASK's work happens, which a draft chat does not have yet.
+   */
+  file?: string;
+  // The client-minted uuid a task draft lives under (`PUT /api/drafts/task/…`).
+  // Present only on a `kind: "draft"` row; it is what the New task form reopens
+  // on, and what `POST /api/schedule` is handed so the server can delete the
+  // draft as the task is created.
+  draft_id?: string;
+  // The saved form itself, verbatim — what the modal re-opens on. Only on a
+  // draft row. Typed loosely on purpose: the authority on this shape is the
+  // form (shell/NewJobModal), and a second copy of its field list here would go
+  // stale the first time the card grows a control.
+  form?: Record<string, unknown>;
+  // THE CHAT DRAFT JOINED ONTO A SESSION ROW (design.md, "List / Board / Cards
+  // rows"): unsent words sitting in this task's composer, so the row can wear a
+  // `Draft` chip and say what they start with. Joined server-side by
+  // `session_id`, the same place the unread numbers are joined; null — or
+  // absent, on a server that predates drafts — means there is nothing unsent.
+  draft?: { preview: string; updated_at: number } | null;
   // Did the newest message's run break? `status` is the authority on which
   // column a task belongs in; this is the raw fact underneath it, and the two
   // disagree in exactly one direction — a task triaged to `done`, or one whose
@@ -4744,6 +4812,12 @@ export function scheduleMessage(body: {
   // of which a minted path can supply. Sent alongside `images`, never instead
   // of it, so an entry keeps the shape every existing reader expects.
   attachments?: TaskAttachment[];
+  // THE DRAFT THIS TASK WAS COMPOSED IN, when it was composed in one: the New
+  // task form's own uuid (`PUT /api/drafts/task/<id>`). The server deletes that
+  // draft as part of creating the task, so the two can never both exist — a
+  // delete the client made separately could be the half that failed, leaving a
+  // draft row beside the task it had already become.
+  draft_id?: string;
 }): Promise<{ entry: ScheduledMessage }> {
   return postJson<{ entry: ScheduledMessage }>("/api/schedule", body);
 }

--- a/frontend/src/platform/lib/drafts.test.ts
+++ b/frontend/src/platform/lib/drafts.test.ts
@@ -30,9 +30,11 @@ import {
   chatDraftKey,
   deleteChatDraft,
   fetchChatDraft,
+  markSentWithoutSession,
   newChatFile,
   rekeyChatDraft,
   saveChatDraft,
+  takeSentWithoutSession,
   saveTaskDraft,
   useAutosave,
   type Autosave,
@@ -406,46 +408,51 @@ describe("rekeyChatDraft", () => {
 describe("the chat rekeys its draft when it learns its session", () => {
   const chat = () =>
     readFileSync(join(import.meta.dir, "../../apps/claude/ClaudeChat.tsx"), "utf8");
+  const composer = () =>
+    readFileSync(join(import.meta.dir, "../../apps/claude/ui/Composer.tsx"), "utf8");
   const effect = () => {
     const s = chat();
-    const at = s.indexOf("const rekeyedFor = useRef<object | null>(null);");
-    return s.slice(at, s.indexOf("}, [controller, file, state.sessionId]);", at));
+    const at = s.indexOf("const id = state.sessionId ?? \"\";\n    if (!id) return;");
+    return s.slice(at, s.indexOf("}, [file, state.sessionId]);", at));
   };
 
   test("posts the move once, from the `new:<file>` key onto the session", () => {
     expect(effect()).toContain("void rekeyChatDraft(chatDraftKey(null, file), id);");
     // The same key the composer autosaves under — one function, so the two
     // halves cannot spell the path differently.
-    expect(chat()).toContain('import { chatDraftKey, rekeyChatDraft } from "@platform/lib/drafts";');
+    expect(chat()).toContain(
+      'import { chatDraftKey, rekeyChatDraft, takeSentWithoutSession } from "@platform/lib/drafts";',
+    );
   });
 
-  test("only for a chat that STARTED without a session", () => {
-    // A chat opened ON a session (a recent row, a deep link, the Tasks page)
-    // never had a `new:<file>` key; renaming one would at best be a no-op and at
-    // worst claim a key belonging to a different unsent chat in the same folder.
+  test("gated on the SEND that had no session, not on an observed empty id", () => {
+    // Bugbot, PR #1118 (2026-09-12): the old latch asked whether the first pass
+    // saw an empty `state.sessionId`, which is the ordinary first pass for every
+    // chat — the id arrives only when boot's `openSession` answers. Opening an
+    // existing session in a folder holding a `new:<file>` draft therefore moved
+    // that unsent row, words and TASK number, onto the wrong conversation.
     const e = effect();
-    expect(e).toContain("if (startedWithoutSession.current === null) startedWithoutSession.current = !id;");
-    expect(e).toContain("if (!startedWithoutSession.current || rekeyed.current || !id) return;");
-    expect(e).toContain("rekeyed.current = true;");
+    expect(e).toContain("if (takeSentWithoutSession(chatDraftKey(null, file))) {");
+    // Nothing infers the answer from what the effect happens to see any more.
+    expect(chat()).not.toContain("startedWithoutSession");
+    expect(chat()).not.toContain("rekeyedFor");
   });
 
-  test("both latches are PER CONTROLLER, so a second session-less chat still rekeys", () => {
-    // `ChatBody` is not keyed on `file` (see the boot's `bootedFor`, Bugbot PR
-    // #1061): switching to a target whose `agentDir` is already cached rebuilds
-    // the controller WITHOUT remounting this tree. As bare per-mount refs, chat
-    // A's first send left `rekeyed` set, and a later session-less chat B in the
-    // same body never moved its `new:<fileB>` draft — nor the TASK number and
-    // List row wearing that key — onto the session its own first send made.
-    const e = effect();
-    expect(e).toContain("const rekeyedFor = useRef<object | null>(null);");
-    expect(e).toContain("if (rekeyedFor.current !== controller) {");
-    expect(e).toContain("rekeyedFor.current = controller;");
-    // BOTH answers are asked again, not just the one: a chat B opened ON a
-    // session must re-learn that too, or A's `startedWithoutSession` decides it.
-    expect(e).toContain("rekeyed.current = false;");
-    expect(e).toContain("startedWithoutSession.current = null;");
-    // ...and the effect has to RUN on the rebuild for any of that to happen.
-    expect(chat()).toContain("}, [controller, file, state.sessionId]);");
+  test("the composer marks it, and only when there is no session under the send", () => {
+    const c = composer();
+    expect(c).toContain("if (!sessionId) markSentWithoutSession(draftKeyRef.current);");
+    // The same key the delete on the next line spends, not a re-derived one.
+    expect(c).toContain("deleteChatDraft(draftKeyRef.current)");
+    expect(c).toContain("  markSentWithoutSession,\n");
+  });
+
+  test("no per-mount latches left, because the fact is spent on read", () => {
+    // A per-key one-shot needs no controller identity and no reset: the effect
+    // may run many times as the id settles, and two chats in the same
+    // `ChatBody` (not keyed on `file` — see the boot's `bootedFor`, Bugbot PR
+    // #1061) hold different keys and so carry their own answers.
+    expect(chat()).toContain("}, [file, state.sessionId]);");
+    expect(effect()).not.toContain("useRef");
   });
 
   test("fire and forget, like every other write in this module", () => {
@@ -453,6 +460,37 @@ describe("the chat rekeys its draft when it learns its session", () => {
     // and the draft it renames is one the send is about to delete anyway.
     expect(effect()).toContain("void rekeyChatDraft(");
     expect(effect()).not.toContain("await ");
+  });
+});
+
+describe("markSentWithoutSession / takeSentWithoutSession", () => {
+  test("a marked key reads back true", () => {
+    const key = chatDraftKey(null, "/Users/me/marked");
+    markSentWithoutSession(key);
+    expect(takeSentWithoutSession(key)).toBe(true);
+  });
+
+  test("spent on read: the second take is false", () => {
+    const key = chatDraftKey(null, "/Users/me/once");
+    markSentWithoutSession(key);
+    expect(takeSentWithoutSession(key)).toBe(true);
+    expect(takeSentWithoutSession(key)).toBe(false);
+  });
+
+  test("an unmarked key is false, and marking one leaves the others alone", () => {
+    const a = chatDraftKey(null, "/Users/me/a");
+    const b = chatDraftKey(null, "/Users/me/b");
+    expect(takeSentWithoutSession(b)).toBe(false);
+    markSentWithoutSession(a);
+    // B's chat never sent from a session-less composer, so nothing is owed to
+    // it — which is the whole of the bug this replaced (Bugbot, PR #1118).
+    expect(takeSentWithoutSession(b)).toBe(false);
+    expect(takeSentWithoutSession(a)).toBe(true);
+  });
+
+  test("an empty key is never marked — there is no draft to move", () => {
+    markSentWithoutSession("");
+    expect(takeSentWithoutSession("")).toBe(false);
   });
 });
 

--- a/frontend/src/platform/lib/drafts.test.ts
+++ b/frontend/src/platform/lib/drafts.test.ts
@@ -220,6 +220,62 @@ describe("useAutosave().settle()", () => {
   });
 });
 
+// ---- the unmount flush that follows the first send --------------------------
+//
+// THE BUG (Bugbot, PR #1118, 2026-09-11). The first send from a session-less
+// chat calls `reset({ text: "", attachments: [] })` and then, one tick later,
+// gains a session — which remounts the whole chat. The composer going away runs
+// the unmount flush, and that flush reads the value REF, which at that instant
+// still holds the render before the clear: the sentence that was just sent. It
+// differed from the empty value `reset` had just recorded, so it was written —
+// a PUT with content, which un-spends the key and puts the message back on the
+// server under it. `reset` has to move the value too, not only the bookkeeping.
+
+describe("the unmount flush after a send", () => {
+  test("reset() leaves it nothing to write", () => {
+    const calls: string[] = [];
+    const box = renderAutosave({ text: "" }, (value) => {
+      calls.push(JSON.stringify(value));
+      return true;
+    });
+    // A sentence typed, then sent: `reset` is told what the box is ABOUT to
+    // hold, because the state write that empties it has not landed yet.
+    box.rerender({ text: "ship the release notes" });
+    box.current().reset({ text: "" });
+    // The session arrives and the chat remounts.
+    box.unmount();
+    expect(calls).toEqual([]);
+  });
+
+  test("…and so does a flush by hand in the same tick", () => {
+    const calls: string[] = [];
+    const box = renderAutosave({ text: "" }, (value) => {
+      calls.push(JSON.stringify(value));
+      return true;
+    });
+    box.rerender({ text: "ship the release notes" });
+    box.current().reset({ text: "" });
+    box.current().flush();
+    expect(calls).toEqual([]);
+    box.unmount();
+    expect(calls).toEqual([]);
+  });
+
+  test("stop() disarms it outright, words in the box or not", () => {
+    // Schedule's half: the server deletes the draft as it creates the task, so
+    // the teardown must not write one back either.
+    const calls: string[] = [];
+    const box = renderAutosave({ text: "" }, (value) => {
+      calls.push(JSON.stringify(value));
+      return true;
+    });
+    box.rerender({ text: "half a thought" });
+    box.current().stop();
+    box.unmount();
+    expect(calls).toEqual([]);
+  });
+});
+
 // ---- the opening value, when it arrived already typed -------------------------
 // design.md, Round 2: the Schedule hop hands the task form the sentence the
 // composer was holding, so the card mounts on words that are already a draft.
@@ -493,5 +549,144 @@ describe("a spent chat key reads back as empty", () => {
     expect(await fetchChatDraft(sent)).toBeNull();
     expect((await fetchChatDraft(other))?.text).toBe("still unsent");
     f.restore();
+  });
+});
+
+// ---- the rekey cannot pass the send's delete ---------------------------------
+//
+// THE BUG (Bugbot, PR #1118, 2026-09-11). `spent` covers `new:<file>` and only
+// that key. The first send fires `DELETE new:<file>` and, on learning the
+// session, `POST /api/drafts/chat/rekey` — two requests in no order at all. If
+// the rekey is served first the record is still there, so the route copies it
+// onto the session id, and the composer that just remounted seeds from the
+// SESSION key, which nothing had marked spent. Same resurrection, one key over.
+
+describe("the rekey cannot pass the send's delete", () => {
+  const held = (text: string): ChatDraft => ({ text, attachments: [], updated_at: 1 });
+
+  /** `fetch` that records every call and answers `GET /api/drafts` out of
+   *  `chat` — but holds every request until `release()`, which is how one is
+   *  kept "in flight" without a clock. After the release the gate is open:
+   *  later requests answer at once, so a test can order what it cares about
+   *  and then let the rest run. */
+  function gate(chat: Record<string, ChatDraft> = {}) {
+    const calls: string[] = [];
+    const waiting: (() => void)[] = [];
+    let holding = true;
+    const answer = () => ({ ok: true, json: () => Promise.resolve({ chat, task: {} }) }) as unknown as Response;
+    const real = globalThis.fetch;
+    globalThis.fetch = ((url: string, init?: RequestInit) => {
+      calls.push(`${init?.method ?? "GET"} ${url}`);
+      if (!holding) return Promise.resolve(answer());
+      return new Promise<Response>((resolve) => {
+        waiting.push(() => resolve(answer()));
+      });
+    }) as typeof fetch;
+    return {
+      calls,
+      release: () => {
+        holding = false;
+        for (const unblock of waiting.splice(0)) unblock();
+      },
+      restore: () => {
+        globalThis.fetch = real;
+      },
+    };
+  }
+
+  const posts = (calls: string[]) => calls.filter((c) => c.startsWith("POST /api/drafts/chat/rekey"));
+
+  test("it waits for a DELETE still in flight before posting the move", async () => {
+    const g = gate();
+    const from = "new:/Users/me/moving";
+    // The send. Not awaited — the DELETE being in the air is the whole race.
+    void deleteChatDraft(from);
+    const moved = rekeyChatDraft(from, "sess-moving");
+    await Promise.resolve();
+    await Promise.resolve();
+    // Nothing posted while the delete is unanswered: the route would have found
+    // the record and copied the sent words onto the session.
+    expect(posts(g.calls)).toEqual([]);
+
+    g.release();
+    await moved;
+    expect(posts(g.calls).length).toBe(1);
+    g.restore();
+  });
+
+  test("a spent `from` hands its spent-ness to `to`", async () => {
+    // Belt and braces for the copy that happens anyway (another tab, a server
+    // that already moved it): whatever is under the new key, it is not restored
+    // into the box the send just emptied.
+    const from = "new:/Users/me/handed";
+    const to = "sess-handed";
+    const g = gate({ [to]: held("ship the release notes") });
+    void deleteChatDraft(from);
+    const moved = rekeyChatDraft(from, to);
+    g.release();
+    await moved;
+    expect(await fetchChatDraft(to)).toBeNull();
+    g.restore();
+  });
+
+  test("…until the reader types under the new key, which brings it back", async () => {
+    const from = "new:/Users/me/typed-on-after";
+    const to = "sess-typed-on-after";
+    const g = gate({ [to]: held("a second thought") });
+    void deleteChatDraft(from);
+    const moved = rekeyChatDraft(from, to);
+    g.release();
+    await moved;
+    await saveChatDraft(to, "a second thought");
+    expect((await fetchChatDraft(to))?.text).toBe("a second thought");
+    g.restore();
+  });
+
+  test("a `from` nobody spent says nothing about `to`", async () => {
+    // The ordinary rekey: a chat that learned its session without a send. Its
+    // draft is a real unsent draft and must survive the move.
+    const from = "new:/Users/me/never-sent";
+    const to = "sess-never-sent";
+    const g = gate({ [to]: held("still unsent") });
+    const moved = rekeyChatDraft(from, to);
+    g.release();
+    await moved;
+    expect((await fetchChatDraft(to))?.text).toBe("still unsent");
+    g.restore();
+  });
+});
+
+// ---- a read already in the air when the send lands ---------------------------
+
+describe("fetchChatDraft re-checks spent after the answer", () => {
+  const held = (text: string): ChatDraft => ({ text, attachments: [], updated_at: 1 });
+
+  test("a GET dispatched before the send still answers null", async () => {
+    // THE BUG (Bugbot, PR #1118, 2026-09-11): the guard ran before the request
+    // only. A seed that passed it while the key was still live answers out of a
+    // snapshot taken before the DELETE landed — and hands the composer the
+    // sentence that was sent in the meantime.
+    const key = "new:/Users/me/mid-flight";
+    const waiting: (() => void)[] = [];
+    const real = globalThis.fetch;
+    globalThis.fetch = (() =>
+      new Promise<Response>((resolve) => {
+        waiting.push(() =>
+          resolve({
+            ok: true,
+            json: () => Promise.resolve({ chat: { [key]: held("ship the release notes") }, task: {} }),
+          } as unknown as Response),
+        );
+      })) as unknown as typeof fetch;
+
+    // The remount's seed goes out while the key is still live…
+    const reading = fetchChatDraft(key);
+    await Promise.resolve();
+    // …and the send marks it spent while that GET is still unanswered.
+    void deleteChatDraft(key);
+    for (const answer of waiting.splice(0)) answer();
+
+    expect(await reading).toBeNull();
+    globalThis.fetch = real;
   });
 });

--- a/frontend/src/platform/lib/drafts.test.ts
+++ b/frontend/src/platform/lib/drafts.test.ts
@@ -1,0 +1,393 @@
+// `useAutosave`'s `settle()` — the fix for the composer-drafts resurrection
+// race (Akshil, 2026-09-11): `reset()`/`stop()` can cancel the PENDING debounce
+// timer, but nothing short of the network can cancel a `fetch` already sent,
+// so Send/Discard/Schedule need a way to wait that one write out before firing
+// the delete that would otherwise land BEFORE it and get resurrected.
+//
+// Driven through the real hook — react-test-renderer, no DOM, the same tool
+// JobRow.test.tsx and apps/explorer/listing/hook-harness.ts both use — because
+// what matters is a SEQUENCE (write starts, write is still running, write
+// resolves, `settle()` resolves only then) that grepping the source cannot
+// show. The harness below is a small reimplementation of hook-harness.ts's own
+// `renderHook`/`Deferred`, not an import of it: `platform/` may not import
+// `apps/` (scripts/check-boundaries; see this module's own header for why).
+//
+// Every test drives the write through `flush()` rather than waiting out the
+// real debounce timer: `bun test` runs every suite in one process, and a real
+// `setTimeout` left pending past a test's own assertions is exactly the kind
+// of leftover that lands during whichever OTHER file happens to be running
+// when it fires — this file's first draft did that (a 30ms real wait per
+// test) and it was enough to shift a completely unrelated suite's mocked
+// `fetch` count elsewhere in the same run. `flush()` dispatches synchronously,
+// so nothing here ever waits on the clock.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { installDomShim } from "@platform/lib/testDomShim";
+import {
+  chatDraftKey,
+  newChatFile,
+  rekeyChatDraft,
+  saveTaskDraft,
+  useAutosave,
+  type Autosave,
+  type AutosaveOptions,
+  type DraftWriteOptions,
+  type TaskDraftForm,
+} from "@platform/lib/drafts";
+
+// `useAutosave`'s unload effect reaches for `window`/`document` — real
+// globals in a browser, absent in bun's DOM-less test runtime. Neither is
+// touched at drafts.ts's MODULE scope (only inside the hook's own effects,
+// which run after this file's synchronous top level), so installing the shim
+// here — rather than via the dynamic-import dance router.test.ts needs — is
+// enough.
+installDomShim();
+
+/** A promise this test resolves by hand, standing in for a PUT in flight. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/** Mount `useAutosave` and expose its latest handle. */
+function renderAutosave<T>(
+  value: T,
+  save: (value: T, opts: DraftWriteOptions) => unknown,
+  options?: AutosaveOptions,
+): { current: () => Autosave<T>; rerender: (next: T) => void; unmount: () => void } {
+  let latest!: Autosave<T>;
+  let renderer!: ReactTestRenderer;
+  const Probe = (props: { value: T }): null => {
+    latest = useAutosave(props.value, save, options);
+    return null;
+  };
+  act(() => {
+    renderer = create(createElement(Probe, { value }));
+  });
+  return {
+    current: () => latest,
+    rerender: (next: T) => {
+      act(() => {
+        renderer.update(createElement(Probe, { value: next }));
+      });
+    },
+    unmount: () => {
+      act(() => {
+        renderer.unmount();
+      });
+    },
+  };
+}
+
+describe("useAutosave().settle()", () => {
+  test("resolves at once when nothing has ever been written", async () => {
+    // Discard on a card nobody touched: no write was ever dispatched, so
+    // there is nothing to wait out.
+    const box = renderAutosave({ n: 0 }, () => true);
+    let settled = false;
+    await box.current()
+      .settle()
+      .then(() => {
+        settled = true;
+      });
+    expect(settled).toBe(true);
+    box.unmount();
+  });
+
+  test("waits for a write already in flight before resolving", async () => {
+    const calls: string[] = [];
+    const put = deferred<boolean>();
+    const box = renderAutosave({ n: 0 }, (value) => {
+      calls.push(JSON.stringify(value));
+      return put.promise;
+    });
+
+    box.rerender({ n: 1 });
+    box.current().flush();
+    expect(calls).toEqual(['{"n":1}']);
+
+    let settled = false;
+    const settling = box.current()
+      .settle()
+      .then(() => {
+        settled = true;
+      });
+    // The PUT has not answered yet — settle must not have resolved either.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    put.resolve(true);
+    await settling;
+    expect(settled).toBe(true);
+    box.unmount();
+  });
+
+  test(
+    "reset() forgets the pending write's bookkeeping but settle() still " +
+      "waits for a write already dispatched",
+    async () => {
+      const put = deferred<boolean>();
+      const box = renderAutosave({ n: 0 }, () => put.promise);
+
+      box.rerender({ n: 1 });
+      // The composer's send: dispatch (standing in for a debounced write that
+      // already went out), then `reset` to the value the box is about to
+      // hold. `reset` cannot reach back and cancel the fetch above.
+      box.current().flush();
+      box.current().reset({ n: 1 });
+
+      let settled = false;
+      const settling = box.current()
+        .settle()
+        .then(() => {
+          settled = true;
+        });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      put.resolve(false);
+      await settling;
+      expect(settled).toBe(true);
+      box.unmount();
+    },
+  );
+
+  test(
+    "stop() disarms future writes but settle() still waits for one already " +
+      "running",
+    async () => {
+      const put = deferred<boolean>();
+      const calls: string[] = [];
+      const box = renderAutosave({ n: 0 }, (value) => {
+        calls.push(JSON.stringify(value));
+        return put.promise;
+      });
+
+      box.rerender({ n: 1 });
+      box.current().flush();
+      expect(calls).toEqual(['{"n":1}']);
+
+      box.current().stop();
+      // A later change, even flushed by hand, must NOT queue a new write —
+      // stop is permanent for this mount.
+      box.rerender({ n: 2 });
+      box.current().flush();
+      expect(calls).toEqual(['{"n":1}']);
+
+      let settled = false;
+      const settling = box.current()
+        .settle()
+        .then(() => {
+          settled = true;
+        });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      put.resolve(true);
+      await settling;
+      expect(settled).toBe(true);
+      box.unmount();
+    },
+  );
+
+  test("a save that rejects still lets settle() resolve, not hang or throw", async () => {
+    const box = renderAutosave({ n: 0 }, () => Promise.reject(new Error("network")));
+    box.rerender({ n: 1 });
+    box.current().flush();
+
+    let settled = false;
+    // If `settle()` propagated the rejection this `await` would throw and
+    // fail the test — same contract every write in this module already keeps
+    // (see drafts.ts's own header).
+    await box.current()
+      .settle()
+      .then(() => {
+        settled = true;
+      });
+    expect(settled).toBe(true);
+    box.unmount();
+  });
+});
+
+// ---- the opening value, when it arrived already typed -------------------------
+// design.md, Round 2: the Schedule hop hands the task form the sentence the
+// composer was holding, so the card mounts on words that are already a draft.
+// `writeInitial` is what lets the first write happen with nobody having typed.
+
+describe("useAutosave({ writeInitial })", () => {
+  test("off by default: mounting alone never writes", () => {
+    // "Nothing minted for an untouched modal" is made of exactly this — the
+    // form's own initial state is not something the user typed.
+    let writes = 0;
+    const box = renderAutosave({ n: 0 }, () => {
+      writes += 1;
+      return true;
+    });
+    box.current().flush();
+    expect(writes).toBe(0);
+    box.unmount();
+  });
+
+  test("on: the mount value counts as unwritten, so the first flush writes it", () => {
+    const seen: unknown[] = [];
+    const box = renderAutosave({ text: "from the chat" }, (v) => {
+      seen.push(v);
+      return true;
+    }, { writeInitial: true });
+    box.current().flush();
+    expect(seen).toEqual([{ text: "from the chat" }]);
+    box.unmount();
+  });
+
+  test("…and only once — the second flush has nothing new to say", () => {
+    let writes = 0;
+    const box = renderAutosave({ text: "from the chat" }, () => {
+      writes += 1;
+      return true;
+    }, { writeInitial: true });
+    box.current().flush();
+    box.current().flush();
+    expect(writes).toBe(1);
+    box.unmount();
+  });
+
+  test("a null opening value writes nothing of substance and still settles", async () => {
+    // An Edit hands `null` here. The hook has no opinion about the value; the
+    // caller's own `save` is what refuses it.
+    const seen: unknown[] = [];
+    const box = renderAutosave<{ n: number } | null>(null, (v) => {
+      seen.push(v);
+      return true;
+    }, { writeInitial: true });
+    box.current().flush();
+    expect(seen).toEqual([null]);
+    await box.current().settle();
+    box.unmount();
+  });
+});
+
+// ---- the wire: a draft that MOVES rather than duplicating ---------------------
+
+const FORM: TaskDraftForm = {
+  title: "", description: "half a thought", target: "~/news",
+  when: null, repeat: null, model: "", effort: "", permission: "",
+  attachments: [], new_task_each_run: null,
+};
+
+/** Swap `fetch` for a recorder, and put the real one back afterwards. */
+function recordFetch(): { calls: { url: string; init: RequestInit }[]; restore: () => void } {
+  const calls: { url: string; init: RequestInit }[] = [];
+  const real = globalThis.fetch;
+  globalThis.fetch = ((url: string, init: RequestInit) => {
+    calls.push({ url, init });
+    return Promise.resolve({ ok: true } as Response);
+  }) as typeof fetch;
+  return { calls, restore: () => { globalThis.fetch = real; } };
+}
+
+describe("saveTaskDraft's from_chat_key", () => {
+  test("is absent unless the caller names one", async () => {
+    const f = recordFetch();
+    await saveTaskDraft("d1", FORM);
+    expect(JSON.parse(String(f.calls[0].init.body))).not.toHaveProperty("from_chat_key");
+    f.restore();
+  });
+
+  test("rides the body when it does, beside the form", async () => {
+    // The server deletes that chat draft as it stores this one, so the sentence
+    // is in exactly one place at every instant (design.md, Round 2).
+    const f = recordFetch();
+    await saveTaskDraft("d1", FORM, undefined, "new:/Users/me/news");
+    const body = JSON.parse(String(f.calls[0].init.body));
+    expect(body.from_chat_key).toBe("new:/Users/me/news");
+    expect(body.description).toBe("half a thought");
+    f.restore();
+  });
+});
+
+describe("rekeyChatDraft", () => {
+  test("moves the number from the `new:<file>` key onto the session", async () => {
+    const f = recordFetch();
+    await rekeyChatDraft(chatDraftKey(null, "/Users/me/news"), "sess-9");
+    expect(f.calls[0].url).toBe("/api/drafts/chat/rekey");
+    expect(f.calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(f.calls[0].init.body)))
+      .toEqual({ from: "new:/Users/me/news", to: "sess-9" });
+    f.restore();
+  });
+
+  test("says nothing at all when there is nothing to move", async () => {
+    // The server answers 400 on a bad shape or `from === to`; a request that
+    // can only be refused is one not worth making.
+    const f = recordFetch();
+    await rekeyChatDraft("", "sess-9");
+    await rekeyChatDraft("new:/x", "");
+    await rekeyChatDraft("sess-9", "sess-9");
+    expect(f.calls).toEqual([]);
+    f.restore();
+  });
+});
+
+// ---- the number follows the session the chat turns out to be -----------------
+// design.md, Round 2: "Every draft has a TASK number." A brand-new chat keys its
+// draft `new:<file>` and is given one under that key; the first send creates the
+// session, and the composer keys on the session id from the next render. Without
+// the rekey, the number — and the row wearing it — is stranded on a key nothing
+// reads again. Source reads: the whole claim is about WHEN this fires and how
+// many times, which a mounted chat cannot be asked without a whole run.
+
+describe("the chat rekeys its draft when it learns its session", () => {
+  const chat = () =>
+    readFileSync(join(import.meta.dir, "../../apps/claude/ClaudeChat.tsx"), "utf8");
+  const effect = () => {
+    const s = chat();
+    const at = s.indexOf("const rekeyed = useRef(false);");
+    return s.slice(at, s.indexOf("}, [file, state.sessionId]);", at));
+  };
+
+  test("posts the move once, from the `new:<file>` key onto the session", () => {
+    expect(effect()).toContain("void rekeyChatDraft(chatDraftKey(null, file), id);");
+    // The same key the composer autosaves under — one function, so the two
+    // halves cannot spell the path differently.
+    expect(chat()).toContain('import { chatDraftKey, rekeyChatDraft } from "@platform/lib/drafts";');
+  });
+
+  test("only for a chat that STARTED without a session", () => {
+    // A chat opened ON a session (a recent row, a deep link, the Tasks page)
+    // never had a `new:<file>` key; renaming one would at best be a no-op and at
+    // worst claim a key belonging to a different unsent chat in the same folder.
+    const e = effect();
+    expect(e).toContain("if (startedWithoutSession.current === null) startedWithoutSession.current = !id;");
+    expect(e).toContain("if (!startedWithoutSession.current || rekeyed.current || !id) return;");
+    expect(e).toContain("rekeyed.current = true;");
+  });
+
+  test("fire and forget, like every other write in this module", () => {
+    // A refusal costs the number's continuity and nothing the reader is doing —
+    // and the draft it renames is one the send is about to delete anyway.
+    expect(effect()).toContain("void rekeyChatDraft(");
+    expect(effect()).not.toContain("await ");
+  });
+});
+
+describe("the two shapes of a chat key", () => {
+  test("reads the file back out of a `new:` key, and nothing out of a session", () => {
+    // The way BACK to a never-sent chat is built out of this string — a reopened
+    // task draft's "Back to chat" and the draft row's own href both have to land
+    // on the same `file` the composer keys on, or the chat that opens seeds from
+    // a key nothing wrote.
+    expect(newChatFile(chatDraftKey(null, "/Users/me/news"))).toBe("/Users/me/news");
+    expect(newChatFile("new:/a/b")).toBe("/a/b");
+    expect(newChatFile("sess-9")).toBe("");
+    expect(newChatFile("")).toBe("");
+    // Nothing is trimmed or normalised — chatDraftKey's rule, held here too.
+    expect(newChatFile("new:/Users/me/news/")).toBe("/Users/me/news/");
+  });
+});

--- a/frontend/src/platform/lib/drafts.test.ts
+++ b/frontend/src/platform/lib/drafts.test.ts
@@ -30,11 +30,9 @@ import {
   chatDraftKey,
   deleteChatDraft,
   fetchChatDraft,
-  markSentWithoutSession,
   newChatFile,
   rekeyChatDraft,
   saveChatDraft,
-  takeSentWithoutSession,
   saveTaskDraft,
   useAutosave,
   type Autosave,
@@ -412,47 +410,62 @@ describe("the chat rekeys its draft when it learns its session", () => {
     readFileSync(join(import.meta.dir, "../../apps/claude/ui/Composer.tsx"), "utf8");
   const effect = () => {
     const s = chat();
-    const at = s.indexOf("const id = state.sessionId ?? \"\";\n    if (!id) return;");
-    return s.slice(at, s.indexOf("}, [file, state.sessionId]);", at));
+    const at = s.indexOf("const pending = pendingRekey.current;");
+    return s.slice(at, s.indexOf("}, [controller, file, state.sessionId, state.status]);", at));
   };
 
   test("posts the move once, from the `new:<file>` key onto the session", () => {
-    expect(effect()).toContain("void rekeyChatDraft(chatDraftKey(null, file), id);");
+    expect(effect()).toContain("void rekeyChatDraft(pending.key, id);");
     // The same key the composer autosaves under — one function, so the two
     // halves cannot spell the path differently.
-    expect(chat()).toContain(
-      'import { chatDraftKey, rekeyChatDraft, takeSentWithoutSession } from "@platform/lib/drafts";',
-    );
+    expect(chat()).toContain('import { chatDraftKey, rekeyChatDraft } from "@platform/lib/drafts";');
+    expect(chat()).toContain("key: chatDraftKey(null, file)");
   });
 
-  test("gated on the SEND that had no session, not on an observed empty id", () => {
-    // Bugbot, PR #1118 (2026-09-12): the old latch asked whether the first pass
-    // saw an empty `state.sessionId`, which is the ordinary first pass for every
-    // chat — the id arrives only when boot's `openSession` answers. Opening an
-    // existing session in a folder holding a `new:<file>` draft therefore moved
-    // that unsent row, words and TASK number, onto the wrong conversation.
-    const e = effect();
-    expect(e).toContain("if (takeSentWithoutSession(chatDraftKey(null, file))) {");
-    // Nothing infers the answer from what the effect happens to see any more.
+  test("the note is written at the SEND, and only with no session under it", () => {
+    // Not inferred from an observed empty `state.sessionId`: that is the
+    // ordinary first pass for every chat, opened-on-a-session ones included,
+    // because the id only arrives when boot's `openSession` answers.
+    expect(chat()).toContain("if (!controller.getState().sessionId) {");
+    expect(chat()).toContain(
+      "pendingRekey.current = { controller, file, key: chatDraftKey(null, file), live: false };",
+    );
     expect(chat()).not.toContain("startedWithoutSession");
     expect(chat()).not.toContain("rekeyedFor");
   });
 
-  test("the composer marks it, and only when there is no session under the send", () => {
-    const c = composer();
-    expect(c).toContain("if (!sessionId) markSentWithoutSession(draftKeyRef.current);");
-    // The same key the delete on the next line spends, not a re-derived one.
-    expect(c).toContain("deleteChatDraft(draftKeyRef.current)");
-    expect(c).toContain("  markSentWithoutSession,\n");
+  test("the note carries the run, so nobody else can spend it", () => {
+    // Bugbot, PR #1118 (2026-09-12): a module-level "a send is owed a rekey"
+    // set said nothing about WHICH session was allowed to spend it, so
+    // switching conversations in the same folder before the first poll
+    // returned moved the unsent row and its TASK number onto the wrong one.
+    const e = effect();
+    expect(e).toContain("if (pending.controller !== controller || pending.file !== file) {");
+    // Dropped UNSPENT on that road — no rekey between the check and its return.
+    const other = e.slice(e.indexOf("pending.file !== file"), e.indexOf("const id ="));
+    expect(other).toContain("pendingRekey.current = null;");
+    expect(other).not.toContain("rekeyChatDraft(");
+    // And the module-level set it replaces is gone from both sides.
+    const drafts = readFileSync(join(import.meta.dir, "drafts.ts"), "utf8");
+    expect(drafts).not.toContain("SentWithoutSession");
+    expect(composer()).not.toContain("SentWithoutSession");
   });
 
-  test("no per-mount latches left, because the fact is spent on read", () => {
-    // A per-key one-shot needs no controller identity and no reset: the effect
-    // may run many times as the id settles, and two chats in the same
-    // `ChatBody` (not keyed on `file` — see the boot's `bootedFor`, Bugbot PR
-    // #1061) hold different keys and so carry their own answers.
-    expect(chat()).toContain("}, [file, state.sessionId]);");
-    expect(effect()).not.toContain("useRef");
+  test("spent only when the run we sent yields the id, and only once", () => {
+    const e = effect();
+    const landed = e.slice(e.indexOf("if (id) {"), e.indexOf("if (state.status !== "));
+    expect(landed).toContain("pendingRekey.current = null;");
+    expect(landed).toContain("void rekeyChatDraft(pending.key, id);");
+  });
+
+  test("a run that ends without minting an id drops the note", () => {
+    // `RunStatus` is idle|starting|running|stopping — no separate "ended" — so
+    // an end is only an end once the run has been seen live; the idle a send is
+    // dispatched into is not one.
+    const e = effect();
+    expect(e).toContain('if (state.status !== "idle") pending.live = true;');
+    expect(e).toContain("else if (pending.live) pendingRekey.current = null;");
+    expect(chat()).toContain("}, [controller, file, state.sessionId, state.status]);");
   });
 
   test("fire and forget, like every other write in this module", () => {
@@ -461,36 +474,11 @@ describe("the chat rekeys its draft when it learns its session", () => {
     expect(effect()).toContain("void rekeyChatDraft(");
     expect(effect()).not.toContain("await ");
   });
-});
 
-describe("markSentWithoutSession / takeSentWithoutSession", () => {
-  test("a marked key reads back true", () => {
-    const key = chatDraftKey(null, "/Users/me/marked");
-    markSentWithoutSession(key);
-    expect(takeSentWithoutSession(key)).toBe(true);
-  });
-
-  test("spent on read: the second take is false", () => {
-    const key = chatDraftKey(null, "/Users/me/once");
-    markSentWithoutSession(key);
-    expect(takeSentWithoutSession(key)).toBe(true);
-    expect(takeSentWithoutSession(key)).toBe(false);
-  });
-
-  test("an unmarked key is false, and marking one leaves the others alone", () => {
-    const a = chatDraftKey(null, "/Users/me/a");
-    const b = chatDraftKey(null, "/Users/me/b");
-    expect(takeSentWithoutSession(b)).toBe(false);
-    markSentWithoutSession(a);
-    // B's chat never sent from a session-less composer, so nothing is owed to
-    // it — which is the whole of the bug this replaced (Bugbot, PR #1118).
-    expect(takeSentWithoutSession(b)).toBe(false);
-    expect(takeSentWithoutSession(a)).toBe(true);
-  });
-
-  test("an empty key is never marked — there is no draft to move", () => {
-    markSentWithoutSession("");
-    expect(takeSentWithoutSession("")).toBe(false);
+  test("the composer no longer needs to know — it just spends its own key", () => {
+    const c = composer();
+    expect(c).toContain("deleteChatDraft(draftKeyRef.current)");
+    expect(c).not.toContain("markSentWithoutSession");
   });
 });
 

--- a/frontend/src/platform/lib/drafts.test.ts
+++ b/frontend/src/platform/lib/drafts.test.ts
@@ -28,12 +28,16 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { installDomShim } from "@platform/lib/testDomShim";
 import {
   chatDraftKey,
+  deleteChatDraft,
+  fetchChatDraft,
   newChatFile,
   rekeyChatDraft,
+  saveChatDraft,
   saveTaskDraft,
   useAutosave,
   type Autosave,
   type AutosaveOptions,
+  type ChatDraft,
   type DraftWriteOptions,
   type TaskDraftForm,
 } from "@platform/lib/drafts";
@@ -277,8 +281,8 @@ describe("useAutosave({ writeInitial })", () => {
 
 const FORM: TaskDraftForm = {
   title: "", description: "half a thought", target: "~/news",
-  when: null, repeat: null, model: "", effort: "", permission: "",
-  attachments: [], new_task_each_run: null,
+  when: null, repeat: null, custom_rule: null, model: "", effort: "",
+  permission: "", attachments: [], new_task_each_run: null,
 };
 
 /** Swap `fetch` for a recorder, and put the real one back afterwards. */
@@ -389,5 +393,105 @@ describe("the two shapes of a chat key", () => {
     expect(newChatFile("")).toBe("");
     // Nothing is trimmed or normalised — chatDraftKey's rule, held here too.
     expect(newChatFile("new:/Users/me/news/")).toBe("/Users/me/news/");
+  });
+});
+
+// ---- a spent chat key never hands its draft back -----------------------------
+//
+// THE BUG (Bugbot, PR #1118). The first send from a session-less chat deletes
+// the draft under `new:<file>` AND gives the landing a session, which remounts
+// the composer. The fresh mount seeds itself from `fetchChatDraft`, and that GET
+// can overtake the DELETE still in flight: the answer is the sentence that was
+// just sent, put back into the box the send had emptied — and the rekey that
+// follows walks it onto the session, so the message the reader sent is sitting
+// on their own task row as an unsent draft.
+//
+// Nothing inside one mount can close that window (`reset`/`stop`/`settle` all
+// belong to the component being thrown away, and the seed runs in the NEXT one),
+// so the fact lives at module scope. These drive the module's own functions,
+// which is where it lives; every test uses a key of its own, because the set is
+// module state and deliberately outlives any one of them.
+
+describe("a spent chat key reads back as empty", () => {
+  const held = (text: string): ChatDraft => ({ text, attachments: [], updated_at: 1 });
+
+  /** `fetch` answering `GET /api/drafts` out of `chat`, and recording every call
+   *  — the writes here never reach a server, which is the point: what is being
+   *  asserted is what the module answers WHILE the DELETE is still in the air. */
+  function serve(chat: Record<string, ChatDraft>) {
+    const calls: string[] = [];
+    const real = globalThis.fetch;
+    globalThis.fetch = ((url: string, init?: RequestInit) => {
+      calls.push(`${init?.method ?? "GET"} ${url}`);
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ chat, task: {} }),
+      } as unknown as Response);
+    }) as typeof fetch;
+    return { calls, restore: () => { globalThis.fetch = real; } };
+  }
+
+  test("the remount's seed gets nothing, though the server still holds the words", async () => {
+    const key = "new:/Users/me/sent";
+    const f = serve({ [key]: held("ship the release notes") });
+    // Before the send: the draft is real and the composer would restore it.
+    expect(await fetchChatDraft(key)).not.toBeNull();
+    // The send. Deliberately NOT awaited — the DELETE being in flight is the
+    // whole of the race.
+    void deleteChatDraft(key);
+    expect(await fetchChatDraft(key)).toBeNull();
+    f.restore();
+  });
+
+  test("and answers without a request at all", async () => {
+    const key = "new:/Users/me/sent-quietly";
+    const f = serve({ [key]: held("ship it") });
+    void deleteChatDraft(key);
+    const before = f.calls.length;
+    expect(await fetchChatDraft(key)).toBeNull();
+    expect(f.calls.length).toBe(before);
+    f.restore();
+  });
+
+  test("typing into the key again brings it back", async () => {
+    // Spent is not dead: a reader who starts a second unsent message in the same
+    // folder has a draft again, and the next composer to open there must see it.
+    const key = "new:/Users/me/typed-on";
+    const f = serve({ [key]: held("and one more thing") });
+    void deleteChatDraft(key);
+    expect(await fetchChatDraft(key)).toBeNull();
+    await saveChatDraft(key, "and one more thing");
+    expect(await fetchChatDraft(key)).not.toBeNull();
+    f.restore();
+  });
+
+  test("an attachment alone is content enough", async () => {
+    const key = "new:/Users/me/dropped-a-file";
+    const f = serve({ [key]: held("") });
+    void deleteChatDraft(key);
+    await saveChatDraft(key, "", [{ path: "/tmp/a.png", name: "a.png", kind: "image" }]);
+    expect(await fetchChatDraft(key)).not.toBeNull();
+    f.restore();
+  });
+
+  test("an empty write does NOT un-spend it — an empty write is itself a delete", async () => {
+    // The composer's autosave fires on the pause after the send cleared the box.
+    // Treating that as "there are words here again" would re-open the window.
+    const key = "new:/Users/me/cleared";
+    const f = serve({ [key]: held("ghost") });
+    void deleteChatDraft(key);
+    await saveChatDraft(key, "   ");
+    expect(await fetchChatDraft(key)).toBeNull();
+    f.restore();
+  });
+
+  test("one key's spending says nothing about any other", async () => {
+    const sent = "new:/Users/me/one";
+    const other = "new:/Users/me/two";
+    const f = serve({ [sent]: held("sent"), [other]: held("still unsent") });
+    void deleteChatDraft(sent);
+    expect(await fetchChatDraft(sent)).toBeNull();
+    expect((await fetchChatDraft(other))?.text).toBe("still unsent");
+    f.restore();
   });
 });

--- a/frontend/src/platform/lib/drafts.test.ts
+++ b/frontend/src/platform/lib/drafts.test.ts
@@ -408,8 +408,8 @@ describe("the chat rekeys its draft when it learns its session", () => {
     readFileSync(join(import.meta.dir, "../../apps/claude/ClaudeChat.tsx"), "utf8");
   const effect = () => {
     const s = chat();
-    const at = s.indexOf("const rekeyed = useRef(false);");
-    return s.slice(at, s.indexOf("}, [file, state.sessionId]);", at));
+    const at = s.indexOf("const rekeyedFor = useRef<object | null>(null);");
+    return s.slice(at, s.indexOf("}, [controller, file, state.sessionId]);", at));
   };
 
   test("posts the move once, from the `new:<file>` key onto the session", () => {
@@ -427,6 +427,25 @@ describe("the chat rekeys its draft when it learns its session", () => {
     expect(e).toContain("if (startedWithoutSession.current === null) startedWithoutSession.current = !id;");
     expect(e).toContain("if (!startedWithoutSession.current || rekeyed.current || !id) return;");
     expect(e).toContain("rekeyed.current = true;");
+  });
+
+  test("both latches are PER CONTROLLER, so a second session-less chat still rekeys", () => {
+    // `ChatBody` is not keyed on `file` (see the boot's `bootedFor`, Bugbot PR
+    // #1061): switching to a target whose `agentDir` is already cached rebuilds
+    // the controller WITHOUT remounting this tree. As bare per-mount refs, chat
+    // A's first send left `rekeyed` set, and a later session-less chat B in the
+    // same body never moved its `new:<fileB>` draft — nor the TASK number and
+    // List row wearing that key — onto the session its own first send made.
+    const e = effect();
+    expect(e).toContain("const rekeyedFor = useRef<object | null>(null);");
+    expect(e).toContain("if (rekeyedFor.current !== controller) {");
+    expect(e).toContain("rekeyedFor.current = controller;");
+    // BOTH answers are asked again, not just the one: a chat B opened ON a
+    // session must re-learn that too, or A's `startedWithoutSession` decides it.
+    expect(e).toContain("rekeyed.current = false;");
+    expect(e).toContain("startedWithoutSession.current = null;");
+    // ...and the effect has to RUN on the rebuild for any of that to happen.
+    expect(chat()).toContain("}, [controller, file, state.sessionId]);");
   });
 
   test("fire and forget, like every other write in this module", () => {

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -245,12 +245,36 @@ export function saveChatDraft(
   return write("PUT", chatUrl(key), { text, attachments }, opts);
 }
 
+/**
+ * DELETES STILL IN THE AIR, one per key at most — what `rekeyChatDraft` waits
+ * on so a move cannot overtake the removal of the thing it is moving (Bugbot,
+ * PR #1118, 2026-09-11).
+ *
+ * `spent` already stops a REMOUNT from reading the sent words back; this stops
+ * the SERVER from being asked to copy them. The two requests the first send
+ * fires — `DELETE new:<file>` and `POST /api/drafts/chat/rekey` — are otherwise
+ * unordered, and the order that loses is the one where the rekey arrives first:
+ * the record is still there, so the route copies it onto the session id, and a
+ * sent message becomes an unsent draft on the session's own row.
+ *
+ * A key drops out the moment its own request answers, and only if it is still
+ * the one being tracked — a second delete for the same key while the first is
+ * running is the later one's to own.
+ */
+const pendingDeletes = new Map<string, Promise<boolean>>();
+
 /** On send, and on an explicit clear. The key is marked spent BEFORE the
  *  request goes out — see `spent` for the remount that would otherwise read the
- *  draft back out from under the delete. */
+ *  draft back out from under the delete — and the request is remembered while
+ *  it runs, for the rekey that must not pass it (see `pendingDeletes`). */
 export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<boolean> {
   spent.add(key);
-  return write("DELETE", chatUrl(key), undefined, opts);
+  const done: Promise<boolean> = write("DELETE", chatUrl(key), undefined, opts).then((ok) => {
+    if (pendingDeletes.get(key) === done) pendingDeletes.delete(key);
+    return ok;
+  });
+  pendingDeletes.set(key, done);
+  return done;
 }
 
 /**
@@ -269,18 +293,31 @@ export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<
  * standing contract, and doubly right here: the thing being renamed is a draft
  * that the send is about to delete anyway (Akshil, 2026-09-11).
  *
- * NO SPENT-KEY GUARD IS NEEDED HERE, and that is worth writing down rather than
- * re-deriving (Bugbot, PR #1118). This never moves spent words: the route
- * deletes `from` unconditionally and only copies text across when `from` still
- * HAS a record, which after a send it does not — the send's DELETE went out
- * first, and it is ordered behind `settle()` precisely so the last PUT cannot
- * land after it. And if the reader typed ON after sending, that PUT carried
- * content, which un-spent the key (`saveChatDraft`) — those words really do
- * belong to the conversation the send created, which is the one case the route's
- * copy exists for.
+ * IT WAITS FOR THE SEND'S DELETE, AND IT CARRIES SPENT-NESS ACROSS (Bugbot,
+ * PR #1118, 2026-09-11). Going out first was never enough: `DELETE new:<file>`
+ * and this POST are two requests with no order between them, and if the rekey
+ * is served first the record is still sitting there — the route copies it onto
+ * the session id, and the composer that just remounted seeds from the SESSION
+ * key, which nothing had marked spent. The sentence the reader sent is back in
+ * their box, one key to the right of where the fix was looking.
+ *
+ * So: await whatever DELETE for `from` is still running (`pendingDeletes` —
+ * nothing to wait for in the ordinary case, where the chat simply learned its
+ * id without a send), and mark `to` spent whenever `from` is, BEFORE either
+ * request, because the window being covered is the one they are in. Spent on
+ * the new key means the same as on the old one: the words were just sent, and
+ * nothing is restored under it until somebody types again — a PUT with content
+ * un-spends it exactly as before (`saveChatDraft`).
+ *
+ * The reader who typed ON after sending is still served: that PUT carried
+ * content, so it had already un-spent `from`, and this copies no spent-ness
+ * onto `to`. Those words belong to the conversation the send created, which is
+ * the one case the route's copy exists for.
  */
-export function rekeyChatDraft(from: string, to: string): Promise<boolean> {
-  if (!from || !to || from === to) return Promise.resolve(false);
+export async function rekeyChatDraft(from: string, to: string): Promise<boolean> {
+  if (!from || !to || from === to) return false;
+  if (spent.has(from)) spent.add(to);
+  await pendingDeletes.get(from);
   return write("POST", "/api/drafts/chat/rekey", { from, to });
 }
 
@@ -338,11 +375,19 @@ export async function fetchDrafts(): Promise<DraftsSnapshot> {
  *
  *  A SPENT KEY IS ALWAYS NULL, whatever the server still holds: this is the
  *  call a remounting composer seeds from, and it is the one that would put a
- *  sent message back in the box (see `spent`). Checked before the request
- *  rather than after it, so the resurrection costs not even a round trip. */
+ *  sent message back in the box (see `spent`).
+ *
+ *  CHECKED TWICE — before the request, so the ordinary resurrection costs not
+ *  even a round trip, and AGAIN once the answer is in hand (Bugbot, PR #1118,
+ *  2026-09-11). A GET dispatched a moment before the send is a GET that passed
+ *  the first check while the key was still live, and it answers out of a
+ *  snapshot taken before the DELETE landed. Whether the key went spent at the
+ *  start of the wait or in the middle of it makes no difference to the reader:
+ *  the words came back after they were sent. */
 export async function fetchChatDraft(key: string): Promise<ChatDraft | null> {
   if (spent.has(key)) return null;
   const all = await fetchDrafts();
+  if (spent.has(key)) return null;
   return all.chat[key] ?? null;
 }
 
@@ -362,6 +407,15 @@ export interface Autosave<T> {
    * state write that empties the box has not been applied yet at the moment
    * this is called.
    *
+   * `next` becomes BOTH what counts as written and what a later write would
+   * send. Saying only the first left the sent sentence behind in the ref every
+   * write reads from, and the unmount flush — which is the one the first send
+   * from the landing always runs, since gaining a session remounts the chat —
+   * found it different from the empty value just recorded and PUT the words
+   * straight back, un-spending the key on the way (Bugbot, PR #1118,
+   * 2026-09-11). Assigning both makes a flush after a reset a flush with
+   * nothing to say.
+   *
    * `reset` ONLY cancels the PENDING timer — a write already dispatched (a
    * `fetch` awaiting its response) cannot be cancelled by anything short of
    * the network, and keeps running underneath. See `settle` for that half
@@ -373,6 +427,11 @@ export interface Autosave<T> {
    * server deletes the draft as part of `POST /api/schedule`, so a debounced
    * write still in the pipe would resurrect a draft for a task that now exists
    * (Akshil, 2026-09-11 — "stop autosave so a late flush can't resurrect it").
+   *
+   * PERMANENTLY includes the unmount flush: every write goes through one
+   * function and that function reads this flag first, so a stopped autosave
+   * writes nothing again for the life of the mount — no timer, no blur, no
+   * pagehide, no teardown (Bugbot, PR #1118, 2026-09-11).
    *
    * Same caveat as `reset`: this stops the NEXT write from being armed, not
    * one already in flight. See `settle`.
@@ -528,6 +587,10 @@ export function useAutosave<T>(
   }, []);
   const reset = useCallback((next: T) => {
     clear();
+    // The VALUE as well as the bookkeeping — see `Autosave.reset`. Until the
+    // render that empties the box arrives, `valueRef` still holds the sentence
+    // that was just sent, and the unmount flush would write it back.
+    valueRef.current = next;
     written.current = JSON.stringify(next) ?? "";
   }, []);
   const settle = useCallback((): Promise<void> => inflight.current.then(() => undefined), []);
@@ -560,7 +623,9 @@ export function useAutosave<T>(
       window.removeEventListener("pagehide", onHide);
       document.removeEventListener("visibilitychange", onVisibility);
       // THE UNMOUNT FLUSH, and it is the important one: leaving a chat for
-      // another unmounts the composer without any window event at all.
+      // another unmounts the composer without any window event at all. It goes
+      // through `writeNow` like every other write, so a `stop()` disarms it and
+      // a `reset()` leaves it nothing to write.
       flush();
     };
   }, [flush]);

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -1,0 +1,497 @@
+// DRAFTS — the half-written thing, kept on the server (design.md, "Where drafts
+// live: server, one file").
+//
+// Two kinds share one store and one contract:
+//
+//   * a CHAT draft, keyed on the session the composer is in — or on `new:<file>`
+//     while the chat has no session yet, because a brand-new conversation only
+//     gets its id at the first send (design.md, "Chat draft key"). First send
+//     creates the session AND deletes the draft, so nothing is ever re-keyed;
+//   * a TASK draft, keyed on a uuid the CLIENT mints at the first keystroke in
+//     the New task form. A task draft never has a session: the session arrives
+//     at the first run like any scheduled entry (Akshil, 2026-09-11).
+//
+// WHY THE SERVER AND NOT localStorage: the List/Board badge needs `/api/tasks`
+// (server-rendered) to join a draft onto its task row, and a draft should
+// survive the browser profile, another window, and the packaged app vs. the dev
+// server. The sessionStorage hop in `apps/claude/ui/sched-draft.ts` stays as it
+// is — it carries the draft ACROSS a navigation, which is a different errand and
+// a different lifetime (design.md, "Not in scope": retiring the hop).
+//
+// THE ONE RULE EVERY WRITE HERE OBEYS: it must never break what the user is
+// doing. Typing is not blocked, a refusal is not shown, a network error is
+// swallowed — the same contract `stashDraft` keeps with a storage refusal. A
+// draft that failed to save costs the user a draft; a draft that threw inside a
+// keystroke handler costs them the keystroke.
+import { useCallback, useEffect, useRef } from "react";
+
+/** ONE ATTACHMENT, as the schedule form stores it — `path`, `name`, `kind`, the
+ *  identical three fields `sched-draft.ts`'s `SchedAttachment` carries and a
+ *  stored entry's `attachments` row holds. Spelled again here rather than
+ *  imported because `platform/` may not import `apps/` (scripts/check-boundaries)
+ *  — and the wire shape is the server's anyway, not the chat's. */
+export interface DraftAttachment {
+  path: string;
+  name: string;
+  kind: "image" | "file";
+}
+
+/** One chat draft as `GET /api/drafts` returns it. */
+export interface ChatDraft {
+  text: string;
+  attachments: DraftAttachment[];
+  updated_at: number;
+}
+
+/**
+ * The New task form, as a draft: every field the card can lose, and nothing
+ * else. `when` / `repeat` / `new_task_each_run` are nullable because "the user
+ * never said" is a real answer for all three and is not the same as the form's
+ * default — the same distinction `timePicked` draws on the card itself.
+ */
+export interface TaskDraftForm {
+  title: string;
+  description: string;
+  target: string;
+  when: string | null;
+  repeat: string | null;
+  model: string;
+  effort: string;
+  permission: string;
+  attachments: DraftAttachment[];
+  new_task_each_run: boolean | null;
+}
+
+export interface TaskDraft extends TaskDraftForm {
+  created_at: number;
+  updated_at: number;
+}
+
+/** `GET /api/drafts` — everything, both kinds, keyed. */
+export interface DraftsSnapshot {
+  chat: Record<string, ChatDraft>;
+  task: Record<string, TaskDraft>;
+}
+
+const EMPTY: DraftsSnapshot = { chat: {}, task: {} };
+
+/**
+ * WHICH KEY THIS COMPOSER'S DRAFT LIVES UNDER (design.md, "Chat draft key").
+ * The session id when the chat has one; otherwise `new:<file>` — the same file
+ * the sessionStorage hop keys on, so the two halves describe one chat.
+ *
+ * WHAT `<file>` IS, written down once because four things now have to agree on
+ * it (Akshil, 2026-09-11). It is the chat's OWN `file` prop — the path the
+ * Claude pane is mounted on, which is the folder for a folder-scoped chat and
+ * the document for a file-scoped one — verbatim and unnormalised, exactly as
+ * `ClaudeChat` receives it. The other three quote that string rather than
+ * building one of their own:
+ *
+ *   * `sched-draft.stashDraft(file, …)`, the sessionStorage hop, keys on it;
+ *   * the Schedule hop's `?target=` param IS it (`sched-draft.schedulerUrl`
+ *     writes `link.file` there), which is how the task form knows which chat
+ *     draft its own first save supersedes (`from_chat_key`, below);
+ *   * `schedule-lib.explorerUrl(target, "")` builds its path out of it, which
+ *     is where a `new:<file>` draft ROW sends a reader — so the chat that opens
+ *     is mounted on the same `file` and its composer seeds from the same key.
+ *
+ * Nothing here trims a trailing slash or expands a tilde, deliberately: a key
+ * normalised in one of the four places and not the others is a draft that can
+ * be written and never read back.
+ */
+export function chatDraftKey(sessionId: string | null, file: string | null): string {
+  return sessionId || `${NEW_CHAT_PREFIX}${file ?? ""}`;
+}
+
+/** The marker a chat draft with no session yet wears — `fused_render/drafts.py`
+ *  spells it `NEW_CHAT_PREFIX` for the same reason, and the two must agree. */
+export const NEW_CHAT_PREFIX = "new:";
+
+/** The file (or folder) a `new:<file>` key was opened on, or `""` for a key
+ *  that is a session id. The twin of `drafts.new_chat_file` server-side, and it
+ *  exists for the same one reason: a reader who has to get BACK to that chat
+ *  needs the path, and every caller re-deriving the prefix arithmetic is a
+ *  caller that can get it subtly wrong (Akshil, 2026-09-11). */
+export function newChatFile(key: string): string {
+  return key.startsWith(NEW_CHAT_PREFIX) ? key.slice(NEW_CHAT_PREFIX.length) : "";
+}
+
+/** The id a task draft is minted under. `crypto.randomUUID` is present in every
+ *  engine this shell runs in, but it is absent over plain http on some older
+ *  builds — and a form that throws on its first keystroke would be a far worse
+ *  bug than a draft with a home-made id. */
+export function newTaskDraftId(): string {
+  const c = globalThis.crypto as Crypto | undefined;
+  if (c && typeof c.randomUUID === "function") return c.randomUUID();
+  return `d-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Extra request options a FLUSH needs and an ordinary autosave does not. */
+export interface DraftWriteOptions {
+  /** Let the request outlive the document — the only way a write started from
+   *  `pagehide` or an unmount actually leaves the browser. */
+  keepalive?: boolean;
+}
+
+/**
+ * THE KEY, AS A PATH. Both routes are declared `{key:path}` server-side, so the
+ * `/` inside a `new:<file>` key is part of the path rather than something to
+ * hide from it: each SEGMENT is encoded and the separators are left standing.
+ * `encodeURIComponent` on the whole key would send `%2F`, which every layer
+ * between here and the route gets to normalise differently — and this key is a
+ * file path, so it is the common case rather than the exotic one.
+ */
+const encodePath = (key: string) => key.split("/").map(encodeURIComponent).join("/");
+
+const chatUrl = (key: string) => `/api/drafts/chat/${encodePath(key)}`;
+const taskUrl = (id: string) => `/api/drafts/task/${encodePath(id)}`;
+
+/**
+ * Every write in this module goes through here, and nothing it can do reaches
+ * the caller. `X-Fused` is the same CSRF-ish marker every mutation in
+ * `platform/lib/api.ts` carries (it forces a CORS preflight, so a foreign page
+ * cannot write blind); the body is omitted for a DELETE, which has none.
+ *
+ * The promise RESOLVES on failure rather than rejecting, so a caller may await
+ * it without a try/catch and an un-awaited call can never become an unhandled
+ * rejection in the middle of somebody typing.
+ */
+async function write(
+  method: "PUT" | "POST" | "DELETE",
+  url: string,
+  body: unknown,
+  opts?: DraftWriteOptions,
+): Promise<boolean> {
+  try {
+    const res = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json", "X-Fused": "1" },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      ...(opts?.keepalive ? { keepalive: true } : {}),
+    });
+    return res.ok;
+  } catch {
+    // Offline, server restarting, the document unloading mid-flight. The draft
+    // just isn't saved; nothing on screen changes and nothing is said.
+    return false;
+  }
+}
+
+/**
+ * Upsert this chat's draft. EMPTY TEXT WITH NO ATTACHMENTS IS A DELETE, decided
+ * server-side (design.md: "writing empty == delete") — so the caller does not
+ * have to tell "cleared the box" apart from "never typed", and a composer
+ * emptied by hand leaves no ghost row on the list.
+ */
+export function saveChatDraft(
+  key: string,
+  text: string,
+  attachments: readonly DraftAttachment[] = [],
+  opts?: DraftWriteOptions,
+): Promise<boolean> {
+  return write("PUT", chatUrl(key), { text, attachments }, opts);
+}
+
+/** On send, and on an explicit clear. */
+export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<boolean> {
+  return write("DELETE", chatUrl(key), undefined, opts);
+}
+
+/**
+ * THE DRAFT MOVES WITH THE SESSION IT TURNED OUT TO BE (design.md, Round 2:
+ * "Every draft has a TASK number").
+ *
+ * A chat with no session yet keys its draft `new:<file>` and is given a TASK
+ * number under that key. The first send creates the session, and from the next
+ * render the composer keys on the session id instead — so without this the
+ * number, and the row wearing it, would be stranded on a key nothing reads
+ * again. The server moves both (`tasks_store.rekey`, the same call that walks a
+ * `pending:` number onto a session).
+ *
+ * FIRE AND FORGET, once, at the moment the id is learned. A refusal costs the
+ * number's continuity and nothing the reader is doing — which is this module's
+ * standing contract, and doubly right here: the thing being renamed is a draft
+ * that the send is about to delete anyway (Akshil, 2026-09-11).
+ */
+export function rekeyChatDraft(from: string, to: string): Promise<boolean> {
+  if (!from || !to || from === to) return Promise.resolve(false);
+  return write("POST", "/api/drafts/chat/rekey", { from, to });
+}
+
+/**
+ * Upsert a task draft under the id the form minted.
+ *
+ * `fromChatKey` is the MOVE (design.md, Round 2: "A draft moves, never
+ * duplicates"). The Schedule hop carries a composer's words into the task form,
+ * and for the moment in between there are two stores holding the same sentence:
+ * the chat draft the composer autosaved, and the task draft this call is
+ * creating. Naming the chat key on the first write makes the server delete that
+ * one in the same request — one draft, one row, one TASK number, with no window
+ * in which the List shows the same words twice.
+ *
+ * Sent on the FIRST write only (the caller latches it): the second PUT is an
+ * ordinary keystroke save, and repeating a delete for a key that is already
+ * gone is a request that can only ever be a no-op or a surprise.
+ */
+export function saveTaskDraft(
+  id: string,
+  form: TaskDraftForm,
+  opts?: DraftWriteOptions,
+  fromChatKey?: string,
+): Promise<boolean> {
+  const body = fromChatKey ? { ...form, from_chat_key: fromChatKey } : form;
+  return write("PUT", taskUrl(id), body, opts);
+}
+
+/** Discard. `POST /api/schedule` deletes the draft itself when it is handed a
+ *  `draft_id`, so this is the DISCARD button's call and not the Schedule path's. */
+export function deleteTaskDraft(id: string, opts?: DraftWriteOptions): Promise<boolean> {
+  return write("DELETE", taskUrl(id), undefined, opts);
+}
+
+/**
+ * Every draft there is. An unreadable answer is an EMPTY SNAPSHOT rather than a
+ * throw, for the reason `parseAttachmentsParam` gives: this is read inside the
+ * effect that seeds a composer, and a parse error there would cost the mount.
+ */
+export async function fetchDrafts(): Promise<DraftsSnapshot> {
+  try {
+    const res = await fetch("/api/drafts");
+    if (!res.ok) return EMPTY;
+    const data = (await res.json()) as Partial<DraftsSnapshot> | null;
+    if (!data || typeof data !== "object") return EMPTY;
+    return { chat: data.chat ?? {}, task: data.task ?? {} };
+  } catch {
+    return EMPTY;
+  }
+}
+
+/** One chat draft, or null. A convenience over `fetchDrafts` — there is no
+ *  per-key GET in the contract, and the store is small enough that the whole of
+ *  it is cheaper than a second endpoint would be. */
+export async function fetchChatDraft(key: string): Promise<ChatDraft | null> {
+  const all = await fetchDrafts();
+  return all.chat[key] ?? null;
+}
+
+/** What `useAutosave` hands back: the things a caller ever needs to do to a
+ *  running autosave by hand. */
+export interface Autosave<T> {
+  /** Write NOW if anything has changed since the last write — what send, submit
+   *  and every unload path spend. */
+  flush(): void;
+  /**
+   * FORGET WHAT IS PENDING and take `next` as already-written.
+   *
+   * The composer's send: the box is about to be cleared and the draft deleted,
+   * and a debounced write armed a keystroke earlier would otherwise land AFTER
+   * the DELETE and resurrect the message that was just sent. Told what the
+   * value is about to become, rather than reading the current one, because the
+   * state write that empties the box has not been applied yet at the moment
+   * this is called.
+   *
+   * `reset` ONLY cancels the PENDING timer — a write already dispatched (a
+   * `fetch` awaiting its response) cannot be cancelled by anything short of
+   * the network, and keeps running underneath. See `settle` for that half
+   * (Akshil, 2026-09-11).
+   */
+  reset(next: T): void;
+  /**
+   * DISARM, permanently for this mount. The Schedule button's other half: the
+   * server deletes the draft as part of `POST /api/schedule`, so a debounced
+   * write still in the pipe would resurrect a draft for a task that now exists
+   * (Akshil, 2026-09-11 — "stop autosave so a late flush can't resurrect it").
+   *
+   * Same caveat as `reset`: this stops the NEXT write from being armed, not
+   * one already in flight. See `settle`.
+   */
+  stop(): void;
+  /**
+   * WAIT OUT WHATEVER WRITE IS RUNNING, if any.
+   *
+   * Neither `reset` nor `stop` can cancel a `fetch` already sent — the PUT for
+   * a keystroke a moment ago may still be in the air when Send, Discard, or
+   * Schedule fires. Each of those follows a `reset`/`stop` with a server-side
+   * DELETE (the draft is spent, or the server drops it as part of creating the
+   * task), and an in-flight PUT that lands after that DELETE resurrects
+   * exactly the draft the delete was for. `settle` resolves once that one
+   * write (whichever is running at the moment it is called) is done, so a
+   * caller can order its own delete after it rather than after a cancellation
+   * that was never possible. Resolves immediately when nothing is in flight.
+   * Never rejects, for the same reason every write in this module never does
+   * (Akshil, 2026-09-11).
+   */
+  settle(): Promise<void>;
+}
+
+export interface AutosaveOptions {
+  /** Quiet time after the last change before a write goes out. */
+  delay?: number;
+  /**
+   * THE OPENING VALUE COUNTS AS UNWRITTEN — so the very first debounce writes
+   * it, with nobody having typed anything (Akshil, 2026-09-11).
+   *
+   * Off by default, and the default is the load-bearing one: the hook seeds
+   * "what was last written" with the value it mounts on, which is exactly what
+   * makes "nothing minted for an untouched modal" true — a form whose fields
+   * are merely non-empty (an Edit, a re-opened draft) never writes until a
+   * person changes something.
+   *
+   * ON is the case where the content ARRIVED already typed, somewhere else:
+   * the Schedule hop hands the task form the sentence the composer was holding
+   * (design.md, Round 2, "A draft moves, never duplicates"). Those words are a
+   * draft the moment they land — the chat's copy is about to be deleted in
+   * favour of this one — so waiting for a keystroke would be waiting to lose
+   * them.
+   *
+   * Read ONCE, at mount, like every other opening fact: flipping it later says
+   * nothing, because by then the question of what the form opened with has
+   * already been answered.
+   */
+  writeInitial?: boolean;
+}
+
+/** The seed for `written` when `writeInitial` says the opening value has not
+ *  been written. Not a value `JSON.stringify` can return for anything — a
+ *  stringified string always carries its quotes — so the first comparison can
+ *  only ever be "different". */
+const UNWRITTEN = "\u0000unwritten";
+
+/** design.md: 600 ms after the last keystroke. Long enough that a sentence is
+ *  one write, short enough that a reader who types and immediately closes the
+ *  tab is covered by the flush rather than by the timer. */
+export const AUTOSAVE_DELAY_MS = 600;
+
+/**
+ * AUTOSAVE, THE WHOLE OF IT — debounce, flush, and the promise never to be in
+ * the way.
+ *
+ * `value` is whatever the caller wants persisted; `save` is called with it. The
+ * hook compares SERIALISED values (`JSON.stringify`), so a caller may hand it a
+ * fresh object every render — which every form does — without that alone
+ * counting as a change. A value that serialises identically is never written
+ * twice, which is what keeps a re-render from becoming a request.
+ *
+ * WHEN IT WRITES:
+ *   * `delay` ms after the last change — the ordinary case;
+ *   * immediately on window blur, on `pagehide`, and on the document going
+ *     hidden — the three moments a half-typed thing is most likely to be
+ *     abandoned;
+ *   * immediately on unmount, which is what covers leaving a chat for another
+ *     one, or closing the task form.
+ *
+ * The last three pass `keepalive`, because a request started while the document
+ * is going away is cancelled with it otherwise. `save` NEVER throws into the
+ * caller (the module's writes swallow everything) and its result is ignored:
+ * there is no retry and no error surface by design — see the header.
+ *
+ * `save` is read through a ref, so an inline closure (what every call site
+ * passes) does not tear down and rebuild the pending write on every render.
+ *
+ * `save` MAY return the promise its own `fetch` wrapper gives back (every call
+ * site does — `saveChatDraft`/`saveTaskDraft` resolve `false` rather than
+ * rejecting; see the header). Returning it is what lets `settle` (below) know
+ * when a write is actually done rather than merely dispatched — a caller that
+ * ignores the return value loses nothing, since `settle` on an autosave whose
+ * `save` never resolves anything just resolves at once.
+ */
+export function useAutosave<T>(
+  value: T,
+  save: (value: T, opts: DraftWriteOptions) => unknown,
+  { delay = AUTOSAVE_DELAY_MS, writeInitial = false }: AutosaveOptions = {},
+): Autosave<T> {
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  // THE VALUE AS ONE STRING, and it is what the debounce below actually depends
+  // on. Every caller hands a fresh object literal each render, and a host that
+  // re-renders on a poll (the chat does, every 400ms) would otherwise clear and
+  // re-arm the timer forever and never write anything.
+  const serial = JSON.stringify(value) ?? "";
+  // What was last WRITTEN, serialised. Seeded with the opening value so a mount
+  // alone never writes: the form's own initial state is not something the user
+  // typed, and a task draft minted by merely opening the card is exactly what
+  // "nothing minted for an untouched modal" forbids.
+  //
+  // …unless the caller says the opening value ARRIVED already typed — see
+  // `writeInitial`, whose one caller is the task form opened from the chat's
+  // Schedule hop. Then the seed is a string no value can serialise to, so the
+  // first debounce finds a difference and the draft is minted with nobody
+  // having touched the card (Akshil, 2026-09-11).
+  const written = useRef<string>(writeInitial ? UNWRITTEN : (JSON.stringify(value) ?? ""));
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const stopped = useRef(false);
+  // THE WRITE CURRENTLY RUNNING, if any — what `settle` waits on. Seeded
+  // resolved so a `settle` called before this autosave has ever written
+  // anything (a Discard on an untouched card, say) returns at once rather
+  // than hanging on a promise nothing ever produced. Wrapped in
+  // `Promise.resolve(...).catch(() => false)` on every write below: `save`'s
+  // own promise already never rejects (see the header), but `settle` must
+  // hold that guarantee regardless of what a future caller's `save` does —
+  // one bad write must not leave every subsequent `settle` rejecting forever
+  // (Akshil, 2026-09-11).
+  const inflight = useRef<Promise<unknown>>(Promise.resolve());
+
+  const clear = () => {
+    if (timer.current !== undefined) clearTimeout(timer.current);
+    timer.current = undefined;
+  };
+
+  const writeNow = useCallback((opts: DraftWriteOptions) => {
+    clear();
+    if (stopped.current) return;
+    const next = JSON.stringify(valueRef.current) ?? "";
+    if (next === written.current) return;
+    written.current = next;
+    inflight.current = Promise.resolve(saveRef.current(valueRef.current, opts)).catch(
+      () => false,
+    );
+  }, []);
+
+  const flush = useCallback(() => writeNow({ keepalive: true }), [writeNow]);
+  const stop = useCallback(() => {
+    stopped.current = true;
+    clear();
+  }, []);
+  const reset = useCallback((next: T) => {
+    clear();
+    written.current = JSON.stringify(next) ?? "";
+  }, []);
+  const settle = useCallback((): Promise<void> => inflight.current.then(() => undefined), []);
+
+  // The debounce. Runs on every render whose serialised value differs from what
+  // was last written — the comparison is inside `writeNow`, so a timer that
+  // fires on an unchanged value costs one string compare and no request.
+  useEffect(() => {
+    if (stopped.current) return;
+    if (serial === written.current) return;
+    clear();
+    timer.current = setTimeout(() => writeNow({}), delay);
+    return clear;
+  }, [serial, delay, writeNow]);
+
+  // The three ways a document leaves, plus the unmount. `pagehide` rather than
+  // `unload` alone: it is the one that fires for a bfcache navigation, which is
+  // most of them. `visibilitychange` covers the phone/tab-switch that never
+  // becomes a pagehide at all.
+  useEffect(() => {
+    const onHide = () => flush();
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    window.addEventListener("blur", onHide);
+    window.addEventListener("pagehide", onHide);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("blur", onHide);
+      window.removeEventListener("pagehide", onHide);
+      document.removeEventListener("visibilitychange", onVisibility);
+      // THE UNMOUNT FLUSH, and it is the important one: leaving a chat for
+      // another unmounts the composer without any window event at all.
+      flush();
+    };
+  }, [flush]);
+
+  return { flush, stop, reset, settle };
+}

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -24,6 +24,7 @@
 // draft that failed to save costs the user a draft; a draft that threw inside a
 // keystroke handler costs them the keystroke.
 import { useCallback, useEffect, useRef } from "react";
+import type { RecurrenceRule } from "./api";
 
 /** ONE ATTACHMENT, as the schedule form stores it — `path`, `name`, `kind`, the
  *  identical three fields `sched-draft.ts`'s `SchedAttachment` carries and a
@@ -60,6 +61,22 @@ export interface TaskDraftForm {
   permission: string;
   attachments: DraftAttachment[];
   new_task_each_run: boolean | null;
+  /**
+   * THE RULE BEHIND A "CUSTOM" REPEAT, because the preset key alone is not an
+   * answer (Bugbot, PR #1118).
+   *
+   * Every other repeat choice IS its own data — "every day" needs nothing but
+   * the word — but `repeat: "custom"` is a pointer at a rule the recurrence
+   * dialog built, and a draft that stored the pointer and dropped the rule
+   * reopened on a card that said Custom, held no rule, and refused Save with
+   * nothing on screen explaining why (`saveEnabled`: a custom repeat needs its
+   * rule). Stored as the object, pass-through on the server, so what comes back
+   * is what the dialog produced.
+   *
+   * Null whenever the choice is not Custom — including a repeat that is switched
+   * off entirely, exactly as `repeat` itself is.
+   */
+  custom_rule: RecurrenceRule | null;
 }
 
 export interface TaskDraft extends TaskDraftForm {
@@ -178,10 +195,45 @@ async function write(
 }
 
 /**
+ * CHAT KEYS WHOSE DRAFT IS SPENT — sent, or cleared on purpose — and which must
+ * therefore read back as EMPTY even while the server still says otherwise
+ * (Bugbot, PR #1118).
+ *
+ * THE RACE IT CLOSES. The first send from a session-less chat does two things in
+ * the same tick: it fires `DELETE /api/drafts/chat/new:<file>`, and it gives the
+ * landing a session — which remounts the whole chat, composer included
+ * (`ClaudeChat`'s remount on the first send). The new mount seeds itself from
+ * the server (`fetchChatDraft`), and that GET can overtake a DELETE that is
+ * still in flight. What it answers is the sentence that was just sent, into a
+ * box the send had emptied; the rekey that follows then walks those words onto
+ * the session, and the message the reader sent is sitting on their own task row
+ * as an unsent draft.
+ *
+ * NOTHING INSIDE ONE MOUNT CAN FIX IT. `reset`, `stop` and `settle` all belong
+ * to a component that is being thrown away at that instant, and the seed that
+ * resurrects the words runs in a DIFFERENT one. So the fact lives at module
+ * scope, where both mounts can see it — which is also where it belongs, since
+ * spent-ness is a fact about the KEY and not about any one composer.
+ *
+ * ENTERED BEFORE THE REQUEST, because covering the window the request is in is
+ * the entire point; and KEPT afterwards, because the window does not close when
+ * the DELETE answers — a remount a second later would seed from a cached or
+ * re-read snapshot just the same. A key stays spent until somebody types into it
+ * again, which is exactly what `saveChatDraft` below hears.
+ */
+const spent = new Set<string>();
+
+/**
  * Upsert this chat's draft. EMPTY TEXT WITH NO ATTACHMENTS IS A DELETE, decided
  * server-side (design.md: "writing empty == delete") — so the caller does not
  * have to tell "cleared the box" apart from "never typed", and a composer
  * emptied by hand leaves no ghost row on the list.
+ *
+ * A write WITH CONTENT un-spends the key (see `spent`): there are words under it
+ * again, they were put there deliberately, and the next composer to open on it
+ * must be allowed to see them. An empty write does not, because an empty write
+ * IS a delete and un-spending on it would re-open the very window `spent`
+ * closes.
  */
 export function saveChatDraft(
   key: string,
@@ -189,11 +241,15 @@ export function saveChatDraft(
   attachments: readonly DraftAttachment[] = [],
   opts?: DraftWriteOptions,
 ): Promise<boolean> {
+  if (text.trim() || attachments.length) spent.delete(key);
   return write("PUT", chatUrl(key), { text, attachments }, opts);
 }
 
-/** On send, and on an explicit clear. */
+/** On send, and on an explicit clear. The key is marked spent BEFORE the
+ *  request goes out — see `spent` for the remount that would otherwise read the
+ *  draft back out from under the delete. */
 export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<boolean> {
+  spent.add(key);
   return write("DELETE", chatUrl(key), undefined, opts);
 }
 
@@ -212,6 +268,16 @@ export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<
  * number's continuity and nothing the reader is doing — which is this module's
  * standing contract, and doubly right here: the thing being renamed is a draft
  * that the send is about to delete anyway (Akshil, 2026-09-11).
+ *
+ * NO SPENT-KEY GUARD IS NEEDED HERE, and that is worth writing down rather than
+ * re-deriving (Bugbot, PR #1118). This never moves spent words: the route
+ * deletes `from` unconditionally and only copies text across when `from` still
+ * HAS a record, which after a send it does not — the send's DELETE went out
+ * first, and it is ordered behind `settle()` precisely so the last PUT cannot
+ * land after it. And if the reader typed ON after sending, that PUT carried
+ * content, which un-spent the key (`saveChatDraft`) — those words really do
+ * belong to the conversation the send created, which is the one case the route's
+ * copy exists for.
  */
 export function rekeyChatDraft(from: string, to: string): Promise<boolean> {
   if (!from || !to || from === to) return Promise.resolve(false);
@@ -268,8 +334,14 @@ export async function fetchDrafts(): Promise<DraftsSnapshot> {
 
 /** One chat draft, or null. A convenience over `fetchDrafts` — there is no
  *  per-key GET in the contract, and the store is small enough that the whole of
- *  it is cheaper than a second endpoint would be. */
+ *  it is cheaper than a second endpoint would be.
+ *
+ *  A SPENT KEY IS ALWAYS NULL, whatever the server still holds: this is the
+ *  call a remounting composer seeds from, and it is the one that would put a
+ *  sent message back in the box (see `spent`). Checked before the request
+ *  rather than after it, so the resurrection costs not even a round trip. */
 export async function fetchChatDraft(key: string): Promise<ChatDraft | null> {
+  if (spent.has(key)) return null;
   const all = await fetchDrafts();
   return all.chat[key] ?? null;
 }

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -278,6 +278,45 @@ export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<
 }
 
 /**
+ * CHAT KEYS A SEND LEFT BEHIND — `new:<file>` keys whose composer had no session
+ * at the moment the user pressed Send, and which are therefore owed a rekey onto
+ * whatever session that send creates (Bugbot, PR #1118, 2026-09-12).
+ *
+ * WHY THE SEND SAYS SO RATHER THAN THE CHAT INFERRING IT. The rekey used to be
+ * decided by watching `state.sessionId`: the chat latched "I started without a
+ * session" on the first pass it saw an empty id, and moved the `new:<file>`
+ * draft the moment an id appeared. But an empty id on the first pass is the
+ * ORDINARY case for every chat, opened-on-a-session ones included — the id only
+ * lands when boot's `openSession` answers. So opening an existing session in a
+ * folder that already held a `new:<file>` draft fired the rekey and walked that
+ * unsent row — words and TASK number — onto a conversation it had nothing to do
+ * with.
+ *
+ * The event the move actually belongs to is a SEND from a composer with no
+ * session, which is a thing the composer knows for certain and nobody else can
+ * observe after the fact. So the composer records it here and the chat spends it.
+ *
+ * SPENT ON READ (`takeSentWithoutSession`), which is what makes "once" and "per
+ * file" fall out for free: the chat's effect may run many times as the id
+ * settles, and two chats in the same `ChatBody` hold different keys, so a
+ * per-key one-shot needs no latch, no controller identity, and no reset.
+ */
+const sentWithoutSession = new Set<string>();
+
+/** The composer's half: this send went out with no session under it, so the
+ *  draft key it was typed under is owed a move (see `sentWithoutSession`). */
+export function markSentWithoutSession(key: string): void {
+  if (key) sentWithoutSession.add(key);
+}
+
+/** The chat's half: was this key's send the one that had no session? Answers
+ *  true at most once per mark — the fact is CONSUMED, because the move it
+ *  authorises happens exactly once. */
+export function takeSentWithoutSession(key: string): boolean {
+  return sentWithoutSession.delete(key);
+}
+
+/**
  * THE DRAFT MOVES WITH THE SESSION IT TURNED OUT TO BE (design.md, Round 2:
  * "Every draft has a TASK number").
  *
@@ -288,7 +327,9 @@ export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<
  * again. The server moves both (`tasks_store.rekey`, the same call that walks a
  * `pending:` number onto a session).
  *
- * FIRE AND FORGET, once, at the moment the id is learned. A refusal costs the
+ * FIRE AND FORGET, once, when the id of the session a session-less send created
+ * is learned — `sentWithoutSession` above is what tells the two apart from a
+ * chat merely opened ON a session. A refusal costs the
  * number's continuity and nothing the reader is doing — which is this module's
  * standing contract, and doubly right here: the thing being renamed is a draft
  * that the send is about to delete anyway (Akshil, 2026-09-11).

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -278,45 +278,6 @@ export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<
 }
 
 /**
- * CHAT KEYS A SEND LEFT BEHIND — `new:<file>` keys whose composer had no session
- * at the moment the user pressed Send, and which are therefore owed a rekey onto
- * whatever session that send creates (Bugbot, PR #1118, 2026-09-12).
- *
- * WHY THE SEND SAYS SO RATHER THAN THE CHAT INFERRING IT. The rekey used to be
- * decided by watching `state.sessionId`: the chat latched "I started without a
- * session" on the first pass it saw an empty id, and moved the `new:<file>`
- * draft the moment an id appeared. But an empty id on the first pass is the
- * ORDINARY case for every chat, opened-on-a-session ones included — the id only
- * lands when boot's `openSession` answers. So opening an existing session in a
- * folder that already held a `new:<file>` draft fired the rekey and walked that
- * unsent row — words and TASK number — onto a conversation it had nothing to do
- * with.
- *
- * The event the move actually belongs to is a SEND from a composer with no
- * session, which is a thing the composer knows for certain and nobody else can
- * observe after the fact. So the composer records it here and the chat spends it.
- *
- * SPENT ON READ (`takeSentWithoutSession`), which is what makes "once" and "per
- * file" fall out for free: the chat's effect may run many times as the id
- * settles, and two chats in the same `ChatBody` hold different keys, so a
- * per-key one-shot needs no latch, no controller identity, and no reset.
- */
-const sentWithoutSession = new Set<string>();
-
-/** The composer's half: this send went out with no session under it, so the
- *  draft key it was typed under is owed a move (see `sentWithoutSession`). */
-export function markSentWithoutSession(key: string): void {
-  if (key) sentWithoutSession.add(key);
-}
-
-/** The chat's half: was this key's send the one that had no session? Answers
- *  true at most once per mark — the fact is CONSUMED, because the move it
- *  authorises happens exactly once. */
-export function takeSentWithoutSession(key: string): boolean {
-  return sentWithoutSession.delete(key);
-}
-
-/**
  * THE DRAFT MOVES WITH THE SESSION IT TURNED OUT TO BE (design.md, Round 2:
  * "Every draft has a TASK number").
  *
@@ -328,8 +289,11 @@ export function takeSentWithoutSession(key: string): boolean {
  * `pending:` number onto a session).
  *
  * FIRE AND FORGET, once, when the id of the session a session-less send created
- * is learned — `sentWithoutSession` above is what tells the two apart from a
- * chat merely opened ON a session. A refusal costs the
+ * is learned. WHICH SEND THAT WAS is not this module's business and never was:
+ * `ClaudeChat` binds the move to the run it dispatched, because a chat merely
+ * opened ON a session also spends its first renders with an empty id and a
+ * module-level "a send is owed a rekey" note could be spent by the wrong one
+ * (Bugbot, PR #1118, 2026-09-12). A refusal costs the
  * number's continuity and nothing the reader is doing — which is this module's
  * standing contract, and doubly right here: the thing being renamed is a draft
  * that the send is about to delete anyway (Akshil, 2026-09-11).

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -2089,6 +2089,19 @@ export function buildSchedulePayload(form: {
   // same request that creates the task: two round trips could half-fail and
   // leave a draft row sitting beside the task it had already become.
   draftId?: string;
+  // THE CHAT DRAFT THESE WORDS WERE TYPED IN, for a card opened from the
+  // composer's Schedule button — or re-opened from a draft that remembers one
+  // (`form.from_chat_key`). Sent so the server drops the chat's copy in the same
+  // request that creates the task.
+  //
+  // IT IS NOT REDUNDANT WITH `draftId`, which is the bug it fixes (Bugbot, PR
+  // #1118): the hop's first autosave is what normally moves the chat draft onto
+  // the task draft, and pressing Schedule inside that 600 ms debounce means
+  // there IS no task draft — no id, no move, and the chat draft (with its row
+  // and its TASK number) outlives the task it just became. Nor is it covered by
+  // `sessionId`: a chat that has never sent anything has no session at all, and
+  // its draft is keyed `new:<file>`.
+  fromChatKey?: string;
   // DID ANYONE PICK THIS TIME? False when the card was opened from the List or
   // the Board — where the when-row starts folded away — and the user never
   // touched it, so `when` is only the form's own default of "now". The task
@@ -2174,6 +2187,7 @@ export function buildSchedulePayload(form: {
     // same reason `title` is.
     ...(form.replacesEntryId ? { replaces: form.replacesEntryId } : {}),
     ...(form.draftId ? { draft_id: form.draftId } : {}),
+    ...(form.fromChatKey ? { from_chat_key: form.fromChatKey } : {}),
     ...(form.images && form.images.length ? { images: form.images } : {}),
     ...(form.attachments && form.attachments.length
       ? { attachments: form.attachments } : {}),
@@ -2329,6 +2343,37 @@ export interface SeededDraftForm {
    * It is what "Back to chat" aims at on that card (`backToChat`).
    */
   fromChatKey: string | null;
+  /**
+   * THE RULE `repeat: "custom"` POINTS AT (Bugbot, PR #1118). The preset key
+   * alone is not an answer for Custom — see `TaskDraftForm.custom_rule` — so a
+   * reopened draft needs this to seed `customRule` with, not just `repeat`.
+   * Null for anything that does not parse as one of the five known shapes:
+   * a draft is loose JSON that may have been written by a different build
+   * (module docstring), and a malformed rule must cost the rule, not the card.
+   */
+  customRule: RecurrenceRule | null;
+}
+
+/** `f.custom_rule`, as a `RecurrenceRule` or not at all. Every field its own
+ *  type check, exactly like `str`/`attachments` below — a draft is loose JSON
+ *  and a bad shape must never throw inside the `useState` initialiser that
+ *  reads this (module docstring). */
+function parseCustomRule(value: unknown): RecurrenceRule | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  const freq = row.freq;
+  if (freq !== "hour" && freq !== "day" && freq !== "week" && freq !== "month" && freq !== "year") {
+    return null;
+  }
+  const rule: RecurrenceRule = { freq };
+  if (typeof row.interval === "number") rule.interval = row.interval;
+  if (Array.isArray(row.byday) && row.byday.every((d) => typeof d === "number")) {
+    rule.byday = row.byday as number[];
+  }
+  if (row.monthly === "day" || row.monthly === "nth-weekday") rule.monthly = row.monthly;
+  if (typeof row.until === "string") rule.until = row.until;
+  if (typeof row.count === "number") rule.count = row.count;
+  return rule;
 }
 
 export function seededDraftForm(seed?: DraftSeed | null): SeededDraftForm {
@@ -2361,6 +2406,7 @@ export function seededDraftForm(seed?: DraftSeed | null): SeededDraftForm {
     attachments: attachments && attachments.length ? attachments : null,
     newTaskEachRun: typeof f.new_task_each_run === "boolean" ? f.new_task_each_run : null,
     fromChatKey: str("from_chat_key"),
+    customRule: parseCustomRule(f.custom_rule),
   };
 }
 
@@ -2732,11 +2778,17 @@ export default function NewJobModal({
   const [repeat, setRepeat] = useState<string>(
     () => saved.repeat ?? initialRepeatKey(editing),
   );
-  const [customRule, setCustomRule] = useState<RecurrenceRule | null>(() =>
-    editing?.rule && keyOfRule(editing.rule, new Date(editing.due)) === "custom"
+  const [customRule, setCustomRule] = useState<RecurrenceRule | null>(() => {
+    // A REOPENED DRAFT'S OWN RULE OUTRANKS `editing` — the two are mutually
+    // exclusive (a draft never carries `editing`, per `hopSeeded`'s comment
+    // above), and reading it here is the other half of the fix `custom_rule`
+    // exists for: storing it was pointless if nothing ever seeded it back
+    // (Bugbot, PR #1118).
+    if (saved.repeat === "custom" && saved.customRule) return saved.customRule;
+    return editing?.rule && keyOfRule(editing.rule, new Date(editing.due)) === "custom"
       ? editing.rule
-      : null,
-  );
+      : null;
+  });
   // Repeat is a CHECKBOX now, and the dropdown only exists while it is ticked
   // (design §6). Editing a repeating task therefore opens ticked, with the
   // stored rule already loaded — which is exactly "the key is not none".
@@ -3113,6 +3165,24 @@ export default function NewJobModal({
    * this card was handed).
    */
   const hopSeeded = !editing && !initialDraft && !!(initialMessage ?? "").trim();
+  /**
+   * THE CHAT THIS CARD'S WORDS CAME OUT OF, whichever way the card was opened —
+   * and the thing `POST /api/schedule` is told so it can drop that draft (Bugbot,
+   * PR #1118).
+   *
+   * The move is normally made by the first autosave (`from_chat_key` on the
+   * task-draft PUT, below). But Schedule pressed inside the 600 ms debounce
+   * never gets there: no id is minted, no PUT goes out, and the composer's draft
+   * — its row and its TASK number with it — sits beside the task it just became.
+   * `session_id` on the payload does not cover it either: a chat with no session
+   * yet is keyed `new:<file>`, which is not a session id.
+   *
+   * Two sources, same answer. The FRESH hop is handed the key as a prop; a card
+   * REOPENED from its draft row has only what the server stored on the draft
+   * (`form.from_chat_key`) — the same fact `backToChat` aims at below, for the
+   * same reason it exists at all.
+   */
+  const originChatKey = (fromChatKey ?? "") || (saved.fromChatKey ?? "");
   const draftBody: TaskDraftForm | null = !editing && (dirty || hopSeeded)
     ? {
       title,
@@ -3129,6 +3199,10 @@ export default function NewJobModal({
         .filter((i) => i.path)
         .map((i) => ({ path: i.path, name: i.name, kind: i.kind })),
       new_task_each_run: repeatOn ? newTaskEachRun : null,
+      // THE RULE `repeat` POINTS AT, when the choice is Custom — null the same
+      // moment `repeat` itself goes null, so a draft can never say "custom"
+      // with nothing behind it (Bugbot, PR #1118; see `TaskDraftForm.custom_rule`).
+      custom_rule: repeatOn && repeat === "custom" ? customRule : null,
     }
     : null;
   // NULL UNTIL THE FORM IS DIRTY, and that is what "nothing minted for an
@@ -3463,6 +3537,14 @@ export default function NewJobModal({
       // `settle` waits that one out too, BEFORE the request below goes out —
       // the server-side delete must be ordered after the last PUT, not merely
       // after the last one this client could still call off.
+      //
+      // `flush` FIRST, and it is load-bearing on a HOP-SEEDED card: `writeInitial`
+      // only arms the 600 ms debounce, so a Schedule pressed within that window
+      // (the whole point of a hop is that the card opens ready to send) would
+      // otherwise reach `stop` before a single write ever went out — no id
+      // minted, no `from_chat_key`, and the chat draft this hop was supposed to
+      // retire outlives the task it became (Bugbot, this batch).
+      autosaveRef.current.flush();
       autosaveRef.current.stop();
       await autosaveRef.current.settle();
       await scheduleMessage(
@@ -3492,6 +3574,9 @@ export default function NewJobModal({
           // in the same request. Empty when the form was never dirty enough to
           // mint one, which is most one-line tasks.
           draftId: draftIdRef.current ?? "",
+          // …and the chat draft this card was composed out of, for the case the
+          // autosave never got to move it. See originChatKey.
+          fromChatKey: originChatKey,
           // Whether anybody chose this time, which is what decides if the task
           // is a plan or a thing to run. See `timePicked`.
           timePicked,

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -35,10 +35,22 @@ import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { navigateUrl } from "@platform/lib/router";
 import { ENTER_LABEL, isMod, MOD_LABEL } from "@platform/lib/platform";
 import {
+  deleteTaskDraft,
+  newChatFile,
+  NEW_CHAT_PREFIX,
+  newTaskDraftId,
+  saveChatDraft,
+  saveTaskDraft,
+  useAutosave,
+  type TaskDraftForm,
+} from "@platform/lib/drafts";
+import {
   TASK_EFFORTS,
   TASK_MODELS,
+  chatPaneUrl,
   describeRepeats,
   describeRule,
+  explorerUrl,
   repeatChoicesFor,
   taskRunLabel,
   taskRunOptions,
@@ -1542,6 +1554,59 @@ export function splitDraft(draft?: string | null): {
   };
 }
 
+/**
+ * WHERE "BACK TO CHAT" LANDS A REOPENED DRAFT, out of the chat key the hop
+ * stored on it (design.md, Round 2: "A draft moves, never duplicates").
+ *
+ * Two key shapes, two doors, because a chat has two ages (platform/lib/drafts
+ * `chatDraftKey`):
+ *
+ *   * a SESSION id — the conversation exists, so the folder opens with that
+ *     thread on the Claude pane, which is `explorerUrl`'s whole job. The folder
+ *     is the draft's own `target`: the hop wrote the chat's `file` into it, and
+ *     it is the only path this card kept;
+ *   * `new:<file>` — there is no session and never was one, so the door is the
+ *     one a never-sent chat's ROW uses (`schedule-lib.chatDraftHref`): that
+ *     file's folder with the Claude pane on it and no `session_id` named at
+ *     all. Built out of the key's own `<file>` rather than out of `target`, for
+ *     `chatDraftHref`'s reason — the composer seeds from a key built on that
+ *     exact string, and a chat mounted anywhere else reads a key nothing wrote.
+ *
+ * `""` for a key that is neither, which is a card with nothing to go back to —
+ * the caller gates on that before ever getting here.
+ */
+export function backChatHref(key: string, target: string): string {
+  if (!key) return "";
+  if (key.startsWith(NEW_CHAT_PREFIX)) {
+    const file = newChatFile(key);
+    return file ? chatPaneUrl(file) : "";
+  }
+  return target ? explorerUrl(target, key) : "";
+}
+
+/**
+ * `splitDraft` RUN BACKWARDS — the card's two fields put back into the one
+ * block of prose the composer was holding (design.md, Round 2: "'Back to chat'
+ * reverses it").
+ *
+ * The hop split a sentence across Title and the description; going back has to
+ * hand the composer one string again. Title line, blank line, body — the same
+ * shape the composer's own text had when it left, so `splitDraft` on the way
+ * out again lands on the same two fields.
+ *
+ * EITHER HALF ALONE IS JUST THAT HALF, with no separator to show for the one
+ * that is missing: a card whose title was cleared must not come back as a
+ * message opening on two blank lines, and one with nothing but a title must not
+ * come back with a trailing gap (Akshil, 2026-09-11).
+ */
+export function joinDraft(title?: string | null, description?: string | null): string {
+  const head = (title ?? "").trim();
+  const body = (description ?? "").trim();
+  if (!head) return body;
+  if (!body) return head;
+  return `${head}\n\n${body}`;
+}
+
 // A prefill this field must refuse, whichever source produced it: a transcript
 // record's machine-written wire, leaked into a title.
 //
@@ -2019,6 +2084,11 @@ export function buildSchedulePayload(form: {
   // across rather than allocate a second one, which is what renamed TASK-078 to
   // TASK-079 when only its time had changed.
   replacesEntryId?: string;
+  // The client-minted uuid of the DRAFT this form was autosaving into, or "" for
+  // a card that never became one. Sent so the server deletes the draft in the
+  // same request that creates the task: two round trips could half-fail and
+  // leave a draft row sitting beside the task it had already become.
+  draftId?: string;
   // DID ANYONE PICK THIS TIME? False when the card was opened from the List or
   // the Board — where the when-row starts folded away — and the user never
   // touched it, so `when` is only the form's own default of "now". The task
@@ -2103,6 +2173,7 @@ export function buildSchedulePayload(form: {
     // nothing, and the key is left off the wire rather than sent as "" for the
     // same reason `title` is.
     ...(form.replacesEntryId ? { replaces: form.replacesEntryId } : {}),
+    ...(form.draftId ? { draft_id: form.draftId } : {}),
     ...(form.images && form.images.length ? { images: form.images } : {}),
     ...(form.attachments && form.attachments.length
       ? { attachments: form.attachments } : {}),
@@ -2220,13 +2291,88 @@ export function saveBlockedReason(f: Parameters<typeof saveEnabled>[0]): {
   return null;
 }
 
+/**
+ * AN UNFINISHED FORM, HANDED BACK (design.md, "Reopen path").
+ *
+ * The draft row's `form` is whatever this card last autosaved, and it arrives as
+ * loose JSON: it was written by a build of this file that may not be this one,
+ * and it round-tripped through a file on disk. So every field is read with its
+ * own type check and every miss is `null` — "the draft does not say", which the
+ * state initialisers below fall back from into the answer they would have given
+ * with no draft at all. A draft with a field this build has never heard of costs
+ * that field and nothing else; one with a field of the wrong shape costs the
+ * same. Neither may throw: this runs in a `useState` initialiser, and a throw
+ * there is a card that will not open at all.
+ */
+export interface DraftSeed {
+  id: string;
+  form?: Record<string, unknown> | null;
+}
+
+export interface SeededDraftForm {
+  title: string | null;
+  description: string | null;
+  target: string | null;
+  when: string | null;
+  repeat: string | null;
+  model: string | null;
+  effort: string | null;
+  permission: string | null;
+  attachments: { path: string; name: string; kind: "image" | "file" }[] | null;
+  newTaskEachRun: boolean | null;
+  /**
+   * THE CONVERSATION THESE WORDS WERE TYPED IN, when the draft came from one.
+   *
+   * Stored server-side by the hop's first save (`drafts.TASK_FIELDS`), so it is
+   * still here when the modal is REOPENED from the draft's row — the one
+   * opening with no `?back=` in the URL and nothing left in sessionStorage.
+   * It is what "Back to chat" aims at on that card (`backToChat`).
+   */
+  fromChatKey: string | null;
+}
+
+export function seededDraftForm(seed?: DraftSeed | null): SeededDraftForm {
+  const f = (seed?.form ?? {}) as Record<string, unknown>;
+  const str = (key: string): string | null =>
+    typeof f[key] === "string" && f[key] !== "" ? (f[key] as string) : null;
+  const attachments = Array.isArray(f.attachments)
+    ? (f.attachments as unknown[])
+        .filter((a): a is { path: string } =>
+          !!a && typeof a === "object" && typeof (a as { path?: unknown }).path === "string"
+          && (a as { path: string }).path !== "")
+        .map((a) => {
+          const row = a as { path: string; name?: unknown; kind?: unknown };
+          return {
+            path: row.path,
+            name: typeof row.name === "string" && row.name ? row.name : row.path,
+            kind: row.kind === "image" ? ("image" as const) : ("file" as const),
+          };
+        })
+    : null;
+  return {
+    title: str("title"),
+    description: str("description"),
+    target: str("target"),
+    when: str("when"),
+    repeat: str("repeat"),
+    model: str("model"),
+    effort: str("effort"),
+    permission: str("permission"),
+    attachments: attachments && attachments.length ? attachments : null,
+    newTaskEachRun: typeof f.new_task_each_run === "boolean" ? f.new_task_each_run : null,
+    fromChatKey: str("from_chat_key"),
+  };
+}
+
 export default function NewJobModal({
   initialTime,
   initialTarget,
   initialMessage,
   initialAttachments,
+  initialDraft,
   chatSessionId,
   chatBack,
+  fromChatKey,
   editing,
   permissionModes,
   recentTargets,
@@ -2254,6 +2400,16 @@ export default function NewJobModal({
   // is seeded through the identical function an Edit uses. An Edit outranks it:
   // that entry's own attachments are the ones being changed.
   initialAttachments?: { path: string; name: string; kind: "image" | "file" }[];
+  // AN UNFINISHED FORM THIS CARD ALREADY SAVED, re-opened from its row on the
+  // List or the Board (design.md, "Reopen path" — the only way back to a
+  // draft). It seeds every field this form owns, and the card keeps autosaving
+  // under the SAME id, so re-opening is not a new draft. The primary button is
+  // still Schedule: a draft becoming a task is the one thing it is for.
+  //
+  // Never combined with `editing`: a stored entry already persists on save, and
+  // abandoning an edit is a cancel rather than a draft (design.md, Not in
+  // scope).
+  initialDraft?: DraftSeed | null;
   // …the open conversation arrives as a session to CONTINUE — but only a
   // one-off resumes it; a repeating task always opens fresh chats, because
   // resuming the same conversation every day compounds context forever.
@@ -2261,6 +2417,20 @@ export default function NewJobModal({
   // And the chat's own URL, so the form can offer the way back — the whole
   // point is a round trip (chat → schedule → back → adjust → again).
   chatBack?: string | null;
+  /**
+   * THE CHAT DRAFT THIS CARD'S WORDS CAME FROM (design.md, Round 2: "A draft
+   * moves, never duplicates").
+   *
+   * Only on the Schedule hop, and it is the key the composer's own autosave was
+   * writing under — `<session_id>`, or `new:<file>` for a chat that has none.
+   * The FIRST task-draft save names it, and the server deletes that chat draft
+   * as it stores this one: the sentence exists in exactly one place at every
+   * instant, so the List never shows it twice and the TASK number moves rather
+   * than being allocated a second time.
+   *
+   * It is also what "Back to chat" reverses — see `backToChat` below.
+   */
+  fromChatKey?: string | null;
   // An existing task to change. The server has no update: saving schedules the
   // replacement first, then withdraws this one — see submit().
   editing?: ScheduledMessage | null;
@@ -2290,7 +2460,13 @@ export default function NewJobModal({
   // because the BASELINE below (`initial`) has to be the identical value, or an
   // Edit opens looking dirty and its ✕ arms the close-twice guard on an
   // untouched modal (QA 2026-08-14).
-  const initialAsk = initialAskOf(editing, initialMessage);
+  // What the saved draft says, field by field, with every miss reading as "the
+  // draft does not say" — see seededDraftForm. Taken ONCE, in a const, for the
+  // same reason `initialAsk` and `draft` below are: the BASELINE (`initial`)
+  // has to be the identical value or a re-opened draft reads as dirty the
+  // moment it mounts.
+  const saved = seededDraftForm(initialDraft);
+  const initialAsk = saved.description ?? initialAskOf(editing, initialMessage);
   // The chat handoff's two halves, and the same held-in-a-const discipline: the
   // title below opens on `draft.title` and the description on the body that goes
   // with it, so the split has to be taken once rather than per reader.
@@ -2306,10 +2482,15 @@ export default function NewJobModal({
   // picture drawn through /api/fs/raw (owner E2E R1, F4 (2026-09-10)). Only when
   // this is not an Edit — an entry being changed already has attachments of its
   // own, and they are the ones on the card.
+  // The attachments this card opens with, as ONE expression used twice — the
+  // state below and the dirty baseline further down must be the same list, or a
+  // re-opened draft reads as dirty on mount. A draft's own attachments outrank a
+  // chat handoff's for the reason an Edit's do: they are the ones being changed.
+  const initialAttachmentRows = saved.attachments ?? initialAttachments ?? [];
   const [images, setImages] = useState<TaskImage[]>(() =>
     editing
       ? restoredAttachments(editing)
-      : restoredAttachments({ images: [], attachments: initialAttachments ?? [] }));
+      : restoredAttachments({ images: [], attachments: initialAttachmentRows }));
   // THE REF IS THE AUTHORITY, the state is its mirror for rendering — and that
   // asymmetry is load-bearing twice (Bugbot, PR #865). Save awaits the uploads
   // and then has to read the paths they wrote; a `setImages` updater only
@@ -2489,8 +2670,9 @@ export default function NewJobModal({
   const nameSession = (editing?.session_id || chatSessionId) ?? "";
   const { title: derivedTitle, lookupSession: titleLookup } =
     initialTitleStateOf(editing, nameSession, draft.title);
-  const [title, setTitle] = useState(derivedTitle);
-  const [target, setTarget] = useState(editing?.target ?? initialTarget ?? "");
+  const [title, setTitle] = useState(saved.title ?? derivedTitle);
+  const initialTargetValue = saved.target ?? editing?.target ?? initialTarget ?? "";
+  const [target, setTarget] = useState(initialTargetValue);
   // ONE date-time drives everything: a one-off runs at it, and every derived
   // repeat choice reads its parts (minute, time, weekday) — Google's model.
   //
@@ -2507,7 +2689,11 @@ export default function NewJobModal({
   // seconds dropped — and `pastNoteFor` compares at that same precision, so the
   // form cannot open printing a warning about its own default.
   const [when, setWhen] = useState(() =>
-    toLocalInput(editing?.due ? new Date(editing.due) : (initialTime ?? new Date())),
+    // A DRAFT'S OWN `when` IS VERBATIM: it is already this field's format (the
+    // draft stores what the field held), so it is used as it stands rather than
+    // re-derived through a Date, which would quietly re-round it.
+    saved.when
+      ?? toLocalInput(editing?.due ? new Date(editing.due) : (initialTime ?? new Date())),
   );
   // DID ANYBODY PICK THIS TIME? The when-row's default is `now`, and "now"
   // means two different things depending on how it got there: a time the user
@@ -2527,17 +2713,25 @@ export default function NewJobModal({
   // no flag, which reads as planned — every one of them came from a form that
   // asked), and a new card is planned exactly when it is `planning`.
   const [timePicked, setTimePicked] = useState(
-    () => (editing ? !editing.immediate : planning),
+    // A draft that carries a time is a draft where somebody opened the when-row
+    // and said one — that is the only way the field gets into the draft at all
+    // (see the autosaved body below, which stores null until it is picked).
+    () => (saved.when !== null ? true : editing ? !editing.immediate : planning),
   );
   // …and the disclosure the when-row now lives behind, open from the start on a
   // planning card. State rather than a bare `open` attribute: `<details>` keeps
   // its own openness in the DOM, and a React re-render would slam a
   // half-controlled one shut under the user's hand.
-  const [moreOpen, setMoreOpen] = useState(planning);
+  // …opened as well for a draft that has a time in it: the row holds the answer
+  // the reader already gave, and folding it away would hide the one thing about
+  // this card that is not on its face.
+  const [moreOpen, setMoreOpen] = useState(planning || saved.when !== null);
   // The repeat CHOICE (a key into repeatChoicesFor) plus the one choice that
   // carries its own data: a custom rule from the recurrence dialog. Legacy
   // cron templates edit under the "cron" key and keep their line verbatim.
-  const [repeat, setRepeat] = useState<string>(() => initialRepeatKey(editing));
+  const [repeat, setRepeat] = useState<string>(
+    () => saved.repeat ?? initialRepeatKey(editing),
+  );
   const [customRule, setCustomRule] = useState<RecurrenceRule | null>(() =>
     editing?.rule && keyOfRule(editing.rule, new Date(editing.due)) === "custom"
       ? editing.rule
@@ -2546,12 +2740,14 @@ export default function NewJobModal({
   // Repeat is a CHECKBOX now, and the dropdown only exists while it is ticked
   // (design §6). Editing a repeating task therefore opens ticked, with the
   // stored rule already loaded — which is exactly "the key is not none".
-  const [repeatOn, setRepeatOn] = useState(() => initialRepeatKey(editing) !== "none");
+  const [repeatOn, setRepeatOn] = useState(
+    () => (saved.repeat ?? initialRepeatKey(editing)) !== "none",
+  );
   // The opt-out behind it: every run of a repeating task lands in this task's
   // own thread — a task IS a session — unless this says to mint a fresh one
   // per occurrence.
   const [newTaskEachRun, setNewTaskEachRun] = useState(
-    () => editing?.new_task_each_run ?? false,
+    () => saved.newTaskEachRun ?? editing?.new_task_each_run ?? false,
   );
   const legacyCron = editing?.repeats ?? "";
   // The thread this task has already been building, if it has one — read once
@@ -2562,14 +2758,16 @@ export default function NewJobModal({
   // picking "Custom…" must not strand the select on a choice with no rule.
   const [recurOpen, setRecurOpen] = useState(false);
   const repeatBefore = useRef(repeat);
-  const [permission, setPermission] = useState(editing?.permission_mode || "auto");
+  const [permission, setPermission] = useState(
+    saved.permission ?? editing?.permission_mode ?? "auto",
+  );
   // The run's model and thinking budget. "" — "Default", the leading option —
   // and NOT a hardcoded name, unlike `permission` above: permissions is a policy
   // this form has an opinion about (a task runs unattended, so "auto"), while a
   // model is one the CLI is better placed to pick per project than we are from
   // here. An edit prefills from the entry, so a task keeps what it was set to.
-  const [model, setModel] = useState(editing?.model || "");
-  const [effort, setEffort] = useState(editing?.effort || "");
+  const [model, setModel] = useState(saved.model ?? editing?.model ?? "");
+  const [effort, setEffort] = useState(saved.effort ?? editing?.effort ?? "");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [picking, setPicking] = useState(false);
@@ -2838,7 +3036,7 @@ export default function NewJobModal({
     // the user did not type must not read as dirty, or the ✕ arms its
     // close-twice guard on an untouched modal (the bug the getConfig effect's
     // setInitial exists for — this is the same one, one prefill earlier).
-    target: editing?.target ?? initialTarget ?? "",
+    target: initialTargetValue,
     message: initialAsk,
     title,
     when,
@@ -2852,7 +3050,12 @@ export default function NewJobModal({
     // Paths only: a fresh attach reads as dirty from the moment it lands
     // (its path is "" until the upload answers, then a path — both differ
     // from this baseline), which is exactly right — the user added something.
-    images: (editing?.images ?? []).join("\n"),
+    // …and a re-opened DRAFT's are baseline too, which a chat handoff's
+    // deliberately are not: the handoff just added them (dirty is right), the
+    // draft already had them (dirty would be a lie the ✕ acts on).
+    images: (editing
+      ? (editing.images ?? [])
+      : (saved.attachments ?? []).map((a) => a.path)).join("\n"),
   }));
   // EVERY field the form can lose arms the guard — time, repeat rule and
   // permission included. Comparing only text fields let a single ✕ silently
@@ -2870,6 +3073,114 @@ export default function NewJobModal({
     model !== initial.model ||
     effort !== initial.effort ||
     images.map((i) => i.path || "pending").join("\n") !== initial.images;
+
+  // ---- THE DRAFT (design.md, "New Task modal (task draft)") -----------------
+  //
+  // WHAT IT IS FOR: closing this card must not throw away what was typed in it.
+  // The first change to any field mints an id and starts autosaving the whole
+  // form; ✕ / Esc / click-out then simply leave, with no prompt, and the card
+  // comes back from its row on the List or the Board. Discard (in the footer) is
+  // the deliberate way to be rid of it.
+  //
+  // NEW TASKS ONLY. An Edit is a stored entry: it already persists on save, and
+  // abandoning one is a cancel rather than a draft (design.md, Not in scope) —
+  // so `editing` writes nothing here and keeps the close-twice guard it has
+  // always had.
+  const [draftId, setDraftId] = useState<string | null>(initialDraft?.id ?? null);
+  const draftIdRef = useRef(draftId);
+  draftIdRef.current = draftId;
+  // The form as the store holds it. `when` / `repeat` / `new_task_each_run` are
+  // stored as null until the reader actually says something about them, which is
+  // the same distinction `timePicked` draws on the card: "never opened the
+  // when-row" is not the same answer as "chose now".
+  /**
+   * THE HOP'S WORDS ARE ALREADY A DRAFT (design.md, Round 2: "the task draft is
+   * minted at once from the hop content").
+   *
+   * `dirty` above is the ✕ guard's question — "has the user changed anything
+   * here" — and on a card opened from the chat's Schedule button the honest
+   * answer is no: the prefill moved the baseline with it, exactly as an Edit's
+   * does, so that a close needs one click and not two. But the DRAFT's question
+   * is a different one: are there words here that would be lost. The hop's words
+   * were typed, a moment ago, in the composer — and the composer's own copy of
+   * them is about to be deleted in favour of this one (`fromChatKey`). Waiting
+   * for a keystroke here would be waiting to lose them.
+   *
+   * So the two questions are asked apart, and the ✕ keeps the behaviour it has
+   * always had. This one is answered once, at mount, off the props: a chat
+   * handoff with something in it, on a card that is neither an Edit (not a draft
+   * at all) nor a re-opened draft (whose words are already stored, under an id
+   * this card was handed).
+   */
+  const hopSeeded = !editing && !initialDraft && !!(initialMessage ?? "").trim();
+  const draftBody: TaskDraftForm | null = !editing && (dirty || hopSeeded)
+    ? {
+      title,
+      description: message,
+      target,
+      when: timePicked ? when : null,
+      repeat: repeatOn ? repeat : null,
+      model,
+      effort,
+      permission,
+      // Paths only once they exist: a chip whose upload has not answered names
+      // no file yet, and a draft holding "" would restore an empty chip.
+      attachments: images
+        .filter((i) => i.path)
+        .map((i) => ({ path: i.path, name: i.name, kind: i.kind })),
+      new_task_each_run: repeatOn ? newTaskEachRun : null,
+    }
+    : null;
+  // NULL UNTIL THE FORM IS DIRTY, and that is what "nothing minted for an
+  // untouched modal" is made of: the autosave writes when its value CHANGES, so
+  // a card nobody has touched — including one whose prefill effects have since
+  // fired, since those move the baseline too — never leaves null and never
+  // writes. The mint happens inside the write, so the id and the first save are
+  // one event and a card cannot end up with an id and no stored draft.
+  //
+  // …and on a HOP-SEEDED card it writes once with nobody having typed at all
+  // (`writeInitial`): the value it mounts on is already a draft, so the opening
+  // value counts as unwritten and the first debounce mints it.
+  //
+  // THE CHAT KEY RIDES THAT FIRST WRITE AND ONLY THAT ONE. It tells the server
+  // to delete the composer's copy of these words as it stores this one, so the
+  // sentence is in exactly one place at every instant (design.md, Round 2: "A
+  // draft moves, never duplicates"). Latched on a ref rather than re-read from
+  // the prop: the second PUT is an ordinary keystroke save, and repeating a
+  // delete for a key that is already gone can only be a no-op or a surprise
+  // (Akshil, 2026-09-11).
+  const chatKeySpent = useRef(false);
+  const autosave = useAutosave(draftBody, (value, opts) => {
+    if (!value) return;
+    let id = draftIdRef.current;
+    if (!id) {
+      id = newTaskDraftId();
+      draftIdRef.current = id;
+      setDraftId(id);
+    }
+    const moving = chatKeySpent.current ? "" : (fromChatKey ?? "");
+    chatKeySpent.current = true;
+    // Returned (not `void`-discarded) so `autosave.settle()` — Discard and
+    // Schedule both call it before their own delete — can tell when this
+    // particular write actually lands (Akshil, 2026-09-11).
+    return saveTaskDraft(id, value, opts, moving || undefined);
+  }, { writeInitial: hopSeeded });
+  const autosaveRef = useRef(autosave);
+  autosaveRef.current = autosave;
+  // Discard: the draft goes, and so does the card. `stop` first — a write still
+  // in the debounce would otherwise land after the DELETE and put it back.
+  // `stop` alone only disarms the NEXT write, though: a PUT already sent to
+  // the server cannot be cancelled, so `settle` waits for that one write
+  // (whichever is running) before the delete goes out — otherwise it can
+  // land after the delete and resurrect the draft this button just asked to
+  // throw away (Akshil, 2026-09-11).
+  const discard = async () => {
+    const id = draftIdRef.current;
+    autosaveRef.current.stop();
+    await autosaveRef.current.settle();
+    if (id) void deleteTaskDraft(id);
+    onClose();
+  };
 
   const picked = useMemo(() => new Date(when), [when]);
   const pickedOk = !Number.isNaN(picked.getTime());
@@ -2958,15 +3269,57 @@ export default function NewJobModal({
     },
     [],
   );
-  const backToChat = () => {
-    if (!chatBack) return;
+  //
+  // AND IT REVERSES THE MOVE (design.md, Round 2: "'Back to chat' reverses it").
+  // The hop deleted the chat draft and minted a task draft in its place; going
+  // back deletes the task draft, and the composer's own autosave re-creates the
+  // chat one from the sessionStorage stash it re-seeds from. Exactly one draft
+  // exists at every instant, and it is the one belonging to whichever surface
+  // the reader is actually looking at — leaving the task draft behind would put
+  // a row on the List for a card the user just walked out of.
+  //
+  // `stop` then `settle` before the delete, for Discard's reason and it is the
+  // same hazard: a debounced PUT still in the pipe (or one already sent) would
+  // land after the DELETE and resurrect exactly the draft this is disposing of.
+  // The navigation waits on that — it is one round trip, and leaving without it
+  // is how the row comes back (Akshil, 2026-09-11).
+  //
+  // THE WAY BACK OUTLIVES THE HOP'S URL (Akshil, 2026-09-11 — the bug). The two
+  // paragraphs above describe the FRESH hop: `?back=…` names where to land, and
+  // the composer re-seeds itself from the sessionStorage stash the hop left. A
+  // draft REOPENED from its row on the List has neither — the URL is `/tasks`
+  // and the stash was spent on read — so for that card the round trip has to be
+  // rebuilt out of the one thing that survived, `form.from_chat_key`, which the
+  // server now stores. Same three steps in the same order, with the chat draft
+  // written BY HAND where the fresh hop had a stash to do it: stop autosaving,
+  // settle whatever is in flight, PUT the words back onto the chat key, delete
+  // the task draft, then navigate. Exactly one draft exists at every instant,
+  // which is the whole rule.
+  const backChatKey = chatBack ? "" : (saved.fromChatKey ?? "");
+  const canGoBack = !!chatBack || !!backChatKey;
+  const backToChat = async () => {
+    if (!canGoBack) return;
     if (dirty && !backConfirm) {
       setBackConfirm(true);
       if (backTimer.current !== null) window.clearTimeout(backTimer.current);
       backTimer.current = window.setTimeout(() => setBackConfirm(false), 2000);
       return;
     }
-    navigateUrl(chatBack);
+    const id = draftIdRef.current;
+    autosaveRef.current.stop();
+    await autosaveRef.current.settle();
+    if (backChatKey) {
+      // The inverse of the split the hop made — `joinDraft` puts the title line
+      // and the body back into the one block of prose the composer holds. The
+      // attachments ride along as the same three fields the task draft stored
+      // them as; a chip whose upload has not answered names no file yet and is
+      // dropped, exactly as the task draft drops it.
+      await saveChatDraft(backChatKey, joinDraft(title, message),
+        images.filter((i) => i.path)
+          .map((i) => ({ path: i.path, name: i.name, kind: i.kind })));
+    }
+    if (id) await deleteTaskDraft(id);
+    navigateUrl(chatBack || backChatHref(backChatKey, target));
   };
 
   // The replacement was created but the original could not be withdrawn: the
@@ -3101,6 +3454,17 @@ export default function NewJobModal({
       // conversation on every run compounds its context forever — Akshil,
       // 2026-08-16; Bugbot, PR #548), and the task's OWN thread is carried
       // through the re-create an edit really is.
+      // THE DRAFT STOPS HERE. The server deletes it as part of creating the
+      // task (it is handed `draft_id` below), so the only thing left to do is
+      // make sure nothing this card has queued can write it back — a debounced
+      // save from the keystroke before Schedule would otherwise resurrect a
+      // draft for a task that now exists (Akshil, 2026-09-11). `stop` disarms
+      // the NEXT write; it cannot cancel one already sent to the server, so
+      // `settle` waits that one out too, BEFORE the request below goes out —
+      // the server-side delete must be ordered after the last PUT, not merely
+      // after the last one this client could still call off.
+      autosaveRef.current.stop();
+      await autosaveRef.current.settle();
       await scheduleMessage(
         buildSchedulePayload({
           target,
@@ -3124,6 +3488,10 @@ export default function NewJobModal({
           // The task's NUMBER has to survive the re-create an edit is; see
           // `replacesEntryId`. Empty on a new task, which replaces nothing.
           replacesEntryId: editing?.id ?? "",
+          // …and the draft this card was composed in, so the server can drop it
+          // in the same request. Empty when the form was never dirty enough to
+          // mint one, which is most one-line tasks.
+          draftId: draftIdRef.current ?? "",
           // Whether anybody chose this time, which is what decides if the task
           // is a plan or a thing to run. See `timePicked`.
           timePicked,
@@ -3232,7 +3600,14 @@ export default function NewJobModal({
       onClose={onClose}
       busy={busy}
       width={460}
-      dirty={dirty}
+      // THE CLOSE-TWICE GUARD IS OFF WHENEVER THERE IS A DRAFT TO CLOSE INTO
+      // (design.md, Decisions: "Modal close keeps the draft silently; Discard in
+      // footer. No prompt."). The guard exists to stop a ✕ discarding typed
+      // work; on a new-task card the work is not discarded — it is autosaved and
+      // the row is waiting on the List — so the confirm would be asking about a
+      // loss that does not happen. An EDIT keeps it: there is no draft there,
+      // and its ✕ really does throw the changes away.
+      dirty={editing ? dirty : false}
       footer={
         <>
           {/* Destructive, so it sits at the far left of the footer, away from
@@ -3254,13 +3629,37 @@ export default function NewJobModal({
               {delConfirm ? del.confirm : del.label}
             </button>
           )}
+          {/* DISCARD — the deliberate way to be rid of a draft, and the only
+              one (design.md: close keeps it, this throws it away). Drawn only
+              once a draft actually exists: on an untouched card there is
+              nothing to discard, and a button offering to delete nothing is a
+              button that makes the reader wonder what it knows.
+
+              It is not `.btn-danger-text` like the Edit card's Delete beside
+              it: that withdraws a real, running task, and this drops an
+              unfinished form nobody has scheduled. Same footer, two weights,
+              which is the difference between the two verbs. */}
+          {draftId && (
+            <button
+              type="button"
+              className="btn btn-secondary new-task-discard"
+              disabled={busy}
+              title="Discard this draft"
+              onClick={discard}
+            >
+              Discard
+            </button>
+          )}
           {/* The way back completes the chat's round trip: chat → schedule →
-              adjust the draft → schedule again. Only shown when a chat sent
-              us here — from anywhere else there is no "back". */}
-          {chatBack && (
+              adjust the draft → schedule again. Only shown when a chat sent us
+              here — from anywhere else there is no "back". Two ways it can have:
+              the hop's own `?back=` URL, and a REOPENED draft's stored
+              `from_chat_key`, which is the only trace left once the hop's URL
+              is gone (see `backToChat`). */}
+          {canGoBack && (
             <button type="button" className="btn btn-secondary schedule-back-chat"
                     disabled={busy}
-                    onClick={backToChat}>
+                    onClick={() => void backToChat()}>
               {backConfirm ? "Discard changes?" : "Back to chat"}
             </button>
           )}

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -59,6 +59,7 @@ import {
   basename,
   cancelIntent,
   carryMarkToHeld,
+  draftTag,
   dropAction,
   dropLanes,
   filingIntent,
@@ -67,6 +68,7 @@ import {
   firstLine,
   groupByColumn,
   heldMessages,
+  isDraftTask,
   isDraggable,
   isExpandable,
   isFailedTask,
@@ -74,7 +76,7 @@ import {
   needsAttention,
   laneRolledUp,
   laneUnread,
-  sortByLane,
+  sortForList,
   showsRowActions,
   statusColumn,
   markAllRead,
@@ -248,6 +250,27 @@ const ICON_OPEN = icon(
     <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /></>, 13);
 const ICON_PENCIL = icon(
   <><path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" /></>, 13);
+/** THE DRAFT MARK — lucide `pencil-line`, the pencil with the ruled line under
+ *  it (design.md, Round 2: a lucide `PencilLine`, not the pencil character).
+ *
+ *  It is NOT `ICON_PENCIL` above, which is Edit — a verb, on a button, in the
+ *  row's action strip. This one is a noun on a chip: the pencil WITH its line is
+ *  Slack's own draft mark and the whole reference this feature is built against,
+ *  and drawing the two the same would make an inert badge read as a control.
+ *  11px, a step under the row's other marks, because it sits inside a pill that
+ *  already carries a word — the glyph is the mark's tone, the word is its
+ *  content (Akshil, 2026-09-11).
+ *
+ *  The path data is lucide-react's own `pencil-line`, copied verbatim out of
+ *  `node_modules/lucide-react/dist/esm/icons/pencil-line.mjs` rather than drawn
+ *  by hand. What was here before was a hand-edited `ICON_PENCIL` with a stub
+ *  stroke bolted on — it read as a broken Edit glyph at 11px, because it was
+ *  one (Akshil, 2026-09-11). */
+const ICON_PENCIL_LINE = icon(
+  <><path d="M13 21h8" />
+    <path d="m15 5 4 4" />
+    <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" /></>,
+  11);
 // The two halves of Cancel, drawn apart because they MEAN different things
 // (tasks-lib.cancelIntent): a one-off is stopped for good (lucide `ban`), an
 // occurrence of a repeat is stepped over and the rule runs on (`skip-forward`).
@@ -326,9 +349,15 @@ export const ICON_TRASH = icon(
 
 // ---- leaf components ---------------------------------------------------------
 
-const STATUS_LABELS: Record<BoardColumn, string> = Object.fromEntries(
-  BOARD_COLUMNS.map((c) => [c.key, c.label]),
-) as Record<BoardColumn, string>;
+const STATUS_LABELS: Record<BoardColumn, string> = {
+  ...(Object.fromEntries(
+    BOARD_COLUMNS.map((c) => [c.key, c.label]),
+  ) as Record<BoardColumn, string>),
+  // …and the one status that is not a column. Spelled here because the array is
+  // the board's lanes and a draft has none (schedule-lib's note on BoardColumn),
+  // but the ring on a draft row still has to have a word to announce.
+  draft: "Draft",
+};
 
 /**
  * The bordered ring — the ONE mark a unit of work wears, on all three views.
@@ -567,6 +596,11 @@ export function IdentityChip({ name, title, onPick, active = false }: {
  * never renumbered — so unlike a session uuid they are meant to be read, said
  * out loud and searched for. Monospaced, because a column of them is scanned. */
 function IdChip({ id, kind }: { id: string; kind: "task" | "message" }) {
+  // NOTHING AT ALL FOR AN EMPTY ID. A draft row carries no TASK-NNN — the
+  // number is allocated when it becomes a scheduled task, exactly as for a
+  // `pending:` entry — and an empty chip is a 20px box of border saying nothing
+  // where every other row says its name.
+  if (!id) return null;
   return <span className={`tasks-id tasks-id--${kind}`}>{id}</span>;
 }
 
@@ -591,6 +625,92 @@ function OutcomePill({ outcome }: { outcome: OutcomeTag }) {
   return (
     <span className="tasks-outcome-pill" title={outcome.title}>
       {outcome.text}
+    </span>
+  );
+}
+
+/**
+ * THE ONE MARK FOR WORDS NOBODY HAS SENT — a pencil and the word `Draft` — and,
+ * on the List and the Board, the control that filters the page down to them
+ * (design.md, Round 2: "It is a filter tag").
+ *
+ * WHY IT IS ITS OWN COMPONENT and no longer just an `OutcomePill`. It is still
+ * the same pill shape — that was never in question, and `.tasks-outcome-pill`
+ * is what it is built out of — but it now does two things the outcome pill
+ * cannot. It carries a GLYPH, because the pencil is the mark a reader learns
+ * this feature by (Slack's own, the reference UI); and it is PRESSABLE, because
+ * the chip that says "there are drafts here" is the natural place to ask for
+ * only those.
+ *
+ * WHERE IT SITS: at the right end of the row, immediately before the project
+ * chip (Akshil, 2026-09-11). It moved there from beside the id, and the move is
+ * the point — the right end is where this page keeps its TAGS (the folder chip
+ * is already one, and presses the same way), while the id end is where the row
+ * says what it IS. Two clickable chips side by side read as one group of
+ * controls; the same chip four hundred pixels from the other read as two
+ * unrelated marks.
+ *
+ * `onPick` is what makes it a control, exactly as on `IdentityChip`: without one
+ * it is the plain badge the Cards wall wants, with one it is a real button
+ * inside the same shield — so a near-miss in the row's padding does nothing
+ * rather than opening the task. `active` is the ON pill, in the accent, for the
+ * reason the folder chip's is: while a filter is on, the thing that set it has
+ * to say so on the rows it is acting on.
+ */
+export function DraftChip({ draft, onPick, active = false }: {
+  draft: OutcomeTag;
+  /** Is the page filtered to drafts right now? Only meaningful with `onPick`. */
+  active?: boolean;
+  /** Makes the chip a TAG. Omitted where the view has no draft filter (the
+   *  Cards wall), where it stays the label it started as. */
+  onPick?: () => void;
+}) {
+  // The words themselves are the tooltip — the first line of what was typed —
+  // for the reason tasks-lib.draftTag gives: the chip already says "draft", and
+  // what a reader hovering it wants is a glimpse of the sentence.
+  const body = (
+    <>
+      <span className="tasks-draft-pill-icon" aria-hidden>{ICON_PENCIL_LINE}</span>
+      {draft.text}
+    </>
+  );
+  if (!onPick) {
+    return (
+      <span className="tasks-outcome-pill tasks-draft-pill" title={draft.title}>
+        {body}
+      </span>
+    );
+  }
+  // The shield, and every word of `IdentityChip`'s note about it applies here
+  // unchanged: the row is one stretched link, so the band around a small pill
+  // belongs to the row unless something stands over it doing nothing.
+  return (
+    <span
+      className="schedule-tv-id-shield"
+      data-hint=""
+      onClick={(e) => e.stopPropagation()}
+    >
+      <button
+        type="button"
+        className={"tasks-outcome-pill tasks-draft-pill" + (active ? " is-on" : "")}
+        // What the press DOES, on top of the words it already showed — and the
+        // opposite sentence once it is on, because that is what the press now
+        // does. `data-hint` rather than `title` for the page's own reason: the
+        // native tooltip arrives a second late, which for a chip is not at all.
+        data-hint={
+          active
+            ? `Showing only drafts — press to clear\n${draft.title}`
+            : `${draft.title}\nShow only drafts`
+        }
+        aria-label={active ? "Showing only drafts, press to clear" : "Show only drafts"}
+        aria-pressed={active}
+        onClick={(e) => {
+          e.stopPropagation();
+          onPick();
+        }}
+      >
+        {body}
+      </button>
     </span>
   );
 }
@@ -1133,9 +1253,12 @@ export function TaskList({
   stale = false,
   missing,
   onEditEntry,
+  onOpenDraft,
   onReload,
   onPickProject,
   pinnedProjects = [],
+  onPickDraft,
+  draftOn = false,
   emptyLabel = "Nothing to show here.",
 }: {
   /** Already filtered, in the SERVER's order. Never re-sorted here. */
@@ -1156,6 +1279,12 @@ export function TaskList({
    * no edit affordance; the thread is then read-only, which is all a thread of
    * already-sent messages could ever be anyway. */
   onEditEntry?: (entryId: string) => void;
+  /** Re-open an unfinished New task form (a `state: "draft"` row — design.md,
+   *  "Reopen path"). Editing a draft row is the ONLY way back to it, so a list
+   *  that draws draft rows without this would draw rows whose press does
+   *  nothing; omitted ⇒ the row is inert, exactly as an unresolvable pending
+   *  row is. */
+  onOpenDraft?: (task: Task) => void;
   /** Re-read the list after a cancel lands (or fails) — the row has to correct
    * itself to whatever the server actually did, and a failed cancel is a race
    * the server won, not a no-op.
@@ -1183,6 +1312,16 @@ export function TaskList({
    * am I looking at"), and it is what a chip reads to know it is the one that
    * is ON. */
   pinnedProjects?: string[];
+  /** THE DRAFT TAG'S PRESS, the exact counterpart of `onPickProject` above
+   *  (design.md, Round 2): it toggles one boolean on the same shared
+   *  `TaskFilters` the toolbar owns, so the chip and the filter are one thing.
+   *  Optional — without it the chip is a plain badge, which is what every view
+   *  that has no draft filter wants. */
+  onPickDraft?: () => void;
+  /** Is that filter on right now? The chip's pressed state, and the only
+   *  row-level trace this filter has — it is set from the rows and there is no
+   *  popover carrying a count for it. */
+  draftOn?: boolean;
   emptyLabel?: string;
 }) {
   // Collapsed by default (§8), so the set holds what is OPEN — an empty set is
@@ -1244,7 +1383,9 @@ export function TaskList({
     [tasks, pinnedKey],
   );
 
-  // The list's rows, in rank order and then by printed time (tasks-lib.sortByLane).
+  // The list's rows: unsent words first, then rank order and printed time
+  // (tasks-lib.sortForList, whose note carries the argument — it is the one
+  // extra pass this view makes over the page's shared `sortByLane`).
   // Memoised for the same reason `showProject` is: this runs on every keystroke of
   // the search box and the answer only moves when the rows do.
   //
@@ -1254,7 +1395,7 @@ export function TaskList({
   // makes the order stale is the same poll that re-runs this memo with a fresh
   // clock. A ticking `now` in the deps would re-sort the list every second to
   // produce the identical order.
-  const rows = useMemo(() => sortByLane(tasks), [tasks]);
+  const rows = useMemo(() => sortForList(tasks), [tasks]);
 
   /**
    * Open or close a task — and, on the way OPEN, fetch the rest of its thread.
@@ -1556,9 +1697,12 @@ export function TaskList({
           loading={!!loading[task.key]}
           error={errors[task.key]}
           onEditEntry={onEditEntry}
+          onOpenDraft={onOpenDraft}
           onReload={onReload}
           onPickProject={onPickProject}
           pinned={pinnedProjects.includes(task.project)}
+          onPickDraft={onPickDraft}
+          draftOn={draftOn}
           onPageNote={setPageNote}
           read={read}
           onRead={clear}
@@ -1587,9 +1731,12 @@ function TaskNode({
   onRetry,
   error,
   onEditEntry,
+  onOpenDraft,
   onReload,
   onPickProject,
   pinned,
+  onPickDraft,
+  draftOn,
   onPageNote,
   read,
   onRead,
@@ -1626,6 +1773,8 @@ function TaskNode({
   onRetry: () => void;
   error?: string;
   onEditEntry?: (entryId: string) => void;
+  /** See TaskList's own prop: the draft row's press. */
+  onOpenDraft?: (task: Task) => void;
   onReload?: () => void;
   /** Filter the page to this row's folder — the List's handler, passed through
    * untouched. See TaskList's own `onPickProject`. */
@@ -1633,6 +1782,11 @@ function TaskNode({
   /** Is the page filtered to THIS row's folder? The chip wears it, so the
    * control that narrowed the list is visibly the one that is on. */
   pinned?: boolean;
+  /** Filter the page to the rows carrying unsent words — see TaskList's own
+   *  `onPickDraft`. Passed through untouched, like the folder's. */
+  onPickDraft?: () => void;
+  /** Is that filter on? The chip wears it, for the folder chip's reason. */
+  draftOn?: boolean;
   /** The List's page-level note — the only holder that survives this row being
    * filtered out by the very move it announces (see TaskList's render). */
   onPageNote: (s: string) => void;
@@ -1714,6 +1868,11 @@ function TaskNode({
   // to open (a thread with no edit affordance is read-only), and then the press
   // falls through to the arms below.
   const edit = onEditEntry ? upcomingEditEntry(task, held) : null;
+  // A DRAFT ROW'S PRESS re-opens the New task form on the form it was saved
+  // from (design.md, "Reopen path": the draft rows in the list/board are the
+  // only way back to a draft). It outranks every other arm below because a
+  // draft has nothing else — no session to open, no entry to edit.
+  const openDraft = onOpenDraft && isDraftTask(task) ? onOpenDraft : null;
   // When this task runs next, or when it last ran — one time at the end of every
   // row, beside the folder. Which of the two is tasks-lib.taskWhen's decision (it
   // reads LANE_SORTS, the same map the Board's lanes are ordered by), and null when
@@ -1726,6 +1885,9 @@ function TaskNode({
   // ...and the one word a settled lane cannot say: that the last run was
   // STOPPED rather than finished (tasks-lib.outcomeTag).
   const outcome = outcomeTag(task);
+  // The `Draft` chip — this task's unsent composer text, or the row's own
+  // unfinished form. tasks-lib.draftTag owns both cases and the tooltip.
+  const draft = draftTag(task);
   // Run now / Re-run. tasks-lib decides all of it — whether it is offered,
   // which message it acts on, and WHICH CALL that is. The run-now half comes
   // from the same function the drag asks (runNowIntent), so the button and the
@@ -2010,7 +2172,8 @@ function TaskNode({
    * openThreadIntent's decision, not this function's.
    */
   const activate = () => {
-    if (chat) openChat(chat);
+    if (openDraft) openDraft(task);
+    else if (chat) openChat(chat);
     else if (edit) onEditEntry?.(edit);
     // A folder that is gone: the chat arm is off (above), the EDIT arm is not —
     // the schedule form needs no folder (Bugbot, #1023) — so this is the row
@@ -2045,7 +2208,7 @@ function TaskNode({
    * with its own tab stop — the row itself stays inert, and pointing at it would
    * be a promise the row's own press no longer keeps.
    */
-  const pressable = href !== null || edit !== null || folderMissing;
+  const pressable = href !== null || edit !== null || openDraft !== null || folderMissing;
 
   const cancel = async (m: TaskMessage, entryId: string) => {
     setCancelling(m.message_id);
@@ -2266,6 +2429,12 @@ function TaskNode({
             (design-principles §1): a tag that moved between the two views would
             be two different marks to learn. */}
         {outcome && <OutcomePill outcome={outcome} />}
+        {/* THE DRAFT CHIP IS NOT HERE ANY MORE (Akshil, 2026-09-11). It sat
+            beside the id for a round, on the outcome pill's own argument: the id
+            line is where marks ABOUT the task live. That was right while it was
+            only a mark. It is a filter TAG now, and this page keeps its tags at
+            the other end of the row — see the chip's new seat, immediately
+            before the folder, and DraftChip's note for the whole argument. */}
         {/* Greyed while the work is still ahead of it (tasks-lib.isUpcomingTask):
             a list is mostly history, and the rows that have not happened yet are
             the ones a reader is not being asked to read. The TITLE only — the id,
@@ -2535,6 +2704,23 @@ function TaskNode({
           >
             Folder missing
           </span>
+        )}
+        {/* UNSENT WORDS, immediately before the folder (design.md, Round 2).
+            The row's right end is its tag strip — this chip and the folder
+            beside it are both filters, both pressed the same way, both wearing
+            the same ON pill when they are on. The draft comes first because it
+            is the rarer fact: a reader sweeping this column for the folder they
+            know finds it in the same place on every row, and the chip that is
+            usually absent sits outside that column rather than shunting it.
+            DraftChip owns the glyph, the press and the shield. */}
+        {draft && (
+          <DraftChip
+            draft={draft}
+            // A TAG on the List, a label everywhere the view has no filter —
+            // the same split `IdentityChip` draws one line below.
+            onPick={onPickDraft}
+            active={draftOn}
+          />
         )}
         {showProject && (
           <IdentityChip
@@ -2928,6 +3114,9 @@ export function TaskBoard({
   tasks,
   home = "",
   onReload,
+  onOpenDraft,
+  onPickDraft,
+  draftOn = false,
   missing,
   emptyLabel = "Nothing to show here.",
 }: {
@@ -2942,6 +3131,16 @@ export function TaskBoard({
   home?: string;
   /** Re-read the list after a drop lands (or fails). */
   onReload: () => void;
+  /** Re-open an unfinished New task form — the press on a `state: "draft"` card
+   *  (design.md, "Reopen path"). Same callback and same gesture as the List's. */
+  onOpenDraft?: (task: Task) => void;
+  /** Filter the board to the cards carrying unsent words — the Draft chip's
+   *  press (design.md, Round 2: the filter is List + Board). One boolean on the
+   *  same shared `TaskFilters` the List's chip writes, so switching view keeps
+   *  the filter and the chip that shows it. */
+  onPickDraft?: () => void;
+  /** Is that filter on? The chip's pressed state. */
+  draftOn?: boolean;
   /** Folders the disk no longer has (Scheduled → useMissingFolders): a card in
    * one says so, and its click raises a toast instead of leaving for an
    * Explorer error. */
@@ -3320,6 +3519,8 @@ export function TaskBoard({
                     task={task}
                     home={home}
                     showProject={showProject}
+                    onPickDraft={onPickDraft}
+                    draftOn={draftOn}
                     folderMissing={missing?.has(taskFolder(task)) ?? false}
                     onMissing={toastMissingFolder}
                     // The DISPLAYED count, so a card cleared by its own click
@@ -3336,6 +3537,7 @@ export function TaskBoard({
                     onRun={runNow}
                     onErased={onReload}
                     onOpen={(intent) => openCard(task, intent)}
+                    {...(onOpenDraft ? { onOpenDraft } : {})}
                   />
                 ))}
                 {hidden > 0 && (
@@ -3370,6 +3572,8 @@ function TaskCard({
   task,
   home,
   showProject,
+  onPickDraft,
+  draftOn,
   folderMissing,
   onMissing,
   unread,
@@ -3379,6 +3583,7 @@ function TaskCard({
   onFile,
   onRun,
   onOpen,
+  onOpenDraft,
   onErased,
 }: {
   task: Task;
@@ -3389,6 +3594,10 @@ function TaskCard({
   /** Whether the folder chip is worth drawing — the BOARD's answer, for the same
    * reason the List row takes it as a prop (spansProjects). */
   showProject: boolean;
+  /** The Draft chip's press and its pressed state, passed through untouched —
+   *  see TaskBoard's own props. */
+  onPickDraft?: () => void;
+  draftOn?: boolean;
   /** The task's folder is gone (useMissingFolders): the card says so, and its
    * click goes to `onMissing` — a toast — rather than `onOpen`. */
   folderMissing: boolean;
@@ -3410,6 +3619,9 @@ function TaskCard({
    * it because the board owns the read set — and it is only ever called with a
    * non-null intent, so this card cannot navigate to nowhere. */
   onOpen: (intent: OpenThreadIntent) => void;
+  /** …and the ONE card whose press is not that: an unfinished New task form,
+   *  which re-opens the modal rather than navigating anywhere (design.md). */
+  onOpenDraft?: (task: Task) => void;
 }) {
   // Whether this card lifts at all, and it is not one question: a task with no
   // session (§5 — Claude Code mints the id on the first run) has nothing to
@@ -3454,6 +3666,9 @@ function TaskCard({
   // function the List row asks, so the two views cannot describe one run
   // differently.
   const outcome = outcomeTag(task);
+  // …and the `Draft` chip: a chat draft joined onto this task's session, or
+  // — on a draft row — the unfinished form itself (tasks-lib.draftTag).
+  const draft = draftTag(task);
   // The lane this card is IN — the COLUMN it is drawn under, which is why it is
   // `laneOf` and not the status alone: a waiting card sits in Blocked, and the
   // header above it says Blocked. Not passed down either way: `groupByColumn`
@@ -3522,7 +3737,10 @@ function TaskCard({
         }}
         onDragEnd={onDragEnd}
         onClick={() => {
-          if (folderMissing) onMissing();
+          // The draft arm first, for the List row's reason: a draft has no
+          // session and no folder to be missing from — the form IS its content.
+          if (onOpenDraft && isDraftTask(task)) onOpenDraft(task);
+          else if (folderMissing) onMissing();
           else if (open) onOpen(open);
         }}
       >
@@ -3582,6 +3800,11 @@ function TaskCard({
             : failedOffLane && <StatusIcon status={lane} failed />}
           <IdChip id={task.task_id} kind="task" />
           {outcome && <OutcomePill outcome={outcome} />}
+          {/* The draft chip left this head with the List row's (Akshil,
+              2026-09-11) and for the same reason — it is a tag now, and the
+              tags sit together at the card's other end. It is in the foot,
+              before the folder, which is the card's own reading of "immediately
+              before the project tag": the foot IS this card's right-hand end. */}
         </span>
         {/* Nothing trails the title any more (2026-08-18). Three arrangements of
             an unread mark lived in this slot and each one was a fix for the last:
@@ -3647,7 +3870,7 @@ function TaskCard({
             anything (spansProjects — every card in a board filtered to one
             project repeats it — and a card with no run coming) the whole line
             goes rather than leaving an empty row of padding. */}
-        {(showProject || folderMissing) && (
+        {(showProject || folderMissing || draft) && (
           <span className="schedule-tv-card-foot">
             {/* The List row's own mark, same words, same colour (see the row). */}
             {folderMissing && (
@@ -3657,6 +3880,21 @@ function TaskCard({
               >
                 Folder missing
               </span>
+            )}
+            {/* Unsent words, immediately before the folder — the List row's
+                order exactly (see DraftChip).
+
+                A TAG HERE TOO, unlike the folder chip beside it, and the
+                difference is deliberate (design.md, Round 2: the filter is
+                "List + Board"). The folder stays a label on a card because a
+                card is a drag target first; this chip is the only control the
+                draft filter has, so leaving it inert on the Board would mean
+                the Board could show the filter's ON state and never turn it
+                off. The cost is bounded in a way the folder's was not: the
+                cards that carry it are mostly drafts, and a draft card does not
+                lift at all (tasks-lib.LANE_EXITS.draft is empty). */}
+            {draft && (
+              <DraftChip draft={draft} onPick={onPickDraft} active={draftOn} />
             )}
             {showProject && (
               <IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -71,6 +71,9 @@ import {
   parseAttachmentsParam,
   type SchedAttachment,
 } from "@apps/claude/ui/sched-draft";
+import { chatDraftKey } from "@platform/lib/drafts";
+import { navigateUrl } from "@platform/lib/router";
+import { chatDraftHref } from "./schedule-lib";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
 import ScheduleCalendar, {
@@ -101,6 +104,7 @@ import {
 } from "./tasksPulse";
 import {
   TASK_VIEWS,
+  isChatDraftTask,
   mergeTaskChanges,
   provisionalTasks,
   viewFromSearch,
@@ -253,7 +257,33 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   const openForm = (at: Date | "blank" | null, entry: ScheduledMessage | null) => {
     setOpenSeq((n) => n + 1);
     setEditing(entry);
+    setDraftRow(null);
     setCreating(at);
+  };
+  // An unfinished New task form, re-opened from its own row (design.md, "Reopen
+  // path": editing a draft row is the only way back to it). It travels as the
+  // ROW rather than as its id, because the row already carries the saved form —
+  // `/api/tasks` emits it — so the card can seed from it on the first paint with
+  // no second fetch, exactly as an Edit seeds from its entry.
+  const [draftRow, setDraftRow] = useState<Task | null>(null);
+  const openDraft = (task: Task) => {
+    // A NEVER-SENT CHAT IS NOT A FORM, so its row's press is a navigation and
+    // not this modal (design.md, Round 2: "Click → opens the folder's chat,
+    // composer prefilled"). There is nothing to re-open here — the words live in
+    // a composer, and the composer seeds itself from the draft keyed on the
+    // folder this URL lands on (schedule-lib.chatDraftHref, whose note explains
+    // why it carries no `session_id`). Asked FIRST, because it is the row that
+    // has no `draft_id` to fall through to.
+    if (isChatDraftTask(task)) {
+      const href = chatDraftHref(task);
+      if (href) navigateUrl(href);
+      return;
+    }
+    if (!task.draft_id) return;
+    setOpenSeq((n) => n + 1);
+    setEditing(null);
+    setCreating(null);
+    setDraftRow(task);
   };
   // What a deep link named (see the effect below); all null for every other
   // way of opening the form.
@@ -266,6 +296,22 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // shape a saved entry's `attachments` has, and the card seeds from it the same
   // way an Edit does (owner E2E R1, F4 (2026-09-10)).
   const [newAttachments, setNewAttachments] = useState<SchedAttachment[]>([]);
+  // WHICH CHAT DRAFT THIS FORM SUPERSEDES (design.md, Round 2: "A draft moves,
+  // never duplicates").
+  //
+  // The Schedule hop carries a composer's words here, and the composer's own
+  // autosave has already stored them as a chat draft. The task draft this card
+  // is about to mint is THE SAME WORDS, so the first save names the key they
+  // came from and the server deletes that one in the same request — one draft,
+  // one row, one TASK number, with no window where the List shows the sentence
+  // twice.
+  //
+  // The key is the hop's own: its `session_id` when the chat had one, else
+  // `new:<target>` — and `target` IS the chat's `file` (sched-draft.schedulerUrl
+  // writes `link.file` into it), which is the whole reason no new param was
+  // needed. platform/lib/drafts.chatDraftKey carries the rule that keeps the
+  // four spellings of that path in step.
+  const [newChatKey, setNewChatKey] = useState<string | null>(null);
   // Search, status and project, client-side only — nothing here is worth a URL
   // or a localStorage row: a filter is how you read the page this minute.
   const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS);
@@ -311,6 +357,16 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     // answers [] for anything it cannot read, because a parse error here would
     // cost the folder, the draft and the session as well as the files.
     setNewAttachments(parseAttachmentsParam(q.get("attachments")));
+    // Only for a hop that came FROM a chat, which is what `message` says: the
+    // other `?new=1&target=…` links (the app page's "+ New task") carry no
+    // composer and have no draft of anybody's to supersede. `message` may be
+    // empty and still present — an empty composer stored no draft, so the key
+    // is simply one the server finds nothing under.
+    setNewChatKey(
+      q.get("message") === null
+        ? null
+        : chatDraftKey(q.get("session_id"), q.get("target")),
+    );
     openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null);
     q.delete("new");
     q.delete("target");
@@ -484,6 +540,15 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
       ...f,
       projects: f.projects.length === 1 && f.projects[0] === project ? [] : [project],
     }));
+
+  // The Draft chip pressed on a row or a card: keep only the rows carrying
+  // unsent words, and press it again to let them all back (design.md, Round 2).
+  // A plain toggle of one boolean, unlike the folder's replace-not-widen rule,
+  // because there is only one of it — and everything else about the filters is
+  // left alone for the same reason: a search or a project already on stays on,
+  // and this narrows what they left. ONE handler for the List and the Board,
+  // exactly like `pickProject`, so the two views cannot drift.
+  const pickDraft = () => setFilters((f) => ({ ...f, draft: !f.draft }));
 
   const pickView = (v: TaskView) => {
     setView(v);
@@ -725,6 +790,14 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               tasks={shown}
               home={home}
               onReload={reload}
+              // A draft card's press re-opens the form it was saved from —
+              // the same gesture, and the same callback, as the List row's.
+              onOpenDraft={openDraft}
+              // …and the Draft chip as a TAG here too: the filter is the List's
+              // and the Board's, on the one shared `TaskFilters`, so switching
+              // view keeps it and keeps the chip that turns it off.
+              onPickDraft={pickDraft}
+              draftOn={filters.draft}
               missing={missing}
               emptyLabel={emptyLabel}
             />
@@ -756,6 +829,9 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               // a reason to hold onto it. See `stale` in TaskList.
               stale={tasksFailed}
               onEditEntry={editEntry}
+              // …and the draft row's press, which opens the same card on the
+              // form the row is carrying rather than on a stored entry.
+              onOpenDraft={openDraft}
               // The folder chip as a TAG: pressing one narrows the page to that
               // project, pressing the pinned one again clears it. It REPLACES
               // the project selection rather than adding to it — the gesture
@@ -767,6 +843,10 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               // Which project the page is pinned to — so the chip survives the
               // filter that makes every row agree, and shows that it is on.
               pinnedProjects={filters.projects}
+              // The Draft chip, the same way: pressing one keeps only the rows
+              // carrying unsent words, pressing it again lets them all back.
+              onPickDraft={pickDraft}
+              draftOn={filters.draft}
               // Cancelling a message changes server state. The 20s poll would
               // catch it anyway, so this is about the row not looking stuck for
               // twenty seconds, not about correctness.
@@ -777,7 +857,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
         </section>
       )}
 
-      {(creating !== null || editing) && state && (
+      {(creating !== null || editing || draftRow) && state && (
         <NewJobModal
           // Keyed on WHICH OPENING this is, and on what is being edited, because
           // the form reads `editing` in `useState` initialisers — they run once,
@@ -795,7 +875,12 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           // the card came up wearing the last form's answers — a Repeat rule the
           // user never chose, one Save away from a real repeating task. See
           // `openSeq` above.
-          key={`${editing ? `edit:${editing.id}` : "new"}#${openSeq}`}
+          // …and a DRAFT is a third identity, for the same reason: its fields are
+          // read in `useState` initialisers, so re-opening one over a card that
+          // was showing another must be a fresh mount.
+          key={`${
+            draftRow ? `draft:${draftRow.draft_id}` : editing ? `edit:${editing.id}` : "new"
+          }#${openSeq}`}
           initialTime={creating instanceof Date ? creating : null}
           // Scoped, a new task is a task FOR THIS APP: the folder is prefilled
           // so the modal opens ready to type. A deep link's own target still
@@ -803,8 +888,18 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           initialTarget={newTarget ?? scope?.project ?? null}
           initialMessage={newMessage}
           initialAttachments={newAttachments}
+          // The saved form, handed back whole. Null on every other opening.
+          initialDraft={
+            draftRow?.draft_id
+              ? { id: draftRow.draft_id, form: draftRow.form ?? null }
+              : null
+          }
           chatSessionId={newSession}
           chatBack={newBack}
+          // The chat draft this card's own first save supersedes — see
+          // `newChatKey` above. Null on every opening that did not come from a
+          // composer, which is every opening but the Schedule hop.
+          fromChatKey={newChatKey}
           editing={editing}
           // IS THIS CARD BEING USED TO PLAN? Three ways it is: the reader is on
           // the calendar (where "when" is the question the view itself asks),
@@ -824,10 +919,15 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           onClose={() => {
             setCreating(null);
             setEditing(null);
+            // CLOSING A DRAFT KEEPS IT (design.md, Decisions): the card is put
+            // away, the row stays on the list, and the modal's own autosave has
+            // already flushed on unmount. Only the OPENING is forgotten here.
+            setDraftRow(null);
             setNewTarget(null);
             setNewMessage(null);
             setNewSession(null);
             setNewBack(null);
+            setNewChatKey(null);
           }}
           onCreated={reload}
         />

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -41,6 +41,7 @@ import {
   ICON_ARCHIVE,
   ICON_TRASH,
   ICON_UNARCHIVE,
+  DraftChip,
   IdentityChip,
   StatusIcon,
 } from "./ScheduleTaskViews";
@@ -50,6 +51,7 @@ import {
   basename,
   cardKey,
   cardsForTasks,
+  draftTag,
   ERASE_BLOCKED_HINT,
   emptyPaneFailed,
   emptyPaneText,
@@ -414,6 +416,10 @@ function TaskCard({
 }) {
   const when = taskWhen(task);
   const title = firstLine(task.title) || "(untitled)";
+  // Words nobody has sent, in this conversation's composer — the List row's and
+  // the Board card's own chip, from the same function, so the three views
+  // cannot describe one draft differently (tasks-lib.draftTag).
+  const draft = draftTag(task);
   // Both halves have to be there before anything can be framed: no session means
   // there is no conversation yet, and no template means the folder's stat has
   // not answered (or has no chat mode at all).
@@ -548,6 +554,18 @@ function TaskCard({
               (Akshil, 2026-09-05: "when we click on them they filter?"): the
               chip stops its own press (IdentityChip's shield), so pressing the
               folder filters the page and does not also open the popup. */}
+          {/* …and, before it, the one thing a card can carry that the head
+              otherwise cannot say: unsent words in this conversation's composer
+              (tasks-lib.draftTag). The same chip, in the same seat relative to
+              the folder, as the List row and the Board card — design-principles
+              §1: a mark that moved between views would be three marks to learn.
+
+              A LABEL HERE, not a tag. The draft filter is the List's and the
+              Board's (design.md, Round 2), and the wall draws no draft ROW at
+              all (CARD_LANES) — so a press here would turn on a filter that
+              removes most of the wall and leaves almost nothing wearing the
+              chip that would turn it off (Akshil, 2026-09-11). */}
+          {draft && <DraftChip draft={draft} />}
           {project && (
             <IdentityChip
               name={basename(task.project)}

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -52,6 +52,7 @@ let splitTargetPath: typeof import("./NewJobModal").splitTargetPath;
 let PATH_MISSING: typeof import("./NewJobModal").PATH_MISSING;
 let twoLevelsMissing: typeof import("./NewJobModal").twoLevelsMissing;
 let saveActionLabel: typeof import("./NewJobModal").saveActionLabel;
+let seededDraftForm: typeof import("./NewJobModal").seededDraftForm;
 
 beforeAll(async () => {
   const mod = await import("./NewJobModal");
@@ -87,6 +88,7 @@ beforeAll(async () => {
   PATH_MISSING = mod.PATH_MISSING;
   twoLevelsMissing = mod.twoLevelsMissing;
   saveActionLabel = mod.saveActionLabel;
+  seededDraftForm = mod.seededDraftForm;
 });
 
 // Only the fields these functions read; the rest of a stored entry is noise
@@ -1996,5 +1998,110 @@ describe("a draft moves with the reader, never duplicating", () => {
     expect(page).toContain('q.get("message") === null');
     // The opening is forgotten on close, like every other deep-link value.
     expect(page).toContain("setNewChatKey(null);");
+  });
+});
+
+// ---- the hop's chat draft does not outlive the task it became ----------------
+//
+// THE BUG (Bugbot, PR #1118). The composer's Schedule button carries what is in
+// the box into this card, and the card's FIRST autosave is what tells the server
+// to drop the chat's copy (`from_chat_key` on the task-draft PUT). Press
+// Schedule inside the 600 ms debounce — which is the ordinary way to use a hop,
+// since the card opens already filled in — and that write never happens: no
+// draft id is minted, none goes on the wire, and the chat draft survives beside
+// the task, row and TASK number and all. `session_id` does not cover it: a chat
+// that has never sent anything HAS no session, and its draft is keyed
+// `new:<file>`.
+
+describe("the chat draft a Schedule leaves behind", () => {
+  const src = () => readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+
+  test("the payload names the chat the words came out of", () => {
+    const body = buildSchedulePayload(form({ fromChatKey: "new:/Users/me/news" }));
+    expect(body.from_chat_key).toBe("new:/Users/me/news");
+    // A session-keyed chat rides the same field — the server validates both
+    // shapes — and the two are independent of each other.
+    expect(buildSchedulePayload(form({ fromChatKey: "sess-9" })).from_chat_key)
+      .toBe("sess-9");
+  });
+
+  test("and leaves the key off the wire when there is no chat behind the card", () => {
+    // "+ New task" from the app page, the `?new=1` hop, every client that
+    // predates drafts. Omitted rather than sent as "", like every other
+    // optional here.
+    expect("from_chat_key" in buildSchedulePayload(form())).toBe(false);
+    expect("from_chat_key" in buildSchedulePayload(form({ fromChatKey: "" }))).toBe(false);
+  });
+
+  test("both openings answer the same question: which chat was this typed in", () => {
+    const s = src();
+    // The FRESH hop is handed the key as a prop; a card REOPENED from its draft
+    // row has only what the server stored on the draft — the same fact
+    // `backToChat` aims at.
+    expect(s).toContain(
+      'const originChatKey = (fromChatKey ?? "") || (saved.fromChatKey ?? "");',
+    );
+    expect(s).toContain("fromChatKey: originChatKey,");
+  });
+
+  test("submit flushes before it stops, so the hop's own write still goes out", () => {
+    // `writeInitial` only ARMS the debounce. A Schedule inside that window would
+    // otherwise reach `stop()` before any write left at all — no id, no
+    // `from_chat_key`, no draft. The flush is what makes the id exist; the
+    // payload's own key is what covers it when even that is too late.
+    const submit = src().slice(src().indexOf("// THE DRAFT STOPS HERE."));
+    expect(submit.indexOf("autosaveRef.current.flush();"))
+      .toBeLessThan(submit.indexOf("autosaveRef.current.stop();"));
+    expect(submit.indexOf("autosaveRef.current.stop();"))
+      .toBeLessThan(submit.indexOf("await autosaveRef.current.settle()"));
+    expect(submit.indexOf("await autosaveRef.current.settle()"))
+      .toBeLessThan(submit.indexOf("await scheduleMessage("));
+  });
+});
+
+// ---- a Custom repeat survives being drafted ----------------------------------
+//
+// THE BUG (Bugbot, PR #1118). The autosave stored `repeat` — the preset KEY —
+// and nothing else. Every other key is its own whole answer ("every day" needs
+// no second field); "custom" is a pointer at a rule the recurrence dialog built.
+// So a Custom draft reopened saying Custom, holding no rule, with Save refused
+// (`saveEnabled`) and nothing on the card explaining the dead button.
+
+describe("a Custom repeat survives being drafted", () => {
+  const src = () => readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+
+  test("the rule comes back off the stored draft", () => {
+    const rule: RecurrenceRule = { freq: "week", interval: 2, byday: [1, 3] };
+    const seeded = seededDraftForm({
+      id: "d1",
+      form: { repeat: "custom", custom_rule: rule },
+    });
+    expect(seeded.repeat).toBe("custom");
+    expect(seeded.customRule).toEqual(rule);
+  });
+
+  test("and a draft with no rule in it still opens, saying nothing", () => {
+    expect(seededDraftForm({ id: "d1", form: {} }).customRule).toBeNull();
+    expect(seededDraftForm(null).customRule).toBeNull();
+  });
+
+  test("a shape this build cannot read costs the rule and never the card", () => {
+    // A draft is loose JSON that may have been written by another build, and
+    // this runs inside a `useState` initialiser: a throw here is a card that
+    // will not open at all.
+    for (const bad of [null, "every week", 7, [], {}, { freq: "fortnight" }]) {
+      expect(seededDraftForm({ id: "d1", form: { custom_rule: bad } }).customRule)
+        .toBeNull();
+    }
+  });
+
+  test("the form stores the rule only while the choice points at one", () => {
+    const s = src();
+    // Null the same moment `repeat` itself goes null, so a draft can never say
+    // "custom" with nothing behind it.
+    expect(s).toContain('custom_rule: repeatOn && repeat === "custom" ? customRule : null,');
+    // …and the card seeds its state back off it, which is the half that makes
+    // storing it worth anything.
+    expect(s).toContain('if (saved.repeat === "custom" && saved.customRule) return saved.customRule;');
   });
 });

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -41,6 +41,8 @@ let ASK_PLACEHOLDER: typeof import("./NewJobModal").ASK_PLACEHOLDER;
 let composeTaskMessage: typeof import("./NewJobModal").composeTaskMessage;
 let withoutTitleHeading: typeof import("./NewJobModal").withoutTitleHeading;
 let splitDraft: typeof import("./NewJobModal").splitDraft;
+let joinDraft: typeof import("./NewJobModal").joinDraft;
+let backChatHref: typeof import("./NewJobModal").backChatHref;
 let pastNoteFor: typeof import("./NewJobModal").pastNoteFor;
 let PAST_NOTE_ONE_OFF: typeof import("./NewJobModal").PAST_NOTE_ONE_OFF;
 let PAST_NOTE_CATCH_UP: typeof import("./NewJobModal").PAST_NOTE_CATCH_UP;
@@ -74,6 +76,8 @@ beforeAll(async () => {
   composeTaskMessage = mod.composeTaskMessage;
   withoutTitleHeading = mod.withoutTitleHeading;
   splitDraft = mod.splitDraft;
+  joinDraft = mod.joinDraft;
+  backChatHref = mod.backChatHref;
   pastNoteFor = mod.pastNoteFor;
   PAST_NOTE_ONE_OFF = mod.PAST_NOTE_ONE_OFF;
   PAST_NOTE_CATCH_UP = mod.PAST_NOTE_CATCH_UP;
@@ -1828,7 +1832,11 @@ describe("where the when-row lives", () => {
     expect(s.indexOf("Google's when-row")).toBeGreaterThan(more);
     // Openness is React state, not a bare `open` attribute: a half-controlled
     // <details> would slam shut on the next re-render, under the user's hand.
-    expect(s).toContain("const [moreOpen, setMoreOpen] = useState(planning);");
+    // …and for a re-opened DRAFT that carries a time, which is the one other
+    // card whose when-row holds an answer the reader already gave.
+    expect(s).toContain(
+      "const [moreOpen, setMoreOpen] = useState(planning || saved.when !== null);",
+    );
     expect(s).toContain("onToggle={(e) => setMoreOpen(e.currentTarget.open)}");
   });
 
@@ -1840,6 +1848,153 @@ describe("where the when-row lives", () => {
     expect(s).toContain("if (on) setTimePicked(true);");
     // And the opening value: an edit inherits what the entry was stored as, a
     // new card is planned exactly when the caller says it is planning.
-    expect(s).toContain("(editing ? !editing.immediate : planning)");
+    // …and a re-opened draft that stored a time is planned by definition: the
+    // draft only carries `when` once somebody opened the row and picked one.
+    expect(s).toContain("(saved.when !== null ? true : editing ? !editing.immediate : planning)");
+  });
+});
+
+// ---- the draft MOVES with the reader (design.md, Round 2) --------------------
+// "A draft moves, never duplicates." The composer's Schedule button carries the
+// sentence here; until it is scheduled there must be exactly one copy of it, and
+// exactly one row on the List wearing exactly one TASK number. Source reads,
+// because what these pin down is the ORDER of three calls — and a rendered form
+// with a stubbed fetch would only show that they all happened.
+
+describe("a draft moves with the reader, never duplicating", () => {
+  const src = () => readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+
+  test("the hop's words are a draft the moment they land, without a keystroke", () => {
+    const s = src();
+    // The ✕ guard's question ("has the user changed anything") and the draft's
+    // ("are there words here that would be lost") are asked APART: the prefill
+    // still moves the dirty baseline, so a close is still one click.
+    expect(s).toContain(
+      "const hopSeeded = !editing && !initialDraft && !!(initialMessage ?? \"\").trim();",
+    );
+    expect(s).toContain("!editing && (dirty || hopSeeded)");
+    // …and the hook is told the opening value counts as unwritten, which is what
+    // makes the first debounce actually write it.
+    expect(s).toContain("{ writeInitial: hopSeeded }");
+  });
+
+  test("an ordinary new card still mints nothing until something changes", () => {
+    const s = src();
+    // `hopSeeded` is false without a chat handoff, so the body is null and the
+    // hook keeps its own default: the mount value is already written.
+    expect(s).toContain("!initialDraft");
+    // An Edit writes nothing here at all, whatever else is true.
+    expect(s).toContain("const draftBody: TaskDraftForm | null = !editing &&");
+  });
+
+  test("the first save names the chat draft it supersedes, and only the first", () => {
+    const s = src();
+    expect(s).toContain("const moving = chatKeySpent.current ? \"\" : (fromChatKey ?? \"\");");
+    expect(s).toContain("chatKeySpent.current = true;");
+    expect(s).toContain("return saveTaskDraft(id, value, opts, moving || undefined);");
+  });
+
+  test("Back to chat reverses the move — and orders the delete after the last write", () => {
+    const s = src();
+    const back = s.slice(
+      s.indexOf("const backToChat = async () => {"),
+      s.indexOf("// The replacement was created but the original could not be withdrawn"),
+    );
+    // The two-step dirty guard still comes first: one click must not silently
+    // abandon an adjusted form (Bugbot, PR #548).
+    expect(back.indexOf("if (dirty && !backConfirm)"))
+      .toBeLessThan(back.indexOf("autosaveRef.current.stop()"));
+    // `stop` disarms the next write, `settle` waits out one already sent, and
+    // only then is the draft deleted — otherwise a PUT lands after the DELETE
+    // and puts the row back.
+    expect(back.indexOf("autosaveRef.current.stop()"))
+      .toBeLessThan(back.indexOf("await autosaveRef.current.settle()"));
+    expect(back.indexOf("await autosaveRef.current.settle()"))
+      .toBeLessThan(back.indexOf("deleteTaskDraft(id)"));
+    expect(back.indexOf("deleteTaskDraft(id)"))
+      .toBeLessThan(back.indexOf("navigateUrl(chatBack || backChatHref("));
+  });
+
+  test("a REOPENED draft can go back too — the key is stored, not in the URL", () => {
+    const s = src();
+    // The bug: the hop's instance had `?back=` and a sessionStorage stash, and a
+    // draft opened from its row on the List has neither — so the way back
+    // vanished the moment the modal was closed. `form.from_chat_key` is what
+    // the server now stores, and it is what this card aims at.
+    expect(s).toContain('const backChatKey = chatBack ? "" : (saved.fromChatKey ?? "");');
+    expect(s).toContain("const canGoBack = !!chatBack || !!backChatKey;");
+    expect(s).toContain('fromChatKey: str("from_chat_key"),');
+    // …and the button is shown on BOTH, not only the hop's instance.
+    expect(s).toContain("{canGoBack && (");
+    expect(s).not.toContain("{chatBack && (");
+  });
+
+  test("that card re-seeds the composer by hand, then deletes the task draft", () => {
+    const s = src();
+    const back = s.slice(
+      s.indexOf("const backToChat = async () => {"),
+      s.indexOf("// The replacement was created but the original could not be withdrawn"),
+    );
+    // No stash exists any more, so the chat draft is written explicitly — and
+    // BEFORE the task draft is deleted, so the sentence is never in no store at
+    // all. Both still come after `settle`, or a late PUT resurrects the row.
+    expect(back.indexOf("await autosaveRef.current.settle()"))
+      .toBeLessThan(back.indexOf("await saveChatDraft(backChatKey"));
+    expect(back.indexOf("await saveChatDraft(backChatKey"))
+      .toBeLessThan(back.indexOf("deleteTaskDraft(id)"));
+    // The two fields go back as the one block of prose they were split from.
+    expect(back).toContain("joinDraft(title, message)");
+  });
+
+  test("joinDraft is splitDraft run backwards, blank line and all", () => {
+    expect(joinDraft("roll up the PRs", "group them by repo"))
+      .toBe("roll up the PRs\n\ngroup them by repo");
+    // A round trip through both is the identity on anything the split produced.
+    const one = "roll up the PRs\n\ngroup them by repo";
+    const parts = splitDraft(one);
+    expect(joinDraft(parts.title, parts.description)).toBe(one);
+    // Either half alone is just that half — no separator for the missing one.
+    expect(joinDraft("", "just a body")).toBe("just a body");
+    expect(joinDraft("just a title", "")).toBe("just a title");
+    expect(joinDraft("", "")).toBe("");
+    expect(joinDraft(null, null)).toBe("");
+  });
+
+  test("where Back to chat lands, by the shape of the key", () => {
+    // A session id: the draft's own folder with that thread on the Claude pane.
+    expect(backChatHref("sess-9", "/Users/me/proj"))
+      .toBe("/explorer/view/Users/me/proj?_side=claude&session_id=sess-9");
+    // `new:<file>`: the SAME door a never-sent chat's row uses — built out of
+    // the key's own file, and naming no session at all, or the composer that
+    // opens seeds from a key nothing wrote (schedule-lib.chatDraftHref).
+    expect(backChatHref("new:/Users/me/news", "/Users/me/elsewhere"))
+      .toBe("/explorer/view/Users/me/news?_side=claude");
+    // Nothing to go back to.
+    expect(backChatHref("", "/Users/me/proj")).toBe("");
+    expect(backChatHref("sess-9", "")).toBe("");
+    expect(backChatHref("new:", "/Users/me/proj")).toBe("");
+  });
+
+  test("Schedule leaves the delete to the server, as it always did", () => {
+    // `POST /api/schedule` is handed `draft_id` and drops the draft itself, so
+    // this path only has to make sure nothing queued can write it back.
+    const s = src();
+    const submit = s.slice(s.indexOf("// THE DRAFT STOPS HERE."));
+    expect(submit.indexOf("autosaveRef.current.stop();"))
+      .toBeLessThan(submit.indexOf("await scheduleMessage("));
+    expect(submit).not.toContain("deleteTaskDraft");
+  });
+
+  test("the page hands the modal the key the hop came from", () => {
+    // `target` IS the chat's `file` (sched-draft.schedulerUrl writes `link.file`
+    // into it), which is why no new param was needed.
+    const page = readFileSync(join(import.meta.dir, "Scheduled.tsx"), "utf8");
+    expect(page).toContain('chatDraftKey(q.get("session_id"), q.get("target"))');
+    expect(page).toContain("fromChatKey={newChatKey}");
+    // …and only for a hop that came FROM a chat: the app page's "+ New task"
+    // deep link carries no composer and has no draft of anybody's to supersede.
+    expect(page).toContain('q.get("message") === null');
+    // The opening is forgotten on close, like every other deep-link value.
+    expect(page).toContain("setNewChatKey(null);");
   });
 });

--- a/frontend/src/shell/new-task-images.test.ts
+++ b/frontend/src/shell/new-task-images.test.ts
@@ -381,8 +381,14 @@ describe("the chat handoff's attachments", () => {
     // Pinned to the source because it is a branch in a `useState` initialiser,
     // which runs once and cannot be observed from a pure call.
     expect(MODAL).toContain("editing\n      ? restoredAttachments(editing)");
+    // The seed is now one const (`initialAttachmentRows`) because the dirty
+    // BASELINE has to read the identical list — a re-opened draft's chips must
+    // not make an untouched card read as dirty — but the precedence is
+    // unchanged: an Edit's own attachments, else a draft's, else the handoff's.
     expect(MODAL).toContain(
-      'restoredAttachments({ images: [], attachments: initialAttachments ?? [] })');
+      "restoredAttachments({ images: [], attachments: initialAttachmentRows })");
+    expect(MODAL).toContain(
+      "const initialAttachmentRows = saved.attachments ?? initialAttachments ?? [];");
   });
 
   it("Save sends them, in the field the backend reads names off", () => {

--- a/frontend/src/shell/schedule-lib.ts
+++ b/frontend/src/shell/schedule-lib.ts
@@ -303,11 +303,26 @@ export const BOARD_COLUMNS = [
   { key: "archived", label: "Archive" },
 ] as const;
 
-export type BoardColumn = (typeof BOARD_COLUMNS)[number]["key"];
+/**
+ * …PLUS `draft`, which is deliberately NOT in the array above.
+ *
+ * A draft is a status a row can be in (api.Task.status) but never a COLUMN: the
+ * array is the board's lanes and the List's ranks, and drafts draw inside
+ * Upcoming (laneOf) with no lane, no header and no count of their own — "no new
+ * lane; six columns is already the width budget" (design.md, Decisions, Akshil
+ * 2026-09-11). Adding it to BOARD_COLUMNS would have drawn a seventh lane and
+ * put a "Draft" entry in the Status filter, neither of which was asked for.
+ *
+ * So the union is widened here and the array is left alone, which is also what
+ * keeps every `Record<BoardColumn, …>` in this page honest: a draft has to be
+ * given an answer in each of them rather than inheriting one by accident.
+ */
+export type BoardColumn = (typeof BOARD_COLUMNS)[number]["key"] | "draft";
 
 /** A column the BOARD actually draws. Every status is one except
- *  `needs_attention`, which shares the Blocked lane — see `laneOf`. */
-export type BoardLane = Exclude<BoardColumn, "needs_attention">;
+ *  `needs_attention`, which shares the Blocked lane, and `draft`, which shares
+ *  Upcoming — see `laneOf`. */
+export type BoardLane = Exclude<BoardColumn, "needs_attention" | "draft">;
 
 /**
  * The lanes, left to right — BOARD_COLUMNS minus the one that shares.
@@ -330,7 +345,12 @@ export const BOARD_LANES = BOARD_COLUMNS.filter(
  * would each have to be remembered again the next time a status is added.
  */
 export function laneOf(column: BoardColumn): BoardLane {
-  return column === "needs_attention" ? "blocked" : column;
+  if (column === "needs_attention") return "blocked";
+  // An unfinished task is the most upcoming thing there is (design.md), and it
+  // sorts to the head of that lane — tasks-lib.groupByColumn does the hoist,
+  // the same stable partition that puts a waiting card at the top of Blocked.
+  if (column === "draft") return "upcoming";
+  return column;
 }
 
 export function boardColumn(entry: ScheduledMessage): BoardColumn {
@@ -516,10 +536,26 @@ export function repeatChoicesFor(picked: Date): RepeatChoice[] {
 // about). Same /view codec + `_side=claude` handoff the retired Inbox's
 // own open-dir button used.
 export function explorerUrl(target: string, sessionId: string): string {
+  return `${chatPaneUrl(target)}&session_id=${encodeURIComponent(sessionId)}`;
+}
+
+/**
+ * THE SAME DOOR WITH NO CONVERSATION NAMED — the folder, with the Claude pane
+ * on it, and no `session_id` at all.
+ *
+ * Split out of `explorerUrl` rather than spelled again because the two differ
+ * in exactly one param and share the whole /view path codec. `explorerUrl` keeps
+ * emitting an EMPTY `session_id=` for its own no-session callers (`folderHref`,
+ * `taskHref`) — those name a task whose session has not been reported yet, and
+ * the empty value is the chat pane's own "this folder's sessions" signal there.
+ * A never-sent chat is a different fact: there is no session to be waiting for,
+ * so the parameter is omitted rather than sent empty (Akshil, 2026-09-11).
+ */
+export function chatPaneUrl(target: string): string {
   const norm = /^[A-Za-z]:[\\/]/.test(target) ? target.replace(/\\/g, "/") : target;
   const encoded = norm.replace(/^\/+/, "").split("/")
     .filter(Boolean).map(encodeURIComponent).join("/");
-  return `/explorer/view/${encoded}?_side=claude&session_id=${encodeURIComponent(sessionId)}`;
+  return `/explorer/view/${encoded}?_side=claude`;
 }
 
 // The same door, for a task that has no thread to open YET.
@@ -546,6 +582,33 @@ export function explorerUrl(target: string, sessionId: string): string {
 export function folderHref(task: Pick<Task, "target" | "project">): string | null {
   const target = task.target || task.project;
   return target ? explorerUrl(target, "") : null;
+}
+
+/**
+ * WHERE A NEVER-SENT CHAT'S ROW GOES (design.md, Round 2: "New-chat drafts are
+ * rows" — "Click → opens the folder's chat, composer prefilled").
+ *
+ * The same door as `folderHref` and deliberately so: a draft chat has no
+ * session to name, so what opens is the FOLDER with the Claude pane on it, and
+ * the composer seeds itself from the draft keyed on that folder. Carrying a
+ * `session_id` would be asserting an identity this conversation has not been
+ * given yet — the very state `new:<file>` exists to describe.
+ *
+ * `file` FIRST, and that is the whole difference from `folderHref`. The chat
+ * draft's key is built out of the chat's own `file` (platform/lib/drafts
+ * `chatDraftKey`, whose note carries the rule), so this URL has to be built out
+ * of the same string or the chat that opens is mounted somewhere else and the
+ * composer seeds from a key nothing wrote. `target` / `project` are the
+ * fallback for a server that sends the row without it.
+ */
+export function chatDraftHref(
+  task: Pick<Task, "file" | "target" | "project">,
+): string | null {
+  const at = task.file || task.target || task.project;
+  // NO `session_id` AT ALL, not an empty one. `&session_id=` claimed the
+  // parameter had been answered with nothing; a chat that has never been sent
+  // has not been asked the question (Akshil, 2026-09-11).
+  return at ? chatPaneUrl(at) : null;
 }
 
 /**
@@ -873,6 +936,12 @@ export function taskChips(
   for (const day of days) out.set(dayKey(day), []);
   for (const task of tasks) {
     if (isArchivedTask(task)) continue;
+    // A DRAFT IS NOT A PLAN (design.md, Decisions: List and Board only, never
+    // Cards or Calendar). It names no time — that is most of what makes it
+    // unfinished — so a calendar drawing it would have to invent a day for it.
+    // `kind`, not `status`: a draft row arrives as `status: "upcoming"` so the
+    // rest of the page needs no new word (api.Task.kind).
+    if (task.kind === "draft") continue;
     const messages = threads[task.key] ?? task.messages ?? [];
     const byDay = new Map<string, TaskMessage[]>();
     const seen = new Set<string>();

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5,7 +5,14 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Task, TaskMessage, TaskPulseTask } from "@platform/lib/api";
-import { BOARD_COLUMNS, BOARD_LANES, cardFrameSrc, laneOf, peekFrameSrc } from "./schedule-lib";
+import {
+  BOARD_COLUMNS,
+  BOARD_LANES,
+  cardFrameSrc,
+  chatDraftHref,
+  laneOf,
+  peekFrameSrc,
+} from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 import {
   ALL_MESSAGES,
@@ -32,12 +39,17 @@ import {
   cancelIntent,
   carryMarkToHeld,
   dayLabel,
+  DRAFT_CHIP,
   dropAction,
   dropLanes,
   filterTasks,
   filtersForView,
   firstLine,
   groupByColumn,
+  hasActiveFilters,
+  hasDraft,
+  isChatDraftTask,
+  draftUpdatedAt,
   heldMessages,
   isAllRead,
   isDraggable,
@@ -59,6 +71,7 @@ import {
   LIST_ORDER,
   showsRowActions,
   sortByLane,
+  sortForList,
   laneTime,
   lastRunAt,
   markAllRead,
@@ -3297,8 +3310,10 @@ describe("a one-message row's click", () => {
     // place — and going through the thread arm means the leaf row, the accordion
     // row and the Board card all open a conversation the same way, with the same
     // mark, through the same performer.
+    // (The draft arm sits ahead of all three — a `kind: "draft"` row has no
+    // session and no entry, so it is the one row whose press is the form.)
     expect(VIEWS).toMatch(
-      /const activate = \(\) => \{\s*if \(chat\) openChat\(chat\);\s*else if \(edit\) onEditEntry\?\.\(edit\);[\s\S]*?else if \(folderMissing\) toastMissingFolder\(\)/,
+      /const activate = \(\) => \{\s*if \(openDraft\) openDraft\(task\);\s*else if \(chat\) openChat\(chat\);\s*else if \(edit\) onEditEntry\?\.\(edit\);[\s\S]*?else if \(folderMissing\) toastMissingFolder\(\)/,
     );
     expect(VIEWS).not.toContain("openMessage(sole)");
     // No per-turn anchor from a TASK row: `msg=` is a message row's business, and
@@ -3382,7 +3397,9 @@ describe("a row with no message at all", () => {
     // affordance cannot drift from the behaviour. `expandable` is deliberately not
     // one of them any more — a disclosure is the CHEVRON's affordance, and it is a
     // button with a tab stop of its own.
-    expect(VIEWS).toContain("const pressable = href !== null || edit !== null || folderMissing;");
+    expect(VIEWS).toContain(
+      "const pressable = href !== null || edit !== null || openDraft !== null || folderMissing;",
+    );
     // The row then claims no role and takes no tab stop...
     expect(ROW).toContain('role={pressable && !href ? "button" : undefined}');
     expect(ROW).toContain("tabIndex={pressable && !href ? 0 : undefined}");
@@ -3524,7 +3541,9 @@ describe("an upcoming row's click", () => {
     // The row's press opens the conversation now, so the disclosure has to be a
     // control in its own right: a real button, with a real name, and its own
     // press that does not also fire the row's.
-    expect(ACTIVATE).toMatch(/^\s*const activate = \(\) => \{\s*if \(chat\) openChat\(chat\);/);
+    expect(ACTIVATE).toMatch(
+      /^\s*const activate = \(\) => \{\s*if \(openDraft\) openDraft\(task\);\s*else if \(chat\) openChat\(chat\);/,
+    );
     const caret = ROW.slice(ROW.indexOf("{expandable ? ("));
     const button = caret.slice(0, caret.indexOf("</button>"));
     expect(button).toContain('type="button"');
@@ -4262,6 +4281,143 @@ const THREAD = VIEWS.slice(
   VIEWS.indexOf("export function TaskBoard("),
 );
 
+// ---- the Draft chip, and where it sits (design.md, Round 2) -------------------
+// It moved out of the id line and into the row's tag strip the day it became a
+// filter. These read the source, because the argument is entirely about ORDER
+// and a rendered DOM would only say that the chip is present.
+
+describe("the Draft chip", () => {
+  it("is a lucide PencilLine and the word, not a ✎ in a string", () => {
+    // One glyph family for the whole page: every other mark on these rows is an
+    // inline lucide path at the same stroke, and a text pencil rendered at the
+    // font's mercy.
+    expect(DRAFT_CHIP).toBe("Draft");
+    expect(VIEWS).toContain("const ICON_PENCIL_LINE = icon(");
+    expect(VIEWS).not.toContain("✎");
+    // …and it is lucide's OWN pencil-line, copied out of node_modules verbatim.
+    // What was here before was `ICON_PENCIL` with a stub stroke bolted onto it,
+    // which at 11px read as a broken Edit glyph (Akshil, 2026-09-11).
+    const lucide = readFileSync(
+      join(import.meta.dir, "../../node_modules/lucide-react/dist/esm/icons/pencil-line.mjs"),
+      "utf8",
+    );
+    const mark = VIEWS.slice(
+      VIEWS.indexOf("const ICON_PENCIL_LINE = icon("),
+      VIEWS.indexOf("// The two halves of Cancel"),
+    );
+    for (const d of lucide.matchAll(/d: "([^"]+)"/g)) expect(mark).toContain(d[1]);
+    // The old hand-drawn data is gone, and the Edit pencil's is not reused.
+    expect(mark).not.toContain("m15 5 3 3");
+    expect(mark).not.toContain("M12 20h9");
+    const chip = VIEWS.slice(
+      VIEWS.indexOf("export function DraftChip("),
+      VIEWS.indexOf("There is no `UnreadDot`"),
+    );
+    expect(chip).toContain("{ICON_PENCIL_LINE}");
+    expect(chip).toContain("{draft.text}");
+    // It is NOT the Edit pencil: that one is a verb on a button, this is a noun
+    // on a badge, and drawing them alike would make an inert mark read as a
+    // control.
+    expect(VIEWS).toContain("const ICON_PENCIL = icon(");
+  });
+
+  it("sits at the RIGHT of a List row, immediately before the folder chip", () => {
+    const chip = ROW.indexOf("<DraftChip");
+    const folder = ROW.indexOf("<IdentityChip");
+    const id = ROW.indexOf("<IdChip id={task.task_id}");
+    expect(chip).toBeGreaterThan(-1);
+    expect(chip).toBeLessThan(folder);
+    // …and no longer beside the id, which is where it lived for a round.
+    expect(chip).toBeGreaterThan(id);
+    expect(ROW.indexOf('className="tasks-grow"')).toBeLessThan(chip);
+  });
+
+  it("sits in the same seat on a Board card — the foot, before the folder", () => {
+    const foot = CARD.slice(CARD.indexOf('className="schedule-tv-card-foot"'));
+    expect(foot.indexOf("<DraftChip")).toBeGreaterThan(-1);
+    expect(foot.indexOf("<DraftChip")).toBeLessThan(foot.indexOf("<IdentityChip"));
+    // Gone from the card's HEAD, where it used to sit beside the id.
+    const head = CARD.slice(
+      CARD.indexOf('className="schedule-tv-card-head"'),
+      CARD.indexOf('className="schedule-tv-card-foot"'),
+    );
+    expect(head).not.toContain("<DraftChip");
+  });
+
+  it("is a control on the List and the Board, and a label on the Cards wall", () => {
+    // The filter is List + Board (design.md, Round 2). The wall draws no draft
+    // ROW at all, so a press there would turn on a filter that removes most of
+    // the wall and leaves almost nothing wearing the chip that turns it off.
+    expect(ROW).toContain("onPick={onPickDraft}");
+    expect(CARD).toContain("<DraftChip draft={draft} onPick={onPickDraft} active={draftOn} />");
+    expect(CARDS).toContain("{draft && <DraftChip draft={draft} />}");
+    expect(CARDS).not.toContain("onPickDraft");
+  });
+
+  it("wears the ON pill the folder chip wears, in the accent, at rest", () => {
+    // The only trace this filter has: there is no popover holding a count for
+    // it and no entry in the Status menu, so a chip that did not show its own
+    // state would leave a narrowed page unexplainable.
+    expect(TASKS_CSS).toContain("button.tasks-draft-pill.is-on {");
+    const on = block(TASKS_CSS, "button.tasks-draft-pill.is-on");
+    expect(on).toContain("var(--accent)");
+    // The same pill the outcome tag is — one shape for one kind of mark.
+    expect(VIEWS).toContain('"tasks-outcome-pill tasks-draft-pill"');
+    // …and inside the row's shield, so a near-miss in the row's padding opens
+    // nothing (IdentityChip's own note).
+    const chip = VIEWS.slice(VIEWS.indexOf("export function DraftChip("));
+    expect(chip.slice(0, chip.indexOf("There is no `UnreadDot`")))
+      .toContain('className="schedule-tv-id-shield"');
+  });
+});
+
+describe("a never-sent chat is a row you can press", () => {
+  it("opens the folder's chat with NO session id, so the composer can seed", () => {
+    // `new:<file>` is the draft's key and the URL is built out of the same
+    // string — a chat mounted anywhere else would seed from a key nothing wrote
+    // (platform/lib/drafts.chatDraftKey carries the rule).
+    const row = task({
+      key: "new:/Users/me/news", kind: "draft", draft_kind: "chat",
+      file: "/Users/me/news", target: "/Users/me/elsewhere",
+    });
+    const href = chatDraftHref(row)!;
+    expect(href).toBe("/explorer/view/Users/me/news?_side=claude");
+    // NOT `&session_id=` with nothing after it. An empty value says the
+    // question was asked and answered with nothing; a chat that has never been
+    // sent has not been asked (Akshil, 2026-09-11). `folderHref` still sends
+    // the empty one — there the session exists and has merely not been
+    // reported yet.
+    expect(href).not.toContain("session_id");
+  });
+
+  it("falls back to the task's folder on a server that sent no `file`", () => {
+    expect(chatDraftHref({ file: "", target: "/a/b", project: "/c" }))
+      .toContain("/explorer/view/a/b");
+    expect(chatDraftHref({ file: "", target: "", project: "/c" }))
+      .toContain("/explorer/view/c");
+    expect(chatDraftHref({ file: "", target: "", project: "" })).toBe(null);
+  });
+
+  it("is the Scheduled page's first question about a draft row's press", () => {
+    // A chat draft has no form to re-open and no `draft_id` to fall through to,
+    // so the navigation arm has to be asked before the modal arm.
+    const open = SCHEDULED.slice(
+      SCHEDULED.indexOf("const openDraft = (task: Task) => {"),
+      SCHEDULED.indexOf("// What a deep link named"),
+    );
+    expect(open.indexOf("isChatDraftTask(task)"))
+      .toBeLessThan(open.indexOf("if (!task.draft_id) return;"));
+    expect(open).toContain("navigateUrl(href)");
+  });
+
+  it("never lifts — a draft is not a task yet, whichever kind it is", () => {
+    expect(isDraggable(task({ kind: "draft", draft_kind: "chat", status: "upcoming" })))
+      .toBe(false);
+    expect(isDraggable(task({ kind: "draft", draft_kind: "task", status: "upcoming" })))
+      .toBe(false);
+  });
+});
+
 describe("the run action on a board card", () => {
   it("offers the intent the List row offers, from the same function", () => {
     // Not a second predicate and not a second entry id: both sides ask
@@ -4560,12 +4716,17 @@ describe("the folder chip on a row and a card", () => {
 
   it("takes the whole chip away, not the name inside it", () => {
     // On the card the foot holds the chip and the run ahead, so it goes
-    // entirely when neither has anything to say rather than leaving a line of
-    // padding. The outcome pill is deliberately NOT among them: it sits beside
-    // the id, where marks about the task live — in the foot it read as part of
-    // the folder's name (Akshil, 2026-08-21).
+    // entirely when nothing in it has anything to say rather than leaving a line
+    // of padding. The outcome pill is deliberately NOT among them: it sits
+    // beside the id, where marks about the task live — in the foot it read as
+    // part of the folder's name (Akshil, 2026-08-21).
+    //
+    // THE DRAFT CHIP IS AMONG THEM (Akshil, 2026-09-11). It moved out of the
+    // card's head and into this foot, immediately before the folder, because it
+    // is a filter tag now and the tags sit together — so a card that has only
+    // unsent words to show still draws the line.
     expect(CARD).toMatch(
-      /\{\(showProject \|\| folderMissing\) && \(\s*<span className="schedule-tv-card-foot">/,
+      /\{\(showProject \|\| folderMissing \|\| draft\) && \(\s*<span className="schedule-tv-card-foot">/,
     );
     // The task's own name is still captioned — on the TITLE now, not the row
     // (Akshil: "the tooltip of title should only show up if I am on title
@@ -5134,6 +5295,99 @@ describe("filters", () => {
   });
 });
 
+// ---- the Draft filter (design.md, Round 2) -----------------------------------
+// The chip on a row is the control, so this is the only facet with no popover
+// behind it — which makes its behaviour worth pinning down here rather than in
+// a view test: what "carries a draft" means, and that nothing else moves.
+
+describe("the Draft filter keeps only what is unsent", () => {
+  // The three shapes that answer yes, and they are genuinely three things: an
+  // unfinished New task form, a chat nobody has sent, and an ordinary task whose
+  // composer is holding something. To a reader they are one fact, which is why
+  // one boolean keeps all three.
+  const taskDraft = task({
+    key: "draft:d1", task_id: "TASK-004", kind: "draft", draft_kind: "task",
+    state: "draft", status: "upcoming", title: "Half a thought",
+    form: { description: "Half a thought about the news", updated_at: 300 },
+  });
+  const chatDraft = task({
+    key: "new:/Users/me/news", task_id: "TASK-005", kind: "draft",
+    draft_kind: "chat", state: "draft", status: "upcoming", file: "/Users/me/news",
+    title: "unsent words", form: undefined,
+    draft: { preview: "unsent words", updated_at: 200 },
+  });
+  const withChatDraft = task({
+    key: "s-live", task_id: "TASK-006", status: "in_progress",
+    draft: { preview: "one more thing", updated_at: 100 },
+  });
+  const plain = task({ key: "s-plain", task_id: "TASK-007", status: "done" });
+  const rows = [taskDraft, chatDraft, withChatDraft, plain];
+
+  it("is off by default, and off says nothing about any row", () => {
+    expect(EMPTY_FILTERS.draft).toBe(false);
+    expect(filterTasks(rows, EMPTY_FILTERS).map((t) => t.key))
+      .toEqual(rows.map((t) => t.key));
+  });
+
+  it("keeps all three kinds of draft and nothing else", () => {
+    const out = filterTasks(rows, { ...EMPTY_FILTERS, draft: true });
+    expect(out.map((t) => t.key)).toEqual(["draft:d1", "new:/Users/me/news", "s-live"]);
+  });
+
+  it("ANDs with the facets already on, like every other one", () => {
+    const newsRows = [
+      { ...taskDraft, project: "/Users/me/news" },
+      { ...withChatDraft, project: "/Users/me/code" },
+    ];
+    const out = filterTasks(newsRows, {
+      ...EMPTY_FILTERS, draft: true, projects: ["/Users/me/news"],
+    });
+    expect(out.map((t) => t.key)).toEqual(["draft:d1"]);
+  });
+
+  it("counts as an active filter, so the page can say it is narrowed", () => {
+    expect(hasActiveFilters(EMPTY_FILTERS)).toBe(false);
+    expect(hasActiveFilters({ ...EMPTY_FILTERS, draft: true })).toBe(true);
+  });
+
+  it("is dropped on the two views that have no chip to turn it off", () => {
+    // Same rule as the calendar's Archive facet, and the same argument: a
+    // facet with no control on the view it is acting on is a page a reader
+    // cannot explain. Neither the calendar nor the Cards wall draws a draft
+    // row (CARD_LANES), and neither offers the chip.
+    const f = { ...EMPTY_FILTERS, draft: true };
+    expect(filtersForView(f, "calendar").draft).toBe(false);
+    expect(filtersForView(f, "cards").draft).toBe(false);
+    expect(filtersForView(f, "list")).toBe(f);
+    expect(filtersForView(f, "board")).toBe(f);
+  });
+
+  it("is IGNORED on those views, never cleared — the chip is still on when you come back", () => {
+    const f = { ...EMPTY_FILTERS, draft: true };
+    filtersForView(f, "calendar");
+    expect(f.draft).toBe(true);
+  });
+
+  it("hasDraft is the one predicate all three readings ask", () => {
+    expect(hasDraft(taskDraft)).toBe(true);
+    expect(hasDraft(chatDraft)).toBe(true);
+    expect(hasDraft(withChatDraft)).toBe(true);
+    expect(hasDraft(plain)).toBe(false);
+    // A joined draft the server sent as an explicit null is no draft at all.
+    expect(hasDraft({ ...plain, draft: null })).toBe(false);
+  });
+
+  it("tells the two kinds of draft ROW apart, and reads the old shape as a task draft", () => {
+    expect(isChatDraftTask(chatDraft)).toBe(true);
+    expect(isChatDraftTask(taskDraft)).toBe(false);
+    // A server that predates the second kind sends no `draft_kind`: every draft
+    // row there is a form, and its press must stay the modal.
+    expect(isChatDraftTask({ ...taskDraft, draft_kind: undefined })).toBe(false);
+    // …and a plain task is neither, whatever it is carrying.
+    expect(isChatDraftTask(withChatDraft)).toBe(false);
+  });
+});
+
 describe("filtersForView — the calendar's Archive facet (2026-08-20)", () => {
   // The calendar draws nothing for an archived task, so Archive is a dead
   // Status option there: picking it always empties the grid, with nothing on
@@ -5629,9 +5883,13 @@ describe("lane order", () => {
   it("names every lane's order exactly once, for every lane the board draws", () => {
     // A lane added to the board without an entry here would fall through to
     // whatever `undefined` sorts as.
+    // …plus `draft`, which is a column taskColumn can return and BOARD_COLUMNS
+    // deliberately does not hold (schedule-lib's note on BoardColumn). It sorts
+    // by the server's order, having no run of its own to be ordered by.
     expect(Object.keys(LANE_SORTS).sort()).toEqual(
-      BOARD_COLUMNS.map((c) => c.key as string).sort(),
+      [...BOARD_COLUMNS.map((c) => c.key as string), "draft"].sort(),
     );
+    expect(LANE_SORTS.draft.key).toBe("server");
     // The one ascending lane, and the one that sorts nothing.
     const asc = BOARD_COLUMNS.filter((c) => LANE_SORTS[c.key].dir === "asc" &&
       LANE_SORTS[c.key].key !== "server").map((c) => c.key);
@@ -6620,6 +6878,7 @@ describe("sortByLane", () => {
     expect(LIST_ORDER).toEqual([
       "needs_attention",
       "blocked",
+      "draft",
       "upcoming",
       "in_progress",
       "done",
@@ -6639,12 +6898,22 @@ describe("sortByLane", () => {
     // set — that is what a drift would break.
     const HOISTED: BoardColumn[] = ["needs_attention", "blocked"];
     expect(LIST_ORDER.slice(0, HOISTED.length)).toEqual(HOISTED);
-    expect(LIST_ORDER.filter((k) => !HOISTED.includes(k))).toEqual(
-      BOARD_COLUMNS.map((c) => c.key).filter((k) => !HOISTED.includes(k)),
+    // …and `draft`, which is a status but never a COLUMN (schedule-lib's note on
+    // BoardColumn: no seventh lane, no seventh Status filter entry). It is taken
+    // out alongside the hoisted two so what remains is still exactly the board's
+    // sequence — the drift this assertion exists to catch.
+    const NOT_A_COLUMN: BoardColumn[] = ["draft"];
+    const APART = [...HOISTED, ...NOT_A_COLUMN];
+    expect(LIST_ORDER.filter((k) => !APART.includes(k))).toEqual(
+      BOARD_COLUMNS.map((c) => c.key).filter((k) => !APART.includes(k)),
     );
+    // Drafts sit directly above Upcoming: an unfinished thing is the most
+    // upcoming thing (design.md, Decisions, Akshil 2026-09-11) — but under the
+    // two ranks that want a person's hands right now.
+    expect(LIST_ORDER.indexOf("draft")).toBe(LIST_ORDER.indexOf("upcoming") - 1);
     // Same set, so a seventh status cannot be silently unsortable.
     expect([...LIST_ORDER].sort()).toEqual(
-      BOARD_COLUMNS.map((c) => c.key).slice().sort(),
+      [...BOARD_COLUMNS.map((c) => c.key), ...NOT_A_COLUMN].sort(),
     );
   });
 
@@ -6800,9 +7069,124 @@ describe("sortByLane", () => {
       expect(VIEWS).not.toContain(gone);
     }
     expect(TASKS_CSS).not.toContain(".tasks-section");
-    // And the rows are drawn straight off the sorted list.
-    expect(VIEWS).toContain("const rows = useMemo(() => sortByLane(tasks), [tasks]);");
+    // And the rows are drawn straight off the sorted list — `sortForList`, which
+    // is `sortByLane` plus the List's own has-draft hoist (design.md, Round 2).
+    expect(VIEWS).toContain("const rows = useMemo(() => sortForList(tasks), [tasks]);");
     expect(VIEWS).toContain("{rows.map((task) => (");
+  });
+});
+
+// ---- sortForList: the List's own hoist (design.md, Round 2) -------------------
+// "status first, then draft, then time" (Akshil, 2026-09-11). `sortByLane`
+// above is the page's shared rank order and stays exactly as it was; this is
+// the one extra pass the List makes INSIDE each lane — rows carrying unsent
+// words go to the top of their own lane, newest draft first, and never leave it.
+
+describe("sortForList", () => {
+  const LIST_NOW = Date.parse("2026-08-16T12:00:00") ;
+
+  /** A draft row, of either kind, whose words were last touched at `at`. */
+  const taskDraftAt = (key: string, at: number) =>
+    task({
+      key, kind: "draft", draft_kind: "task", state: "draft", status: "upcoming",
+      form: { description: "half a thought", updated_at: at }, last_active: 0,
+    });
+  const chatDraftAt = (key: string, at: number) =>
+    task({
+      key, kind: "draft", draft_kind: "chat", state: "draft", status: "upcoming",
+      file: "/Users/me/news", draft: { preview: "unsent", updated_at: at },
+      last_active: 0,
+    });
+  /** An ORDINARY task, in a real lane, whose composer is holding something. */
+  const carrying = (key: string, status: Task["status"], at: number) =>
+    task({ key, status, draft: { preview: "one more thing", updated_at: at } });
+
+  it("keeps status first: a Done row holding a draft stays under Upcoming", () => {
+    const rows = [
+      task({ key: "ask", status: "needs_attention" }),
+      carrying("done-draft", "done", 100),
+      task({ key: "soon", status: "upcoming" }),
+      taskDraftAt("form", 300),
+      chatDraftAt("chat", 200),
+    ];
+    // Lanes in the page's order — Needs attention, the draft rank, Upcoming,
+    // Done — and the two never-sent drafts newest words first within theirs.
+    expect(sortForList(rows, LIST_NOW).map((t) => t.key))
+      .toEqual(["ask", "form", "chat", "soon", "done-draft"]);
+  });
+
+  it("puts a draft-carrying row first WITHIN its lane, by the draft's clock", () => {
+    const rows = [
+      task({ key: "quiet", status: "in_progress", last_active: LIST_NOW / 1000 }),
+      carrying("older-words", "in_progress", 10),
+      carrying("newer-words", "in_progress", 900),
+    ];
+    // Both carriers above the quiet run, newest words first; the lane itself
+    // does not move.
+    expect(sortForList(rows, LIST_NOW).map((t) => t.key))
+      .toEqual(["newer-words", "older-words", "quiet"]);
+  });
+
+  it("never lets a draft lift a row out of its lane", () => {
+    const rows = [
+      carrying("done", "done", 900),
+      carrying("ask", "needs_attention", 10),
+    ];
+    expect(sortForList(rows, LIST_NOW).map((t) => t.key)).toEqual(["ask", "done"]);
+  });
+
+  it("keeps the server's order among drafts whose clocks tie", () => {
+    const rows = [chatDraftAt("first", 500), taskDraftAt("second", 500)];
+    expect(sortForList(rows, LIST_NOW).map((t) => t.key)).toEqual(["first", "second"]);
+  });
+
+  it("leaves lanes without drafts exactly as sortByLane had them", () => {
+    // The hoist must not re-sort what it does not lift: turning the Draft filter
+    // off has to give the reader back the page they had.
+    const tail = [
+      task({ key: "arch", status: "archived" }),
+      task({ key: "run", status: "in_progress" }),
+      task({ key: "ask", status: "needs_attention" }),
+    ];
+    const withDraft = [taskDraftAt("form", 1), ...tail];
+    // The draft rank sits between Blocked and Upcoming in LIST_ORDER, so the
+    // lone draft lands after "ask" and before "run".
+    expect(sortForList(withDraft, LIST_NOW).map((t) => t.key))
+      .toEqual(["ask", "form", "run", "arch"]);
+    expect(sortByLane(tail, LIST_NOW).map((t) => t.key)).toEqual(["ask", "run", "arch"]);
+  });
+
+  it("is sortByLane exactly when nothing carries a draft", () => {
+    const rows = [
+      task({ key: "done", status: "done" }),
+      task({ key: "soon", status: "upcoming" }),
+    ];
+    expect(sortForList(rows, LIST_NOW).map((t) => t.key))
+      .toEqual(sortByLane(rows, LIST_NOW).map((t) => t.key));
+  });
+
+  it("loses no row, duplicates none, and never mutates the polled list", () => {
+    const rows = [
+      taskDraftAt("form", 2),
+      task({ key: "done", status: "done" }),
+      carrying("live", "in_progress", 1),
+    ];
+    const before = rows.map((t) => t.key);
+    const out = sortForList(rows, LIST_NOW);
+    expect(out.map((t) => t.key).sort()).toEqual(["done", "form", "live"]);
+    expect(rows.map((t) => t.key)).toEqual(before);
+  });
+
+  it("reads the draft's clock from wherever the server put it", () => {
+    // The server states the fact in different places for the three kinds of row,
+    // and the client is not the authority on which — most specific first.
+    expect(draftUpdatedAt(chatDraftAt("c", 200))).toBe(200);
+    expect(draftUpdatedAt(taskDraftAt("t", 300))).toBe(300);
+    // Neither field: the row's own last-active is the closest thing there is,
+    // and a row with none of the three is 0 rather than NaN or 1970.
+    const bare = task({ key: "b", kind: "draft", last_active: 77, form: undefined });
+    expect(draftUpdatedAt(bare)).toBe(77);
+    expect(draftUpdatedAt(task({ key: "z", last_active: 0 }))).toBe(0);
   });
 });
 
@@ -6852,9 +7236,13 @@ describe("cardsForTasks", () => {
     // test, and it is LIST_ORDER itself rather than a second list — so the wall
     // and the List can never disagree about which lane comes first. Every name
     // in it is still a real board column.
-    expect(CARD_LANES).toEqual(LIST_ORDER);
+    // …minus `draft`, the one row the wall does not draw at all (design.md,
+    // Decisions: List and Board only) — it has no session, so there is not even
+    // an empty conversation to show.
+    expect(CARD_LANES).toEqual(LIST_ORDER.filter((k) => k !== "draft"));
     expect(CARD_LANES).toEqual(["needs_attention", "blocked", "upcoming", "in_progress", "done", "archived"]);
-    for (const key of CARD_LANES) expect(BOARD_COLUMNS.map((c) => c.key)).toContain(key);
+    const COLUMN_KEYS: string[] = BOARD_COLUMNS.map((c) => c.key);
+    for (const key of CARD_LANES) expect(COLUMN_KEYS).toContain(key);
     const rows = [
       running("a", 100),
       task({ key: "b", task_id: "TASK-b", status: "done" }),

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -7115,16 +7115,23 @@ describe("sortForList", () => {
       .toEqual(["ask", "form", "chat", "soon", "done-draft"]);
   });
 
-  it("puts a draft-carrying row first WITHIN its lane, by the draft's clock", () => {
+  it("puts draft-carrying rows first WITHIN their lane, in the lane's own recency", () => {
+    // Three In Progress runs. The two holding drafts come first; between them
+    // the order is the lane's — which ran most recently — NOT whose draft was
+    // touched last (Akshil, 2026-09-11: "in both drafts and non drafts we sort
+    // them by recency"). "stale-words" has the NEWER draft but the OLDER run,
+    // and it still comes second.
+    // In Progress ranks by the last run, so each row gets one message at a
+    // distinct time; the lane's clock is that message's `ran_at`.
+    const sec = LIST_NOW / 1000;
+    const ranAt = (at: number) => [msg({ message_id: "MSG-001", at, ran_at: at })];
     const rows = [
-      task({ key: "quiet", status: "in_progress", last_active: LIST_NOW / 1000 }),
-      carrying("older-words", "in_progress", 10),
-      carrying("newer-words", "in_progress", 900),
+      task({ key: "quiet", status: "in_progress", messages: ranAt(sec) }),
+      { ...carrying("stale-words", "in_progress", 900), messages: ranAt(sec - 3600) },
+      { ...carrying("fresh-run", "in_progress", 10), messages: ranAt(sec - 60) },
     ];
-    // Both carriers above the quiet run, newest words first; the lane itself
-    // does not move.
     expect(sortForList(rows, LIST_NOW).map((t) => t.key))
-      .toEqual(["newer-words", "older-words", "quiet"]);
+      .toEqual(["fresh-run", "stale-words", "quiet"]);
   });
 
   it("never lets a draft lift a row out of its lane", () => {
@@ -7133,6 +7140,11 @@ describe("sortForList", () => {
       carrying("ask", "needs_attention", 10),
     ];
     expect(sortForList(rows, LIST_NOW).map((t) => t.key)).toEqual(["ask", "done"]);
+  });
+
+  it("orders the draft rank itself by the draft's clock, server order on a tie", () => {
+    const rows = [taskDraftAt("older", 100), chatDraftAt("newer", 500)];
+    expect(sortForList(rows, LIST_NOW).map((t) => t.key)).toEqual(["newer", "older"]);
   });
 
   it("keeps the server's order among drafts whose clocks tie", () => {

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -3167,45 +3167,51 @@ export function sortByLane(tasks: Task[], now: number = Date.now()): Task[] {
 
 /**
  * THE LIST'S OWN ORDER: filter → status → has-draft first → recency (design.md,
- * Round 2, "List sort"; Akshil, 2026-09-11: "the priority of sorting is status
- * first, then draft and the time").
+ * Round 2, "List sort"; Akshil, 2026-09-11: "1st layer of sort is status …
+ * inside status we sort by drafts tasks on top and non drafts below them. in
+ * both drafts and non drafts we sort them by recency, most recent on top").
  *
  * `sortByLane` above is the page's shared rank order and stays exactly as it
  * was — the Board reads it through `groupByColumn`, the Cards wall reads it
- * directly. This is the one extra pass the LIST makes INSIDE each lane: the
- * rows carrying unsent words (`hasDraft` — a task draft, a never-sent chat, or
- * an ordinary task whose composer is holding something) are lifted to the top
- * of THEIR lane, newest draft first, and the rest of the lane keeps the order
- * it already had. An In Progress task with a half-typed follow-up is still in
- * progress and stays in In Progress; it is simply the first row there, because
- * within a status the thing waiting on the reader is the thing to see first.
+ * directly. This is the one extra pass the LIST makes INSIDE each lane, and it
+ * is a stable PARTITION of what `sortRank` already ordered: the rows carrying
+ * unsent words (`hasDraft` — a task draft, a never-sent chat, or an ordinary
+ * task whose composer is holding something) come first, the rest after, and
+ * BOTH halves keep the lane's own recency — the time the row prints. So an In
+ * Progress task with a half-typed follow-up is still in In Progress, first
+ * among its lane, and two such tasks are ordered by which ran most recently,
+ * not by which draft was touched last; the draft's own clock is not a time the
+ * row shows, and ordering by a clock the reader cannot see reads as random.
  *
- * RECENCY IS `draftUpdatedAt`, newest first, with the original position as the
- * tie-break so a page of drafts the server sent in one order does not shuffle
- * between polls (the same stability `sortRank` keeps). A lane with no drafts
- * comes back byte-for-byte as `sortRank` ranked it.
+ * The draft rank itself (`LIST_ORDER` "draft", the rows that ARE drafts and
+ * have no run at all) is the one lane where the draft's clock is the only
+ * clock, so there — and only there — it is the order: newest words first.
  */
 export function sortForList(tasks: Task[], now: number = Date.now()): Task[] {
   const buckets = new Map<BoardColumn, Task[]>(
     LIST_ORDER.map((key) => [key, [] as Task[]]),
   );
   for (const task of tasks) buckets.get(taskColumn(task))?.push(task);
-  return LIST_ORDER.flatMap((key) =>
-    hoistDrafts(sortRank(buckets.get(key) ?? [], key, now)),
-  );
+  return LIST_ORDER.flatMap((key) => {
+    const lane = sortRank(buckets.get(key) ?? [], key, now);
+    return key === "draft" ? byDraftClock(lane) : hoistDrafts(lane);
+  });
 }
 
-/** One lane, drafts first by recency, everything else in the order given. */
+/** One lane, drafts first, everything in the order `sortRank` gave it. */
 function hoistDrafts(lane: Task[]): Task[] {
   const drafts: Task[] = [];
   const rest: Task[] = [];
   for (const task of lane) (hasDraft(task) ? drafts : rest).push(task);
-  if (!drafts.length) return lane;
-  const ranked = drafts
+  return drafts.length ? [...drafts, ...rest] : lane;
+}
+
+/** The draft rank: newest words first, the server's order breaking ties. */
+function byDraftClock(lane: Task[]): Task[] {
+  return lane
     .map((task, index) => ({ task, index, at: draftUpdatedAt(task) }))
     .sort((a, b) => b.at - a.at || a.index - b.index)
     .map((r) => r.task);
-  return [...ranked, ...rest];
 }
 
 // ---- the Cards view's set ----------------------------------------------------

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -379,7 +379,13 @@ export function threadRunning(messages: TaskMessage[]): boolean {
  * Done. Read as a plain string on purpose: the union this file was compiled
  * against is a snapshot of what the server said LAST time.
  */
-export function taskColumn(task: Pick<Task, "status">): BoardColumn {
+export function taskColumn(task: Pick<Task, "status" | "kind">): BoardColumn {
+  // A DRAFT IS NOT A STATUS THE SERVER SENDS. A draft row arrives with
+  // `status: "upcoming"` on purpose — so every lane switch on this page keeps
+  // working on it without being taught a seventh word — and `kind: "draft"` is
+  // the fact that tells the two apart. Asked here, once, so the List's rank, the
+  // Board's lane, the drag matrix and the time column all read one answer.
+  if (isDraftTask(task)) return "draft";
   return statusColumn(task.status);
 }
 
@@ -396,6 +402,133 @@ export function statusColumn(status: string): BoardColumn {
   const known = BOARD_COLUMNS.find((c) => c.key === status);
   return known ? known.key : "done";
 }
+
+/**
+ * IS THIS ROW AN UNFINISHED NEW-TASK FORM rather than a task?
+ *
+ * One predicate for every view that has to leave drafts out (the Cards wall, the
+ * calendar) or treat them apart (the List's time column, the Board's hoist), so
+ * "what is a draft" is decided once.
+ *
+ * It asks `kind` and NOT `status`, which is the one thing to know about this
+ * row: the server sends a draft as `status: "upcoming"` so that every existing
+ * lane reading keeps working on it untaught, and says `kind: "draft"` beside it.
+ * A predicate written against `status` would therefore be quietly false on every
+ * draft there is.
+ */
+export function isDraftTask(task: Pick<Task, "kind">): boolean {
+  return task.kind === "draft";
+}
+
+/**
+ * …AND WHICH OF THE TWO KINDS IT IS (design.md, Round 2: "New-chat drafts are
+ * rows").
+ *
+ * A chat draft row is a conversation with words in it that nobody has sent, in
+ * a folder whose chat has no session yet — so unlike a task draft it has no
+ * form to re-open and no `draft_id`, and its press is a NAVIGATION rather than
+ * a modal (schedule-lib.chatDraftHref).
+ *
+ * Read as "is it explicitly the chat kind", so a server that predates the
+ * second kind — every draft row there is a task draft — answers no and the old
+ * press survives untouched (Akshil, 2026-09-11).
+ */
+export function isChatDraftTask(task: Pick<Task, "kind" | "draft_kind">): boolean {
+  return isDraftTask(task) && task.draft_kind === "chat";
+}
+
+/**
+ * DOES THIS ROW CARRY UNSENT WORDS OF ANY SORT — the question the Draft chip,
+ * the Draft filter and the List's hoist all ask, spelled once.
+ *
+ * Three rows answer yes and they are genuinely three different things: an
+ * unfinished New task form (`kind: "draft"`, the task kind), a never-sent chat
+ * (`kind: "draft"`, the chat kind), and an ORDINARY TASK whose composer is
+ * holding something (`draft` joined onto its session). To a reader scanning the
+ * page they are one fact — there are words here nobody has sent — which is
+ * exactly why one predicate answers for all three (design.md, Round 2: the
+ * filter "keeps only rows carrying any draft").
+ */
+export function hasDraft(task: Pick<Task, "kind" | "draft">): boolean {
+  return isDraftTask(task) || !!task.draft;
+}
+
+/**
+ * WHEN THOSE WORDS WERE LAST TOUCHED, for the List's own order among drafts
+ * (design.md, Round 2: "Drafts among themselves by recency").
+ *
+ * Epoch seconds, the API's unit throughout, and 0 for "the row does not say" —
+ * which sorts last among drafts rather than being formatted as 1970, the same
+ * care `taskWhen` takes with a zero.
+ *
+ * THREE SOURCES, most specific first, because the server states the fact in
+ * different places for the three kinds of draft row and the client is not the
+ * authority on which:
+ *
+ *   1. `draft.updated_at` — the joined chat draft, and the new-chat row's own;
+ *   2. `form.updated_at` — the stored task-draft body, which is emitted
+ *      verbatim (api.Task.form is deliberately loose, so this is read as an
+ *      unknown and only believed when it is a number);
+ *   3. `last_active` — every task row has one, and on a draft row it is the
+ *      closest thing to "when this was last worked on" the listing carries.
+ */
+export function draftUpdatedAt(task: Pick<Task, "draft" | "form" | "last_active">): number {
+  const joined = task.draft?.updated_at;
+  if (typeof joined === "number" && joined > 0) return joined;
+  const stored = task.form?.updated_at;
+  if (typeof stored === "number" && stored > 0) return stored;
+  return task.last_active || 0;
+}
+
+/** The chip's word, spelled once. The mark beside it is a pencil — Slack's own
+ *  draft mark, which is the reference UI this whole feature is built against
+ *  (design.md) — but it is a lucide `PencilLine` drawn by the view now rather
+ *  than a pencil character in this string (design.md, Round 2). One glyph family
+ *  for the whole page: every other mark on these rows is an inline lucide path
+ *  at the same stroke, and a text pencil was the one that rendered at the
+ *  font's mercy. */
+export const DRAFT_CHIP = "Draft";
+
+/**
+ * THE `Draft` CHIP, for both the chat draft and the task draft (design.md,
+ * Decisions: "`Draft` chip + tooltip first line").
+ *
+ * ONE mark for the two kinds, which is the point: a reader scanning the list is
+ * being told the same thing either way — there are words here nobody has sent.
+ * What differs is only whose words they are, and that is what the tooltip says.
+ * Null when the row has neither, which is almost every row.
+ *
+ * It is an `OutcomeTag` so it is drawn by the pill the row already has
+ * (ScheduleTaskViews.DraftChip wraps `.tasks-outcome-pill` — muted, currentColor
+ * border, sized to the id beside it). No new CSS primitive: a second chip shape
+ * for a second kind of note is how a row grows marks nobody can tell apart.
+ */
+export function draftTag(task: Task): OutcomeTag | null {
+  // Both tooltips show the WORDS, not a description of the chip: the row's
+  // title already says it is a draft, and what a reader hovering wants is a
+  // glimpse of what they were writing (Akshil, 2026-09-11 — same rule the chat
+  // draft's badge follows). A task draft's words are its description first
+  // (the title is already on the row), else its title, else nothing to add.
+  if (isDraftTask(task)) {
+    // A NEW-CHAT row's words are the composer's, and the server sends them in
+    // the same `draft.preview` an ordinary session row carries — asked first,
+    // so the two chat drafts (one with a session, one without) caption
+    // identically. It falls through to the form/title pair below on a task
+    // draft, and on a chat row from a server that sent no preview.
+    const preview = task.draft?.preview?.trim();
+    if (preview) return { text: DRAFT_CHIP, title: preview };
+    const description = task.form?.description;
+    const words =
+      (typeof description === "string" ? firstLine(description) : "") ||
+      task.title?.trim() ||
+      "";
+    return { text: DRAFT_CHIP, title: words || "Draft" };
+  }
+  const preview = task.draft?.preview?.trim();
+  if (!preview) return null;
+  return { text: DRAFT_CHIP, title: preview };
+}
+
 
 /**
  * Is this column a run that is genuinely happening — the one question every
@@ -1445,6 +1578,10 @@ export function messageEditEntry(m: TaskMessage): string | null {
  * is not one (schedule-lib.BOARD_LANES).
  */
 const LANE_EXITS: Record<BoardColumn, BoardLane[]> = {
+  // NOWHERE. A draft is not a task yet — there is no entry to run, nothing to
+  // archive and no session to triage — so it does not lift at all (isDraggable
+  // reads this). The one thing to do with it is open it and finish it.
+  draft: [],
   // Run it early, or call it off.
   upcoming: ["in_progress", "archived"],
   // Locked: a run in flight is Claude's output, and it leaves this lane when it
@@ -2201,12 +2338,36 @@ export interface TaskFilters {
   statuses: BoardColumn[];
   /** Project FOLDERS, full paths — the value `Task.project` carries. */
   projects: string[];
+  /**
+   * ONLY THE ROWS WITH UNSENT WORDS IN THEM (design.md, Round 2: the Draft chip
+   * "is a filter tag").
+   *
+   * A BOOLEAN and not a list, unlike the two facets above, because there is one
+   * of it: "draft" is not a value a row has one of several of, it is a thing a
+   * row either carries or does not (`hasDraft`). And deliberately NOT a member
+   * of `statuses` — the Status menu offers the Board's lanes, and a draft is
+   * drawn INSIDE Upcoming rather than being a lane (schedule-lib's note on
+   * `BoardColumn`), so a "Draft" entry there would advertise a seventh column
+   * that does not exist.
+   *
+   * Its only control is the chip on the rows themselves, which is why it is not
+   * offered in the toolbar's popovers at all: the filter and the mark that sets
+   * it are one object, the way the project chip already is.
+   */
+  draft: boolean;
 }
 
-export const EMPTY_FILTERS: TaskFilters = { search: "", statuses: [], projects: [] };
+export const EMPTY_FILTERS: TaskFilters = {
+  search: "",
+  statuses: [],
+  projects: [],
+  draft: false,
+};
 
 export function hasActiveFilters(f: TaskFilters): boolean {
-  return f.statuses.length > 0 || f.projects.length > 0 || f.search.trim() !== "";
+  return (
+    f.statuses.length > 0 || f.projects.length > 0 || f.draft || f.search.trim() !== ""
+  );
 }
 
 // THE ARCHIVE FACET, SCOPED TO THE VIEW (Akshil, 2026-08-20). The calendar
@@ -2230,9 +2391,25 @@ export function hasActiveFilters(f: TaskFilters): boolean {
 // person who ticks Archive on Calendar and then switches to List sees Archive
 // still ticked and the archived tasks it was always going to show — the
 // facet was ignored, never cleared.
+//
+// THE DRAFT FACET IS SCOPED THE SAME WAY, and for the identical argument
+// (Akshil, 2026-09-11). Its only control is the chip on a List row or a Board
+// card, so it can only ever be turned ON from those two views — and neither the
+// Calendar nor the Cards wall draws a draft row at all (CARD_LANES; the
+// calendar's own note), so on those two it is a facet with no control and
+// almost nothing to keep. Ignored there rather than cleared, exactly like
+// Archive: a reader who filters the List to drafts, glances at the calendar and
+// comes back finds the chip still on.
 export function filtersForView(f: TaskFilters, view: TaskView): TaskFilters {
-  if (view !== "calendar" || !f.statuses.includes("archived")) return f;
-  return { ...f, statuses: f.statuses.filter((s) => s !== "archived") };
+  const drops = view === "calendar" || view === "cards";
+  const draft = drops && f.draft;
+  const archived = view === "calendar" && f.statuses.includes("archived");
+  if (!draft && !archived) return f;
+  return {
+    ...f,
+    ...(draft ? { draft: false } : {}),
+    ...(archived ? { statuses: f.statuses.filter((s) => s !== "archived") } : {}),
+  };
 }
 
 /**
@@ -2295,6 +2472,10 @@ export function taskMatches(task: Task, filters: TaskFilters): boolean {
     if (!filters.statuses.some((s) => laneOf(s) === lane)) return false;
   }
   if (filters.projects.length && !filters.projects.includes(task.project)) return false;
+  // The Draft tag, and it is the same shape as the two facets above: OFF says
+  // nothing at all about a row, ON keeps only the rows carrying unsent words of
+  // any of the three sorts (`hasDraft`; design.md, Round 2).
+  if (filters.draft && !hasDraft(task)) return false;
   const q = filters.search.trim().toLowerCase();
   if (!q) return true;
   return (
@@ -2480,6 +2661,11 @@ export interface LaneSort {
  *                move is to leave the server's own order alone.
  */
 export const LANE_SORTS: Record<BoardColumn, LaneSort> = {
+  // A draft has no run to be ordered by — no next, no last — so the order it
+  // arrives in is the only honest one, exactly as for Archive. It is also what
+  // keeps `taskWhen` from claiming a time for a row that has none: the map is
+  // where that question is asked.
+  draft: { key: "server", dir: "asc" },
   upcoming: { key: "next-run", dir: "asc", overdueFirst: true },
   in_progress: { key: "last-run", dir: "desc" },
   needs_attention: { key: "last-run", dir: "desc" },
@@ -2504,7 +2690,7 @@ export function laneTime(task: Task, lane: BoardColumn): number | null {
 
 // ---- the time a task ROW prints ----------------------------------------------
 
-export type TaskWhenKind = "next" | "last" | "active" | "none";
+export type TaskWhenKind = "next" | "last" | "active" | "none" | "draft";
 
 /** What a row prints when the task has no timestamp of any kind. An em dash and
  * not a blank: the time is the last cell of every row, so an empty one reads as a
@@ -2575,6 +2761,20 @@ export interface TaskWhen {
  * zero to a formatter, which is why `none` is a KIND rather than a stamp.
  */
 export function taskWhen(task: Task, now: number = Date.now()): TaskWhen {
+  // A DRAFT PRINTS THE WORD "Draft" IN THE TIME COLUMN (design.md: "the 'when'
+  // column reads Draft"). Every other answer this function can give is a
+  // timestamp, and a draft has none of the three — no run ahead, no run behind,
+  // no session activity — so the honest cell is the one fact it does have: this
+  // is not scheduled yet. `at` stays 0 and the kind says so, for `none`'s
+  // reason: 0 formats as 1970, so nothing may hand this to a formatter.
+  if (isDraftTask(task)) {
+    return {
+      at: 0,
+      kind: "draft",
+      text: "Draft",
+      title: "Not scheduled yet — an unfinished task",
+    };
+  }
   const nextFirst = LANE_SORTS[taskColumn(task)].key === "next-run";
   const next = nextRunAt(task);
   const last = lastRunAt(task);
@@ -2592,6 +2792,10 @@ export function taskWhen(task: Task, now: number = Date.now()): TaskWhen {
     last: "Last run",
     active: "Active",
     none: "",
+    // Unreachable — the draft arm returns above, with its own sentence — but the
+    // map is exhaustive by type and an omission here would be a compile error
+    // rather than a missing word.
+    draft: "",
   };
   for (const [kind, at] of order) {
     if (at === null) continue;
@@ -2709,6 +2913,18 @@ export function groupByColumn(
     map.set("blocked", [
       ...blocked.filter((t) => needsAttention(t)),
       ...blocked.filter((t) => !needsAttention(t)),
+    ]);
+  }
+  // DRAFTS FIRST, inside the other lane that holds two statuses, and by the same
+  // stable partition for the same kind of reason: the lane's order is by next
+  // run and a draft has no run to be ordered by, so without this it would land
+  // wherever "no time" happens to sort. An unfinished task is the most upcoming
+  // thing there is (design.md, Decisions, Akshil 2026-09-11).
+  const upcoming = map.get("upcoming");
+  if (upcoming && upcoming.length > 1) {
+    map.set("upcoming", [
+      ...upcoming.filter((t) => isDraftTask(t)),
+      ...upcoming.filter((t) => !isDraftTask(t)),
     ]);
   }
   return map;
@@ -2888,10 +3104,20 @@ export function laneRolledUp(
 // the same second must not trade places between polls).
 
 /** Rank order, top to bottom. Every BoardColumn appears exactly once — the test
- * holds it to that, so a seventh status cannot be silently unsortable. */
+ * holds it to that, so a seventh status cannot be silently unsortable.
+ *
+ * DRAFTS SIT DIRECTLY ABOVE UPCOMING, which is the List's reading of the same
+ * ruling that hoists them to the head of the Board's Upcoming lane: an
+ * unfinished thing is the most upcoming thing (design.md, Decisions, Akshil
+ * 2026-09-11). Not hoisted above Needs attention and Blocked — those two want a
+ * person's hands NOW, and a draft wants only their attention when they next have
+ * some. A rank of its own rather than an in-rank partition because the List
+ * spends this array as its whole order, and the Board's hoist is already the
+ * one place that distinction is drawn inside a lane. */
 export const LIST_ORDER: BoardColumn[] = [
   "needs_attention",
   "blocked",
+  "draft",
   "upcoming",
   "in_progress",
   "done",
@@ -2906,7 +3132,10 @@ function sortRank(tasks: Task[], rank: BoardColumn, now: number): Task[] {
   const asc = rank === "upcoming";
   const rows = tasks.map((task, index) => {
     const when = taskWhen(task, now);
-    return { task, index, at: when.kind === "none" ? null : when.at };
+    // `draft` joins `none` as a row that prints no instant: both carry `at: 0`,
+    // which is 1970 and must never be sorted as a time.
+    const timeless = when.kind === "none" || when.kind === "draft";
+    return { task, index, at: timeless ? null : when.at };
   });
   rows.sort((a, b) => {
     if (a.at === null || b.at === null) {
@@ -2934,6 +3163,49 @@ export function sortByLane(tasks: Task[], now: number = Date.now()): Task[] {
   );
   for (const task of tasks) buckets.get(taskColumn(task))?.push(task);
   return LIST_ORDER.flatMap((key) => sortRank(buckets.get(key) ?? [], key, now));
+}
+
+/**
+ * THE LIST'S OWN ORDER: filter → status → has-draft first → recency (design.md,
+ * Round 2, "List sort"; Akshil, 2026-09-11: "the priority of sorting is status
+ * first, then draft and the time").
+ *
+ * `sortByLane` above is the page's shared rank order and stays exactly as it
+ * was — the Board reads it through `groupByColumn`, the Cards wall reads it
+ * directly. This is the one extra pass the LIST makes INSIDE each lane: the
+ * rows carrying unsent words (`hasDraft` — a task draft, a never-sent chat, or
+ * an ordinary task whose composer is holding something) are lifted to the top
+ * of THEIR lane, newest draft first, and the rest of the lane keeps the order
+ * it already had. An In Progress task with a half-typed follow-up is still in
+ * progress and stays in In Progress; it is simply the first row there, because
+ * within a status the thing waiting on the reader is the thing to see first.
+ *
+ * RECENCY IS `draftUpdatedAt`, newest first, with the original position as the
+ * tie-break so a page of drafts the server sent in one order does not shuffle
+ * between polls (the same stability `sortRank` keeps). A lane with no drafts
+ * comes back byte-for-byte as `sortRank` ranked it.
+ */
+export function sortForList(tasks: Task[], now: number = Date.now()): Task[] {
+  const buckets = new Map<BoardColumn, Task[]>(
+    LIST_ORDER.map((key) => [key, [] as Task[]]),
+  );
+  for (const task of tasks) buckets.get(taskColumn(task))?.push(task);
+  return LIST_ORDER.flatMap((key) =>
+    hoistDrafts(sortRank(buckets.get(key) ?? [], key, now)),
+  );
+}
+
+/** One lane, drafts first by recency, everything else in the order given. */
+function hoistDrafts(lane: Task[]): Task[] {
+  const drafts: Task[] = [];
+  const rest: Task[] = [];
+  for (const task of lane) (hasDraft(task) ? drafts : rest).push(task);
+  if (!drafts.length) return lane;
+  const ranked = drafts
+    .map((task, index) => ({ task, index, at: draftUpdatedAt(task) }))
+    .sort((a, b) => b.at - a.at || a.index - b.index)
+    .map((r) => r.task);
+  return [...ranked, ...rest];
 }
 
 // ---- the Cards view's set ----------------------------------------------------
@@ -2964,7 +3236,12 @@ export function sortByLane(tasks: Task[], now: number = Date.now()): Task[] {
 /** The lanes a Cards view draws, top rank first — LIST_ORDER, whole. Kept as
  * its own name so the view's membership test reads as a decision, not a
  * coincidence of the List's table. */
-export const CARD_LANES: BoardColumn[] = LIST_ORDER;
+/** …minus drafts, which the wall does not draw at all (design.md, Decisions:
+ *  List and Board only). Derived from LIST_ORDER rather than written out again,
+ *  so the wall still cannot fall out of step with the List's rank order — the
+ *  one thing it deliberately does not share is the one row that has no
+ *  conversation to show. */
+export const CARD_LANES: BoardColumn[] = LIST_ORDER.filter((k) => k !== "draft");
 
 /**
  * HOW MANY LIVE CHATS PER PAGE. Each card is an iframe running the chat template,
@@ -3204,7 +3481,11 @@ export function cardsForTasks(
     // task has no chat to show, so its tile was a sentence in a frame — the
     // Calendar and the List are where a future run is read. The wall shows
     // work that has happened or is happening.
-    if (task.status === "upcoming") continue;
+    // …and that already excludes DRAFTS, which the server sends as `upcoming`.
+    // Said again anyway, by name: the wall's membership must not depend on a
+    // coincidence between two fields (design.md, Decisions: List and Board
+    // only, never Cards or Calendar).
+    if (task.status === "upcoming" || isDraftTask(task)) continue;
     const id = cardKey(task);
     if (seen.has(id)) continue;
     seen.add(id);

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2583,6 +2583,12 @@ input.schedule-when-field {
    costs no hue at all, so the list is back to naming the one mark that has a
    lane. */
 .schedule-ring--upcoming { color: var(--status-upcoming); }
+/* A draft wears UPCOMING'S hue and no hue of its own, which is the same claim
+   the board makes with its lanes: a draft draws inside Upcoming (laneOf), so a
+   colour arguing with that lane would be the one place on the page where the
+   mark and the column disagree. The `✎ Draft` chip beside the title is what
+   tells the two apart — one mark for one fact (design.md, Akshil 2026-09-11). */
+.schedule-ring--draft { color: var(--status-upcoming); }
 .schedule-ring--in_progress { color: var(--status-progress); }
 .schedule-ring--done { color: var(--status-done); }
 .schedule-ring--archived { color: var(--status-archived); }

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -811,6 +811,20 @@ button.tasks-caret,
   cursor: default;
 }
 
+/* THE SHIELD ON A BOARD CARD'S FOOT, which is where the Draft chip is a tag as
+   well (design.md, Round 2). Only the layout half: the rule above stretches the
+   shield to the ROW's height so it can cover the row's own padding band, and a
+   card's foot has no such band to cover — there is no stretched link under it,
+   so the press needs no shielding, only the same box model as the pill beside
+   it. Without this the shield is a plain inline span and the pill inside it sat
+   on the foot's text baseline instead of centred with the folder chip. */
+.schedule-tv-card-foot .schedule-tv-id-shield {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
+}
+
 .tasks-row .schedule-tv-id-shield::after {
   content: "";
   position: absolute;
@@ -1776,6 +1790,73 @@ button.tasks-caret,
   font-size: 10px;
   line-height: 1;
   white-space: nowrap;
+}
+
+/* -- the Draft chip (design.md, Round 2) ---------------------------------------
+   `[✎ Draft]` — the one mark for words nobody has sent, and on the List and the
+   Board the control that filters the page down to them. It IS the outcome pill
+   above: same height, same radius, same muted hairline, because it is the same
+   kind of object — a correction to what the row otherwise implies — and a second
+   pill shape for a second kind of note is how a row grows marks nobody can tell
+   apart. Only two things are added here.
+
+   The GLYPH, which the outcome pill never has: a 3px gap and a mark that does
+   not shrink. `line-height: 0` on the holder is what keeps an 11px SVG from
+   pushing the 14px pill taller — an inline svg sits on the text baseline and
+   carries the line box's descender with it.
+
+   And the PRESS, on the arm that has one. `button` in the selector rather than a
+   modifier class: the pressable and the inert chip differ by which element they
+   are, so the skin cannot be asked for on the wrong one. Everything in it is the
+   folder tag's, verbatim (`.schedule-tv-id--tag`, above) — the quiet wash on
+   hover, the accent fill when the filter is on, the hairline that gives the fill
+   an edge — because the two chips sit side by side at the row's right end and
+   read as one group of controls. Two nearly-identical pills with two different
+   pressed states would be the one thing this seat was chosen to avoid. */
+.tasks-draft-pill {
+  gap: 3px;
+}
+
+.tasks-draft-pill-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  line-height: 0;
+}
+
+button.tasks-draft-pill {
+  appearance: none;
+  font: inherit;
+  font-size: 10px;
+  background: none;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+button.tasks-draft-pill:hover,
+button.tasks-draft-pill:focus-visible {
+  background: var(--ctl-quiet-bg-hover);
+}
+
+button.tasks-draft-pill:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 0;
+}
+
+/* ON: the filter is running, and the chip that set it says so at rest — the
+   folder chip's own argument (see `.schedule-tv-id--tag.is-on`), and it matters
+   more here because this filter has NO other control. There is no popover
+   holding a count for it and no entry in the Status menu; if the chip did not
+   wear the state, a filtered page would be one a reader could not explain. */
+button.tasks-draft-pill.is-on {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 22%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--fg);
+}
+
+button.tasks-draft-pill.is-on:hover,
+button.tasks-draft-pill.is-on:focus-visible {
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
 }
 
 /* -- dropping ONE filter, from the control that set it (D448) -----------------

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -1823,10 +1823,25 @@ button.tasks-caret,
   line-height: 0;
 }
 
+/* AS A TAG it wears the folder chip's skin, not the outcome pill's (Akshil,
+   2026-09-11: "the draft should not have outline, when we hover we can see
+   hover effect around it similar to folder tag"): no border at rest, the same
+   5px radius, the same 3px/5px padding with the negative block margin that
+   keeps the row at its height, and the same quiet wash on hover. Two tags side
+   by side on the row's right edge that look like two different controls would
+   be telling the reader they do two different kinds of thing; they do not —
+   both narrow the page. `height: auto` undoes the outcome pill's 14px so the
+   padding, not a fixed box, sets the ink, exactly as on the folder chip. */
 button.tasks-draft-pill {
   appearance: none;
   font: inherit;
   font-size: 10px;
+  height: auto;
+  border: 0;
+  border-radius: 5px;
+  padding: 3px 5px;
+  margin-block: -3px;
+  align-self: center;
   background: none;
   cursor: pointer;
   transition: background-color 120ms ease;
@@ -1849,7 +1864,6 @@ button.tasks-draft-pill:focus-visible {
    wear the state, a filtered page would be one a reader could not explain. */
 button.tasks-draft-pill.is-on {
   background: color-mix(in srgb, var(--accent) 18%, transparent);
-  border-color: color-mix(in srgb, var(--accent) 22%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
   color: var(--fg);
 }

--- a/fused_render/drafts.py
+++ b/fused_render/drafts.py
@@ -1,0 +1,549 @@
+"""Drafts — what the composer and the New task modal were still typing.
+
+Two surfaces lose text today. The chat composer keeps it in `useState`, seeded
+once from a sessionStorage hop that is spent on read, so it dies on tab close,
+on opening another chat, on reload. The New task modal keeps it per open and
+`key="new#<seq>"` remounts blank, so closing the modal is the same as never
+having typed. Neither is a place unfinished work can live, and unfinished work
+is most of what a person has open at any moment.
+
+**Server, one file, global.** `<FUSED_RENDER_HOME>/claude-sessions/drafts.json`
+— the same never-branch-nested directory `tasks_store` keeps `task_ids.json`
+and `read.json` in, and for exactly the same reason: chat drafts key on session
+ids, and `~/.claude/projects` is one machine-wide pool. A draft written from a
+worktree's dev server must be there when the packaged app opens the same
+conversation.
+
+Why not the alternatives (design.md, "Where drafts live"): a draft is not a
+place you can link to, so not the URL; the `✎ Draft` badge in the List and the
+Board needs the server to join draft ↔ task row and `/api/tasks` is
+server-rendered, so not localStorage; and `state:"draft"` inside `tasks.jsonl`
+would put a row with no `due` in front of schedule.py's ticker, claim and queue,
+every one of which assumes there is one. A separate store, joined at read.
+
+Shape::
+
+    {"chat": {"<session-id>": {"text": …, "attachments": […], "updated_at": …}},
+     "task": {"<draft-id>": {"title": …, …, "created_at": …, "updated_at": …}}}
+
+**Empty is never stored.** Writing an empty draft IS deleting it — there is no
+such thing as a draft with nothing in it, and a store that kept one would paint
+a `✎ Draft` badge on a task whose composer is blank. `put_chat` and `put_task`
+therefore both answer `None` for a write they turned into a delete, so the
+caller never has to ask which of the two it just did.
+
+**Nothing here raises for input it cannot read.** A missing store, a corrupt
+store, a record of the wrong shape, an attachment row with no path — each
+degrades to "no draft", never to a failed request. Same posture as tasks_store
+and every other registry in this package: a draft is a convenience, and a
+convenience that can break a page is worse than one that is missing.
+
+No import of anything under `fused_render.server`, and none of
+`fused_render.schedule` either — importing the schedule model to borrow its
+`_attachments` validator would pull the whole ticker, its storage seams and its
+event log in behind it, for one shape check. The local validator below is
+deliberately the LENIENT twin of that one: `schedule._attachments` refuses an
+attachment whose file has gone, because a scheduled run must not be handed a
+path it cannot read, where a draft is text somebody has not sent yet and losing
+it over a moved file would be the store failing at its only job (Akshil,
+2026-09-11).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+
+try:
+    import fcntl  # POSIX only — Windows falls back to no inter-process lock,
+    # the same posture (and the same directory) as tasks_store._update.
+except ImportError:  # pragma: no cover
+    fcntl = None
+
+# Derived from the env at import, exactly like `tasks_store.STATE_DIR` — same
+# deliberate local duplication, same consequence for tests: a test that
+# redirects one module's dir must redirect this one's too.
+STATE_DIR = os.path.join(
+    os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render"),
+    "claude-sessions")
+
+DRAFTS_FILE = "drafts.json"
+
+#: The two kinds, and the two top-level keys of the file. A chat draft belongs
+#: to a conversation; a task draft belongs to nothing yet, which is why it needs
+#: an id of its own.
+CHAT = "chat"
+TASK = "task"
+
+#: A chat with no session yet (the composer's first message has not been sent)
+#: keys on the file it opened on instead — the same key `takeDraft(file)` uses
+#: in the client.
+#:
+#: Round 1 said such a key never joined a listing and was never re-keyed: the
+#: first send deleted the draft, and that was the end of it. Round 2 reversed
+#: both halves. A `new:<file>` draft IS a row (the folder is its project, the
+#: first line its title, and it carries a TASK number like any other), and the
+#: first send therefore has somewhere to carry that number TO — which is what
+#: `POST /api/drafts/chat/rekey` is: `new:<file>` → the session id, by the same
+#: `tasks_store.rekey` that moves `pending:<entry-id>` forward. Nothing about
+#: the SHAPE changed; what changed is that the key is now worth keeping
+#: (design.md, "Round 2"; Akshil, 2026-09-11).
+NEW_CHAT_PREFIX = "new:"
+
+#: A client-minted uuid, in practice. Validated as a shape rather than parsed as
+#: a uuid so a client that mints `d-<random>` is not refused over a format
+#: nothing in here depends on — what matters is that it is one path-free token
+#: that cannot be confused with a task key.
+_DRAFT_ID = re.compile(r"^[A-Za-z0-9_-]{8,64}$")
+
+#: A session id as Claude Code writes it — the same shape
+#: `tasks.py::_SESSION_ID_SHAPE` accepts, for the same reason: it becomes a
+#: json key and is compared against task keys, and neither wants a separator.
+_SESSION_KEY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+#: How long a `new:<file>` key may be. A path, so generous; bounded at all so a
+#: request body cannot grow the store's key space without limit.
+_CHAT_KEY_MAX = 512
+
+#: How much of a chat draft the `✎ Draft` badge's tooltip carries. The listing
+#: joins a preview onto every session row, so this rides on rows the Tasks page
+#: polls — one line is the whole affordance, and the rest of the draft is in the
+#: composer where the user left it.
+PREVIEW_MAX = 120
+
+#: Every field a task draft stores, in the order the form reads them. A key the
+#: client sends that is not in here is DROPPED rather than refused (the modal
+#: gains fields over time and an older server must not start 400ing a newer
+#: page), and a field the client omits keeps whatever the stored draft had.
+TASK_FIELDS = ("title", "description", "target", "when", "repeat", "model",
+               "effort", "permission", "attachments", "new_task_each_run",
+               "from_chat_key")
+
+#: The three fields that are plain text. The rest are pass-through (`when`,
+#: `repeat`), a tri-state flag (`new_task_each_run`), rows (`attachments`) or
+#: the chat key this draft was moved out of (`from_chat_key`, which is a chat
+#: key rather than free text and is validated as one).
+#:
+#: `from_chat_key` is DELIBERATELY NOT IN HERE, and that is the whole of what
+#: keeps it from changing what a draft is: `_empty_task` asks "is there anything
+#: a person typed in this record", and a provenance key is not that. A form that
+#: arrives blank is still a delete even when it names the chat it came from —
+#: which is exactly the bargain `an empty task put keeps the chat draft` rests
+#: on (Akshil, 2026-09-11).
+_TASK_TEXT = ("title", "description", "target", "model", "effort", "permission")
+
+#: What an attachment's `kind` may be — the same two `schedule._ATTACH_KINDS`
+#: allows, and a third local copy of a list that is already spelled twice (see
+#: the module docstring for why this is not an import).
+_ATTACH_KINDS = ("image", "file")
+_ATTACH_NAME_MAX = 255
+
+
+# ------------------------------------------------------------------- the keys
+
+
+def chat_key(value) -> str:
+    """One chat draft's key, or `""` for anything that is not one.
+
+    Two shapes, because a chat has two ages: a session id once the conversation
+    exists, and `new:<file>` before it does. `""` rather than a raise — every
+    caller here is an HTTP route that turns it into a 400, and the store itself
+    must never be the thing that throws."""
+    if not isinstance(value, str):
+        return ""
+    key = value.strip()
+    if not key or len(key) > _CHAT_KEY_MAX:
+        return ""
+    if key.startswith(NEW_CHAT_PREFIX):
+        rest = key[len(NEW_CHAT_PREFIX):]
+        # A file path, so nearly anything goes — but not a control character,
+        # which would be a json key no human could read back out of the store.
+        if not rest.strip() or any(ch < " " for ch in rest):
+            return ""
+        return key
+    return key if _SESSION_KEY.match(key) else ""
+
+
+def is_new_chat_key(key: str) -> bool:
+    """Is this the pre-session shape?
+
+    Round 1 used this to say "no row, announce nothing". Round 2 gave such a
+    draft a row of its own — a folder, a title, a TASK number — so what it now
+    says is narrower and more useful: this draft is filed under a FOLDER and
+    not under a conversation, which is what decides how the listing builds its
+    row and what `session_id` it can print (nothing) (Akshil, 2026-09-11)."""
+    return isinstance(key, str) and key.startswith(NEW_CHAT_PREFIX)
+
+
+def new_chat_file(key: str) -> str:
+    """The file (or folder) a `new:<file>` key was opened on, or `""`.
+
+    The listing needs it twice — the row's `file`, and the folder its project
+    and target are derived from — and neither should be re-deriving the prefix
+    arithmetic. `""` for any other key, so a caller may ask without testing
+    first."""
+    if not is_new_chat_key(key):
+        return ""
+    return key[len(NEW_CHAT_PREFIX):]
+
+
+def session_key(value) -> str:
+    """One SESSION id, or `""` — `chat_key` minus the `new:` shape.
+
+    `POST /api/drafts/chat/rekey` is the one caller that needs the difference
+    spelled out: it moves a draft (and its TASK number) from the folder key a
+    chat had before its first send onto the session that send created, and a
+    `to` that was itself a `new:` key would move a number sideways into another
+    folder row rather than forward onto a conversation (Akshil, 2026-09-11)."""
+    if not isinstance(value, str):
+        return ""
+    key = value.strip()
+    if not key or key.startswith(NEW_CHAT_PREFIX):
+        return ""
+    return key if _SESSION_KEY.match(key) else ""
+
+
+def draft_id(value) -> str:
+    """One task draft's id, or `""` for anything that is not one."""
+    if not isinstance(value, str):
+        return ""
+    ident = value.strip()
+    return ident if _DRAFT_ID.match(ident) else ""
+
+
+def task_key(ident: str) -> str:
+    """The task key a task draft is listed under. `draft:` rather than
+    `pending:` (tasks_store's key for a scheduled message with no session yet)
+    because the two are genuinely different rows: a pending message WILL run,
+    and a draft will not until somebody finishes it."""
+    return "draft:" + ident
+
+
+# ------------------------------------------------------------------ the file
+
+
+def load() -> dict:
+    """The whole store, `{"chat": {}, "task": {}}` — missing or corrupt is not
+    an error. Both sections always present, so no caller has to test for them."""
+    data = None
+    try:
+        with open(os.path.join(STATE_DIR, DRAFTS_FILE), "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        data = None
+    if not isinstance(data, dict):
+        data = {}
+    for section in (CHAT, TASK):
+        if not isinstance(data.get(section), dict):
+            data[section] = {}
+    return data
+
+
+def _update(mutate):
+    """Read-modify-write the store under an exclusive lock; return whatever
+    `mutate` returns.
+
+    A copy of `tasks_store._update`, sibling `.lock` file and all, and a copy
+    rather than a call for the module docstring's reason: this module imports
+    nothing. The lock covers the READ as well as the write for the reason
+    documented there — the app runs several windows against one server, and a
+    second writer holding a snapshot taken before the first one's change would
+    persist the loss."""
+    os.makedirs(STATE_DIR, exist_ok=True)
+    path = os.path.join(STATE_DIR, DRAFTS_FILE)
+    with open(path + ".lock", "w") as lock:
+        if fcntl is not None:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+        data = load()
+        result, changed = mutate(data)
+        if changed:
+            # Temp + rename, unlike tasks_store's plain overwrite: this file
+            # holds text a person typed and has not sent, which is the one
+            # thing in `claude-sessions/` that cannot be rebuilt from anywhere
+            # else. A half-written read.json costs read marks; a half-written
+            # drafts.json costs the draft (Akshil, 2026-09-11).
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2, ensure_ascii=False)
+            os.replace(tmp, path)
+    return result
+
+
+# ------------------------------------------------------------ the two shapes
+
+
+def _attachments(value) -> list[dict]:
+    """A draft's attachments as stored `{path, name, kind}` rows.
+
+    The lenient twin of `schedule._attachments` (module docstring): a row that
+    cannot be read is DROPPED, never raised over, and a file that has since
+    moved is kept — the schedule validates again at create time, which is the
+    moment a missing file actually matters. Containment under the task-shots
+    dir is likewise the schedule's check to make: nothing in this store is ever
+    handed to a run."""
+    if not isinstance(value, list):
+        return []
+    out: list[dict] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        path = item.get("path")
+        if not isinstance(path, str) or not path.strip():
+            continue
+        kind = item.get("kind")
+        if kind not in _ATTACH_KINDS:
+            kind = _ATTACH_KINDS[0]
+        name = item.get("name")
+        # BASENAME and one line, the same two rules `schedule._attachments`
+        # applies and for the same reason: this name is only ever displayed, so
+        # a client that sent a path here must not have it read back as one.
+        name = os.path.basename(str(name or "").strip().replace("\\", "/"))
+        name = name.replace("\r", " ").replace("\n", " ").strip()
+        if len(name) > _ATTACH_NAME_MAX:
+            name = name[:_ATTACH_NAME_MAX]
+        out.append({"path": path.strip(),
+                    "name": name or os.path.basename(path.strip()),
+                    "kind": kind})
+    return out
+
+
+def _jsonable(value):
+    """`when` and `repeat` pass through whatever the form put in them — a
+    datetime-local string, a cron line, or a structured `recur` rule object —
+    so the modal reopens on exactly what it closed on. Only "can this be
+    written back out as json" is checked; anything else becomes None, because a
+    value that cannot be serialized would take the whole store down with it."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()
+                if isinstance(k, str)}
+    return None
+
+
+def _text(value) -> str:
+    """One text field. Not length-capped: this is work the user has typed and
+    not sent, and silently truncating it is the one failure a draft store may
+    never have (the same reasoning D615 deleted the chat's byte cap for)."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    return ""
+
+
+def _flag(value):
+    """A tri-state: True, False, or "the form never said". None rather than
+    False for the third, so a draft that predates the checkbox reopens with the
+    form's own default rather than with it forced off."""
+    return None if value is None else bool(value)
+
+
+def preview(text) -> str:
+    """The one line the `✎ Draft` chip's tooltip shows: the first non-empty
+    line, clipped to `PREVIEW_MAX` including the ellipsis. A draft that starts
+    with blank lines still has something to say about itself."""
+    for line in _text(text).splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if len(line) > PREVIEW_MAX:
+            return line[:PREVIEW_MAX - 1].rstrip() + "…"
+        return line
+    return ""
+
+
+# ------------------------------------------------------------- chat drafts
+
+
+def list_chat() -> dict:
+    """Every chat draft, `{key: {text, attachments, updated_at}}`, unreadable
+    records dropped."""
+    out: dict[str, dict] = {}
+    for key, rec in load()[CHAT].items():
+        if not chat_key(key) or not isinstance(rec, dict):
+            continue
+        out[key] = {"text": _text(rec.get("text")),
+                    "attachments": _attachments(rec.get("attachments")),
+                    "updated_at": _epoch(rec.get("updated_at"))}
+    return out
+
+
+def get_chat(session_id) -> dict | None:
+    """One chat draft, or None. None and "an empty draft" are the same thing
+    here, because the empty one is never stored."""
+    key = chat_key(session_id)
+    return list_chat().get(key) if key else None
+
+
+def put_chat(session_id, text=None, attachments=None) -> dict | None:
+    """Upsert one chat draft — and DELETE it when it comes in empty.
+
+    "Empty" is no text and no attachments, which is the state a composer is in
+    the moment its message is sent. The send path therefore does not have to
+    choose between PUT and DELETE: writing what the box now holds is correct in
+    both directions. Answers the stored record, or None when the write was a
+    delete."""
+    key = chat_key(session_id)
+    if not key:
+        return None
+    body = _text(text)
+    rows = _attachments(attachments)
+    if not body.strip() and not rows:
+        delete_chat(key)
+        return None
+    record = {"text": body, "attachments": rows, "updated_at": time.time()}
+
+    def mutate(data: dict):
+        data[CHAT][key] = record
+        return record, True
+
+    return _update(mutate)
+
+
+def delete_chat(session_id) -> bool:
+    """Drop one chat draft; True if there was one. Called on send, on an
+    explicit clear, and by every verb that takes the task away —
+    archive/delete/erase — because a draft for a conversation nobody can reach
+    any more is a badge on a row that is gone."""
+    key = chat_key(session_id)
+    if not key:
+        return False
+
+    def mutate(data: dict):
+        if key not in data[CHAT]:
+            return False, False
+        data[CHAT].pop(key, None)
+        return True, True
+
+    return _update(mutate)
+
+
+# ------------------------------------------------------------- task drafts
+
+
+def _task_record(rec) -> dict | None:
+    if not isinstance(rec, dict):
+        return None
+    out = {field: "" for field in _TASK_TEXT}
+    for field in _TASK_TEXT:
+        out[field] = _text(rec.get(field))
+    out["when"] = _jsonable(rec.get("when"))
+    out["repeat"] = _jsonable(rec.get("repeat"))
+    out["attachments"] = _attachments(rec.get("attachments"))
+    out["new_task_each_run"] = _flag(rec.get("new_task_each_run"))
+    # WHERE THESE WORDS CAME FROM, and it is stored rather than merely acted on
+    # (design.md, Round 2: "A draft moves, never duplicates"). The hop deletes
+    # the chat draft as it writes this one, so without a record of the key the
+    # move is irreversible the moment the modal is closed: a draft REOPENED from
+    # its row has no `?back=` in the URL and no sessionStorage stash left, and
+    # "Back to chat" — the only thing that puts the sentence back where it was
+    # typed — had nothing to aim at. Validated through `chat_key`, so the field
+    # is either a key the chat half can actually be written under or "" (Akshil,
+    # 2026-09-11).
+    out["from_chat_key"] = chat_key(rec.get("from_chat_key"))
+    out["created_at"] = _epoch(rec.get("created_at"))
+    out["updated_at"] = _epoch(rec.get("updated_at"))
+    return out
+
+
+def _empty_task(record: dict) -> bool:
+    """Is there nothing in this draft at all?
+
+    Every stored field, not a chosen few: the client mints a draft id on the
+    FIRST KEYSTROKE and never for an untouched modal (design.md, "New Task
+    modal"), so a draft that arrives with every field blank is a person having
+    cleared it out by hand, and the honest answer to that is to stop keeping
+    it."""
+    if any(record[field].strip() for field in _TASK_TEXT):
+        return False
+    if record["attachments"]:
+        return False
+    return (record["when"] in (None, "") and record["repeat"] in (None, "")
+            and record["new_task_each_run"] is None)
+
+
+def list_task() -> dict:
+    """Every task draft, `{draft_id: {…fields, created_at, updated_at}}`."""
+    out: dict[str, dict] = {}
+    for ident, rec in load()[TASK].items():
+        if not draft_id(ident):
+            continue
+        record = _task_record(rec)
+        if record is not None:
+            out[ident] = record
+    return out
+
+
+def get_task(ident) -> dict | None:
+    key = draft_id(ident)
+    return list_task().get(key) if key else None
+
+
+def put_task(ident, fields) -> dict | None:
+    """Upsert one task draft — and DELETE it when every field comes in empty.
+
+    Fields the client did not send keep the value the stored draft had, so the
+    modal's autosave may send only what it knows; fields the client sent that
+    this store does not know are dropped silently, so a newer page cannot 400
+    against an older server (see `TASK_FIELDS`).
+
+    `created_at` is written once and then never moves — it is the row's `at` on
+    the List and the Board, and a draft that jumped to the top of Upcoming on
+    every keystroke would be a row that will not sit still. Answers the stored
+    record, or None when the write was a delete."""
+    key = draft_id(ident)
+    if not key:
+        return None
+    patch = fields if isinstance(fields, dict) else {}
+
+    def mutate(data: dict):
+        stored = _task_record(data[TASK].get(key)) or {}
+        merged = dict(stored)
+        for field in TASK_FIELDS:
+            if field in patch:
+                merged[field] = patch[field]
+        record = _task_record(merged)
+        if record is None or _empty_task(record):
+            if key not in data[TASK]:
+                return None, False
+            data[TASK].pop(key, None)
+            return None, True
+        now = time.time()
+        record["created_at"] = stored.get("created_at") or now
+        record["updated_at"] = now
+        data[TASK][key] = record
+        return record, True
+
+    return _update(mutate)
+
+
+def delete_task(ident) -> bool:
+    """Discard one task draft; True if there was one. Called by the modal's
+    Discard button and by `POST /api/schedule` once the draft has become a real
+    scheduled entry — the draft's whole purpose is over at that moment, and a
+    row left behind would be the same task twice."""
+    key = draft_id(ident)
+    if not key:
+        return False
+
+    def mutate(data: dict):
+        if key not in data[TASK]:
+            return False, False
+        data[TASK].pop(key, None)
+        return True, True
+
+    return _update(mutate)
+
+
+def _epoch(value) -> float:
+    """A stored stamp as a float. 0.0 for one that cannot be read, which is how
+    every other absent time in this feature reads (`tasks_store`'s rows, the
+    listing's `last_active`)."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0

--- a/fused_render/drafts.py
+++ b/fused_render/drafts.py
@@ -360,17 +360,23 @@ def preview(text) -> str:
 # ------------------------------------------------------------- chat drafts
 
 
-def list_chat() -> dict:
-    """Every chat draft, `{key: {text, attachments, updated_at}}`, unreadable
-    records dropped."""
+def _project_chat(section: dict) -> dict:
+    """The chat section of an ALREADY-LOADED store, projected. Split out of
+    `list_chat` so `list_all` can answer both questions off one read."""
     out: dict[str, dict] = {}
-    for key, rec in load()[CHAT].items():
+    for key, rec in section.items():
         if not chat_key(key) or not isinstance(rec, dict):
             continue
         out[key] = {"text": _text(rec.get("text")),
                     "attachments": _attachments(rec.get("attachments")),
                     "updated_at": _epoch(rec.get("updated_at"))}
     return out
+
+
+def list_chat() -> dict:
+    """Every chat draft, `{key: {text, attachments, updated_at}}`, unreadable
+    records dropped."""
+    return _project_chat(load()[CHAT])
 
 
 def get_chat(session_id) -> dict | None:
@@ -477,16 +483,35 @@ def _empty_task(record: dict) -> bool:
             and record["new_task_each_run"] is None)
 
 
-def list_task() -> dict:
-    """Every task draft, `{draft_id: {…fields, created_at, updated_at}}`."""
+def _project_task(section: dict) -> dict:
+    """The task section of an ALREADY-LOADED store, projected. Split out of
+    `list_task` for the same reason as `_project_chat`."""
     out: dict[str, dict] = {}
-    for ident, rec in load()[TASK].items():
+    for ident, rec in section.items():
         if not draft_id(ident):
             continue
         record = _task_record(rec)
         if record is not None:
             out[ident] = record
     return out
+
+
+def list_task() -> dict:
+    """Every task draft, `{draft_id: {…fields, created_at, updated_at}}`."""
+    return _project_task(load()[TASK])
+
+
+def list_all() -> tuple[dict, dict]:
+    """Both sections off ONE read of the file: `(task_drafts, chat_drafts)`.
+
+    `list_task()` and `list_chat()` are each a whole `load()`, and the callers
+    that want drafts almost always want both — the tasks listing asks for the
+    chat drafts to join onto its rows and the task drafts to build draft rows
+    from, on every build, including the `/api/tasks/changes` polls. One file,
+    one read. Same projections, so this is interchangeable with calling the
+    two in turn."""
+    store = load()
+    return _project_task(store[TASK]), _project_chat(store[CHAT])
 
 
 def get_task(ident) -> dict | None:

--- a/fused_render/drafts.py
+++ b/fused_render/drafts.py
@@ -116,14 +116,15 @@ PREVIEW_MAX = 120
 #: client sends that is not in here is DROPPED rather than refused (the modal
 #: gains fields over time and an older server must not start 400ing a newer
 #: page), and a field the client omits keeps whatever the stored draft had.
-TASK_FIELDS = ("title", "description", "target", "when", "repeat", "model",
-               "effort", "permission", "attachments", "new_task_each_run",
-               "from_chat_key")
+TASK_FIELDS = ("title", "description", "target", "when", "repeat", "custom_rule",
+               "model", "effort", "permission", "attachments",
+               "new_task_each_run", "from_chat_key")
 
 #: The three fields that are plain text. The rest are pass-through (`when`,
-#: `repeat`), a tri-state flag (`new_task_each_run`), rows (`attachments`) or
-#: the chat key this draft was moved out of (`from_chat_key`, which is a chat
-#: key rather than free text and is validated as one).
+#: `repeat`, `custom_rule`), a tri-state flag (`new_task_each_run`), rows
+#: (`attachments`) or the chat key this draft was moved out of
+#: (`from_chat_key`, which is a chat key rather than free text and is validated
+#: as one).
 #:
 #: `from_chat_key` is DELIBERATELY NOT IN HERE, and that is the whole of what
 #: keeps it from changing what a draft is: `_empty_task` asks "is there anything
@@ -433,6 +434,15 @@ def _task_record(rec) -> dict | None:
         out[field] = _text(rec.get(field))
     out["when"] = _jsonable(rec.get("when"))
     out["repeat"] = _jsonable(rec.get("repeat"))
+    # THE RULE BEHIND A `custom` REPEAT (Bugbot, PR #1118). `repeat` is a preset
+    # KEY, and every key but one is its own whole answer — "every day" needs no
+    # second field. `custom` is a pointer at a rule the recurrence dialog built,
+    # so a draft that stored the key and dropped the rule reopened saying Custom,
+    # holding nothing, with Save refused and nothing on the card saying why.
+    # Pass-through like `when` and `repeat`, and for the same reason: this store
+    # is not the authority on what a recurrence rule looks like, and a shape it
+    # validated would be a second copy of `recur`'s grammar going stale.
+    out["custom_rule"] = _jsonable(rec.get("custom_rule"))
     out["attachments"] = _attachments(rec.get("attachments"))
     out["new_task_each_run"] = _flag(rec.get("new_task_each_run"))
     # WHERE THESE WORDS CAME FROM, and it is stored rather than merely acted on
@@ -463,6 +473,7 @@ def _empty_task(record: dict) -> bool:
     if record["attachments"]:
         return False
     return (record["when"] in (None, "") and record["repeat"] in (None, "")
+            and record["custom_rule"] in (None, "")
             and record["new_task_each_run"] is None)
 
 

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -74,6 +74,7 @@ from fused_render.server.routers.schedule import router as schedule_router
 from fused_render.server.routers.search import router as search_router
 from fused_render.server.routers.shell import router as shell_router
 from fused_render.server.routers.current_apps import router as current_apps_router
+from fused_render.server.routers.drafts import router as drafts_router
 from fused_render.server.routers.tasks import router as tasks_router
 from fused_render.server.routers.update import router as update_router
 # The MODULE, not `from … import TEMPLATES_DIR`: that constant is a live seam
@@ -740,6 +741,11 @@ def create_app(start_dir: str) -> FastAPI:
     # message that entered it, typed or scheduled. Reads are unguarded; the one
     # POST marks a message read, the same weight of change as the triage POST.
     app.include_router(tasks_router)
+    # Drafts (routers/drafts.py): the composer's unsent text and the New task
+    # modal's half-filled form, kept server-side so the `✎ Draft` chip the
+    # listing above paints can be a JOIN rather than a second store the client
+    # keeps. Unguarded like the tasks POSTs — a draft executes nothing.
+    app.include_router(drafts_router)
     # The Current apps desk (fused_render/current_apps.py): GET the table,
     # DELETE one app (archiving its tasks). Fed by the tasks listing above.
     app.include_router(current_apps_router)

--- a/fused_render/server/routers/drafts.py
+++ b/fused_render/server/routers/drafts.py
@@ -1,0 +1,208 @@
+"""Drafts over HTTP — the composer's unsent text, and the New task modal's
+half-filled form.
+
+The model is `fused_render/drafts.py`; this is the HTTP skin over it, and it is
+deliberately thin. Every rule about what a draft is — empty is a delete, an
+unknown field is dropped, a key is one of two shapes — lives in the store,
+because the badge join in `routers/tasks.py` and the schedule router's
+delete-on-create read the same store and must not be able to disagree with this
+file about any of them.
+
+**No D3 write guard**, unlike `POST /api/schedule`. That guard is on the two
+endpoints that start and stop an unattended agent turn; a draft executes
+nothing, and the POSTs in `routers/tasks.py` (read, archive, delete) are
+unguarded for the same reason — this is the same weight of change as marking a
+message read.
+
+**Every mutation announces itself** (`tasks_watch.notify`). A draft is a listed
+fact now: a chat draft puts a `✎ Draft` chip on its session's row, and a task
+draft IS a row. Both have to appear and vanish without a reload, and the
+long-poll in `/api/tasks/changes` is how every other change to a row already
+travels. The key announced is the key the listing files the row under — the
+session id for a chat draft, `draft:<id>` for a task draft — so the changes
+endpoint rebuilds exactly that row and nothing else.
+
+`new:<file>` announces itself too, as of round 2. It used to be the one key
+that did not — no session meant no task row meant nothing for a listening page
+to repaint — but an unsent chat IS a row now, filed under the folder it was
+opened on (`routers/tasks.py::_new_chat_draft_row`), so it has to appear and
+vanish live like every other (design.md, "Round 2"; Akshil, 2026-09-11).
+
+Routes take `{key:path}` rather than `{key}` for one reason: a `new:<file>` key
+carries a file path, separators and all, and a plain path parameter stops at
+the first one.
+"""
+from fastapi import APIRouter, Body, HTTPException
+
+from fused_render import drafts, tasks_store, tasks_watch
+
+router = APIRouter()
+
+
+def _chat_key(raw: str) -> str:
+    key = drafts.chat_key(raw)
+    if not key:
+        raise HTTPException(
+            status_code=400,
+            detail="chat draft key: expected a session id or `new:<file>`")
+    return key
+
+
+def _draft_id(raw: str) -> str:
+    ident = drafts.draft_id(raw)
+    if not ident:
+        raise HTTPException(
+            status_code=400,
+            detail="draft id: expected 8-64 characters of [A-Za-z0-9_-]")
+    return ident
+
+
+def _announce(*keys: str) -> None:
+    """Tell the Tasks page's long-poll that these rows moved. Best-effort by
+    construction — `notify` is an in-memory bump and cannot fail.
+
+    Nothing is silent any more: all three shapes this file handles — a session
+    id, `draft:<id>` and `new:<file>` — are keys the listing files a row under
+    (module docstring)."""
+    named = {key for key in keys if key}
+    if named:
+        tasks_watch.notify(named)
+
+
+@router.get("/api/drafts")
+def api_drafts():
+    """Everything, both kinds. The modal's "resume" affordance reads the task
+    half; the composer reads its own key out of the chat half rather than
+    paying for a request per conversation."""
+    return {"chat": drafts.list_chat(), "task": drafts.list_task()}
+
+
+@router.post("/api/drafts/chat/rekey")
+def api_draft_chat_rekey(body: dict = Body(default={})):
+    """`{from, to}` — the first send has learned the session id.
+
+    A chat opened on a folder is drafted under `new:<file>` and listed under
+    that key, TASK number and all. The moment its first message is sent Claude
+    Code mints a session, and the conversation the user is looking at is now
+    filed somewhere else. Without this the number would be stranded on a row
+    nobody can reach and the session would allocate a second one — the same
+    break `pending:<entry-id>` → session id already has an answer for, which is
+    why this is that answer: one `tasks_store.rekey`, same file, same
+    allocate-once promise, same refusal to overwrite a number `to` already has
+    (design.md, "Round 2").
+
+    A no-op that still answers 200 when `from` has no number — a chat sent
+    before the debounce ever saved a draft never had a row to number — because
+    the client fires this on every first send and cannot know which it was.
+
+    THE TEXT MOVES WITH THE NUMBER, when there is any. Normally there is none:
+    the send is what cleared the composer, so `from` is already empty and this
+    is purely a delete. When the user typed on after sending, the leftover
+    text belongs to the conversation that send created. A draft already stored
+    under `to` is left alone — it is the newer of the two and the one the
+    composer is actually showing.
+    """
+    src = _chat_key(body.get("from"))
+    dst = drafts.session_key(body.get("to"))
+    if not dst:
+        raise HTTPException(
+            status_code=400, detail="to: expected a session id")
+    if src == dst:
+        raise HTTPException(
+            status_code=400, detail="from and to: expected two different keys")
+
+    number = ""
+    try:
+        number = tasks_store.rekey(src, dst)
+    except OSError:
+        # The message IS sent and the conversation IS open; a read-only state
+        # dir must not turn that into a 500. The session simply allocates its
+        # own number on the next listing. Same posture as the rekey in
+        # `routers/schedule.py`.
+        pass
+
+    record = drafts.get_chat(src)
+    moved = False
+    if record and drafts.get_chat(dst) is None:
+        moved = drafts.put_chat(dst, record.get("text"),
+                                record.get("attachments")) is not None
+    drafts.delete_chat(src)
+    _announce(src, dst)
+    return {"ok": True, "from": src, "to": dst,
+            "task_id": number, "moved": moved}
+
+
+@router.put("/api/drafts/chat/{key:path}")
+def api_draft_chat_put(key: str, body: dict = Body(default={})):
+    """Upsert one chat draft. An empty one is a DELETE, and the answer says so
+    (`draft: null`) rather than making the caller infer it — the composer's
+    autosave fires on every pause including the one after the send cleared the
+    box, and it must be allowed to keep sending what it now holds."""
+    chat = _chat_key(key)
+    record = drafts.put_chat(chat, body.get("text"), body.get("attachments"))
+    _announce(chat)
+    return {"ok": True, "key": chat, "draft": record}
+
+
+@router.delete("/api/drafts/chat/{key:path}")
+def api_draft_chat_delete(key: str):
+    """Drop one chat draft — on send, or on an explicit clear. Answers whether
+    there was one, and is not a 404 when there was not: the composer clears
+    after a send whether or not the debounce ever got round to a first save,
+    and a red line in the console over that would be noise about nothing."""
+    chat = _chat_key(key)
+    removed = drafts.delete_chat(chat)
+    _announce(chat)
+    return {"ok": True, "key": chat, "removed": removed}
+
+
+@router.put("/api/drafts/task/{draft_id:path}")
+def api_draft_task_put(draft_id: str, body: dict = Body(default={})):
+    """Upsert one task draft from the modal's form fields.
+
+    The body IS the form — `title`, `description`, `target`, `when`, `repeat`,
+    `model`, `effort`, `permission`, `attachments`, `new_task_each_run`,
+    `from_chat_key` — and
+    anything else in it is dropped by the store rather than refused here, so
+    the modal may grow a field without this endpoint learning about it. An
+    all-empty form is a delete, the same bargain the chat half makes."""
+    ident = _draft_id(draft_id)
+    record = drafts.put_task(ident, body)
+    # A DRAFT MOVES, IT NEVER DUPLICATES. The composer → New task hop mints the
+    # task draft out of what was in the chat box, so for one instant the same
+    # unfinished sentence is two drafts and two rows. `from_chat_key` is the
+    # client naming the one it came from, and this is the same request that
+    # made the new one — a client that deleted the old one afterwards would
+    # leave both listed through any failure between the two calls, which is the
+    # one outcome the rule forbids (design.md, "Round 2"; Akshil, 2026-09-11).
+    #
+    # Only on SUCCESS: an all-empty form is a delete (the store says so by
+    # answering None), and dropping the chat draft over a write that stored
+    # nothing would lose the text outright. Optional and silently ignored when
+    # absent or malformed — the modal's ordinary autosave sends no such key,
+    # and a hop is not worth a 400.
+    #
+    # IT IS ALSO A STORED FIELD, not only a side effect (`drafts.TASK_FIELDS`),
+    # and every later save that omits it keeps what was stored. That is what
+    # rides down in the draft row's `form`, and it is what lets a draft REOPENED
+    # from the List still know which conversation to put its words back into:
+    # such a card has no `?back=` in its URL and no sessionStorage stash left,
+    # so without a stored key "Back to chat" had nothing to aim at and the move
+    # was one-way the moment the modal closed (Akshil, 2026-09-11).
+    from_chat = drafts.chat_key(body.get("from_chat_key")) if record else ""
+    if from_chat:
+        drafts.delete_chat(from_chat)
+    _announce(drafts.task_key(ident), from_chat)
+    return {"ok": True, "draft_id": ident, "draft": record,
+            "from_chat_key": from_chat}
+
+
+@router.delete("/api/drafts/task/{draft_id:path}")
+def api_draft_task_delete(draft_id: str):
+    """Discard one task draft — the modal's Discard button, and the tidy-up
+    after a draft has been scheduled for real (which `POST /api/schedule` does
+    for itself, given a `draft_id`)."""
+    ident = _draft_id(draft_id)
+    removed = drafts.delete_task(ident)
+    _announce(drafts.task_key(ident))
+    return {"ok": True, "draft_id": ident, "removed": removed}

--- a/fused_render/server/routers/drafts.py
+++ b/fused_render/server/routers/drafts.py
@@ -74,7 +74,8 @@ def api_drafts():
     """Everything, both kinds. The modal's "resume" affordance reads the task
     half; the composer reads its own key out of the chat half rather than
     paying for a request per conversation."""
-    return {"chat": drafts.list_chat(), "task": drafts.list_task()}
+    task, chat = drafts.list_all()  # one file, one read
+    return {"chat": chat, "task": task}
 
 
 @router.post("/api/drafts/chat/rekey")

--- a/fused_render/server/routers/drafts.py
+++ b/fused_render/server/routers/drafts.py
@@ -161,8 +161,8 @@ def api_draft_task_put(draft_id: str, body: dict = Body(default={})):
     """Upsert one task draft from the modal's form fields.
 
     The body IS the form — `title`, `description`, `target`, `when`, `repeat`,
-    `model`, `effort`, `permission`, `attachments`, `new_task_each_run`,
-    `from_chat_key` — and
+    `custom_rule`, `model`, `effort`, `permission`, `attachments`,
+    `new_task_each_run`, `from_chat_key` — and
     anything else in it is dropped by the store rather than refused here, so
     the modal may grow a field without this endpoint learning about it. An
     all-empty form is a delete, the same bargain the chat half makes."""

--- a/fused_render/server/routers/schedule.py
+++ b/fused_render/server/routers/schedule.py
@@ -393,6 +393,31 @@ def api_schedule_create(body: dict = Body(...),
                 tasks_watch.notify({session})
         except OSError:
             pass
+
+    # ...AND THE CHAT THE COMPOSER HOP CAME FROM, WHICH `session_id` CANNOT NAME
+    # (Bugbot, PR #1118).
+    #
+    # The Schedule button carries what is in the composer into the New task card,
+    # and the card's FIRST autosave is what tells the server to drop the chat's
+    # copy (`from_chat_key` on `PUT /api/drafts/task/<id>`). Press Schedule
+    # inside the 600 ms debounce and that write never happens: no draft id is
+    # minted, none is sent here, and the chat draft — row, TASK number and all —
+    # survives beside the task it just became. `session_id` above covers a chat
+    # that HAS a session; a brand-new one is keyed `new:<file>`, which is not a
+    # session id and never rides in that field.
+    #
+    # So the card names its origin here too. Validated through `chat_key` (both
+    # shapes), optional, and silently ignored when absent — every client that
+    # predates drafts sends none. Best-effort like the two deletes above: the
+    # task IS scheduled, and a draft that could not be dropped costs one stale
+    # row, never the task.
+    origin = drafts.chat_key(body.get("from_chat_key"))
+    if origin and origin != session:
+        try:
+            if drafts.delete_chat(origin):
+                tasks_watch.notify({origin})
+        except OSError:
+            pass
     return {"entry": entry}
 
 

--- a/fused_render/server/routers/schedule.py
+++ b/fused_render/server/routers/schedule.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Body, File, Header, UploadFile
 
-from fused_render import recur, schedule, tasks_store
+from fused_render import drafts, recur, schedule, tasks_store, tasks_watch
 from fused_render.server import image_convert
 from fused_render.server.common import _error, _require_fused
 
@@ -340,6 +340,57 @@ def api_schedule_create(body: dict = Body(...),
         try:
             tasks_store.rekey(tasks_store.pending_key(replaces),
                               tasks_store.pending_key(str(entry.get("id") or "")))
+        except OSError:
+            pass
+
+    # THE DRAFT IS OVER. The New task modal autosaves what you are typing into
+    # `drafts.json` and lists it as a `draft:<id>` row (design.md, "Where
+    # drafts live"); scheduling it is the moment that form becomes a real
+    # entry, so the draft must go in the SAME request — a client that deleted
+    # it afterwards would leave the task listed twice through any failure
+    # between the two calls, which is the one outcome a draft must never
+    # produce. Optional and silently ignored when absent: every client written
+    # before drafts existed sends no `draft_id`, and so does the `?new=1` hop.
+    #
+    # Best-effort, like the rekey above and for the same reason: the message IS
+    # scheduled, and a read-only state dir must not turn that into a 500. A
+    # draft that could not be dropped costs one stale row, never the task.
+    draft = drafts.draft_id(body.get("draft_id"))
+    if draft:
+        try:
+            # THE NUMBER SURVIVES THE DRAFT, exactly as it survives an edit
+            # above and as a pending row's survives its first run. A draft is
+            # listed under `draft:<id>` with a TASK number of its own (round 2
+            # of design.md), and scheduling it is the same event for that row
+            # that a first run is for a `pending:` one: the thing keeps going,
+            # under a new key. Without this the user would watch the TASK-118
+            # they had been typing into become TASK-119 the moment they
+            # pressed Schedule — the renumber `replaces` exists to prevent,
+            # one stage earlier (Akshil, 2026-09-11).
+            #
+            # Before the delete, and in that order for a reason: `rekey` reads
+            # `task_ids.json`, not the draft store, so the order does not
+            # actually matter to it — but a failure between the two must leave
+            # the draft, which is recoverable, rather than a numberless task,
+            # which is not.
+            tasks_store.rekey(drafts.task_key(draft),
+                              tasks_store.pending_key(str(entry.get("id") or "")))
+            if drafts.delete_task(draft):
+                tasks_watch.notify({drafts.task_key(draft)})
+        except OSError:
+            pass
+
+    # ...AND SO IS THE CHAT DRAFT THIS CAME FROM. Scheduling into a session is
+    # the composer's other exit: the words in the box are now a booked message,
+    # and text left behind would paint a `✎ Draft` chip on the very task that
+    # just consumed it. Same request as the create for the same reason the
+    # `draft_id` delete is, and best-effort for the same one (Akshil,
+    # 2026-09-11).
+    session = drafts.chat_key(body.get("session_id"))
+    if session:
+        try:
+            if drafts.delete_chat(session):
+                tasks_watch.notify({session})
         except OSError:
             pass
     return {"entry": entry}

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -45,6 +45,15 @@ this file is written around:
   Nothing survives to revive, which is the whole difference from delete (D307).
   Same section.
 
+**Drafts ride on this listing** (fused_render/drafts.py, routers/drafts.py).
+Two joins, no new list endpoint: every session row gains `draft` — the one-line
+preview of whatever is sitting unsent in that conversation's composer, or None
+— and every TASK draft is emitted as a row of its own (`kind:"draft"`,
+`state:"draft"`, key `draft:<id>`, no number). Both travel down
+`/api/tasks/changes` like any other change to a row, which is what makes the
+`✎ Draft` chip appear and a new draft land in Upcoming without a reload. Both
+are absent from the pulse, deliberately — see `api_tasks_pulse`.
+
 **What a message is.** A user prompt in the transcript, or a scheduled entry.
 Those two overlap: a scheduled message that fired IS a prompt in the transcript
 (`_send` hands `entry["message"]` over verbatim), so listing both would show it
@@ -99,7 +108,8 @@ import time
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
-from fused_render import current_apps, schedule, tasks_store, tasks_watch
+from fused_render import (current_apps, drafts, schedule, tasks_store,
+                          tasks_watch)
 from fused_render._view_url_codec import canonical_fs_path
 from fused_render.server.routers import claude_sessions as sessions
 
@@ -1715,7 +1725,8 @@ def _next_run(entries: list[dict]) -> tuple[float, str, bool]:
 
 
 def _row(task: dict, number: str, triage: dict, read: dict, now: float,
-         busy: set[str], revived: list[str], parked: dict | None = None) -> dict:
+         busy: set[str], revived: list[str], parked: dict | None = None,
+         chat_drafts: dict | None = None) -> dict:
     """One listing row. The tail parse only: three messages, and a count.
 
     `parked` is `_parked_runs()` — every session whose live run is waiting on a
@@ -1729,6 +1740,14 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     own entries because a resume that forked is filed under the session it RAN
     in (`_entry_session` reads the answer first) while it still holds the
     session it NAMED busy, and that one is another row.
+
+    `chat_drafts` is `drafts.list_chat()`, read once by the caller for the same
+    reason `read` and the numbers are: it is one file, and asking it per row
+    would open it once per task on the machine. Joined on the SESSION ID rather
+    than the key, because that is what the composer keys on — a `pending:` row
+    has no conversation to have been typed into, and a `new:<file>` draft has no
+    row at all until its first send makes the session (design.md, "Chat draft
+    key").
 
     `revived` is an OUT parameter and the only one: a session whose archive
     record this row has just found stale is appended to it, and the caller does
@@ -1872,6 +1891,16 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         "attention": ({"tool": waiting["tool"], "summary": waiting["summary"]}
                       if waiting is not None else None),
         "live": live,
+        # UNSENT TEXT SITTING IN THIS TASK'S COMPOSER — `{preview, updated_at}`
+        # or None, which is what the `✎ Draft` chip and its tooltip are drawn
+        # from. A join and not a second poll: the chip has to appear and vanish
+        # live, and this row already travels down the changes long-poll every
+        # time anything about the task moves (design.md, "Joins"). Only the
+        # PREVIEW rides along — one line — because the draft itself belongs in
+        # the composer the user left it in, and a listing that carried every
+        # unsent message on the machine would be paying transcript-sized costs
+        # for a badge.
+        "draft": _chat_draft(task["session_id"], chat_drafts),
         "unread": _unread_count(task, total, unfired, read),
         # WHEN THIS TASK BEGAN — the EARLIEST clock it has (`_place`, which
         # explains the choice at length): the scheduled entry's `created`, else
@@ -1898,6 +1927,308 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # Newest first, which is how every list in this feature reads.
         "messages": list(reversed(tail)),
     }
+
+
+def _chat_draft(session_id: str, chat_drafts: dict | None) -> dict | None:
+    """One row's `draft` field: the preview of the unsent text in its composer,
+    or None. `None` and "an empty draft" are the same thing — the store never
+    keeps an empty one — so the client has exactly one question to ask."""
+    if not session_id or not chat_drafts:
+        return None
+    record = chat_drafts.get(session_id)
+    if not record:
+        return None
+    line = drafts.preview(record.get("text"))
+    rows = record.get("attachments") or []
+    if not line and not rows:
+        return None
+    return {"preview": line, "updated_at": float(record.get("updated_at") or 0.0)}
+
+
+# What a task draft's row calls itself where a real task names its lane. A
+# draft has no derived status — nothing has run, nothing is booked — and
+# `upcoming` is the honest one of the six: design.md puts drafts in the Board's
+# Upcoming lane ("an unfinished thing is the most upcoming thing") and the
+# List's when-column reads `Draft` off `state`, not off this. `kind` and
+# `state` are what tell the two apart; `status` is what keeps every view that
+# already switches on the six lanes working without learning a seventh
+# (Akshil, 2026-09-11).
+_DRAFT_STATUS = "upcoming"
+
+#: What a draft with nothing to call itself is called. A draft row has to be
+#: clickable — it is the ONLY way back into the modal (design.md, "Reopen
+#: path") — so it can never render as a blank line.
+_UNTITLED_DRAFT = "Untitled draft"
+
+#: ...and the same for a chat nobody has sent yet. Different word because it is
+#: a different way back in: a task draft reopens the modal, an unsent chat
+#: opens the folder's conversation with the composer already holding the text.
+_UNTITLED_CHAT = "Untitled chat"
+
+#: How long a draft row's title may be. Shorter than `drafts.PREVIEW_MAX` (the
+#: chip's tooltip, which is allowed a whole line) because this is a TITLE, and
+#: it sits in the same column as a task's — a draft that printed 120 characters
+#: there would be the one row on the page setting its own width
+#: (Akshil, 2026-09-11).
+_DRAFT_TITLE_MAX = 80
+
+
+def _draft_title(text, fallback: str) -> str:
+    """A draft row's title: the first non-empty line of what was typed, clipped
+    to `_DRAFT_TITLE_MAX`, else `fallback`. `drafts.preview` already answers the
+    first half of that (and clips to its own, larger, bound), so this only has
+    the tighter cut to make."""
+    line = drafts.preview(text)
+    if len(line) > _DRAFT_TITLE_MAX:
+        line = line[:_DRAFT_TITLE_MAX - 1].rstrip() + "…"
+    return line or fallback
+
+
+def _draft_row(ident: str, record: dict, number: str = "") -> dict:
+    """One task draft as a listing row.
+
+    THE SAME FIELD SET AS `_row`, deliberately and in full: the List, the Board
+    and the changes long-poll all read one row shape, and a row missing half of
+    it would make every one of them test for a kind before touching a field.
+    What differs is what a draft actually is — no session, no messages, and
+    nothing that has happened (`happened_at` 0.0 — the desk must not read an
+    unfinished form as work that finished under an app).
+
+    IT DOES HAVE A NUMBER. Round 1 printed `task_id: ""` here on the reasoning
+    that a number is minted when a task becomes real; round 2 reversed that,
+    because the number is how a person NAMES the thing ("what happened to
+    TASK-118?") and a draft they have been typing into for ten minutes is
+    already a thing they can name. `draft:<id>` is allocated through exactly
+    the path `pending:<entry-id>` uses and is rekeyed forward onto
+    `pending:<entry-id>` when the draft is scheduled, so the number the row
+    showed while it was a form is the number it keeps once it is a task
+    (design.md, "Round 2"; Akshil, 2026-09-11).
+
+    The three fields `_row` has no use for — `draft_kind`, `cwd` and `file` —
+    are carried by BOTH draft kinds rather than by whichever needs them, for
+    the same reason the rest of the set is: one row shape, tested once.
+
+    `form` is the WHOLE stored draft, which is the one field here that is not
+    about drawing the row: clicking a draft row reopens the modal on it, and
+    the modal needs every field back, not a summary. It is small — one form —
+    and fetching it separately would mean a request between the click and the
+    modal, which is exactly the pause the feature exists to remove.
+    """
+    title = str(record.get("title") or "").strip()
+    if not title:
+        title = _draft_title(record.get("description"), "")
+    target = str(record.get("target") or "")
+    project = tasks_store.project_of(_workdir(target))
+    created = float(record.get("created_at") or 0.0)
+    updated = float(record.get("updated_at") or 0.0)
+    return {
+        "key": drafts.task_key(ident),
+        # ALLOCATED, and allocated under `draft:<id>` so it can be moved onto
+        # `pending:<entry-id>` by one `tasks_store.rekey` the moment the form
+        # is scheduled. "" only when the state dir is unwritable, which is the
+        # same "" every other row falls back to.
+        "task_id": number,
+        "draft_id": ident,
+        "kind": "draft",
+        # WHICH composer this draft belongs to. The two are opened by different
+        # clicks — a task draft reopens the New task modal, a chat draft opens
+        # the folder's conversation — and the row is the only thing that knows
+        # which (Akshil, 2026-09-11).
+        "draft_kind": "task",
+        "state": "draft",
+        "project": canonical_fs_path(project),
+        "cwd": canonical_fs_path(project),
+        "target": canonical_fs_path(target),
+        # The raw thing the draft was pointed at, file or folder, BEFORE
+        # `_workdir` resolved it to a project. The modal reopens on this.
+        "file": canonical_fs_path(target),
+        "session_id": "",
+        "title": title or _UNTITLED_DRAFT,
+        "title_source": "draft",
+        "description": str(record.get("description") or ""),
+        "status": _DRAFT_STATUS,
+        "failed": False,
+        "blocked_reason": "",
+        "attention": None,
+        "live": False,
+        # The chat half of the store keys on a session, and a draft has none.
+        # Present anyway so one row shape answers one question.
+        "draft": None,
+        "unread": 0,
+        # WHEN: a draft has none, and null is the difference between "runs at
+        # no particular time" (an immediate task, which has a time) and "has
+        # not been given one yet". The List's when-column prints `Draft` here.
+        "when": None,
+        # The row's clock, and there is only one honest source for it: when the
+        # form was started. `at` alongside `started` because the two names are
+        # already both in use on this page's rows and a draft answers the same
+        # for each.
+        "at": created,
+        "started": created,
+        "created_at": created,
+        "updated_at": updated,
+        # THE NEWEST EDIT, so the Upcoming lane sorts a draft by when it was
+        # last touched. `_row_order` reads this and nothing else once the
+        # status ranks tie, which is what puts a draft being typed at the top
+        # of the lane where the person who is typing it can see it.
+        "last_active": updated or created,
+        # Nothing has HAPPENED — see the docstring. `current_apps.observe`
+        # reads this field and must not put an app on the desk over a form.
+        "happened_at": 0.0,
+        "message_count": 0,
+        "next_run": 0.0,
+        "next_run_entry": "",
+        "next_run_repeats": False,
+        "messages": [],
+        # The modal's way back in. See the docstring.
+        "form": dict(record),
+    }
+
+
+def _new_chat_draft_row(key: str, record: dict, number: str = "") -> dict:
+    """One UNSENT CHAT as a listing row — a draft keyed `new:<file>`.
+
+    Round 1 gave this key no row: it names no session, so there was nothing for
+    the `✎ Draft` chip to hang off. That was the wrong way round. A person who
+    has typed half a message into a folder they have never chatted in has
+    exactly the same unfinished thing as one who has half-filled the New task
+    modal, and the only surface that remembered it was the composer they would
+    have to find again. So it is a row, with the folder as its project and its
+    first line as its title, and clicking it opens that folder's chat with the
+    composer already holding the text (design.md, "Round 2").
+
+    THE SAME FIELD SET as `_draft_row` and `_row`, with a draft's answers: no
+    session (there is none until the first send — that send is what
+    `POST /api/drafts/chat/rekey` reports, and it carries this number forward),
+    no messages, nothing that has happened. `form` is null rather than a dict:
+    a chat draft is text and attachments, which is what `draft` already
+    carries, and there is no form to reopen.
+    """
+    raw = drafts.new_chat_file(key)
+    folder = _workdir(raw)
+    project = tasks_store.project_of(folder)
+    updated = float(record.get("updated_at") or 0.0)
+    line = drafts.preview(record.get("text"))
+    rows = record.get("attachments") or []
+    return {
+        "key": key,
+        "task_id": number,
+        # There is no `draft:<id>` behind this one — the store keys it on the
+        # folder. "" rather than the key so a client testing `draft_id` cannot
+        # send this to the task-draft routes, which would 400 on the shape.
+        "draft_id": "",
+        "kind": "draft",
+        "draft_kind": "chat",
+        "state": "draft",
+        "project": canonical_fs_path(project),
+        "cwd": canonical_fs_path(project),
+        # A chat opens on the FILE when the key named one — that is where the
+        # person was looking — and the project is still the folder above it,
+        # which is the rule every other row's target follows (`_place`).
+        "target": canonical_fs_path(raw or project),
+        "file": canonical_fs_path(raw),
+        "session_id": "",
+        "title": _draft_title(record.get("text"), _UNTITLED_CHAT),
+        "title_source": "draft",
+        "description": "",
+        "status": _DRAFT_STATUS,
+        "failed": False,
+        "blocked_reason": "",
+        "attention": None,
+        "live": False,
+        # THIS row's chip is about itself. Every other row joins its draft off
+        # the session id; this one IS the draft, so the join is the identity.
+        "draft": ({"preview": line, "updated_at": updated}
+                  if (line or rows) else None),
+        "unread": 0,
+        "when": None,
+        # One clock, because the store keeps one: a chat draft has no
+        # `created_at` (it is a single upsert keyed on the folder, not a form
+        # with a birth), so `updated_at` answers every time on this row. That
+        # also puts it at the top of Upcoming while it is being typed, which is
+        # where the person typing it can see it.
+        "at": updated,
+        "started": updated,
+        "created_at": updated,
+        "updated_at": updated,
+        "last_active": updated,
+        "happened_at": 0.0,
+        "message_count": 0,
+        "next_run": 0.0,
+        "next_run_entry": "",
+        "next_run_repeats": False,
+        "messages": [],
+        # Nothing to reopen a modal on — see the docstring.
+        "form": None,
+    }
+
+
+def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
+    """TASK numbers for every draft, allocating what is missing.
+
+    `tasks_store.ensure_ids` and nothing else — the same call, the same file
+    and the same allocate-once promise the listing's `_numbers` uses, because
+    the whole point is that the number a draft shows is the number its task
+    will keep. The project each draft is numbered in is the FOLDER it is
+    pointed at, which is what `_workdir` resolves and what both row builders
+    above print.
+
+    Over EVERY draft, never the `only` subset: `ensure_ids` hands numbers out
+    in the order it is given them, so numbering a narrowed set would let the
+    changes endpoint allocate in a different order than the listing does.
+
+    Sorted by when the draft was started, the same `order` the listing passes,
+    so a backfill over a store that predates numbering reads in the order the
+    drafts were actually typed. Degrades to no numbers on an unwritable state
+    dir, exactly like `_numbers`: blank numbers, never a lost page.
+    """
+    items = []
+    for ident, record in task_drafts.items():
+        target = str(record.get("target") or "")
+        items.append((drafts.task_key(ident),
+                      tasks_store.project_of(_workdir(target)),
+                      float(record.get("created_at") or 0.0)))
+    for key, record in chat_drafts.items():
+        if not drafts.is_new_chat_key(key):
+            continue  # a chat draft on a real session is a chip, not a row
+        items.append((key,
+                      tasks_store.project_of(_workdir(drafts.new_chat_file(key))),
+                      float(record.get("updated_at") or 0.0)))
+    if not items:
+        return {}
+    try:
+        return tasks_store.ensure_ids(items)
+    except OSError:
+        return {}
+
+
+def _draft_rows(only: frozenset | set | None = None,
+                chat_drafts: dict | None = None) -> list[dict]:
+    """Every draft as a row — task drafts AND unsent new chats — narrowed to
+    `only` when the caller is the changes endpoint.
+
+    `chat_drafts` is `drafts.list_chat()`, read once by the caller for the same
+    reason the row join reads it once: it is one file, and this is the second
+    question asked of it. Read here when the caller has no copy, so the
+    function still answers on its own.
+    """
+    task_drafts = drafts.list_task()
+    if chat_drafts is None:
+        chat_drafts = drafts.list_chat()
+    numbers = _draft_numbers(task_drafts, chat_drafts)
+    rows = []
+    for ident, record in task_drafts.items():
+        key = drafts.task_key(ident)
+        if only is not None and key not in only:
+            continue
+        rows.append(_draft_row(ident, record, numbers.get(key, "")))
+    for key, record in chat_drafts.items():
+        if not drafts.is_new_chat_key(key):
+            continue
+        if only is not None and key not in only:
+            continue
+        rows.append(_new_chat_draft_row(key, record, numbers.get(key, "")))
+    return rows
 
 
 def _description(task: dict) -> str:
@@ -2040,6 +2371,10 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     # One scan of the runs tree for every row: which conversations are parked on
     # a card nobody has answered. See `_parked_runs`.
     parked = _parked_runs()
+    # One read of the drafts store for every row, for the same reason `read`
+    # and `busy` are read once: it is one small file, and the join below asks
+    # it per session.
+    chat_drafts = drafts.list_chat()
     for task in tasks.values():
         _place(task)
     numbers = _numbers(tasks)
@@ -2051,7 +2386,7 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     for task in tasks.values():
         try:
             row = _row(task, numbers.get(task["key"], ""), triage, read, now,
-                       busy, revived, parked)
+                       busy, revived, parked, chat_drafts)
         except (OSError, ValueError, KeyError, TypeError):
             continue  # one unreadable task, not an unreadable page
         rows.append(row)
@@ -2071,6 +2406,13 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     # one extra pass on exactly one request in the store's lifetime.
     if only is None and not tasks_store.initialized(read):
         tasks_store.initialize([(r["key"], r["message_count"]) for r in rows])
+    # DRAFTS ARE ROWS TOO — the New task modal's half-filled forms AND the
+    # chats that have been typed into but never sent (`new:<file>`) — added
+    # here, AFTER the day-one read baseline and BEFORE the sort. After, because
+    # a draft has no messages and nothing to have read; before, because the
+    # Board orders Upcoming off this list and a draft has to arrive already in
+    # its place rather than appended past the end of the lane.
+    rows.extend(_draft_rows(only, chat_drafts))
     rows.sort(key=_row_order)
     # The Current apps desk (current_apps.py) learns about NEW tasks here —
     # the one place every task on the machine passes, whatever started it.
@@ -2080,7 +2422,11 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     # task and prunes what it does not see (bugbot, PR #892).
     if only is None:
         try:
-            current_apps.observe(rows)
+            # WITHOUT THE DRAFTS. `observe` reads a row as a task that exists
+            # and puts its folder on the desk; a half-typed form is not a task
+            # under an app yet, and a draft that was discarded would leave an
+            # app behind that nothing ever ran in.
+            current_apps.observe([r for r in rows if r.get("kind") != "draft"])
         except OSError:
             pass
     return rows
@@ -2174,11 +2520,18 @@ _PULSE_FIELDS = (
 
 @router.get("/api/tasks/pulse")
 def api_tasks_pulse():
-    """The compact task facts used by the global sidebar's status pulse."""
+    """The compact task facts used by the global sidebar's status pulse.
+
+    NO DRAFTS. The sidebar's dot, its unread count and its Notifications
+    section are about work that is happening; a form somebody has not finished
+    is not news, and design.md puts task drafts in the List and the Board only
+    — never the Cards wall, never the Calendar, and by the same reasoning never
+    here (Akshil, 2026-09-11)."""
     return {
         "tasks": [
             {field: row[field] for field in _PULSE_FIELDS}
             for row in _task_rows()
+            if row.get("kind") != "draft"
         ]
     }
 
@@ -2455,6 +2808,12 @@ def api_task_archive(patch: ArchivePatch):
     if task is None:
         raise HTTPException(status_code=404, detail=f"no task with key {key!r}")
     cancelled, filed = archive_task(task)
+    # AND THE UNSENT TEXT GOES WITH IT. A draft is a promise that the composer
+    # will still hold it when you come back; filing the task away is saying you
+    # are not coming back, and a `✎ Draft` chip on an archived row would be a
+    # badge pointing at a conversation the user just put down (design.md,
+    # "Joins": archive/delete/erase drop the chat draft).
+    drafts.delete_chat(task["session_id"])
     tasks_watch.notify({key})
     return {"ok": True, "key": key, "cancelled": cancelled, "filed": filed}
 
@@ -2621,6 +2980,10 @@ def api_task_delete(patch: DeletePatch):
             cancelled += 1
 
     tasks_store.mark_deleted(key)
+    # The chat draft goes with the row, for archive's reason and one more: the
+    # row is the only place the chip could have been drawn, so a draft left
+    # behind is bytes nothing can ever show or reach.
+    drafts.delete_chat(task["session_id"])
     tasks_watch.notify({key})
     return {"ok": True, "key": key, "cancelled": cancelled,
             "erased_transcript": False}
@@ -2728,6 +3091,10 @@ def api_task_erase(patch: ErasePatch):
                         "see the server log"))
         sessions.forget_triage(session_id)
         tasks_store.forget_session(session_id)
+        # Nothing about this session survives an erase, and unsent text is
+        # emphatically something about it — there is no conversation left for
+        # it to be typed into.
+        drafts.delete_chat(session_id)
 
     tasks_store.mark_deleted(key)
     tasks_watch.notify({key})

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -2215,19 +2215,44 @@ def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
         return {}
 
 
+def _draft_shaped(only: frozenset | set) -> bool:
+    """Could ANY of these keys name a draft row?
+
+    `_draft_rows` emits exactly two key shapes: `draft:<id>` for a task draft
+    and `new:<file>` for a chat that has never been sent. A session key never
+    reaches it — a chat draft filed under a real session is a CHIP on that
+    session's own row (`_chat_draft`, off the `chat_drafts` the build already
+    holds), not a row of its own.
+
+    So a narrowed build asking about anything else has no draft row to find,
+    and running the draft half anyway cost it `ensure_ids(reproject=True)` —
+    a write-shaped pass under the task_ids lock — on every `/api/tasks/changes`
+    poll about an unrelated session. The full build (`only is None`) never
+    takes this door.
+    """
+    return any(key.startswith(("draft:", drafts.NEW_CHAT_PREFIX)) for key in only)
+
+
 def _draft_rows(only: frozenset | set | None = None,
-                chat_drafts: dict | None = None) -> list[dict]:
+                chat_drafts: dict | None = None,
+                task_drafts: dict | None = None) -> list[dict]:
     """Every draft as a row — task drafts AND unsent new chats — narrowed to
     `only` when the caller is the changes endpoint.
 
-    `chat_drafts` is `drafts.list_chat()`, read once by the caller for the same
-    reason the row join reads it once: it is one file, and this is the second
-    question asked of it. Read here when the caller has no copy, so the
-    function still answers on its own.
+    `chat_drafts` and `task_drafts` are `drafts.list_all()`, read once by the
+    caller for the same reason the row join reads the chat half once: it is
+    ONE file, and between the row join, the row build and the numbering it was
+    being asked three times per listing. Read here when the caller has no copy,
+    so the function still answers on its own.
     """
-    task_drafts = drafts.list_task()
-    if chat_drafts is None:
-        chat_drafts = drafts.list_chat()
+    if only is not None and not _draft_shaped(only):
+        return []
+    if task_drafts is None or chat_drafts is None:
+        loaded_task, loaded_chat = drafts.list_all()
+        if task_drafts is None:
+            task_drafts = loaded_task
+        if chat_drafts is None:
+            chat_drafts = loaded_chat
     numbers = _draft_numbers(task_drafts, chat_drafts)
     rows = []
     for ident, record in task_drafts.items():
@@ -2384,10 +2409,10 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     # One scan of the runs tree for every row: which conversations are parked on
     # a card nobody has answered. See `_parked_runs`.
     parked = _parked_runs()
-    # One read of the drafts store for every row, for the same reason `read`
-    # and `busy` are read once: it is one small file, and the join below asks
-    # it per session.
-    chat_drafts = drafts.list_chat()
+    # ONE read of the drafts store for the whole build, for the same reason
+    # `read` and `busy` are read once: it is one small file, the join below
+    # asks it per session, and `_draft_rows` asks it again.
+    task_drafts, chat_drafts = drafts.list_all()
     for task in tasks.values():
         _place(task)
     numbers = _numbers(tasks)
@@ -2425,7 +2450,7 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     # a draft has no messages and nothing to have read; before, because the
     # Board orders Upcoming off this list and a draft has to arrive already in
     # its place rather than appended past the end of the lane.
-    rows.extend(_draft_rows(only, chat_drafts))
+    rows.extend(_draft_rows(only, chat_drafts, task_drafts))
     rows.sort(key=_row_order)
     # The Current apps desk (current_apps.py) learns about NEW tasks here —
     # the one place every task on the machine passes, whatever started it.

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -2181,6 +2181,19 @@ def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
     so a backfill over a store that predates numbering reads in the order the
     drafts were actually typed. Degrades to no numbers on an unwritable state
     dir, exactly like `_numbers`: blank numbers, never a lost page.
+
+    `reproject=True` is the ONE way this differs from `_numbers`, and it is the
+    one thing a draft has that a task does not: a folder the user can still
+    change. The number is allocated at the first keystroke, under the folder the
+    modal opened on — change the folder afterwards and the number allocated in
+    the old project rode along into the new one, which is how a list of
+    TASK-001…015 came to show a TASK-202. A draft's number belongs to the
+    project it points at NOW, so the store drops the old mapping and allocates
+    afresh (`tasks_store.ensure_ids`); the old number stays spent, a gap in the
+    project it was minted in. Nothing is renumbered once the draft is scheduled
+    — that rekey onto `pending:` is what fixes it for good (Akshil,
+    2026-09-11). `new:<file>` chat drafts carry their file IN the key and so can
+    never move, which is why one flag covers both kinds here.
     """
     items = []
     for ident, record in task_drafts.items():
@@ -2197,7 +2210,7 @@ def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
     if not items:
         return {}
     try:
-        return tasks_store.ensure_ids(items)
+        return tasks_store.ensure_ids(items, reproject=True)
     except OSError:
         return {}
 

--- a/fused_render/tasks_store.py
+++ b/fused_render/tasks_store.py
@@ -26,6 +26,21 @@ deleted. A number the user has seen, quoted in a note, or typed into a message
 must keep meaning the same thing, and a compacting scheme buys tidiness by
 breaking that. Gaps are the price and they are the correct price.
 
+**A draft is the one row whose project can still change**, and it is the one
+exception this rule needs. The New task modal numbers what you are typing at the
+first keystroke, in whatever folder the form is pointed at THEN — and then the
+person changes the folder. Allocate-once let the number ride along, so a project
+counting TASK-001…015 showed a TASK-202 borrowed from the project the draft was
+started in (Akshil, 2026-09-11). Nothing had been promised: a draft is not a
+task yet, nobody has quoted its number in a note, and the number it shows is a
+claim about which project it belongs to. So `ensure_ids(…, reproject=True)`
+drops the mapping of a draft whose project has moved and allocates afresh in the
+project it NOW points at. The old number is SPENT, never released (`_spend`) —
+a gap in the old project, which is the same price every delete above pays. The
+moment the draft becomes a real task (`rekey` onto `pending:<entry-id>`) the
+number is fixed like every other, because from there on it is one the user has
+been shown as booked.
+
 A task that exists before its session does (§5: a message scheduled for
 tomorrow has nothing to run in yet) is keyed `pending:<entry-id>` and gets its
 number then. `rekey` moves that number onto the session id at the first run, so
@@ -120,6 +135,11 @@ READ_FILE = "read.json"
 # What a task with no session yet is keyed by (§5). The entry id is already
 # unique and already sorts by due time, so nothing is minted for this.
 PENDING_PREFIX = "pending:"
+
+# What a number nobody holds any more is parked under (`_spend`). Not a task
+# key and never read as one: a `(project, n)` pair is allocated exactly once, so
+# this can collide with no session id, no `pending:` key and no draft key.
+SPENT_PREFIX = "spent:"
 
 # Zero-padded to three, and no further: TASK-1000 is simply four digits wide.
 # Padding is for a column of numbers to line up, not a limit.
@@ -244,7 +264,21 @@ def _next_numbers(store: dict) -> dict[str, int]:
     return high
 
 
-def ensure_ids(items, rekeys=()) -> dict[str, str]:
+def _spend(store: dict, rec: dict) -> None:
+    """Park a number nobody holds any more where nothing will hand it out again.
+
+    Releasing a number is the one thing allocate-once forbids, and a record
+    simply DELETED would release it: `_next_numbers` reads the high-water mark
+    straight off this store, so dropping the highest record in a project hands
+    that number to the next task there — the exact renumber `rekey` refuses to
+    cause and `forget_session` keeps a reservation to avoid. The reservation
+    here is the same idea under a key that is not a task's: the mark stands, the
+    number becomes a gap, and nothing joins a row onto it (Akshil, 2026-09-11).
+    """
+    store[SPENT_PREFIX + "%s#%d" % (rec["project"], rec["n"])] = dict(rec)
+
+
+def ensure_ids(items, rekeys=(), reproject=False) -> dict[str, str]:
     """Numbers for `items`, allocating any that are missing.
 
     `items` is an iterable of `(key, project, order)`: the task key (a session
@@ -256,9 +290,17 @@ def ensure_ids(items, rekeys=()) -> dict[str, str]:
     a session that has just minted its id keeps the number its pending row was
     already showing rather than being renumbered by the allocation below it.
 
-    Idempotent: an item that already has a number is left exactly as it is, so
-    calling this on every listing costs one read and no write once the store has
-    caught up.
+    `reproject` is the DRAFT rule (see the module docstring): with it on, an
+    item whose stored record names a different project than the one passed has
+    that record spent and a new number allocated in the project it now names.
+    Only the draft listing passes it — `routers/tasks.py::_draft_numbers` — and
+    a `pending:` key is skipped even there, because a booked task's number is
+    one the user has already been shown as final. Off by default, so every other
+    caller keeps the plain allocate-once behaviour.
+
+    Idempotent: an item that already has a number in the project it is passed
+    under is left exactly as it is, so calling this on every listing costs one
+    read and no write once the store has caught up.
     """
     items = [
         (str(key), str(project or ""), order)
@@ -286,6 +328,27 @@ def ensure_ids(items, rekeys=()) -> dict[str, str]:
             store.pop(old, None)
             store[new] = rec
             changed = True
+
+        if reproject:
+            for key, project, _order in items:
+                # Never a booked row: `pending:<entry-id>` is a scheduled task
+                # whose number the user has been watching, and moving THAT is
+                # the renumber schedule.py's `replaces` rekey exists to prevent.
+                if key.startswith(PENDING_PREFIX):
+                    continue
+                # A draft whose target has been CLEARED names no project, and
+                # "somewhere else" is not somewhere: it keeps the number it has
+                # until it points at a folder again, which costs nothing and
+                # saves a number every time a half-typed path resolves to a
+                # different parent on its way to the real one.
+                if not project:
+                    continue
+                rec = _record(store, key)
+                if rec is None or rec["project"] == project:
+                    continue
+                _spend(store, rec)
+                store.pop(key, None)
+                changed = True
 
         high = _next_numbers(store)
         missing = [it for it in items if _record(store, it[0]) is None]

--- a/tests/test_claude_schedule_button.py
+++ b/tests/test_claude_schedule_button.py
@@ -369,8 +369,18 @@ def test_the_link_beats_the_guess_and_an_edit_beats_the_link(modal):
     """Three sources for one field, in order: a stored target (Edit), the folder
     a link named, and only then defaultTargetOf() — the server's resolved
     workspace, which is what you offer when nobody said."""
-    assert modal.count('editing?.target ?? initialTarget ?? ""') == 2, \
-        "the state and the dirty baseline must be the same expression"
+    # ONE const, read twice — not the same expression written out twice
+    # (Akshil, 2026-09-11). It used to be the literal in both seats and this
+    # counted them; the draft work added a fourth source in front of the three
+    # (a re-opened draft's own stored target), and repeating a four-term
+    # precedence chain in two places is exactly the drift the count was guarding
+    # against. The guarantee is unchanged and now structural: there is one
+    # expression, so the state and the dirty baseline cannot disagree.
+    assert modal.count('const initialTargetValue = ') == 1
+    assert 'editing?.target ?? initialTarget ?? ""' in modal, \
+        "Edit beats the link beats the guess"
+    assert modal.count("initialTargetValue") == 3, \
+        "the const, the state seed, and the dirty baseline"
     # the async default only fills a still-EMPTY field, which is what keeps it
     # from clobbering the link's target when getConfig resolves
     effect = modal[modal.index("getConfig().then("):]

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -931,3 +931,77 @@ def test_the_rule_rides_down_on_the_draft_row(client, tmp_path):
     row = _by_key(client)["draft:draft-0001"]
     assert row["form"]["repeat"] == "custom"
     assert row["form"]["custom_rule"] == rule
+
+
+# ------------------------------------------- one read of the file, one lock
+
+
+def test_list_all_answers_both_halves_off_one_read(state_dir, monkeypatch):
+    """`list_task()` and `list_chat()` are each a whole `load()`, and the tasks
+    listing wants both on every build. Same projections, half the reads."""
+    drafts.put_task("draft-0001", {"title": "Nightly report"})
+    drafts.put_chat("sess-a", "half a thought", [])
+
+    reads = []
+    real = drafts.load
+    monkeypatch.setattr(drafts, "load", lambda: (reads.append(1), real())[1])
+
+    task, chat = drafts.list_all()
+    assert len(reads) == 1
+    assert task == drafts.list_task()
+    assert chat == drafts.list_chat()
+
+
+def test_a_narrowed_build_about_nothing_draft_shaped_never_takes_the_ids_lock(
+        client, projects_dir, tmp_path, monkeypatch):
+    """`ensure_ids(reproject=True)` is a write-shaped pass under the task_ids
+    lock, and `_draft_numbers` was taking it on EVERY build — including the
+    `/api/tasks/changes` builds narrowed to one unrelated session. `_draft_rows`
+    only ever emits `draft:`/`new:` keys (a chat draft on a real session is a
+    CHIP on that session's row, not a row), so such a build had no draft row to
+    find and was paying the lock for an empty list."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj",
+                      [_user("pull today's news", T9)])
+    # Both kinds of draft exist, so the skip is about the NARROWING and not
+    # about an empty store — and sess-a carries a chat draft of its own, the
+    # one thing a session key does have to keep answering for.
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "target": str(tmp_path)})
+    client.put("/api/drafts/chat/sess-a", json={"text": "half a thought"})
+
+    calls = []
+    real = tasks_store.ensure_ids
+    monkeypatch.setattr(tasks_store, "ensure_ids",
+                        lambda *a, **kw: (calls.append(kw), real(*a, **kw))[1])
+
+    rows = tasks_mod._task_rows(only=frozenset({"sess-a"}))
+    assert [r["key"] for r in rows] == ["sess-a"]
+    # The chip is still joined on — that read is the build's own, not the
+    # draft-row half's.
+    assert rows[0]["draft"]["preview"] == "half a thought"
+    assert not any(kw.get("reproject") for kw in calls)
+
+    # ...and a build that DOES name a draft still numbers it.
+    calls.clear()
+    rows = tasks_mod._task_rows(only=frozenset({"draft:draft-0001"}))
+    assert [r["key"] for r in rows] == ["draft:draft-0001"]
+    assert any(kw.get("reproject") for kw in calls)
+
+
+def test_the_full_listing_is_unchanged_by_the_narrowing(client, projects_dir,
+                                                        tmp_path):
+    """The skip is `only`-only: an unnarrowed build still builds every draft
+    row, numbers and all."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj",
+                      [_user("pull today's news", T9)])
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "target": str(tmp_path)})
+    client.put(f"/api/drafts/chat/{quote('new:' + str(tmp_path), safe='')}",
+               json={"text": "never sent"})
+
+    rows = _by_key(client)
+    assert rows["draft:draft-0001"]["title"] == "Nightly report"
+    assert rows["draft:draft-0001"]["task_id"]
+    chat_key = "new:" + str(tmp_path)
+    assert rows[chat_key]["title"] == "never sent"
+    assert rows[chat_key]["task_id"]

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -1,0 +1,757 @@
+"""Drafts — the store (fused_render/drafts.py), the routes
+(server/routers/drafts.py), and the two joins onto the Tasks listing.
+
+What is under test is what design.md decided and nothing else: a draft lives on
+the server in one global file, an empty draft is a delete, a task draft is a row
+with no TASK number, a chat draft is a one-line preview on its session's row,
+and every verb that ends a task — archive, delete, erase, and scheduling the
+draft for real — takes the draft with it.
+
+Nothing here reads the real ~/.claude or the real ~/.fused-render: every path is
+under tmp_path, and `drafts.STATE_DIR` is redirected alongside tasks_store's
+because both are computed at import from the same env var.
+"""
+import json
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render import drafts, schedule, schedule_wake, tasks_store
+from fused_render.server import create_app
+from fused_render.server.routers import claude_sessions as sessions_mod
+from fused_render.server.routers import tasks as tasks_mod
+
+WRITE = {"X-Fused": "1"}
+
+
+@pytest.fixture(autouse=True)
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+
+
+@pytest.fixture(autouse=True)
+def projects_dir(tmp_path, monkeypatch):
+    d = tmp_path / "claude-projects"
+    d.mkdir()
+    monkeypatch.setattr(tasks_store, "PROJECTS_DIR", str(d))
+    monkeypatch.setattr(sessions_mod, "PROJECTS_DIR", str(d))
+    return d
+
+
+@pytest.fixture(autouse=True)
+def state_dir(tmp_path, monkeypatch):
+    """The one global dir all three stores share. `drafts.STATE_DIR` is derived
+    from the env at import exactly like `tasks_store.STATE_DIR`, so a test that
+    redirects one and not the other would write drafts into the developer's own
+    ~/.fused-render."""
+    d = tmp_path / "state" / "claude-sessions"
+    d.mkdir(parents=True)
+    monkeypatch.setattr(tasks_store, "STATE_DIR", str(d))
+    monkeypatch.setattr(sessions_mod, "STATE_DIR", str(d))
+    monkeypatch.setattr(drafts, "STATE_DIR", str(d))
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    tasks_mod.reset_cache()
+    sessions_mod._HEAD_CACHE.clear()
+    yield
+    tasks_mod.reset_cache()
+    sessions_mod._HEAD_CACHE.clear()
+
+
+@pytest.fixture(autouse=True)
+def no_real_wake(monkeypatch):
+    monkeypatch.setattr(schedule_wake, "sync", lambda due: None)
+
+
+@pytest.fixture()
+def client(tmp_path):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+T9 = "2026-09-11T09:00:00Z"
+T10 = "2026-09-11T10:00:00Z"
+
+
+def _write_transcript(projects_dir, session_id, cwd, records):
+    d = projects_dir / ("-encoded-" + session_id)
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{session_id}.jsonl"
+    lines = []
+    for i, record in enumerate(records):
+        record = dict(record)
+        record.setdefault("cwd", cwd)
+        record.setdefault("sessionId", session_id)
+        record.setdefault("uuid", f"{session_id}-{i}")
+        lines.append(json.dumps(record))
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _user(text, ts):
+    return {"type": "user", "timestamp": ts,
+            "message": {"role": "user",
+                        "content": [{"type": "text", "text": text}]}}
+
+
+def _by_key(client):
+    r = client.get("/api/tasks")
+    assert r.status_code == 200, r.text
+    return {t["key"]: t for t in r.json()["tasks"]}
+
+
+# ---------------------------------------------------------------- the store
+
+
+def test_a_chat_draft_round_trips(state_dir):
+    stored = drafts.put_chat("sess-a", "half a thought", [])
+    assert stored["text"] == "half a thought"
+    assert stored["updated_at"] > 0
+    assert drafts.get_chat("sess-a")["text"] == "half a thought"
+    assert list(drafts.list_chat()) == ["sess-a"]
+    # One file, in the global dir every other session store uses.
+    assert (state_dir / "drafts.json").exists()
+
+
+def test_an_empty_chat_draft_is_a_delete(state_dir):
+    """The composer's autosave fires again after the send cleared the box, and
+    that write must not resurrect what the send deleted."""
+    drafts.put_chat("sess-a", "typing", [])
+    assert drafts.put_chat("sess-a", "   ", []) is None
+    assert drafts.get_chat("sess-a") is None
+    assert drafts.list_chat() == {}
+
+
+def test_attachments_alone_keep_a_chat_draft(state_dir):
+    """A picture dropped into an empty composer is a draft. Text is not the
+    only thing a person can leave unsent."""
+    stored = drafts.put_chat("sess-a", "", [
+        {"path": "/shots/a1b2.png", "name": "screenshot.png", "kind": "image"}])
+    assert stored is not None
+    assert stored["attachments"] == [
+        {"path": "/shots/a1b2.png", "name": "screenshot.png", "kind": "image"}]
+
+
+def test_an_unreadable_attachment_row_is_dropped_not_raised(state_dir):
+    """Lenient where schedule._attachments is strict — see the module
+    docstring: a draft that refused to save over a malformed row would be the
+    store failing at its only job."""
+    stored = drafts.put_chat("sess-a", "hi", [
+        "not-an-object", {"name": "no path"},
+        {"path": "/shots/x.pdf", "name": "../../etc/passwd", "kind": "nonsense"}])
+    assert stored["attachments"] == [
+        # The name is a BASENAME and the unknown kind fell back to the first.
+        {"path": "/shots/x.pdf", "name": "passwd", "kind": "image"}]
+
+
+def test_a_new_chat_key_is_accepted_and_a_bad_one_is_not(state_dir):
+    """Two shapes, because a chat has two ages (design.md, "Chat draft key")."""
+    assert drafts.chat_key("sess-a") == "sess-a"
+    assert drafts.chat_key("new:/Users/me/x.py") == "new:/Users/me/x.py"
+    assert drafts.is_new_chat_key("new:/Users/me/x.py") is True
+    assert drafts.chat_key("/etc/passwd") == ""
+    assert drafts.chat_key("") == ""
+    assert drafts.chat_key(None) == ""
+    assert drafts.chat_key("x" * 600) == ""
+
+
+def test_a_draft_id_is_a_token(state_dir):
+    assert drafts.draft_id("d-1234-abcd") == "d-1234-abcd"
+    assert drafts.draft_id("short") == "", "under eight characters"
+    assert drafts.draft_id("has/slash/init") == ""
+    assert drafts.put_task("nope", {"title": "x"}) is None
+
+
+def test_a_task_draft_merges_fields_and_keeps_created_at(state_dir):
+    first = drafts.put_task("draft-0001", {"title": "Ship it", "junk": "dropped"})
+    assert "junk" not in first
+    assert first["title"] == "Ship it"
+    assert first["created_at"] == first["updated_at"]
+
+    # A second autosave sends only what changed; the rest stands.
+    second = drafts.put_task("draft-0001", {"target": "/tmp/proj"})
+    assert second["title"] == "Ship it"
+    assert second["target"] == "/tmp/proj"
+    assert second["created_at"] == first["created_at"], "the row must sit still"
+
+
+def test_when_and_repeat_pass_through_whatever_the_form_held(state_dir):
+    """A structured repeat is an object and a cron line is a string; the modal
+    has to reopen on exactly what it closed on."""
+    stored = drafts.put_task("draft-0001", {
+        "when": "2026-09-12T09:00", "repeat": {"every": "week", "on": ["mon"]}})
+    assert stored["when"] == "2026-09-12T09:00"
+    assert stored["repeat"] == {"every": "week", "on": ["mon"]}
+
+
+def test_an_all_empty_task_draft_is_a_delete(state_dir):
+    drafts.put_task("draft-0001", {"title": "Ship it"})
+    assert drafts.put_task("draft-0001", {"title": "  "}) is None
+    assert drafts.get_task("draft-0001") is None
+    assert drafts.delete_task("draft-0001") is False
+
+
+def test_a_corrupt_store_reads_as_no_drafts(state_dir):
+    (state_dir / "drafts.json").write_text("{ not json")
+    assert drafts.list_chat() == {}
+    assert drafts.list_task() == {}
+    # ...and writing over it still works.
+    assert drafts.put_chat("sess-a", "recovered", []) is not None
+
+
+def test_the_preview_is_the_first_non_empty_line(state_dir):
+    assert drafts.preview("\n\n  hello there \nsecond line") == "hello there"
+    assert drafts.preview("   \n\t") == ""
+    long_line = "x" * 500
+    clipped = drafts.preview(long_line)
+    assert len(clipped) == drafts.PREVIEW_MAX
+    assert clipped.endswith("…")
+
+
+# ---------------------------------------------------------------- the routes
+
+
+def test_the_chat_routes_upsert_and_delete(client):
+    r = client.put("/api/drafts/chat/sess-a", json={"text": "unsent"})
+    assert r.status_code == 200, r.text
+    assert r.json()["draft"]["text"] == "unsent"
+
+    assert client.get("/api/drafts").json()["chat"]["sess-a"]["text"] == "unsent"
+
+    # Empty in is a delete, and the answer says so.
+    assert client.put("/api/drafts/chat/sess-a", json={"text": ""}).json()["draft"] is None
+    assert client.get("/api/drafts").json()["chat"] == {}
+
+    # Deleting one that was never saved is not a 404 — the composer clears
+    # after a send whether or not the debounce ever got round to a first save.
+    r = client.delete("/api/drafts/chat/sess-a")
+    assert r.status_code == 200
+    assert r.json()["removed"] is False
+
+
+def test_a_new_chat_key_round_trips_through_the_route(client):
+    """The key carries a file path, so the route has to accept separators."""
+    r = client.put("/api/drafts/chat/new:%2FUsers%2Fme%2Fx.py",
+                   json={"text": "before the first send"})
+    assert r.status_code == 200, r.text
+    assert r.json()["key"] == "new:/Users/me/x.py"
+    assert client.get("/api/drafts").json()["chat"]["new:/Users/me/x.py"]["text"] \
+        == "before the first send"
+
+
+def test_a_bad_key_is_a_400(client):
+    assert client.put("/api/drafts/chat/%2Fetc%2Fpasswd",
+                      json={"text": "x"}).status_code == 400
+    assert client.put("/api/drafts/task/short", json={"title": "x"}).status_code == 400
+    assert client.delete("/api/drafts/task/short").status_code == 400
+
+
+def test_the_task_routes_upsert_and_delete(client):
+    r = client.put("/api/drafts/task/draft-0001",
+                   json={"title": "Nightly report", "target": "/tmp/proj"})
+    assert r.status_code == 200, r.text
+    assert r.json()["draft"]["title"] == "Nightly report"
+
+    assert list(client.get("/api/drafts").json()["task"]) == ["draft-0001"]
+
+    r = client.delete("/api/drafts/task/draft-0001")
+    assert r.json() == {"ok": True, "draft_id": "draft-0001", "removed": True}
+    assert client.get("/api/drafts").json()["task"] == {}
+
+
+def test_every_mutation_bumps_the_watch_generation(client):
+    """The chip has to appear without a reload, which is the long-poll's job.
+
+    EVERY key, including `new:` — round 1 kept that one silent because no row
+    carried it, and round 2 gave it a row of its own (Akshil, 2026-09-11)."""
+    before = client.get("/api/tasks").json()["generation"]
+    client.put("/api/drafts/chat/sess-a", json={"text": "unsent"})
+    after = client.get("/api/tasks").json()["generation"]
+    assert after > before
+
+    client.put("/api/drafts/chat/new:%2Ftmp%2Fx.py", json={"text": "unsent"})
+    assert client.get("/api/tasks").json()["generation"] > after
+
+
+# ----------------------------------------------------------------- the joins
+
+
+def test_a_session_row_carries_its_chat_draft(client, projects_dir):
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj",
+                      [_user("pull today's news", T9)])
+    assert _by_key(client)["sess-a"]["draft"] is None
+
+    client.put("/api/drafts/chat/sess-a",
+               json={"text": "\nand also check the\nsecond line"})
+    row = _by_key(client)["sess-a"]
+    assert row["draft"]["preview"] == "and also check the"
+    assert row["draft"]["updated_at"] > 0
+
+    client.delete("/api/drafts/chat/sess-a")
+    assert _by_key(client)["sess-a"]["draft"] is None
+
+
+def test_a_task_draft_is_a_row_with_a_number(client, tmp_path):
+    target = tmp_path / "proj"
+    target.mkdir()
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "description": "roll it up",
+                     "target": str(target), "model": "opus"})
+    row = _by_key(client)["draft:draft-0001"]
+    assert row["kind"] == "draft"
+    assert row["draft_kind"] == "task"
+    assert row["state"] == "draft"
+    assert row["draft_id"] == "draft-0001"
+    # ROUND 2: a draft is a thing you can name, so it is numbered — allocated
+    # in the project it points at, through the same store `pending:` rows use.
+    assert row["task_id"] == "TASK-001"
+    assert tasks_store.task_number("draft:draft-0001") == "TASK-001"
+    assert row["title"] == "Nightly report"
+    # The same rule every other row's project follows (`_workdir`): a folder
+    # target IS the project, a file target is the folder it sits in.
+    assert row["target"] == str(target)
+    assert row["project"] == str(target)
+    assert row["when"] is None
+    assert row["session_id"] == ""
+    assert row["message_count"] == 0
+    assert row["happened_at"] == 0.0
+    assert row["at"] == row["created_at"] > 0
+    assert row["updated_at"] > 0
+    # The whole form, so the modal can reopen on it without a second request.
+    assert row["form"]["model"] == "opus"
+    assert row["form"]["description"] == "roll it up"
+
+
+def test_a_draft_row_falls_back_to_its_description_then_to_a_name(client):
+    client.put("/api/drafts/task/draft-0001",
+               json={"description": "  \nroll up yesterday's PRs\nand file them"})
+    assert _by_key(client)["draft:draft-0001"]["title"] == "roll up yesterday's PRs"
+
+    client.put("/api/drafts/task/draft-0002", json={"model": "opus"})
+    assert _by_key(client)["draft:draft-0002"]["title"] == "Untitled draft"
+
+
+def test_draft_rows_reach_the_changes_endpoint_but_not_the_pulse(client):
+    """A new draft has to appear without a reload (changes), and must not be
+    counted as news in the sidebar (pulse) — design.md puts drafts in the List
+    and the Board only."""
+    before = client.get("/api/tasks").json()["generation"]
+    client.put("/api/drafts/task/draft-0001", json={"title": "Nightly report"})
+
+    r = client.get(f"/api/tasks/changes?since={before}&wait=0")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert [row["key"] for row in body["rows"]] == ["draft:draft-0001"]
+    assert body["gone"] == []
+
+    assert [t["key"] for t in client.get("/api/tasks/pulse").json()["tasks"]] == []
+
+    # ...and discarding it names the key as gone rather than leaving the row.
+    gen = body["generation"]
+    client.delete("/api/drafts/task/draft-0001")
+    body = client.get(f"/api/tasks/changes?since={gen}&wait=0").json()
+    assert body["rows"] == []
+    assert body["gone"] == ["draft:draft-0001"]
+
+
+# ------------------------------------------------------------- the lifecycle
+
+
+def test_archiving_a_task_drops_its_chat_draft(client, projects_dir):
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj",
+                      [_user("pull today's news", T9)])
+    client.put("/api/drafts/chat/sess-a", json={"text": "unsent"})
+
+    r = client.post("/api/tasks/archive", json={"key": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert drafts.get_chat("sess-a") is None
+    assert _by_key(client)["sess-a"]["draft"] is None
+
+
+def test_deleting_and_erasing_a_task_drop_its_chat_draft(client, projects_dir):
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj",
+                      [_user("one", T9)])
+    _write_transcript(projects_dir, "sess-b", "/home/me/proj",
+                      [_user("two", T10)])
+    client.put("/api/drafts/chat/sess-a", json={"text": "unsent a"})
+    client.put("/api/drafts/chat/sess-b", json={"text": "unsent b"})
+
+    assert client.post("/api/tasks/delete", json={"key": "sess-a"}).status_code == 200
+    assert drafts.get_chat("sess-a") is None
+    assert drafts.get_chat("sess-b") is not None
+
+    assert client.post("/api/tasks/erase", json={"key": "sess-b"}).status_code == 200
+    assert drafts.get_chat("sess-b") is None
+
+
+def test_scheduling_a_draft_deletes_it_in_the_same_request(client, tmp_path):
+    target = tmp_path / "project"
+    target.mkdir()
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "target": str(target)})
+    assert "draft:draft-0001" in _by_key(client)
+
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(target), "message": "roll it up",
+                          "delay_seconds": 600, "title": "Nightly report",
+                          "draft_id": "draft-0001"})
+    assert r.status_code == 200, r.text
+    assert drafts.get_task("draft-0001") is None
+    rows = _by_key(client)
+    assert "draft:draft-0001" not in rows, "one task, not two"
+    assert any(row["title"] == "Nightly report" for row in rows.values())
+
+
+def test_a_schedule_without_a_draft_id_is_unchanged(client, tmp_path):
+    """Every client written before drafts existed sends no `draft_id`, and the
+    `?new=1` hop still does not."""
+    target = tmp_path / "project"
+    target.mkdir()
+    drafts.put_task("draft-0001", {"title": "keep me"})
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(target), "message": "hi",
+                          "delay_seconds": 600})
+    assert r.status_code == 200, r.text
+    assert r.json()["entry"]["state"] == schedule.PENDING
+    assert drafts.get_task("draft-0001") is not None
+
+
+# -------------------------------------------------------- round 2: numbers
+#
+# Every draft has a TASK number, and the number moves forward with the draft
+# rather than being minted again on the other side (design.md, "Round 2";
+# Akshil, 2026-09-11). What these hold is the pair of promises `allocate once,
+# never renumber` already makes for `pending:<entry-id>`, one stage earlier.
+
+
+def _chat_url(key: str) -> str:
+    return "/api/drafts/chat/" + quote(key, safe="")
+
+
+def test_a_draft_keeps_its_number_when_it_is_scheduled(client, tmp_path):
+    """The renumber this prevents is the one a person would actually notice:
+    pressing Schedule on the TASK-001 they had been typing into and watching a
+    TASK-002 appear."""
+    target = tmp_path / "project"
+    target.mkdir()
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "target": str(target)})
+    number = _by_key(client)["draft:draft-0001"]["task_id"]
+    assert number == "TASK-001"
+
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(target), "message": "roll it up",
+                          "delay_seconds": 600, "title": "Nightly report",
+                          "draft_id": "draft-0001"})
+    assert r.status_code == 200, r.text
+    entry_id = r.json()["entry"]["id"]
+
+    rows = _by_key(client)
+    assert "draft:draft-0001" not in rows, "one task, not two"
+    assert rows["pending:" + entry_id]["task_id"] == number
+
+
+def test_a_discarded_draft_does_not_give_its_number_back(client, tmp_path):
+    """Gaps are the price. Releasing a number is the one thing allocate-once
+    forbids — the project's high-water mark would drop and the next draft would
+    be handed a number the user has already seen on something else."""
+    target = tmp_path / "project"
+    target.mkdir()
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "one", "target": str(target)})
+    assert _by_key(client)["draft:draft-0001"]["task_id"] == "TASK-001"
+
+    assert client.delete("/api/drafts/task/draft-0001").status_code == 200
+    client.put("/api/drafts/task/draft-0002",
+               json={"title": "two", "target": str(target)})
+    assert _by_key(client)["draft:draft-0002"]["task_id"] == "TASK-002"
+    # ...and the discarded one's record is still in the store, unread by
+    # anything, holding the mark.
+    assert tasks_store.task_number("draft:draft-0001") == "TASK-001"
+
+
+# ----------------------------------------------- round 2: new-chat drafts
+
+
+def test_an_unsent_new_chat_is_a_row(client, tmp_path):
+    """A folder somebody has typed into but never sent is the same unfinished
+    thing as a half-filled form, and round 1 listed only one of the two."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    view = folder / "page.html"
+    view.write_text("<p>hi</p>")
+    key = "new:" + str(view)
+
+    r = client.put(_chat_url(key), json={"text": "look at the chart\nand fix it"})
+    assert r.status_code == 200, r.text
+
+    row = _by_key(client)[key]
+    assert row["kind"] == "draft"
+    assert row["draft_kind"] == "chat"
+    assert row["state"] == "draft"
+    assert row["status"] == "upcoming"
+    assert row["task_id"] == "TASK-001"
+    assert row["draft_id"] == ""
+    assert row["session_id"] == ""
+    assert row["title"] == "look at the chart", "the first line, nothing else"
+    # The FOLDER is the project — the file is what the chat opens on.
+    assert row["project"] == str(folder)
+    assert row["cwd"] == str(folder)
+    assert row["target"] == str(view)
+    assert row["file"] == str(view)
+    assert row["draft"]["preview"] == "look at the chart"
+    assert row["draft"]["updated_at"] > 0
+    assert row["form"] is None, "no form to reopen — it is a composer"
+    assert row["message_count"] == 0
+    assert row["happened_at"] == 0.0
+    assert row["when"] is None
+
+
+def test_a_new_chat_draft_on_a_folder_is_numbered_in_that_folder(client, tmp_path):
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "start here"})
+    row = _by_key(client)[key]
+    assert row["project"] == str(folder) == row["target"]
+    assert row["task_id"] == "TASK-001"
+
+
+def test_a_new_chat_draft_with_no_text_still_has_a_name(client, tmp_path):
+    """A picture dropped into an empty composer is a draft, and a draft row has
+    to be clickable, so it can never render as a blank line."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key),
+               json={"text": "", "attachments": [
+                   {"path": "/shots/a1.png", "name": "a1.png", "kind": "image"}]})
+    assert _by_key(client)[key]["title"] == "Untitled chat"
+
+
+def test_a_new_chat_draft_title_is_clipped(client, tmp_path):
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "y" * 300})
+    title = _by_key(client)[key]["title"]
+    assert len(title) == 80 and title.endswith("…")
+
+
+def test_new_chat_draft_rows_appear_and_vanish_through_the_changes_endpoint(
+        client, tmp_path):
+    """Round 1 announced nothing for a `new:` key — there was no row. There is
+    now, so it has to arrive and leave without a reload."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+
+    before = client.get("/api/tasks").json()["generation"]
+    client.put(_chat_url(key), json={"text": "unsent"})
+
+    body = client.get(f"/api/tasks/changes?since={before}&wait=0").json()
+    assert [row["key"] for row in body["rows"]] == [key]
+    assert body["rows"][0]["draft_kind"] == "chat"
+
+    gen = body["generation"]
+    client.delete(_chat_url(key))
+    body = client.get(f"/api/tasks/changes?since={gen}&wait=0").json()
+    assert body["rows"] == []
+    assert body["gone"] == [key]
+
+    # ...and never in the pulse. A form nobody has finished is not news.
+    client.put(_chat_url(key), json={"text": "unsent again"})
+    assert [t["key"] for t in client.get("/api/tasks/pulse").json()["tasks"]] == []
+
+
+# ------------------------------------------------- round 2: rekey forward
+
+
+def test_the_rekey_route_moves_the_number_onto_the_session(client, projects_dir,
+                                                           tmp_path):
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "first message"})
+    number = _by_key(client)[key]["task_id"]
+    assert number == "TASK-001"
+
+    # The send happened: Claude Code minted a session and wrote a transcript.
+    _write_transcript(projects_dir, "sess-a", str(folder),
+                      [_user("first message", T9)])
+    r = client.post("/api/drafts/chat/rekey", json={"from": key, "to": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert r.json()["task_id"] == number
+
+    rows = _by_key(client)
+    assert key not in rows, "the folder row is the session's row now"
+    assert rows["sess-a"]["task_id"] == number
+    assert tasks_store.task_number("sess-a") == number
+
+
+def test_the_rekey_route_deletes_a_draft_the_send_already_emptied(client, tmp_path):
+    """The normal case: the send cleared the box, so there is nothing to move
+    and the `new:` key is simply gone."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "first message"})
+    client.put(_chat_url(key), json={"text": ""})  # the send
+
+    r = client.post("/api/drafts/chat/rekey", json={"from": key, "to": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert r.json()["moved"] is False
+    assert drafts.get_chat(key) is None
+    assert drafts.get_chat("sess-a") is None
+
+
+def test_the_rekey_route_carries_text_typed_after_the_send(client, tmp_path):
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "and one more thing"})
+
+    r = client.post("/api/drafts/chat/rekey", json={"from": key, "to": "sess-a"})
+    assert r.json()["moved"] is True
+    assert drafts.get_chat(key) is None
+    assert drafts.get_chat("sess-a")["text"] == "and one more thing"
+
+
+def test_the_rekey_route_is_a_no_op_for_a_draft_that_never_existed(client, tmp_path):
+    """The client fires this on every first send and cannot know whether the
+    debounce ever got round to a first save."""
+    key = "new:" + str(tmp_path / "proj")
+    r = client.post("/api/drafts/chat/rekey", json={"from": key, "to": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True, "from": key, "to": "sess-a",
+                        "task_id": "", "moved": False}
+
+
+def test_the_rekey_route_refuses_a_to_that_is_not_a_session(client, tmp_path):
+    key = "new:" + str(tmp_path / "proj")
+    assert client.post("/api/drafts/chat/rekey",
+                       json={"from": key, "to": "new:/tmp/x"}).status_code == 400
+    assert client.post("/api/drafts/chat/rekey",
+                       json={"from": key, "to": "/etc/passwd"}).status_code == 400
+    assert client.post("/api/drafts/chat/rekey",
+                       json={"from": "/etc/passwd", "to": "sess-a"}).status_code == 400
+    assert client.post("/api/drafts/chat/rekey",
+                       json={"from": "sess-a", "to": "sess-a"}).status_code == 400
+
+
+# --------------------------------------- round 2: a draft moves, never twice
+
+
+def test_a_task_draft_put_takes_the_chat_draft_it_came_from(client, tmp_path):
+    """The composer → New task hop. For one instant the same unfinished
+    sentence would be two rows; `from_chat_key` is the client naming the one it
+    came from, in the request that made the other."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "roll up yesterday's PRs"})
+    assert key in _by_key(client)
+
+    r = client.put("/api/drafts/task/draft-0001",
+                   json={"title": "roll up yesterday's PRs",
+                         "target": str(folder), "from_chat_key": key})
+    assert r.status_code == 200, r.text
+    assert r.json()["from_chat_key"] == key
+    assert drafts.get_chat(key) is None
+
+    rows = _by_key(client)
+    assert key not in rows
+    assert "draft:draft-0001" in rows
+    # …and the key is KEPT, because the move has to be reversible: the row's
+    # form is what a reopened modal seeds from, and "Back to chat" reads the
+    # key off it.
+    assert rows["draft:draft-0001"]["form"]["from_chat_key"] == key
+
+
+def test_the_chat_key_is_stored_and_survives_later_saves(client, tmp_path):
+    """The way back, once the hop's URL is gone.
+
+    A draft reopened from its row carries no `?back=` and no sessionStorage
+    stash — the stored key is the only thing left that knows which conversation
+    these words were typed in, so a keystroke save that names nothing must not
+    erase it (Akshil, 2026-09-11)."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "roll up yesterday's PRs"})
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "roll up", "target": str(folder),
+                     "from_chat_key": key})
+    stored = drafts.get_task("draft-0001")
+    assert stored["from_chat_key"] == key
+
+    # The ordinary autosave that follows sends the form and nothing else.
+    r = client.put("/api/drafts/task/draft-0001",
+                   json={"title": "roll up yesterday's PRs",
+                         "target": str(folder)})
+    assert r.json()["draft"]["from_chat_key"] == key
+    assert drafts.get_task("draft-0001")["from_chat_key"] == key
+    assert _by_key(client)["draft:draft-0001"]["form"]["from_chat_key"] == key
+
+
+def test_a_chat_key_that_is_not_one_is_stored_as_nothing(client, tmp_path):
+    """Validated as a key, not kept as text: the field is either something the
+    chat half can be written under or it is empty."""
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "a thought", "from_chat_key": "/etc/passwd"})
+    assert drafts.get_task("draft-0001")["from_chat_key"] == ""
+
+
+def test_the_chat_key_alone_is_not_a_draft(client, tmp_path):
+    """`from_chat_key` is provenance, not content — an all-empty form that
+    names one is still a delete."""
+    key = "new:" + str(tmp_path)
+    client.put(_chat_url(key), json={"text": "still here"})
+    r = client.put("/api/drafts/task/draft-0001",
+                   json={"title": "", "description": "", "from_chat_key": key})
+    assert r.json()["draft"] is None
+    assert drafts.get_task("draft-0001") is None
+    # …and the chat draft it named is untouched, for the same reason.
+    assert drafts.get_chat(key) is not None
+
+
+def test_a_session_chat_draft_is_taken_too(client, projects_dir):
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj",
+                      [_user("one", T9)])
+    client.put("/api/drafts/chat/sess-a", json={"text": "half a thought"})
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "half a thought", "from_chat_key": "sess-a"})
+    assert drafts.get_chat("sess-a") is None
+    assert _by_key(client)["sess-a"]["draft"] is None
+
+
+def test_an_empty_task_put_keeps_the_chat_draft(client, tmp_path):
+    """An all-empty form is a delete, and dropping the chat draft over a write
+    that stored nothing would lose the text outright."""
+    key = "new:" + str(tmp_path)
+    client.put(_chat_url(key), json={"text": "still here"})
+    r = client.put("/api/drafts/task/draft-0001",
+                   json={"title": "  ", "from_chat_key": key})
+    assert r.json()["draft"] is None
+    assert drafts.get_chat(key) is not None
+
+
+def test_scheduling_into_a_session_drops_that_session_chat_draft(client, tmp_path,
+                                                                 projects_dir):
+    """The words were just booked as a message; text left behind would paint a
+    `✎ Draft` chip on the very task that consumed it."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj",
+                      [_user("one", T9)])
+    target = tmp_path / "project"
+    target.mkdir()
+    client.put("/api/drafts/chat/sess-a", json={"text": "and then deploy"})
+
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(target), "message": "and then deploy",
+                          "delay_seconds": 600, "session_id": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert drafts.get_chat("sess-a") is None
+    assert _by_key(client)["sess-a"]["draft"] is None

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -18,6 +18,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from fused_render import drafts, schedule, schedule_wake, tasks_store
+from fused_render._view_url_codec import canonical_fs_path
 from fused_render.server import create_app
 from fused_render.server.routers import claude_sessions as sessions_mod
 from fused_render.server.routers import tasks as tasks_mod
@@ -311,9 +312,11 @@ def test_a_task_draft_is_a_row_with_a_number(client, tmp_path):
     assert tasks_store.task_number("draft:draft-0001") == "TASK-001"
     assert row["title"] == "Nightly report"
     # The same rule every other row's project follows (`_workdir`): a folder
-    # target IS the project, a file target is the folder it sits in.
-    assert row["target"] == str(target)
-    assert row["project"] == str(target)
+    # target IS the project, a file target is the folder it sits in. Compared
+    # through `canonical_fs_path`, the same normalisation the row itself
+    # applies — `str(target)` is backslashed on Windows, and the row is not.
+    assert row["target"] == canonical_fs_path(str(target))
+    assert row["project"] == canonical_fs_path(str(target))
     assert row["when"] is None
     assert row["session_id"] == ""
     assert row["message_count"] == 0
@@ -473,6 +476,70 @@ def test_a_discarded_draft_does_not_give_its_number_back(client, tmp_path):
     assert tasks_store.task_number("draft:draft-0001") == "TASK-001"
 
 
+def test_a_draft_changing_folder_is_renumbered_in_the_new_project(client, tmp_path):
+    """A draft's number belongs to the project it points at NOW.
+
+    The bug this ends: the number is allocated at the first keystroke, in
+    whatever folder the modal happened to open on, and then the person picks a
+    different one — the number rode along, and a project counting TASK-001…015
+    showed a TASK-202 borrowed from the project the draft was started in
+    (Akshil, 2026-09-11). Nothing has been promised while it is still a draft,
+    which is what makes this the one row allocate-once may renumber."""
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    beta = tmp_path / "beta"
+    beta.mkdir()
+    client.put("/api/drafts/task/draft-beta1",
+               json={"title": "already here", "target": str(beta)})
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "target": str(alpha)})
+    assert _by_key(client)["draft:draft-0001"]["task_id"] == "TASK-001"
+
+    # The folder changes — the same autosave PUT every other keystroke makes.
+    client.put("/api/drafts/task/draft-0001", json={"target": str(beta)})
+    row = _by_key(client)["draft:draft-0001"]
+    assert row["project"] == canonical_fs_path(str(beta))
+    assert row["title"] == "Nightly report", "an omitted field is not a delete"
+    assert row["task_id"] == "TASK-002", "beta's next free number, not alpha's"
+    assert tasks_store.task_number("draft:draft-0001") == "TASK-002"
+
+    # ...and alpha's TASK-001 is a GAP, not a number handed out twice: the same
+    # price a discarded draft pays two tests up.
+    client.put("/api/drafts/task/draft-0002",
+               json={"title": "later", "target": str(alpha)})
+    assert _by_key(client)["draft:draft-0002"]["task_id"] == "TASK-002"
+
+
+def test_a_moved_draft_keeps_the_new_number_when_it_is_scheduled(client, tmp_path):
+    """Scheduling is where the renumbering STOPS. The number the draft ends up
+    with is the one the pending row carries, so the last thing the user saw in
+    the modal is what they see in the list."""
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    beta = tmp_path / "beta"
+    beta.mkdir()
+    client.put("/api/drafts/task/draft-beta1",
+               json={"title": "already here", "target": str(beta)})
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "target": str(alpha)})
+    # Listed BEFORE the move, which is what allocates alpha's number — without
+    # it the draft would simply be numbered late, in beta, and prove nothing.
+    assert _by_key(client)["draft:draft-0001"]["task_id"] == "TASK-001"
+
+    client.put("/api/drafts/task/draft-0001", json={"target": str(beta)})
+    number = _by_key(client)["draft:draft-0001"]["task_id"]
+    assert number == "TASK-002"
+
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(beta), "message": "roll it up",
+                          "delay_seconds": 600, "title": "Nightly report",
+                          "draft_id": "draft-0001"})
+    assert r.status_code == 200, r.text
+    rows = _by_key(client)
+    assert "draft:draft-0001" not in rows, "one task, not two"
+    assert rows["pending:" + r.json()["entry"]["id"]]["task_id"] == number
+
+
 # ----------------------------------------------- round 2: new-chat drafts
 
 
@@ -497,11 +564,12 @@ def test_an_unsent_new_chat_is_a_row(client, tmp_path):
     assert row["draft_id"] == ""
     assert row["session_id"] == ""
     assert row["title"] == "look at the chart", "the first line, nothing else"
-    # The FOLDER is the project — the file is what the chat opens on.
-    assert row["project"] == str(folder)
-    assert row["cwd"] == str(folder)
-    assert row["target"] == str(view)
-    assert row["file"] == str(view)
+    # The FOLDER is the project — the file is what the chat opens on. Compared
+    # through `canonical_fs_path`, same as above.
+    assert row["project"] == canonical_fs_path(str(folder))
+    assert row["cwd"] == canonical_fs_path(str(folder))
+    assert row["target"] == canonical_fs_path(str(view))
+    assert row["file"] == canonical_fs_path(str(view))
     assert row["draft"]["preview"] == "look at the chart"
     assert row["draft"]["updated_at"] > 0
     assert row["form"] is None, "no form to reopen — it is a composer"
@@ -516,7 +584,7 @@ def test_a_new_chat_draft_on_a_folder_is_numbered_in_that_folder(client, tmp_pat
     key = "new:" + str(folder)
     client.put(_chat_url(key), json={"text": "start here"})
     row = _by_key(client)[key]
-    assert row["project"] == str(folder) == row["target"]
+    assert row["project"] == canonical_fs_path(str(folder)) == row["target"]
     assert row["task_id"] == "TASK-001"
 
 
@@ -755,3 +823,111 @@ def test_scheduling_into_a_session_drops_that_session_chat_draft(client, tmp_pat
     assert r.status_code == 200, r.text
     assert drafts.get_chat("sess-a") is None
     assert _by_key(client)["sess-a"]["draft"] is None
+
+
+# ----------------------------------------------- round 3: what Schedule takes
+#
+# Two things the first cut of the feature let slip past the create endpoint
+# (Bugbot, PR #1118). Both are about a draft OUTLIVING the thing it turned into,
+# which is the one outcome "a draft moves, never duplicates" forbids.
+
+
+def test_scheduling_a_hop_drops_the_chat_draft_it_came_from(client, tmp_path):
+    """The composer hop's chat draft, retired by the create rather than by the
+    task draft's first autosave.
+
+    That autosave is what normally moves it (`from_chat_key` on the task-draft
+    PUT), but a card opened from the Schedule button opens ready to send: press
+    it inside the 600 ms debounce and no task draft is minted at all, so nothing
+    ever names the chat key. `session_id` cannot stand in — a chat that has never
+    sent anything has no session, and its draft is keyed `new:<file>`."""
+    target = tmp_path / "project"
+    target.mkdir()
+    key = "new:" + str(target / "notes.py")
+    client.put(_chat_url(key), json={"text": "roll up the PRs"})
+    assert key in _by_key(client), "the unsent chat is a row of its own"
+
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(target), "message": "roll up the PRs",
+                          "delay_seconds": 600, "title": "Roll up the PRs",
+                          "from_chat_key": key})
+    assert r.status_code == 200, r.text
+    assert drafts.get_chat(key) is None
+    rows = _by_key(client)
+    assert key not in rows, "one task, not a task and the draft it came from"
+    assert any(row["title"] == "Roll up the PRs" for row in rows.values())
+
+
+def test_a_session_keyed_from_chat_key_is_taken_too(client, tmp_path, projects_dir):
+    """The same field carries the other shape — a chat that HAS a session, hopped
+    to the card before `session_id` was ever on the payload."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    target = tmp_path / "project"
+    target.mkdir()
+    client.put("/api/drafts/chat/sess-a", json={"text": "and then deploy"})
+
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(target), "message": "and then deploy",
+                          "delay_seconds": 600, "from_chat_key": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert drafts.get_chat("sess-a") is None
+
+
+def test_a_bad_or_absent_from_chat_key_changes_nothing(client, tmp_path):
+    """Optional and silently ignored — every client written before drafts
+    existed sends none, and a malformed one is not worth a 400 on a request that
+    has already scheduled the task."""
+    target = tmp_path / "project"
+    target.mkdir()
+    key = "new:" + str(target)
+    client.put(_chat_url(key), json={"text": "untouched"})
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(target), "message": "hi",
+                          "delay_seconds": 600, "from_chat_key": "/etc/passwd"})
+    assert r.status_code == 200, r.text
+    assert drafts.get_chat(key) is not None
+
+
+def test_a_custom_repeat_keeps_its_rule(state_dir):
+    """`repeat` is a preset KEY, and "custom" is a pointer at a rule the
+    recurrence dialog built. A draft that stored the key and dropped the rule
+    reopened saying Custom, holding nothing, with Save refused and nothing on the
+    card saying why."""
+    rule = {"freq": "week", "interval": 2, "byday": [1, 3]}
+    stored = drafts.put_task("draft-0001", {"title": "Standup notes",
+                                            "repeat": "custom",
+                                            "custom_rule": rule})
+    assert stored["custom_rule"] == rule
+    assert drafts.get_task("draft-0001")["custom_rule"] == rule
+    # Pass-through, not parsed: this store is not the authority on what a
+    # recurrence rule looks like, and a shape it validated would be a second
+    # copy of `recur`'s grammar going stale.
+    assert drafts.put_task("draft-0002", {"custom_rule": {"freq": "fortnight"}}
+                           )["custom_rule"] == {"freq": "fortnight"}
+    # A field the client omits keeps what the stored draft had, like every other.
+    assert drafts.put_task("draft-0001", {"title": "Standup"}
+                           )["custom_rule"] == rule
+    # …and clearing the choice clears the rule with it.
+    assert drafts.put_task("draft-0001", {"repeat": None, "custom_rule": None}
+                           )["custom_rule"] is None
+
+
+def test_a_rule_alone_is_still_a_draft(state_dir):
+    """`_empty_task` asks "is there anything a person chose here", and opening
+    the recurrence dialog and building a rule is exactly that."""
+    assert drafts.put_task("draft-0001",
+                           {"custom_rule": {"freq": "month"}}) is not None
+    assert drafts.put_task("draft-0001", {"custom_rule": None}) is None
+    assert drafts.get_task("draft-0001") is None
+
+
+def test_the_rule_rides_down_on_the_draft_row(client, tmp_path):
+    """The row's `form` is what the modal reopens on, so the rule has to be in
+    it or the round trip is only half built."""
+    rule = {"freq": "month", "monthly": "nth-weekday"}
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Monthly report", "target": str(tmp_path),
+                     "repeat": "custom", "custom_rule": rule})
+    row = _by_key(client)["draft:draft-0001"]
+    assert row["form"]["repeat"] == "custom"
+    assert row["form"]["custom_rule"] == rule

--- a/tests/test_tasks_store.py
+++ b/tests/test_tasks_store.py
@@ -157,6 +157,64 @@ def test_rekey_of_something_that_has_no_number_does_nothing():
     assert tasks_store.task_ids() == {}
 
 
+# --------------------------------------------------- a draft that moves house
+
+
+def test_reproject_renumbers_a_draft_in_the_project_it_now_points_at():
+    """The one exception to allocate-once, and only for a row nobody has been
+    promised anything about: a draft numbered under the folder the modal opened
+    on and then pointed somewhere else (Akshil, 2026-09-11)."""
+    draft = "draft:d1"
+    assert tasks_store.ensure_ids([(draft, "/a", 1.0)],
+                                  reproject=True)[draft] == "TASK-001"
+    assert tasks_store.ensure_ids([(draft, "/b", 1.0)],
+                                  reproject=True)[draft] == "TASK-001", \
+        "the first number of /b, not the one it carried out of /a"
+    assert tasks_store.task_ids()[draft] == {"project": "/b", "n": 1}
+    # Idempotent from there: the project it names is the project it is in.
+    assert tasks_store.ensure_ids([(draft, "/b", 1.0)],
+                                  reproject=True)[draft] == "TASK-001"
+
+
+def test_a_reprojected_number_is_spent_not_released():
+    """Gaps over renumbering, the same price every delete in here pays: /a's
+    high-water mark stands, so nothing is handed TASK-001 twice."""
+    draft = "draft:d1"
+    tasks_store.ensure_ids([(draft, "/a", 1.0)], reproject=True)
+    tasks_store.ensure_ids([(draft, "/b", 1.0)], reproject=True)
+    assert tasks_store.ensure_ids([("next", "/a", 2.0)])["next"] == "TASK-002"
+
+
+def test_a_booked_number_is_never_reprojected():
+    """`pending:<entry-id>` is a scheduled task, and its number is one the user
+    has already been shown as final — the renumber schedule.py's `replaces`
+    rekey exists to prevent."""
+    key = tasks_store.pending_key("e1")
+    tasks_store.ensure_ids([(key, "/a", 1.0)])
+    assert tasks_store.ensure_ids([(key, "/b", 1.0)], reproject=True)[key] == \
+        "TASK-001"
+    assert tasks_store.task_ids()[key] == {"project": "/a", "n": 1}
+
+
+def test_a_draft_with_no_target_keeps_the_number_it_has():
+    """"Somewhere else" is not somewhere. A cleared target names no project, so
+    there is nothing to renumber INTO — and nothing is spent on the parent
+    folders a half-typed path passes through on its way to the real one."""
+    draft = "draft:d1"
+    tasks_store.ensure_ids([(draft, "/a", 1.0)], reproject=True)
+    assert tasks_store.ensure_ids([(draft, "", 1.0)],
+                                  reproject=True)[draft] == "TASK-001"
+    assert tasks_store.task_ids()[draft] == {"project": "/a", "n": 1}
+
+
+def test_a_project_change_moves_nothing_without_the_flag():
+    """Off by default: the listing's own `_numbers` passes a session's project
+    on every poll, and a transcript read two ways must not renumber a task."""
+    tasks_store.ensure_ids([("s1", "/a", 1.0)])
+    assert tasks_store.ensure_ids([("s1", "/b", 1.0)])["s1"] == "TASK-001"
+    assert tasks_store.task_ids()["s1"] == {"project": "/a", "n": 1}
+
+
 # ------------------------------------------------------------------- backfill
 
 


### PR DESCRIPTION
## What

Slack-style drafts. Anything typed into the Claude chat composer or the New Task modal is remembered and comes back where you left it, and the Tasks page tells you where you have unfinished words.

## Where drafts live

Server-side, one file: `~/.fused-render/claude-sessions/drafts.json` (same global, never-branch-nested dir as `task_ids.json`, because chat drafts key on session ids). Not URL (a draft is not a place), not localStorage (the badge is server-rendered and must survive the browser profile), not `tasks.jsonl` (the ticker assumes `due`).

Three key shapes, never colliding: `<session_id>` (chat draft on an existing task), `new:<file>` (chat with no session yet), `draft:<uuid>` (New Task modal).

## API

- `PUT/DELETE /api/drafts/chat/{key}` — empty text + no attachments == delete
- `PUT/DELETE /api/drafts/task/{id}` — optional `from_chat_key` deletes the chat draft it came from and is stored for Back to chat
- `GET /api/drafts`, `POST /api/drafts/chat/rekey {from, to}`
- `POST /api/schedule` takes `draft_id`; rekeys `draft:<id>` → `pending:<entry>` (same TASK number) and deletes the draft and the session's chat draft
- every mutation calls `tasks_watch.notify` so `/api/tasks/changes` repaints rows live

## Tasks page

- `/api/tasks` joins chat drafts onto session rows (`draft: {preview, updated_at}`) and emits task drafts and new-chat drafts as rows (`kind: "draft"`, `draft_kind: task|chat`), each with a TASK-NNN allocated at first keystroke and rekeyed forward. Discarded drafts leave gaps, same price `task_ids.json` already pays.
- List + Board: lucide PencilLine "Draft" chip on the right, just before the folder tag; tooltip = first line. Clicking it toggles a Draft filter. Not in Cards/Calendar; not draggable.
- List order: lane → drafts within the lane by recency → the lane's usual order.

## Composer + modal

- Autosave 600 ms after the last keystroke, plus blur/pagehide/unmount with `keepalive`. `settle()` guarantees an in-flight PUT never lands after the DELETE that send/discard/schedule issued.
- Composer restores the server draft on mount (once per key; fixed an autofocus/cleanup race that dropped every restore) without re-PUTting it.
- New Task modal: close keeps the draft silently, Discard removes it, untouched modal mints nothing. Reopening a draft row opens the same form.
- Schedule hop from the composer mints the task draft immediately and deletes the chat draft — exactly one draft exists. Back to chat reverses it, and works on a reopened draft because `from_chat_key` is stored.
- Chat drafts are native-chat only; `template.html` untouched.

## Tests

- `tests/test_drafts.py` (43), schedule-button/tasks suites updated. pytest: 12121 pass; the 12 failures are pre-existing on main (`test_claude_health` env-dependent, `test_subprocess_encoding` on `claude_sessions.py:754`).
- Frontend: `bun test` 5340 pass, `tsc` clean. Composer tests now stub fetch and unmount so autosave timers don't leak across suites.
- Browser-verified with cmux: new-task draft create/keep/reopen/discard/schedule, chat draft save/chip/restore/reload/clear/send, new-chat rows, hop move + Back to chat, filter, sort, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches send/schedule/delete ordering and cross-surface draft moves (chat ↔ task ↔ session rekey); mistakes could resurrect drafts or attach TASK numbers to the wrong conversation, though the PR adds explicit ownership and race guards plus broad tests.
> 
> **Overview**
> Adds **server-persisted drafts** for the Claude composer and New Task modal, wired through a new `@platform/lib/drafts` layer (`save`/`fetch`/`rekey`, debounced **`useAutosave`** with **`settle()`** so deletes cannot lose to in-flight PUTs, and **spent-key** guards so a first send cannot resurrect text on remount).
> 
> The **composer** autosaves under `chatDraftKey(sessionId, file)` (`new:<file>` until a session exists), restores once per key on mount, and clears the draft on send after `reset` + `settle` + `deleteChatDraft`. **`ClaudeChat`** records a **run-scoped `pendingRekey`** when dispatching a send with no session yet, then **`rekeyChatDraft`** moves the `new:<file>` row’s TASK number onto the new session id (fixing wrong-conversation rekey races).
> 
> The **New Task modal** mints task drafts on first change (or immediately on Schedule hop via `writeInitial`), passes **`draft_id`** / **`from_chat_key`** into **`POST /api/schedule`**, supports **Discard**, silent close-into-draft, **reopen from List/Board rows**, and **Back to chat** (including reopened drafts via stored `from_chat_key`). **`Task`** API types gain draft row/join fields (`kind`, `draft_kind`, `file`, `form`, joined `draft` preview, etc.).
> 
> **Tasks List/Board** show a **Draft** chip (filter toggle), sort drafts first within lanes, and route presses: **chat draft rows** open the folder chat prefilled; **task draft rows** reopen the modal. **Cards** show the chip as a label only (no filter). Tests add **`drafts.test.ts`** and harden **Composer** tests with fetch stubs and unmount cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e36f84cad05d5ae355f944a386a6ba3fe24cb22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->