### PR TITLE
AI Models: give the capability list and the model cards room to breathe

### DIFF
--- a/frontend/src/styles/ai-models.css
+++ b/frontend/src/styles/ai-models.css
@@ -3062,10 +3062,10 @@ button.am-bench-model:focus-visible {
      is an index INSIDE the page — a rule, not a slab. */
   background: transparent;
   border-right: 1px solid var(--border);
-  padding: 2px 10px 10px 2px;
+  padding: 16px 10px 16px 2px;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
   min-width: 0;
   /* Item 8 (fix round 5): `.tp` itself no longer scrolls (only `.tp-pane`,
      the right column, does) so this does not need to stick against a
@@ -3077,21 +3077,21 @@ button.am-bench-model:focus-visible {
 }
 
 .tp-nav h5 {
-  margin: 2px 8px 6px;
+  margin: 0 8px var(--am-gap-tight);
   font-size: 11.5px;
   font-weight: 400;
   color: var(--fg-muted);
 }
 
 .tp-nav button {
-  /* One line, 28px tall. The count sits at the right edge as a quiet number:
+  /* One line, 37px tall. The count sits at the right edge as a quiet number:
      a status dot on every row said nothing, since every capability had one. */
   display: flex;
   align-items: center;
   gap: 9px;
   width: 100%;
   text-align: left;
-  padding: 5px 8px;
+  padding: 9px 12px;
   border-radius: 6px;
   border: 0;
   background: transparent;
@@ -3171,7 +3171,7 @@ button.am-bench-model:focus-visible {
 .tp-nav .rule {
   height: 1px;
   background: var(--border);
-  margin: 8px 8px;
+  margin: var(--am-gap-head) 8px;
 }
 
 .offpane {
@@ -3266,7 +3266,7 @@ button.am-bench-model:focus-visible {
 }
 
 .tp-group h5 {
-  margin: 0 0 var(--am-gap-tight);
+  margin: 0 0 var(--am-gap-head);
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.06em;
@@ -3368,14 +3368,14 @@ button.am-bench-model:focus-visible {
   grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: var(--am-gap-head);
-  padding: 10px 12px;
+  padding: 12px 16px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--am-surface-none);
 }
 
 .tp .row + .row {
-  margin-top: 6px;
+  margin-top: var(--am-gap-tight);
 }
 
 .tp .row.partial {
@@ -3454,7 +3454,7 @@ button.am-bench-model:focus-visible {
    panel — so the identity facts stay attached to the thing they describe and
    closing it costs nothing. */
 .tp .rowwrap + .rowwrap {
-  margin-top: 6px;
+  margin-top: var(--am-gap-tight);
 }
 
 .tp .rowwrap.open .row {
@@ -3835,6 +3835,12 @@ button.am-bench-model:focus-visible {
      every `.row.hit.rich` is 73px, base model or not) keeps that
      centring and stops the list's outer edge from stair-stepping. */
   min-height: 73px;
+  /* The pane's roomier `.tp .row` padding-block (12px) is for a 2-line card
+     whose height is content-driven. A hit row is PINNED to 73px and its
+     right-hand column already stacks three 11px lines into exactly that —
+     so 12px pushed every hit past the pin and un-did the fixed height the
+     comment above exists to keep. Horizontal padding stays the shared 16px. */
+  padding-block: 10px;
 }
 
 .tp .row.hit.rich .row-act {


### PR DESCRIPTION
## Summary

- The two-pane Local tab on AI Models read as one dense slab. Every model card sat closer to its neighbour (6px) than to its own border (10px), so a list of cards looked like a single block instead of separate items.
- The capability list on the left was built at 2–6px throughout while the pane beside it used 16 and 24, so its heading floated above the pane's header and the divider before Engine files was spaced exactly like a row gap, separating nothing.
- The stylesheet already defines one vertical scale (`--am-gap-tight` / `-head` / `-subgroup` / `-section`) at the top of `ai-models.css`. Most of this change is those rows finally taking the token the scale already prescribes for them instead of an ad hoc number.
- CSS only. No markup, no behaviour, no new values invented where a token existed.

## Visuals

Search hits share the `.tp .row` base rule with the pane's cards, so they pick up the new horizontal padding and card gap. Their vertical padding is deliberately pinned back, because that row has a fixed height the pane's does not.

```mermaid
flowchart TD
    A[".tp .row<br/>shared card base"] --> B["padding 12px 16px"]
    A --> C["card gap --am-gap-tight"]
    B --> D["Pane card<br/>height follows content"]
    B --> E[".row.hit.rich<br/>pinned min-height 73px"]
    E --> F["padding-block back to 10px<br/>so the pin still governs"]
```

| Rule | Before | After |
|---|---|---|
| Pane card gap | 6px | `--am-gap-tight` |
| Group heading to first card | `--am-gap-tight` | `--am-gap-head` |
| Card padding | `10px 12px` | `12px 16px` |
| Capability row padding | `5px 8px` | `9px 12px` |
| Capability list gap | 2px | 4px |
| Capability list top/bottom padding | 2px / 10px | 16px / 16px |
| Divider before Engine files | 8px | `--am-gap-head` |
| Search hit vertical padding | 10px | 10px, re-pinned |

Screenshots of the before state are in the originating conversation. A reviewer can see the after by following Usage below.

## Usage

Not user-invocable; it is presentation only. To look at it:

```
./dev.sh
```

Open AI Models, stay on the Local tab. The left capability list and the model cards are the change. Then click **Search Hugging Face for more text generation models →** to confirm the hit rows kept their fixed 73px height.

## Test Plan

- [x] No automated tests added. This is spacing-only CSS with no logic, and per this repo's convention UI-only rounds get no tests.
- [x] Full frontend suite green: `bun test` → 5386 pass, 0 fail, 271 files.
- [x] `bun run build` succeeds, so no unterminated comment or malformed rule slipped in. A stylesheet syntax error is invisible to `bun test` and only the build catches it.
- [x] Confirmed no test asserts any of the changed literals (`grep` over `tests/` and `*.test.*` for `am-gap-card`, `row + .row`, `rowwrap + .rowwrap`, `min-height: 73`).
- [ ] Reviewer: on the Local tab, check that the gap between two cards no longer reads tighter than the padding inside one.
- [ ] Reviewer: on the Hugging Face search screen, check every hit row is still the same height, including rows with and without a `from <base>` line. That is the regression this PR most plausibly could have caused, and the re-pin is what prevents it.
- [ ] Reviewer: check both light and dark themes. Only spacing changed, no colours, so this is a sanity pass rather than a likely failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
