### PR TITLE
Fix Windows recap test failures: send the transcript tail over stdin, not argv

### DIFF
--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -684,19 +684,35 @@ def _recap_tail(turns: list) -> str:
 
 
 def _recap_result(stdout: str) -> str:
-    """The recap out of `--output-format json`'s single result object, capped.
+    """The recap out of `--output-format stream-json`'s terminal `result`
+    event, capped.
+
+    `--output-format json` (a single result object on its own) is not on offer
+    here: the CLI refuses `--input-format stream-json` — load-bearing for the
+    tail, see `_recap_generate` — paired with anything but
+    `--output-format stream-json` ("--input-format=stream-json requires
+    output-format=stream-json", verified live against 2.1.269). So `stdout` is
+    one JSON object PER LINE (init/system/assistant events, then the terminal
+    one), and the `result` event is found by scanning from the END rather than
+    assumed to be the literal last line — a trailing `rate_limit_event` or
+    `post_turn_summary` housekeeping line after it is ordinary, not an error.
 
     BOTH of `is_error` and `subtype` are checked because they fail differently:
     a refusal or a hit turn limit comes back with `is_error` false and a subtype
     like `error_max_turns`, and its `result` is then a machine message rather
-    than a recap. Anything that is not a clean success — unparseable stdout, a
-    non-success subtype, a `result` that is not a string — is "", which the
-    caller shows as no recap at all."""
-    try:
-        payload = json.loads(stdout.strip() or "{}")
-    except ValueError:
-        return ""
-    if not isinstance(payload, dict):
+    than a recap. Anything that is not a clean success — no `result` event at
+    all, a non-success subtype, a `result` that is not a string — is "", which
+    the caller shows as no recap at all."""
+    payload = None
+    for line in reversed(stdout.splitlines()):
+        try:
+            candidate = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(candidate, dict) and candidate.get("type") == "result":
+            payload = candidate
+            break
+    if payload is None:
         return ""
     if payload.get("is_error") or payload.get("subtype") != "success":
         return ""
@@ -753,6 +769,15 @@ def _recap_generate(agent, file: str, session_id: str) -> str:
     quoted. Passed over stdin instead, the tail never touches the command
     line cmd.exe parses, on any platform.
 
+    `--output-format stream-json` is not a choice: the CLI rejects
+    `--input-format stream-json` paired with anything else
+    ("--input-format=stream-json requires output-format=stream-json"), so the
+    single-JSON-object reply `--output-format json` gave us is gone too —
+    `_recap_result` reads the terminal `result` event back out of the
+    line-per-event stream instead. `--verbose` rides along because the CLI
+    requires it whenever `--output-format stream-json` is used (exits 1
+    without it, same rule `ai.py`'s `_ai_cmd` documents).
+
     `cwd` is the target's own working directory when there is one, and a temp
     directory otherwise. It genuinely does not matter — a fresh session with no
     tools cannot look at the filesystem — but a cwd that does not exist fails
@@ -772,7 +797,8 @@ def _recap_generate(agent, file: str, session_id: str) -> str:
         [agent._claude_bin(), "-p", "--no-session-persistence",
          "--input-format", "stream-json",
          "--max-turns", "1", "--tools", "", "--model", "haiku",
-         "--output-format", "json", "--system-prompt", _RECAP_SYSTEM],
+         "--output-format", "stream-json", "--verbose",
+         "--system-prompt", _RECAP_SYSTEM],
         cwd=workdir, env=agent._spawn_env(), stdin=subprocess.PIPE,
         stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
         encoding="utf-8", errors="replace")

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -739,6 +739,20 @@ def _recap_generate(agent, file: str, session_id: str) -> str:
     `haiku` because the job is small, the reader is waiting, and this fires on
     every return.
 
+    The tail travels over stdin as a `--input-format stream-json` message,
+    never as an argv element — same rule as every other prompt this template
+    sends (`_write_inbox_entry`, `ai.py`'s `_ai_cmd`), and load-bearing here
+    for a reason unique to this one caller: a transcript tail is the only
+    prompt in the app built out of the CONVERSATION rather than typed by a
+    person, so it is the one guaranteed to contain embedded newlines. On the
+    Windows `.bat`/`.cmd` shim an npm install of the CLI commonly resolves to,
+    CreateProcess reroutes the whole argv through `cmd.exe /c`, which reads
+    its command line ONE LINE AT A TIME — a raw newline inside a quoted argv
+    string ends that line as far as cmd.exe is concerned, silently
+    truncating the prompt at the first turn break no matter how it was
+    quoted. Passed over stdin instead, the tail never touches the command
+    line cmd.exe parses, on any platform.
+
     `cwd` is the target's own working directory when there is one, and a temp
     directory otherwise. It genuinely does not matter — a fresh session with no
     tools cannot look at the filesystem — but a cwd that does not exist fails
@@ -751,16 +765,19 @@ def _recap_generate(agent, file: str, session_id: str) -> str:
     workdir = agent._workdir(file)
     if not os.path.isdir(workdir):
         workdir = tempfile.gettempdir()
+    message = json.dumps({"type": "user", "message": {
+        "role": "user",
+        "content": [{"type": "text", "text": _RECAP_PROMPT % tail}]}})
     proc = subprocess.Popen(
         [agent._claude_bin(), "-p", "--no-session-persistence",
+         "--input-format", "stream-json",
          "--max-turns", "1", "--tools", "", "--model", "haiku",
-         "--output-format", "json", "--system-prompt", _RECAP_SYSTEM,
-         _RECAP_PROMPT % tail],
-        cwd=workdir, env=agent._spawn_env(), stdin=subprocess.DEVNULL,
+         "--output-format", "json", "--system-prompt", _RECAP_SYSTEM],
+        cwd=workdir, env=agent._spawn_env(), stdin=subprocess.PIPE,
         stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
         encoding="utf-8", errors="replace")
     try:
-        stdout, _ = proc.communicate(timeout=_RECAP_TIMEOUT)
+        stdout, _ = proc.communicate(input=message + "\n", timeout=_RECAP_TIMEOUT)
     except subprocess.TimeoutExpired:
         # Killed rather than left to finish: the answer is already unwanted, and
         # an abandoned `claude` would keep burning tokens for nobody.

--- a/tests/test_claude_session_recap.py
+++ b/tests/test_claude_session_recap.py
@@ -30,10 +30,11 @@ SESSION = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 FOR_UUID = "u-1"
 
 # Records argv AND stdin (the prompt travels on stdin — see D-recap's
-# `--input-format stream-json` fix), optionally stalls (the single-flight test
-# needs the first run to still be in flight when the second reader arrives),
-# then prints whatever JSON the test asked for on stdout — which is all
-# `--output-format json` is to us.
+# `--input-format stream-json` fix, which forces `--output-format stream-json`
+# too: the CLI refuses the two paired with anything else), optionally stalls
+# (the single-flight test needs the first run to still be in flight when the
+# second reader arrives), then prints one `result` event line — the only line
+# of the stream `_recap_result` actually reads — on stdout.
 _STUB = """#!{python}
 import json
 import os
@@ -167,6 +168,11 @@ def test_recap_comes_back_capped_with_the_turn_it_is_about(
     assert argv[argv.index("--tools") + 1] == ""
     assert argv[argv.index("--max-turns") + 1] == "1"
     assert argv[argv.index("--input-format") + 1] == "stream-json"
+    # Not a free choice: the CLI rejects --input-format stream-json paired
+    # with anything but --output-format stream-json, which in turn requires
+    # --verbose or the CLI exits 1.
+    assert argv[argv.index("--output-format") + 1] == "stream-json"
+    assert "--verbose" in argv
     tail = "User: make the tests pass\n\nAssistant: " + "x" * 900
     prompt = _prompt(call)
     assert prompt == recap_mod._RECAP_PROMPT % tail
@@ -257,6 +263,32 @@ def test_blank_parameters_are_a_400(client, project, calls):
     assert _get(client, target, session_id="").status_code == 400
     assert _get(client, target, for_uuid="").status_code == 400
     assert _spawns(calls) == []
+
+
+def test_recap_result_scans_a_stream_json_reply_for_the_result_event():
+    """`--output-format stream-json` (forced by `--input-format stream-json`,
+    which the tail's newlines require — see `_recap_generate`) is a line per
+    event, not one object: the terminal `result` line is found by scanning
+    from the end, not by assuming it is the literal last line — a
+    `rate_limit_event`/`post_turn_summary` housekeeping line trailing it is
+    ordinary (observed live), not a parse failure."""
+    from fused_render.server.routers.claude_sessions import _recap_result
+
+    stream = "\n".join([
+        json.dumps({"type": "system", "subtype": "init"}),
+        json.dumps({"type": "stream_event", "event": {"type": "message_stop"}}),
+        _ok("the model's actual recap, long enough to count as one"),
+        json.dumps({"type": "rate_limit_event", "rate_limit_info": {}}),
+    ])
+    assert _recap_result(stream) == "the model's actual recap, long enough to count as one"
+
+    # No `result` event anywhere (a process killed mid-stream, or a CLI
+    # version that never got that far) is the same "no recap" as empty stdout.
+    assert _recap_result("\n".join([
+        json.dumps({"type": "system", "subtype": "init"}),
+        "not even json",
+    ])) == ""
+    assert _recap_result("") == ""
 
 
 def test_recap_plain_strips_markdown_and_refuses_one_word_answers():

--- a/tests/test_claude_session_recap.py
+++ b/tests/test_claude_session_recap.py
@@ -29,17 +29,21 @@ from _claude_stub_cli import write_stub_cli
 SESSION = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 FOR_UUID = "u-1"
 
-# Records argv, optionally stalls (the single-flight test needs the first run to
-# still be in flight when the second reader arrives), then prints whatever JSON
-# the test asked for on stdout — which is all `--output-format json` is to us.
+# Records argv AND stdin (the prompt travels on stdin — see D-recap's
+# `--input-format stream-json` fix), optionally stalls (the single-flight test
+# needs the first run to still be in flight when the second reader arrives),
+# then prints whatever JSON the test asked for on stdout — which is all
+# `--output-format json` is to us.
 _STUB = """#!{python}
 import json
 import os
 import sys
 import time
 
+stdin_data = sys.stdin.read()
+record = dict(argv=sys.argv[1:], stdin=stdin_data)
 with open(os.environ["RECAP_STUB_CALLS"], "a", encoding="utf-8") as fh:
-    fh.write(json.dumps(sys.argv[1:]) + "\\n")
+    fh.write(json.dumps(record) + "\\n")
 time.sleep(float(os.environ.get("RECAP_STUB_DELAY") or 0))
 sys.stdout.write(os.environ["RECAP_STUB_OUT"])
 """
@@ -78,7 +82,8 @@ def agent(tmp_path, monkeypatch):
 
 @pytest.fixture
 def calls(tmp_path, monkeypatch):
-    """Path of the stub's argv log. Reading it is how the tests count spawns."""
+    """Path of the stub's call log (argv + stdin). Reading it is how the
+    tests count spawns."""
     log = tmp_path / "stub-calls.jsonl"
     monkeypatch.setenv("RECAP_STUB_CALLS", str(log))
     monkeypatch.setenv("RECAP_STUB_OUT", _ok("the recap, long enough to count as one"))
@@ -93,6 +98,14 @@ def _spawns(log):
         return []
     return [json.loads(line) for line in
             log.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _prompt(call):
+    """The prompt text out of one spawn's stdin — a single `--input-format
+    stream-json` user-message line, the one place the tail actually travels
+    now that it no longer rides in argv."""
+    message = json.loads(call["stdin"].strip())
+    return message["message"]["content"][0]["text"]
 
 
 @pytest.fixture
@@ -143,16 +156,21 @@ def test_recap_comes_back_capped_with_the_turn_it_is_about(
     assert body["for_uuid"] == FOR_UUID
     assert body["at"]
 
-    argv, = _spawns(calls)
+    call, = _spawns(calls)
+    argv = call["argv"]
     # The flags that make this safe: no JSONL written, no tools, one turn, and
-    # the tail passed as the prompt rather than the live session resumed.
+    # the tail passed as a stream-json message over stdin — never an argv
+    # element, or a Windows .bat/.cmd shim's cmd.exe would truncate it at its
+    # first newline — rather than the live session resumed.
     assert "--no-session-persistence" in argv
     assert "--resume" not in argv and "--fork-session" not in argv
     assert argv[argv.index("--tools") + 1] == ""
     assert argv[argv.index("--max-turns") + 1] == "1"
+    assert argv[argv.index("--input-format") + 1] == "stream-json"
     tail = "User: make the tests pass\n\nAssistant: " + "x" * 900
-    assert argv[-1] == recap_mod._RECAP_PROMPT % tail
-    assert "<transcript>\n" + tail + "\n</transcript>" in argv[-1]
+    prompt = _prompt(call)
+    assert prompt == recap_mod._RECAP_PROMPT % tail
+    assert "<transcript>\n" + tail + "\n</transcript>" in prompt
 
 
 def test_a_failed_cli_run_is_empty_text_not_an_error(
@@ -278,10 +296,11 @@ def test_an_interrupted_reply_still_gets_a_recap(client, project, calls):
 
     assert _get(client, target).json()["text"] == (
         "the recap, long enough to count as one")
-    argv, = _spawns(calls)
+    call, = _spawns(calls)
+    prompt = _prompt(call)
     # …and the marker is not in what the model was asked to summarize.
-    assert recap_mod._INTERRUPT_MARK not in argv[-1]
-    assert "Assistant: Reading the tree now" in argv[-1]
+    assert recap_mod._INTERRUPT_MARK not in prompt
+    assert "Assistant: Reading the tree now" in prompt
 
 
 def test_two_copies_of_a_folder_do_not_share_one_recap(
@@ -305,6 +324,7 @@ def test_two_copies_of_a_folder_do_not_share_one_recap(
     assert _get(client, str(other)).status_code == 200
 
     first, second = _spawns(calls)
-    assert "in the original" in first[-1] and "in the copy" not in first[-1]
-    assert "in the copy" in second[-1], (
+    first_prompt, second_prompt = _prompt(first), _prompt(second)
+    assert "in the original" in first_prompt and "in the copy" not in first_prompt
+    assert "in the copy" in second_prompt, (
         "the second file must not be answered out of the first file's cache")


### PR DESCRIPTION
## Summary

`main`'s Windows `test` job (`test-python-windows`) has been red for several runs, with 3 failures all in `tests/test_claude_session_recap.py`:

- `test_recap_comes_back_capped_with_the_turn_it_is_about`
- `test_an_interrupted_reply_still_gets_a_recap`
- `test_two_copies_of_a_folder_do_not_share_one_recap`

**Root cause:** `_recap_generate` (the "while you were away" session recap, `fused_render/server/routers/claude_sessions.py`) built the conversation tail into `_RECAP_PROMPT % tail` and passed it as a raw positional CLI argument to the `claude` CLI. That prompt always contains embedded newlines (it wraps the transcript tail in `<transcript>...</transcript>` on its own lines).

On Windows, when `claude` resolves to an npm-installed `.bat`/`.cmd` shim (a common real install shape, and exactly what the test's own `_claude_stub_cli.py` mirrors), `CreateProcess` reroutes the whole invocation through `cmd.exe /c`. cmd.exe's parser reads its command line **one line at a time**, so a raw newline inside a quoted argument ends that line as far as cmd.exe is concerned — silently truncating the prompt at the very first turn break, no matter how the argument was quoted. The CLI actually received just the string's first sentence ("...the returning user."), with everything else (the transcript, the model's own instructions) dropped.

This is exactly the failure mode the codebase already guards against elsewhere with a documented rule — "no user-controlled STRING may enter argv" (`fused_render/server/ai.py`'s `_ai_cmd`, `fused_render/templates/claude/agent.py`'s `_write_inbox_entry`) — but the recap feature's one-shot CLI call predated/missed that convention.

## Fix

- `_recap_generate` now sends the prompt as a `--input-format stream-json` message over stdin (the exact same `{"type": "user", "message": {...}}` shape already used by `ai.py`'s `_ai_drive` and `agent.py`'s `_write_inbox_entry`), instead of embedding it in argv.
- Updated `tests/test_claude_session_recap.py`'s CLI stub to also capture stdin (not just argv), and updated the three affected tests' assertions to read the prompt out of stdin instead of `argv[-1]`.

## Test plan

- [x] `tests/test_claude_session_recap.py` — 10/10 pass locally
- [x] Related suites (`test_claude_sessions_api.py`, `test_claude_session_summaries.py`, `test_tasks_*.py`, `test_app_fused_dir.py`) — 353/353 pass locally
- [ ] CI: Windows `test-python-windows` job should go green (can't run Windows locally to confirm the exact cmd.exe truncation, but the fix follows the codebase's own established, documented pattern for this exact class of bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFGA8qKUDvGvzqzfVNPUzZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01KFGA8qKUDvGvzqzfVNPUzZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the optional session recap subprocess path and test updates; behavior change is input/output wiring, not auth or persisted data.
> 
> **Overview**
> Fixes Windows CI failures in session recap by **not putting the multi-line transcript prompt on the CLI argv**, which `cmd.exe` truncates when the `claude` shim runs through a `.bat`/`.cmd` wrapper.
> 
> **`_recap_generate`** now sends the recap prompt as a `--input-format stream-json` user message on **stdin** (same shape as `ai.py` / inbox writes), and switches the subprocess to **`--output-format stream-json`** with **`--verbose`** because the CLI requires that pairing. **`_recap_result`** no longer assumes a single JSON blob on stdout; it walks the line-delimited stream **from the end** until it finds a `type: "result"` event with a successful subtype.
> 
> Tests update the stub to record **argv + stdin**, assert flags and prompt content from stdin, and add coverage for trailing housekeeping lines after the result event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943e75980178f702b7249073c1cb5c9bbe834281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->