### PR TITLE
Omnibar: a click selects the path that's already in the box

### DIFF
--- a/frontend/src/apps/explorer/SearchField.tsx
+++ b/frontend/src/apps/explorer/SearchField.tsx
@@ -276,6 +276,14 @@ export function SearchField({
   // (the field was already focused, so no event fires at all) can't leave a
   // stale flag around to swallow the NEXT, unrelated plain focus.
   const focusFromRequestRef = useRef(false);
+  // A click that FOCUSES the field arrives as mousedown (focus, seed, select)
+  // and then mouseup — and the browser's own mouseup default collapses the
+  // selection we just made down to a caret where the pointer landed. Set on
+  // the mousedown that focuses an unfocused field, and read by the input's
+  // `onMouseUp` to suppress that one default; a click inside an ALREADY
+  // focused field never sets it, so ordinary caret placement and drag-select
+  // keep working once the field is live. This is what an address bar does.
+  const selectOnMouseUpRef = useRef(false);
   // Bumped on every seed request, never read for its value — only so the
   // effect below has a dependency that changes EVERY time, unlike `query`.
   // `query` doesn't change when the seed equals what is already in the box
@@ -587,6 +595,15 @@ export function SearchField({
           className="listing-search-input"
           placeholder={pinnedOpen ? (boxWide ? HINT_LONG : HINT_SHORT) : ""}
           value={query}
+          onMouseDown={() => {
+            selectOnMouseUpRef.current =
+              document.activeElement !== searchInputRef.current;
+          }}
+          onMouseUp={(e) => {
+            if (!selectOnMouseUpRef.current) return;
+            selectOnMouseUpRef.current = false;
+            e.preventDefault();
+          }}
           onFocus={() => {
             // `requestSearchFocus` already decided what this field should
             // show — the Search button's deliberate "" included — and this
@@ -606,6 +623,25 @@ export function SearchField({
               // already teaches you to expect.
               setQuery(contractHome(fsPath, home));
               seedSelectRef.current = true;
+              // The select effect below is keyed on `seedRequestToken`
+              // ALONE, so arming `seedSelectRef` without also bumping the
+              // token left a plain focus seeded but never selected — the
+              // path went in, nothing was highlighted, and the armed flag
+              // sat there waiting to fire on the next unrelated
+              // `requestSearchFocus` instead. Same reasoning as the
+              // requested-focus path: a token that changes unconditionally
+              // is the only dependency that can't be bailed out of.
+              setSeedRequestToken((t) => t + 1);
+            } else if (isPristineQuery(query, fsPath, home)) {
+              // Already holding the pre-filled path from an earlier focus
+              // that blurred without committing (searchBoxBlurAction's
+              // "unpin" keeps the text). Nothing to re-seed, but a click
+              // here is the same gesture as the one above and gets the same
+              // whole-value selection — the rule is "a plain focus on an
+              // un-typed-in field selects what's there", not "a focus that
+              // happened to do the seeding itself".
+              seedSelectRef.current = true;
+              setSeedRequestToken((t) => t + 1);
             }
             setPinnedOpen(true);
             setFieldActive(true);


### PR DESCRIPTION
## Summary

Clicking the omnibar pre-filled the current path but left it unselected — you had to press Cmd+L to get the select-all every address bar teaches you to expect. Two separate causes, both of which had to be fixed for a click to work:

**The select never ran on a plain focus.** `onFocus` seeded the path and armed `seedSelectRef`, but the effect that actually calls `.select()` is keyed on `seedRequestToken` alone, and only `requestSearchFocus` (Cmd+L, crumb click) bumped that token. So a click seeded the text and left the flag armed to fire on some later, unrelated seed request. `onFocus` now bumps the token too. A focus landing on a box that is *already* holding the pristine path (blurred uncommitted, so `searchBoxBlurAction` kept the text) gets the same selection — the rule is "a plain focus on an un-typed-in field selects what's there", not "a focus that happened to do the seeding itself".

**Mouseup would have eaten the selection anyway.** Focus fires on mousedown, so `.select()` runs and then the browser's own mouseup default collapses it to a caret under the pointer. The input now records whether a mousedown is the focusing click, and suppresses the default on that one mouseup only.

## Visual

```mermaid
sequenceDiagram
    participant U as User
    participant I as input
    participant E as select effect
    U->>I: mousedown
    Note over I: onMouseDown — field unfocused,<br/>arm selectOnMouseUp
    I->>I: onFocus — seed path,<br/>arm seedSelectRef,<br/>bump seedRequestToken (new)
    I->>E: token changed
    E->>I: .select()
    U->>I: mouseup
    Note over I: onMouseUp — armed, so<br/>preventDefault (new):<br/>selection survives
```

Before, the two new steps were missing: the token never moved, so the effect never ran; and had it run, mouseup would have collapsed the selection.

## Usage

- Click the omnibar once → the whole path is selected, type to replace it.
- Click again inside the now-focused field → caret lands where you clicked, as before.
- Drag inside the focused field → normal drag-select, as before.
- Cmd+L → unchanged.

## Test plan

- `bunx tsc --noEmit` clean.
- `bun test src/apps/explorer/listing` — 691 pass. The 6 failures are the known process-wide `mock.module` router.ts contamination unrelated to this diff; each of those files passes when run alone (verified on `search-button-empty-open.render.test.tsx`).
- Pointer behavior can't be verified headlessly — needs a manual pass in the running app for the three Usage cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
