### PR TITLE
Claude chat: a follow-up no longer re-types the previous reply into the new bubble

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -16188,6 +16188,24 @@ let loopSeq = 0;
 // NEW assistant bubble after the follow-up rather than keep growing the one
 // already positioned before it (see the reset check inside pollLoop).
 let followupSeq = 0;
+// THE WINDOW THAT IS ALREADY ON SCREEN, so a follow-up never re-types the
+// reply before it.
+//
+// agent.py's cursor only advances past a turn boundary it has PROVEN — a
+// `_starts_new_turn` echo with a `result` before it — so a message sent into
+// a live host reopens the window on the PREVIOUS reply and keeps it there
+// until the new turn's echo lands. That is several polls, and `sendMessage`'s
+// live-host road starts a FRESH pollLoop for them with `segBase`/`textBase` at
+// zero: the previous answer was typed into the new bubble, in full, and then
+// replaced by the real reply once the cursor finally moved — the duplicate a
+// reader sees "before the new response starts streaming".
+//
+// Recorded by the loop that SETTLED that reply (the only reader that knows
+// what it settled), consumed by the next loop on the SAME run, and retired the
+// moment the window stops opening on it — see both sites in pollLoop. The
+// landed PROSE is what it anchors to rather than a pair of lengths, because
+// the newer reply is not reliably longer or shorter than the one it replaces.
+let landedWindow = null;   // {run_id, segs, text}
 // The generation of the visible log. The back button bumps it when it wipes
 // the transcript, and a streaming pollLoop that wakes to a bumped number
 // bails before touching the DOM or the URL params — the run itself keeps
@@ -16228,6 +16246,19 @@ async function pollLoop(run_id, gen = logGen) {
   // the follow-up landed below — see the reset check inside the loop below.
   let segBase = 0;
   let textBase = 0;
+  // What the previous loop on THIS run left on screen — see `landedWindow`.
+  // The text is kept whole so the retire check below can ask whether the
+  // window still opens on it, rather than trusting a length.
+  let baseText = "";
+  if (landedWindow && landedWindow.run_id === run_id) {
+    segBase = landedWindow.segs;
+    textBase = landedWindow.text.length;
+    baseText = landedWindow.text;
+  }
+  // Consumed either way: one settled reply, one loop that may skip it. A base
+  // left standing past the loop that could use it would hide the opening of
+  // some later turn instead.
+  landedWindow = null;
   // `data.segments.length`/`data.text.length` as of the PREVIOUS iteration —
   // what the reset check freezes into `segBase`/`textBase` on a follow-up,
   // not this poll's own (already possibly grown) lengths. See the reset
@@ -16281,9 +16312,21 @@ async function pollLoop(run_id, gen = logGen) {
         // time underneath the follow-up.
         segBase = lastSegLen;
         textBase = lastTextLen;
+        baseText = "";   // not a landed-window prefix — see the retire check
       }
       const fullSegs = Array.isArray(data.segments) ? data.segments : [];
       const fullText = data.text || "";
+      // THE ALREADY-LANDED PREFIX RETIRES ITSELF the moment the window stops
+      // OPENING on it, because that is the cursor having stepped over the
+      // boundary: from that poll on the payload is the new turn ALONE, and
+      // slicing it against the old reply's length would cut the new answer's
+      // head off (or blank it entirely). Anchored on the prose, not the
+      // lengths — a newer reply can be any size. Only the `landedWindow` seed
+      // is retired here; `followupSeq`'s base is about a window that provably
+      // has not advanced, and it sets `baseText` to "" so this never fires.
+      if (baseText && !fullText.startsWith(baseText)) {
+        segBase = 0; textBase = 0; baseText = "";
+      }
       const segs = fullSegs.slice(segBase);
       const flatText = fullText.slice(textBase);
       lastSegLen = fullSegs.length;
@@ -16366,6 +16409,12 @@ async function pollLoop(run_id, gen = logGen) {
           // that carried segments here rendered its flat text instead of them.
           attachCodeCopy(addAssistantTurn(data.text, data.segments));
         }
+        // AND THE WINDOW IS NOW ON SCREEN, so the next send's loop does not
+        // type it a second time (see `landedWindow`). Only where the text
+        // STAYS: a dropped bubble is not a prefix of anything.
+        landedWindow = end.keepText
+          ? { run_id, segs: fullSegs.length, text: fullText }
+          : null;
         if (end.error) addError(end.error);
         // Same guard: a superseded loop's own "Stopped." note (the respawn's
         // `_cancel` is what actually stopped it) must not land in the log

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -16324,7 +16324,23 @@ async function pollLoop(run_id, gen = logGen) {
       // lengths — a newer reply can be any size. Only the `landedWindow` seed
       // is retired here; `followupSeq`'s base is about a window that provably
       // has not advanced, and it sets `baseText` to "" so this never fires.
-      if (baseText && !fullText.startsWith(baseText)) {
+      //
+      // A BLANK PAYLOAD IS NOT EVIDENCE OF ANYTHING (Bugbot, PR #1119), and it
+      // is the commonest first poll there is: a send into an IDLE host leaves
+      // out.jsonl ending on the previous `result`, so agent.py reads the run as
+      // idle and `pending_echo` blanks BOTH `text` and `segments` until this
+      // send's echo lands. An empty string starts with nothing, so the test
+      // below read that as "the cursor stepped over the boundary", threw the
+      // base away on the very first poll, and the polls after it — still the
+      // previous reply, because the cursor had NOT moved — typed it into the
+      // new bubble: the exact flash this whole change exists to stop.
+      // Reproduced in the app with a host that takes a moment to start.
+      //
+      // `fullSegs` is in the test too, not just `fullText`: a turn that opens
+      // on a tool call carries segments with no prose at all, and that payload
+      // is a real window that must retire the base rather than be slid past.
+      const blank = !fullText && !fullSegs.length;
+      if (baseText && !blank && !fullText.startsWith(baseText)) {
         segBase = 0; textBase = 0; baseText = "";
       }
       const segs = fullSegs.slice(segBase);
@@ -16412,9 +16428,20 @@ async function pollLoop(run_id, gen = logGen) {
         // AND THE WINDOW IS NOW ON SCREEN, so the next send's loop does not
         // type it a second time (see `landedWindow`). Only where the text
         // STAYS: a dropped bubble is not a prefix of anything.
-        landedWindow = end.keepText
-          ? { run_id, segs: fullSegs.length, text: fullText }
-          : null;
+        //
+        // OWNERSHIP-GUARDED, exactly like the `run` param above and the stop
+        // note below (Bugbot, PR #1119). A respawn kills this run and starts a
+        // NEW pollLoop while this one is still on its way back from the poll it
+        // already sent; its late arrival here would overwrite — or null — the
+        // record the newer loop has already made, and the send after that would
+        // open with no base and flash the previous reply again. Being the
+        // NEWEST loop is the test, the same one every other write in this
+        // block makes.
+        if (loopSeq === seat) {
+          landedWindow = end.keepText
+            ? { run_id, segs: fullSegs.length, text: fullText }
+            : null;
+        }
         if (end.error) addError(end.error);
         // Same guard: a superseded loop's own "Stopped." note (the respawn's
         // `_cancel` is what actually stopped it) must not land in the log

--- a/tests/test_claude_followup_reply_bubble.py
+++ b/tests/test_claude_followup_reply_bubble.py
@@ -189,6 +189,11 @@ let reply = null, typer = null, segBody = null, segMode = false, tailText = null
 let followupSeq = 0;
 let seenFollowupSeq = followupSeq;
 let segBase = 0, textBase = 0;
+// The `landedWindow` prefix this loop opened on (PR #1119). Empty on every
+// path this file drives — a mid-turn follow-up's base is not a landed window —
+// which is exactly what keeps the retire check inside `_segs_flat_src` from
+// firing here and undoing the reset these tests are about.
+let baseText = "";
 let lastSegLen = 0, lastTextLen = 0;
 
 // First poll of the turn: no text yet, then some streams in — the reply
@@ -232,6 +237,11 @@ def test_reply_segments_are_not_duplicated_after_a_mid_turn_followup(html):
 let followupSeq = 0;
 let seenFollowupSeq = followupSeq;
 let segBase = 0, textBase = 0;
+// The `landedWindow` prefix this loop opened on (PR #1119). Empty on every
+// path this file drives — a mid-turn follow-up's base is not a landed window —
+// which is exactly what keeps the retire check inside `_segs_flat_src` from
+// firing here and undoing the reset these tests are about.
+let baseText = "";
 let lastSegLen = 0, lastTextLen = 0;
 let reply = null, typer = null, segBody = null, segMode = false, tailText = null;
 let seenByPoll = [];
@@ -278,6 +288,11 @@ let reply = null, typer = null, segBody = null, segMode = false, tailText = null
 let followupSeq = 0;
 let seenFollowupSeq = followupSeq;
 let segBase = 0, textBase = 0;
+// The `landedWindow` prefix this loop opened on (PR #1119). Empty on every
+// path this file drives — a mid-turn follow-up's base is not a landed window —
+// which is exactly what keeps the retire check inside `_segs_flat_src` from
+// firing here and undoing the reset these tests are about.
+let baseText = "";
 let lastSegLen = 0, lastTextLen = 0;
 """ + poll + poll + poll + """
 console.log(JSON.stringify({ order: classNamesOf(log) }));

--- a/tests/test_claude_followup_respawn_ownership.py
+++ b/tests/test_claude_followup_respawn_ownership.py
@@ -64,6 +64,15 @@ let reply = null;
 let typer = null;
 let segMode = false;
 let tailText = null;
+// What the done branch records for the NEXT loop on this run (PR #1119's
+// `landedWindow`): the run it belongs to and the window it settled. Declared
+// here because the branch these tests extract now writes it — the ownership
+// rules below are unchanged by it, and asserting it stays untouched is not
+// this file's job.
+const run_id = "r1";
+const fullSegs = [];
+const fullText = "";
+let landedWindow = null;
 """
 
 

--- a/tests/test_claude_landed_window.py
+++ b/tests/test_claude_landed_window.py
@@ -1,0 +1,201 @@
+"""A send into a live host must not re-type the reply already on screen.
+
+THE REPORTED BUG (PR #1119), reproduced in the real app before this test was
+written: with a conversation already going, sending a second message made the
+previous answer appear a SECOND time, in a fresh bubble under the new message,
+for about a second — then it was replaced by the real reply. "The last response
+gets duplicated into the UI before the new response starts streaming."
+
+WHY IT HAPPENS. `_read_current_turn`'s cursor only advances past a turn
+boundary it has PROVEN — a `_starts_new_turn` echo with a `result` before it —
+so a message sent into a still-live host reopens the poll window on the
+PREVIOUS reply and keeps it there until the new turn's echo lands (several
+polls: the CLI writes `system/init` and `system/status` first). `sendMessage`'s
+live-host road starts a FRESH `pollLoop` for those polls, and it used to begin
+with `segBase`/`textBase` at zero — so the whole previous reply was typed into
+the new bubble, then overwritten once the cursor finally moved.
+
+`landedWindow` is the fix: the loop that SETTLES a reply records the window it
+settled, the next loop on the SAME run opens with that as its base, and the
+base retires itself the moment the window stops opening on it (the cursor
+having stepped over the boundary — from that poll on the payload is the new
+turn alone, and slicing it against the old reply's length would cut its head
+off).
+
+Node probes over the shipping source, the same discipline as
+test_claude_followup_reply_bubble.py: the three snippets are extracted from
+template.html by textual anchors and wired together the way `pollLoop`'s own
+loop body wires them, so an anchor that stops matching is a test error rather
+than a silent pass.
+"""
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+TEMPLATE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "templates", "claude", "template.html")
+
+
+@pytest.fixture(scope="module")
+def html():
+    with open(TEMPLATE, encoding="utf-8") as f:
+        return f.read()
+
+
+def _seed_src(html):
+    """`pollLoop`'s base seeding: consume `landedWindow` when this loop opens
+    on the same run the last one settled."""
+    start = html.index("  // What the previous loop on THIS run left on screen")
+    end = html.index("landedWindow = null;", start)
+    return html[start:end + len("landedWindow = null;")]
+
+
+def _segs_flat_src(html):
+    """The retire check and the `segs`/`flatText` slice right after it."""
+    start = html.index("const fullSegs = Array.isArray(data.segments)")
+    end = html.index("lastTextLen = fullText.length;", start)
+    return html[start:html.index("\n", end) + 1]
+
+
+def _record_src(html):
+    """What the done branch records for the next loop."""
+    start = html.index("        // AND THE WINDOW IS NOW ON SCREEN")
+    end = html.index("          : null;", start)
+    return html[start:end + len("          : null;")]
+
+
+_HARNESS = """
+let landedWindow = null;
+let segBase = 0, textBase = 0;
+// NOT `baseText`: the seeding snippet extracted from the page declares that
+// one itself, and a second declaration here would shadow the shipping line
+// this test exists to exercise.
+let lastSegLen = 0, lastTextLen = 0;
+const seg = (t) => ({ kind: "text", text: t });
+const out = [];
+"""
+
+
+def _run(body):
+    if not shutil.which("node"):
+        pytest.skip("node is needed to run the page's own poll-loop glue")
+    proc = subprocess.run(["node", "-e", _HARNESS + body],
+                          capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _poll(html, data):
+    """One trip through the loop body, as far as this fix reaches: the retire
+    check, the slice, and what the bubble would be handed."""
+    return """
+{
+  const data = %s;
+  %s
+  out.push({ segs: segs.map((s) => s.text), flat: flatText, segBase, textBase });
+}
+""" % (json.dumps(data), _segs_flat_src(html))
+
+
+PREV = "The answer that was already on screen."
+NEW = "A brand new answer."
+
+
+def test_a_settled_turn_is_recorded_for_the_next_loop(html):
+    """The done branch hands the next loop the window it settled — but only
+    where the text STAYS: a dropped bubble is not a prefix of anything."""
+    body = _record_src(html) + """
+out.push(landedWindow);
+console.log(JSON.stringify(out));
+"""
+    kept = _run("""
+const run_id = "r1";
+const fullSegs = [%s];
+const fullText = %s;
+const end = { keepText: true };
+""" % (json.dumps(PREV), json.dumps(PREV)) + body)
+    assert kept[0] == {"run_id": "r1", "segs": 1, "text": PREV}
+
+    dropped = _run("""
+const run_id = "r1";
+const fullSegs = [%s];
+const fullText = %s;
+const end = { keepText: false };
+""" % (json.dumps(PREV), json.dumps(PREV)) + body)
+    assert dropped[0] is None, "a reply that was removed is not a base"
+
+
+def test_a_send_into_a_live_host_does_not_retype_the_reply_on_screen(html):
+    """THE BUG. The window reopens on the previous reply and stays there for
+    several polls; not one byte of it may reach the new bubble."""
+    frames = _run("""
+const run_id = "r1";
+landedWindow = { run_id: "r1", segs: 1, text: %s };
+""" % json.dumps(PREV) + _seed_src(html) + """
+""" + _poll(html, {"segments": [{"kind": "text", "text": PREV}], "text": PREV})
+        + _poll(html, {"segments": [{"kind": "text", "text": PREV}], "text": PREV})
+        + """
+console.log(JSON.stringify(out));
+""")
+    for i, f in enumerate(frames):
+        assert f["segs"] == [], "poll %d re-typed the previous reply" % i
+        assert f["flat"] == "", "poll %d re-typed the previous reply" % i
+
+
+def test_the_new_reply_still_lands_once_it_starts(html):
+    """...and the fix must not swallow the answer it is protecting: the new
+    turn's own text, arriving in the SAME window behind the old reply, is the
+    only thing the new bubble gets."""
+    frames = _run("""
+const run_id = "r1";
+landedWindow = { run_id: "r1", segs: 1, text: %s };
+""" % json.dumps(PREV) + _seed_src(html) + """
+""" + _poll(html, {"segments": [{"kind": "text", "text": PREV}], "text": PREV})
+        + _poll(html, {"segments": [{"kind": "text", "text": PREV},
+                                    {"kind": "text", "text": NEW}],
+                       "text": PREV + NEW})
+        + """
+console.log(JSON.stringify(out));
+""")
+    assert frames[0]["segs"] == []
+    assert frames[1]["segs"] == [NEW], "the new reply, and nothing of the old"
+    assert frames[1]["flat"] == NEW
+
+
+def test_the_base_retires_when_the_cursor_steps_over_the_boundary(html):
+    """The poll after the cursor advances carries the NEW turn alone. Slicing
+    that against the old reply's length would cut its head off — or blank it
+    when the new answer is shorter, which is the commoner case."""
+    short = "OK"
+    frames = _run("""
+const run_id = "r1";
+landedWindow = { run_id: "r1", segs: 1, text: %s };
+""" % json.dumps(PREV) + _seed_src(html) + """
+""" + _poll(html, {"segments": [{"kind": "text", "text": PREV}], "text": PREV})
+        + _poll(html, {"segments": [{"kind": "text", "text": short}], "text": short})
+        + """
+console.log(JSON.stringify(out));
+""")
+    assert frames[0]["segs"] == []
+    assert frames[1]["segs"] == [short], "the whole new reply, not a slice of it"
+    assert frames[1]["flat"] == short
+    assert frames[1]["textBase"] == 0, "the base retired itself"
+
+
+def test_a_different_run_does_not_inherit_the_base(html):
+    """`landedWindow` is per run. A loop on a DIFFERENT run — a respawn, a
+    fresh `start` — opens on its own turn from byte zero, and hiding a prefix
+    it never rendered would drop the head of that turn's reply."""
+    frames = _run("""
+const run_id = "r2";
+landedWindow = { run_id: "r1", segs: 1, text: %s };
+""" % json.dumps(PREV) + _seed_src(html) + """
+""" + _poll(html, {"segments": [{"kind": "text", "text": NEW}], "text": NEW}) + """
+console.log(JSON.stringify(out));
+""")
+    assert frames[0]["segs"] == [NEW]
+    assert frames[0]["flat"] == NEW

--- a/tests/test_claude_landed_window.py
+++ b/tests/test_claude_landed_window.py
@@ -62,10 +62,12 @@ def _segs_flat_src(html):
 
 
 def _record_src(html):
-    """What the done branch records for the next loop."""
+    """What the done branch records for the next loop, ownership guard and
+    all."""
     start = html.index("        // AND THE WINDOW IS NOW ON SCREEN")
     end = html.index("          : null;", start)
-    return html[start:end + len("          : null;")]
+    end = html.index("\n        }\n", end) + len("\n        }\n")
+    return html[start:end]
 
 
 _HARNESS = """
@@ -117,6 +119,8 @@ const run_id = "r1";
 const fullSegs = [%s];
 const fullText = %s;
 const end = { keepText: true };
+const seat = 1;
+let loopSeq = 1;
 """ % (json.dumps(PREV), json.dumps(PREV)) + body)
     assert kept[0] == {"run_id": "r1", "segs": 1, "text": PREV}
 
@@ -125,6 +129,8 @@ const run_id = "r1";
 const fullSegs = [%s];
 const fullText = %s;
 const end = { keepText: false };
+const seat = 1;
+let loopSeq = 1;
 """ % (json.dumps(PREV), json.dumps(PREV)) + body)
     assert dropped[0] is None, "a reply that was removed is not a base"
 
@@ -199,3 +205,91 @@ console.log(JSON.stringify(out));
 """)
     assert frames[0]["segs"] == [NEW]
     assert frames[0]["flat"] == NEW
+
+
+# ---- the two Bugbot findings on the first cut of this fix -------------------
+
+
+def test_a_blank_poll_does_not_retire_the_landed_base(html):
+    """BUGBOT, HIGH. A send into an IDLE host leaves out.jsonl ending on the
+    previous `result`, so agent.py reads the run as idle and `pending_echo`
+    blanks BOTH `text` and `segments` until this send's echo lands.
+
+    An empty string starts with nothing, so the first cut of the retire check
+    read that blank payload as "the cursor stepped over the boundary" and threw
+    the base away — and the polls after it, still carrying the previous reply
+    because the cursor had NOT moved, typed it into the new bubble. Reproduced
+    in the running app with a host that takes a moment to start: the duplicate
+    came straight back.
+    """
+    frames = _run("""
+const run_id = "r1";
+landedWindow = { run_id: "r1", segs: 1, text: %s };
+""" % json.dumps(PREV) + _seed_src(html) + """
+"""
+        # `pending_echo` blanks the payload...
+        + _poll(html, {"segments": [], "text": ""})
+        # ...and the cursor has still not moved, so this is the OLD reply.
+        + _poll(html, {"segments": [{"kind": "text", "text": PREV}], "text": PREV})
+        + """
+console.log(JSON.stringify(out));
+""")
+    assert frames[0]["segs"] == [] and frames[0]["flat"] == ""
+    assert frames[0]["textBase"] == len(PREV), (
+        "a blank payload proves nothing; the base must survive it")
+    assert frames[1]["segs"] == [], "the previous reply was re-typed"
+    assert frames[1]["flat"] == "", "the previous reply was re-typed"
+
+
+def test_a_segments_only_window_still_retires_the_base(html):
+    """...and the guard for that must not swallow a real window. A turn that
+    opens on a tool call carries segments with no prose at all: `text` is empty
+    but the payload is the NEW turn, and slicing its segments against the old
+    reply's count would drop them."""
+    frames = _run("""
+const run_id = "r1";
+landedWindow = { run_id: "r1", segs: 1, text: %s };
+""" % json.dumps(PREV) + _seed_src(html) + """
+""" + _poll(html, {"segments": [{"kind": "tool", "text": ""}], "text": ""}) + """
+console.log(JSON.stringify(out));
+""")
+    assert frames[0]["segBase"] == 0, "a segments-only window is a real window"
+    assert len(frames[0]["segs"]) == 1, "the new turn's own segment, not a slice"
+
+
+def test_a_superseded_loop_does_not_overwrite_the_record(html):
+    """BUGBOT, MEDIUM. A respawn kills this run and starts a NEW pollLoop while
+    the old one is still on its way back from the poll it already sent. Its
+    late arrival in the done branch would overwrite — or null — the record the
+    newer loop has already made, and the send after that would open with no
+    base and flash the previous reply again.
+
+    Same `loopSeq === seat` test the `run` param and the stop note in that very
+    block already make."""
+    newer = {"run_id": "r1", "segs": 2, "text": "what the newer loop settled"}
+    body = _record_src(html) + """
+out.push(landedWindow);
+console.log(JSON.stringify(out));
+"""
+    stale = _run("""
+const run_id = "r1";
+const fullSegs = [%s];
+const fullText = %s;
+const end = { keepText: true };
+const seat = 1;      // this loop
+let loopSeq = 2;     // ...but a newer one has taken over
+landedWindow = %s;
+""" % (json.dumps(PREV), json.dumps(PREV), json.dumps(newer)) + body)
+    assert stale[0] == newer, "the superseded loop wrote over the newer record"
+
+    owner = _run("""
+const run_id = "r1";
+const fullSegs = [%s];
+const fullText = %s;
+const end = { keepText: true };
+const seat = 2;
+let loopSeq = 2;     // still the newest loop
+landedWindow = null;
+""" % (json.dumps(PREV), json.dumps(PREV)) + body)
+    assert owner[0] == {"run_id": "r1", "segs": 1, "text": PREV}, (
+        "the loop that owns the turn still records it")


### PR DESCRIPTION
## The bug

With a conversation already going, sending a second message makes the **previous** answer appear again, in a fresh bubble under the new message, for about a second — then it is replaced by the real reply. In the reporter's words: *"the last response gets duplicated into the UI before the new response starts streaming."*

Reproduced in the running app and captured mid-flash — a new bubble under "second message please", typing `ALPHA00 A` (the start of the previous reply) while the status line still reads "Sending to Claude…".

Two things about the report turned out to be wrong, both mine, and both corrected by reproducing it rather than reasoning about it:

- **It is the default (template) chat, not the native one.** `native_chat_enabled` is an opt-in beta that defaults off, so `templates/claude/template.html` is what almost everyone runs. Measured on `126b06c`, before any of this work: legacy duplicates (peak 2 copies), native is clean (peak 1). The native chat was born with `landedWindow`; the template never got an equivalent. That is the whole of this PR.
- **A second window is not required.** An A/B with and without one duplicates identically. It reproduces with a single window on the ordinary second message.

## Cause

`_read_current_turn`'s cursor only advances past a turn boundary it has **proven** — a `_starts_new_turn` echo with a `result` before it. So a message sent into a still-live host reopens the poll window on the previous reply and holds it there for several polls (the CLI writes `system/init` and `system/status` before the echo lands).

`sendMessage`'s live-host road starts a **fresh** `pollLoop` for exactly those polls, and it began with `segBase`/`textBase` at zero. The captured wire shows it plainly — the first poll after the send:

```
poll  window:0  done:false  textLen:319  head:"ALPHA00 ALPHA01 "  segs:[319]  breaks:[]
```

The whole previous reply, no seam. The duplicate appears ~100 ms later, and is overwritten once the cursor finally steps.

## Fix

`landedWindow` — the same shape the native chat already had:

- the loop that **settles** a reply records the window it settled (`run_id`, segment count, prose);
- the next loop on the **same run** opens with that as its base, so the interim polls render nothing into the new bubble;
- the base **retires itself** the moment the window stops opening on it — the cursor having stepped over the boundary, from which point the payload is the new turn alone. Anchored on the prose, not a length, because a newer reply can be any size.

Two follow-up corrections from Cursor Bugbot, both verified before acting and both real:

- **A blank payload is not evidence the cursor moved** (high). A send into an *idle* host leaves `out.jsonl` ending on the previous `result`, so `pending_echo` blanks `text` **and** `segments` until the echo lands. `"".startsWith(baseText)` is false, so the first cut threw the base away on that very first poll and the duplicate came straight back. Confirmed by slowing the stub CLI so the host takes a moment to start — peak 2 again — then fixed and re-measured. `fullSegs` is in the guard too, not just `fullText`: a turn opening on a tool call carries segments with no prose, and that *is* a real window that must retire the base.
- **The record is ownership-guarded** (medium). The two writes either side of it in that block already take the `loopSeq === seat` test; a superseded loop's late arrival would otherwise overwrite the newer loop's record, and the next send would open with no base.

## Verification

Beyond unit tests, this was verified in the **real app** — React shell, real server, a stub `claude` CLI emitting genuine stream-json into `out.jsonl`, driven through Chromium exactly as reported:

| | before | after |
|---|---|---|
| peak copies of the previous reply | **2** | **1** |
| fast host | duplicates | clean |
| slow host (idle / `pending_echo` path) | duplicates | clean |
| three turns, every reply intact | — | ✅ |

Re-run again **after** the rebase onto `main`, not just re-tested. The reload behaviour this does not touch was also checked against the pristine template and is unchanged.

## Scope

Four files, two commits, and **no Python product code** — the coverage bot reads it as "does not seem to contain any modification to coverable code".

```
fused_render/templates/claude/template.html
tests/test_claude_landed_window.py            (new)
tests/test_claude_followup_reply_bubble.py    (driver gains the new bindings)
tests/test_claude_followup_respawn_ownership.py
```

The native-chat and `agent.py` work that was originally in this PR has moved to #1123. It fixes a different, narrower gap (the reload and adopted roads) and is not what was reported here. Nothing in this PR depends on it — the template does not read `turn_breaks` at all.

## Test plan

- [x] 8 node probes in `tests/test_claude_landed_window.py`, extracted from the shipping source by textual anchors (the house style in this file's neighbours), each confirmed failing against the commit before its fix — including one guard-rail test that fails if the fix overreaches and swallows the new reply
- [x] The two existing probe files whose drivers reproduce the loop body declare the bindings it gained
- [x] 206 Python pass across the template probe suites; full suite 11,644 pass (7 pre-existing sandbox failures, identical on a clean tree)
- [x] App-level reproduction, before/after, on both host speeds, post-rebase

> **Note on CI:** `fused-engine` intermittently fails `tests/test_desktop_probe.py::test_matching_server_true_for_our_token` — a pre-existing flake in that file's own `_serve` fixture, unrelated to this PR (which contains no Python), green on `main`, and diagnosed with a patch [here](https://github.com/fusedio/fused-render/pull/1119#issuecomment-5640883641). Left out deliberately rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUo4BiYdwk9GDnW7qT4AeL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes streaming poll-loop slicing and cross-loop state; regressions could hide new replies or briefly flash duplicates, but scope is chat UI only.
> 
> **Overview**
> Fixes native chat briefly **re-typing the previous assistant reply** into a new bubble when the user sends again on a **still-live run**, before the new turn's stream starts.
> 
> **`pollLoop` in `template.html`** adds a `landedWindow` handoff (`run_id`, segment count, full settled text). The loop that finishes a reply records it (only when `loopSeq === seat` and the bubble is kept); the next loop on the **same** `run_id` seeds `segBase`/`textBase` from that window so interim polls that still carry the old payload render nothing into the new bubble. A **retire** step drops the prefix once the poll payload is non-blank and no longer starts with that prose (so the real new turn isn't truncated); **blank** polls are ignored so idle-host `pending_echo` doesn't clear the base too early. Mid-turn follow-up resets still clear `baseText` so they don't fight the follow-up slice logic.
> 
> **Tests:** new `test_claude_landed_window.py` (Node extracts from the template); existing follow-up and respawn-ownership harnesses gain `baseText` / `landedWindow` stubs so older suites stay valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9958358047f373d84457fdf8fd6aa7fd3b5aef34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
