### PR TITLE
Native chat: the reload and adopted roads no longer flash the old reply into the new bubble

### DIFF
--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1381,17 +1381,23 @@ describe("follow-ups (T:16024, D687)", () => {
             await controller.sendFollowUp("and one more thing");
             return poll({ segments: [A], text: A.text });
           }
-          // Now a seam arrives — but this one closes the reply the follow-up
-          // was folded into, so it is OURS, not the base.
+          // Now the echo lands, and the payload carries TWO seams: the
+          // pre-send boundary (end of the reply already on screen) and the
+          // `result` closing the reply the follow-up was folded into. The
+          // first is the base; the second is ours.
+          const twoSeams = [
+            { segments: 1, text: A.text.length },
+            { segments: 2, text: A.text.length + B.text.length },
+          ];
           if (n === 2) {
             return poll({
               segments: [A, B, C],
               text: A.text + B.text + C.text,
-              turn_breaks: [{ segments: 2, text: A.text.length + B.text.length }],
+              turn_breaks: twoSeams,
             });
           }
           return poll({ done: true, segments: [A, B, C], text: A.text + B.text + C.text,
-                        turn_breaks: [{ segments: 2, text: A.text.length + B.text.length }] });
+                        turn_breaks: twoSeams });
         },
       },
       params,
@@ -1408,6 +1414,72 @@ describe("follow-ups (T:16024, D687)", () => {
     );
     expect(bodies.some((b) => b.includes(B.text))).toBe(true);
     // …and the reply already on screen is still not duplicated into it.
+    expect(bodies.slice(1).some((b) => b.includes(A.text))).toBe(false);
+    // The follow-up's own answer is here too, and in its own bubble rather
+    // than merged into this send's.
+    expect(bodies.some((b) => b.includes(C.text))).toBe(true);
+    expect(bodies.some((b) => b.includes(B.text) && b.includes(C.text))).toBe(false);
+  });
+
+  // AND THE BASE SEAM IS STILL ADOPTED AFTERWARDS (Bugbot, PR #1119). Refusing
+  // to adopt once a follow-up had landed — the first attempt at the test above
+  // — left the pre-send boundary unadopted too, and `priorReply`'s text was
+  // sampled when this send was composed, BEFORE a wake appended anything to
+  // the turn already on screen. So the wake's continuation had nothing
+  // excluding it and rendered into this turn's bubble: the same duplication
+  // the rest of this PR closes, arriving by the other door.
+  test("a wake that grew the previous turn after the send is still excluded", async () => {
+    let controller!: ChatController;
+    const A = text("The answer from before the reload.");
+    const WAKE = text(" And the background task finished.");
+    const B = text("The new answer.");
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const made = makeController(
+      {
+        history: () => ({
+          turns: [
+            { role: "user" as const, text: "earlier question", uuid: "u1" },
+            { role: "assistant" as const, text: A.text, uuid: "a1" },
+          ],
+        }),
+        live_run: () => ({ run_id: "" }),
+        live_host: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        start: () => {
+          throw new Error("the live host took it");
+        },
+        poll: async (_f, n) => {
+          // The wake grows the turn already on screen — AFTER `priorReply`
+          // sampled its text, so `baseText` alone cannot exclude it.
+          if (n === 0) return poll({ segments: [A, WAKE], text: A.text + WAKE.text });
+          // A follow-up lands before this send's own echo does.
+          if (n === 1) {
+            await controller.sendFollowUp("and one more thing");
+            return poll({ segments: [A, WAKE], text: A.text + WAKE.text });
+          }
+          // The echo lands and the pre-send boundary is named — past the
+          // wake's continuation, which belongs to the previous turn.
+          return poll({
+            done: n > 2,
+            segments: [A, WAKE, B],
+            text: A.text + WAKE.text + B.text,
+            turn_breaks: [{ segments: 2, text: A.text.length + WAKE.text.length }],
+          });
+        },
+      },
+      params,
+    );
+    controller = made.controller;
+    await controller.openSession("s1");
+    await controller.sendMessage("and now this");
+
+    const bodies = assistants(controller).map(
+      (t) => (t.segments || []).map(bodyOf).join("") + (t.text || ""),
+    );
+    // This send's reply is here, and neither the old reply NOR the wake's
+    // continuation came with it.
+    expect(bodies.some((b) => b.includes(B.text))).toBe(true);
+    expect(bodies.slice(1).some((b) => b.includes(WAKE.text))).toBe(false);
     expect(bodies.slice(1).some((b) => b.includes(A.text))).toBe(false);
   });
 

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1062,6 +1062,62 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply.length).toBe(2);
   });
 
+  // BUGBOT, PR #1119: the fix above's first shape `continue`d past every poll
+  // for as long as `baseSegTrusted` stayed down, waiting for the "already
+  // landed prefix retires" check to notice `fullText` no longer starts with
+  // the old reply. A short new reply that happens to share the old one's own
+  // prefix ("OK" answering into "OK, done.") never makes that true — so that
+  // shape skipped `poll.done` forever, never cleared `sending`, and left the
+  // composer stuck. This is that exact shape, and it must still terminate.
+  test("a short reply sharing the old reply's own prefix still finishes and clears `sending` (no seam)", async () => {
+    const A = text("OK");
+    const Bgrowing = text("OK, d");
+    const Bfull = text("OK, done.");
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const { controller, returned } = makeController(
+      {
+        history: () => ({
+          turns: [
+            { role: "user" as const, text: "earlier question", uuid: "u1" },
+            { role: "assistant" as const, text: A.text, uuid: "a1" },
+          ],
+        }),
+        live_run: () => ({ run_id: "" }),
+        live_host: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        start: () => {
+          throw new Error("the live host took it");
+        },
+        poll: (_f, n) => {
+          if (n === 0) return poll({ segments: [], text: "" });
+          // No `turn_breaks` — the ambiguous poll `baseSegGrace` is spent on.
+          if (n === 1) return poll({ segments: [A, Bgrowing], text: A.text + Bgrowing.text });
+          // The cursor has advanced (a clean window, B alone) — but B's own
+          // full text STILL starts with "OK", so a check keyed on the prefix
+          // no longer matching would never fire here either.
+          return poll({ done: true, segments: [Bfull], text: Bfull.text });
+        },
+      },
+      params,
+    );
+    await controller.openSession("s1");
+
+    // Must resolve on its own — a hang here means `sending` never clears.
+    await controller.sendMessage("and now what?");
+
+    expect(controller.getState().status).toBe("idle");
+    expect(controller.getState().working).toBeNull();
+    const reply = assistants(controller);
+    expect(reply[0]!.text).toBe(A.text);
+    expect(reply[1]!.text).toBe(Bfull.text);
+    expect(reply.length).toBe(2);
+
+    // `sending` itself cleared: a second send is accepted, not refused.
+    const returnedBefore = returned.length;
+    await controller.sendMessage("one more");
+    expect(returned.length).toBe(returnedBefore);
+  });
+
   // VERIFIED LIVE, on :2019: a mid-stream follow-up drained AFTER the first
   // reply's `result` is a GENUINE turn boundary, not a fold-in — and agent.py
   // used to report no seam for one, on the reasoning that the cursor moves and

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1136,13 +1136,26 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply.length).toBe(2);
   });
 
-  // BUGBOT, PR #1119: the fix above's first shape `continue`d past every poll
-  // for as long as `baseSegTrusted` stayed down, waiting for the "already
-  // landed prefix retires" check to notice `fullText` no longer starts with
-  // the old reply. A short new reply that happens to share the old one's own
-  // prefix ("OK" answering into "OK, done.") never makes that true — so that
-  // shape skipped `poll.done` forever, never cleared `sending`, and left the
-  // composer stuck. This is that exact shape, and it must still terminate.
+  // BUGBOT, PR #1119: a `continue` here used to skip every poll for as long as
+  // `baseSegTrusted` stayed down, waiting for the "already landed prefix
+  // retires" check to notice `fullText` no longer starts with the old reply.
+  // A short new reply that happens to share the old one's own prefix ("OK"
+  // answering into "OK, done.") never makes that true — so that shape skipped
+  // `poll.done` forever, never cleared `sending`, and left the composer stuck.
+  // This is that exact shape, and it must still terminate.
+  //
+  // What it must NOT do is trust `segs` just because time (or polls) passed
+  // (Bugbot, PR #1119, second pass): earlier attempts spent a one-poll
+  // allowance unconditionally, which — on a payload where the FIRST body
+  // this loop ever sees is not yet the cursor-advancing one (a busy host, not
+  // an idle one — see `baseSegTrusted`'s own note) — burns it on the wrong
+  // poll and trusts an unsliced `segs` on the poll that actually needed
+  // protecting. So trust here is never time-based: it is earned (a reported
+  // seam, or the prefix genuinely retiring) or not earned at all, and NOT
+  // earning it for this reply's whole duration renders it as plain text
+  // rather than segments — losing the shared "OK" out of the display (an
+  // accepted, cosmetic cost of `baseText` never being disprovable here), but
+  // never duplicating anything and never leaving a poll unhandled.
   test("a short reply sharing the old reply's own prefix still finishes and clears `sending` (no seam)", async () => {
     const A = text("OK");
     const Bgrowing = text("OK, d");
@@ -1164,7 +1177,8 @@ describe("follow-ups (T:16024, D687)", () => {
         },
         poll: (_f, n) => {
           if (n === 0) return poll({ segments: [], text: "" });
-          // No `turn_breaks` — the ambiguous poll `baseSegGrace` is spent on.
+          // No `turn_breaks` reported, ever — `baseSegTrusted` has nothing to
+          // earn it with, on this poll or any later one.
           if (n === 1) return poll({ segments: [A, Bgrowing], text: A.text + Bgrowing.text });
           // The cursor has advanced (a clean window, B alone) — but B's own
           // full text STILL starts with "OK", so a check keyed on the prefix
@@ -1183,13 +1197,80 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(controller.getState().working).toBeNull();
     const reply = assistants(controller);
     expect(reply[0]!.text).toBe(A.text);
-    expect(reply[1]!.text).toBe(Bfull.text);
+    // NEVER a duplicate: the new turn's own segments array stays empty the
+    // whole time (never earned), so it falls back to plain text — the tail
+    // beyond the shared "OK" prefix, not "OK, done." in full (see the test's
+    // own note above) and never `A.text` alongside it.
+    expect((reply[1] as { segments?: unknown[] }).segments || []).toEqual([]);
+    expect(reply[1]!.text).toBe(Bfull.text.slice(A.text.length));
     expect(reply.length).toBe(2);
 
     // `sending` itself cleared: a second send is accepted, not refused.
     const returnedBefore = returned.length;
     await controller.sendMessage("one more");
     expect(returned.length).toBe(returnedBefore);
+  });
+
+  // BUGBOT, PR #1119, second pass: a BUSY host (a D415 wake in progress, not
+  // an idle one) means `pending_echo` never blanks the polls before the
+  // combined window lands — those earlier polls carry the OLD reply alone,
+  // non-blank, same as every ordinary poll of a settled turn. A one-poll
+  // "grace" spent unconditionally on the first non-blank poll — this loop's
+  // earlier fix — burns itself on one of THESE, and the actually-ambiguous
+  // combined poll (old + new, no seam) then lands with the allowance already
+  // gone, `baseSegTrusted` wrongly flipped, and `segs` sliced from 0 as if it
+  // were clean. Two non-blank, old-reply-only polls stand in for the busy
+  // host here, before the combined one arrives.
+  test("a busy host's non-blank polls before the echo lands do not spend the same allowance a hang fix once relied on", async () => {
+    const A = text("The answer from before the reload.");
+    const B = text("The new answer.");
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const { controller } = makeController(
+      {
+        history: () => ({
+          turns: [
+            { role: "user" as const, text: "earlier question", uuid: "u1" },
+            { role: "assistant" as const, text: A.text, uuid: "a1" },
+          ],
+        }),
+        live_run: () => ({ run_id: "" }),
+        live_host: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        start: () => {
+          throw new Error("the live host took it");
+        },
+        poll: (_f, n) => {
+          // NOT blank: the host is busy (a wake in flight), so `pending_echo`
+          // never applies. Both of these are the OLD reply alone — nothing
+          // of this send is in the window yet.
+          if (n === 0 || n === 1) return poll({ segments: [A], text: A.text });
+          // The echo has landed. Old + new, combined, no `turn_breaks` — the
+          // one poll this whole mechanism exists to protect.
+          if (n === 2) return poll({ segments: [A, B], text: A.text + B.text });
+          return poll({ done: true, segments: [B], text: B.text });
+        },
+      },
+      params,
+    );
+    await controller.openSession("s1");
+
+    const seen: string[][][] = [];
+    const off = controller.subscribe(() => {
+      seen.push(assistants(controller).map((t) => (t.segments || []).map(bodyOf)));
+    });
+    await controller.sendMessage("and now this");
+    off();
+
+    const newBubbleFrames = seen.map((assistantTurns) => assistantTurns[assistantTurns.length - 1] || []);
+    const flashed = newBubbleFrames.filter(
+      (segs) => segs.some((s) => s.includes(A.text)) && segs.some((s) => s.includes(B.text)),
+    );
+    expect(flashed).toEqual([]);
+
+    const reply = assistants(controller);
+    expect(reply[0]!.text).toBe(A.text);
+    expect(reply[1]!.text).toBe(B.text);
+    expect(reply.length).toBe(2);
   });
 
   // VERIFIED LIVE, on :2019: a mid-stream follow-up drained AFTER the first

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1339,6 +1339,74 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply.length).toBe(2);
   });
 
+  // …AND A WAKE GROWING THE TURN ALREADY ON SCREEN DOES NOT SPEND THE WAIT
+  // (Bugbot, PR #1119). A D415 wake appends to the PREVIOUS turn, so the
+  // payload grows past `priorReply`'s text while this send's own echo is still
+  // outstanding. Treating any growth as "this turn has started" spent the
+  // arming on one of those polls, and the real seam — which lands with the
+  // echo a poll later — was then read as this send's own follow-up instead of
+  // as the base, putting the old reply back in the new bubble.
+  test("a wake growing the previous turn does not spend the wait for the seam", async () => {
+    const A = text("The answer from before the reload.");
+    const WAKE = text(" And the background task finished.");
+    const B = text("The new answer.");
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const { controller } = makeController(
+      {
+        history: () => ({
+          turns: [
+            { role: "user" as const, text: "earlier question", uuid: "u1" },
+            { role: "assistant" as const, text: A.text, uuid: "a1" },
+          ],
+        }),
+        live_run: () => ({ run_id: "" }),
+        live_host: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        start: () => {
+          throw new Error("the live host took it");
+        },
+        poll: (_f, n) => {
+          // The wake appends to the turn already on screen: the payload grows
+          // past `priorReply`'s text, and none of it is ours.
+          if (n === 0) return poll({ segments: [A, WAKE], text: A.text + WAKE.text });
+          // Now the echo lands and agent.py names the boundary — past the
+          // wake's own continuation, which belongs to the previous turn.
+          if (n === 1) {
+            return poll({
+              segments: [A, WAKE, B],
+              text: A.text + WAKE.text + B.text,
+              turn_breaks: [{ segments: 2, text: A.text.length + WAKE.text.length }],
+            });
+          }
+          return poll({ done: true, segments: [B], text: B.text });
+        },
+      },
+      params,
+    );
+    await controller.openSession("s1");
+
+    const seen: string[][][] = [];
+    const off = controller.subscribe(() => {
+      seen.push(assistants(controller).map((t) => (t.segments || []).map(bodyOf)));
+    });
+    await controller.sendMessage("and now this");
+    off();
+
+    // The new bubble never carries the old reply OR the wake's continuation.
+    const newBubbleFrames = seen.map((t) => t[t.length - 1] || []);
+    expect(
+      newBubbleFrames.filter((segs) =>
+        segs.some((s) => s.includes(A.text) || s.includes(WAKE.text)),
+      ),
+    ).toEqual([]);
+
+    const reply = assistants(controller);
+    expect(reply[0]!.text).toBe(A.text);
+    expect(reply[1]!.text).toBe(B.text);
+    expect((reply[1]!.segments || []).map(bodyOf)).toEqual([B.text]);
+    expect(reply.length).toBe(2);
+  });
+
   // VERIFIED LIVE, on :2019: a mid-stream follow-up drained AFTER the first
   // reply's `result` is a GENUINE turn boundary, not a fold-in — and agent.py
   // used to report no seam for one, on the reasoning that the cursor moves and

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1273,6 +1273,72 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply.length).toBe(2);
   });
 
+  // …AND THE SEAM THAT ARRIVES A POLL LATE IS STILL ADOPTED. Same busy host,
+  // but agent.py DOES name the boundary once the echo lands (it does now, for
+  // every genuine boundary — `_absorbed_turn_breaks` no longer requires the
+  // `result` to be the row immediately before the echo). `adoptFirstSeam` used
+  // to be spent on the first payload carrying any body at all, which here is a
+  // pre-echo one with no seam in it, so the real seam was thrown away and the
+  // reply rendered without its segments for the rest of the turn.
+  test("a seam reported after the first non-blank poll is still adopted as the base", async () => {
+    const A = text("The answer from before the reload.");
+    const B = text("The new answer.");
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const { controller } = makeController(
+      {
+        history: () => ({
+          turns: [
+            { role: "user" as const, text: "earlier question", uuid: "u1" },
+            { role: "assistant" as const, text: A.text, uuid: "a1" },
+          ],
+        }),
+        live_run: () => ({ run_id: "" }),
+        live_host: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        start: () => {
+          throw new Error("the live host took it");
+        },
+        poll: (_f, n) => {
+          // Busy host: the old reply alone, non-blank, before the echo lands.
+          if (n === 0) return poll({ segments: [A], text: A.text });
+          // The echo landed and agent.py names the boundary.
+          if (n === 1) {
+            return poll({
+              segments: [A, B],
+              text: A.text + B.text,
+              turn_breaks: [{ segments: 1, text: A.text.length }],
+            });
+          }
+          return poll({ done: true, segments: [B], text: B.text });
+        },
+      },
+      params,
+    );
+    await controller.openSession("s1");
+
+    const seen: string[][][] = [];
+    const off = controller.subscribe(() => {
+      seen.push(assistants(controller).map((t) => (t.segments || []).map(bodyOf)));
+    });
+    await controller.sendMessage("and now this");
+    off();
+
+    const newBubbleFrames = seen.map((t) => t[t.length - 1] || []);
+    expect(
+      newBubbleFrames.filter(
+        (segs) => segs.some((s) => s.includes(A.text)) && segs.some((s) => s.includes(B.text)),
+      ),
+    ).toEqual([]);
+
+    const reply = assistants(controller);
+    expect(reply[0]!.text).toBe(A.text);
+    expect(reply[1]!.text).toBe(B.text);
+    // The seam WAS adopted, so the reply keeps its segments rather than being
+    // held back to plain text for the whole turn.
+    expect((reply[1]!.segments || []).map(bodyOf)).toEqual([B.text]);
+    expect(reply.length).toBe(2);
+  });
+
   // VERIFIED LIVE, on :2019: a mid-stream follow-up drained AFTER the first
   // reply's `result` is a GENUINE turn boundary, not a fold-in — and agent.py
   // used to report no seam for one, on the reasoning that the cursor moves and

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -984,6 +984,84 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply[1]!.text).not.toContain("before the reload");
   });
 
+  // THE RELOAD ROAD WITHOUT A SEAM. `_absorbed_turn_breaks` only reports a
+  // genuine boundary when the previous `result` is the row RIGHT BEFORE this
+  // send's echo — a D415 wake (or anything else) sitting between them makes it
+  // withhold the seam entirely (agent.py's own adjacency rule), and the test
+  // above assumes the seam always arrives. `priorReply` (what the restored
+  // transcript already had on screen, seeded before `turn_breaks` is even
+  // read) is the fallback for exactly this.
+  //
+  // Without it, the payload below (no `turn_breaks`, both replies' segments in
+  // one window) lands in ONE bubble carrying BOTH replies — reply A rendered a
+  // second time, alongside B, for as long as the disk cursor has not yet
+  // stepped over the boundary. The NEXT poll (cursor advanced, B alone) then
+  // silently overwrites that bubble down to just B, so a final-state assertion
+  // never sees it: the duplication is a one-tick flash, exactly "the last
+  // response gets duplicated ... before the new response starts streaming" —
+  // which is why every intermediate frame is inspected here, the same way the
+  // R4-3 test above catches it for the same-tab shape.
+  test("a send into a restored session never flashes the old reply into the new bubble (no seam)", async () => {
+    const A = text("The answer from before the reload.");
+    const B = text("The new answer.");
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const { controller } = makeController(
+      {
+        history: () => ({
+          turns: [
+            { role: "user" as const, text: "earlier question", uuid: "u1" },
+            { role: "assistant" as const, text: A.text, uuid: "a1" },
+          ],
+        }),
+        live_run: () => ({ run_id: "" }),
+        live_host: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        start: () => {
+          throw new Error("the live host took it");
+        },
+        poll: (_f, n) => {
+          if (n === 0) return poll({ segments: [], text: "" });
+          // No `turn_breaks` at all — a wake sat between the old `result` and
+          // this send's echo, so agent.py cannot prove the seam. Without
+          // `priorReply` this is exactly the payload that flashes the old
+          // reply into the new bubble.
+          if (n === 1) return poll({ segments: [A, B], text: A.text + B.text });
+          return poll({ done: true, segments: [B], text: B.text });
+        },
+      },
+      params,
+    );
+    await controller.openSession("s1");
+
+    const seen: string[][][] = [];
+    const off = controller.subscribe(() => {
+      seen.push(assistants(controller).map((t) => (t.segments || []).map(bodyOf)));
+    });
+    await controller.sendMessage("and now this");
+    off();
+
+    // The new bubble (the last assistant turn in every frame) must never carry
+    // reply A's text alongside reply B's — whatever it holds mid-stream, it is
+    // either A alone (untouched, from before the send) or B alone/growing,
+    // never both together.
+    const newBubbleFrames = seen.map((assistantTurns) => assistantTurns[assistantTurns.length - 1] || []);
+    const flashed = newBubbleFrames.filter(
+      (segs) => segs.some((s) => s.includes(A.text)) && segs.some((s) => s.includes(B.text)),
+    );
+    expect(flashed).toEqual([]);
+
+    expect(controller.getState().turns.map((t) => t.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    const reply = assistants(controller);
+    expect(reply[0]!.text).toBe(A.text);
+    expect(reply[1]!.text).toBe(B.text);
+    expect(reply.length).toBe(2);
+  });
+
   // VERIFIED LIVE, on :2019: a mid-stream follow-up drained AFTER the first
   // reply's `result` is a GENUINE turn boundary, not a fold-in — and agent.py
   // used to report no seam for one, on the reasoning that the cursor moves and

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1346,6 +1346,71 @@ describe("follow-ups (T:16024, D687)", () => {
   // arming on one of those polls, and the real seam — which lands with the
   // echo a poll later — was then read as this send's own follow-up instead of
   // as the base, putting the old reply back in the new bubble.
+  // …BUT A FOLLOW-UP LANDING IN THIS LOOP DOES SPEND IT (Bugbot, PR #1119).
+  // Once one has, a seam can be the `result` closing the reply that follow-up
+  // was folded into — this send's OWN boundary, which belongs to a bubble.
+  // Adopting it as the base instead would swallow this send's reply whole. The
+  // gate for that was first written against `seenFollowupSeq`, which the top of
+  // every poll has already synced to `followupSeq`, so it could never fire.
+  test("a follow-up landing in this loop stops a later seam being taken as the base", async () => {
+    let controller!: ChatController;
+    const A = text("The answer from before the reload.");
+    const B = text("The new answer.");
+    const C = text("And the follow-up's answer.");
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const made = makeController(
+      {
+        history: () => ({
+          turns: [
+            { role: "user" as const, text: "earlier question", uuid: "u1" },
+            { role: "assistant" as const, text: A.text, uuid: "a1" },
+          ],
+        }),
+        live_run: () => ({ run_id: "" }),
+        live_host: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        start: () => {
+          throw new Error("the live host took it");
+        },
+        poll: async (_f, n) => {
+          // Still the old reply alone — the echo has not landed, so the wait
+          // for the base seam is still armed and nothing is ours yet.
+          if (n === 0) return poll({ segments: [A], text: A.text });
+          // A follow-up is typed into this very loop while that is still true.
+          if (n === 1) {
+            await controller.sendFollowUp("and one more thing");
+            return poll({ segments: [A], text: A.text });
+          }
+          // Now a seam arrives — but this one closes the reply the follow-up
+          // was folded into, so it is OURS, not the base.
+          if (n === 2) {
+            return poll({
+              segments: [A, B, C],
+              text: A.text + B.text + C.text,
+              turn_breaks: [{ segments: 2, text: A.text.length + B.text.length }],
+            });
+          }
+          return poll({ done: true, segments: [A, B, C], text: A.text + B.text + C.text,
+                        turn_breaks: [{ segments: 2, text: A.text.length + B.text.length }] });
+        },
+      },
+      params,
+    );
+    controller = made.controller;
+    await controller.openSession("s1");
+    await controller.sendMessage("and now this");
+
+    // This send's own reply survives: it is NOT swallowed into the base.
+    // Read through whichever mode it rendered in — with the adoption refused
+    // there is no confirmed segment count, so it falls back to plain text.
+    const bodies = assistants(controller).map(
+      (t) => (t.segments || []).map(bodyOf).join("") + (t.text || ""),
+    );
+    expect(bodies.some((b) => b.includes(B.text))).toBe(true);
+    // …and the reply already on screen is still not duplicated into it.
+    expect(bodies.slice(1).some((b) => b.includes(A.text))).toBe(false);
+  });
+
   test("a wake growing the previous turn does not spend the wait for the seam", async () => {
     const A = text("The answer from before the reload.");
     const WAKE = text(" And the background task finished.");

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1062,6 +1062,80 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply.length).toBe(2);
   });
 
+  // THE REAL SEND ROAD, not the bare `sendMessage()` every other test in this
+  // file uses. `dispatchSend` (ClaudeChat.tsx) calls `postOptimisticUser` —
+  // which posts this send's OWN user bubble — synchronously, BEFORE
+  // `sendMessage` ever runs, so by the time `sendMessage` reads `state.turns`
+  // for `priorReply` the last turn is usually this message's own words, not
+  // the reply before it (`addUser` only ADOPTS that row in place; it never
+  // pushes a second one). Every test above called `sendMessage` bare, with no
+  // optimistic bubble first, which is exactly why none of them could catch
+  // this: `priorReply` silently read back nothing, `baseText` never seeded,
+  // and the reload's old reply rendered in full inside the new bubble anyway
+  // (user recording, PR #1119, reproduced on 0af2328 too — the hang fix
+  // changed nothing about this).
+  test("a send into a restored session still finds the prior reply behind its own optimistic bubble", async () => {
+    const A = text("The answer from before the reload.");
+    const B = text("The new answer.");
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const { controller } = makeController(
+      {
+        history: () => ({
+          turns: [
+            { role: "user" as const, text: "earlier question", uuid: "u1" },
+            { role: "assistant" as const, text: A.text, uuid: "a1" },
+          ],
+        }),
+        live_run: () => ({ run_id: "" }),
+        live_host: () => ({ run_id: "r1" }),
+        send: () => ({ sent: true as const }),
+        start: () => {
+          throw new Error("the live host took it");
+        },
+        poll: (_f, n) => {
+          if (n === 0) return poll({ segments: [], text: "" });
+          if (n === 1) return poll({ segments: [A, B], text: A.text + B.text });
+          return poll({ done: true, segments: [B], text: B.text });
+        },
+      },
+      params,
+    );
+    await controller.openSession("s1");
+
+    // Exactly what `dispatchSend` does: post the optimistic bubble FIRST,
+    // then send with its key so `addUser` adopts that same row.
+    const optimisticKey = controller.postOptimisticUser("and now this");
+    expect(controller.getState().turns.map((t) => t.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+
+    const seen: string[][][] = [];
+    const off = controller.subscribe(() => {
+      seen.push(assistants(controller).map((t) => (t.segments || []).map(bodyOf)));
+    });
+    await controller.sendMessage("and now this", { optimisticKey });
+    off();
+
+    const newBubbleFrames = seen.map((assistantTurns) => assistantTurns[assistantTurns.length - 1] || []);
+    const flashed = newBubbleFrames.filter(
+      (segs) => segs.some((s) => s.includes(A.text)) && segs.some((s) => s.includes(B.text)),
+    );
+    expect(flashed).toEqual([]);
+
+    expect(controller.getState().turns.map((t) => t.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    const reply = assistants(controller);
+    expect(reply[0]!.text).toBe(A.text);
+    expect(reply[1]!.text).toBe(B.text);
+    expect(reply.length).toBe(2);
+  });
+
   // BUGBOT, PR #1119: the fix above's first shape `continue`d past every poll
   // for as long as `baseSegTrusted` stayed down, waiting for the "already
   // landed prefix retires" check to notice `fullText` no longer starts with

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -1598,6 +1598,163 @@ describe("follow-ups (T:16024, D687)", () => {
     expect(reply[0]!.text).toBe(A.text);
   });
 
+  // ── the SECOND WINDOW's duplicate (PR #1119), from a real `poll` capture ──
+  //
+  // The reported symptom, in the reporter's words: "if multiple tabs are open
+  // to the same conversation, the last response gets duplicated into the UI
+  // before the new response starts streaming when a new prompt is sent".
+  //
+  // The window a second tab adopts opens on the PREVIOUS turn, and it stays
+  // that way for several polls: agent.py's cursor cannot step past that reply
+  // until a NEWER turn's echo proves it closed, and the echo does not land the
+  // moment the other tab sends — the CLI writes `system/init` and
+  // `system/status` first. Every poll in between hands this loop the previous
+  // reply in full (`echo_pending` does not blank them: the run is not idle any
+  // more, those two rows came after the `result`).
+  //
+  // `sendMessage`'s road has always seeded `priorReply` against exactly that.
+  // The ADOPTED road seeded nothing, so the reply already on screen was typed
+  // into a fresh bubble underneath itself — and then, once the new reply began,
+  // it was left stranded in a bubble of its own below it.
+  //
+  // Every payload below is the shape agent.py actually produced, replayed out
+  // of the capture the reporter sent: `window` and `turn_breaks` included, the
+  // seam arriving only on the poll where the newer echo does.
+  const CAPTURED_PREV = "P".repeat(483); // the real lengths, from the capture
+  const CAPTURED_NEW = "Yes";
+  /** The captured poll sequence a second window sees, from its first lap. */
+  const capturedSecondWindow = (n: number): PollResponse => {
+    // Laps 0-3: the send has gone out in the other tab, the echo has not
+    // landed, and the window is still the previous reply alone. No seam —
+    // there is no boundary inside a window holding one turn.
+    if (n <= 3) {
+      return poll({ window: 0, segments: [text(CAPTURED_PREV)], text: CAPTURED_PREV });
+    }
+    // The echo lands: two replies in one window, and agent.py names the seam.
+    // The separator rides INSIDE the newer segment (`_segments_from_rows`'s
+    // `grow`), so the seam is at the previous reply's own length.
+    if (n === 4) {
+      return poll({
+        window: 0,
+        segments: [text(CAPTURED_PREV), text("\n\n" + CAPTURED_NEW)],
+        text: CAPTURED_PREV + "\n\n" + CAPTURED_NEW,
+        turn_breaks: [{ segments: 1, text: CAPTURED_PREV.length }],
+      });
+    }
+    // The cursor steps over the boundary: the newer reply alone, no seam left.
+    if (n === 5) return poll({ window: 9537, segments: [text(CAPTURED_NEW)], text: CAPTURED_NEW });
+    return poll({
+      done: true,
+      window: 9537,
+      segments: [text(CAPTURED_NEW + ", that is correct")],
+      text: CAPTURED_NEW + ", that is correct",
+    });
+  };
+
+  test("a second window adopting a live run never re-types the reply on screen", async () => {
+    let live = false;
+    const made = makeController({
+      history: () => ({
+        turns: [
+          { role: "user" as const, text: "the run's first message", uuid: "u0" },
+          { role: "assistant" as const, text: "An older answer.", uuid: "a0" },
+          { role: "user" as const, text: "the previous question", uuid: "u1" },
+          { role: "assistant" as const, text: CAPTURED_PREV, uuid: "a1" },
+        ],
+      }),
+      live_run: () => ({ run_id: live ? "r-live" : "" }),
+      // agent.py's `message` is the run's FIRST message, not the turn in
+      // flight — which is why a second window cannot reconcile the new turn
+      // against its own last user line, and goes straight to `pollLoop`.
+      poll: (_f, n) => ({ ...capturedSecondWindow(n), message: "the run's first message" }),
+    });
+    await made.controller.openSession("s1");
+    // Let `openSession`'s own adoption window run out before the run starts,
+    // so this is the STANDING WATCH's posture — a tab that was already open.
+    await new Promise<void>((r) => setTimeout(r, 30));
+
+    // EVERY FRAME, not the final state. The duplicate is a FLASH: it is on
+    // screen only until agent.py's cursor steps over the boundary, and the
+    // payload after that step overwrites the bubble down to the newer reply —
+    // which is precisely the reported symptom ("duplicated into the UI BEFORE
+    // the new response starts streaming") and precisely what a final-state
+    // assertion cannot see.
+    const seen: string[][] = [];
+    const off = made.controller.subscribe(() => {
+      seen.push(assistants(made.controller).map((t) => t.text));
+    });
+    live = true;
+    await made.controller.adoptLiveRun("s1", { laps: 1, quiet: true });
+    await new Promise<void>((r) => setTimeout(r, 30));
+    off();
+
+    // No frame ever shows the restored reply twice.
+    expect(seen.filter((f) => f.filter((t) => t === CAPTURED_PREV).length > 1)).toEqual([]);
+    // And the run lands as three bubbles, not four: before the fix the last
+    // frame carried a stray "\n\nYes" the newer reply had been lifted out of.
+    expect(assistants(made.controller).map((t) => t.text)).toEqual([
+      "An older answer.",
+      CAPTURED_PREV,
+      CAPTURED_NEW + ", that is correct",
+    ]);
+  });
+
+  test("an adopted loop never skips past a seam the prefix on screen does not reach", async () => {
+    // THE LIMIT ON THE FIX ABOVE, and the reason the adopted road cannot just
+    // borrow `adoptFirstSeam`.
+    //
+    // A loop started by a send owns only the turn it sent, so every span the
+    // first payload has already closed off predates it and the base may
+    // advance to the first of them, wherever it falls. An ADOPTED loop owns
+    // nothing: a span past the prefix already on screen may be a reply this
+    // page has never rendered, and advancing past one would drop it outright.
+    //
+    // So the adopted road takes a seam only where it CONFIRMS the base — at
+    // exactly the end of the prefix on screen, which costs nothing to believe
+    // — and leaves every other seam alone. Here agent.py reports one seam and
+    // it is past the prefix: taking it would swallow the reply in between.
+    const NEW = "The reply this window is here for. ";
+    const EXTRA = "And what came after it.";
+    let live = false;
+    const made = makeController({
+      history: () => ({
+        turns: [
+          { role: "user" as const, text: "the previous question", uuid: "u1" },
+          { role: "assistant" as const, text: CAPTURED_PREV, uuid: "a1" },
+        ],
+      }),
+      live_run: () => ({ run_id: live ? "r-live" : "" }),
+      poll: (_f, n) => ({
+        ...(n <= 1
+          ? poll({ window: 0, segments: [text(CAPTURED_PREV)], text: CAPTURED_PREV })
+          : poll({
+              done: n > 2,
+              window: 0,
+              segments: [text(CAPTURED_PREV), text(NEW), text(EXTRA)],
+              text: CAPTURED_PREV + NEW + EXTRA,
+              // The ONLY seam, and it is past the prefix on screen.
+              turn_breaks: [{ segments: 2, text: CAPTURED_PREV.length + NEW.length }],
+            })),
+        // After the spread, or `poll`'s own default blanks it — and a blank
+        // `message` reaches `pollLoop` down a DIFFERENT road (no reconciliation
+        // at all), which is not the one this test is about.
+        message: "the run's first message",
+      }),
+    });
+    await made.controller.openSession("s1");
+    await new Promise<void>((r) => setTimeout(r, 30));
+    live = true;
+    await made.controller.adoptLiveRun("s1", { laps: 1, quiet: true });
+    await new Promise<void>((r) => setTimeout(r, 30));
+
+    // Nothing is dropped: the reply between the prefix and the seam is on
+    // screen, and the reply already there was still not typed twice.
+    const shown = assistants(made.controller).map((t) => t.text).join("\n");
+    expect(shown).toContain(NEW);
+    expect(shown).toContain(EXTRA);
+    expect(shown.split(CAPTURED_PREV).length - 1).toBe(1);
+  });
+
   test("an agent.py with no `turn_breaks` keeps one payload as one reply", async () => {
     // The compatibility floor: no seam reported, so nothing is split. One
     // bubble that grows, which is the pre-feedback-#9 rendering minus the

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -1263,10 +1263,23 @@ export function createChatController(deps: ControllerDeps): ChatController {
             // reconciliation.
             baseSegTrusted = true;
             adoptFirstSeam = false;
-          } else if (!baseText || !fullText.startsWith(baseText) || fullText.length > baseText.length) {
-            // Nothing to keep waiting behind: either there is no base at all
-            // (every body is this turn's), or the payload has moved past the
-            // one there is. Any seam from here on is this turn's own.
+          } else if (!baseText || !fullText.startsWith(baseText) || followupSeq !== seenFollowupSeq) {
+            // Nothing left to wait behind, or waiting is no longer safe:
+            //
+            //   * no base at all — every body is this turn's (a fresh chat);
+            //   * the window no longer OPENS on the base — the cursor stepped
+            //     past it, so the payload is this turn alone and a later seam
+            //     would be its own;
+            //   * a follow-up landed in THIS loop — from here a seam can be
+            //     the `result` closing a reply that follow-up was folded
+            //     into, which belongs to a bubble, not to the base.
+            //
+            // GROWTH ALONE IS NOT ON THAT LIST (Bugbot, PR #1119). A D415 wake
+            // appends to the turn ALREADY on screen, so the payload grows past
+            // `baseText` while this send's own echo is still outstanding — the
+            // very busy-host wait this arming exists for. Spending it there
+            // left the real seam, which lands with the echo a poll later, read
+            // as this send's own follow-up instead of as the base.
             adoptFirstSeam = false;
           }
         }

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -1087,24 +1087,6 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // some later turn instead.
     landedWindow = null;
     /**
-     * ONE TICK'S GRACE for `baseSegTrusted` to resolve on its own (a reported
-     * seam confirms it, or the prefix retires because it no longer applies)
-     * before this loop stops waiting for either and trusts `segs` regardless.
-     *
-     * NOT a guess: agent.py's cursor write is synchronous inside the very
-     * `_read_current_turn` call that hands back an unconfirmed, combined
-     * window (see `priorReply`'s note above) — so the NEXT poll's `segs` is
-     * already clean whether or not this loop's own heuristics noticed. A
-     * bug report (Bugbot, PR #1119) is why this exists as an explicit,
-     * unconditionally-spent allowance rather than "keep waiting until the
-     * text stops matching": a short reply that happens to share a prefix with
-     * the one before it ("OK" answering into "OK, done") never makes that
-     * text stop matching, and skipping every poll until it did — this loop's
-     * first attempt — left `poll.done` unhandled right along with the
-     * segments, `sending` stuck, and the composer dead.
-     */
-    let baseSegGrace = true;
-    /**
      * A LOOP STARTED BY A SEND OWNS ONLY THE TURN IT SENT.
      *
      * `landedWindow` (or, on the reload road, `priorReply` above) covers the
@@ -1294,29 +1276,28 @@ export function createChatController(deps: ControllerDeps): ChatController {
           baseText = "";
           baseSegTrusted = true;
         }
-        // `baseSegGrace` is spent here — UNCONDITIONALLY, the one poll this
-        // loop first has anything to render at all with `baseSegTrusted`
-        // still down — never only on the poll where suppression actually
-        // fires. That is what keeps it a ONE-TIME allowance rather than a
-        // wait for a condition that might not arrive (see its own note): by
-        // the poll after the one it is spent on, agent.py's cursor is
-        // provably already past the old turn, so `segs` needs no more
-        // protecting whether or not `baseSegTrusted` itself ever flips.
-        if (!baseSegTrusted && anyBody) {
-          if (baseSegGrace) baseSegGrace = false;
-          else baseSegTrusted = true;
-        }
         // AN UNCONFIRMED TEXT BASE WITH SEGMENTS STILL IN THE PAYLOAD IS NOT
         // SAFE TO SLICE — see `baseSegTrusted`'s note. `baseText` is exact
         // either way, so `bodyText` below is unaffected: only `bodySegs` is
-        // held back, for exactly the one poll `baseSegGrace` just spent, so
-        // this reply still renders (as plain text, not segments, for that one
-        // poll) rather than showing nothing, and every poll still reaches
-        // `poll.done`/`syncPermissions` below whether or not this fires
-        // (Bugbot, PR #1119 — the previous shape `continue`d past all of
-        // that, and a short reply sharing a prefix with the one before it,
-        // "OK" answering into "OK, done", never made the OLDER retirement
-        // check below fire, so `sending` never cleared at all).
+        // held back, and for as long as this stays true rather than for a
+        // fixed one poll (Bugbot, PR #1119, second pass): a `continue` here
+        // used to skip `poll.done`/`syncPermissions` outright, and the first
+        // fix for THAT swapped it for a one-poll allowance, spent on
+        // whichever poll first had anything to render at all — which is
+        // provably safe only when the FIRST such poll is the cursor-advancing
+        // one, true after an idle host's `pending_echo` blanks every payload
+        // before it. A D415 wake leaves the host busy, not idle: the payloads
+        // before the echo lands still carry the old reply, non-blank, and
+        // spent the allowance on a poll that was never the dangerous one —
+        // so the actually-ambiguous combined poll landed with the grace
+        // already gone and `baseSegTrusted` wrongly true. Trusting `segs`
+        // only once EARNED (a reported seam, or the prefix retiring — never a
+        // countdown) has no such window: every poll still reaches
+        // `poll.done` either way, so the worst case of never earning it (a
+        // reply that happens to share the one before it's own prefix start to
+        // finish, "OK" answering into "OK, done") is a turn that renders as
+        // plain text for its own duration rather than segments — never a
+        // duplicate, never a stuck `sending`.
         const segSliceUnsafe = !baseSegTrusted && segs.length > 0;
         const bodySegs = segSliceUnsafe ? [] : baseSeg ? segs.slice(baseSeg) : segs;
         const bodyText = baseText ? fullText.slice(baseText.length) : fullText;

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -1240,10 +1240,20 @@ export function createChatController(deps: ControllerDeps): ChatController {
         }
 
         // THE SPANS THIS LOOP DID NOT SEND, taken as the base — see
-        // `adoptFirstSeam`. Once only, off the first payload that carries a
-        // body: after that, a seam is this turn's own and belongs to a bubble.
+        // `adoptFirstSeam`. Once only: after this turn has visibly started, a
+        // seam is this turn's OWN (a follow-up folded into it) and belongs to a
+        // bubble of its own rather than to the base.
+        //
+        // "Visibly started" is the gate, NOT "the payload has any body at all".
+        // Those are the same thing only for an idle host, where `pending_echo`
+        // blanks every payload until the echo lands. A busy one (a D415 wake in
+        // flight) never blanks them: the polls before the echo carry the
+        // already-on-screen reply, in full, and spending the adoption on one of
+        // THOSE — which has no seam in it, because the echo that makes the seam
+        // has not landed — threw away the real seam when it arrived a poll
+        // later, leaving `baseSegTrusted` down for the whole reply and its
+        // segments suppressed with it.
         if (adoptFirstSeam && anyBody) {
-          adoptFirstSeam = false;
           const last = reported[reported.length - 1];
           if (last && (last.segments > baseSeg || last.text > baseText.length)) {
             baseSeg = last.segments;
@@ -1252,6 +1262,12 @@ export function createChatController(deps: ControllerDeps): ChatController {
             // very payload's segmentation — unlike `priorReply`'s, it needs no
             // reconciliation.
             baseSegTrusted = true;
+            adoptFirstSeam = false;
+          } else if (!baseText || !fullText.startsWith(baseText) || fullText.length > baseText.length) {
+            // Nothing to keep waiting behind: either there is no base at all
+            // (every body is this turn's), or the payload has moved past the
+            // one there is. Any seam from here on is this turn's own.
+            adoptFirstSeam = false;
           }
         }
 

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -1029,6 +1029,15 @@ export function createChatController(deps: ControllerDeps): ChatController {
     let prevWindow: number | null = null;
     let seenFollowupSeq = followupSeq;
     /**
+     * The same counter as this loop ENTERED on, never advanced — so
+     * "has a follow-up landed since this loop started" stays answerable after
+     * `seenFollowupSeq` has caught up to it (which it does at the top of every
+     * poll that saw one). `adoptFirstSeam` below is the reader, and comparing
+     * against `seenFollowupSeq` there was dead code: the two are already equal
+     * by the time it runs (Bugbot, PR #1119).
+     */
+    const followupSeqAtStart = followupSeq;
+    /**
      * HOW MANY SEAMS ARE STILL OWED — a COUNT, not a flag (Bugbot PR #1061).
      *
      * One per follow-up that landed and whose reply this loop has not yet seen
@@ -1255,24 +1264,34 @@ export function createChatController(deps: ControllerDeps): ChatController {
         // segments suppressed with it.
         if (adoptFirstSeam && anyBody) {
           const last = reported[reported.length - 1];
-          if (last && (last.segments > baseSeg || last.text > baseText.length)) {
+          if (followupSeq !== followupSeqAtStart) {
+            // A FOLLOW-UP LANDED IN THIS LOOP, so STOP WAITING WITHOUT
+            // ADOPTING — checked ahead of the adoption, not beside it. From
+            // here a payload can carry two seams, the pre-send boundary AND
+            // the `result` closing the reply this loop's own follow-up was
+            // folded into, and the adoption below takes the LAST one: it would
+            // take that second seam and swallow this send's whole reply into
+            // the base (Bugbot, PR #1119 — where this gate first sat in the
+            // `else` and so could not stop the adoption at all, on top of
+            // being written against `seenFollowupSeq`, which the top of every
+            // poll has already caught up to `followupSeq`).
+            adoptFirstSeam = false;
+          } else if (last && (last.segments > baseSeg || last.text > baseText.length)) {
             baseSeg = last.segments;
             baseText = fullText.slice(0, last.text);
             // A REPORTED SEAM IS agent.py's OWN COUNT, measured against THIS
             // very payload's segmentation — unlike `priorReply`'s, it needs no
-            // reconciliation.
+            // reconciliation. Taking the LAST seam is safe only because of the
+            // branch above: with no follow-up of this loop's own in the
+            // payload, every seam in it closes a turn that ended before this
+            // send, and the last of them is where this turn begins.
             baseSegTrusted = true;
             adoptFirstSeam = false;
-          } else if (!baseText || !fullText.startsWith(baseText) || followupSeq !== seenFollowupSeq) {
-            // Nothing left to wait behind, or waiting is no longer safe:
-            //
-            //   * no base at all — every body is this turn's (a fresh chat);
-            //   * the window no longer OPENS on the base — the cursor stepped
-            //     past it, so the payload is this turn alone and a later seam
-            //     would be its own;
-            //   * a follow-up landed in THIS loop — from here a seam can be
-            //     the `result` closing a reply that follow-up was folded
-            //     into, which belongs to a bubble, not to the base.
+          } else if (!baseText || !fullText.startsWith(baseText)) {
+            // Nothing left to wait behind: no base at all (every body is this
+            // turn's — a fresh chat), or the window no longer OPENS on the
+            // base, so the cursor stepped past it and the payload is this turn
+            // alone.
             //
             // GROWTH ALONE IS NOT ON THAT LIST (Bugbot, PR #1119). A D415 wake
             // appends to the turn ALREADY on screen, so the payload grows past

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -1703,12 +1703,29 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // count: `_history` segments a turn with no stream deltas at all, which
     // can disagree with a live poll's reconstruction of the very same rows
     // once a newer turn's deltas are in the same window (`pollLoop`'s
-    // `baseSegTrusted` is what makes that safe to seed anyway). Only a SETTLED
-    // assistant turn counts: a streaming one is either impossible here
-    // (`sending` is one-at-a-time) or, if seen anyway, not a safe prefix to
-    // assume closed.
+    // `baseSegTrusted` is what makes that safe to seed anyway).
+    //
+    // SKIP THIS SEND'S OWN OPTIMISTIC BUBBLE FIRST. `dispatchSend`
+    // (ClaudeChat.tsx) calls `postOptimisticUser` — which is `addUser` under
+    // another name — SYNCHRONOUSLY, before this function's caller ever runs,
+    // so by the time this line executes `state.turns` usually already ends
+    // with THIS message's own user turn: `addUser` below only adopts that row
+    // in place (see its own docstring — "the optimistic row is already the
+    // last bubble in the log"), it does not push a second one. Reading
+    // `state.turns[state.turns.length - 1]` without skipping past it read this
+    // send's own words back as "the reply already on screen", found no
+    // assistant turn, and seeded nothing at all — every real send through the
+    // composer takes this road, since a bare `sendMessage()` call with no
+    // optimistic bubble first (every one of this file's own tests) is the
+    // exception, not the rule (Bugbot report + user recording, PR #1119).
+    //
+    // Only a SETTLED assistant turn counts once that skip lands on one: a
+    // streaming one is either impossible here (`sending` is one-at-a-time) or,
+    // if seen anyway, not a safe prefix to assume closed.
     const priorReply = (() => {
-      const last = state.turns[state.turns.length - 1];
+      let i = state.turns.length - 1;
+      while (i >= 0 && state.turns[i]!.role === "user") i--;
+      const last = state.turns[i];
       if (!last || last.role !== "assistant" || last.streaming) return null;
       return { text: last.text || "" };
     })();

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -1087,6 +1087,24 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // some later turn instead.
     landedWindow = null;
     /**
+     * ONE TICK'S GRACE for `baseSegTrusted` to resolve on its own (a reported
+     * seam confirms it, or the prefix retires because it no longer applies)
+     * before this loop stops waiting for either and trusts `segs` regardless.
+     *
+     * NOT a guess: agent.py's cursor write is synchronous inside the very
+     * `_read_current_turn` call that hands back an unconfirmed, combined
+     * window (see `priorReply`'s note above) — so the NEXT poll's `segs` is
+     * already clean whether or not this loop's own heuristics noticed. A
+     * bug report (Bugbot, PR #1119) is why this exists as an explicit,
+     * unconditionally-spent allowance rather than "keep waiting until the
+     * text stops matching": a short reply that happens to share a prefix with
+     * the one before it ("OK" answering into "OK, done") never makes that
+     * text stop matching, and skipping every poll until it did — this loop's
+     * first attempt — left `poll.done` unhandled right along with the
+     * segments, `sending` stuck, and the composer dead.
+     */
+    let baseSegGrace = true;
+    /**
      * A LOOP STARTED BY A SEND OWNS ONLY THE TURN IT SENT.
      *
      * `landedWindow` (or, on the reload road, `priorReply` above) covers the
@@ -1276,22 +1294,31 @@ export function createChatController(deps: ControllerDeps): ChatController {
           baseText = "";
           baseSegTrusted = true;
         }
+        // `baseSegGrace` is spent here — UNCONDITIONALLY, the one poll this
+        // loop first has anything to render at all with `baseSegTrusted`
+        // still down — never only on the poll where suppression actually
+        // fires. That is what keeps it a ONE-TIME allowance rather than a
+        // wait for a condition that might not arrive (see its own note): by
+        // the poll after the one it is spent on, agent.py's cursor is
+        // provably already past the old turn, so `segs` needs no more
+        // protecting whether or not `baseSegTrusted` itself ever flips.
+        if (!baseSegTrusted && anyBody) {
+          if (baseSegGrace) baseSegGrace = false;
+          else baseSegTrusted = true;
+        }
         // AN UNCONFIRMED TEXT BASE WITH SEGMENTS STILL IN THE PAYLOAD IS NOT
-        // SAFE TO SLICE. `baseText` is exact either way (see `baseSegTrusted`'s
-        // own note), but a `baseSeg` of 0 left over from `priorReply` means
-        // "unknown", not "nothing to skip" — slicing `segs` on it would render
-        // the reload's old reply right alongside the new one, in the very
-        // shape this exists to prevent. So: skip this one poll rather than
-        // guess a count nobody has confirmed. It resolves within one more poll
-        // guaranteed, not a hope — THIS poll is itself proof that the new
-        // turn's echo, with a `result` already closing the reply before it,
-        // has reached the file, which is exactly what advances agent.py's
-        // cursor past the old turn (`_read_current_turn`) for every poll after
-        // this one. A payload with nothing left to slice (`segs.length === 0`,
-        // the flat-text-only path) never hits this at all — `bodyText` alone
-        // already renders it correctly.
-        if (!baseSegTrusted && anyBody && segs.length > 0) continue;
-        const bodySegs = baseSeg ? segs.slice(baseSeg) : segs;
+        // SAFE TO SLICE — see `baseSegTrusted`'s note. `baseText` is exact
+        // either way, so `bodyText` below is unaffected: only `bodySegs` is
+        // held back, for exactly the one poll `baseSegGrace` just spent, so
+        // this reply still renders (as plain text, not segments, for that one
+        // poll) rather than showing nothing, and every poll still reaches
+        // `poll.done`/`syncPermissions` below whether or not this fires
+        // (Bugbot, PR #1119 — the previous shape `continue`d past all of
+        // that, and a short reply sharing a prefix with the one before it,
+        // "OK" answering into "OK, done", never made the OLDER retirement
+        // check below fire, so `sending` never cleared at all).
+        const segSliceUnsafe = !baseSegTrusted && segs.length > 0;
+        const bodySegs = segSliceUnsafe ? [] : baseSeg ? segs.slice(baseSeg) : segs;
         const bodyText = baseText ? fullText.slice(baseText.length) : fullText;
         // Rebased onto the body, and a seam that falls AT the base is the
         // boundary the base already stands for — it names no reply of ours.

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -1029,15 +1029,6 @@ export function createChatController(deps: ControllerDeps): ChatController {
     let prevWindow: number | null = null;
     let seenFollowupSeq = followupSeq;
     /**
-     * The same counter as this loop ENTERED on, never advanced — so
-     * "has a follow-up landed since this loop started" stays answerable after
-     * `seenFollowupSeq` has caught up to it (which it does at the top of every
-     * poll that saw one). `adoptFirstSeam` below is the reader, and comparing
-     * against `seenFollowupSeq` there was dead code: the two are already equal
-     * by the time it runs (Bugbot, PR #1119).
-     */
-    const followupSeqAtStart = followupSeq;
-    /**
      * HOW MANY SEAMS ARE STILL OWED — a COUNT, not a flag (Bugbot PR #1061).
      *
      * One per follow-up that landed and whose reply this loop has not yet seen
@@ -1263,28 +1254,32 @@ export function createChatController(deps: ControllerDeps): ChatController {
         // later, leaving `baseSegTrusted` down for the whole reply and its
         // segments suppressed with it.
         if (adoptFirstSeam && anyBody) {
-          const last = reported[reported.length - 1];
-          if (followupSeq !== followupSeqAtStart) {
-            // A FOLLOW-UP LANDED IN THIS LOOP, so STOP WAITING WITHOUT
-            // ADOPTING — checked ahead of the adoption, not beside it. From
-            // here a payload can carry two seams, the pre-send boundary AND
-            // the `result` closing the reply this loop's own follow-up was
-            // folded into, and the adoption below takes the LAST one: it would
-            // take that second seam and swallow this send's whole reply into
-            // the base (Bugbot, PR #1119 — where this gate first sat in the
-            // `else` and so could not stop the adoption at all, on top of
-            // being written against `seenFollowupSeq`, which the top of every
-            // poll has already caught up to `followupSeq`).
-            adoptFirstSeam = false;
-          } else if (last && (last.segments > baseSeg || last.text > baseText.length)) {
-            baseSeg = last.segments;
-            baseText = fullText.slice(0, last.text);
+          // THE FIRST SEAM PAST THE BASE, NOT THE LAST (Bugbot, PR #1119,
+          // twice). The base is where THIS turn begins, and this turn begins at
+          // the FIRST boundary the payload closes off beyond what was already
+          // on screen. Every seam after that one is this turn's own — the
+          // `result` closing a reply a follow-up of this loop's was folded into
+          // — and belongs to a bubble.
+          //
+          // Taking the last seam read those as the base and swallowed this
+          // send's whole reply into it. Refusing to adopt at all once a
+          // follow-up had landed — the first attempt at that — cost the other
+          // half: the pre-send boundary then went unadopted too, so a D415
+          // wake that grew the turn already on screen AFTER this send was
+          // composed stayed in this turn's bubble, `priorReply`'s text having
+          // been sampled before the wake appended anything. One seam is both
+          // answers: the pre-send boundary is exactly the first one past the
+          // base, wake continuation included, and it is adopted whether or not
+          // a follow-up has landed since.
+          const opening = reported.find(
+            (b) => b.segments > baseSeg || b.text > baseText.length,
+          );
+          if (opening) {
+            baseSeg = opening.segments;
+            baseText = fullText.slice(0, opening.text);
             // A REPORTED SEAM IS agent.py's OWN COUNT, measured against THIS
             // very payload's segmentation — unlike `priorReply`'s, it needs no
-            // reconciliation. Taking the LAST seam is safe only because of the
-            // branch above: with no follow-up of this loop's own in the
-            // payload, every seam in it closes a turn that ended before this
-            // send, and the last of them is where this turn begins.
+            // reconciliation.
             baseSegTrusted = true;
             adoptFirstSeam = false;
           } else if (!baseText || !fullText.startsWith(baseText)) {

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -939,7 +939,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
   async function pollLoop(
     runId: string,
     gen: number,
-    opts: { ownTurn?: boolean } = {},
+    opts: { ownTurn?: boolean; priorReply?: { text: string } | null } = {},
   ): Promise<void> {
     const seat = ++loopSeq;
     // This run is now the one the stop button aims at. Set here, the one place a
@@ -1050,9 +1050,37 @@ export function createChatController(deps: ControllerDeps): ChatController {
     /** The already-landed prefix of this run's window — see `landedWindow`. */
     let baseSeg = 0;
     let baseText = "";
+    /**
+     * WHETHER `baseSeg` IS SAFE TO SLICE `segs` WITH. `landedWindow` is always
+     * trusted: both its numbers came from THIS controller's own reconstruction
+     * of the very same live window. `priorReply` (below) is not — it comes
+     * from `_history`, which segments a turn with NO stream deltas at all
+     * (`_segments_from_rows`'s own docstring: "reply A carrying finalized text
+     * only, followed by a reply B that streams, made `streamed` False for the
+     * prefix and True for the window, and the offset then pointed at the wrong
+     * segment entirely"). Its TEXT is still exact (byte-identical either way),
+     * so `baseText` is seeded regardless — only the segment COUNT is left at 0
+     * and marked untrusted, and the render loop below skips rather than slices
+     * `segs` on it until either a reported seam confirms a count or the prefix
+     * retires and there is nothing left to slice.
+     */
+    let baseSegTrusted = true;
     if (landedWindow && landedWindow.runId === runId) {
       baseSeg = landedWindow.segments;
       baseText = landedWindow.text;
+    } else if (opts.priorReply && opts.priorReply.text) {
+      // THE RELOAD ROAD's OWN BASE — see `priorReply`'s definition at its one
+      // call site (`sendMessage`). `landedWindow` only ever covers a reply THIS
+      // controller watched land; a page that restored its transcript from
+      // `_history` (or a second tab open on the same conversation) has never
+      // run a pollLoop to completion, so it has nothing there — but it already
+      // has the reply rendered, and that rendering is exactly the prefix the
+      // live window reopens on. Seeding it here means `adoptFirstSeam` below is
+      // no longer the ONLY thing standing between a stale reply and a
+      // duplicate bubble: it still runs, but now as a check against a base
+      // already known to be right, not as the sole source of one.
+      baseText = opts.priorReply.text;
+      baseSegTrusted = false;
     }
     // CONSUMED EITHER WAY: one settled reply, one loop that may skip it. A base
     // left standing past the loop that could use it would hide the opening of
@@ -1061,17 +1089,18 @@ export function createChatController(deps: ControllerDeps): ChatController {
     /**
      * A LOOP STARTED BY A SEND OWNS ONLY THE TURN IT SENT.
      *
-     * `landedWindow` covers the case where THIS controller watched the previous
-     * reply land. It cannot cover the reload road: a page that restored its
-     * transcript from `_history` and then sent into the still-open host has
-     * every earlier turn on screen and no memory of any payload at all. The
-     * window it gets back opens on the previous reply just the same.
+     * `landedWindow` (or, on the reload road, `priorReply` above) covers the
+     * case where the previous reply is already known. Either can miss: a fresh
+     * controller with no prior turn at all, or a `priorReply` whose text the
+     * live window's payload does not actually start with (the "already-landed
+     * prefix retires" check below resets it if so — never trust it blindly).
      *
-     * So the FIRST payload's own seams answer it: a span the payload has
+     * So the FIRST payload's own seams answer it too: a span the payload has
      * already closed off (`turn_breaks`) is a reply that ended BEFORE this send
      * — this loop was started by the send, so nothing it owns can have finished
      * yet — and the last of those seams is exactly where this turn begins. It
-     * is adopted as the base, and everything below runs unchanged from there.
+     * is adopted as the base (advancing it, never retreating it), and
+     * everything below runs unchanged from there.
      *
      * Never set for an ADOPTED run (`resumeRun`, `adoptLiveRun`): there the
      * earlier spans are a cold read of turns this page has not rendered, and
@@ -1219,6 +1248,10 @@ export function createChatController(deps: ControllerDeps): ChatController {
           if (last && (last.segments > baseSeg || last.text > baseText.length)) {
             baseSeg = last.segments;
             baseText = fullText.slice(0, last.text);
+            // A REPORTED SEAM IS agent.py's OWN COUNT, measured against THIS
+            // very payload's segmentation — unlike `priorReply`'s, it needs no
+            // reconciliation.
+            baseSegTrusted = true;
           }
         }
 
@@ -1241,7 +1274,23 @@ export function createChatController(deps: ControllerDeps): ChatController {
         ) {
           baseSeg = 0;
           baseText = "";
+          baseSegTrusted = true;
         }
+        // AN UNCONFIRMED TEXT BASE WITH SEGMENTS STILL IN THE PAYLOAD IS NOT
+        // SAFE TO SLICE. `baseText` is exact either way (see `baseSegTrusted`'s
+        // own note), but a `baseSeg` of 0 left over from `priorReply` means
+        // "unknown", not "nothing to skip" — slicing `segs` on it would render
+        // the reload's old reply right alongside the new one, in the very
+        // shape this exists to prevent. So: skip this one poll rather than
+        // guess a count nobody has confirmed. It resolves within one more poll
+        // guaranteed, not a hope — THIS poll is itself proof that the new
+        // turn's echo, with a `result` already closing the reply before it,
+        // has reached the file, which is exactly what advances agent.py's
+        // cursor past the old turn (`_read_current_turn`) for every poll after
+        // this one. A payload with nothing left to slice (`segs.length === 0`,
+        // the flat-text-only path) never hits this at all — `bodyText` alone
+        // already renders it correctly.
+        if (!baseSegTrusted && anyBody && segs.length > 0) continue;
         const bodySegs = baseSeg ? segs.slice(baseSeg) : segs;
         const bodyText = baseText ? fullText.slice(baseText.length) : fullText;
         // Rebased onto the body, and a seam that falls AT the base is the
@@ -1611,6 +1660,31 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // `composeBlocks` ranks `<live-app-state>` first wherever it arrives from
     // (Bugbot, PR #1064).
     const outgoing = composeOutgoing(text, composeBlocks(blocks, live ? [live] : []));
+    // WHAT IS ALREADY ON SCREEN, taken BEFORE `addUser` appends this turn's own
+    // bubble — see `priorReply`'s one consumer, `pollLoop`'s base seeding. A
+    // controller that restored this conversation from `_history` (a reload, or
+    // a second tab open on the same chat) has never run a pollLoop to
+    // completion, so `landedWindow` is empty even though the reply is right
+    // there, rendered. Sending into a still-live host reopens the window on
+    // that same reply (agent.py's cursor cannot advance past it until a NEWER
+    // turn proves it closed), and without this the only defense left is
+    // `turn_breaks`, which the backend deliberately withholds whenever
+    // anything — most commonly a D415 wake — sits between the old `result` and
+    // this send's own echo (`_absorbed_turn_breaks`'s adjacency rule). Missing
+    // that seam left the old reply duplicated into the new bubble until the
+    // cursor finally stepped over it. Only the TEXT travels, never a segment
+    // count: `_history` segments a turn with no stream deltas at all, which
+    // can disagree with a live poll's reconstruction of the very same rows
+    // once a newer turn's deltas are in the same window (`pollLoop`'s
+    // `baseSegTrusted` is what makes that safe to seed anyway). Only a SETTLED
+    // assistant turn counts: a streaming one is either impossible here
+    // (`sending` is one-at-a-time) or, if seen anyway, not a safe prefix to
+    // assume closed.
+    const priorReply = (() => {
+      const last = state.turns[state.turns.length - 1];
+      if (!last || last.role !== "assistant" || last.streaming) return null;
+      return { text: last.text || "" };
+    })();
     // The bubble shows what the user TYPED (or the markers for a wordless
     // send); the raw wire rides along for the "what was sent" popover.
     //
@@ -1704,8 +1778,9 @@ export function createChatController(deps: ControllerDeps): ChatController {
         setRunParam(runId);
         // `ownTurn`: this loop was started by THIS send, so anything the first
         // payload has already closed off is a turn that ended before it — see
-        // `adoptFirstSeam`.
-        await pollLoop(runId, gen, { ownTurn: true });
+        // `adoptFirstSeam`. `priorReply`: what was already on screen before
+        // this send, in case `landedWindow` has nothing (the reload road).
+        await pollLoop(runId, gen, { ownTurn: true, priorReply });
       }
       // else: the reader left during start — the run continues server-side and
       // resumeRun can re-attach; the landing gains no run param.

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -276,6 +276,35 @@ export function createChatController(deps: ControllerDeps): ChatController {
    * replaced (it commonly is not), so no length test can see the step.
    */
   let landedWindow: { runId: string; segments: number; text: string } | null = null;
+  /**
+   * THE SETTLED REPLY THE TRANSCRIPT IS ALREADY SHOWING — `pollLoop`'s
+   * `priorReply` base, for the two roads that start a loop over a window that
+   * may still open on a reply this page has rendered.
+   *
+   * `landedWindow` only ever covers a reply THIS controller watched land, so a
+   * transcript restored from `_history` — a reload, or a second tab opened on
+   * the same conversation — has nothing there even though the reply is right
+   * in front of the reader. This is the answer for those: the prose is exact
+   * either way (`_history` and a live poll agree byte for byte), and it is
+   * the prefix the live window reopens on until agent.py's cursor steps past
+   * the boundary.
+   *
+   * TRAILING USER TURNS ARE SKIPPED FIRST, because both callers read this
+   * with one on the end: `sendMessage` after `dispatchSend`'s optimistic
+   * bubble, `resumeRun` after `stripAfterLastUser` (or its own `addUser`).
+   * Without the skip the caller's OWN message read back as "the reply already
+   * on screen", no assistant turn was found, and nothing was seeded at all.
+   *
+   * Only a SETTLED assistant turn counts once that skip lands on one: a
+   * streaming one is not a safe prefix to assume closed.
+   */
+  const settledReply = (): { text: string } | null => {
+    let i = state.turns.length - 1;
+    while (i >= 0 && state.turns[i]!.role === "user") i--;
+    const last = state.turns[i];
+    if (!last || last.role !== "assistant" || last.streaming) return null;
+    return { text: last.text || "" };
+  };
   /** A live-run adoption watch is in flight — see `adoptLiveRun`. Separate
    *  from `state.adopting`, which is the RENDERER's gate: this one is the
    *  one-watch-at-a-time latch and stays set for as long as the adopted run
@@ -1107,6 +1136,24 @@ export function createChatController(deps: ControllerDeps): ChatController {
      * skipping them would drop them.
      */
     let adoptFirstSeam = !!opts.ownTurn;
+    /**
+     * THE ADOPTED ROAD'S NARROWER HALF OF THE SAME QUESTION.
+     *
+     * An adopted loop cannot take the first seam past the base — that is what
+     * the paragraph above rules out, and for a reason that still holds: the
+     * spans before it may be a cold read of turns this page has never
+     * rendered, and advancing past one would drop it.
+     *
+     * But it can still have a seam CONFIRM the base it was handed. A
+     * `priorReply` seed is exact prose and an unknown segment count
+     * (`baseSegTrusted`), so `segs` cannot be sliced on it and the new reply
+     * renders as flat text — no tool timeline, no thinking block — for as long
+     * as the window still opens on the old one. A seam landing at EXACTLY the
+     * end of that prefix is agent.py's own count for the same boundary, so it
+     * costs nothing to believe and hides nothing: the base does not move, it
+     * only becomes sliceable. Anything past the prefix is left alone.
+     */
+    let confirmBaseSeam = !opts.ownTurn && !baseSegTrusted;
     let tick = 0;
 
     try {
@@ -1253,7 +1300,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
         // has not landed — threw away the real seam when it arrived a poll
         // later, leaving `baseSegTrusted` down for the whole reply and its
         // segments suppressed with it.
-        if (adoptFirstSeam && anyBody) {
+        if ((adoptFirstSeam || confirmBaseSeam) && anyBody) {
           // THE FIRST SEAM PAST THE BASE, NOT THE LAST (Bugbot, PR #1119,
           // twice). The base is where THIS turn begins, and this turn begins at
           // the FIRST boundary the payload closes off beyond what was already
@@ -1271,9 +1318,12 @@ export function createChatController(deps: ControllerDeps): ChatController {
           // answers: the pre-send boundary is exactly the first one past the
           // base, wake continuation included, and it is adopted whether or not
           // a follow-up has landed since.
-          const opening = reported.find(
-            (b) => b.segments > baseSeg || b.text > baseText.length,
-          );
+          const opening = adoptFirstSeam
+            ? reported.find((b) => b.segments > baseSeg || b.text > baseText.length)
+            // The adopted road's seam — see `confirmBaseSeam`: the one that
+            // ends exactly where the prefix already on screen does, and no
+            // other.
+            : reported.find((b) => b.text === baseText.length && b.segments > baseSeg);
           if (opening) {
             baseSeg = opening.segments;
             baseText = fullText.slice(0, opening.text);
@@ -1282,6 +1332,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
             // reconciliation.
             baseSegTrusted = true;
             adoptFirstSeam = false;
+            confirmBaseSeam = false;
           } else if (!baseText || !fullText.startsWith(baseText)) {
             // Nothing left to wait behind: no base at all (every body is this
             // turn's — a fresh chat), or the window no longer OPENS on the
@@ -1295,6 +1346,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
             // left the real seam, which lands with the echo a poll later, read
             // as this send's own follow-up instead of as the base.
             adoptFirstSeam = false;
+            confirmBaseSeam = false;
           }
         }
 
@@ -1746,13 +1798,7 @@ export function createChatController(deps: ControllerDeps): ChatController {
     // Only a SETTLED assistant turn counts once that skip lands on one: a
     // streaming one is either impossible here (`sending` is one-at-a-time) or,
     // if seen anyway, not a safe prefix to assume closed.
-    const priorReply = (() => {
-      let i = state.turns.length - 1;
-      while (i >= 0 && state.turns[i]!.role === "user") i--;
-      const last = state.turns[i];
-      if (!last || last.role !== "assistant" || last.streaming) return null;
-      return { text: last.text || "" };
-    })();
+    const priorReply = settledReply();
     // The bubble shows what the user TYPED (or the markers for a wordless
     // send); the raw wire rides along for the "what was sent" popover.
     //
@@ -3001,7 +3047,25 @@ export function createChatController(deps: ControllerDeps): ChatController {
         addUser(probeMsg);
       }
       sending = false; // pollLoop is not gated on it, and follow-ups need it free
-      await pollLoop(runId, gen);
+      // AND THE REPLY ALREADY ON SCREEN IS THIS LOOP'S BASE TOO (PR #1119,
+      // second window).
+      //
+      // A run reopened on a still-live host begins its window at the PREVIOUS
+      // turn: agent.py's cursor cannot advance past that reply until a newer
+      // turn's echo proves it closed, so every poll between the send in the
+      // other tab and that echo landing hands this loop the previous reply in
+      // full. With no base at all, that is a fresh bubble carrying a verbatim
+      // copy of the answer already above it — the duplicate that shows up in
+      // a SECOND window "before the new response starts streaming", captured
+      // in a real `poll` trace and pinned in the tests below.
+      //
+      // `sendMessage`'s road has always seeded this; the difference was never
+      // anything about the window, only which road opened it. Read HERE rather
+      // than before the probe because the two reconciliation branches above
+      // both move the log: `stripAfterLastUser` drops the partial rows under
+      // the matched user line (leaving the previous reply as the last settled
+      // one), and `addUser` appends a line this has to skip past.
+      await pollLoop(runId, gen, { priorReply: settledReply() });
     } catch (err) {
       // A THROWN PROBE IS A TROUBLE CARD, not an unhandled rejection. Every
       // road in here is reached as a bare `void` (the boot's, `adoptWatch`'s,

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -3661,6 +3661,28 @@ def _segments_from_rows(rows: list, shape: tuple = (),
             # See `hard_break`. Nothing is emitted for a `result` row itself.
             hard_break = True
         elif t == "user" and isinstance(content, list):
+            # A GENUINE NEW TURN ENDS THE SEGMENT BEFORE IT, exactly as a
+            # `result` does and for the same reason: the prose after a message
+            # the user actually sent is a different answer to a different
+            # question, and merging the two into one segment leaves a caller
+            # splitting the payload (`_absorbed_turn_breaks`) no place to cut.
+            #
+            # `result` alone did not cover it. A D415 wake appends more rows of
+            # the SAME displayed turn after that `result` — a `notice` divider
+            # and its continuation — and the continuation consumes the
+            # `result`'s break, so the NEXT turn's text grew onto the wake's own
+            # segment: "\n\nWake continuation.\n\nReply B." as one segment,
+            # the exact shape `_absorbed_turn_breaks` used to refuse to report
+            # a seam for (and the refusal is what left the previous reply
+            # duplicated into the new bubble on a second window — PR #1119).
+            # Breaking here instead makes the boundary a segment edge in EVERY
+            # shape, so the seam is always safe to place.
+            #
+            # `_starts_new_turn` is what tells this row apart from the far
+            # commoner `tool_result` row below, which is a `user` row too and
+            # must NOT break: it belongs to the reply that called the tool.
+            if _starts_new_turn(row):
+                hard_break = True
             for block in content:
                 if not isinstance(block, dict) or block.get("type") != "tool_result":
                     continue
@@ -3873,11 +3895,9 @@ def _absorbed_turn_breaks(rows: list, app_reads: bool = False) -> list:
     # WITH one before it is a genuinely new turn (the cursor is about to advance
     # past it), an echo WITHOUT one was folded into the reply still in flight.
     seen_result = False
-    # A main-turn `result` this scan has not turned into a seam yet, and the
-    # index of the row before the one being looked at (subagent rows skipped) —
-    # see the genuine-boundary branch below for why the ADJACENCY matters.
+    # A main-turn `result` this scan has not turned into a seam yet. How FAR
+    # back it is no longer matters — see the genuine-boundary branch below.
     last_result = None
-    last_main = None
     for i, row in enumerate(rows):
         if not isinstance(row, dict):
             continue
@@ -3885,7 +3905,6 @@ def _absorbed_turn_breaks(rows: list, app_reads: bool = False) -> list:
         # `_read_current_turn`'s cursor and `_segments_from_rows` both make.
         if row.get("parent_tool_use_id"):
             continue
-        prev_main, last_main = last_main, i
         if row.get("type") == "result":
             seen_result = True
             if outstanding:
@@ -3925,24 +3944,24 @@ def _absorbed_turn_breaks(rows: list, app_reads: bool = False) -> list:
                 # (`_segments_from_rows` joins it with a `notice` divider), so
                 # it never reaches this branch: only an echo can, and an echo
                 # is a new message by definition.
-                # ONLY WHEN THE `result` IS THE ROW RIGHT BEFORE THIS ECHO.
                 #
-                # A D415 wake appends more rows of the SAME displayed turn after
-                # that `result` — a `notice` divider and its continuation — and
-                # a seam is only ever safe at a `hard_break`, which is what
-                # `_segments_from_rows` puts at a `result` and nowhere else. Cut
-                # anywhere else and the seam falls INSIDE a segment: with a wake
-                # in between, its continuation and the next reply are one merged
-                # text segment, so the offset either files the wake's text under
-                # the turn that had not started yet or swallows the new reply
-                # whole (Bugbot, PR #1061).
+                # WHATEVER SITS BETWEEN THE `result` AND THIS ECHO, the seam is
+                # this echo. It used to be reported only when the `result` was
+                # the row IMMEDIATELY before, because a seam is only safe at a
+                # segment edge and `_segments_from_rows` broke at a `result` and
+                # nowhere else — so anything in between (a D415 wake and its
+                # continuation, a `system` row, a control-request answer to the
+                # `model`/`permission_mode` every send carries) consumed that
+                # break and left the next turn's prose merged onto the previous
+                # segment, with no edge to cut at (Bugbot, PR #1061).
                 #
-                # So a wake-continued turn reports nothing here, exactly as it
-                # did before genuine boundaries were reported at all — the page
-                # still has its shrink test for that one, and the shape this
-                # branch exists for (a follow-up the CLI drained straight after
-                # the reply's `result`) has no wake in it by construction.
-                if last_result is not None and prev_main == last_result:
+                # `_segments_from_rows` now breaks at a genuine new turn TOO, so
+                # that merge cannot happen any more and the edge is always
+                # there. Requiring adjacency on top of it only withheld a seam
+                # the page needs: without one it re-renders the previous reply
+                # into the new turn's own bubble, which is exactly the duplicate
+                # a second window on one conversation was showing (PR #1119).
+                if last_result is not None:
                     _seam(breaks, rows, i, shape, app_reads)
                     last_result = None
             else:

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -3493,6 +3493,10 @@ def _segments_from_rows(rows: list, shape: tuple = (),
     # continues past one — a D415 wake — puts a `notice` segment in between, so
     # the tail was already a different kind and no merge was happening.
     hard_break = False
+    # Whether a main-turn `result` has closed a reply since the last echo —
+    # what tells a GENUINE new turn's echo from a follow-up the CLI drained
+    # into the reply still streaming. See the `user` branch that reads it.
+    closed_since_echo = False
 
     def tail(kind):
         return segments[-1] if segments and segments[-1]["kind"] == kind else None
@@ -3660,6 +3664,7 @@ def _segments_from_rows(rows: list, shape: tuple = (),
         elif t == "result" and not row.get("parent_tool_use_id"):
             # See `hard_break`. Nothing is emitted for a `result` row itself.
             hard_break = True
+            closed_since_echo = True
         elif t == "user" and isinstance(content, list):
             # A GENUINE NEW TURN ENDS THE SEGMENT BEFORE IT, exactly as a
             # `result` does and for the same reason: the prose after a message
@@ -3681,8 +3686,22 @@ def _segments_from_rows(rows: list, shape: tuple = (),
             # `_starts_new_turn` is what tells this row apart from the far
             # commoner `tool_result` row below, which is a `user` row too and
             # must NOT break: it belongs to the reply that called the tool.
+            #
+            # AND A `result` HAS TO HAVE CLOSED A REPLY SINCE THE LAST ECHO —
+            # the same test `_absorbed_turn_breaks` and `_read_current_turn`
+            # both make, and for the same reason. `_send` exists so a follow-up
+            # can be absorbed into a turn still in flight: the CLI echoes it
+            # back mid-reply, in exactly this shape, with no `result` in
+            # between, and the answer then KEEPS STREAMING past it. Breaking
+            # there splits one reply's prose into two segments mid-thought —
+            # the first half settling as finished, and markdown that spanned
+            # the echo no longer rendering as one document (Bugbot, PR #1119).
+            # An echo with a `result` before it is a genuinely new turn; an
+            # echo without one was folded into the reply still being written.
             if _starts_new_turn(row):
-                hard_break = True
+                if closed_since_echo:
+                    hard_break = True
+                closed_since_echo = False
             for block in content:
                 if not isinstance(block, dict) or block.get("type") != "tool_result":
                     continue

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -3917,6 +3917,15 @@ def _absorbed_turn_breaks(rows: list, app_reads: bool = False) -> list:
     # A main-turn `result` this scan has not turned into a seam yet. How FAR
     # back it is no longer matters — see the genuine-boundary branch below.
     last_result = None
+    # WHETHER THE WINDOW'S OWN OPENING ECHO HAS GONE PAST. A window always
+    # opens at a turn boundary — that is the whole of `_read_current_turn`'s
+    # cursor rule — so the FIRST echo in it with no `result` before it is the
+    # echo of the turn the window opens on, not a follow-up folded into
+    # anything. Counting it as outstanding made the window's own closing
+    # `result` report a fold-in seam for a payload holding ONE turn, and
+    # spent the `last_result` that the genuinely new turn's echo later in the
+    # same window needed (see the `else` that reads this).
+    opened = False
     for i, row in enumerate(rows):
         if not isinstance(row, dict):
             continue
@@ -3937,9 +3946,9 @@ def _absorbed_turn_breaks(rows: list, app_reads: bool = False) -> list:
                 # Not a seam YET. It becomes one if a new user turn shows up
                 # after it inside this window — see the `elif` below.
                 last_result = i
-        elif i and _starts_new_turn(row):
-            # `i and` skips `rows[0]`: the window opens on its own turn's echo.
+        elif _starts_new_turn(row):
             if seen_result:
+                opened = True
                 seen_result = False   # a genuine new turn, not a fold-in
                 # A GENUINE BOUNDARY IS A SEAM TOO, and it has to be reported
                 # for the same reason a fold-in does: the page gets ONE payload
@@ -3983,6 +3992,24 @@ def _absorbed_turn_breaks(rows: list, app_reads: bool = False) -> list:
                 if last_result is not None:
                     _seam(breaks, rows, i, shape, app_reads)
                     last_result = None
+            elif not opened:
+                # THE WINDOW'S OWN OPENING ECHO, and `opened` is the whole of
+                # what tells it from a fold-in. It used to be `rows[0]` — index
+                # 0 and nothing else — which held only while the echo was
+                # literally the first row of the window. It is not: a window
+                # reopened on a still-live host begins with the CLI's
+                # `system/init` and `system/status` before the echo (the real
+                # capture in `test_...second_window...`), and with the echo at
+                # index 2 this branch read the window's own turn as a follow-up
+                # absorbed into a reply that had not even started. Its closing
+                # `result` then reported a fold-in seam for a one-turn payload,
+                # and cleared `last_result`, so when the genuinely new turn's
+                # echo did arrive later in that same window it found nothing to
+                # report a boundary against — the page was handed two replies
+                # in one payload with no seam, and re-rendered the older one
+                # into the new turn's bubble (the second-window duplicate,
+                # PR #1119).
+                opened = True
             else:
                 outstanding += 1
     return breaks

--- a/tests/test_claude_followup_seam.py
+++ b/tests/test_claude_followup_seam.py
@@ -335,6 +335,53 @@ def test_any_row_between_the_result_and_the_echo_still_leaves_a_seam(agent):
         "and the seam still falls between the segments, never inside one")
 
 
+def test_the_captured_second_window_shape_reports_its_seam(agent):
+    """THE REAL ROWS, from a transcript where the duplication was reproduced.
+
+    Everything above reasons about what CAN sit between a `result` and the next
+    echo. This is what actually did, read out of `out.jsonl` on a machine that
+    had just hit the bug — the previous reply's `result`, then `system/init`
+    and `system/status`, then the echo of the message the reader sent:
+
+        111  result
+        112  system subtype=init
+        113  system subtype=status
+        114  user blocks=text <<< starts a new turn
+        119  assistant blocks=text
+
+    Two rows in between, so the old adjacency rule reported nothing and the
+    page had no boundary to place the new reply against — it rendered the
+    previous reply into the new bubble instead. Pinned with the real shape
+    rather than a one-row stand-in, because the one-row case passed a rule
+    this one still failed."""
+    prev, new = "P" * 524, "N" * 11      # the real lengths, from the capture
+    rows = [
+        _user_row("the earlier question"),
+        _text_row(prev),
+        {"type": "assistant", "message": {"role": "assistant",
+         "content": [{"type": "text", "text": prev}]}},
+        {"type": "stream_event", "event": {"type": "message_stop"}},
+        _result_row(prev),
+        {"type": "system", "subtype": "init", "session_id": "s"},
+        {"type": "system", "subtype": "status"},
+        _user_row("x" * 706),
+        _text_row(new),
+        {"type": "assistant", "message": {"role": "assistant",
+         "content": [{"type": "text", "text": new}]}},
+    ]
+    breaks = agent._absorbed_turn_breaks(rows)
+    assert len(breaks) == 1, "the boundary is real and has to be reported"
+    seam = breaks[0]
+    segs = agent._segments_from_rows(rows)
+    full = "".join(sg["text"] for sg in segs if sg["kind"] == "text")
+    # Everything up to the seam is the reply that was already on screen, and
+    # everything after it is the answer to the message just sent — which is
+    # the whole of what the page needs to keep them in separate bubbles.
+    assert set(full[:seam["text"]]) == {"P"}
+    assert set(full[seam["text"]:].strip()) == {"N"}
+    assert seam["text"] == len(prev)
+
+
 def test_a_wake_with_nothing_after_it_is_not_a_seam(agent):
     """A D415 wake is a `result` followed by more rows of the SAME displayed
     turn and NO user echo — `_segments_from_rows` joins it with a `notice`

--- a/tests/test_claude_followup_seam.py
+++ b/tests/test_claude_followup_seam.py
@@ -287,6 +287,28 @@ def test_a_wake_continued_turn_reports_its_seam_too(agent):
     assert seam["text"] == len("A.") + len("And the task is done.")
 
 
+def test_an_absorbed_follow_ups_echo_does_not_split_the_reply_it_landed_in(agent):
+    """Bugbot, PR #1119. The echo of a follow-up the CLI drained MID-REPLY has
+    the same row shape as a genuine new turn's, and the reply it landed in
+    keeps streaming past it — so breaking the segment there would cut one
+    answer's prose in two, settling the first half as finished and leaving
+    markdown that spanned the echo rendering as two documents instead of one.
+
+    A `result` closing a reply since the last echo is what tells the two
+    apart, which is the same test `_absorbed_turn_breaks` and
+    `_read_current_turn` already make."""
+    rows = [
+        _user_row("q1"), _text_row("Reply A, first half. "),
+        _user_row("q2"),                       # absorbed mid-reply: no result yet
+        _text_row("Reply A, second half."),
+        _result_row("Reply A."),
+        _text_row("Reply B."),
+    ]
+    texts = [sg["text"] for sg in agent._segments_from_rows(rows)
+             if sg["kind"] == "text"]
+    assert texts == ["Reply A, first half. Reply A, second half.", "Reply B."]
+
+
 def test_any_row_between_the_result_and_the_echo_still_leaves_a_seam(agent):
     """The shape a SECOND WINDOW on one conversation hits (PR #1119).
 

--- a/tests/test_claude_followup_seam.py
+++ b/tests/test_claude_followup_seam.py
@@ -245,12 +245,24 @@ def test_a_genuinely_new_turn_IS_a_seam(agent):
         "and the seam falls between the segments, never inside one")
 
 
-def test_a_wake_continued_turn_reports_no_seam(agent):
-    """Bugbot, PR #1061. A D415 wake appends more rows of the SAME displayed
-    turn after that turn's `result` — a `notice` divider and its continuation —
-    and when a genuinely new turn then opens there is no `result` adjacent to
-    the echo to cut at. Cutting at the earlier `result` anyway filed the wake's
-    own text under the turn that had not started yet."""
+def test_a_wake_continued_turn_reports_its_seam_too(agent):
+    """Bugbot, PR #1061, reopened by PR #1119. A D415 wake appends more rows of
+    the SAME displayed turn after that turn's `result` — a `notice` divider and
+    its continuation — so when a genuinely new turn then opens there is no
+    `result` adjacent to the echo.
+
+    This reported NOTHING, because a seam is only safe at a segment edge and
+    `_segments_from_rows` broke at a `result` and nowhere else: the wake's
+    continuation consumed that break, the next turn's prose grew onto the
+    continuation's own segment, and any offset would have filed the wake's text
+    under the turn that had not started yet.
+
+    Withholding it has its own cost, and it is the one a second window on a
+    conversation kept paying: with no seam the page has nothing to place the
+    new reply against, so it re-rendered the PREVIOUS reply into the new turn's
+    bubble. `_segments_from_rows` breaks at a genuine new turn now — the merge
+    that made the seam unsafe cannot happen — so the honest answer is the seam,
+    and the wake's text stays where it belongs."""
     rows = [
         _user_row("q1"), _text_row("A."), _result_row("A."),
         {"type": "system", "subtype": "task_notification",
@@ -258,16 +270,47 @@ def test_a_wake_continued_turn_reports_no_seam(agent):
         _text_row("And the task is done."),
         _user_row("q2"), _text_row("B."),
     ]
-    # NOTHING, and that is the only honest answer. A seam is safe only at a
-    # `hard_break`, which `_segments_from_rows` puts at a `result` and nowhere
-    # else — with a wake in between, its continuation and the next reply are one
-    # merged text segment, so any offset here either files the wake's text under
-    # the turn that had not started yet or swallows the new reply whole. The
-    # page's shrink test still covers this shape, as it did before genuine
-    # boundaries were reported at all.
-    assert agent._absorbed_turn_breaks(rows) == []
+    breaks = agent._absorbed_turn_breaks(rows)
     segs = agent._segments_from_rows(rows)
-    assert [sg.get("kind") for sg in segs].count("text") >= 1
+    texts = [sg["text"] for sg in segs if sg["kind"] == "text"]
+    # The new reply is a segment of its own — never grown onto the wake's.
+    assert texts == ["A.", "And the task is done.", "B."]
+    assert len(breaks) == 1
+    seam = breaks[0]
+    # AND IT FALLS BETWEEN SEGMENTS, never inside one: everything up to it is
+    # the previous displayed turn, wake continuation included, and everything
+    # after it is the reply to `q2` alone.
+    assert [sg["text"] for sg in segs[:seam["segments"]] if sg["kind"] == "text"] \
+        == ["A.", "And the task is done."]
+    assert [sg["text"] for sg in segs[seam["segments"]:] if sg["kind"] == "text"] \
+        == ["B."]
+    assert seam["text"] == len("A.") + len("And the task is done.")
+
+
+def test_any_row_between_the_result_and_the_echo_still_leaves_a_seam(agent):
+    """The shape a SECOND WINDOW on one conversation hits (PR #1119).
+
+    Every send carries `model` and `permission_mode`, and `_send` queues a
+    control request ahead of the message whenever either differs from what the
+    host was spawned with — which a second window, with its own defaults, can
+    easily make true. Whatever the CLI writes for that lands between the
+    previous turn's `result` and this send's echo, and while the seam required
+    the two to be ADJACENT, a single row in between was enough to withhold it —
+    leaving the page to render the previous reply into the new turn's bubble.
+
+    Nothing about a row in between makes the boundary less real, and nothing
+    about it makes the cut less safe: `_segments_from_rows` breaks at the echo
+    itself now, so the edge is there either way."""
+    rows = [
+        _user_row("q1"), _text_row("A."), _result_row("A."),
+        {"type": "system", "subtype": "init", "session_id": "s"},
+        _user_row("q2"), _text_row("B."),
+    ]
+    breaks = agent._absorbed_turn_breaks(rows)
+    segs = agent._segments_from_rows(rows)
+    assert breaks == [{"segments": 1, "text": len("A.")}]
+    assert [sg["text"] for sg in segs if sg["kind"] == "text"] == ["A.", "B."], (
+        "and the seam still falls between the segments, never inside one")
 
 
 def test_a_wake_with_nothing_after_it_is_not_a_seam(agent):

--- a/tests/test_claude_followup_seam.py
+++ b/tests/test_claude_followup_seam.py
@@ -335,6 +335,91 @@ def test_any_row_between_the_result_and_the_echo_still_leaves_a_seam(agent):
         "and the seam still falls between the segments, never inside one")
 
 
+def test_a_window_that_opens_on_the_CLI_s_plumbing_reports_no_seam_of_its_own(agent):
+    """ONE TURN IS NEVER A SEAM, however the window opens on it.
+
+    Taken from a `poll` capture of the reproduction: a send into a still-live
+    host makes the CLI write `system/init` and `system/status` before it echoes
+    the message, so the window does NOT open on its own turn's echo — the echo
+    is at index 2. The rule that skipped it was `rows[0]` and nothing else, so
+    with two rows in front of it the window's OWN opening turn was counted as a
+    follow-up absorbed into a reply that had not even started, and the `result`
+    that closed it reported a fold-in seam for a payload holding ONE turn.
+
+    The page then took the whole of that reply as the base for the turn it was
+    waiting on. See the test below for the other half of the damage."""
+    body = "A" * 483                      # the real length, from the capture
+    rows = [
+        {"type": "system", "subtype": "init", "session_id": "s"},
+        {"type": "system", "subtype": "status"},
+        _user_row("the question"),        # index 2, not index 0
+        _text_row(body),
+        _result_row(body),
+    ]
+    assert agent._absorbed_turn_breaks(rows) == [], (
+        "one turn in the window, so there is no boundary inside it to report")
+
+
+def test_the_captured_reopened_window_reports_the_boundary_it_actually_has(agent):
+    """THE SAME CAPTURE, ONE POLL LATER: the newer turn's echo has landed, so
+    the window really does carry two replies and really does need a seam.
+
+    THIS ONE ANSWERED THE SAME BEFORE THE FIX, and it is here to pin that,
+    because the two roads to it are not the same thing and only one of them is
+    a boundary. Miscounting the window's own opening echo as a fold-in made its
+    `result` report the seam and clear `last_result` on the way past, so the
+    genuinely new echo below reported nothing — the offsets coincide only
+    because the window opens on the very turn the fold-in branch was crediting.
+    They stop coinciding the moment the window holds ONE turn (the test above,
+    which is where the wrong road shows), and a reader is entitled to the
+    boundary being reported by the row that actually is one.
+
+    The offsets are the reply already on screen, exactly — which is what makes
+    this payload safe for a reader to slice."""
+    prev, new = "A" * 483, "Yes"
+    rows = [
+        {"type": "system", "subtype": "init", "session_id": "s"},
+        {"type": "system", "subtype": "status"},
+        _user_row("the question"),
+        _text_row(prev),
+        {"type": "stream_event", "event": {"type": "message_stop"}},
+        _result_row(prev),
+        {"type": "system", "subtype": "init", "session_id": "s"},
+        {"type": "system", "subtype": "status"},
+        _user_row("the follow-up question"),
+        _text_row(new),
+    ]
+    breaks = agent._absorbed_turn_breaks(rows)
+    assert breaks == [{"segments": 1, "text": len(prev)}]
+    segs = agent._segments_from_rows(rows)
+    texts = [sg["text"] for sg in segs if sg["kind"] == "text"]
+    # The seam falls BETWEEN the segments, never inside one, so a reader can
+    # cut on it: everything before it is the reply already on screen.
+    assert texts[0] == prev
+    assert "".join(texts)[:breaks[0]["text"]] == prev
+
+
+def test_a_follow_up_absorbed_into_a_window_that_opens_on_plumbing_still_reports(agent):
+    """...and the opening-echo rule must not swallow a REAL fold-in.
+
+    The window opens on plumbing and its own echo, exactly as above, and then a
+    follow-up is drained into the reply while it is still streaming. That
+    second echo is a genuine fold-in — no `result` between it and the reply it
+    landed in — and its seam is the `result` that closes that reply."""
+    rows = [
+        {"type": "system", "subtype": "init", "session_id": "s"},
+        {"type": "system", "subtype": "status"},
+        _user_row("q1"), _text_row("Reply A, first half. "),
+        _user_row("q2"),                      # absorbed mid-reply
+        _text_row("Reply A, second half."),
+        _result_row("Reply A."),
+        _text_row("Reply B."),
+    ]
+    breaks = agent._absorbed_turn_breaks(rows)
+    assert breaks == [{"segments": 1,
+                       "text": len("Reply A, first half. Reply A, second half.")}]
+
+
 def test_the_captured_second_window_shape_reports_its_seam(agent):
     """THE REAL ROWS, from a transcript where the duplication was reproduced.
 


### PR DESCRIPTION
Split out of #1119, which is now just the legacy-chat fix for the reported duplication. **This PR is a different, narrower bug** and is not what that report was about — see "Scope" below.

## What this fixes

`pollLoop` opens on a window that can still hold the PREVIOUS reply: `_read_current_turn`'s cursor only advances past a turn boundary it has proven (a `_starts_new_turn` echo with a `result` before it), so a send into a still-live host reopens the window on the reply already on screen and keeps it there for several polls. Two roads reached that window with no base to hide it behind:

- **The reload road.** `landedWindow` only ever covers a reply *this* controller watched land, so a transcript restored from `_history` — a reload, or a second tab opened on the same conversation — had nothing there even though the reply was rendered. `priorReply`/`settledReply` is the base for those.
- **The adopted road** (`resumeRun`/`adoptLiveRun`) started its loop with no base at all. `sendMessage` had always seeded one; the difference was never the window, only which road opened it.

Plus, in `agent.py`, `_absorbed_turn_breaks` skipped the window's own opening echo *by index* (`rows[0]`). A window reopened on a live host doesn't start with that echo — the CLI writes `system/init` and `system/status` first — so the window's own turn was counted as a follow-up folded into a reply that hadn't begun, its closing `result` reported a fold-in seam for a payload holding one turn, and the genuinely new echo later in the window had nothing left to report a boundary against.

## Scope — please read

This does **not** fix the duplication reported against the default chat. That is #1119, in `templates/claude/template.html`. I spent a long time fixing the wrong implementation before noticing that `native_chat_enabled` defaults to off and that the legacy template contains no reference to `turn_breaks` at all.

Measured on `126b06c` (pre-any-fix), same scenario driven through the real app:

| chat | peak copies of the previous reply |
|---|---|
| native | 1 — clean |
| legacy (default) | 2 — duplicates |

So the native chat never had the reported bug; it was born with `landedWindow`. What it *did* have are the narrower gaps above, which is what this PR closes. They are worth having, but they are not urgent, and nothing here is load-bearing for #1119.

The `agent.py` change is likewise invisible to the default chat, which never reads `turn_breaks`.

## Verification

Every fix here has a regression test confirmed failing against the commit before it. The later commits in this branch are corrections to earlier ones, each prompted by a Cursor Bugbot finding on #1119 that turned out to be correct — the history is kept rather than squashed because those exchanges are the reasoning.

`bun test src/apps/claude` 1562 pass · `tsc --noEmit` clean · `tests/test_claude_followup_seam.py` + `test_claude_agent_segments.py` 82 pass.

Rebased on `main` (`0f6f36ddd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUo4BiYdwk9GDnW7qT4AeL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUo4BiYdwk9GDnW7qT4AeL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live poll rendering and Python turn-break/segmentation logic for multi-tab and post-reload sends; wrong seam handling could drop or duplicate turns, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes a **one-frame flash** where the previous assistant reply could appear inside the new bubble when sending after a reload, opening a second tab on the same live conversation, or when the backend withholds `turn_breaks` (e.g. rows between an old `result` and the new echo).
> 
> **Native chat (`run-controller.ts`)** seeds `pollLoop` with the **already-rendered prior reply** via `settledReply()` / `priorReply` on `sendMessage` and `resumeRun`/`adoptLiveRun`, skipping the optimistic user bubble so the composer path is covered. Segment slicing stays **untrusted** until a reported seam confirms the count or the window no longer opens on that text—avoiding history/live segment mismatches, stuck `sending`, and one-poll “grace” mistakes on busy hosts. Seam adoption uses the **first** boundary past the base (not the last) and a narrower **confirm-base** path for adopted loops.
> 
> **Backend (`agent.py`)** breaks segments at genuine new user turns when a `result` closed since the last echo (so wake continuations don’t merge into the next reply), reports turn seams **without** requiring `result` adjacency to the echo, and treats the window’s **opening** echo correctly when `system/init` rows precede it.
> 
> Regression coverage is expanded heavily in `run-controller.test.ts` and `test_claude_followup_seam.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c014c2c6a45daf77061e15ecb6e3acae77a06b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->