### PR TITLE
Drafts follow-ups: one open rule, stricter drafts, red chips, server-owned rekey

### DIFF
--- a/frontend/src/apps/claude/ClaudeChat.tsx
+++ b/frontend/src/apps/claude/ClaudeChat.tsx
@@ -132,7 +132,6 @@ import { useChatRecapEnabled } from "./feature-flag";
 import { useSchedule } from "./sched/useSchedule";
 import { createLiveWatch } from "./live/watch";
 import { getClaudeSessionLiveness } from "@platform/lib/api";
-import { chatDraftKey, rekeyChatDraft } from "@platform/lib/drafts";
 import "./styles/ann.css";
 import "./styles/chat.css";
 import "./styles/hljs.css";
@@ -1960,29 +1959,6 @@ function ChatBody(props: ChatBodyProps) {
   );
 
   /**
-   * THE SEND THAT IS OWED A REKEY — set when a Send goes out of a chat that has
-   * no session yet, because that send is the one about to create one and the
-   * `new:<file>` draft's TASK number has to follow it (the rekey effect below
-   * spends this).
-   *
-   * BOUND TO THE RUN, not left lying in the module (Bugbot, PR #1118,
-   * 2026-09-12). `controller` and `file` together are the only thing that says
-   * which conversation a later `state.sessionId` belongs to: `ChatBody` is not
-   * keyed on `file`, so switching targets can swap the file, the controller, or
-   * both under this same tree. A note kept outside the component could be spent
-   * by whichever conversation happened to report an id next — another chat in
-   * the same folder, or a session opened rather than sent — and would walk the
-   * unsent row and its number onto it. `live` is how the run's END is told from
-   * its start: `RunStatus` spells both `idle`.
-   */
-  const pendingRekey = useRef<{
-    controller: ReturnType<typeof createChatController>;
-    file: string | null;
-    key: string;
-    live: boolean;
-  } | null>(null);
-
-  /**
    * THE SEND WINDOW, SERIALIZED — one road, both kinds of send.
    *
    * `beginSend` is AWAITED (a round of notes has its pane photographed before
@@ -2019,13 +1995,6 @@ function ChatBody(props: ChatBodyProps) {
       setSendLocked(true);
       const sendId = `s${++sendSeq.current}`;
       sendHolder.current = sendId;
-      // NO SESSION UNDER THIS SEND MEANS THIS SEND MAKES ONE, which is the one
-      // moment the answer is certain — read off the controller rather than off
-      // a render, so a poll that has not landed yet cannot make an opened
-      // session look like a new one (`pendingRekey` above).
-      if (!controller.getState().sessionId) {
-        pendingRekey.current = { controller, file, key: chatDraftKey(null, file), live: false };
-      }
       // A WORDLESS send (notes or pictures alone) posts no optimistic row: its
       // bubble is the markers `stripBlocks` builds out of the composed wire,
       // and only the controller can write those.
@@ -2480,64 +2449,27 @@ function ChatBody(props: ChatBodyProps) {
   }, [controller, inChat, state.sessionId]);
 
   /**
-   * THE DRAFT'S TASK NUMBER FOLLOWS THE SESSION THE CHAT TURNS OUT TO BE
-   * (design.md, Round 2: "Every draft has a TASK number").
+   * THE DRAFT'S TASK NUMBER FOLLOWS THE SESSION THE CHAT TURNS OUT TO BE — and
+   * NOT FROM HERE (design.md, Round 2: "Every draft has a TASK number").
    *
-   * A brand-new conversation has no session id, so its composer autosaves under
-   * `new:<file>` and the server gives THAT key a TASK-NNN and a row on the List.
-   * The first send creates the session; from the next render the composer keys
-   * on the session id instead (Composer's `draftKey`), and without this the
-   * number — and the row wearing it — would be stranded on a key nothing reads
-   * again. One POST moves both, the same way `pending:<entry>` is walked onto a
-   * session when a scheduled run reports one.
+   * A brand-new conversation drafts under `new:<file>` and is numbered under
+   * that key; the first send creates the session, and the number has to follow
+   * it or the row the reader has been watching is stranded. This page used to
+   * make that move itself, and four rounds of bugbot said it cannot: every way
+   * a page has of telling "this session id is the one MY send created" is an
+   * inference, and each one had a gap — a send that threw, a refusal that never
+   * left `idle`, a Back before the id landed — that left the note for the next
+   * session id to claim, walking an unsent row onto a conversation the send had
+   * nothing to do with (Bugbot, PR #1118, 2026-09-12).
    *
-   * ONLY FOR THE SEND THAT MADE THIS SESSION. This used to be inferred from
-   * what the effect itself saw: latch "started without a session" on the first
-   * pass with an empty `state.sessionId`, then rekey when an id turned up. But
-   * an empty id on the first pass is the ORDINARY case for every chat — the id
-   * arrives only when boot's `openSession` answers — so the latch caught chats
-   * that had been opened ON a session too, and opening one in a folder that
-   * already held a `new:<file>` draft silently moved that unsent row, words and
-   * TASK number, onto a conversation it had nothing to do with. Its first
-   * replacement moved the answer into a module-level set the composer wrote at
-   * the send; that fixed the inference but not the OWNERSHIP — nothing said
-   * which session was allowed to spend the note, so switching conversations in
-   * the same folder before the first poll returned spent it on the wrong one
-   * (Bugbot, PR #1118, 2026-09-12).
-   *
-   * SO THE NOTE CARRIES ITS RUN. `pendingRekey` is written where the send is
-   * dispatched and remembers the controller and file it was dispatched for; the
-   * three things that can happen to it are all answered here, in order:
-   *
-   *   * THIS IS NOT THAT CONVERSATION any more (a different controller, or the
-   *     same one now pointed at another file) — drop the note unspent, because
-   *     the id this chat is about to report was not made by our send;
-   *   * THE ID LANDED for the run we sent — move the draft, once, and drop it;
-   *   * THE RUN ENDED WITHOUT ONE — drop it. `RunStatus` has no separate
-   *     "ended", so an end is only an end after the run has been seen live;
-   *     a send refused before it ever ran leaves the note to the ownership
-   *     check, which is the next thing that touches it.
-   *
-   * Fire and forget, like every other write in platform/lib/drafts: a refusal
-   * costs the number's continuity and nothing the reader is doing — and the
-   * draft this renames is one the send is about to delete anyway.
+   * What the send CAN say is which draft it is spending — it knows that before
+   * it leaves — so a session-less start carries the key (`draft_key`,
+   * `protocol/run-controller.ts`), `agent._start` writes it into the run's
+   * `meta.json`, and the server moves the number onto the session that run
+   * turns out to have made (`routers/tasks.py::_settle_new_chats`). Nothing on
+   * this page decides which session that was; all it still owes the draft is
+   * the DELETE the composer already fires on send.
    */
-  useEffect(() => {
-    const pending = pendingRekey.current;
-    if (!pending) return;
-    if (pending.controller !== controller || pending.file !== file) {
-      pendingRekey.current = null;
-      return;
-    }
-    const id = state.sessionId ?? "";
-    if (id) {
-      pendingRekey.current = null;
-      void rekeyChatDraft(pending.key, id);
-      return;
-    }
-    if (state.status !== "idle") pending.live = true;
-    else if (pending.live) pendingRekey.current = null;
-  }, [controller, file, state.sessionId, state.status]);
 
   const card = useMemo(
     () => ({

--- a/frontend/src/apps/claude/protocol/run-controller.test.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.test.ts
@@ -252,6 +252,44 @@ describe("start → poll → done", () => {
     }
   });
 
+  // ---- the draft this send spends (`draft_key`, PR #1118 round 5) ----------
+  //
+  // A chat with no session has been drafting — and carrying its TASK number —
+  // under `new:<file>`, and the number has to follow the session this start
+  // mints. Nothing here can tell afterwards WHICH session that was, so the run
+  // is tagged with the key on the way out and the server reads it back off
+  // `meta.json` (`routers/tasks.py::_settle_new_chats`). The tag rides exactly
+  // the sends that create a session, because a run nobody could spend the draft
+  // on is a claim on words somebody may still be typing.
+
+  test("a session-less start names the draft it is spending", async () => {
+    const { controller, agent } = makeController({
+      start: () => ({ run_id: "r1" }),
+      poll: () => poll({ done: true }),
+    });
+    await controller.sendMessage("hi");
+    // `platform/lib/drafts.chatDraftKey(null, file)` — the chat's own `file`,
+    // verbatim and unnormalised, which is the spelling the composer drafts
+    // under and the server matches on.
+    expect(agent.of("start")[0].fields.draft_key).toBe("new:/proj/app.py");
+  });
+
+  test("a start that has a session to resume names no draft", async () => {
+    const params = createMemoryParamsStore({ session_id: "s1" });
+    const { controller, agent } = makeController(
+      {
+        live_host: () => ({ error: "no host" }),
+        start: () => ({ run_id: "r2" }),
+        poll: () => poll({ done: true }),
+      },
+      params,
+    );
+    await controller.sendMessage("again");
+    const started = agent.of("start")[0].fields;
+    expect(started.session_id).toBe("s1");
+    expect("draft_key" in started).toBe(false);
+  });
+
   test("`start` refusing rolls the bubble back and reports the failure", async () => {
     const { controller, params } = makeController({
       start: () => ({ error: "(empty message)" }),
@@ -455,7 +493,12 @@ describe("follow-ups (T:16024, D687)", () => {
     });
     await made.controller.sendMessage("go");
     const started = made.agent.of("start")[0]!;
+    // `draft_key` is the one field T never sent, and it is native's own: this
+    // send has no session, so it is the send that CREATES one and it names the
+    // `new:<file>` draft whose TASK number has to follow (PR #1118 round 5).
+    // Every other field is T's, spelled T's way.
     expect(Object.keys(started.fields).sort()).toEqual([
+      "draft_key",
       "effort",
       "file",
       "has_pane",

--- a/frontend/src/apps/claude/protocol/run-controller.ts
+++ b/frontend/src/apps/claude/protocol/run-controller.ts
@@ -32,6 +32,7 @@
 //    the segment render, every poll, and re-pins the open cards last
 //    (T:16305-16311, 14665-14775).
 import { scheduleMessage } from "@platform/lib/api";
+import { chatDraftKey } from "@platform/lib/drafts";
 import { announceTasksChanged } from "@platform/lib/tasksChanged";
 
 import { runAgent } from "./agent";
@@ -1687,6 +1688,18 @@ export function createChatController(deps: ControllerDeps): ChatController {
             // Granted for the SESSION, not the turn (Task 6): the process this
             // starts stays up across every follow-up it sends (T:16657-16668).
             read_dirs: JSON.stringify(opts.readDirs || []),
+            // THE DRAFT THIS SEND SPENDS, and only when there is no session to
+            // send into — which is exactly the send that CREATES one. The chat
+            // has been drafting (and carrying its TASK number) under
+            // `new:<file>`, and the number has to follow the session this start
+            // mints. Nothing here can tell afterwards which id that was, so the
+            // run is tagged on the way out and the server reads the tag back off
+            // `meta.json` (`routers/tasks.py::_settle_new_chats`; four earlier
+            // rounds of asking the page instead are in `platform/lib/drafts.ts`).
+            // Omitted on a send into an existing session: that send creates
+            // nothing, and a tag it could not spend would be a claim on a draft
+            // still being typed.
+            ...(sessionId ? {} : { draft_key: chatDraftKey(null, FILE) }),
           },
           { key: null },
         )) as StartResponse;

--- a/frontend/src/apps/claude/protocol/types.ts
+++ b/frontend/src/apps/claude/protocol/types.ts
@@ -57,6 +57,20 @@ export interface StartRequest {
   has_pane: "0" | "1" | "";
   /** JSON array of folders granted for reading (T:16617). */
   read_dirs: string;
+  /**
+   * THE DRAFT THIS SEND SPENDS — `new:<file>` — and ONLY on a send with no
+   * `session_id` (platform/lib/drafts.chatDraftKey).
+   *
+   * A chat that has never been sent keeps its half-typed message and its TASK
+   * number under that key; this send is what creates the session, and the
+   * number has to follow it. The page cannot prove afterwards WHICH session its
+   * own send made (bugbot, PR #1118 — four rounds of inference, each with a
+   * gap), so it tags the run on the way out instead: `agent._start` writes the
+   * key into `meta.json` verbatim and `routers/tasks.py::_settle_new_chats`
+   * reads it back. Absent on every other start, which is what keeps a
+   * scheduler's first fire on the same folder from claiming the draft.
+   */
+  draft_key?: string;
 }
 
 export interface PollRequest {

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -3086,6 +3086,20 @@ export interface Task {
   // `session_id`, the same place the unread numbers are joined; null — or
   // absent, on a server that predates drafts — means there is nothing unsent.
   draft?: { preview: string; updated_at: number } | null;
+  /**
+   * THE UNSENT NEW TASK FORM BOUND TO THIS CONVERSATION — its draft id, or ""
+   * (or absent, on an older server) when there is none.
+   *
+   * A task draft made out of a chat is a message INTO that chat, so it gets no
+   * row and no number of its own: this row is the one the reader knows, and it
+   * simply wears the `Draft` chip, whose preview arrives in `draft` above when
+   * the conversation's own composer is empty (routers/tasks.py `_bound_chips`).
+   *
+   * Nothing draws it. It is what the composer's Schedule hop looks up so a
+   * second press reopens the SAME form instead of minting another
+   * (shell/Scheduled `boundDraftSeed`).
+   */
+  bound_draft?: string;
   // Did the newest message's run break? `status` is the authority on which
   // column a task belongs in; this is the raw fact underneath it, and the two
   // disagree in exactly one direction — a task triaged to `done`, or one whose

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -3085,7 +3085,14 @@ export interface Task {
   // `Draft` chip and say what they start with. Joined server-side by
   // `session_id`, the same place the unread numbers are joined; null — or
   // absent, on a server that predates drafts — means there is nothing unsent.
-  draft?: { preview: string; updated_at: number } | null;
+  // …and `kind` says WHERE those words are, because the two answers are two
+  // different presses (Bugbot, PR #1126). `"chat"` is this conversation's own
+  // composer — the press opens the chat and there they are. `"form"` is a New
+  // task card bound to this session (`bound_draft` names it), of which the chat
+  // holds nothing, so that press has to reopen the card instead. Absent on a
+  // server that predates the field; read as `"chat"`, which is what every draft
+  // joined onto a session row was before a form could be bound to one.
+  draft?: { preview: string; updated_at: number; kind?: "chat" | "form" } | null;
   /**
    * THE UNSENT NEW TASK FORM BOUND TO THIS CONVERSATION — its draft id, or ""
    * (or absent, on an older server) when there is none.

--- a/frontend/src/platform/lib/drafts.test.ts
+++ b/frontend/src/platform/lib/drafts.test.ts
@@ -31,7 +31,6 @@ import {
   deleteChatDraft,
   fetchChatDraft,
   newChatFile,
-  rekeyChatDraft,
   saveChatDraft,
   saveTaskDraft,
   useAutosave,
@@ -372,113 +371,46 @@ describe("saveTaskDraft's from_chat_key", () => {
   });
 });
 
-describe("rekeyChatDraft", () => {
-  test("moves the number from the `new:<file>` key onto the session", async () => {
-    const f = recordFetch();
-    await rekeyChatDraft(chatDraftKey(null, "/Users/me/news"), "sess-9");
-    expect(f.calls[0].url).toBe("/api/drafts/chat/rekey");
-    expect(f.calls[0].init.method).toBe("POST");
-    expect(JSON.parse(String(f.calls[0].init.body)))
-      .toEqual({ from: "new:/Users/me/news", to: "sess-9" });
-    f.restore();
-  });
-
-  test("says nothing at all when there is nothing to move", async () => {
-    // The server answers 400 on a bad shape or `from === to`; a request that
-    // can only be refused is one not worth making.
-    const f = recordFetch();
-    await rekeyChatDraft("", "sess-9");
-    await rekeyChatDraft("new:/x", "");
-    await rekeyChatDraft("sess-9", "sess-9");
-    expect(f.calls).toEqual([]);
-    f.restore();
-  });
-});
-
-// ---- the number follows the session the chat turns out to be -----------------
+// ---- the number follows the session, and NOT from here ----------------------
 // design.md, Round 2: "Every draft has a TASK number." A brand-new chat keys its
 // draft `new:<file>` and is given one under that key; the first send creates the
-// session, and the composer keys on the session id from the next render. Without
-// the rekey, the number — and the row wearing it — is stranded on a key nothing
-// reads again. Source reads: the whole claim is about WHEN this fires and how
-// many times, which a mounted chat cannot be asked without a whole run.
+// session, and the number has to follow it or the row the reader was watching is
+// stranded on a key nothing reads again.
+//
+// THE MOVE IS THE SERVER'S (Bugbot, PR #1118, 2026-09-12). Four rounds went into
+// asking this page which session its own send created, and every answer was an
+// inference with a gap in it — a send that threw, a refusal that never left
+// `idle`, a Back before the id landed — that left the move owed to whichever
+// session id turned up next, walking an unsent row onto a conversation the send
+// had nothing to do with. `routers/tasks.py::_settle_new_chats` reads it off the
+// run's own `meta.json` instead. These hold the client's side of that: it does
+// the delete and nothing else, and the machinery it used to need is gone.
 
-describe("the chat rekeys its draft when it learns its session", () => {
+describe("the chat does not rekey its own draft", () => {
   const chat = () =>
     readFileSync(join(import.meta.dir, "../../apps/claude/ClaudeChat.tsx"), "utf8");
   const composer = () =>
     readFileSync(join(import.meta.dir, "../../apps/claude/ui/Composer.tsx"), "utf8");
-  const effect = () => {
-    const s = chat();
-    const at = s.indexOf("const pending = pendingRekey.current;");
-    return s.slice(at, s.indexOf("}, [controller, file, state.sessionId, state.status]);", at));
-  };
+  const drafts = () => readFileSync(join(import.meta.dir, "drafts.ts"), "utf8");
 
-  test("posts the move once, from the `new:<file>` key onto the session", () => {
-    expect(effect()).toContain("void rekeyChatDraft(pending.key, id);");
-    // The same key the composer autosaves under — one function, so the two
-    // halves cannot spell the path differently.
-    expect(chat()).toContain('import { chatDraftKey, rekeyChatDraft } from "@platform/lib/drafts";');
-    expect(chat()).toContain("key: chatDraftKey(null, file)");
-  });
-
-  test("the note is written at the SEND, and only with no session under it", () => {
-    // Not inferred from an observed empty `state.sessionId`: that is the
-    // ordinary first pass for every chat, opened-on-a-session ones included,
-    // because the id only arrives when boot's `openSession` answers.
-    expect(chat()).toContain("if (!controller.getState().sessionId) {");
-    expect(chat()).toContain(
-      "pendingRekey.current = { controller, file, key: chatDraftKey(null, file), live: false };",
-    );
-    expect(chat()).not.toContain("startedWithoutSession");
-    expect(chat()).not.toContain("rekeyedFor");
-  });
-
-  test("the note carries the run, so nobody else can spend it", () => {
-    // Bugbot, PR #1118 (2026-09-12): a module-level "a send is owed a rekey"
-    // set said nothing about WHICH session was allowed to spend it, so
-    // switching conversations in the same folder before the first poll
-    // returned moved the unsent row and its TASK number onto the wrong one.
-    const e = effect();
-    expect(e).toContain("if (pending.controller !== controller || pending.file !== file) {");
-    // Dropped UNSPENT on that road — no rekey between the check and its return.
-    const other = e.slice(e.indexOf("pending.file !== file"), e.indexOf("const id ="));
-    expect(other).toContain("pendingRekey.current = null;");
-    expect(other).not.toContain("rekeyChatDraft(");
-    // And the module-level set it replaces is gone from both sides.
-    const drafts = readFileSync(join(import.meta.dir, "drafts.ts"), "utf8");
-    expect(drafts).not.toContain("SentWithoutSession");
+  test("no rekey call, no note, no route — on either side", () => {
+    const c = chat();
+    expect(c).not.toContain("rekeyChatDraft");
+    expect(c).not.toContain("pendingRekey");
+    // Nor any of the inferences the rounds before it tried.
+    expect(c).not.toContain("startedWithoutSession");
+    expect(c).not.toContain("rekeyedFor");
+    const d = drafts();
+    expect(d).not.toContain("export async function rekeyChatDraft");
+    // The URL as it would be WRITTEN, not as the module's own prose names it.
+    expect(d).not.toContain('"/api/drafts/chat/rekey"');
+    expect(d).not.toContain("SentWithoutSession");
     expect(composer()).not.toContain("SentWithoutSession");
   });
 
-  test("spent only when the run we sent yields the id, and only once", () => {
-    const e = effect();
-    const landed = e.slice(e.indexOf("if (id) {"), e.indexOf("if (state.status !== "));
-    expect(landed).toContain("pendingRekey.current = null;");
-    expect(landed).toContain("void rekeyChatDraft(pending.key, id);");
-  });
-
-  test("a run that ends without minting an id drops the note", () => {
-    // `RunStatus` is idle|starting|running|stopping — no separate "ended" — so
-    // an end is only an end once the run has been seen live; the idle a send is
-    // dispatched into is not one.
-    const e = effect();
-    expect(e).toContain('if (state.status !== "idle") pending.live = true;');
-    expect(e).toContain("else if (pending.live) pendingRekey.current = null;");
-    expect(chat()).toContain("}, [controller, file, state.sessionId, state.status]);");
-  });
-
-  test("fire and forget, like every other write in this module", () => {
-    // A refusal costs the number's continuity and nothing the reader is doing —
-    // and the draft it renames is one the send is about to delete anyway.
-    expect(effect()).toContain("void rekeyChatDraft(");
-    expect(effect()).not.toContain("await ");
-  });
-
-  test("the composer no longer needs to know — it just spends its own key", () => {
-    const c = composer();
-    expect(c).toContain("deleteChatDraft(draftKeyRef.current)");
-    expect(c).not.toContain("markSentWithoutSession");
+  test("the send still spends its own key, which is all it ever owed", () => {
+    expect(composer()).toContain("deleteChatDraft(draftKeyRef.current)");
+    expect(composer()).not.toContain("markSentWithoutSession");
   });
 });
 
@@ -503,9 +435,8 @@ describe("the two shapes of a chat key", () => {
 // the draft under `new:<file>` AND gives the landing a session, which remounts
 // the composer. The fresh mount seeds itself from `fetchChatDraft`, and that GET
 // can overtake the DELETE still in flight: the answer is the sentence that was
-// just sent, put back into the box the send had emptied — and the rekey that
-// follows walks it onto the session, so the message the reader sent is sitting
-// on their own task row as an unsent draft.
+// just sent, put back into the box the send had emptied — a message the reader
+// sent, sitting in their composer as an unsent draft.
 //
 // Nothing inside one mount can close that window (`reset`/`stop`/`settle` all
 // belong to the component being thrown away, and the seed runs in the NEXT one),
@@ -594,110 +525,6 @@ describe("a spent chat key reads back as empty", () => {
     expect(await fetchChatDraft(sent)).toBeNull();
     expect((await fetchChatDraft(other))?.text).toBe("still unsent");
     f.restore();
-  });
-});
-
-// ---- the rekey cannot pass the send's delete ---------------------------------
-//
-// THE BUG (Bugbot, PR #1118, 2026-09-11). `spent` covers `new:<file>` and only
-// that key. The first send fires `DELETE new:<file>` and, on learning the
-// session, `POST /api/drafts/chat/rekey` — two requests in no order at all. If
-// the rekey is served first the record is still there, so the route copies it
-// onto the session id, and the composer that just remounted seeds from the
-// SESSION key, which nothing had marked spent. Same resurrection, one key over.
-
-describe("the rekey cannot pass the send's delete", () => {
-  const held = (text: string): ChatDraft => ({ text, attachments: [], updated_at: 1 });
-
-  /** `fetch` that records every call and answers `GET /api/drafts` out of
-   *  `chat` — but holds every request until `release()`, which is how one is
-   *  kept "in flight" without a clock. After the release the gate is open:
-   *  later requests answer at once, so a test can order what it cares about
-   *  and then let the rest run. */
-  function gate(chat: Record<string, ChatDraft> = {}) {
-    const calls: string[] = [];
-    const waiting: (() => void)[] = [];
-    let holding = true;
-    const answer = () => ({ ok: true, json: () => Promise.resolve({ chat, task: {} }) }) as unknown as Response;
-    const real = globalThis.fetch;
-    globalThis.fetch = ((url: string, init?: RequestInit) => {
-      calls.push(`${init?.method ?? "GET"} ${url}`);
-      if (!holding) return Promise.resolve(answer());
-      return new Promise<Response>((resolve) => {
-        waiting.push(() => resolve(answer()));
-      });
-    }) as typeof fetch;
-    return {
-      calls,
-      release: () => {
-        holding = false;
-        for (const unblock of waiting.splice(0)) unblock();
-      },
-      restore: () => {
-        globalThis.fetch = real;
-      },
-    };
-  }
-
-  const posts = (calls: string[]) => calls.filter((c) => c.startsWith("POST /api/drafts/chat/rekey"));
-
-  test("it waits for a DELETE still in flight before posting the move", async () => {
-    const g = gate();
-    const from = "new:/Users/me/moving";
-    // The send. Not awaited — the DELETE being in the air is the whole race.
-    void deleteChatDraft(from);
-    const moved = rekeyChatDraft(from, "sess-moving");
-    await Promise.resolve();
-    await Promise.resolve();
-    // Nothing posted while the delete is unanswered: the route would have found
-    // the record and copied the sent words onto the session.
-    expect(posts(g.calls)).toEqual([]);
-
-    g.release();
-    await moved;
-    expect(posts(g.calls).length).toBe(1);
-    g.restore();
-  });
-
-  test("a spent `from` hands its spent-ness to `to`", async () => {
-    // Belt and braces for the copy that happens anyway (another tab, a server
-    // that already moved it): whatever is under the new key, it is not restored
-    // into the box the send just emptied.
-    const from = "new:/Users/me/handed";
-    const to = "sess-handed";
-    const g = gate({ [to]: held("ship the release notes") });
-    void deleteChatDraft(from);
-    const moved = rekeyChatDraft(from, to);
-    g.release();
-    await moved;
-    expect(await fetchChatDraft(to)).toBeNull();
-    g.restore();
-  });
-
-  test("…until the reader types under the new key, which brings it back", async () => {
-    const from = "new:/Users/me/typed-on-after";
-    const to = "sess-typed-on-after";
-    const g = gate({ [to]: held("a second thought") });
-    void deleteChatDraft(from);
-    const moved = rekeyChatDraft(from, to);
-    g.release();
-    await moved;
-    await saveChatDraft(to, "a second thought");
-    expect((await fetchChatDraft(to))?.text).toBe("a second thought");
-    g.restore();
-  });
-
-  test("a `from` nobody spent says nothing about `to`", async () => {
-    // The ordinary rekey: a chat that learned its session without a send. Its
-    // draft is a real unsent draft and must survive the move.
-    const from = "new:/Users/me/never-sent";
-    const to = "sess-never-sent";
-    const g = gate({ [to]: held("still unsent") });
-    const moved = rekeyChatDraft(from, to);
-    g.release();
-    await moved;
-    expect((await fetchChatDraft(to))?.text).toBe("still unsent");
-    g.restore();
   });
 });
 

--- a/frontend/src/platform/lib/drafts.test.ts
+++ b/frontend/src/platform/lib/drafts.test.ts
@@ -337,7 +337,7 @@ describe("useAutosave({ writeInitial })", () => {
 const FORM: TaskDraftForm = {
   title: "", description: "half a thought", target: "~/news",
   when: null, repeat: null, custom_rule: null, model: "", effort: "",
-  permission: "", attachments: [], new_task_each_run: null,
+  permission: "", attachments: [], new_task_each_run: null, session_id: "",
 };
 
 /** Swap `fetch` for a recorder, and put the real one back afterwards. */

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -42,6 +42,20 @@ export interface ChatDraft {
   text: string;
   attachments: DraftAttachment[];
   updated_at: number;
+  /**
+   * THE FORM THESE WORDS ARE ACTUALLY IN, or `""` for the ordinary chat draft
+   * that is a record of its own (`fused_render/drafts.py`, "one record, two
+   * doors"; Akshil, 2026-09-12).
+   *
+   * A New task card bound to a session IS that conversation's unsent message,
+   * so the server serves it under the session key too — the same words, the
+   * card's title and description joined back into one box — and the composer
+   * seeds from it, edits it and deletes it through exactly the calls it already
+   * makes. The id is here so a client that wants to tell the two apart can;
+   * nothing in the composer has to. Absent on an older server, which is the
+   * same fact as `""`.
+   */
+  bound_draft?: string;
 }
 
 /**

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -112,8 +112,6 @@ export interface DraftsSnapshot {
   task: Record<string, TaskDraft>;
 }
 
-const EMPTY: DraftsSnapshot = { chat: {}, task: {} };
-
 /**
  * WHICH KEY THIS COMPOSER'S DRAFT LIVES UNDER (design.md, "Chat draft key").
  * The session id when the chat has one; otherwise `new:<file>` — the same file
@@ -312,15 +310,39 @@ export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<
  * Sent on the FIRST write only (the caller latches it): the second PUT is an
  * ordinary keystroke save, and repeating a delete for a key that is already
  * gone is a request that can only ever be a no-op or a surprise.
+ *
+ * ANSWERS THE ID THE WRITE ACTUALLY LANDED ON — normally `id`, and somebody
+ * else's when the server folded this form into a draft that already held its
+ * session (fused_render/drafts.py `put_task`, Bugbot PR #1126). The caller has
+ * to adopt it: every later call names the draft by id, so a card that went on
+ * using the id it minted would autosave, Discard and Schedule against a record
+ * that is not there. `""` for a write that failed — the same silence every
+ * other write in this module keeps, and the caller simply keeps the id it had.
  */
-export function saveTaskDraft(
+export async function saveTaskDraft(
   id: string,
   form: TaskDraftForm,
   opts?: DraftWriteOptions,
   fromChatKey?: string,
-): Promise<boolean> {
+): Promise<string> {
   const body = fromChatKey ? { ...form, from_chat_key: fromChatKey } : form;
-  return write("PUT", taskUrl(id), body, opts);
+  try {
+    const res = await fetch(taskUrl(id), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "X-Fused": "1" },
+      body: JSON.stringify(body),
+      ...(opts?.keepalive ? { keepalive: true } : {}),
+    });
+    if (!res.ok) return "";
+    const data = (await res.json()) as { draft_id?: unknown } | null;
+    return typeof data?.draft_id === "string" ? data.draft_id : "";
+  } catch {
+    // Offline, server restarting, the document unloading mid-flight — the same
+    // silence `write` keeps, and the same reason: a draft that failed to save
+    // costs a draft, and a draft that threw inside a keystroke handler costs a
+    // keystroke.
+    return "";
+  }
 }
 
 /** Discard. `POST /api/schedule` deletes the draft itself when it is handed a
@@ -330,19 +352,28 @@ export function deleteTaskDraft(id: string, opts?: DraftWriteOptions): Promise<b
 }
 
 /**
- * Every draft there is. An unreadable answer is an EMPTY SNAPSHOT rather than a
- * throw, for the reason `parseAttachmentsParam` gives: this is read inside the
- * effect that seeds a composer, and a parse error there would cost the mount.
+ * Every draft there is — or NULL, which means "could not find out" and never
+ * "there are none" (Bugbot, PR #1126, 2026-09-12).
+ *
+ * It still does not throw, for the reason `parseAttachmentsParam` gives: this is
+ * read inside the effect that seeds a composer, and a rejection there would cost
+ * the mount. But answering an empty snapshot made a failed lookup indistinguish-
+ * able from an empty store, and the one caller that asks a question of it — "is
+ * there already a form bound to this session?" — then read a network blip as
+ * "no", minted a second draft, and the server's one-per-session rule threw the
+ * first one away with its time, repeat rule, model and files in it. The two
+ * answers are different facts, so they are two different values; what a caller
+ * does with "unknown" is its own business, and none of them may treat it as no.
  */
-export async function fetchDrafts(): Promise<DraftsSnapshot> {
+export async function fetchDrafts(): Promise<DraftsSnapshot | null> {
   try {
     const res = await fetch("/api/drafts");
-    if (!res.ok) return EMPTY;
+    if (!res.ok) return null;
     const data = (await res.json()) as Partial<DraftsSnapshot> | null;
-    if (!data || typeof data !== "object") return EMPTY;
+    if (!data || typeof data !== "object") return null;
     return { chat: data.chat ?? {}, task: data.task ?? {} };
   } catch {
-    return EMPTY;
+    return null;
   }
 }
 
@@ -365,7 +396,11 @@ export async function fetchChatDraft(key: string): Promise<ChatDraft | null> {
   if (spent.has(key)) return null;
   const all = await fetchDrafts();
   if (spent.has(key)) return null;
-  return all.chat[key] ?? null;
+  // A lookup that failed and a composer with nothing in it read the same here,
+  // and that is right for THIS caller: seeding a composer from nothing is the
+  // state it is already in, and there is nothing to lose by it. The caller that
+  // must tell the two apart is the bound-draft hop — see `fetchDrafts`.
+  return all?.chat[key] ?? null;
 }
 
 /** What `useAutosave` hands back: the things a caller ever needs to do to a

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -62,6 +62,28 @@ export interface TaskDraftForm {
   attachments: DraftAttachment[];
   new_task_each_run: boolean | null;
   /**
+   * THE CONVERSATION THIS TASK IS A MESSAGE TO, or "" when it is a message to
+   * nobody yet (Akshil, 2026-09-12).
+   *
+   * The composer's Schedule button can hop out of a chat that has ALREADY RUN,
+   * and then the task being written is the next turn of that thread — the server
+   * schedules it into the session and the number it keeps is the session's. The
+   * page knew that while it stayed open and the draft on disk did not, so
+   * exiting the card and reopening the draft scheduled it into a NEW session
+   * under a NEW number, and the task the reader had been watching was gone.
+   *
+   * Sent on EVERY save rather than only the first, unlike `from_chat_key`
+   * (which is a side effect — it tells the server to delete something — and so
+   * is spent once). This is plain state: restating it costs a short string and
+   * means a reopened card cannot lose the binding to a merge that went the
+   * wrong way.
+   *
+   * "" for every other opening — the "+ New task" button, a calendar slot, and
+   * a hop out of a chat that has never been sent, which has no session to bind
+   * to at all (its draft is keyed `new:<file>`).
+   */
+  session_id: string;
+  /**
    * THE RULE BEHIND A "CUSTOM" REPEAT, because the preset key alone is not an
    * answer (Bugbot, PR #1118).
    *

--- a/frontend/src/platform/lib/drafts.ts
+++ b/frontend/src/platform/lib/drafts.ts
@@ -205,9 +205,8 @@ async function write(
  * (`ClaudeChat`'s remount on the first send). The new mount seeds itself from
  * the server (`fetchChatDraft`), and that GET can overtake a DELETE that is
  * still in flight. What it answers is the sentence that was just sent, into a
- * box the send had emptied; the rekey that follows then walks those words onto
- * the session, and the message the reader sent is sitting on their own task row
- * as an unsent draft.
+ * box the send had emptied — the message the reader sent, back in their
+ * composer as an unsent draft.
  *
  * NOTHING INSIDE ONE MOUNT CAN FIX IT. `reset`, `stop` and `settle` all belong
  * to a component that is being thrown away at that instant, and the seed that
@@ -245,86 +244,37 @@ export function saveChatDraft(
   return write("PUT", chatUrl(key), { text, attachments }, opts);
 }
 
-/**
- * DELETES STILL IN THE AIR, one per key at most — what `rekeyChatDraft` waits
- * on so a move cannot overtake the removal of the thing it is moving (Bugbot,
- * PR #1118, 2026-09-11).
- *
- * `spent` already stops a REMOUNT from reading the sent words back; this stops
- * the SERVER from being asked to copy them. The two requests the first send
- * fires — `DELETE new:<file>` and `POST /api/drafts/chat/rekey` — are otherwise
- * unordered, and the order that loses is the one where the rekey arrives first:
- * the record is still there, so the route copies it onto the session id, and a
- * sent message becomes an unsent draft on the session's own row.
- *
- * A key drops out the moment its own request answers, and only if it is still
- * the one being tracked — a second delete for the same key while the first is
- * running is the later one's to own.
- */
-const pendingDeletes = new Map<string, Promise<boolean>>();
-
 /** On send, and on an explicit clear. The key is marked spent BEFORE the
  *  request goes out — see `spent` for the remount that would otherwise read the
- *  draft back out from under the delete — and the request is remembered while
- *  it runs, for the rekey that must not pass it (see `pendingDeletes`). */
+ *  draft back out from under the delete. */
 export function deleteChatDraft(key: string, opts?: DraftWriteOptions): Promise<boolean> {
   spent.add(key);
-  const done: Promise<boolean> = write("DELETE", chatUrl(key), undefined, opts).then((ok) => {
-    if (pendingDeletes.get(key) === done) pendingDeletes.delete(key);
-    return ok;
-  });
-  pendingDeletes.set(key, done);
-  return done;
+  return write("DELETE", chatUrl(key), undefined, opts);
 }
 
 /**
- * THE DRAFT MOVES WITH THE SESSION IT TURNED OUT TO BE (design.md, Round 2:
- * "Every draft has a TASK number").
+ * THE DRAFT'S KEY MOVES WITH THE SESSION IT TURNED OUT TO BE, AND NOT FROM HERE
+ * (design.md, Round 2: "Every draft has a TASK number").
  *
- * A chat with no session yet keys its draft `new:<file>` and is given a TASK
- * number under that key. The first send creates the session, and from the next
- * render the composer keys on the session id instead — so without this the
- * number, and the row wearing it, would be stranded on a key nothing reads
- * again. The server moves both (`tasks_store.rekey`, the same call that walks a
- * `pending:` number onto a session).
+ * There is no `rekeyChatDraft` and no `POST /api/drafts/chat/rekey`, and their
+ * absence is the fix. A chat with no session drafts under `new:<file>` and is
+ * numbered under that key; the first send creates the session, and the number
+ * has to follow it. Four rounds of bugbot went into asking the CLIENT which
+ * session its own send created, and every answer was an inference with a gap in
+ * it — a send that threw, a refusal that never left `idle`, a Back before the id
+ * landed — that left the move owed to whichever session id turned up next
+ * (Bugbot, PR #1118, 2026-09-12).
  *
- * FIRE AND FORGET, once, when the id of the session a session-less send created
- * is learned. WHICH SEND THAT WAS is not this module's business and never was:
- * `ClaudeChat` binds the move to the run it dispatched, because a chat merely
- * opened ON a session also spends its first renders with an empty id and a
- * module-level "a send is owed a rekey" note could be spent by the wrong one
- * (Bugbot, PR #1118, 2026-09-12). A refusal costs the
- * number's continuity and nothing the reader is doing — which is this module's
- * standing contract, and doubly right here: the thing being renamed is a draft
- * that the send is about to delete anyway (Akshil, 2026-09-11).
+ * What the client DOES know at the moment of the send is which draft it is
+ * spending, so that is what it says: a session-less start carries `draft_key`
+ * (`apps/claude/protocol/run-controller.ts`), `agent._start` writes it into the
+ * run's `meta.json`, and the server moves the number when that run's session id
+ * appears (`routers/tasks.py::_settle_new_chats`). It moves the NUMBER only and
+ * never the words — those are in the transcript by then — which is also why
+ * nothing here has to carry spent-ness onto a second key any more.
  *
- * IT WAITS FOR THE SEND'S DELETE, AND IT CARRIES SPENT-NESS ACROSS (Bugbot,
- * PR #1118, 2026-09-11). Going out first was never enough: `DELETE new:<file>`
- * and this POST are two requests with no order between them, and if the rekey
- * is served first the record is still sitting there — the route copies it onto
- * the session id, and the composer that just remounted seeds from the SESSION
- * key, which nothing had marked spent. The sentence the reader sent is back in
- * their box, one key to the right of where the fix was looking.
- *
- * So: await whatever DELETE for `from` is still running (`pendingDeletes` —
- * nothing to wait for in the ordinary case, where the chat simply learned its
- * id without a send), and mark `to` spent whenever `from` is, BEFORE either
- * request, because the window being covered is the one they are in. Spent on
- * the new key means the same as on the old one: the words were just sent, and
- * nothing is restored under it until somebody types again — a PUT with content
- * un-spends it exactly as before (`saveChatDraft`).
- *
- * The reader who typed ON after sending is still served: that PUT carried
- * content, so it had already un-spent `from`, and this copies no spent-ness
- * onto `to`. Those words belong to the conversation the send created, which is
- * the one case the route's copy exists for.
+ * What this module still owes a send is `deleteChatDraft(new:<file>)`, above.
  */
-export async function rekeyChatDraft(from: string, to: string): Promise<boolean> {
-  if (!from || !to || from === to) return false;
-  if (spent.has(from)) spent.add(to);
-  await pendingDeletes.get(from);
-  return write("POST", "/api/drafts/chat/rekey", { from, to });
-}
 
 /**
  * Upsert a task draft under the id the form minted.

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -3494,6 +3494,14 @@ export default function NewJobModal({
       backTimer.current = window.setTimeout(() => setBackConfirm(false), 2000);
       return;
     }
+    // FLUSH FIRST, on the bound arm's account (Bugbot, PR #1126, 2026-09-12):
+    // the last 600 ms of typing are still in the debounce, and the composer
+    // this hands off to seeds from the FORM — so those keystrokes have to land
+    // in the form before the walk, and `stop` would otherwise also silence the
+    // unmount flush that used to catch them. The unbound arm re-saves the live
+    // words by hand below, so the flush is harmless there (one write, same
+    // value, then the delete).
+    autosaveRef.current.flush();
     autosaveRef.current.stop();
     await autosaveRef.current.settle();
     // AFTER `settle`, for Discard's reason (Bugbot, PR #1126, 2026-09-12): the

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -3503,6 +3503,19 @@ export default function NewJobModal({
     // the bound draft outlives the words being handed back to the composer —
     // which is the duplicate the whole move exists to prevent.
     const id = draftIdRef.current;
+    // ONE RECORD, TWO DOORS (Bugbot, PR #1126, 2026-09-12). A draft bound to a
+    // session IS the chat draft: the server's chat view reads the form's words
+    // off the same record the autosave just wrote (`put_chat` writes the bound
+    // form when the key is that session). Re-saving the chat draft here would
+    // only update that record, and the delete that follows would remove it —
+    // the composer then seeds from nothing. So on the bound arm the record must
+    // survive: stop, settle, walk through the other door. Only the unbound
+    // draft (`new:<file>`, no session) is two records, and only it re-seeds by
+    // hand and deletes.
+    if (boundSessionId) {
+      navigateUrl(chatBack || backChatHref(backChatKey, target));
+      return;
+    }
     if (backChatKey) {
       // The inverse of the split the hop made — `joinDraft` puts the title line
       // and the body back into the one block of prose the composer holds. The

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -3352,10 +3352,21 @@ export default function NewJobModal({
   // (whichever is running) before the delete goes out — otherwise it can
   // land after the delete and resurrect the draft this button just asked to
   // throw away (Akshil, 2026-09-11).
+  //
+  // AND THE ID IS READ AFTER `settle`, NOT BEFORE IT (Bugbot, PR #1126,
+  // 2026-09-12). The write being waited out is also the write that can CHANGE
+  // the id: a card whose `GET /api/drafts` failed saves under a freshly minted
+  // one, the server folds that write into the draft already bound to this
+  // conversation, and the autosave adopts the id it answers with — inside the
+  // promise `settle` waits on (see the save above), so by the line below the
+  // adoption has happened. Reading the id first aimed the DELETE at the minted
+  // id the server had already dropped: the request succeeded against nothing
+  // and the bound draft lived on holding the very words this button was pressed
+  // to be rid of.
   const discard = async () => {
-    const id = draftIdRef.current;
     autosaveRef.current.stop();
     await autosaveRef.current.settle();
+    const id = draftIdRef.current;
     if (id) void deleteTaskDraft(id);
     onClose();
   };
@@ -3483,9 +3494,15 @@ export default function NewJobModal({
       backTimer.current = window.setTimeout(() => setBackConfirm(false), 2000);
       return;
     }
-    const id = draftIdRef.current;
     autosaveRef.current.stop();
     await autosaveRef.current.settle();
+    // AFTER `settle`, for Discard's reason (Bugbot, PR #1126, 2026-09-12): the
+    // write this just waited out is the one that can rename the draft, when the
+    // server folds it into a form already bound to this conversation. Read
+    // before, the DELETE below names an id the server has already dropped and
+    // the bound draft outlives the words being handed back to the composer —
+    // which is the duplicate the whole move exists to prevent.
+    const id = draftIdRef.current;
     if (backChatKey) {
       // The inverse of the split the hop made — `joinDraft` puts the title line
       // and the body back into the one block of prose the composer holds. The
@@ -3680,6 +3697,13 @@ export default function NewJobModal({
           // …and the draft this card was composed in, so the server can drop it
           // in the same request. Empty when the form was never dirty enough to
           // mint one, which is most one-line tasks.
+          //
+          // READ HERE, which is to say after the `settle` above — this payload
+          // is built once that await has returned, so the id is whatever the
+          // last write landed on rather than whatever was minted before it
+          // (Bugbot, PR #1126, 2026-09-12; the same ordering Discard and Back
+          // to chat now take). Naming the minted id instead left the bound
+          // draft standing beside the task it had just become.
           draftId: draftIdRef.current ?? "",
           // …and the chat draft this card was composed out of, for the case the
           // autosave never got to move it. See originChatKey.

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1565,12 +1565,14 @@ export function splitDraft(draft?: string | null): {
  *     thread on the Claude pane, which is `explorerUrl`'s whole job. The folder
  *     is the draft's own `target`: the hop wrote the chat's `file` into it, and
  *     it is the only path this card kept;
- *   * `new:<file>` — there is no session and never was one, so the door is the
- *     one a never-sent chat's ROW uses (`schedule-lib.chatDraftHref`): that
- *     file's folder with the Claude pane on it and no `session_id` named at
- *     all. Built out of the key's own `<file>` rather than out of `target`, for
- *     `chatDraftHref`'s reason — the composer seeds from a key built on that
- *     exact string, and a chat mounted anywhere else reads a key nothing wrote.
+ *   * `new:<file>` — there is no session and never was one, so the door is that
+ *     file's folder with the Claude pane on it (`schedule-lib.chatPaneUrl`) and
+ *     no `session_id` named at all: an empty value claims the question was
+ *     asked and answered with nothing, and this conversation has not been asked
+ *     it. Built out of the key's own `<file>` rather than out of `target`,
+ *     because the composer seeds from a key built on that exact string
+ *     (platform/lib/drafts.chatDraftKey) and a chat mounted anywhere else reads
+ *     a key nothing wrote.
  *
  * `""` for a key that is neither, which is a card with nothing to go back to —
  * the caller gates on that before ever getting here.
@@ -3164,7 +3166,12 @@ export default function NewJobModal({
    * at all) nor a re-opened draft (whose words are already stored, under an id
    * this card was handed).
    */
-  const hopSeeded = !editing && !initialDraft && !!(initialMessage ?? "").trim();
+  // …and a hop can arrive as FILES with no words at all — a picture dropped into
+  // an empty composer is a chat draft (`drafts.put_chat`), so it is a task draft
+  // the moment it lands here, or the composer's copy would sit beside this card
+  // as a second row (Akshil, 2026-09-12).
+  const hopSeeded = !editing && !initialDraft
+    && (!!(initialMessage ?? "").trim() || !!initialAttachments?.length);
   /**
    * THE CHAT THIS CARD'S WORDS CAME OUT OF, whichever way the card was opened —
    * and the thing `POST /api/schedule` is told so it can drop that draft (Bugbot,
@@ -3183,7 +3190,32 @@ export default function NewJobModal({
    * same reason it exists at all.
    */
   const originChatKey = (fromChatKey ?? "") || (saved.fromChatKey ?? "");
+  /**
+   * IS THERE ANYTHING IN THIS CARD WORTH KEEPING — words, or files. Nothing
+   * else (Akshil, 2026-09-12).
+   *
+   * The folder, the model, the effort, the permission mode, the time and the
+   * repeat rule are SETTINGS: they ride along with a draft, they are not what
+   * makes one. Gating the first write on `dirty` alone meant that opening the
+   * card and picking a folder — or opening the when-row and touching a time —
+   * minted a draft and put an "Untitled draft" row on the List for a form
+   * holding nothing anybody typed. An attachment counts only once it has a
+   * PATH: a chip whose upload has not answered names no file yet, which is the
+   * same rule the body's `attachments` uses two lines down.
+   */
+  const draftContent = !!title.trim() || !!message.trim()
+    || images.some((i) => i.path);
+  /**
+   * …AND ONCE A DRAFT EXISTS, EMPTYING IT IS A WRITE, not a silence. The body
+   * keeps being produced while `draftId` is set, so clearing the last words
+   * sends the empty form and the server turns that PUT into a delete
+   * (`drafts._empty_task`). Without it the card went quiet at exactly the
+   * moment it had something to say, and the reported shape of that was: clear
+   * the text and the row reads "Untitled draft", then remove the attachment and
+   * the row never goes away at all.
+   */
   const draftBody: TaskDraftForm | null = !editing && (dirty || hopSeeded)
+    && (draftContent || draftId !== null)
     ? {
       title,
       description: message,
@@ -3720,18 +3752,26 @@ export default function NewJobModal({
               nothing to discard, and a button offering to delete nothing is a
               button that makes the reader wonder what it knows.
 
-              It is not `.btn-danger-text` like the Edit card's Delete beside
-              it: that withdraws a real, running task, and this drops an
-              unfinished form nobody has scheduled. Same footer, two weights,
-              which is the difference between the two verbs. */}
+              ONE SEAT, ONE SKIN (Akshil, 2026-09-12). Delete and Discard can
+              never both be on a card — `del` is an Edit's and `draftId` is a
+              new task's — so they are not two controls sharing a footer, they
+              are the same control under the two names the card can be in. It
+              therefore takes Delete's exact class (`.new-task-delete` carries
+              the glyph spacing, `.btn-danger-text` the `margin-right:auto` that
+              anchors the far-left seat) and Delete's trash glyph. Two weights
+              for one position read as a footer that moves its buttons around
+              depending on what you opened. The LABEL still differs, because the
+              verbs do: one withdraws a running task, one drops an unfinished
+              form. No arming step here — there is nothing scheduled to undo. */}
           {draftId && (
             <button
               type="button"
-              className="btn btn-secondary new-task-discard"
+              className="btn btn-danger-text new-task-delete"
               disabled={busy}
               title="Discard this draft"
               onClick={discard}
             >
+              {ICON_TRASH}
               Discard
             </button>
           )}

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -3179,15 +3179,24 @@ export default function NewJobModal({
    *
    * So the two questions are asked apart, and the ✕ keeps the behaviour it has
    * always had. This one is answered once, at mount, off the props: a chat
-   * handoff with something in it, on a card that is neither an Edit (not a draft
-   * at all) nor a re-opened draft (whose words are already stored, under an id
-   * this card was handed).
+   * handoff with something in it, on a card that is not an Edit (an Edit is a
+   * stored entry, not a draft at all).
+   *
+   * A RE-OPENED DRAFT IS INCLUDED WHEN THE HOP BROUGHT WORDS (Akshil,
+   * 2026-09-12). Reopening a draft from its row carries no hop, so nothing
+   * changes there. But a hop out of a chat that already has a bound form
+   * reopens THAT form (shell/Scheduled `boundDraftSeed`) with the composer's
+   * newer words merged into it — and those words are in exactly the position
+   * this flag exists for: typed a moment ago, about to have the composer's own
+   * copy deleted, and not yet anywhere else. Writing at mount is what stops a
+   * close from losing them; the id is the draft's own, so it is one more save
+   * of the same form rather than a second draft.
    */
   // …and a hop can arrive as FILES with no words at all — a picture dropped into
   // an empty composer is a chat draft (`drafts.put_chat`), so it is a task draft
   // the moment it lands here, or the composer's copy would sit beside this card
   // as a second row (Akshil, 2026-09-12).
-  const hopSeeded = !editing && !initialDraft
+  const hopSeeded = !editing
     && (!!(initialMessage ?? "").trim() || !!initialAttachments?.length);
   /**
    * THE CHAT THIS CARD'S WORDS CAME OUT OF, whichever way the card was opened —

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -3323,7 +3323,25 @@ export default function NewJobModal({
     // Returned (not `void`-discarded) so `autosave.settle()` — Discard and
     // Schedule both call it before their own delete — can tell when this
     // particular write actually lands (Akshil, 2026-09-11).
-    return saveTaskDraft(id, value, opts, moving || undefined);
+    //
+    // …AND THE ID COMES BACK, because the write may not have landed on the id
+    // it named (Bugbot, PR #1126, 2026-09-12). A card opened by the Schedule
+    // hop whose `GET /api/drafts` failed cannot see the form already bound to
+    // this conversation, so it mints a new id and saves under it; the server
+    // folds that write into the bound draft rather than evicting it, and
+    // answers the id it actually landed on. Adopting it here is what keeps the
+    // rest of this card pointing at the same record — the next autosave, the
+    // Discard, and the `draft_id` Schedule hands the server so it can drop the
+    // draft as the task is created. Keeping the minted id instead would leave
+    // every one of those three aimed at a record that does not exist. `""` is a
+    // write that failed and says nothing about anything.
+    return saveTaskDraft(id, value, opts, moving || undefined).then((landed) => {
+      if (landed && landed !== draftIdRef.current) {
+        draftIdRef.current = landed;
+        setDraftId(landed);
+      }
+      return !!landed;
+    });
   }, { writeInitial: hopSeeded });
   const autosaveRef = useRef(autosave);
   autosaveRef.current = autosave;

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -2346,6 +2346,22 @@ export interface SeededDraftForm {
    */
   fromChatKey: string | null;
   /**
+   * THE CONVERSATION THIS DRAFT IS A MESSAGE TO (Akshil, 2026-09-12).
+   *
+   * `fromChatKey` above is where the words were TYPED and is spent the moment
+   * the chat's own copy is deleted; this is where the task is GOING, and it has
+   * to survive the card being closed. A hop out of a session that has already
+   * run schedules into that session — same thread, same TASK number — and the
+   * page knew that only while it stayed open: exit the card, reopen the draft
+   * from its row and press Schedule, and the message started a new conversation
+   * under a new number instead.
+   *
+   * It is what `sessionId` on the Schedule payload falls back to, and it is
+   * what the server's listing reads to give this draft the session's own row
+   * identity rather than minting a second one.
+   */
+  sessionId: string | null;
+  /**
    * THE RULE `repeat: "custom"` POINTS AT (Bugbot, PR #1118). The preset key
    * alone is not an answer for Custom — see `TaskDraftForm.custom_rule` — so a
    * reopened draft needs this to seed `customRule` with, not just `repeat`.
@@ -2408,6 +2424,7 @@ export function seededDraftForm(seed?: DraftSeed | null): SeededDraftForm {
     attachments: attachments && attachments.length ? attachments : null,
     newTaskEachRun: typeof f.new_task_each_run === "boolean" ? f.new_task_each_run : null,
     fromChatKey: str("from_chat_key"),
+    sessionId: str("session_id"),
     customRule: parseCustomRule(f.custom_rule),
   };
 }
@@ -3191,6 +3208,29 @@ export default function NewJobModal({
    */
   const originChatKey = (fromChatKey ?? "") || (saved.fromChatKey ?? "");
   /**
+   * THE CONVERSATION THIS CARD'S TASK IS A MESSAGE TO — the destination, where
+   * `originChatKey` is the provenance (Akshil, 2026-09-12).
+   *
+   * A hop out of a chat that HAS ALREADY RUN is a message into that thread:
+   * `POST /api/schedule` is given the session, the entry is filed under it, and
+   * the task keeps the number the conversation already has. Press Schedule
+   * straight away and that worked, because the page still held the id. Exit the
+   * card and the draft on disk knew nothing about it, so reopening it and
+   * pressing Schedule opened a SECOND session with a SECOND task number and the
+   * TASK-nnn the reader had been watching was gone.
+   *
+   * Two sources, same answer, and the same shape as `originChatKey` one line
+   * up: the fresh hop is handed the id as a prop, and a card reopened from its
+   * draft row has only what the server stored on the draft. It rides the
+   * autosave body (below) and the Schedule payload (`sessionId`), so the
+   * binding is written down the first time the card saves and read back every
+   * time it opens.
+   *
+   * "" for a hop out of a chat with no session yet: there is no thread to
+   * continue, and that draft is keyed `new:<file>` precisely because of it.
+   */
+  const boundSessionId = (chatSessionId ?? "") || (saved.sessionId ?? "");
+  /**
    * IS THERE ANYTHING IN THIS CARD WORTH KEEPING — words, or files. Nothing
    * else (Akshil, 2026-09-12).
    *
@@ -3231,6 +3271,11 @@ export default function NewJobModal({
         .filter((i) => i.path)
         .map((i) => ({ path: i.path, name: i.name, kind: i.kind })),
       new_task_each_run: repeatOn ? newTaskEachRun : null,
+      // WHERE THIS TASK IS GOING, restated on every save — see
+      // `boundSessionId`. Unlike `from_chat_key` (spent once, because it makes
+      // the server delete something) this is plain state, and a card that
+      // restates it cannot lose the binding to a merge.
+      session_id: boundSessionId,
       // THE RULE `repeat` POINTS AT, when the choice is Custom — null the same
       // moment `repeat` itself goes null, so a draft can never say "custom"
       // with nothing behind it (Bugbot, PR #1118; see `TaskDraftForm.custom_rule`).
@@ -3596,7 +3641,10 @@ export default function NewJobModal({
           // survives a repeat, a CHAT's does not. A one-off entry's stored id
           // travels in the chat slot — see learnedSessionOf — and still
           // outranks the deep link's, as it always did.
-          sessionId: (!learnedSession && editing?.session_id) || chatSessionId || "",
+          // …and a REOPENED draft's stored binding is the third source, for the
+          // card that has no `chatSessionId` because the hop that made it is
+          // long over. See `boundSessionId`.
+          sessionId: (!learnedSession && editing?.session_id) || boundSessionId,
           learnedSessionId: learnedSession,
           newTaskEachRun,
           // The task's NUMBER has to survive the re-create an edit is; see

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1256,6 +1256,7 @@ export function TaskList({
   missing,
   onEditEntry,
   onOpenDraft,
+  onOpenBoundDraft,
   onReload,
   onPickProject,
   pinnedProjects = [],
@@ -1287,6 +1288,14 @@ export function TaskList({
    *  nothing; omitted ⇒ the row is inert, exactly as an unresolvable pending
    *  row is. */
   onOpenDraft?: (task: Task) => void;
+  /** Open the New task form BOUND TO THIS CONVERSATION — the thread's leading
+   *  draft line, when the words it is quoting are in a form rather than in the
+   *  composer (`task.draft.kind === "form"`; Bugbot, PR #1126). Mirrors
+   *  `onOpenDraft` in every way but which draft it is about: that one is a draft
+   *  ROW's press, this one is a session row's, and a bound draft has no row.
+   *  Omitted ⇒ the line falls back to opening the chat, which is what it always
+   *  did. */
+  onOpenBoundDraft?: (task: Task) => void;
   /** Re-read the list after a cancel lands (or fails) — the row has to correct
    * itself to whatever the server actually did, and a failed cancel is a race
    * the server won, not a no-op.
@@ -1700,6 +1709,7 @@ export function TaskList({
           error={errors[task.key]}
           onEditEntry={onEditEntry}
           onOpenDraft={onOpenDraft}
+          onOpenBoundDraft={onOpenBoundDraft}
           onReload={onReload}
           onPickProject={onPickProject}
           pinned={pinnedProjects.includes(task.project)}
@@ -1734,6 +1744,7 @@ function TaskNode({
   error,
   onEditEntry,
   onOpenDraft,
+  onOpenBoundDraft,
   onReload,
   onPickProject,
   pinned,
@@ -1777,6 +1788,9 @@ function TaskNode({
   onEditEntry?: (entryId: string) => void;
   /** See TaskList's own prop: the draft row's press. */
   onOpenDraft?: (task: Task) => void;
+  /** See TaskList's own prop: the thread's draft line, when the words are in the
+   *  form bound to this conversation rather than in its composer. */
+  onOpenBoundDraft?: (task: Task) => void;
   onReload?: () => void;
   /** Filter the page to this row's folder — the List's handler, passed through
    * untouched. See TaskList's own `onPickProject`. */
@@ -2198,6 +2212,32 @@ function TaskNode({
     // the schedule form needs no folder (Bugbot, #1023) — so this is the row
     // with neither, and its press says why (a toast) rather than doing nothing.
     else if (folderMissing) toastMissingFolder();
+  };
+
+  /**
+   * ARE THE THREAD'S UNSENT WORDS IN A FORM RATHER THAN IN THE COMPOSER?
+   *
+   * The server says so (`draft.kind`, routers/tasks.py `_row`), and absent — an
+   * older server — means `"chat"`, which is what every draft joined onto a
+   * session row was before a New task form could be bound to one.
+   */
+  const draftIsForm = task.draft?.kind === "form";
+  /**
+   * THE DRAFT LINE'S PRESS, which is not always the row's (Bugbot, PR #1126,
+   * 2026-09-12).
+   *
+   * That line quotes `task.draft.preview` — the reader's own unsent sentence —
+   * and pressing your own sentence has to land where it is. For a composer draft
+   * that is the chat, which is what `activate` already opens. For a form bound
+   * to this conversation it is the New task card: the chat holds nothing of it,
+   * so the old press showed the words on a row and then took the reader to an
+   * empty composer. `onOpenBoundDraft` is the hop door back into the form
+   * (shell/Scheduled `openBoundDraft`); without it — a caller that passes no
+   * handler — the line does what it always did.
+   */
+  const pressDraftLine = () => {
+    if (draftIsForm && onOpenBoundDraft) onOpenBoundDraft(task);
+    else activate();
   };
 
   /**
@@ -2908,18 +2948,23 @@ function TaskNode({
               `isExpandable` is false and there is no thread to head — including
               the session-bound task draft, which has a session but still no
               messages of its own. The one row that draws this is an ordinary
-              conversation whose composer is holding something. */}
+              conversation whose composer is holding something — or a New task
+              form bound to it, which is the same question to the reader and a
+              different place to send them (`pressDraftLine`). */}
           {task.draft && (
             <div
               className="tasks-msg"
               role="button"
               tabIndex={0}
-              aria-label={`Draft — ${firstLine(task.draft.preview) || "(empty)"}`}
-              onClick={activate}
+              aria-label={
+                (draftIsForm ? "Draft task — " : "Draft — ")
+                + (firstLine(task.draft.preview) || "(empty)")
+              }
+              onClick={pressDraftLine}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  activate();
+                  pressDraftLine();
                 }
               }}
             >
@@ -2930,7 +2975,12 @@ function TaskNode({
                   (fused_render/drafts.py `preview`) — the same string the chip
                   captions with. No fetch: an expanded row must not go and get
                   what the listing already handed it. */}
-              <span className="tasks-msg-body" data-hint={task.draft.preview}>
+              <span
+                className="tasks-msg-body"
+                data-hint={
+                  draftIsForm ? "Draft task — open to continue" : task.draft.preview
+                }
+              >
                 {firstLine(task.draft.preview) || "(empty)"}
               </span>
               <span className="tasks-grow" />

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1868,10 +1868,15 @@ function TaskNode({
   // to open (a thread with no edit affordance is read-only), and then the press
   // falls through to the arms below.
   const edit = onEditEntry ? upcomingEditEntry(task, held) : null;
-  // A DRAFT ROW'S PRESS re-opens the New task form on the form it was saved
-  // from (design.md, "Reopen path": the draft rows in the list/board are the
-  // only way back to a draft). It outranks every other arm below because a
-  // draft has nothing else — no session to open, no entry to edit.
+  // A DRAFT ROW'S PRESS OPENS THE NEW TASK FORM — every draft row, both kinds
+  // (Akshil, 2026-09-12: "a row without a session is a draft and always opens
+  // the New Task modal; a row with a session always opens the chat"). It
+  // outranks every other arm below because a draft has nothing else — no
+  // session to open, no entry to edit — and the rule it states is the row's, so
+  // `isDraftTask` is the whole question here: WHICH kind it is decides only
+  // what the modal is seeded from, and that is Scheduled.openDraft's business,
+  // not this row's. A never-sent chat used to be routed past this arm into a
+  // navigation, which made one mark on the page promise two different presses.
   const openDraft = onOpenDraft && isDraftTask(task) ? onOpenDraft : null;
   // When this task runs next, or when it last ran — one time at the end of every
   // row, beside the folder. Which of the two is tasks-lib.taskWhen's decision (it
@@ -3739,6 +3744,8 @@ function TaskCard({
         onClick={() => {
           // The draft arm first, for the List row's reason: a draft has no
           // session and no folder to be missing from — the form IS its content.
+          // Both kinds of draft come through here, the never-sent chat included
+          // (Akshil, 2026-09-12).
           if (onOpenDraft && isDraftTask(task)) onOpenDraft(task);
           else if (folderMissing) onMissing();
           else if (open) onOpen(open);

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -84,6 +84,8 @@ import {
   markReadIntent,
   messageEditEntry,
   messageHref,
+  messageStamp,
+  nextMessageId,
   taskFile,
   threadTone,
   messageWhenTitle,
@@ -2868,6 +2870,93 @@ function TaskNode({
 
       {open && (
         <div className="tasks-thread">
+          {/* THE UNSENT LINE, AT THE HEAD OF THE THREAD (Akshil, 2026-09-12).
+              The row already wears the red `Draft` chip, which says THAT there
+              are words here; expanding it used to show the thread without them,
+              so the one place a reader goes to read this conversation was the
+              one place the newest thing in it was missing.
+
+              It is drawn as a MESSAGE ROW because that is what it is about to
+              be: same class, same seats, same quoted body, same relative time,
+              so the thread reads as one column with a line at the top that has
+              not gone yet. Three things differ, and each is the fact itself:
+
+                * THE SEAT WHERE THE RING GOES holds the pencil instead, in the
+                  error colour — the chip's own mark and the chip's own red, so
+                  the mark on the row and the line under it are visibly the same
+                  news. A status ring would be the wrong glyph outright: the
+                  statuses are about runs, and nothing has run.
+                * THE ID IS THE NEXT ONE (tasks-lib.nextMessageId, the client
+                  half of tasks_store.format_message_id). These words have no
+                  message and so no id, but they stand in the id column, and what
+                  they can honestly say is which message they would be.
+                * IT IS NOT A LINK. Every other row here addresses a turn in the
+                  transcript (`msg=`); this one addresses nothing — there is no
+                  turn — so there is no anchor to ⌘-click into a tab. Its press
+                  is the TASK's (`activate`), which is the same thing the row
+                  above it does and the only honest destination: the composer
+                  holding these words is at the end of that chat.
+
+              OUTSIDE `view.messages`, deliberately: the cap, the `hidden` count
+              and the "Loading N more…" line are all arithmetic about what the
+              SERVER holds, and a row the client drew from a joined draft is not
+              one of those. Adding it there would have made a thread of three
+              report four and then fetch the missing one for ever.
+
+              A DRAFT ROW never reaches this: both kinds carry `message_count: 0`
+              (routers/tasks.py `_draft_row`, `_new_chat_draft_row`), so
+              `isExpandable` is false and there is no thread to head — including
+              the session-bound task draft, which has a session but still no
+              messages of its own. The one row that draws this is an ordinary
+              conversation whose composer is holding something. */}
+          {task.draft && (
+            <div
+              className="tasks-msg"
+              role="button"
+              tabIndex={0}
+              aria-label={`Draft — ${firstLine(task.draft.preview) || "(empty)"}`}
+              onClick={activate}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  activate();
+                }
+              }}
+            >
+              <span className="tasks-msg-pencil" aria-hidden>{ICON_PENCIL_LINE}</span>
+              <IdChip id={nextMessageId(task.message_count)} kind="message" />
+              {/* The words as they arrived: `draft.preview` is already the first
+                  line, cut at 120 characters, by the server that joined it
+                  (fused_render/drafts.py `preview`) — the same string the chip
+                  captions with. No fetch: an expanded row must not go and get
+                  what the listing already handed it. */}
+              <span className="tasks-msg-body" data-hint={task.draft.preview}>
+                {firstLine(task.draft.preview) || "(empty)"}
+              </span>
+              <span className="tasks-grow" />
+              {/* The message rows' own cell, in the message rows' own
+                  vocabulary (relativeWhen), off the draft's clock. The word for
+                  WHICH kind of time this is lives in the tooltip, exactly where
+                  `messageWhenTitle` and `taskWhen` keep theirs.
+
+                  Guarded for `updated_at` being 0: `messageStamp`/`relativeWhen`
+                  both answer "" for a falsy stamp (an older store, or a record
+                  that predates the field), and an ungated template would have
+                  printed a bare "Drafted" tooltip with a trailing space and a
+                  blank time cell — a row with nothing where its clock should
+                  be. "Draft" is not a lie the way "" would be silence. */}
+              <span
+                className="tasks-msg-time"
+                data-hint={
+                  task.draft.updated_at
+                    ? `Drafted ${messageStamp(task.draft.updated_at)}`
+                    : "Drafted"
+                }
+              >
+                {task.draft.updated_at ? relativeWhen(task.draft.updated_at) : "Draft"}
+              </span>
+            </div>
+          )}
           {view.messages.map((m) => {
             // threadTone, not messageTone: a thread under an archived task is
             // archived with it, except for a turn that is still running

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1851,7 +1851,19 @@ function TaskNode({
   // No chat arm for a folder that is gone: the thread's URL is the Explorer at
   // that folder with the Claude pane, and the Explorer would answer with a raw
   // stat error and no pane. The row's press says so instead (see `activate`).
-  const chat = folderMissing ? null : openThreadIntent(task, unread);
+  //
+  // …AND NONE FOR A DRAFT, WHATEVER IT NAMES (Akshil, 2026-09-12). A draft row
+  // opens the New task form and nothing else (`openDraft` below), and a draft
+  // bound to a conversation is the first one that could ALSO have answered
+  // `taskHref` — it carries the session it is a message to. That would have
+  // made the row draw a real `<a href>` at its chat: the plain click would still
+  // open the form (the arm order decides it), but ⌘-click, middle click and
+  // "Open in new tab" would go somewhere else entirely, which is the one mark
+  // promising two presses this page keeps refusing. Asked here rather than in
+  // `taskHref`, because it is this ROW's rule about its own press.
+  const chat = folderMissing || isDraftTask(task)
+    ? null
+    : openThreadIntent(task, unread);
   const label = firstLine(task.title) || "(untitled)";
   // Whether this row's work is still ahead of it, which is the one thing that
   // greys its title. tasks-lib.isUpcomingTask owns both halves of the question

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -304,6 +304,12 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     entry: ScheduledMessage | null,
     seed: HopSeed = NO_HOP,
   ) => {
+    // Every opening ABANDONS any chat-draft fetch still in flight (Bugbot on
+    // PR #1126, 2026-09-12): a press that lands here through any door — New
+    // task, a calendar slot, an Edit, a draft row, or a resolved hop — is the
+    // opening the reader meant, and an older `openChatDraft` answer arriving
+    // afterwards must not paint over it. See `chatDraftGen` below.
+    chatDraftGen.current++;
     setOpenSeq((n) => n + 1);
     setHop(seed);
     setEditing(entry);
@@ -339,7 +345,18 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
    * unreadable answer falls back to the preview rather than refusing the press
    * — a truncated draft is worth more than a dead row — and `fetchChatDraft`
    * already answers null instead of throwing.
+   *
+   * AND BECAUSE IT FETCHES FIRST, IT IS THE ONE OPENING THAT CAN ARRIVE LATE
+   * (Bugbot on PR #1126, 2026-09-12): a second press — another draft row, "+
+   * New task", or this same row again — used to be overwritten when the first
+   * fetch resolved, so the modal showed the wrong hop or minted two task drafts
+   * from one chat row. `chatDraftGen` is the click's generation: each press
+   * takes the next number, `openForm` (every door) takes one too, and an
+   * answer whose number is no longer current is dropped on the floor. The
+   * number is captured BEFORE the fetch and compared BEFORE this arm's own
+   * `openForm` call, so the bump that call makes cannot invalidate itself.
    */
+  const chatDraftGen = useRef(0);
   const openChatDraft = (task: Task) => {
     // The chat's own `file` FIRST, for platform/lib/drafts.chatDraftKey's
     // reason: the draft is keyed on that exact string, and the way back has to
@@ -347,7 +364,10 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     // wrote. `target` is the fallback for a server that sends the row without
     // it.
     const at = task.file || task.target || "";
+    const gen = ++chatDraftGen.current;
     void fetchChatDraft(task.key).then((stored) => {
+      // A newer press, through this arm or any other door, owns the modal now.
+      if (gen !== chatDraftGen.current) return;
       const seed: HopSeed = {
         target: at || null,
         message: stored?.text ?? task.draft?.preview ?? null,

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -943,6 +943,12 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               // (Akshil, 2026-09-05): same handler, same pinned state.
               onPickProject={pickProject}
               pinnedProjects={filters.projects}
+              // …and the Draft chip is a TAG here too (Akshil, 2026-09-12), the
+              // same handler and the same shared `TaskFilters` the List and the
+              // Board press: three views, one filter, one gesture to set it and
+              // one to let it go.
+              onPickDraft={pickDraft}
+              draftOn={filters.draft}
               missing={missing}
             />
           ) : (

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -71,9 +71,8 @@ import {
   parseAttachmentsParam,
   type SchedAttachment,
 } from "@apps/claude/ui/sched-draft";
-import { chatDraftKey } from "@platform/lib/drafts";
-import { navigateUrl } from "@platform/lib/router";
-import { chatDraftHref } from "./schedule-lib";
+import { chatDraftKey, fetchChatDraft } from "@platform/lib/drafts";
+import { chatPaneUrl } from "./schedule-lib";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
 import ScheduleCalendar, {
@@ -159,6 +158,37 @@ const VIEW_KEY = "fused-render:scheduled-view";
 // rather than one because the when-field is minute-precision, and a value
 // inside the CURRENT minute opens the form on a time already behind the clock.
 const NEW_LINK_LEAD_MS = 120_000;
+
+/**
+ * WHAT A DEEP LINK HANDED THIS ONE OPENING — the chat composer's Schedule
+ * button, and nothing else on the page.
+ *
+ * ONE OBJECT, SEEDED BY `openForm`, because the bug was that it used to be six
+ * loose `useState`s cleared one at a time in the modal's `onClose` — and
+ * `attachments` was never on that list (Akshil, 2026-09-12). A composer hop
+ * carrying an image therefore left the chips standing in page state, and the
+ * NEXT "+ New task" — and every one after it, for the life of the page — opened
+ * holding a picture from a chat the reader had walked away from. A
+ * clear-on-close is a list somebody has to keep in step with the fields; a
+ * seed-on-open cannot fall out of step, because there is no second place that
+ * says what a hop is made of.
+ */
+interface HopSeed {
+  target: string | null;
+  message: string | null;
+  session: string | null;
+  back: string | null;
+  attachments: SchedAttachment[];
+  /** Which chat draft this form supersedes — see the effect that reads it. */
+  chatKey: string | null;
+}
+
+/** The opening that came from nowhere: every way into the form but the hop.
+ *  A module constant so `openForm`'s default argument is one stable value. */
+const NO_HOP: HopSeed = {
+  target: null, message: null, session: null, back: null,
+  attachments: [], chatKey: null,
+};
 
 export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // THIS PAGE IS THE POLLER while it is open. The sidebar's Tasks entry reads the
@@ -254,13 +284,28 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // WHAT the openings differ in — it is that "this is a new opening" was never
   // stated at all, and any key built out of the form's inputs collides again the
   // moment two openings happen to share them.
+  // WHAT THE OPENING CARRIED IN FROM A DEEP LINK — see `HopSeed` above. Set by
+  // `openForm` and by nothing else, which is what keeps one chat's handoff from
+  // seeding the next card the reader opens.
+  const [hop, setHop] = useState<HopSeed>(NO_HOP);
   const [openSeq, setOpenSeq] = useState(0);
   // The single door into the form, so "clean slate" is one rule in one place: a
   // new opening is a new mount, and opening a NEW task drops whatever was being
   // edited (leaving it set kept the card in Edit mode under a "+ New task"
   // press).
-  const openForm = (at: Date | "blank" | null, entry: ScheduledMessage | null) => {
+  //
+  // …and it is where the deep link's values are SPENT: every opening states its
+  // own hop, and the ones that had none say so by saying nothing (`NO_HOP`, the
+  // default). That is the whole of fix for the attachments that used to follow
+  // the reader from one New task card to the next — see `HopSeed` (Akshil,
+  // 2026-09-12).
+  const openForm = (
+    at: Date | "blank" | null,
+    entry: ScheduledMessage | null,
+    seed: HopSeed = NO_HOP,
+  ) => {
     setOpenSeq((n) => n + 1);
+    setHop(seed);
     setEditing(entry);
     setDraftRow(null);
     setCreating(at);
@@ -271,36 +316,94 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // `/api/tasks` emits it — so the card can seed from it on the first paint with
   // no second fetch, exactly as an Edit seeds from its entry.
   const [draftRow, setDraftRow] = useState<Task | null>(null);
+  /**
+   * A NEVER-SENT CHAT'S ROW, OPENED AS A NEW TASK (Akshil, 2026-09-12: "a row
+   * without a session is a draft and always opens the New Task modal").
+   *
+   * It builds the very `HopSeed` the chat composer's Schedule button builds —
+   * the folder, the words, the tray's chips, the way back, and the chat draft
+   * this card supersedes — and spends it through `openForm` exactly as the
+   * `?new=1` effect below does. Same door, same seeding, same aftermath: the
+   * modal mints a task draft at once (`hopSeeded`), the first save names
+   * `from_chat_key` so the server deletes the `new:<file>` draft in the same
+   * request, and "Back to chat" (`backChatHref`) hands the words back to the
+   * composer they came from. Nothing here is a second implementation of that
+   * handoff; it is the same one, reached from a row instead of a button.
+   *
+   * IT HAS TO FETCH FIRST, and that is the one cost. The row carries only
+   * `draft.preview` — the first LINE — and the card's two prose fields are the
+   * whole message split across them (`splitDraft`), so opening on the preview
+   * would quietly drop every line after the first. The card seeds in `useState`
+   * initialisers, which run once at mount, so there is no patching it
+   * afterwards: the text has to be in hand BEFORE the modal opens. An
+   * unreadable answer falls back to the preview rather than refusing the press
+   * — a truncated draft is worth more than a dead row — and `fetchChatDraft`
+   * already answers null instead of throwing.
+   */
+  const openChatDraft = (task: Task) => {
+    // The chat's own `file` FIRST, for platform/lib/drafts.chatDraftKey's
+    // reason: the draft is keyed on that exact string, and the way back has to
+    // mount the pane on the same one or the composer seeds from a key nothing
+    // wrote. `target` is the fallback for a server that sends the row without
+    // it.
+    const at = task.file || task.target || "";
+    void fetchChatDraft(task.key).then((stored) => {
+      const seed: HopSeed = {
+        target: at || null,
+        message: stored?.text ?? task.draft?.preview ?? null,
+        // NO SESSION, and that is what this row IS: a conversation that has
+        // never been sent has no id to continue, which is the whole meaning of
+        // a `new:<file>` key.
+        session: null,
+        back: at ? chatPaneUrl(at) : null,
+        attachments: stored?.attachments ?? [],
+        // The row's key IS the chat draft's key (`new:<file>`), which is what
+        // lets the card's first save move the draft rather than duplicate it
+        // (design.md, Round 2: "A draft moves, never duplicates").
+        chatKey: task.key,
+      };
+      openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null, seed);
+    });
+  };
   const openDraft = (task: Task) => {
-    // A NEVER-SENT CHAT IS NOT A FORM, so its row's press is a navigation and
-    // not this modal (design.md, Round 2: "Click → opens the folder's chat,
-    // composer prefilled"). There is nothing to re-open here — the words live in
-    // a composer, and the composer seeds itself from the draft keyed on the
-    // folder this URL lands on (schedule-lib.chatDraftHref, whose note explains
-    // why it carries no `session_id`). Asked FIRST, because it is the row that
-    // has no `draft_id` to fall through to.
+    // A NEVER-SENT CHAT OPENS THIS MODAL TOO (Akshil, 2026-09-12). The rule is
+    // the ROW's, not the draft's kind: a row with no session is a draft and
+    // always opens the New task modal; a row with a session always opens the
+    // chat. The build before this one sent the two draft kinds to two different
+    // places and tried to warn about it in the chip's wording ("Draft reply"),
+    // which is a label apologising for a press — the press was the thing to fix.
+    //
+    // What it is seeded from is where the two kinds still differ, and that is
+    // the only thing `isChatDraftTask` decides now. A task draft has a stored
+    // form to re-open (`draftRow`, below); a chat draft has none, so its words
+    // travel as a HOP — the identical object the composer's own Schedule button
+    // builds, so this press and that button land on the same card, mint the
+    // same task draft, delete the same chat draft (`from_chat_key`) and offer
+    // the same way back. Asked FIRST, because it is the row that has no
+    // `draft_id` to fall through to.
     if (isChatDraftTask(task)) {
-      const href = chatDraftHref(task);
-      if (href) navigateUrl(href);
+      openChatDraft(task);
       return;
     }
     if (!task.draft_id) return;
     setOpenSeq((n) => n + 1);
+    // A reopened draft carries its own everything (the row's stored `form`), so
+    // whatever a deep link said earlier in this page's life is not about it.
+    setHop(NO_HOP);
     setEditing(null);
     setCreating(null);
     setDraftRow(task);
   };
-  // What a deep link named (see the effect below); all null for every other
-  // way of opening the form.
-  const [newTarget, setNewTarget] = useState<string | null>(null);
-  const [newMessage, setNewMessage] = useState<string | null>(null);
-  const [newSession, setNewSession] = useState<string | null>(null);
-  const [newBack, setNewBack] = useState<string | null>(null);
-  // The chips the chat's tray was holding, already copied into the task-shots
-  // dir by the composer's Schedule button — so what arrives here is exactly the
-  // shape a saved entry's `attachments` has, and the card seeds from it the same
-  // way an Edit does (owner E2E R1, F4 (2026-09-10)).
-  const [newAttachments, setNewAttachments] = useState<SchedAttachment[]>([]);
+  // `hop` (above) is what a deep link named — the folder, the composer's words,
+  // the session it was typed in, the way back, the tray's chips, and the chat
+  // draft this form supersedes. `NO_HOP` for every other way of opening the
+  // form, and it is the OPENING that says so, not a clear-up afterwards.
+  //
+  // The chips are the half worth naming twice: they were already copied into
+  // the task-shots dir by the composer's Schedule button, so what arrives here
+  // is exactly the shape a saved entry's `attachments` has, and the card seeds
+  // from them the same way an Edit does (owner E2E R1, F4 (2026-09-10)).
+  //
   // WHICH CHAT DRAFT THIS FORM SUPERSEDES (design.md, Round 2: "A draft moves,
   // never duplicates").
   //
@@ -316,7 +419,6 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // writes `link.file` into it), which is the whole reason no new param was
   // needed. platform/lib/drafts.chatDraftKey carries the rule that keeps the
   // four spellings of that path in step.
-  const [newChatKey, setNewChatKey] = useState<string | null>(null);
   // Search, status and project, client-side only — nothing here is worth a URL
   // or a localStorage row: a filter is how you read the page this minute.
   const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS);
@@ -348,31 +450,31 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     const q = new URLSearchParams(location.search);
     if (q.get("new") !== "1") return;
     setEditId(q.get("edit"));
-    setNewTarget(q.get("target"));
-    // The chat's whole handoff: the typed draft fills the card's two prose
-    // fields — its first line names the task and the rest is the description
-    // (NewJobModal splitDraft) — the
-    // open conversation the session a ONE-OFF will continue, and the chat's URL
-    // the way back — the form's round trip.
-    setNewMessage(q.get("message"));
-    setNewSession(q.get("session_id"));
-    setNewBack(q.get("back"));
-    // Defensive by contract, not by suspicion: this is a URL a user can edit
-    // and a param an older build may not have written — `parseAttachmentsParam`
-    // answers [] for anything it cannot read, because a parse error here would
-    // cost the folder, the draft and the session as well as the files.
-    setNewAttachments(parseAttachmentsParam(q.get("attachments")));
-    // Only for a hop that came FROM a chat, which is what `message` says: the
-    // other `?new=1&target=…` links (the app page's "+ New task") carry no
-    // composer and have no draft of anybody's to supersede. `message` may be
-    // empty and still present — an empty composer stored no draft, so the key
-    // is simply one the server finds nothing under.
-    setNewChatKey(
-      q.get("message") === null
+    // The chat's whole handoff, read in one go and handed to the opening it is
+    // about: the typed draft fills the card's two prose fields — its first line
+    // names the task and the rest is the description (NewJobModal splitDraft) —
+    // the open conversation the session a ONE-OFF will continue, and the chat's
+    // URL the way back — the form's round trip.
+    const seed: HopSeed = {
+      target: q.get("target"),
+      message: q.get("message"),
+      session: q.get("session_id"),
+      back: q.get("back"),
+      // Defensive by contract, not by suspicion: this is a URL a user can edit
+      // and a param an older build may not have written — `parseAttachmentsParam`
+      // answers [] for anything it cannot read, because a parse error here would
+      // cost the folder, the draft and the session as well as the files.
+      attachments: parseAttachmentsParam(q.get("attachments")),
+      // Only for a hop that came FROM a chat, which is what `message` says: the
+      // other `?new=1&target=…` links (the app page's "+ New task") carry no
+      // composer and have no draft of anybody's to supersede. `message` may be
+      // empty and still present — an empty composer stored no draft, so the key
+      // is simply one the server finds nothing under.
+      chatKey: q.get("message") === null
         ? null
         : chatDraftKey(q.get("session_id"), q.get("target")),
-    );
-    openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null);
+    };
+    openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null, seed);
     q.delete("new");
     q.delete("target");
     q.delete("message");
@@ -894,21 +996,21 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           // Prefill only — the field shows exactly what will be saved, and
           // deleting the filename back to the folder is the user's to make. A
           // deep link's own target still wins: it named a path on purpose.
-          initialTarget={newTarget ?? scope?.entry ?? scope?.project ?? null}
-          initialMessage={newMessage}
-          initialAttachments={newAttachments}
+          initialTarget={hop.target ?? scope?.entry ?? scope?.project ?? null}
+          initialMessage={hop.message}
+          initialAttachments={hop.attachments}
           // The saved form, handed back whole. Null on every other opening.
           initialDraft={
             draftRow?.draft_id
               ? { id: draftRow.draft_id, form: draftRow.form ?? null }
               : null
           }
-          chatSessionId={newSession}
-          chatBack={newBack}
+          chatSessionId={hop.session}
+          chatBack={hop.back}
           // The chat draft this card's own first save supersedes — see
-          // `newChatKey` above. Null on every opening that did not come from a
+          // `HopSeed` above. Null on every opening that did not come from a
           // composer, which is every opening but the Schedule hop.
-          fromChatKey={newChatKey}
+          fromChatKey={hop.chatKey}
           editing={editing}
           // IS THIS CARD BEING USED TO PLAN? Three ways it is: the reader is on
           // the calendar (where "when" is the question the view itself asks),
@@ -922,21 +1024,19 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           // Newest-first fallback recents: past entries arrive newest first,
           // and the modal dedupes against what localStorage already knows.
           recentTargets={entries.map((e) => e.target)}
-          // `newTarget` is cleared with the rest: it described the ONE form the
-          // deep link opened, and left standing it would prefill the next
-          // "+ New task" with a folder the user arrived from some time ago.
+          // NOTHING TO CLEAR HERE ANY MORE, and that is the fix rather than an
+          // omission (Akshil, 2026-09-12). The hop used to be six values undone
+          // one by one on close — with `attachments` missing from the list, so a
+          // composer handoff's picture rode into every New task card opened
+          // afterwards. The opening states its own hop now (`openForm`), so a
+          // close has nothing to forget and no list to keep in step.
           onClose={() => {
             setCreating(null);
             setEditing(null);
             // CLOSING A DRAFT KEEPS IT (design.md, Decisions): the card is put
             // away, the row stays on the list, and the modal's own autosave has
-            // already flushed on unmount. Only the OPENING is forgotten here.
+            // already flushed on unmount.
             setDraftRow(null);
-            setNewTarget(null);
-            setNewMessage(null);
-            setNewSession(null);
-            setNewBack(null);
-            setNewChatKey(null);
           }}
           onCreated={reload}
         />

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -71,7 +71,8 @@ import {
   parseAttachmentsParam,
   type SchedAttachment,
 } from "@apps/claude/ui/sched-draft";
-import { chatDraftKey, fetchChatDraft } from "@platform/lib/drafts";
+import { chatDraftKey, fetchChatDraft, fetchDrafts } from "@platform/lib/drafts";
+import type { TaskDraft } from "@platform/lib/drafts";
 import { chatPaneUrl } from "./schedule-lib";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
@@ -81,7 +82,8 @@ import ScheduleCalendar, {
   ICON_VIEW_CARDS,
   ICON_VIEW_LIST,
 } from "./ScheduleCalendar";
-import NewJobModal from "./NewJobModal";
+import NewJobModal, { splitDraft } from "./NewJobModal";
+import type { DraftSeed } from "./NewJobModal";
 import {
   EMPTY_FILTERS,
   TaskBoard,
@@ -189,6 +191,54 @@ const NO_HOP: HopSeed = {
   target: null, message: null, session: null, back: null,
   attachments: [], chatKey: null,
 };
+
+/**
+ * THE UNSENT FORM ALREADY BOUND TO THIS CONVERSATION, as the seed that reopens
+ * it — or null when there is none, and the hop mints one exactly as it always
+ * did (Akshil, 2026-09-12).
+ *
+ * A task draft made out of a chat stores that chat's `session_id`
+ * (platform/lib/drafts.TaskDraftForm) and is deliberately NOT a row of its own:
+ * the conversation's row is the one the reader knows, and it wears the `✎
+ * Draft` chip instead (routers/tasks.py `_bound_chips`). Which leaves exactly
+ * one way back into the form — the composer's own Schedule button, the door the
+ * form came out of — so this is what that door looks up before opening a card.
+ * Without it, the second press minted a second draft over the first: two forms
+ * bound to one session, one chip, and whichever saved last owning it.
+ *
+ * NEWEST WINS if a store somehow holds two — the same tie-break the server's
+ * chip takes, so the card the user reopens is the draft the row is advertising.
+ *
+ * THE COMPOSER'S WORDS OUTRANK THE STORED ONES, and only those two fields. The
+ * hop carries whatever is in the composer right now; if that is something, it is
+ * newer than what the form was saved with and the reader typed it a second ago,
+ * so it is split across title and description exactly as a fresh hop's would be
+ * (`splitDraft`). Everything else the form remembers — the folder, the time, the
+ * repeat rule, the model, the tray — is untouched, and so is the id: this is the
+ * same draft, being written a bit further. An empty composer overrides nothing.
+ */
+export function boundDraftSeed(
+  stored: Record<string, TaskDraft>,
+  session: string,
+  message: string | null,
+): DraftSeed | null {
+  let id = "";
+  let found: TaskDraft | null = null;
+  for (const [ident, draft] of Object.entries(stored ?? {})) {
+    if (!draft || draft.session_id !== session) continue;
+    if (found && (found.updated_at ?? 0) >= (draft.updated_at ?? 0)) continue;
+    id = ident;
+    found = draft;
+  }
+  if (!id || !found) return null;
+  const words = (message ?? "").trim();
+  if (!words) return { id, form: { ...found } };
+  const split = splitDraft(words);
+  return {
+    id,
+    form: { ...found, title: split.title, description: split.description },
+  };
+}
 
 export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // THIS PAGE IS THE POLLER while it is open. The sidebar's Tasks entry reads the
@@ -303,6 +353,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     at: Date | "blank" | null,
     entry: ScheduledMessage | null,
     seed: HopSeed = NO_HOP,
+    draft: DraftSeed | null = null,
   ) => {
     // Every opening ABANDONS any chat-draft fetch still in flight (Bugbot on
     // PR #1126, 2026-09-12): a press that lands here through any door — New
@@ -313,15 +364,21 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     setOpenSeq((n) => n + 1);
     setHop(seed);
     setEditing(entry);
-    setDraftRow(null);
+    setDraftSeed(draft);
     setCreating(at);
   };
-  // An unfinished New task form, re-opened from its own row (design.md, "Reopen
-  // path": editing a draft row is the only way back to it). It travels as the
-  // ROW rather than as its id, because the row already carries the saved form —
-  // `/api/tasks` emits it — so the card can seed from it on the first paint with
-  // no second fetch, exactly as an Edit seeds from its entry.
-  const [draftRow, setDraftRow] = useState<Task | null>(null);
+  // An unfinished New task form this card already saved, re-opened: its id and
+  // the stored form, which is everything `NewJobModal` needs to come up on it
+  // and to go on autosaving under the SAME id.
+  //
+  // TWO DOORS REACH IT, and they hand it over the same way. A draft ROW carries
+  // the form on the row itself (`/api/tasks` emits it), so `openDraft` seeds
+  // from the row with no second fetch. And a SESSION-BOUND draft has no row at
+  // all — the conversation's row wears the chip instead (routers/tasks.py
+  // `_bound_chips`) — so the composer's own Schedule hop is the way back to it,
+  // and the effect below looks it up by session before opening (Akshil,
+  // 2026-09-12).
+  const [draftSeed, setDraftSeed] = useState<DraftSeed | null>(null);
   /**
    * A NEVER-SENT CHAT'S ROW, OPENED AS A NEW TASK (Akshil, 2026-09-12: "a row
    * without a session is a draft and always opens the New Task modal").
@@ -406,13 +463,10 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
       return;
     }
     if (!task.draft_id) return;
-    setOpenSeq((n) => n + 1);
     // A reopened draft carries its own everything (the row's stored `form`), so
-    // whatever a deep link said earlier in this page's life is not about it.
-    setHop(NO_HOP);
-    setEditing(null);
-    setCreating(null);
-    setDraftRow(task);
+    // whatever a deep link said earlier in this page's life is not about it —
+    // `NO_HOP`, through the same door every other opening takes.
+    openForm(null, null, NO_HOP, { id: task.draft_id, form: task.form ?? null });
   };
   // `hop` (above) is what a deep link named — the folder, the composer's words,
   // the session it was typed in, the way back, the tray's chips, and the chat
@@ -494,7 +548,39 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
         ? null
         : chatDraftKey(q.get("session_id"), q.get("target")),
     };
-    openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null, seed);
+    // THE HOP COMES BACK TO THE FORM IT ALREADY MADE (Akshil, 2026-09-12).
+    //
+    // A task draft made out of a conversation is bound to it (`session_id`) and
+    // has no row of its own — the conversation's row wears the `✎ Draft` chip
+    // instead — so this hop IS the way back into it. Press Schedule in a chat
+    // that already has an unsent form and the card must reopen THAT form, under
+    // its own id, or the second press mints a second draft and the chip on the
+    // row starts pointing at whichever of them saved last.
+    //
+    // Looked up by session against `GET /api/drafts`, which is the only place
+    // the binding is legible to the client (the listing deliberately does not
+    // emit a row for it). One small request, and only for a hop that names a
+    // session — every other door opens synchronously as before.
+    //
+    // AND IT CAN ARRIVE LATE, like `openChatDraft`, so it takes the same
+    // generation: a second press through any door owns the modal, and an
+    // answer that is no longer current is dropped rather than painted over it.
+    // A failed or empty lookup falls through to the ordinary opening — a hop
+    // that cannot find its draft is a hop, not a dead button.
+    const at = new Date(Date.now() + NEW_LINK_LEAD_MS);
+    const session = (q.get("session_id") ?? "").trim();
+    if (session) {
+      const gen = ++chatDraftGen.current;
+      void fetchDrafts().then((all) => {
+        if (gen !== chatDraftGen.current) return;
+        openForm(at, null, seed, boundDraftSeed(all.task, session, seed.message));
+      }, () => {
+        if (gen !== chatDraftGen.current) return;
+        openForm(at, null, seed);
+      });
+    } else {
+      openForm(at, null, seed);
+    }
     q.delete("new");
     q.delete("target");
     q.delete("message");
@@ -990,7 +1076,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
         </section>
       )}
 
-      {(creating !== null || editing || draftRow) && state && (
+      {(creating !== null || editing || draftSeed) && state && (
         <NewJobModal
           // Keyed on WHICH OPENING this is, and on what is being edited, because
           // the form reads `editing` in `useState` initialisers — they run once,
@@ -1012,7 +1098,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           // read in `useState` initialisers, so re-opening one over a card that
           // was showing another must be a fresh mount.
           key={`${
-            draftRow ? `draft:${draftRow.draft_id}` : editing ? `edit:${editing.id}` : "new"
+            draftSeed ? `draft:${draftSeed.id}` : editing ? `edit:${editing.id}` : "new"
           }#${openSeq}`}
           initialTime={creating instanceof Date ? creating : null}
           // Scoped, a new task is a task FOR THIS APP: the entry page is
@@ -1026,11 +1112,7 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
           initialMessage={hop.message}
           initialAttachments={hop.attachments}
           // The saved form, handed back whole. Null on every other opening.
-          initialDraft={
-            draftRow?.draft_id
-              ? { id: draftRow.draft_id, form: draftRow.form ?? null }
-              : null
-          }
+          initialDraft={draftSeed}
           chatSessionId={hop.session}
           chatBack={hop.back}
           // The chat draft this card's own first save supersedes — see
@@ -1060,9 +1142,10 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
             setCreating(null);
             setEditing(null);
             // CLOSING A DRAFT KEEPS IT (design.md, Decisions): the card is put
-            // away, the row stays on the list, and the modal's own autosave has
+            // away, the draft stays — as its own row, or as the `Draft` chip on
+            // the conversation it is bound to — and the modal's own autosave has
             // already flushed on unmount.
-            setDraftRow(null);
+            setDraftSeed(null);
           }}
           onCreated={reload}
         />

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -72,7 +72,7 @@ import {
   type SchedAttachment,
 } from "@apps/claude/ui/sched-draft";
 import { chatDraftKey, fetchChatDraft, fetchDrafts } from "@platform/lib/drafts";
-import type { TaskDraft } from "@platform/lib/drafts";
+import type { DraftAttachment, TaskDraft } from "@platform/lib/drafts";
 import { chatPaneUrl } from "./schedule-lib";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
@@ -214,13 +214,23 @@ const NO_HOP: HopSeed = {
  * newer than what the form was saved with and the reader typed it a second ago,
  * so it is split across title and description exactly as a fresh hop's would be
  * (`splitDraft`). Everything else the form remembers — the folder, the time, the
- * repeat rule, the model, the tray — is untouched, and so is the id: this is the
- * same draft, being written a bit further. An empty composer overrides nothing.
+ * repeat rule, the model — is untouched, and so is the id: this is the same
+ * draft, being written a bit further. An empty composer overrides nothing.
+ *
+ * THE TRAY IS THE ONE THING THAT MERGES RATHER THAN WINS (Bugbot, PR #1126,
+ * 2026-09-12). Words are a rewrite — the newer sentence replaces the older one —
+ * but a file is a thing, and a composer holding two pictures is not a statement
+ * that the three already in the form are gone. Dropping the hop's files lost
+ * what was just dragged in; taking only the hop's threw away what the form was
+ * built with. So both, deduped on `path` (the id every other attachment list in
+ * this feature keys on) with the HOP's copy last, because that is the newer
+ * description of a file both sides happen to name.
  */
 export function boundDraftSeed(
   stored: Record<string, TaskDraft>,
   session: string,
   message: string | null,
+  hopped: readonly DraftAttachment[] = [],
 ): DraftSeed | null {
   let id = "";
   let found: TaskDraft | null = null;
@@ -231,12 +241,17 @@ export function boundDraftSeed(
     found = draft;
   }
   if (!id || !found) return null;
+  const byPath = new Map<string, DraftAttachment>();
+  for (const file of [...(found.attachments ?? []), ...hopped]) {
+    if (file?.path) byPath.set(file.path, file);
+  }
+  const form = { ...found, attachments: [...byPath.values()] };
   const words = (message ?? "").trim();
-  if (!words) return { id, form: { ...found } };
+  if (!words) return { id, form };
   const split = splitDraft(words);
   return {
     id,
-    form: { ...found, title: split.title, description: split.description },
+    form: { ...form, title: split.title, description: split.description },
   };
 }
 
@@ -468,6 +483,52 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     // `NO_HOP`, through the same door every other opening takes.
     openForm(null, null, NO_HOP, { id: task.draft_id, form: task.form ?? null });
   };
+  /**
+   * THE BOUND FORM, OPENED FROM THE THREAD LINE THAT QUOTES IT (Bugbot, PR
+   * #1126, 2026-09-12).
+   *
+   * The leading line of an expanded thread prints `task.draft.preview`, which is
+   * this conversation's unsent words — and since the bound form arrived, those
+   * words are sometimes in a New task card instead of in the composer. Pressing
+   * it went to the chat either way, and after a hop the chat holds nothing: the
+   * reader pressed their own sentence and landed somewhere it was not. The
+   * server now says which (`draft.kind`), and this is the other press.
+   *
+   * IT IS THE HOP DOOR, not a second way in. A bound draft has no row and no
+   * `draft_id` on this row to open it by (`bound_draft` names the form but the
+   * card seeds from the stored form, which only `GET /api/drafts` carries), so
+   * this builds the same `{session, target}` hop the composer's Schedule button
+   * builds and lets `boundDraftSeed` find the form exactly as that door does —
+   * one lookup, one seeding rule, one card. No `message`: this press came off a
+   * row and not out of a composer, so there are no newer words to merge over
+   * the stored ones.
+   *
+   * Same generation guard as every other opening that fetches first, and the
+   * same fallthrough: a lookup that fails opens the card anyway rather than
+   * dying under the cursor, and the server's merge (drafts.py `put_task`) is
+   * what makes that harmless.
+   */
+  const openBoundDraft = (task: Task) => {
+    const session = (task.session_id ?? "").trim();
+    if (!session) return;
+    const seed: HopSeed = {
+      target: task.target || null,
+      message: null,
+      session,
+      back: null,
+      attachments: [],
+      chatKey: null,
+    };
+    const at = new Date(Date.now() + NEW_LINK_LEAD_MS);
+    const gen = ++chatDraftGen.current;
+    void fetchDrafts().then((all) => {
+      if (gen !== chatDraftGen.current) return;
+      openForm(at, null, seed, all && boundDraftSeed(all.task, session, null));
+    }, () => {
+      if (gen !== chatDraftGen.current) return;
+      openForm(at, null, seed);
+    });
+  };
   // `hop` (above) is what a deep link named — the folder, the composer's words,
   // the session it was typed in, the way back, the tray's chips, and the chat
   // draft this form supersedes. `NO_HOP` for every other way of opening the
@@ -567,13 +628,27 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     // answer that is no longer current is dropped rather than painted over it.
     // A failed or empty lookup falls through to the ordinary opening — a hop
     // that cannot find its draft is a hop, not a dead button.
+    //
+    // A FAILED LOOKUP IS "UNKNOWN", NOT "NONE" (Bugbot, PR #1126, 2026-09-12).
+    // `fetchDrafts` answers null for a blip, and this hop still opens on it: the
+    // words in the composer are about to be deleted in favour of this card and
+    // they must not be made to wait on a GET. What it must NOT do is act on the
+    // guess — the card that opens with no seed mints a fresh id, and the write
+    // that follows used to EVICT the bound draft it could not see, taking the
+    // time, repeat rule, model and tray with it. The server no longer allows
+    // that: a write naming a session another draft holds is folded into that
+    // draft and the canonical id comes back in the answer (drafts.py
+    // `put_task`; NewJobModal adopts it). So "unknown" costs nothing but a card
+    // that opens a moment less informed than it would like.
     const at = new Date(Date.now() + NEW_LINK_LEAD_MS);
     const session = (q.get("session_id") ?? "").trim();
     if (session) {
       const gen = ++chatDraftGen.current;
       void fetchDrafts().then((all) => {
         if (gen !== chatDraftGen.current) return;
-        openForm(at, null, seed, boundDraftSeed(all.task, session, seed.message));
+        openForm(at, null, seed,
+                 all && boundDraftSeed(all.task, session, seed.message,
+                                       seed.attachments));
       }, () => {
         if (gen !== chatDraftGen.current) return;
         openForm(at, null, seed);
@@ -1051,6 +1126,11 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
               // …and the draft row's press, which opens the same card on the
               // form the row is carrying rather than on a stored entry.
               onOpenDraft={openDraft}
+              // …and the thread's leading draft line, when the words it is
+              // quoting are in the form bound to that conversation rather than
+              // in its composer — the chat holds nothing of those, so that
+              // press has to reopen the card instead (Bugbot, PR #1126).
+              onOpenBoundDraft={openBoundDraft}
               // The folder chip as a TAG: pressing one narrows the page to that
               // project, pressing the pinned one again clears it. It REPLACES
               // the project selection rather than adding to it — the gesture

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -255,6 +255,37 @@ export function boundDraftSeed(
   };
 }
 
+/**
+ * WHAT TIME A FORM THAT ALREADY EXISTS OPENS ON — its own, or none (Bugbot, PR
+ * #1126, 2026-09-12).
+ *
+ * `NEW_LINK_LEAD_MS` is an answer to a question a FRESH link asks: a card that
+ * has never been saved opens on now+2m because a deep link means "set this up",
+ * and a near-now time is the one to adjust from. A form that has been saved
+ * already answered that question, and the answer is in it — `when`, which the
+ * store keeps as null until somebody actually opens the when-row and picks one
+ * (NewJobModal `draftBody`). Null there means IMMEDIATE: a task to run, not a
+ * task to plan.
+ *
+ * Handing the lead date to such a form overwrote that. `creating` being a Date
+ * is what makes the card `planning`, `planning` is what makes `timePicked` open
+ * true, and `timePicked` is what puts `when` in the next autosave — so merely
+ * reopening an immediate draft rewrote it as one scheduled for two minutes'
+ * time, and Schedule sent it that way. So: the stored time when there is one,
+ * and nothing at all when there is not. Only the opening with no stored form
+ * behind it keeps the lead (see both call sites).
+ *
+ * An unreadable `when` reads as none here. The card seeds its own field from
+ * the string verbatim (`seededDraftForm`), so nothing is lost by this one
+ * declining to guess a Date out of it.
+ */
+export function reopenTime(seed: DraftSeed | null): Date | null {
+  const when = (seed?.form as { when?: unknown } | null | undefined)?.when;
+  if (typeof when !== "string" || !when) return null;
+  const at = new Date(when);
+  return Number.isNaN(at.getTime()) ? null : at;
+}
+
 export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
   // THIS PAGE IS THE POLLER while it is open. The sidebar's Tasks entry reads the
   // same rows (shell/tasksPulse) and would otherwise run a timer of its own
@@ -481,6 +512,12 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     // A reopened draft carries its own everything (the row's stored `form`), so
     // whatever a deep link said earlier in this page's life is not about it —
     // `NO_HOP`, through the same door every other opening takes.
+    //
+    // …AND NO TIME, which is `reopenTime`'s rule stated the short way (Bugbot,
+    // PR #1126, 2026-09-12). This door never had the lead date to hand, so it
+    // never had the bug the bound-draft doors had; the card reads its own
+    // `when` out of the stored form and decides `timePicked` from that, and a
+    // form that stored none is an immediate task that must stay one.
     openForm(null, null, NO_HOP, { id: task.draft_id, form: task.form ?? null });
   };
   /**
@@ -523,7 +560,12 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
     const gen = ++chatDraftGen.current;
     void fetchDrafts().then((all) => {
       if (gen !== chatDraftGen.current) return;
-      openForm(at, null, seed, all && boundDraftSeed(all.task, session, null));
+      // THE FOUND FORM'S OWN TIME, and no time at all when it had none — see
+      // `reopenTime`. This press is a REOPEN, so the lead date belongs only to
+      // the arm below, where the lookup found nothing and the card is being
+      // opened fresh.
+      const found = all && boundDraftSeed(all.task, session, null);
+      openForm(found ? reopenTime(found) : at, null, seed, found);
     }, () => {
       if (gen !== chatDraftGen.current) return;
       openForm(at, null, seed);
@@ -646,9 +688,16 @@ export default function Scheduled({ scope }: { scope?: TasksScope } = {}) {
       const gen = ++chatDraftGen.current;
       void fetchDrafts().then((all) => {
         if (gen !== chatDraftGen.current) return;
-        openForm(at, null, seed,
-                 all && boundDraftSeed(all.task, session, seed.message,
-                                       seed.attachments));
+        // …AND A HOP THAT FINDS ITS FORM IS A REOPEN, so it opens on the time
+        // that form holds rather than on the lead date (`reopenTime`, Bugbot PR
+        // #1126, 2026-09-12). The words are newer than the stored ones and win;
+        // the TIME is not something the composer said anything about, and
+        // `now+2m` here turned every reopened immediate draft into a scheduled
+        // one. The lead survives where it means something: the arm below, and
+        // the `else` further down — a hop with no form behind it.
+        const found = all && boundDraftSeed(all.task, session, seed.message,
+                                            seed.attachments);
+        openForm(found ? reopenTime(found) : at, null, seed, found);
       }, () => {
         if (gen !== chatDraftGen.current) return;
         openForm(at, null, seed);

--- a/frontend/src/shell/TaskCards.tsx
+++ b/frontend/src/shell/TaskCards.tsx
@@ -174,6 +174,8 @@ export function TaskCards({
   onReload,
   onPickProject,
   pinnedProjects = [],
+  onPickDraft,
+  draftOn = false,
   missing,
   emptyLabel = CARDS_EMPTY,
 }: {
@@ -195,6 +197,12 @@ export function TaskCards({
   /** Which projects the page is pinned to — the chip wears the ON state, and
    * survives the filter that makes every card agree (see `showProject`). */
   pinnedProjects?: string[];
+  /** The Draft chip's press and its pressed state, passed through untouched —
+   *  the List row's and the Board card's own props, and deliberately the same
+   *  ones (Akshil, 2026-09-12): the chip is one control in three views, so a
+   *  wall that drew it inert would be a fourth thing to learn. */
+  onPickDraft?: () => void;
+  draftOn?: boolean;
   /** Folders the disk no longer has — the SAME set the List and the Board read
    * (Scheduled → useMissingFolders), so the three views can never disagree
    * about one folder. A card in one says "Folder no longer exists" and its
@@ -372,6 +380,8 @@ export function TaskCards({
               ? { pinned: pinnedProjects.includes(task.project), onPick: onPickProject }
               : null
           }
+          onPickDraft={onPickDraft}
+          draftOn={draftOn}
         />
       ))}
       </div>
@@ -397,6 +407,8 @@ function TaskCard({
   onPeek,
   onReload,
   project,
+  onPickDraft,
+  draftOn = false,
 }: {
   task: Task;
   home: string;
@@ -413,6 +425,10 @@ function TaskCard({
   /** Draw the folder chip, and how: null hides it (one folder, nothing to tell
    * apart); otherwise whether the page is pinned to it and the tag's handler. */
   project: { pinned: boolean; onPick?: (project: string) => void } | null;
+  /** The Draft chip's press and its pressed state — the wall's, from Scheduled,
+   *  unchanged on the way down (see TaskCards' own props). */
+  onPickDraft?: () => void;
+  draftOn?: boolean;
 }) {
   const when = taskWhen(task);
   const title = firstLine(task.title) || "(untitled)";
@@ -560,12 +576,19 @@ function TaskCard({
               the folder, as the List row and the Board card — design-principles
               §1: a mark that moved between views would be three marks to learn.
 
-              A LABEL HERE, not a tag. The draft filter is the List's and the
-              Board's (design.md, Round 2), and the wall draws no draft ROW at
-              all (CARD_LANES) — so a press here would turn on a filter that
-              removes most of the wall and leaves almost nothing wearing the
-              chip that would turn it off (Akshil, 2026-09-11). */}
-          {draft && <DraftChip draft={draft} />}
+              A TAG HERE TOO (Akshil, 2026-09-12), reversing the label this was
+              for a day. The argument for the label was that the wall draws no
+              draft ROW (CARD_LANES), so pressing it would empty the wall and
+              leave nothing wearing the chip that turns it back off. That reads
+              the wrong row: the chip a CARD carries is never a draft row's — a
+              card has a session by construction (cardsForTasks) — it is an
+              ordinary conversation whose composer is holding unsent words, and
+              those cards keep wearing it after the press. So the filter narrows
+              the wall to exactly the cards that can clear it, which is the
+              condition the label was protecting against, and the chip is now one
+              control with one gesture in all three views (design-principles §1).
+              tasks-lib.filtersForView stopped dropping the facet here to match. */}
+          {draft && <DraftChip draft={draft} onPick={onPickDraft} active={draftOn} />}
           {project && (
             <IdentityChip
               name={basename(task.project)}

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1961,10 +1961,40 @@ describe("a draft moves with the reader, never duplicating", () => {
     // and puts the row back.
     expect(back.indexOf("autosaveRef.current.stop()"))
       .toBeLessThan(back.indexOf("await autosaveRef.current.settle()"));
+    // …on the UNBOUND arm, the only one that deletes (see the next test).
+    const unbound = back.slice(back.indexOf("if (backChatKey) {"));
     expect(back.indexOf("await autosaveRef.current.settle()"))
-      .toBeLessThan(back.indexOf("deleteTaskDraft(id)"));
-    expect(back.indexOf("deleteTaskDraft(id)"))
-      .toBeLessThan(back.indexOf("navigateUrl(chatBack || backChatHref("));
+      .toBeLessThan(back.indexOf("if (backChatKey) {"));
+    expect(unbound.indexOf("deleteTaskDraft(id)"))
+      .toBeLessThan(unbound.indexOf("navigateUrl(chatBack || backChatHref("));
+  });
+
+  test("a BOUND draft goes back through the other door — no re-seed, no delete", () => {
+    // `put_chat` writes the bound form when the key is that session, so the
+    // task draft and the chat draft are ONE record: saving the chat draft would
+    // update it and the delete that followed would remove it, and the composer
+    // seeded from nothing (Bugbot, PR #1126, 2026-09-12). The bound arm stops,
+    // settles and navigates; the record survives for the chat view to read.
+    const s = src();
+    const back = s.slice(
+      s.indexOf("const backToChat = async () => {"),
+      s.indexOf("// The replacement was created but the original could not be withdrawn"),
+    );
+    const bound = back.slice(back.indexOf("if (boundSessionId) {"),
+                             back.indexOf("if (backChatKey) {"));
+    expect(bound.length).toBeGreaterThan(0);
+    expect(bound).not.toContain("saveChatDraft(");
+    expect(bound).not.toContain("deleteTaskDraft(");
+    expect(bound).toContain("navigateUrl(chatBack || backChatHref(");
+    expect(bound).toContain("return;");
+    expect(back.indexOf("await autosaveRef.current.settle()"))
+      .toBeLessThan(back.indexOf("if (boundSessionId) {"));
+    // …and the unbound arm keeps both, in order.
+    const unbound = back.slice(back.indexOf("if (backChatKey) {"));
+    expect(unbound.indexOf("await saveChatDraft(backChatKey"))
+      .toBeLessThan(unbound.indexOf("deleteTaskDraft(id)"));
+    expect(unbound.indexOf("deleteTaskDraft(id)"))
+      .toBeLessThan(unbound.indexOf("navigateUrl(chatBack || backChatHref("));
   });
 
   test("a REOPENED draft can go back too — the key is stored, not in the URL", () => {

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1893,7 +1893,21 @@ describe("a draft moves with the reader, never duplicating", () => {
     const s = src();
     expect(s).toContain("const moving = chatKeySpent.current ? \"\" : (fromChatKey ?? \"\");");
     expect(s).toContain("chatKeySpent.current = true;");
-    expect(s).toContain("return saveTaskDraft(id, value, opts, moving || undefined);");
+    expect(s).toContain(
+      "return saveTaskDraft(id, value, opts, moving || undefined).then((landed) => {");
+  });
+
+  test("the card adopts whatever id the write actually landed on", () => {
+    // A hop whose `GET /api/drafts` failed cannot see the form already bound to
+    // this conversation, so it mints a new id and saves under it; the server
+    // folds that write into the bound draft and answers the id it landed on
+    // (drafts.py `put_task`, Bugbot PR #1126). Keeping the minted id would aim
+    // the next autosave, the Discard and Schedule's `draft_id` at a record that
+    // does not exist.
+    const s = src();
+    expect(s).toContain("if (landed && landed !== draftIdRef.current) {");
+    expect(s).toContain("draftIdRef.current = landed;");
+    expect(s).toContain("setDraftId(landed);");
   });
 
   test("Back to chat reverses the move — and orders the delete after the last write", () => {
@@ -2358,6 +2372,32 @@ describe("a Schedule hop out of a chat that already has a form", () => {
     expect((quiet?.form as Record<string, unknown>).title).toBe("Ship the changelog");
   });
 
+  test("the tray MERGES rather than one side winning", () => {
+    // Words are a rewrite; a file is a thing. A composer holding two pictures is
+    // not a statement that the three already in the form are gone, and the form
+    // is not a statement that the two just dragged in are (Bugbot, PR #1126).
+    const file = (path: string, name: string) =>
+      ({ path, name, kind: "file" as const });
+    const seed = boundDraftSeed(
+      { "draft-0001": stored({ attachments: [file("/a.png", "a"), file("/b.png", "b")] }) },
+      "sess-a", null,
+      [file("/b.png", "b — renamed in the composer"), file("/c.png", "c")],
+    );
+    const files = (seed?.form as Record<string, unknown>)
+      .attachments as { path: string; name: string }[];
+    expect(files.map((f) => f.path)).toEqual(["/a.png", "/b.png", "/c.png"]);
+    // Deduped on `path`, and the HOP's copy of a file both sides name is the
+    // newer description of it.
+    expect(files[1].name).toBe("b — renamed in the composer");
+  });
+
+  test("a hop with no files of its own leaves the form's tray alone", () => {
+    const file = { path: "/a.png", name: "a", kind: "file" as const };
+    const seed = boundDraftSeed(
+      { "draft-0001": stored({ attachments: [file] }) }, "sess-a", null);
+    expect((seed?.form as Record<string, unknown>).attachments).toEqual([file]);
+  });
+
   test("newest wins if a store somehow holds two", () => {
     // The same tie-break the server's chip takes, so the card that opens is the
     // draft the row is advertising.
@@ -2375,8 +2415,14 @@ describe("a Schedule hop out of a chat that already has a form", () => {
     // painted over a newer press.
     expect(s).toContain("const session = (q.get(\"session_id\") ?? \"\").trim();");
     expect(s).toContain("const gen = ++chatDraftGen.current;");
-    expect(s).toContain(
-      "openForm(at, null, seed, boundDraftSeed(all.task, session, seed.message));");
+    expect(s).toContain("all && boundDraftSeed(all.task, session, seed.message,");
+    expect(s).toContain("seed.attachments));");
+    // A LOOKUP THAT FAILED IS NOT "THERE IS NONE" (Bugbot, PR #1126).
+    // `fetchDrafts` answers null for a blip and this hop still opens on it —
+    // the composer's words must not wait on a GET — but it must not act on the
+    // guess either, which is why the seed is gated on `all` rather than read
+    // off an empty snapshot. The server's merge is what makes the guess
+    // harmless (drafts.py `put_task`).
     // Every other door still opens synchronously, and a failed lookup falls
     // through to the ordinary opening: a hop that cannot find its draft is a
     // hop, not a dead button.

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -2062,6 +2062,86 @@ describe("the chat draft a Schedule leaves behind", () => {
   });
 });
 
+// ---- a draft remembers which conversation it is going into -------------------
+//
+// THE BUG (Akshil, 2026-09-12). The composer's Schedule button can hop out of a
+// chat that HAS ALREADY RUN, and the task being written is the next message of
+// that thread. Press Schedule straight away and it landed there — `session_id`
+// was still in page state. Exit the card and the draft on disk knew nothing
+// about it, so reopening the draft and scheduling it opened a SECOND session
+// with a SECOND task number, and the TASK-nnn the reader had been watching was
+// gone.
+//
+// `from_chat_key` could not stand in: that is where the words were TYPED and it
+// is spent the moment the chat's copy is deleted. This is where the task is
+// GOING, and it has to be stored.
+
+describe("a draft remembers the conversation it is a message to", () => {
+  const src = () => readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+
+  test("both openings answer it, the same way the chat key is answered", () => {
+    const s = src();
+    // The FRESH hop is handed the id as a prop; a card REOPENED from its draft
+    // row has only what the server stored on the draft.
+    expect(s).toContain(
+      'const boundSessionId = (chatSessionId ?? "") || (saved.sessionId ?? "");',
+    );
+    expect(s).toContain('sessionId: str("session_id"),');
+  });
+
+  test("the autosave body carries it, so the hop's first write stores it", () => {
+    const s = src();
+    // In the BODY rather than beside it: `from_chat_key` is a side effect (it
+    // makes the server delete something) and is spent once, where this is plain
+    // state and is restated on every save.
+    expect(s).toContain("      session_id: boundSessionId,");
+    const body = s.slice(
+      s.indexOf("const draftBody: TaskDraftForm | null ="),
+      s.indexOf("const chatKeySpent = useRef(false);"),
+    );
+    expect(body).toContain("session_id: boundSessionId,");
+  });
+
+  test("a reopened draft's Schedule payload carries it", () => {
+    // The whole bug in one line: without the stored id this read
+    // `|| chatSessionId || ""`, and a reopened card has no `chatSessionId` —
+    // the hop that made it is long over.
+    expect(src()).toContain(
+      "sessionId: (!learnedSession && editing?.session_id) || boundSessionId,",
+    );
+  });
+
+  test("…and the payload sends it as the session to continue", () => {
+    // Nothing new on the wire: `session_id` is the field a fresh hop already
+    // used, which is why the entry lands in the thread and keeps its number.
+    expect(buildSchedulePayload(form({ sessionId: "sess-9" })).session_id)
+      .toBe("sess-9");
+    // A draft that belongs to nobody leaves the key off entirely, as it always
+    // did — a chat with no session yet included.
+    expect("session_id" in buildSchedulePayload(form({ sessionId: "" }))).toBe(false);
+  });
+
+  test("a draft row still opens the form, session or no session", () => {
+    const views = readFileSync(join(import.meta.dir, "ScheduleTaskViews.tsx"), "utf8");
+    // The row's rule is the row's: a draft opens the New task modal, and the
+    // draft arm is asked before the chat arm.
+    expect(views).toContain("const openDraft = onOpenDraft && isDraftTask(task) ? onOpenDraft : null;");
+    expect(views).toMatch(
+      /const activate = \(\) => \{\s*if \(openDraft\) openDraft\(task\);\s*else if \(chat\) openChat\(chat\);/,
+    );
+    // …and a bound draft is the first row that could ALSO have answered
+    // `taskHref`, so the chat arm is refused outright rather than merely
+    // out-ranked: otherwise the row draws a real <a href> at the conversation
+    // and ⌘-click, middle click and "Open in new tab" all go somewhere the
+    // plain click does not.
+    expect(views).toContain(
+      "const chat = folderMissing || isDraftTask(task)\n"
+      + "    ? null\n"
+      + "    : openThreadIntent(task, unread);",
+    );
+  });
+});
+
 // ---- a Custom repeat survives being drafted ----------------------------------
 //
 // THE BUG (Bugbot, PR #1118). The autosave stored `repeat` — the preset KEY —

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1871,7 +1871,7 @@ describe("a draft moves with the reader, never duplicating", () => {
     // The ✕ guard's question ("has the user changed anything") and the draft's
     // ("are there words here that would be lost") are asked APART: the prefill
     // still moves the dirty baseline, so a close is still one click.
-    expect(s).toContain("const hopSeeded = !editing && !initialDraft");
+    expect(s).toContain("const hopSeeded = !editing");
     expect(s).toContain("(!!(initialMessage ?? \"\").trim() || !!initialAttachments?.length)");
     expect(s).toContain("!editing && (dirty || hopSeeded)");
     // …and the hook is told the opening value counts as unwritten, which is what
@@ -1881,9 +1881,10 @@ describe("a draft moves with the reader, never duplicating", () => {
 
   test("an ordinary new card still mints nothing until something changes", () => {
     const s = src();
-    // `hopSeeded` is false without a chat handoff, so the body is null and the
-    // hook keeps its own default: the mount value is already written.
-    expect(s).toContain("!initialDraft");
+    // `hopSeeded` is false without a chat handoff — no words, no files — so the
+    // body is null and the hook keeps its own default: the mount value is
+    // already written.
+    expect(s).toContain("const hopSeeded = !editing\n    && (!!(initialMessage");
     // An Edit writes nothing here at all, whatever else is true.
     expect(s).toContain("const draftBody: TaskDraftForm | null = !editing &&");
   });
@@ -2283,5 +2284,102 @@ describe("Delete and Discard share one seat and one skin", () => {
     expect(s).toContain("const draftBody: TaskDraftForm | null = !editing &&");
     expect(s).toContain("{del && (");
     expect(s).toContain("{draftId && (");
+  });
+});
+
+// ---- the hop comes back to the form it already made ---------------------------
+//
+// THE RULE (Akshil, 2026-09-12). A task draft made out of a chat is bound to it
+// and has NO ROW of its own — the conversation's row wears the `Draft` chip
+// instead (routers/tasks.py `_bound_chips`) — so the composer's Schedule button
+// is the only way back into that form. Press it a second time and the card has
+// to reopen the SAME draft, or the store grows a second form bound to one
+// session and whichever saved last owns the chip.
+
+describe("a Schedule hop out of a chat that already has a form", () => {
+  const page = () => readFileSync(join(import.meta.dir, "Scheduled.tsx"), "utf8");
+  let boundDraftSeed: typeof import("./Scheduled").boundDraftSeed;
+  beforeAll(async () => {
+    ({ boundDraftSeed } = await import("./Scheduled"));
+  });
+
+  const stored = (over: Record<string, unknown>) => ({
+    title: "Ship the changelog",
+    description: "then tag it",
+    target: "/Users/me/proj",
+    when: null,
+    repeat: null,
+    model: "",
+    effort: "",
+    permission: "",
+    attachments: [],
+    new_task_each_run: null,
+    session_id: "sess-a",
+    custom_rule: null,
+    created_at: 1,
+    updated_at: 2,
+    ...over,
+  }) as unknown as import("@platform/lib/drafts").TaskDraft;
+
+  test("it reopens the draft bound to that session, under its own id", () => {
+    const seed = boundDraftSeed({ "draft-0001": stored({}) }, "sess-a", null);
+    expect(seed?.id).toBe("draft-0001");
+    // The whole stored form comes back, not a summary: the card seeds every
+    // field from it and goes on autosaving under the same id.
+    expect((seed?.form as Record<string, unknown>).title).toBe("Ship the changelog");
+    expect((seed?.form as Record<string, unknown>).description).toBe("then tag it");
+  });
+
+  test("a chat with no form of its own still mints one, exactly as before", () => {
+    expect(boundDraftSeed({}, "sess-a", null)).toBeNull();
+    // Bound to somebody else's conversation is bound to somebody else.
+    expect(boundDraftSeed({ "draft-0001": stored({ session_id: "sess-b" }) },
+                          "sess-a", null)).toBeNull();
+    // …and a draft bound to nobody is a row of its own; this door is not it.
+    expect(boundDraftSeed({ "draft-0001": stored({ session_id: "" }) },
+                          "sess-a", null)).toBeNull();
+  });
+
+  test("the composer's words outrank the stored ones — and only those two fields", () => {
+    // Whatever is in the box right now was typed a second ago, so it wins, and
+    // it is split across the card's two fields exactly as a fresh hop's is.
+    const seed = boundDraftSeed({ "draft-0001": stored({}) }, "sess-a",
+                                "Cut the release\nand post the notes");
+    const form = seed?.form as Record<string, unknown>;
+    expect(seed?.id).toBe("draft-0001");
+    expect(form.title).toBe("Cut the release");
+    expect(form.description).toBe("and post the notes");
+    // Everything else the form remembers is untouched — this is the same draft,
+    // written a bit further.
+    expect(form.target).toBe("/Users/me/proj");
+    expect(form.session_id).toBe("sess-a");
+    // An empty composer overrides nothing.
+    const quiet = boundDraftSeed({ "draft-0001": stored({}) }, "sess-a", "   ");
+    expect((quiet?.form as Record<string, unknown>).title).toBe("Ship the changelog");
+  });
+
+  test("newest wins if a store somehow holds two", () => {
+    // The same tie-break the server's chip takes, so the card that opens is the
+    // draft the row is advertising.
+    const seed = boundDraftSeed({
+      "draft-0001": stored({ updated_at: 2, title: "older" }),
+      "draft-0002": stored({ updated_at: 9, title: "newer" }),
+    }, "sess-a", null);
+    expect(seed?.id).toBe("draft-0002");
+  });
+
+  test("only a hop that names a session pays for the lookup", () => {
+    const s = page();
+    // One small request, and the answer can arrive late — so it takes the same
+    // generation `openChatDraft` does, and a stale one is dropped rather than
+    // painted over a newer press.
+    expect(s).toContain("const session = (q.get(\"session_id\") ?? \"\").trim();");
+    expect(s).toContain("const gen = ++chatDraftGen.current;");
+    expect(s).toContain(
+      "openForm(at, null, seed, boundDraftSeed(all.task, session, seed.message));");
+    // Every other door still opens synchronously, and a failed lookup falls
+    // through to the ordinary opening: a hop that cannot find its draft is a
+    // hop, not a dead button.
+    expect(s).toContain("} else {\n      openForm(at, null, seed);\n    }");
   });
 });

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1910,6 +1910,42 @@ describe("a draft moves with the reader, never duplicating", () => {
     expect(s).toContain("setDraftId(landed);");
   });
 
+  test("…and every disposal reads that id AFTER settling, never before", () => {
+    // The write `settle` waits out is the same write that can RENAME the draft
+    // (the adoption above runs inside the promise it waits on). Read first, the
+    // id is the one this card minted — and on a fold the server has already
+    // dropped it, so the DELETE hits nothing, the bound draft survives holding
+    // the merged words, and Schedule tells the server to drop a draft that does
+    // not exist (Bugbot, PR #1126, 2026-09-12).
+    const s = src();
+    const discard = s.slice(s.indexOf("const discard = async () => {"),
+                            s.indexOf("const picked = useMemo("));
+    expect(discard.indexOf("await autosaveRef.current.settle()"))
+      .toBeLessThan(discard.indexOf("const id = draftIdRef.current;"));
+    expect(discard.indexOf("const id = draftIdRef.current;"))
+      .toBeLessThan(discard.indexOf("deleteTaskDraft(id)"));
+
+    const back = s.slice(
+      s.indexOf("const backToChat = async () => {"),
+      s.indexOf("// The replacement was created but the original could not be withdrawn"),
+    );
+    expect(back.indexOf("await autosaveRef.current.settle()"))
+      .toBeLessThan(back.indexOf("const id = draftIdRef.current;"));
+
+    // Schedule reads it inside the payload it builds, which is built after its
+    // own `await settle()` — so it is the same rule, kept by ordering rather
+    // than by a local.
+    const submit = s.slice(s.indexOf("// THE DRAFT STOPS HERE."));
+    expect(submit.indexOf("await autosaveRef.current.settle()"))
+      .toBeLessThan(submit.indexOf('draftId: draftIdRef.current ?? "",'));
+    // …and none of the three latches it on the way in, which is the shape the
+    // bug actually had: a read sitting above the await.
+    for (const body of [discard, back, submit.slice(0, submit.indexOf("await scheduleMessage("))]) {
+      expect(body.slice(0, body.indexOf("await autosaveRef.current.settle()")))
+        .not.toContain("draftIdRef.current");
+    }
+  });
+
   test("Back to chat reverses the move — and orders the delete after the last write", () => {
     const s = src();
     const back = s.slice(
@@ -2416,7 +2452,7 @@ describe("a Schedule hop out of a chat that already has a form", () => {
     expect(s).toContain("const session = (q.get(\"session_id\") ?? \"\").trim();");
     expect(s).toContain("const gen = ++chatDraftGen.current;");
     expect(s).toContain("all && boundDraftSeed(all.task, session, seed.message,");
-    expect(s).toContain("seed.attachments));");
+    expect(s).toContain("seed.attachments);");
     // A LOOKUP THAT FAILED IS NOT "THERE IS NONE" (Bugbot, PR #1126).
     // `fetchDrafts` answers null for a blip and this hop still opens on it —
     // the composer's words must not wait on a GET — but it must not act on the
@@ -2427,5 +2463,81 @@ describe("a Schedule hop out of a chat that already has a form", () => {
     // through to the ordinary opening: a hop that cannot find its draft is a
     // hop, not a dead button.
     expect(s).toContain("} else {\n      openForm(at, null, seed);\n    }");
+  });
+});
+
+// ---- reopening a form does not reschedule it ---------------------------------
+//
+// THE BUG (Bugbot, PR #1126, 2026-09-12). `NEW_LINK_LEAD_MS` — now+2m — is what
+// a FRESH deep link opens on, and the bound-draft doors were handing it to forms
+// that already existed. A Date in `creating` makes the card `planning`,
+// `planning` opens `timePicked` true, and `timePicked` is what puts `when` into
+// the next autosave — so merely reopening a draft that had been left IMMEDIATE
+// rewrote it as scheduled two minutes out, and Schedule sent it that way.
+
+describe("a reopened form opens on its own time, or on none", () => {
+  const page = () => readFileSync(join(import.meta.dir, "Scheduled.tsx"), "utf8");
+  let reopenTime: typeof import("./Scheduled").reopenTime;
+  beforeAll(async () => {
+    ({ reopenTime } = await import("./Scheduled"));
+  });
+
+  const seedWith = (when: unknown) =>
+    ({ id: "draft-0001", form: { when } }) as import("./NewJobModal").DraftSeed;
+
+  test("no stored time is no time at all — an immediate draft stays immediate", () => {
+    // The store keeps `when` null until somebody opens the when-row and picks
+    // one, so null here is the positive statement "run it now", not a gap.
+    expect(reopenTime(seedWith(null))).toBeNull();
+    expect(reopenTime(seedWith(""))).toBeNull();
+    expect(reopenTime({ id: "draft-0001", form: null })).toBeNull();
+    expect(reopenTime(null)).toBeNull();
+  });
+
+  test("a stored time comes back as the time it says", () => {
+    const at = reopenTime(seedWith("2026-09-20T08:30"));
+    expect(at).toBeInstanceOf(Date);
+    // The field's format is local, so it reads back as the local minute the
+    // reader picked rather than drifting by the zone offset.
+    expect(at?.getFullYear()).toBe(2026);
+    expect(at?.getMonth()).toBe(8);
+    expect(at?.getDate()).toBe(20);
+    expect(at?.getHours()).toBe(8);
+    expect(at?.getMinutes()).toBe(30);
+  });
+
+  test("an unreadable one reads as none, and never as an Invalid Date", () => {
+    // The card seeds its own field from the string verbatim, so nothing is lost
+    // by declining to guess — and an Invalid Date is still `instanceof Date`,
+    // which is exactly the thing that would flip `planning` back on.
+    expect(reopenTime(seedWith("whenever"))).toBeNull();
+    expect(reopenTime(seedWith(1758350000000))).toBeNull();
+  });
+
+  test("both bound-draft doors take it, and only a lookup that found nothing keeps the lead", () => {
+    const s = page();
+    // The thread line's press…
+    expect(s).toContain("const found = all && boundDraftSeed(all.task, session, null);");
+    expect(s).toContain("openForm(found ? reopenTime(found) : at, null, seed, found);");
+    // …and the composer's own hop, which merges newer WORDS over the stored
+    // form but has nothing to say about its time.
+    expect(s).toContain("const found = all && boundDraftSeed(all.task, session, seed.message,");
+    expect(s).toContain("openForm(found ? reopenTime(found) : at, null, seed, found);");
+    // The lead date survives exactly where it means something: a card with no
+    // stored form behind it.
+    expect(s).toContain("const at = new Date(Date.now() + NEW_LINK_LEAD_MS);");
+    expect(s).toContain("} else {\n      openForm(at, null, seed);\n    }");
+  });
+
+  test("the ordinary draft row never had the bug — it passes no time and still does", () => {
+    // `openDraft` opens on the stored form alone, so the card decides
+    // `timePicked` from the form's own `when` and an immediate draft is left
+    // immediate. Pinned so the lead date cannot drift into this door either.
+    const s = page();
+    const open = s.slice(s.indexOf("const openDraft = (task: Task) => {"),
+                         s.indexOf("const openBoundDraft = (task: Task) => {"));
+    expect(open).toContain(
+      "openForm(null, null, NO_HOP, { id: task.draft_id, form: task.form ?? null });");
+    expect(open).not.toContain("NEW_LINK_LEAD_MS");
   });
 });

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1871,9 +1871,8 @@ describe("a draft moves with the reader, never duplicating", () => {
     // The ✕ guard's question ("has the user changed anything") and the draft's
     // ("are there words here that would be lost") are asked APART: the prefill
     // still moves the dirty baseline, so a close is still one click.
-    expect(s).toContain(
-      "const hopSeeded = !editing && !initialDraft && !!(initialMessage ?? \"\").trim();",
-    );
+    expect(s).toContain("const hopSeeded = !editing && !initialDraft");
+    expect(s).toContain("(!!(initialMessage ?? \"\").trim() || !!initialAttachments?.length)");
     expect(s).toContain("!editing && (dirty || hopSeeded)");
     // …and the hook is told the opening value counts as unwritten, which is what
     // makes the first debounce actually write it.
@@ -1966,9 +1965,11 @@ describe("a draft moves with the reader, never duplicating", () => {
     // A session id: the draft's own folder with that thread on the Claude pane.
     expect(backChatHref("sess-9", "/Users/me/proj"))
       .toBe("/explorer/view/Users/me/proj?_side=claude&session_id=sess-9");
-    // `new:<file>`: the SAME door a never-sent chat's row uses — built out of
-    // the key's own file, and naming no session at all, or the composer that
-    // opens seeds from a key nothing wrote (schedule-lib.chatDraftHref).
+    // `new:<file>`: the folder's chat with no session named at all, built out
+    // of the key's own file (schedule-lib.chatPaneUrl) — or the composer that
+    // opens seeds from a key nothing wrote. It is the same door a never-sent
+    // chat's ROW sends its words back through, that row now opening this very
+    // card (Akshil, 2026-09-12).
     expect(backChatHref("new:/Users/me/news", "/Users/me/elsewhere"))
       .toBe("/explorer/view/Users/me/news?_side=claude");
     // Nothing to go back to.
@@ -1992,12 +1993,14 @@ describe("a draft moves with the reader, never duplicating", () => {
     // into it), which is why no new param was needed.
     const page = readFileSync(join(import.meta.dir, "Scheduled.tsx"), "utf8");
     expect(page).toContain('chatDraftKey(q.get("session_id"), q.get("target"))');
-    expect(page).toContain("fromChatKey={newChatKey}");
+    expect(page).toContain("fromChatKey={hop.chatKey}");
     // …and only for a hop that came FROM a chat: the app page's "+ New task"
     // deep link carries no composer and has no draft of anybody's to supersede.
     expect(page).toContain('q.get("message") === null');
-    // The opening is forgotten on close, like every other deep-link value.
-    expect(page).toContain("setNewChatKey(null);");
+    // The key rides the same one-object seed as the rest of the hop, so it
+    // cannot outlive the opening it was read for — see new-task-images.test.ts,
+    // "the hop is ONE value" (Akshil, 2026-09-12).
+    expect(page).toContain("chatKey: q.get(\"message\") === null");
   });
 });
 
@@ -2103,5 +2106,102 @@ describe("a Custom repeat survives being drafted", () => {
     // …and the card seeds its state back off it, which is the half that makes
     // storing it worth anything.
     expect(s).toContain('if (saved.repeat === "custom" && saved.customRule) return saved.customRule;');
+  });
+});
+
+// ---- a draft exists only when there are words or files -----------------------
+//
+// THE RULE (Akshil, 2026-09-12): a task draft is non-empty iff
+// `title.strip() or description.strip() or attachments`. The folder, the model,
+// the effort, the permission mode, the time and the repeat rule are SETTINGS —
+// how a task would run, not a task. They used to mint one, so opening the card
+// and changing the folder (or opening the when-row and picking a time) put an
+// "Untitled draft" row on the List for a form holding nothing anybody typed.
+//
+// Source reads, because what these pin is a `useState`-adjacent expression and
+// the ORDER of two conditions — a rendered form with a stubbed fetch would only
+// show that a write happened, not which change armed it.
+
+describe("only words or files make a draft", () => {
+  const src = () => readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+
+  test("the content predicate is the three things and nothing else", () => {
+    const s = src();
+    expect(s).toContain('const draftContent = !!title.trim() || !!message.trim()');
+    expect(s).toContain("|| images.some((i) => i.path);");
+    // A chip whose upload has not answered names no file yet — the same rule
+    // the body's own `attachments` uses.
+    expect(s).toContain('.filter((i) => i.path)');
+  });
+
+  test("the FIRST write waits for content — a settings-only change mints nothing", () => {
+    const s = src();
+    expect(s).toContain(
+      "const draftBody: TaskDraftForm | null = !editing && (dirty || hopSeeded)\n"
+      + "    && (draftContent || draftId !== null)",
+    );
+    // The gate is on the BODY, which is what the autosave watches: null is not
+    // a value it can write, so no id is minted and no PUT goes out.
+    expect(s).toContain("const autosave = useAutosave(draftBody,");
+    expect(s).toContain("if (!value) return;");
+  });
+
+  test("…and once a draft exists, emptying it is a write, not a silence", () => {
+    // `draftId !== null` is the second half deliberately: the body keeps being
+    // produced after the words are gone, so the PUT goes out and the server
+    // turns it into a delete. Without it the card fell silent at exactly the
+    // moment it had something to say — the reported "clear the text, then lose
+    // the attachment, and the draft never clears".
+    expect(src()).toContain("(draftContent || draftId !== null)");
+  });
+
+  test("a hop that is only files is already a draft when it lands", () => {
+    // A picture dropped into an empty composer IS a chat draft, so it has to
+    // become a task draft the moment it hops — or the composer's copy sits
+    // beside this card as a second row.
+    expect(src()).toContain('!!(initialMessage ?? "").trim() || !!initialAttachments?.length');
+  });
+});
+
+// ---- Delete and Discard are one seat, one skin -------------------------------
+//
+// They can never both be on a card — `del` belongs to an Edit and `draftId` to a
+// new task — so they are not two controls sharing a footer: they are the same
+// control under the two names the card can be in. Two weights for one position
+// read as a footer that moves its buttons around depending on what you opened
+// (Akshil, 2026-09-12).
+
+describe("Delete and Discard share one seat and one skin", () => {
+  const src = () => readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+
+  test("Discard wears Delete's class, so it takes Delete's far-left seat", () => {
+    const s = src();
+    // `.btn-danger-text` is what carries `margin-right: auto`; `.new-task-delete`
+    // carries the glyph spacing. The old `btn-secondary new-task-discard` skin
+    // is gone, and its absence is the assertion that matters.
+    expect(s).toContain('className="btn btn-danger-text new-task-delete"');
+    expect(s).not.toContain("new-task-discard");
+    expect(s).not.toContain('className="btn btn-secondary new-task-discard"');
+  });
+
+  test("…and Delete's glyph, with the label and the tooltip that are its own", () => {
+    const s = src();
+    const discard = s.slice(s.indexOf("{draftId && ("));
+    const button = discard.slice(0, discard.indexOf("</button>"));
+    expect(button).toContain("{ICON_TRASH}");
+    expect(button).toContain('title="Discard this draft"');
+    expect(button).toContain("Discard");
+    // No arming step: there is nothing scheduled here to undo.
+    expect(button).not.toContain("is-armed");
+  });
+
+  test("only one is ever drawn, because only one condition can hold", () => {
+    const s = src();
+    // An Edit has no draft (`draftBody` is null on `editing`) and a new card has
+    // no entry to delete.
+    expect(s).toContain("const del = deleteActionFor(editing);");
+    expect(s).toContain("const draftBody: TaskDraftForm | null = !editing &&");
+    expect(s).toContain("{del && (");
+    expect(s).toContain("{draftId && (");
   });
 });

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1946,6 +1946,20 @@ describe("a draft moves with the reader, never duplicating", () => {
     }
   });
 
+  test("Back to chat flushes the debounce before it stops, so the last keystrokes reach the form", () => {
+    // The bound arm hands off to a composer that seeds from the FORM; `stop`
+    // alone would silence both the pending timer and the unmount flush, and the
+    // last 600 ms of typing would never land (Bugbot, PR #1126, 2026-09-12).
+    const s = src();
+    const back = s.slice(s.indexOf("const backToChat = async () => {"));
+    const flush = back.indexOf("autosaveRef.current.flush();");
+    const stop = back.indexOf("autosaveRef.current.stop();");
+    const settle = back.indexOf("await autosaveRef.current.settle();");
+    expect(flush).toBeGreaterThan(-1);
+    expect(flush).toBeLessThan(stop);
+    expect(stop).toBeLessThan(settle);
+  });
+
   test("Back to chat reverses the move — and orders the delete after the last write", () => {
     const s = src();
     const back = s.slice(

--- a/frontend/src/shell/new-task-images.test.ts
+++ b/frontend/src/shell/new-task-images.test.ts
@@ -437,14 +437,14 @@ describe("the chat handoff's attachments", () => {
     expect(SCHEDULED).toContain('openForm("blank", null)');
     expect(SCHEDULED).toContain("onCreateAt={(t) => openForm(t, null)}");
     expect(SCHEDULED).toContain("openForm(null, template ?? entry);");
-    // The draft reopen path drops it explicitly, since it does not go through
-    // `openForm` at all.
+    // The draft reopen path says it in the same words, through the same door:
+    // it names `NO_HOP` outright rather than setting the state by hand.
     const draft = SCHEDULED.slice(SCHEDULED.indexOf("const openDraft ="));
-    expect(draft.slice(0, draft.indexOf("};"))).toContain("setHop(NO_HOP);");
+    expect(draft.slice(0, draft.indexOf("};"))).toContain(
+      "openForm(null, null, NO_HOP, { id: task.draft_id, form: task.form ?? null });");
     // …and the ONLY opening that seeds one is the deep link.
     expect(SCHEDULED.match(/setHop\(seed\)/g) ?? []).toHaveLength(1);
-    expect(SCHEDULED).toContain(
-      "openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null, seed);");
+    expect(SCHEDULED).toContain("openForm(at, null, seed);");
   });
 
   it("and the close has nothing left to forget", () => {

--- a/frontend/src/shell/new-task-images.test.ts
+++ b/frontend/src/shell/new-task-images.test.ts
@@ -399,9 +399,62 @@ describe("the chat handoff's attachments", () => {
 
   it("the Tasks page parses the param through the chat's own parser and CONSUMES it", () => {
     expect(SCHEDULED).toContain(
-      'setNewAttachments(parseAttachmentsParam(q.get("attachments")));');
+      'attachments: parseAttachmentsParam(q.get("attachments")),');
     // Deleted with the rest, or a reload reopens the modal forever.
     expect(SCHEDULED).toContain('q.delete("attachments");');
-    expect(SCHEDULED).toContain("initialAttachments={newAttachments}");
+    expect(SCHEDULED).toContain("initialAttachments={hop.attachments}");
+  });
+
+  // ---- and they do not follow the reader to the NEXT card -------------------
+  //
+  // THE REGRESSION (Akshil, 2026-09-12): after a composer→Schedule hop carrying
+  // an image, the picture turned up in whatever New task modal was opened next,
+  // and the one after that. The URL params were stripped correctly; what leaked
+  // was the PAGE STATE they had been read into. Six loose `useState`s were
+  // cleared one by one in the modal's `onClose` and `attachments` was simply not
+  // on that list — so `newAttachments` stood for the life of the page and
+  // re-seeded every opening through `initialAttachments`.
+
+  it("the hop is ONE value, seeded by the opening rather than cleared afterwards", () => {
+    // The fix is structural: there is no second place that says what a hop is
+    // made of, so no list can fall out of step with the fields again.
+    expect(SCHEDULED).toContain("const [hop, setHop] = useState<HopSeed>(NO_HOP);");
+    expect(SCHEDULED).toContain("seed: HopSeed = NO_HOP,");
+    expect(SCHEDULED).toContain("setHop(seed);");
+    // Every value the card reads comes off that one object.
+    for (const read of ["hop.target ?? scope?.entry ?? scope?.project ?? null", "initialMessage={hop.message}",
+                        "initialAttachments={hop.attachments}", "chatSessionId={hop.session}",
+                        "chatBack={hop.back}", "fromChatKey={hop.chatKey}"]) {
+      expect(SCHEDULED).toContain(read);
+    }
+  });
+
+  it("a NON-hop opening carries no hop at all — the default, not a clean-up", () => {
+    // "+ New task", a calendar slot, an Edit: all reach `openForm` without a
+    // seed, so they get `NO_HOP`. A reopened draft says it in its own words.
+    expect(SCHEDULED).toContain("NO_HOP: HopSeed = {");
+    expect(SCHEDULED).toContain("attachments: [], chatKey: null,");
+    expect(SCHEDULED).toContain('openForm("blank", null)');
+    expect(SCHEDULED).toContain("onCreateAt={(t) => openForm(t, null)}");
+    expect(SCHEDULED).toContain("openForm(null, template ?? entry);");
+    // The draft reopen path drops it explicitly, since it does not go through
+    // `openForm` at all.
+    const draft = SCHEDULED.slice(SCHEDULED.indexOf("const openDraft ="));
+    expect(draft.slice(0, draft.indexOf("};"))).toContain("setHop(NO_HOP);");
+    // …and the ONLY opening that seeds one is the deep link.
+    expect(SCHEDULED.match(/setHop\(seed\)/g) ?? []).toHaveLength(1);
+    expect(SCHEDULED).toContain(
+      "openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null, seed);");
+  });
+
+  it("and the close has nothing left to forget", () => {
+    // The clear-on-close list is GONE rather than extended: keeping it and
+    // adding `attachments` would leave the same trap for the next field.
+    const close = SCHEDULED.slice(SCHEDULED.indexOf("onClose={() => {"));
+    const body = close.slice(0, close.indexOf("}}"));
+    expect(body).not.toContain("setNewAttachments");
+    expect(body).not.toContain("setNewTarget");
+    expect(body).not.toContain("setNewChatKey");
+    expect(SCHEDULED).not.toContain("newAttachments");
   });
 });

--- a/frontend/src/shell/schedule-lib.ts
+++ b/frontend/src/shell/schedule-lib.ts
@@ -596,33 +596,6 @@ export function folderHref(task: Pick<Task, "target" | "project">): string | nul
 }
 
 /**
- * WHERE A NEVER-SENT CHAT'S ROW GOES (design.md, Round 2: "New-chat drafts are
- * rows" — "Click → opens the folder's chat, composer prefilled").
- *
- * The same door as `folderHref` and deliberately so: a draft chat has no
- * session to name, so what opens is the FOLDER with the Claude pane on it, and
- * the composer seeds itself from the draft keyed on that folder. Carrying a
- * `session_id` would be asserting an identity this conversation has not been
- * given yet — the very state `new:<file>` exists to describe.
- *
- * `file` FIRST, and that is the whole difference from `folderHref`. The chat
- * draft's key is built out of the chat's own `file` (platform/lib/drafts
- * `chatDraftKey`, whose note carries the rule), so this URL has to be built out
- * of the same string or the chat that opens is mounted somewhere else and the
- * composer seeds from a key nothing wrote. `target` / `project` are the
- * fallback for a server that sends the row without it.
- */
-export function chatDraftHref(
-  task: Pick<Task, "file" | "target" | "project">,
-): string | null {
-  const at = task.file || task.target || task.project;
-  // NO `session_id` AT ALL, not an empty one. `&session_id=` claimed the
-  // parameter had been answered with nothing; a chat that has never been sent
-  // has not been asked the question (Akshil, 2026-09-11).
-  return at ? chatPaneUrl(at) : null;
-}
-
-/**
  * The same conversation as an IFRAME — one card on the Tasks page's Cards view
  * (shell/TaskCards.tsx), showing the run as it happens.
  *

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -9,7 +9,7 @@ import {
   BOARD_COLUMNS,
   BOARD_LANES,
   cardFrameSrc,
-  chatDraftHref,
+  chatPaneUrl,
   laneOf,
   peekFrameSrc,
 } from "./schedule-lib";
@@ -40,6 +40,7 @@ import {
   carryMarkToHeld,
   dayLabel,
   DRAFT_CHIP,
+  draftTag,
   dropAction,
   dropLanes,
   filterTasks,
@@ -4369,45 +4370,204 @@ describe("the Draft chip", () => {
     expect(chip.slice(0, chip.indexOf("There is no `UnreadDot`")))
       .toContain('className="schedule-tv-id-shield"');
   });
+
+  it("is RED — the ink and the glyph, and nothing else painted", () => {
+    // Akshil, 2026-09-12: Gmail's "Draft". The word and the pencil take the
+    // page's error colour; no fill, no hairline, no second treatment. One rule
+    // covers all three views because all three draw `.tasks-draft-pill`.
+    const pill = block(TASKS_CSS, ".tasks-draft-pill");
+    expect(pill).toContain("color: var(--error);");
+    // The glyph rides on it: the inline SVG is currentColor, so the mark cannot
+    // drift away from the word it sits beside.
+    expect(VIEWS).toContain("const ICON_PENCIL_LINE = icon(");
+    // No BOX. The outcome pill it borrows its shape from draws a currentColor
+    // hairline, which in red would read as an alarm rather than a note — and
+    // it is the one thing that differed between the Cards wall's inert span and
+    // the pressable chip on the List and the Board.
+    expect(pill).toContain("border: 0;");
+    expect(pill).not.toContain("background:");
+    // The ON state keeps the accent wash — the filter still says it is running —
+    // and no longer repaints the word, so the chip is red whatever the page is
+    // filtered to.
+    const on = block(TASKS_CSS, "button.tasks-draft-pill.is-on");
+    expect(on).toContain("var(--accent)");
+    expect(on).not.toContain("color:");
+    // …and the hover wash is still the quiet one, not a danger wash.
+    expect(TASKS_CSS).toContain("background: var(--ctl-quiet-bg-hover);");
+    // Both themes define the token this leans on, so the contrast is the
+    // palette's problem and not this chip's (tokens.css: #c62828 on light,
+    // #ff6b6b on dark).
+    expect(TOKENS_CSS.match(/--error: #[0-9a-f]{6};/g)?.length).toBeGreaterThanOrEqual(2);
+  });
 });
 
-describe("a never-sent chat is a row you can press", () => {
-  it("opens the folder's chat with NO session id, so the composer can seed", () => {
-    // `new:<file>` is the draft's key and the URL is built out of the same
-    // string — a chat mounted anywhere else would seed from a key nothing wrote
-    // (platform/lib/drafts.chatDraftKey carries the rule).
-    const row = task({
-      key: "new:/Users/me/news", kind: "draft", draft_kind: "chat",
-      file: "/Users/me/news", target: "/Users/me/elsewhere",
-    });
-    const href = chatDraftHref(row)!;
-    expect(href).toBe("/explorer/view/Users/me/news?_side=claude");
-    // NOT `&session_id=` with nothing after it. An empty value says the
-    // question was asked and answered with nothing; a chat that has never been
-    // sent has not been asked (Akshil, 2026-09-11). `folderHref` still sends
-    // the empty one — there the session exists and has merely not been
-    // reported yet.
-    expect(href).not.toContain("session_id");
+// ---- where does a draft row's press go? (Akshil, 2026-09-12) ----------------
+// ONE RULE, and it is the ROW's rather than the draft's kind: a row with no
+// session is a draft and always opens the New task modal; a row with a session
+// always opens its chat. The build before this one sent the two draft kinds to
+// two different places and tried to warn about it in the chip's wording ("Draft
+// reply") — a label apologising for a press. The press is what changed instead,
+// and the chip went back to one word for every kind.
+
+describe("the Draft chip says ONE word, whichever kind of draft it is", () => {
+  const taskDraft = task({
+    key: "draft:d1", kind: "draft", draft_kind: "task", status: "upcoming",
+    title: "Half a thought",
+    form: { description: "Half a thought about the news", updated_at: 300 },
+  });
+  const chatDraft = task({
+    key: "new:/Users/me/news", kind: "draft", draft_kind: "chat",
+    status: "upcoming", file: "/Users/me/news", title: "unsent words",
+    form: undefined, draft: { preview: "unsent words", updated_at: 200 },
+  });
+  const withChatDraft = task({
+    key: "s-live", status: "in_progress",
+    draft: { preview: "one more thing", updated_at: 100 },
   });
 
-  it("falls back to the task's folder on a server that sent no `file`", () => {
-    expect(chatDraftHref({ file: "", target: "/a/b", project: "/c" }))
-      .toContain("/explorer/view/a/b");
-    expect(chatDraftHref({ file: "", target: "", project: "/c" }))
-      .toContain("/explorer/view/c");
-    expect(chatDraftHref({ file: "", target: "", project: "" })).toBe(null);
+  it("is `Draft` on all three rows that carry unsent words", () => {
+    // An unfinished form, a never-sent chat, and an ordinary task whose
+    // composer is holding something: one mark, because a reader scanning the
+    // list is being told the same thing by all three.
+    expect(draftTag(taskDraft)!.text).toBe(DRAFT_CHIP);
+    expect(draftTag(chatDraft)!.text).toBe(DRAFT_CHIP);
+    expect(draftTag(withChatDraft)!.text).toBe(DRAFT_CHIP);
+    // Almost every row has neither.
+    expect(draftTag(task({ key: "plain", status: "done" }))).toBe(null);
+    expect(draftTag(task({ key: "plain", status: "done", draft: null }))).toBe(null);
+  });
+
+  it("says the same word on a server that predates the second kind", () => {
+    // No `draft_kind` at all: every draft row on that server is a form, and
+    // nothing about the chip depends on the distinction anyway.
+    expect(draftTag({ ...taskDraft, draft_kind: undefined })!.text).toBe(DRAFT_CHIP);
+  });
+
+  it("captions with the WORDS, not with the kind", () => {
+    // What a reader hovering wants is a glimpse of the sentence.
+    expect(draftTag(taskDraft)!.title).toBe("Half a thought about the news");
+    expect(draftTag(chatDraft)!.title).toBe("unsent words");
+    expect(draftTag(withChatDraft)!.title).toBe("one more thing");
+    // A task draft with nothing typed anywhere still captions something.
+    expect(draftTag(task({ key: "d", kind: "draft", draft_kind: "task",
+                          title: "", form: undefined }))!.title).toBe("Draft");
+  });
+
+  it("does not split the FILTER either: all three are one facet", () => {
+    for (const row of [taskDraft, chatDraft, withChatDraft]) {
+      expect(hasDraft(row)).toBe(true);
+      expect(draftTag(row)).not.toBe(null);
+    }
+  });
+
+  it("has no second word left in the module to drift back in", () => {
+    // The word was the wrong fix and it is GONE, not merely unused: a second
+    // chip constant sitting in tasks-lib is an invitation to re-split the chip.
+    // (The note above `DRAFT_CHIP` still names it, which is the point of a
+    // note — it says why there is one word and not two.)
+    expect(LIB).not.toContain("DRAFT_REPLY_CHIP");
+    expect(LIB).not.toContain('= "Draft reply"');
+  });
+});
+
+describe("a never-sent chat opens the New task modal, like every other draft", () => {
+  const chatDraft = task({
+    key: "new:/Users/me/news", kind: "draft", draft_kind: "chat",
+    status: "upcoming", file: "/Users/me/news", target: "/Users/me/elsewhere",
+    // A conversation nobody has sent has no session — that absence IS the row.
+    session_id: "",
+    draft: { preview: "unsent words", updated_at: 200 },
+  });
+
+  /** Scheduled.tsx's chat-draft arm, which is where the rule is spent. */
+  const ARM = SCHEDULED.slice(
+    SCHEDULED.indexOf("const openChatDraft = (task: Task) => {"),
+    SCHEDULED.indexOf("const openDraft = (task: Task) => {"),
+  );
+
+  it("builds a hop seed and opens the form — it does not navigate", () => {
+    // The same object the composer's Schedule button builds, spent through the
+    // same door (`openForm`), so one press and the other land on one card.
+    expect(ARM).toContain("const seed: HopSeed = {");
+    expect(ARM).toContain("openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null, seed);");
+    // NOT a navigation, and the page no longer holds the tools for one: the
+    // chat-draft href and the router hop are both gone from this file.
+    expect(SCHEDULED).not.toContain("navigateUrl");
+    expect(SCHEDULED).not.toContain("chatDraftHref");
+  });
+
+  it("carries the row's own key as `fromChatKey`, so the draft MOVES", () => {
+    // `new:<file>` is what the composer stored the words under, so naming it is
+    // what lets the first task-draft save delete that row rather than leave the
+    // sentence on the list twice (design.md, Round 2: "A draft moves, never
+    // duplicates").
+    expect(ARM).toContain("chatKey: task.key,");
+    // …and the row's key IS that spelling — `new:` plus the chat's own file,
+    // the one platform/lib/drafts.chatDraftKey writes.
+    expect(chatDraft.key).toBe("new:/Users/me/news");
+  });
+
+  it("goes BACK to the folder's chat, built out of the chat's own `file`", () => {
+    // The way back is the door a never-sent chat's composer is mounted on, and
+    // it has to be built out of `file` — the string the draft is keyed on
+    // (platform/lib/drafts.chatDraftKey) — or the composer seeds from a key
+    // nothing wrote. `target` is the fallback for a server that sent no file.
+    expect(ARM).toContain("const at = task.file || task.target || \"\";");
+    expect(ARM).toContain("back: at ? chatPaneUrl(at) : null,");
+    expect(chatPaneUrl(chatDraft.file!)).toBe("/explorer/view/Users/me/news?_side=claude");
+    // NOT `&session_id=` with nothing after it. An empty value says the
+    // question was asked and answered with nothing; a chat that has never been
+    // sent has not been asked (Akshil, 2026-09-11).
+    expect(chatPaneUrl(chatDraft.file!)).not.toContain("session_id");
+    // …and the seed names no session at all, for the same reason.
+    expect(ARM).toContain("session: null,");
+  });
+
+  it("fetches the WHOLE message first, and falls back to the preview", () => {
+    // The row carries only `draft.preview` — the first LINE — and the card
+    // splits the message across Title and description (`splitDraft`), so
+    // opening on the preview would drop every line after the first. The card
+    // seeds in `useState` initialisers, so the text has to be in hand before
+    // the modal opens.
+    expect(ARM).toContain("fetchChatDraft(task.key)");
+    expect(ARM).toContain("message: stored?.text ?? task.draft?.preview ?? null,");
+    expect(ARM).toContain("attachments: stored?.attachments ?? [],");
+    expect(ARM.indexOf("fetchChatDraft(task.key)"))
+      .toBeLessThan(ARM.indexOf("openForm("));
   });
 
   it("is the Scheduled page's first question about a draft row's press", () => {
     // A chat draft has no form to re-open and no `draft_id` to fall through to,
-    // so the navigation arm has to be asked before the modal arm.
+    // so the hop arm has to be asked before the stored-form arm.
     const open = SCHEDULED.slice(
       SCHEDULED.indexOf("const openDraft = (task: Task) => {"),
       SCHEDULED.indexOf("// What a deep link named"),
     );
     expect(open.indexOf("isChatDraftTask(task)"))
       .toBeLessThan(open.indexOf("if (!task.draft_id) return;"));
-    expect(open).toContain("navigateUrl(href)");
+    expect(open).toContain("openChatDraft(task);");
+  });
+
+  it("routes BOTH draft kinds through the rows' one draft arm", () => {
+    // The List row and the Board card ask `isDraftTask`, never
+    // `isChatDraftTask`: which kind it is decides what the modal is seeded
+    // from, not whether it opens.
+    expect(VIEWS).toContain("const openDraft = onOpenDraft && isDraftTask(task) ? onOpenDraft : null;");
+    expect(VIEWS).toContain("if (onOpenDraft && isDraftTask(task)) onOpenDraft(task);");
+    expect(VIEWS).not.toContain("isChatDraftTask");
+  });
+
+  it("gives a session-less row no chat link to be ⌘-clicked into either", () => {
+    // The row stretches a real <a href> over itself, and that href is the
+    // thread's — null without a session. So "no row click opens the chat for a
+    // session-less row" holds for every gesture, not just the plain click.
+    expect(openThreadIntent(chatDraft)).toBe(null);
+    expect(taskHref(chatDraft)).toBe(null);
+    // …while a row WITH a session still opens its chat, unchanged.
+    const live = task({ key: "s-live", session_id: "sess-9", target: "/Users/me/proj",
+                        draft: { preview: "one more thing", updated_at: 100 } });
+    expect(openThreadIntent(live)!.href)
+      .toBe("/explorer/view/Users/me/proj?_side=claude&session_id=sess-9");
   });
 
   it("never lifts — a draft is not a task yet, whichever kind it is", () => {
@@ -5475,6 +5635,56 @@ describe("groupByColumn", () => {
       .toEqual(["parked", "broke-new", "broke-old"]);
     // ...and recency still orders what is left, so nothing else moved.
     expect(map.get("needs_attention" as never)).toBeUndefined();
+  });
+
+  it("puts a card holding UNSENT WORDS at the top of its lane, as the List does", () => {
+    // THE BUG (Akshil, 2026-09-12): a Done card with a chat draft showed no
+    // Draft chip on the Board while its List row showed one. Nothing was wrong
+    // with the chip. The lane is ordered by the time the card PRINTS — the last
+    // run — and a draft's own clock is not that time, so a task whose composer
+    // was holding words but whose last run was yesterday sorted to rank 64 of a
+    // 416-card Done lane, on a board that draws the first twenty
+    // (ScheduleTaskViews LANE_INITIAL_VISIBLE). The card was never drawn.
+    //
+    // The List had already cured this in itself (sortForList's hoistDrafts);
+    // the Board now makes the same pass, so the two views agree about which
+    // card is at the top of a lane and the chip is inside the page either way.
+    const at = 1_700_000_000;
+    const done = (key: string, ranAt: number, over: Partial<Task> = {}) =>
+      task({ key, status: "done", last_active: ranAt,
+             messages: [msg({ ran_at: ranAt, at: ranAt, state: "sent" })], ...over });
+    const rows = [
+      done("fresh-3", at + 30),
+      done("fresh-2", at + 20),
+      done("fresh-1", at + 10),
+      // Ran a day ago, and somebody is halfway through a reply to it.
+      done("stale-draft", at - 86_400, { draft: { preview: "one more thing", updated_at: at + 99 } }),
+    ];
+    const lane = groupByColumn(rows, (at + 100) * 1000).get("done")!;
+    expect(lane.map((t) => t.key))
+      .toEqual(["stale-draft", "fresh-3", "fresh-2", "fresh-1"]);
+    // …and it is the List's own answer, not a second opinion about it.
+    expect(lane.map((t) => t.key))
+      .toEqual(sortForList(rows, (at + 100) * 1000).map((t) => t.key));
+  });
+
+  it("keeps WAITING above a draft in Blocked — the hoist is the inner order", () => {
+    // The two partitions stack rather than fight: whoever is being waited on is
+    // still the top of that lane, and inside each half the drafts come first.
+    const at = 1_700_000_000;
+    const held = { preview: "half a reply", updated_at: at + 99 };
+    const rows = [
+      task({ key: "broke-new", status: FAILED, last_active: at + 30,
+             messages: [msg({ ran_at: at + 30, at: at + 30, state: "error" })] }),
+      task({ key: "broke-draft", status: FAILED, last_active: at, draft: held,
+             messages: [msg({ ran_at: at, at, state: "error" })] }),
+      task({ key: "parked", status: "needs_attention", last_active: at + 20,
+             messages: [msg({ ran_at: at + 20, at: at + 20 })] }),
+      task({ key: "parked-draft", status: "needs_attention", last_active: at + 10, draft: held,
+             messages: [msg({ ran_at: at + 10, at: at + 10 })] }),
+    ];
+    expect(groupByColumn(rows, (at + 100) * 1000).get("blocked")!.map((t) => t.key))
+      .toEqual(["parked-draft", "parked", "broke-draft", "broke-new"]);
   });
 });
 
@@ -7242,32 +7452,81 @@ function asking(key: string, at: number, over: Partial<Task> = {}): Task {
 }
 
 describe("cardsForTasks", () => {
-  it("draws every lane, Archive included, in the List's own rank order", () => {
+  it("draws every lane with a conversation in it, Archive included, in the List's rank order", () => {
     // Akshil, 2026-09-05: "show all status tasks in cards even archived ones"
-    // (that morning it was every lane but Archive). CARD_LANES is the membership
-    // test, and it is LIST_ORDER itself rather than a second list — so the wall
+    // (that morning it was every lane but Archive). CARD_LANES is the lane
+    // rule, and it is LIST_ORDER itself rather than a second list — so the wall
     // and the List can never disagree about which lane comes first. Every name
     // in it is still a real board column.
-    // …minus `draft`, the one row the wall does not draw at all (design.md,
-    // Decisions: List and Board only) — it has no session, so there is not even
-    // an empty conversation to show.
-    expect(CARD_LANES).toEqual(LIST_ORDER.filter((k) => k !== "draft"));
-    expect(CARD_LANES).toEqual(["needs_attention", "blocked", "upcoming", "in_progress", "done", "archived"]);
+    // …minus the two lanes with nothing to frame: `draft` (design.md,
+    // Decisions: List and Board only) and `upcoming` (Akshil, 2026-09-10) —
+    // neither has a transcript, which is the whole of what a card draws.
+    expect(CARD_LANES).toEqual(LIST_ORDER.filter((k) => k !== "draft" && k !== "upcoming"));
+    expect(CARD_LANES).toEqual(["needs_attention", "blocked", "in_progress", "done", "archived"]);
     const COLUMN_KEYS: string[] = BOARD_COLUMNS.map((c) => c.key);
     for (const key of CARD_LANES) expect(COLUMN_KEYS).toContain(key);
     const rows = [
       running("a", 100),
-      task({ key: "b", task_id: "TASK-b", status: "done" }),
-      task({ key: "c", task_id: "TASK-c", status: "upcoming" }),
-      task({ key: "d", task_id: "TASK-d", status: "blocked" }),
-      task({ key: "e", task_id: "TASK-e", status: "archived" }),
+      task({ key: "b", task_id: "TASK-b", session_id: "b", status: "done" }),
+      task({ key: "c", task_id: "TASK-c", session_id: "c", status: "upcoming" }),
+      task({ key: "d", task_id: "TASK-d", session_id: "d", status: "blocked" }),
+      task({ key: "e", task_id: "TASK-e", session_id: "e", status: "archived" }),
       asking("f", 50),
     ];
     // "f" is OLDER than "a" and still comes first: the lane outranks the clock.
     // "e" — archived — is drawn too, in the bottom lane.
-    // Upcoming ("c") is not a card (Akshil, 2026-09-10): a run that has not
-    // happened has no chat to show. It keeps its lane on the List and Calendar.
+    // Upcoming ("c") is not a card even when it HAS a session (a template that
+    // has run before): a run that has not happened is read on the List and the
+    // Calendar.
     expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["f", "d", "a", "b", "e"]);
+  });
+
+  it("draws only rows that HAVE a session — no transcript, no card", () => {
+    // Akshil, 2026-09-12: "only in cards we don't show tasks that don't have
+    // sessions because we have no history or transcript of claude chat to
+    // show". One question, asked of the ROW, and it answers what used to be a
+    // list of statuses.
+    const rows = [
+      running("live", 300),
+      // A task draft and a never-sent chat: no session, and the wall never drew
+      // them (design.md, Decisions) — now for the reason underneath that rule.
+      task({ key: "draft:d1", task_id: "TASK-d1", session_id: "", kind: "draft",
+             draft_kind: "task", status: "upcoming" }),
+      task({ key: "new:/Users/me/news", task_id: "TASK-d2", session_id: "",
+             kind: "draft", draft_kind: "chat", status: "upcoming" }),
+      // A pending run that has never started: nothing was ever recorded.
+      task({ key: "pending", task_id: "TASK-p", session_id: "", status: "upcoming" }),
+      // THE ONE THIS ADDS. A settled row whose child died before its first
+      // status line never got a `claude_session_id` and never will — the card
+      // that sat on "Starting…" for a run that had ended a day earlier
+      // (cardBlank, FIX-A). It is simply not drawn now.
+      task({ key: "settled-mute", task_id: "TASK-m", session_id: "", status: "done" }),
+      task({ key: "arch-mute", task_id: "TASK-am", session_id: "", status: "archived" }),
+    ];
+    expect(cardsForTasks(rows).cards.map((t) => t.key)).toEqual(["live"]);
+    // …and a row with no session does not count toward "Show more" either.
+    expect(cardsForTasks(rows, 1).hidden).toBe(0);
+  });
+
+  it("hoists a card holding unsent words to the top of its lane, as the List does", () => {
+    // The wall shows SIX cards and a Done lane can be four hundred long, so a
+    // task whose composer is holding a half-written reply was pages deep if its
+    // last run was a day old — which is to say, gone (Akshil, 2026-09-12; the
+    // same bug the Board had). `sortForList`, not `sortByLane`: the List's rank
+    // AND the List's drafts-first pass inside a lane.
+    const rows = [
+      running("run-new", 500),
+      running("run-draft", 100, { draft: { preview: "one more thing", updated_at: 9_000 } }),
+      task({ key: "done-new", task_id: "TASK-dn", session_id: "done-new", status: "done",
+             messages: [msg({ at: 400, ran_at: 400, state: "sent" })] }),
+      task({ key: "done-draft", task_id: "TASK-dd", session_id: "done-draft", status: "done",
+             draft: { preview: "half a reply", updated_at: 9_000 },
+             messages: [msg({ at: 50, ran_at: 50, state: "sent" })] }),
+    ];
+    const cards = cardsForTasks(rows).cards.map((t) => t.key);
+    expect(cards).toEqual(["run-draft", "run-new", "done-draft", "done-new"]);
+    // The List's very answer, not a second opinion about it.
+    expect(cards).toEqual(sortForList(rows).map((t) => t.key));
   });
 
   it("is the List's order, exactly — sortByLane, not a second opinion", () => {
@@ -7283,6 +7542,7 @@ describe("cardsForTasks", () => {
       task({
         key,
         task_id: `TASK-${key}`,
+        session_id: key,
         status: "done",
         started,
         messages: [msg({ at: S(ran), ran_at: S(ran), state: "sent" })],
@@ -7297,6 +7557,8 @@ describe("cardsForTasks", () => {
       asking("ask", 10),
     ];
     const cards = cardsForTasks(rows).cards.map((t) => t.key);
+    expect(cards).toEqual(sortForList(rows).map((t) => t.key));
+    // …which on rows carrying no drafts is `sortByLane` exactly.
     expect(cards).toEqual(sortByLane(rows).map((t) => t.key));
     expect(cards).toEqual(["ask", "run-b", "run-a", "weekly", "oneoff"]);
   });
@@ -7330,15 +7592,22 @@ describe("cardsForTasks", () => {
     // the run due in ten minutes under one due in October if it was scheduled
     // later. The List sorts that lane by the run ahead, ascending; so does this.
     const NOW_S = Math.floor(NOW / 1000);
-    const soon = (key: string, at: number) =>
+    // Given a session on purpose: the lane rule (CARD_LANES) has to hold on its
+    // own, not lean on the fact that a pending row usually has none.
+    const soon = (key: string, at: number, session: string) =>
       task({
         key,
         task_id: `TASK-${key}`,
+        session_id: session,
         status: "upcoming",
         next_run: at,
         messages: [msg({ at, ran_at: 0, state: "pending" })],
       });
-    const rows = [soon("october", NOW_S + 30 * 86_400), soon("tenmin", NOW_S + 600), soon("late", NOW_S - 600)];
+    const rows = [
+      soon("october", NOW_S + 30 * 86_400, "sess-oct"),
+      soon("tenmin", NOW_S + 600, "sess-ten"),
+      soon("late", NOW_S - 600, "sess-late"),
+    ];
     expect(cardsForTasks(rows, CARD_PAGE, NOW)).toEqual({ cards: [], hidden: 0 });
     // Nor does a hidden Upcoming count toward "Show more".
     expect(cardsForTasks([...rows, running("a", 100)], 1, NOW)).toEqual({

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -91,6 +91,7 @@ import {
   nextRunRepeats,
   ringFailed,
   outcomeTag,
+  nextMessageId,
   nextRunAt,
   openMessageHref,
   openThreadIntent,
@@ -304,6 +305,17 @@ describe("isExpandable", () => {
     expect(isExpandable(task({}, 2))).toBe(true);
     expect(isExpandable(task({}, 3))).toBe(true);
     expect(isExpandable(task({}, 40))).toBe(true);
+  });
+
+  it("opens a one-message task that is holding a draft, and only then", () => {
+    // The expanded thread leads with the composer's unsent words, so a draft is
+    // the second voice a single message lacked (Akshil, 2026-09-12). Without one
+    // the row stays a leaf; a pending task that never ran stays a leaf even with
+    // words in its box, because there is no thread to lead.
+    const holding = { preview: "one more thing", updated_at: 1 };
+    expect(isExpandable({ ...task({}, 1), draft: holding })).toBe(true);
+    expect(isExpandable({ ...task({}, 1), draft: null })).toBe(false);
+    expect(isExpandable({ ...task({}, 0), draft: holding })).toBe(false);
   });
 
   it("asks message_count, never the tail the client happens to hold", () => {
@@ -4377,13 +4389,41 @@ describe("the Draft chip", () => {
     expect(cardsHead.indexOf("<DraftChip")).toBeLessThan(cardsHead.indexOf("<IdentityChip"));
   });
 
-  it("wears the ON pill the folder chip wears, in the accent, at rest", () => {
+  it("…and the card's head row SPENDS its free space once, at the group's head", () => {
+    // Akshil, 2026-09-12, screenshot: the chip floating mid-row on the wall. The
+    // JSX order above was already right; the CSS was not. `margin-left: auto` is
+    // asked of a SHAPE — IdentityChip's shield — and the pressable Draft chip
+    // arrives in the very same shield, so a card carrying both had two auto
+    // margins in one flex line, which splits the free space between them rather
+    // than pushing the group right.
+    expect(block(CARDS_CSS, ".task-card-head-row > .schedule-tv-id-shield"))
+      .toContain("margin-left: auto;");
+    // Everything after the first shape in the group gives its own back, so the
+    // group is chip, folder, time with the row's ordinary gap between them —
+    // the List's and the Board's seat, not a third one.
+    const rest = block(
+      CARDS_CSS,
+      ".task-card-head-row > .schedule-tv-id-shield ~ .schedule-tv-id-shield",
+    );
+    expect(rest).toContain("margin-left: 0;");
+    // The gap is the row's own and nothing adds to it.
+    expect(block(CARDS_CSS, ".task-card-head-row")).toContain("gap: 8px;");
+  });
+
+  it("wears an ON pill at rest — the folder chip's shape, in its own red", () => {
     // The only trace this filter has: there is no popover holding a count for
     // it and no entry in the Status menu, so a chip that did not show its own
     // state would leave a narrowed page unexplainable.
     expect(TASKS_CSS).toContain("button.tasks-draft-pill.is-on {");
     const on = block(TASKS_CSS, "button.tasks-draft-pill.is-on");
-    expect(on).toContain("var(--accent)");
+    // The SHAPE is the folder tag's — a wash and an inset hairline — and the
+    // HUE is this chip's own (Akshil, 2026-09-12): a red word in a blue box was
+    // two hues arguing inside one 40px chip.
+    expect(on).toContain("background: color-mix(in srgb, var(--error) 14%, transparent);");
+    expect(on).toContain(
+      "box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--error) 28%, transparent);",
+    );
+    expect(on).not.toContain("var(--accent)");
     // The same pill the outcome tag is — one shape for one kind of mark.
     expect(VIEWS).toContain('"tasks-outcome-pill tasks-draft-pill"');
     // …and inside the row's shield, so a near-miss in the row's padding opens
@@ -4408,12 +4448,19 @@ describe("the Draft chip", () => {
     // the pressable chip on the List and the Board.
     expect(pill).toContain("border: 0;");
     expect(pill).not.toContain("background:");
-    // The ON state keeps the accent wash — the filter still says it is running —
-    // and no longer repaints the word, so the chip is red whatever the page is
-    // filtered to.
+    // The ON state is a wash of the SAME red — the filter still says it is
+    // running — and it never repaints the word, so the chip is red whatever the
+    // page is filtered to. Lighter than the folder tag's 18/22 of `--accent`,
+    // because the ink standing in this fill is the fill's own hue.
     const on = block(TASKS_CSS, "button.tasks-draft-pill.is-on");
-    expect(on).toContain("var(--accent)");
+    expect(on).toContain("var(--error) 14%");
+    expect(on).toContain("var(--error) 28%");
     expect(on).not.toContain("color:");
+    // …and the hover on an ON chip is one step up of the same wash, never the
+    // accent that used to be here.
+    const onHot = block(TASKS_CSS, "button.tasks-draft-pill.is-on:hover");
+    expect(onHot).toContain("var(--error) 22%");
+    expect(onHot).not.toContain("var(--accent)");
     // …and the hover wash is still the quiet one, not a danger wash.
     expect(TASKS_CSS).toContain("background: var(--ctl-quiet-bg-hover);");
     // Both themes define the token this leans on, so the contrast is the
@@ -4446,6 +4493,131 @@ describe("the Draft chip", () => {
     // rest, hover, focus and the filter being on all read this one.
     expect(block(TASKS_CSS, "button.tasks-draft-pill.is-on")).not.toContain("color:");
     expect(block(TASKS_CSS, "button.tasks-draft-pill:hover")).not.toContain("color:");
+  });
+});
+
+// ---- the draft, as the thread's first row (Akshil, 2026-09-12) --------------
+// Expanding a task shows its messages. A task whose composer is holding unsent
+// words showed them all EXCEPT the newest thing in the conversation, which is
+// the one a reader expanded the row to find. So the thread grows one row at its
+// head: the pencil where the ring goes, the id the words would have, the words
+// quoted like every other row, and when they were typed.
+
+describe("an expanded thread leads with the draft it is carrying", () => {
+  const THREAD = (() => {
+    const at = VIEWS.indexOf('<div className="tasks-thread">');
+    expect(at).toBeGreaterThan(-1);
+    return VIEWS.slice(at, VIEWS.indexOf("{view.messages.map((m) => {", at));
+  })();
+
+  it("numbers it as the NEXT message of the thread", () => {
+    // A message id is derived — the Nth message in time order IS MSG-N
+    // (tasks_store.message_ids) — so the words that have not gone yet are
+    // `message_count + 1`, and no fetch is needed to say so.
+    expect(nextMessageId(3)).toBe("MSG-004");
+    expect(nextMessageId(0)).toBe("MSG-001");
+    // The Python's width is a MINIMUM, not a cap: a four-digit thread grows a
+    // digit rather than wrapping to a wrong id.
+    expect(nextMessageId(999)).toBe("MSG-1000");
+    // Nonsense off the wire lands on the first message rather than on `MSG-NaN`.
+    expect(nextMessageId(-4)).toBe("MSG-001");
+    expect(nextMessageId(Number.NaN)).toBe("MSG-001");
+    // Shaped exactly like the ids the server sends, which is the whole point of
+    // a second implementation of `tasks_store.format_message_id`.
+    expect(nextMessageId(11)).toMatch(/^MSG-\d{3}$/);
+    // …and it is asked of the SERVER's total, never of the three-message window
+    // this client happens to hold.
+    expect(THREAD).toContain("nextMessageId(task.message_count)");
+  });
+
+  it("draws it as a message row, with the pencil in the ring's seat", () => {
+    // Same class, same seats, same quoted body: it is about to BE a message.
+    expect(THREAD).toContain('{task.draft && (');
+    expect(THREAD).toContain('className="tasks-msg"');
+    expect(THREAD).toContain('className="tasks-msg-body"');
+    expect(THREAD).toContain('className="tasks-msg-time"');
+    // The ring's seat holds the chip's own mark instead — nothing has run, so a
+    // status ring would be the wrong glyph outright.
+    expect(THREAD).toContain('<span className="tasks-msg-pencil" aria-hidden>{ICON_PENCIL_LINE}</span>');
+    expect(THREAD).not.toContain("<StatusIcon");
+    // ONE new class, and it is sized to the ring it stands in for
+    // (schedule.css `.schedule-ring`), so the thread's column of marks holds.
+    const seat = block(TASKS_CSS, ".tasks-msg-pencil");
+    expect(seat).toContain("width: 16px;");
+    expect(seat).toContain("flex: 0 0 16px;");
+    // The chip's red, which is the page's one red — the mark on the row and the
+    // line under it are the same news.
+    expect(seat).toContain("color: var(--error);");
+  });
+
+  it("quotes the preview it was given and never fetches one", () => {
+    // `draft.preview` is already the first line, cut at 120 characters, by the
+    // server that joined it — the same string the chip captions with.
+    expect(THREAD).toContain("data-hint={task.draft.preview}");
+    expect(THREAD).toContain('{firstLine(task.draft.preview) || "(empty)"}');
+    expect(THREAD).not.toContain("fetch(");
+    // The time is the message rows' own cell and the message rows' own
+    // vocabulary; WHICH kind of time it is lives in the tooltip, exactly where
+    // `taskWhen` now keeps the same word.
+    expect(THREAD).toContain("relativeWhen(task.draft.updated_at)");
+    expect(THREAD).toContain("`Drafted ${messageStamp(task.draft.updated_at)}`");
+  });
+
+  it("guards a falsy updated_at instead of printing a blank clock", () => {
+    // `messageStamp`/`relativeWhen` both answer "" for a falsy stamp (an older
+    // store, or a record written before the field existed), and an unguarded
+    // template prints a "Drafted " tooltip with a trailing space over a blank
+    // time cell — a row with nothing where its clock should be.
+    expect(THREAD).toContain(
+      'task.draft.updated_at ? relativeWhen(task.draft.updated_at) : "Draft"');
+    expect(THREAD).toContain('task.draft.updated_at\n');
+    expect(THREAD).toContain(': "Drafted"');
+  });
+
+  it("is not a message link, and its press is the task's", () => {
+    // Every other row here addresses a turn (`msg=`); this one addresses
+    // nothing, so there is no anchor to ⌘-click into a tab and no `pressMessage`
+    // to run. What it does is what the row above it does.
+    expect(THREAD).not.toContain("tasks-rowlink");
+    expect(THREAD).not.toContain("openMessageHref");
+    expect(THREAD).not.toContain("pressMessage");
+    expect(THREAD).toContain("onClick={activate}");
+    expect(THREAD).toContain('role="button"');
+    expect(THREAD).toContain("tabIndex={0}");
+  });
+
+  it("costs the thread's arithmetic nothing", () => {
+    // It is drawn OUTSIDE `view.messages`, so the preview cap, the `hidden`
+    // count and the "Loading N more…" line — all of them arithmetic about what
+    // the SERVER holds — are untouched. A thread of three still reports three.
+    const listing = VIEWS.slice(VIEWS.indexOf("{view.messages.map((m) => {"));
+    expect(listing.slice(0, listing.indexOf("</div>"))).not.toContain("task.draft");
+    const view = threadView(
+      task({ message_count: 3, draft: { preview: "unsent", updated_at: 1 },
+             messages: [msg({}), msg({}), msg({})] }),
+    );
+    expect(view.messages).toHaveLength(3);
+    expect(view.hidden).toBe(0);
+    expect(view.more).toBe(false);
+  });
+
+  it("is never a DRAFT row's, because a draft row has no thread to head", () => {
+    // Both kinds carry `message_count: 0` (routers/tasks.py `_draft_row`,
+    // `_new_chat_draft_row`) — the session-bound task draft included, which has
+    // a session but still no messages of its own — so `isExpandable` is false
+    // and the accordion never opens. Nothing to leave out; there is no row.
+    const bound = task({
+      key: "draft:d9", kind: "draft", draft_kind: "task", state: "draft",
+      status: "upcoming", session_id: "s-9", message_count: 0, messages: [],
+      draft: { preview: "half a thought", updated_at: 1 },
+    });
+    expect(isExpandable(bound)).toBe(false);
+    const chat = task({
+      key: "new:/Users/me/news", kind: "draft", draft_kind: "chat", state: "draft",
+      status: "upcoming", message_count: 0, messages: [],
+      draft: { preview: "unsent", updated_at: 1 },
+    });
+    expect(isExpandable(chat)).toBe(false);
   });
 });
 
@@ -5218,12 +5390,17 @@ describe("the time a task row prints", () => {
     expect(soon.text).toBe("in 4d");
   });
 
-  it("says `drafted 3h ago` on a draft row, in the column's own vocabulary", () => {
+  it("says `3h ago` on a draft row, in the column's own vocabulary and no other", () => {
     // Akshil, 2026-09-12. The cell used to print the literal word "Draft", which
     // the red chip on the same row already says — so the row's last column was
     // repeating a mark and the one fact it could not state was how stale the
     // words are. Both kinds of draft ROW, because both are the same fact to a
     // reader: an unfinished New task form, and a never-sent chat.
+    //
+    // …and NOT "drafted 3h ago" either (same day, second pass): the prefix was
+    // the chip's word said twice, and it made the last column of the list ragged
+    // — every other row ends in two short units and these ended in three. Which
+    // kind of time it is stays in the tooltip, where the other rows keep it.
     const at = T("2026-08-16T09:00:00");
     const form = task({
       key: "draft:d1", kind: "draft", draft_kind: "task", state: "draft",
@@ -5240,8 +5417,11 @@ describe("the time a task row prints", () => {
       expect(when.kind).toBe("draft");
       // TIED TO THE COLUMN'S FORMATTER, not to a second one that happens to
       // agree today: the cell beside it on every other row is `relativeWhen`.
-      expect(when.text).toBe(`drafted ${relativeWhen(at, NOW)}`);
-      expect(when.text).toBe("drafted 3h ago");
+      expect(when.text).toBe(relativeWhen(at, NOW));
+      expect(when.text).toBe("3h ago");
+      // Nothing is prefixed onto the unit — it is exactly what the row beside it
+      // prints for a run.
+      expect(when.text).not.toContain("drafted");
       expect(when.title).toBe(`Drafted ${messageStamp(at)}`);
       // …and the instant it printed is the one the draft rank sorts by, so the
       // order of these rows and the times on them come off ONE number.
@@ -5260,7 +5440,8 @@ describe("the time a task row prints", () => {
     // Review, 2026-09-12. A draft is written in the past by definition — there is
     // no such thing as one typed in two minutes — but the stamp comes off the
     // machine's clock, and a clock nudged backwards (an NTP correction, a laptop
-    // waking in another timezone) put "drafted in 2m" on the row.
+    // waking in another timezone) put "in 2m" on a row nobody can have typed
+    // into yet.
     const ahead = T("2026-08-16T12:02:00"); // two minutes past NOW
     const row = task({
       key: "draft:d2", kind: "draft", draft_kind: "task", state: "draft",
@@ -5268,7 +5449,7 @@ describe("the time a task row prints", () => {
       last_active: 0,
     });
     const when = taskWhen(row, NOW);
-    expect(when.text).toBe("drafted just now");
+    expect(when.text).toBe("just now");
     expect(when.text).not.toContain(" in ");
     // The STAMP itself is untouched: `at` is what the row sorts on and what the
     // tooltip prints, and rewriting a stored fact to fix a sentence would be the
@@ -5837,7 +6018,7 @@ describe("groupByColumn", () => {
     // settled on: for rows it scores as "no time", the server's. So the List
     // ranked two drafts newest-words-first and the Board, drawing the same two,
     // did not (Akshil, 2026-09-12). Both now read `byDraftClock`, off the very
-    // number the List row prints beside them ("drafted 3h ago").
+    // number the List row prints beside them ("3h ago").
     const at = 1_700_000_000;
     const draftAt = (key: string, updated: number) =>
       task({ key, kind: "draft", draft_kind: "task", state: "draft", status: "upcoming",

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -1849,6 +1849,11 @@ const SCHEDULED = readFileSync(join(SHELL, "Scheduled.tsx"), "utf8");
 const TASKS_CSS = readFileSync(join(SHELL, "../styles/tasks.css"), "utf8");
 const SCHEDULE_CSS = readFileSync(join(SHELL, "../styles/schedule.css"), "utf8");
 const TOKENS_CSS = readFileSync(join(SHELL, "../styles/tokens.css"), "utf8");
+/** The settings page's stylesheet, read for ONE rule: `.prefs-section button`,
+ *  which skins every unarmoured button on this page too (Scheduled draws the
+ *  whole view inside a `.prefs-section`) and is the opponent several rules in
+ *  tasks.css exist to outrank. */
+const PREFS_CSS = readFileSync(join(SHELL, "../styles/preferences.css"), "utf8");
 /** The server's own shape of a task — read for the one claim that is about the
  *  MODEL surviving a change to how it is drawn. */
 const API_TYPES = readFileSync(join(SHELL, "../platform/lib/api.ts"), "utf8");
@@ -3271,7 +3276,11 @@ describe("the one-message row's missing chevron", () => {
     // DRAWN — see "the hidden row actions" — not about what it is.)
     expect(ROW).toContain("{SHOW_ROW_ACTIONS && chat && (");
     expect(ROW).toContain("openChat(chat)");
-    expect(VIEWS).toContain("const chat = folderMissing ? null : openThreadIntent(task, unread);");
+    expect(VIEWS).toContain(
+      "const chat = folderMissing || isDraftTask(task)\n"
+      + "    ? null\n"
+      + "    : openThreadIntent(task, unread);",
+    );
     expect(VIEWS).toMatch(/const openChat = \(intent: OpenThreadIntent\) => \{[\s\S]*?performOpen\(/);
     // Its own presence is decided by openThreadIntent — a session, not a message
     // count — so shortening the thread cannot take the button away.
@@ -3359,7 +3368,11 @@ describe("a row with no message at all", () => {
     expect(ACTIVATE).toContain("if (chat) openChat(chat);");
     // Not a second url and not a second performer: `chat` is the row's existing
     // openThreadIntent value and openChat is the row's existing performOpen call.
-    expect(VIEWS).toContain("const chat = folderMissing ? null : openThreadIntent(task, unread);");
+    expect(VIEWS).toContain(
+      "const chat = folderMissing || isDraftTask(task)\n"
+      + "    ? null\n"
+      + "    : openThreadIntent(task, unread);",
+    );
     expect(VIEWS).toMatch(
       /const openChat = \(intent: OpenThreadIntent\) => \{[\s\S]*?performOpen\(/,
     );
@@ -4345,14 +4358,23 @@ describe("the Draft chip", () => {
     expect(head).not.toContain("<DraftChip");
   });
 
-  it("is a control on the List and the Board, and a label on the Cards wall", () => {
-    // The filter is List + Board (design.md, Round 2). The wall draws no draft
-    // ROW at all, so a press there would turn on a filter that removes most of
-    // the wall and leaves almost nothing wearing the chip that turns it off.
+  it("is the SAME control in all three views that draw it", () => {
+    // The wall was the exception for a day — a plain label, on the reading that
+    // it draws no draft ROW so a press would empty it (CARD_LANES). Reversed
+    // (Akshil, 2026-09-12): a card's chip is never a draft row's (a card has a
+    // session by construction), it is an ordinary conversation holding unsent
+    // words, and those cards keep wearing the chip after the press. So one chip,
+    // one gesture, three views.
     expect(ROW).toContain("onPick={onPickDraft}");
     expect(CARD).toContain("<DraftChip draft={draft} onPick={onPickDraft} active={draftOn} />");
-    expect(CARDS).toContain("{draft && <DraftChip draft={draft} />}");
-    expect(CARDS).not.toContain("onPickDraft");
+    expect(CARDS).toContain("{draft && <DraftChip draft={draft} onPick={onPickDraft} active={draftOn} />}");
+    // …and the wall is handed them by the page, the way the other two are.
+    expect(SCHEDULED.slice(SCHEDULED.indexOf("<TaskCards"))).toContain("onPickDraft={pickDraft}");
+    // On the Cards wall the chip sits immediately BEFORE the folder chip, which
+    // is the seat it has on a List row and on a Board card's foot.
+    const cardsHead = CARDS.slice(CARDS.indexOf('className="task-card-head-row"'));
+    expect(cardsHead.indexOf("<DraftChip")).toBeGreaterThan(-1);
+    expect(cardsHead.indexOf("<DraftChip")).toBeLessThan(cardsHead.indexOf("<IdentityChip"));
   });
 
   it("wears the ON pill the folder chip wears, in the accent, at rest", () => {
@@ -4398,6 +4420,32 @@ describe("the Draft chip", () => {
     // palette's problem and not this chip's (tokens.css: #c62828 on light,
     // #ff6b6b on dark).
     expect(TOKENS_CSS.match(/--error: #[0-9a-f]{6};/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("and the red actually WINS, on the two views whose chip is a button", () => {
+    // The bug the rule above could not fix on its own (Akshil, 2026-09-12,
+    // screenshot of the List: a grey chip). Every view here is drawn inside
+    // `<section className="prefs-section">`, and preferences.css skins EVERY
+    // button on such a page — `color: var(--fg)` at (0,1,1) — which outranks the
+    // lone class above. The Cards wall's chip was a `<span>` and was the only one
+    // that was ever red; now that it is a button too, all three need this.
+    expect(SCHEDULED).toContain('className="prefs-section schedule-main"');
+    expect(block(PREFS_CSS, ".prefs-section button")).toContain("color: var(--fg);");
+    // The cure is the page's own idiom — name the opponent, do not lean on load
+    // order: (0,2,1) beats it outright.
+    const won = block(TASKS_CSS, ".prefs-section button.tasks-draft-pill");
+    expect(won).toContain("color: var(--error);");
+    // ...and ONE selector doing it (review, 2026-09-12). The neighbouring rules
+    // carry a `.deploy-body` twin because their controls are drawn in the modal
+    // shell too; every renderer of THIS chip is inside `Scheduled`'s
+    // `.prefs-section`, which is a page and never a modal body, so the twin
+    // matched nothing and claimed otherwise.
+    expect(TASKS_CSS).not.toContain(".deploy-body button.tasks-draft-pill");
+    // ONE declaration for every state, which is the whole reason there is no
+    // hover or `.is-on` twin of it: neither of those rules names a colour, so
+    // rest, hover, focus and the filter being on all read this one.
+    expect(block(TASKS_CSS, "button.tasks-draft-pill.is-on")).not.toContain("color:");
+    expect(block(TASKS_CSS, "button.tasks-draft-pill:hover")).not.toContain("color:");
   });
 });
 
@@ -5170,6 +5218,80 @@ describe("the time a task row prints", () => {
     expect(soon.text).toBe("in 4d");
   });
 
+  it("says `drafted 3h ago` on a draft row, in the column's own vocabulary", () => {
+    // Akshil, 2026-09-12. The cell used to print the literal word "Draft", which
+    // the red chip on the same row already says — so the row's last column was
+    // repeating a mark and the one fact it could not state was how stale the
+    // words are. Both kinds of draft ROW, because both are the same fact to a
+    // reader: an unfinished New task form, and a never-sent chat.
+    const at = T("2026-08-16T09:00:00");
+    const form = task({
+      key: "draft:d1", kind: "draft", draft_kind: "task", state: "draft",
+      status: "upcoming", form: { description: "half a thought", updated_at: at },
+      last_active: 0,
+    });
+    const chat = task({
+      key: "new:/Users/me/news", kind: "draft", draft_kind: "chat", state: "draft",
+      status: "upcoming", file: "/Users/me/news",
+      draft: { preview: "unsent", updated_at: at }, last_active: 0,
+    });
+    for (const row of [form, chat]) {
+      const when = taskWhen(row, NOW);
+      expect(when.kind).toBe("draft");
+      // TIED TO THE COLUMN'S FORMATTER, not to a second one that happens to
+      // agree today: the cell beside it on every other row is `relativeWhen`.
+      expect(when.text).toBe(`drafted ${relativeWhen(at, NOW)}`);
+      expect(when.text).toBe("drafted 3h ago");
+      expect(when.title).toBe(`Drafted ${messageStamp(at)}`);
+      // …and the instant it printed is the one the draft rank sorts by, so the
+      // order of these rows and the times on them come off ONE number.
+      expect(when.at).toBe(draftUpdatedAt(row));
+    }
+    // A SESSION ROW CARRYING A COMPOSER DRAFT IS UNTOUCHED: it has run, its own
+    // time is a real answer, and the chip is what says there are unsent words.
+    const carrying = task({
+      status: "done", draft: { preview: "one more thing", updated_at: at },
+      messages: [msg({ at: T("2026-08-16T11:00:00"), ran_at: T("2026-08-16T11:00:00") })],
+    });
+    expect(taskWhen(carrying, NOW)).toMatchObject({ kind: "last", text: "1h ago" });
+  });
+
+  it("never says a draft was written in the FUTURE, whatever the clock says", () => {
+    // Review, 2026-09-12. A draft is written in the past by definition — there is
+    // no such thing as one typed in two minutes — but the stamp comes off the
+    // machine's clock, and a clock nudged backwards (an NTP correction, a laptop
+    // waking in another timezone) put "drafted in 2m" on the row.
+    const ahead = T("2026-08-16T12:02:00"); // two minutes past NOW
+    const row = task({
+      key: "draft:d2", kind: "draft", draft_kind: "task", state: "draft",
+      status: "upcoming", form: { description: "half a thought", updated_at: ahead },
+      last_active: 0,
+    });
+    const when = taskWhen(row, NOW);
+    expect(when.text).toBe("drafted just now");
+    expect(when.text).not.toContain(" in ");
+    // The STAMP itself is untouched: `at` is what the row sorts on and what the
+    // tooltip prints, and rewriting a stored fact to fix a sentence would be the
+    // second vocabulary this column exists to avoid.
+    expect(when.at).toBe(ahead);
+    expect(when.title).toBe(`Drafted ${messageStamp(ahead)}`);
+  });
+
+  it("keeps the bare word for a draft with no clock at all", () => {
+    // Every source zero (`draftUpdatedAt` → 0). 0 through a formatter is 1970,
+    // which is the confident wrong answer the `none` arm exists to avoid, so
+    // this one keeps the old cell and says why in words.
+    const bare = task({
+      key: "draft:d0", kind: "draft", draft_kind: "task", state: "draft",
+      status: "upcoming", form: undefined, last_active: 0,
+    });
+    expect(draftUpdatedAt(bare)).toBe(0);
+    const when = taskWhen(bare, NOW);
+    expect(when).toMatchObject({ at: 0, kind: "draft", text: "Draft" });
+    expect(when.title).toBe("Not scheduled yet — an unfinished task");
+    expect(when.title).not.toContain("1970");
+  });
+
   it("says `ago` about an OVERDUE next run, because that is what it is", () => {
     // Scheduling into the past is allowed on this branch and catch-up is unbounded,
     // so an Upcoming task's next run can already have gone by. The direction comes
@@ -5529,16 +5651,19 @@ describe("the Draft filter keeps only what is unsent", () => {
     expect(hasActiveFilters({ ...EMPTY_FILTERS, draft: true })).toBe(true);
   });
 
-  it("is dropped on the two views that have no chip to turn it off", () => {
+  it("is dropped on the ONE view that has no chip to turn it off", () => {
     // Same rule as the calendar's Archive facet, and the same argument: a
     // facet with no control on the view it is acting on is a page a reader
-    // cannot explain. Neither the calendar nor the Cards wall draws a draft
-    // row (CARD_LANES), and neither offers the chip.
+    // cannot explain. The calendar draws chips for scheduled runs and no draft
+    // anywhere, so it is the one.
     const f = { ...EMPTY_FILTERS, draft: true };
     expect(filtersForView(f, "calendar").draft).toBe(false);
-    expect(filtersForView(f, "cards").draft).toBe(false);
     expect(filtersForView(f, "list")).toBe(f);
     expect(filtersForView(f, "board")).toBe(f);
+    // The Cards wall was the second until 2026-09-12: its head row now draws the
+    // same pressable chip, so the facet has a control there and passes through
+    // untouched — the same object, not a copy, like the other two.
+    expect(filtersForView(f, "cards")).toBe(f);
   });
 
   it("is IGNORED on those views, never cleared — the chip is still on when you come back", () => {
@@ -5704,6 +5829,30 @@ describe("groupByColumn", () => {
     ];
     expect(groupByColumn(rows, (at + 100) * 1000).get("blocked")!.map((t) => t.key))
       .toEqual(["parked-draft", "parked", "broke-draft", "broke-new"]);
+  });
+
+  it("orders the drafts at the head of Upcoming by their own clock, as the List does", () => {
+    // Drafts draw inside Upcoming (laneOf — no seventh lane), and the partition
+    // that puts them at its head left them in whatever order the lane's sort had
+    // settled on: for rows it scores as "no time", the server's. So the List
+    // ranked two drafts newest-words-first and the Board, drawing the same two,
+    // did not (Akshil, 2026-09-12). Both now read `byDraftClock`, off the very
+    // number the List row prints beside them ("drafted 3h ago").
+    const at = 1_700_000_000;
+    const draftAt = (key: string, updated: number) =>
+      task({ key, kind: "draft", draft_kind: "task", state: "draft", status: "upcoming",
+             form: { description: "half a thought", updated_at: updated }, last_active: 0 });
+    const rows = [
+      task({ key: "soon", status: "upcoming", next_run: at + 60,
+             messages: [msg({ state: "pending", ran_at: 0, at: at + 60 })] }),
+      draftAt("older", at - 900),
+      draftAt("newer", at - 10),
+    ];
+    const lane = groupByColumn(rows, at * 1000).get("upcoming")!;
+    expect(lane.map((t) => t.key)).toEqual(["newer", "older", "soon"]);
+    // …and it is the List's own answer again, not a second opinion about it:
+    // the draft rank comes first in LIST_ORDER, so the two sequences coincide.
+    expect(lane.map((t) => t.key)).toEqual(sortForList(rows, at * 1000).map((t) => t.key));
   });
 });
 
@@ -8081,7 +8230,11 @@ describe("the Cards view's frame", () => {
     // ONE detection path for three views: Cards read the page's `missing` set
     // (review, #1023) and keep no folder-gone state of their own.
     expect(CARDS).not.toContain("chatFolderMissing");
-    expect(SCHEDULED).toContain("pinnedProjects={filters.projects}\n              missing={missing}");
+    // …and the wall reads it too. Sliced to the `<TaskCards>` element rather
+    // than matched as an adjacent pair of lines, which is what this was until
+    // the two Draft-chip props moved in between them (2026-09-12).
+    const wall = SCHEDULED.slice(SCHEDULED.indexOf("<TaskCards"));
+    expect(wall.slice(0, wall.indexOf("/>"))).toContain("missing={missing}");
     expect(CARDS.split("folderMissing={missing?.has(taskFolder(peekLive)) ?? false}").length).toBe(2);
     expect(CARDS.split("folderMissing={missing?.has(taskFolder(task)) ?? false}").length).toBe(2);
     expect(HOOK).toContain(

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -4553,7 +4553,7 @@ describe("an expanded thread leads with the draft it is carrying", () => {
   it("quotes the preview it was given and never fetches one", () => {
     // `draft.preview` is already the first line, cut at 120 characters, by the
     // server that joined it — the same string the chip captions with.
-    expect(THREAD).toContain("data-hint={task.draft.preview}");
+    expect(THREAD).toContain("draftIsForm ? \"Draft task — open to continue\" : task.draft.preview");
     expect(THREAD).toContain('{firstLine(task.draft.preview) || "(empty)"}');
     expect(THREAD).not.toContain("fetch(");
     // The time is the message rows' own cell and the message rows' own
@@ -4574,16 +4574,41 @@ describe("an expanded thread leads with the draft it is carrying", () => {
     expect(THREAD).toContain(': "Drafted"');
   });
 
-  it("is not a message link, and its press is the task's", () => {
+  it("is not a message link, and its press goes where the words are", () => {
     // Every other row here addresses a turn (`msg=`); this one addresses
     // nothing, so there is no anchor to ⌘-click into a tab and no `pressMessage`
-    // to run. What it does is what the row above it does.
+    // to run.
     expect(THREAD).not.toContain("tasks-rowlink");
     expect(THREAD).not.toContain("openMessageHref");
     expect(THREAD).not.toContain("pressMessage");
-    expect(THREAD).toContain("onClick={activate}");
+    expect(THREAD).toContain("onClick={pressDraftLine}");
     expect(THREAD).toContain('role="button"');
     expect(THREAD).toContain("tabIndex={0}");
+  });
+
+  it("sends a FORM draft to the card and a CHAT draft to the chat", () => {
+    // The line quotes the reader's own unsent sentence, and pressing your own
+    // sentence has to land where it is. Since the bound form arrived, those
+    // words are sometimes in a New task card and the chat holds nothing of them
+    // — the old press showed them on a row and then opened an empty composer
+    // (Bugbot, PR #1126). The server says which (`draft.kind`), and absent
+    // means "chat", which is what every joined draft was before.
+    expect(VIEWS).toContain('const draftIsForm = task.draft?.kind === "form";');
+    expect(VIEWS).toContain("if (draftIsForm && onOpenBoundDraft) onOpenBoundDraft(task);");
+    expect(VIEWS).toContain("else activate();");
+    // …and the tooltip says what the press will do, rather than repeating the
+    // line it is already printing.
+    expect(THREAD).toContain('"Draft task — open to continue"');
+    // The callback is threaded from the page exactly as `onOpenDraft` is: one
+    // handler, passed down, and a list that omits it keeps the old press.
+    expect(VIEWS).toContain("onOpenBoundDraft?: (task: Task) => void;");
+    expect(VIEWS).toContain("onOpenBoundDraft={onOpenBoundDraft}");
+    const page = readFileSync(join(SHELL, "Scheduled.tsx"), "utf8");
+    expect(page).toContain("onOpenBoundDraft={openBoundDraft}");
+    // …and the handler is the composer's own hop door, so there is one lookup
+    // and one seeding rule for the bound form, not two.
+    expect(page).toContain("const openBoundDraft = (task: Task) => {");
+    expect(page).toContain("boundDraftSeed(all.task, session, null)");
   });
 
   it("costs the thread's arithmetic nothing", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -4536,6 +4536,25 @@ describe("a never-sent chat opens the New task modal, like every other draft", (
       .toBeLessThan(ARM.indexOf("openForm("));
   });
 
+  it("drops a fetch that a later press has overtaken", () => {
+    // Because it fetches first, this is the one opening that can arrive LATE
+    // (Bugbot on PR #1126, 2026-09-12): a second press used to be painted over
+    // when the first fetch resolved. The click's generation is taken before
+    // the fetch and compared before the open; every door (`openForm`) bumps
+    // it, so an in-flight answer for an older press is abandoned.
+    expect(ARM).toContain("const gen = ++chatDraftGen.current;");
+    expect(ARM).toContain("if (gen !== chatDraftGen.current) return;");
+    expect(ARM.indexOf("const gen = ++chatDraftGen.current;"))
+      .toBeLessThan(ARM.indexOf("fetchChatDraft(task.key)"));
+    expect(ARM.indexOf("if (gen !== chatDraftGen.current) return;"))
+      .toBeLessThan(ARM.indexOf("openForm("));
+    const door = SCHEDULED.slice(
+      SCHEDULED.indexOf("const openForm = ("),
+      SCHEDULED.indexOf("const [draftRow, setDraftRow]"),
+    );
+    expect(door).toContain("chatDraftGen.current++;");
+  });
+
   it("is the Scheduled page's first question about a draft row's press", () => {
     // A chat draft has no form to re-open and no `draft_id` to fall through to,
     // so the hop arm has to be asked before the stored-form arm.

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -426,12 +426,19 @@ export function isDraftTask(task: Pick<Task, "kind">): boolean {
  *
  * A chat draft row is a conversation with words in it that nobody has sent, in
  * a folder whose chat has no session yet — so unlike a task draft it has no
- * form to re-open and no `draft_id`, and its press is a NAVIGATION rather than
- * a modal (schedule-lib.chatDraftHref).
+ * form to re-open and no `draft_id`.
+ *
+ * BOTH KINDS OPEN THE SAME DOOR, which is the whole of the rule (Akshil,
+ * 2026-09-12): a row with no session is a draft and opens the New task modal; a
+ * row with a session opens its chat. So this predicate no longer decides
+ * WHETHER the modal opens — it decides what the modal is seeded FROM, because a
+ * chat draft has no stored form and its words have to be carried in as a hop,
+ * exactly as the composer's own Schedule button carries them
+ * (Scheduled.openDraft).
  *
  * Read as "is it explicitly the chat kind", so a server that predates the
- * second kind — every draft row there is a task draft — answers no and the old
- * press survives untouched (Akshil, 2026-09-11).
+ * second kind — every draft row there is a task draft — answers no and falls
+ * through to the stored-form arm it has always used (Akshil, 2026-09-11).
  */
 export function isChatDraftTask(task: Pick<Task, "kind" | "draft_kind">): boolean {
   return isDraftTask(task) && task.draft_kind === "chat";
@@ -497,6 +504,14 @@ export const DRAFT_CHIP = "Draft";
  * being told the same thing either way — there are words here nobody has sent.
  * What differs is only whose words they are, and that is what the tooltip says.
  * Null when the row has neither, which is almost every row.
+ *
+ * ONE WORD, TOO, and that is the settled answer (Akshil, 2026-09-12). A second
+ * label — "Draft reply" for the composer's words — was tried for a day, to warn
+ * that the two kinds opened in two different places. The wording was never the
+ * fix for that; the PRESS was. A row with no session is a draft and opens the
+ * New task modal, a row with a session opens its chat, and the rule is the
+ * row's own rather than something the chip has to whisper (see `isDraftTask`,
+ * and Scheduled.openDraft where it is spent).
  *
  * It is an `OutcomeTag` so it is drawn by the pill the row already has
  * (ScheduleTaskViews.DraftChip wraps `.tasks-outcome-pill` — muted, currentColor
@@ -2900,7 +2915,26 @@ export function groupByColumn(
   // the bucket a card lands in is the column the reader will look for it under.
   for (const task of tasks) map.get(laneOf(taskColumn(task)))?.push(task);
   for (const col of BOARD_LANES) {
-    map.set(col.key, sortLane(map.get(col.key)!, col.key, now));
+    // …then DRAFTS FIRST inside the lane, the List's own extra pass
+    // (`hoistDrafts`, which `sortForList` makes) — and it is a BUG FIX, not a
+    // preference (Akshil, 2026-09-12: a Done card with a chat draft showed no
+    // chip while the List row showed one).
+    //
+    // The lane is sorted by the time the card PRINTS — the last run — and a
+    // draft's own clock is not that time, so a task whose composer is holding
+    // unsent words but whose last run was yesterday sat wherever yesterday
+    // sorts: rank 64 of a 416-card Done lane, on a board that draws the first
+    // twenty (ScheduleTaskViews LANE_INITIAL_VISIBLE). The chip rendered
+    // perfectly; the card was never drawn. The List had already cured this in
+    // itself, and the cure was exactly this partition — so the Board takes the
+    // same one rather than a cap of its own or a rule about which lane is
+    // special.
+    //
+    // A STABLE partition, so both halves keep the lane's recency and no card
+    // moves for any other reason; and BEFORE the two partitions below, which is
+    // what lets them stay the outer order (waiting still outranks a draft in
+    // Blocked) while the hoist survives inside each of their halves.
+    map.set(col.key, hoistDrafts(sortLane(map.get(col.key)!, col.key, now)));
   }
   // WAITING FIRST, inside the one lane that holds two statuses. The lane's own
   // order (last run, descending) says nothing about which of its cards somebody
@@ -3198,7 +3232,11 @@ export function sortForList(tasks: Task[], now: number = Date.now()): Task[] {
   });
 }
 
-/** One lane, drafts first, everything in the order `sortRank` gave it. */
+/** One lane, drafts first, everything in the order it arrived in. Used by the
+ *  List (`sortForList`) and by the Board (`groupByColumn`), which is the point:
+ *  a row carrying unsent words is at the top of its lane in both views, so it is
+ *  inside the twenty cards a Board lane draws rather than buried at the depth
+ *  its last run happens to sort to. */
 function hoistDrafts(lane: Task[]): Task[] {
   const drafts: Task[] = [];
   const rest: Task[] = [];
@@ -3219,21 +3257,30 @@ function byDraftClock(lane: Task[]): Task[] {
 // in at the same time"). It is not another arrangement of the same rows — each
 // card shows the task's live conversation rather than a title and a time.
 //
-// EVERY TASK, EVERY STATUS (Akshil, 2026-09-05, later the same day: "show all
-// status tasks in cards even archived ones"). The wall began as the running set
-// alone, grew to every lane but Archive that morning, and now draws Archive too:
-// an archived conversation is still a conversation worth a glance, and the
-// Status filter — not the view — is where a reader narrows the wall. So the
-// membership test is the List's own rank order, whole, and the RANK is the
-// List's too: which lane comes first is written down exactly once (LIST_ORDER)
-// and this view reads it rather than keeping a second table in step. Needs
-// attention at the top, because a parked run is the one card that needs a
-// person; Archive at the bottom, under Done.
+// EVERY CONVERSATION, EVERY STATUS (Akshil, 2026-09-05, later the same day:
+// "show all status tasks in cards even archived ones"). The wall began as the
+// running set alone, grew to every lane but Archive that morning, and now draws
+// Archive too: an archived conversation is still a conversation worth a glance,
+// and the Status filter — not the view — is where a reader narrows the wall.
 //
-// And the ORDER inside a lane is the List's too — sortByLane, the same call
+// A CONVERSATION, though, and not a row (Akshil, 2026-09-12: "only in cards we
+// don't show tasks that don't have sessions because we have no history or
+// transcript of claude chat to show"). Every other view draws a line of text
+// about a task and can draw one for a task that has never run; this view draws
+// the task's CHAT, and a card with no session has nothing behind its frame. So
+// the membership test is the row's own `session_id`, which is the one fact that
+// answers it, and the RANK is the List's: which lane comes first is written
+// down exactly once (LIST_ORDER) and this view reads it rather than keeping a
+// second table in step. Needs attention at the top, because a parked run is the
+// one card that needs a person; Archive at the bottom, under Done.
+//
+// And the ORDER inside a lane is the List's too — sortForList, the same call
 // (Akshil, 2026-09-08: "for list as a reference in order the cards"). This view
 // once kept a clock of its own there (`started`) and its cards read out of order
-// against the times printed on their own heads; see cardsForTasks, below.
+// against the times printed on their own heads; then it read `sortByLane`, the
+// List's rank WITHOUT the List's drafts-first pass, and a card holding unsent
+// words sat at the depth its last run sorted to — off the first page entirely.
+// See cardsForTasks, below.
 //
 // So the only decisions it makes — membership, dedupe, the page — are here, out
 // of the component, because they are the ones worth testing and a grid of
@@ -3242,12 +3289,20 @@ function byDraftClock(lane: Task[]): Task[] {
 /** The lanes a Cards view draws, top rank first — LIST_ORDER, whole. Kept as
  * its own name so the view's membership test reads as a decision, not a
  * coincidence of the List's table. */
-/** …minus drafts, which the wall does not draw at all (design.md, Decisions:
- *  List and Board only). Derived from LIST_ORDER rather than written out again,
- *  so the wall still cannot fall out of step with the List's rank order — the
- *  one thing it deliberately does not share is the one row that has no
- *  conversation to show. */
-export const CARD_LANES: BoardColumn[] = LIST_ORDER.filter((k) => k !== "draft");
+/** …minus the two lanes with no conversation on file. Derived from LIST_ORDER
+ *  rather than written out again, so the wall still cannot fall out of step with
+ *  the List's rank order — the only thing it deliberately does not share is
+ *  WHICH rows it draws.
+ *
+ *  `draft` (design.md, Decisions: List and Board only) and `upcoming` (Akshil,
+ *  2026-09-10, E2E R1) are both the same absence stated per lane, and
+ *  `cardsForTasks` now states it per ROW as well — "does it have a session" —
+ *  which is the fact underneath both (Akshil, 2026-09-12: "only in cards we
+ *  don't show tasks that don't have sessions because we have no history or
+ *  transcript of claude chat to show"). */
+export const CARD_LANES: BoardColumn[] = LIST_ORDER.filter(
+  (k) => k !== "draft" && k !== "upcoming",
+);
 
 /**
  * HOW MANY LIVE CHATS PER PAGE. Each card is an iframe running the chat template,
@@ -3436,12 +3491,18 @@ export function cardKey(task: Pick<Task, "key" | "task_id" | "project">): string
  * the bottom of Done here. Switching views reshuffled the lane, which is the one
  * thing the shared LIST_ORDER was there to prevent.
  *
- * So the order is `sortByLane`, the very function the List calls: rank by
- * LIST_ORDER, and inside a rank by the time the row prints — last run, most
- * recent first; Upcoming by the run ahead, soonest first, overdue at the top;
+ * So the order is `sortForList`, the very function the List calls: rank by
+ * LIST_ORDER, then the rows carrying unsent words first inside their lane, and
+ * inside each half the time the row prints — last run, most recent first;
  * Archive as the server lists it; a row with no time at all last in its rank.
  * Same rows, same order, in both views, and a card's place on the wall is the
  * place a reader can check against the stamp on its own head.
+ *
+ * THE DRAFTS-FIRST PASS IS PART OF IT (Akshil, 2026-09-12), not a detail of the
+ * List: the wall shows six cards and a Done lane can be four hundred long, so a
+ * task whose composer is holding a half-written reply was on page eleven if its
+ * last run was a day old — which is to say, gone. The row the reader is most
+ * likely to be looking for is the one they were in the middle of writing.
  *
  * WHY `started` WAS HERE, AND WHY THE LIST'S KEY IS SAFE TOO. The wall first ran
  * by `last_active`, which climbs on every write and reaches this page within a
@@ -3482,16 +3543,24 @@ export function cardsForTasks(
 ): TaskCardSet {
   const seen = new Set<string>();
   const all: Task[] = [];
-  for (const task of sortByLane(tasks, now)) {
-    // NOT YET DUE IS NOT A CARD (Akshil, 2026-09-10, E2E R1): an upcoming
-    // task has no chat to show, so its tile was a sentence in a frame — the
-    // Calendar and the List are where a future run is read. The wall shows
-    // work that has happened or is happening.
-    // …and that already excludes DRAFTS, which the server sends as `upcoming`.
-    // Said again anyway, by name: the wall's membership must not depend on a
-    // coincidence between two fields (design.md, Decisions: List and Board
-    // only, never Cards or Calendar).
-    if (task.status === "upcoming" || isDraftTask(task)) continue;
+  for (const task of sortForList(tasks, now)) {
+    // A CARD IS A TRANSCRIPT, so a row with no session is not a card (Akshil,
+    // 2026-09-12: "only in cards we don't show tasks that don't have sessions
+    // because we have no history or transcript of claude chat to show"). ONE
+    // question, asked of the row itself, and it answers every membership rule
+    // this view used to keep as a list of statuses: a draft has no session, a
+    // pending run that has never started has no session, and a settled row
+    // whose child died before its first status line has none either — that last
+    // one is the card that sat on "Starting…" for a run that ended a day
+    // earlier (cardBlank, FIX-A), and it is now simply not drawn.
+    if (!task.session_id) continue;
+    // …and the lane rule on top of it, because "has a session" is not the whole
+    // of it: an upcoming row CAN carry one (a template that has run before),
+    // and a run that has not happened yet is still not what this wall is for —
+    // the Calendar and the List are where a future run is read. CARD_LANES is
+    // that rule, and asking it by name is what keeps the constant and the
+    // behaviour one decision rather than two.
+    if (!CARD_LANES.includes(taskColumn(task))) continue;
     const id = cardKey(task);
     if (seen.has(id)) continue;
     seen.add(id);

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -1117,9 +1117,52 @@ export function threadView(task: Task, loaded?: TaskMessage[]): ThreadView {
  * we hold would call a forty-message task unexpandable. It is the same number
  * threadView already trusts for "is there more?", so the chevron and the "Show N
  * more" button under it cannot disagree about how long the thread is.
+ *
+ * A DRAFT COUNTS AS A SECOND VOICE (Akshil, 2026-09-12: "if i have a single
+ * message task, and i have a draft message, let's show accordion in that one").
+ * The expanded thread leads with the composer's unsent words as a row of their
+ * own, so a one-message task holding a draft has something to reveal — the words
+ * the row's title does not show. One message and no draft stays a plain row.
  */
 export function isExpandable(task: Task): boolean {
-  return task.message_count > 1;
+  if (task.message_count > 1) return true;
+  return task.message_count === 1 && !!task.draft;
+}
+
+/** How many digits a message number is padded to — `tasks_store._MSG_WIDTH`,
+ *  which is the only place this number is decided. Named rather than typed into
+ *  the template below so the two files can be read against each other. */
+const MSG_WIDTH = 3;
+
+/**
+ * THE ID THE NEXT MESSAGE OF THIS THREAD WILL HAVE — `MSG-004` on a task of
+ * three (Akshil, 2026-09-12).
+ *
+ * The client-side half of `tasks_store.format_message_id`, and it exists for
+ * exactly one row: the DRAFT line at the head of an expanded thread
+ * (ScheduleTaskViews). That line is words nobody has sent, so it has no message
+ * and therefore no id of its own — but it stands in the column the ids stand in,
+ * and a blank there would read as a broken row the way every other hole in a
+ * column on this page does. What it can honestly say is which message these
+ * words would BE, and that is arithmetic the client is allowed to do: a message
+ * id is *derived* — the Nth message of a task in time order IS MSG-N
+ * (tasks_store.message_ids says so, and stores nothing) — so the next one is
+ * `count + 1` and nothing has to be asked of the server.
+ *
+ * `count` is `task.message_count`, the SERVER's total, and never the tail this
+ * client happens to hold: the listing sends a three-message window, so counting
+ * what is in hand would number the draft of a forty-message task `MSG-004`.
+ *
+ * A count of zero (or a negative one, or a number that is not one) gives
+ * `MSG-001`, which is the truth for a thread with nothing in it — the first
+ * thing sent there will be its first message. Past 999 the number simply grows a
+ * digit, exactly as the Python does: the width is a MINIMUM, not a cap, and
+ * silently wrapping a four-digit thread back to `MSG-000` would be a wrong id
+ * rather than a wide one.
+ */
+export function nextMessageId(count: number): string {
+  const n = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+  return `MSG-${String(n + 1).padStart(MSG_WIDTH, "0")}`;
 }
 
 /**
@@ -2781,7 +2824,7 @@ export interface TaskWhen {
  */
 export function taskWhen(task: Task, now: number = Date.now()): TaskWhen {
   // A DRAFT PRINTS WHEN IT WAS LAST TYPED IN (Akshil, 2026-09-12: "drafted 3h
-  // ago"). It used to print the literal word "Draft", on the argument that a
+  // ago" — the word itself dropped later the same day, see below). It used to print the literal word "Draft", on the argument that a
   // draft has none of the three times this function knows — no run ahead, no run
   // behind, no session activity — and the honest cell was the one fact it did
   // have. That was a true sentence in the wrong column: the chip on the same row
@@ -2797,8 +2840,16 @@ export function taskWhen(task: Task, now: number = Date.now()): TaskWhen {
   // AND THE COLUMN'S OWN FORMATTER, `relativeWhen`, not a second one: the cell
   // beside it on every other row reads "5h ago", and a draft that spoke a
   // different dialect of the same fact would be two vocabularies in one column.
-  // The word "drafted" is the only thing added, and it is what stops the unit
-  // being read as a run — this row has never run.
+  //
+  // NOTHING IS ADDED TO IT EITHER (Akshil, 2026-09-12, second pass). The cell
+  // said "drafted 5h ago" for a day, on the argument that the word is what stops
+  // the unit being read as a run. The red `Draft` chip on the same row already
+  // says it — in a word and a pencil, four hundred pixels to the left — so the
+  // prefix was the second statement of one fact, and it was the one that made
+  // the last column of the list ragged: every other row ends in two short units
+  // and these ended in three. The unit alone is the column's vocabulary, and
+  // WHICH kind of time it is stays where the other rows keep it, in the tooltip
+  // ("Drafted <absolute>").
   //
   // A draft with NO clock at all (every source zero — `draftUpdatedAt` returns 0)
   // keeps the old cell. Not a fallback so much as the same care `none` takes: 0
@@ -2822,14 +2873,15 @@ export function taskWhen(task: Task, now: number = Date.now()): TaskWhen {
       // in two minutes — but the stamp comes off the machine's clock and
       // `relativeWhen` reads a future number as "in 2m", so a clock nudged
       // backwards (an NTP correction, a laptop waking in another timezone) put
-      // "drafted in 2m" on the row. Pinning the argument at `now` degrades that
-      // to "drafted just now", which is both true and unremarkable. `at` itself
+      // "in 2m" on a row nobody can have typed into yet. Pinning the argument at
+      // `now` degrades that to "just now", which is both true and
+      // unremarkable. `at` itself
       // is NOT clamped: it is what the row sorts on and what the tooltip prints,
       // and rewriting the stored fact to fix a sentence would be a second
       // vocabulary again. `now / 1000` because this function's `now` is in
       // MILLISECONDS (it is `Date.now()`) and every stamp it handles is in
       // seconds — `relativeWhen` does the same division on the way in.
-      text: `drafted ${relativeWhen(Math.min(at, now / 1000), now)}`,
+      text: relativeWhen(Math.min(at, now / 1000), now),
       title: `Drafted ${messageStamp(at)}`,
     };
   }
@@ -3004,7 +3056,7 @@ export function groupByColumn(
   // and for rows it scores as "no time" that is the server's order: so the List
   // ranked two drafts newest-words-first and the Board, drawing the same two,
   // did not. Neither view shows a draft's clock as ink on a card, but both now
-  // print it on the List row beside them (`taskWhen`: "drafted 3h ago"), and one
+  // print it on the List row beside them (`taskWhen`: "3h ago"), and one
   // order for one number is the whole of why this reads the same function rather
   // than sorting here.
   const upcoming = map.get("upcoming");

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2408,16 +2408,19 @@ export function hasActiveFilters(f: TaskFilters): boolean {
 // facet was ignored, never cleared.
 //
 // THE DRAFT FACET IS SCOPED THE SAME WAY, and for the identical argument
-// (Akshil, 2026-09-11). Its only control is the chip on a List row or a Board
-// card, so it can only ever be turned ON from those two views — and neither the
-// Calendar nor the Cards wall draws a draft row at all (CARD_LANES; the
-// calendar's own note), so on those two it is a facet with no control and
-// almost nothing to keep. Ignored there rather than cleared, exactly like
-// Archive: a reader who filters the List to drafts, glances at the calendar and
-// comes back finds the chip still on.
+// (Akshil, 2026-09-11). Its control is the chip on a row or a card, so the
+// question is only ever "does THIS view draw one?" — and the calendar draws
+// chips for scheduled runs and no draft anywhere, so there it is a facet with
+// no control: ignored, exactly like Archive, rather than cleared.
+//
+// THE CARDS WALL IS NO LONGER ONE OF THEM (Akshil, 2026-09-12). It was, on the
+// reading that the wall draws no draft ROW (CARD_LANES) — true, and beside the
+// point: a card's head carries the chip whenever the task's composer is holding
+// unsent words, and that chip is now the same pressable tag the List and the
+// Board draw (TaskCards → DraftChip). So the wall has a control, the facet has
+// something to keep, and the one view left dropping it is the calendar.
 export function filtersForView(f: TaskFilters, view: TaskView): TaskFilters {
-  const drops = view === "calendar" || view === "cards";
-  const draft = drops && f.draft;
+  const draft = view === "calendar" && f.draft;
   const archived = view === "calendar" && f.statuses.includes("archived");
   if (!draft && !archived) return f;
   return {
@@ -2714,8 +2717,9 @@ export type TaskWhenKind = "next" | "last" | "active" | "none" | "draft";
 export const NO_TIME = "—";
 
 export interface TaskWhen {
-  /** The instant, epoch seconds. 0 on `none`, which is the one kind that names no
-   * instant at all — and is why nothing may format this without checking. */
+  /** The instant, epoch seconds. 0 on `none` — and on the one `draft` that has no
+   * clock of any kind either — which is why nothing may format this without
+   * checking: 0 through a formatter is 1970. */
   at: number;
   /** Which time it is — the row prints it, the tooltip says which. */
   kind: TaskWhenKind;
@@ -2776,18 +2780,57 @@ export interface TaskWhen {
  * zero to a formatter, which is why `none` is a KIND rather than a stamp.
  */
 export function taskWhen(task: Task, now: number = Date.now()): TaskWhen {
-  // A DRAFT PRINTS THE WORD "Draft" IN THE TIME COLUMN (design.md: "the 'when'
-  // column reads Draft"). Every other answer this function can give is a
-  // timestamp, and a draft has none of the three — no run ahead, no run behind,
-  // no session activity — so the honest cell is the one fact it does have: this
-  // is not scheduled yet. `at` stays 0 and the kind says so, for `none`'s
-  // reason: 0 formats as 1970, so nothing may hand this to a formatter.
+  // A DRAFT PRINTS WHEN IT WAS LAST TYPED IN (Akshil, 2026-09-12: "drafted 3h
+  // ago"). It used to print the literal word "Draft", on the argument that a
+  // draft has none of the three times this function knows — no run ahead, no run
+  // behind, no session activity — and the honest cell was the one fact it did
+  // have. That was a true sentence in the wrong column: the chip on the same row
+  // ALREADY says "Draft", in red, with a pencil, so the time column was spending
+  // the row's last cell repeating it, and the one thing the row could not say was
+  // how stale the words are. A draft nobody has touched in a week and one typed a
+  // minute ago read identically.
+  //
+  // The clock is `draftUpdatedAt` — the same three sources, most specific first,
+  // that the draft rank sorts by (`byDraftClock`), so the order of these rows and
+  // the times printed on them come off one number rather than two.
+  //
+  // AND THE COLUMN'S OWN FORMATTER, `relativeWhen`, not a second one: the cell
+  // beside it on every other row reads "5h ago", and a draft that spoke a
+  // different dialect of the same fact would be two vocabularies in one column.
+  // The word "drafted" is the only thing added, and it is what stops the unit
+  // being read as a run — this row has never run.
+  //
+  // A draft with NO clock at all (every source zero — `draftUpdatedAt` returns 0)
+  // keeps the old cell. Not a fallback so much as the same care `none` takes: 0
+  // formats as 1970, so nothing may hand this to a formatter, and `at` stays 0
+  // with the kind saying why.
   if (isDraftTask(task)) {
+    const at = draftUpdatedAt(task);
+    if (!at) {
+      return {
+        at: 0,
+        kind: "draft",
+        text: "Draft",
+        title: "Not scheduled yet — an unfinished task",
+      };
+    }
     return {
-      at: 0,
+      at,
       kind: "draft",
-      text: "Draft",
-      title: "Not scheduled yet — an unfinished task",
+      // CLAMPED TO NOW for the phrasing only (review, 2026-09-12). A draft is
+      // written in the past by definition — there is no such thing as one typed
+      // in two minutes — but the stamp comes off the machine's clock and
+      // `relativeWhen` reads a future number as "in 2m", so a clock nudged
+      // backwards (an NTP correction, a laptop waking in another timezone) put
+      // "drafted in 2m" on the row. Pinning the argument at `now` degrades that
+      // to "drafted just now", which is both true and unremarkable. `at` itself
+      // is NOT clamped: it is what the row sorts on and what the tooltip prints,
+      // and rewriting the stored fact to fix a sentence would be a second
+      // vocabulary again. `now / 1000` because this function's `now` is in
+      // MILLISECONDS (it is `Date.now()`) and every stamp it handles is in
+      // seconds — `relativeWhen` does the same division on the way in.
+      text: `drafted ${relativeWhen(Math.min(at, now / 1000), now)}`,
+      title: `Drafted ${messageStamp(at)}`,
     };
   }
   const nextFirst = LANE_SORTS[taskColumn(task)].key === "next-run";
@@ -2954,10 +2997,20 @@ export function groupByColumn(
   // run and a draft has no run to be ordered by, so without this it would land
   // wherever "no time" happens to sort. An unfinished task is the most upcoming
   // thing there is (design.md, Decisions, Akshil 2026-09-11).
+  //
+  // …AND AMONG THEMSELVES BY THEIR OWN CLOCK (Akshil, 2026-09-12), which is
+  // `byDraftClock` — the very call the List's draft rank makes (`sortForList`).
+  // The partition alone left them in whatever order `sortLane` had settled on,
+  // and for rows it scores as "no time" that is the server's order: so the List
+  // ranked two drafts newest-words-first and the Board, drawing the same two,
+  // did not. Neither view shows a draft's clock as ink on a card, but both now
+  // print it on the List row beside them (`taskWhen`: "drafted 3h ago"), and one
+  // order for one number is the whole of why this reads the same function rather
+  // than sorting here.
   const upcoming = map.get("upcoming");
   if (upcoming && upcoming.length > 1) {
     map.set("upcoming", [
-      ...upcoming.filter((t) => isDraftTask(t)),
+      ...byDraftClock(upcoming.filter((t) => isDraftTask(t))),
       ...upcoming.filter((t) => !isDraftTask(t)),
     ]);
   }

--- a/frontend/src/styles/task-cards.css
+++ b/frontend/src/styles/task-cards.css
@@ -187,6 +187,26 @@
   margin-left: auto;
 }
 
+/* …AND ONLY THE FIRST OF THEM TAKES IT (Akshil, 2026-09-12, screenshot: the
+   Draft chip floating in the middle of the head row). The rule above names a
+   SHAPE, not a seat, and the Draft chip arrives in the very same shield — so a
+   card carrying both had two `auto` margins in one flex line, which is not "push
+   the group right" but "split the free space between them", and the chip landed
+   halfway across the row with a hole on either side.
+
+   The group is chip, folder, time, in that order, and the seat rule is the
+   List's and the Board's: the chip sits immediately LEFT of the folder with the
+   row's ordinary gap between them (design-principles §1 — a mark that moved
+   between views would be three marks to learn). So the free space is spent ONCE,
+   at the head of the group, and every shape after a shield gives its own auto
+   margin back. Written as a sibling combinator rather than by naming the draft
+   chip, because the fact being stated is about the SECOND member of the group,
+   whatever it turns out to be. */
+.task-card-head-row > .schedule-tv-id-shield ~ .schedule-tv-id-shield,
+.task-card-head-row > .schedule-tv-id-shield ~ .schedule-tv-id {
+  margin-left: 0;
+}
+
 /* CENTRED ON THE ROW'S OWN LINE. The List row pays for the tag's 3px of padding
    with `margin-block: -3px` and lets the shield stretch to the row's height,
    which is right in a 36px row and wrong here: this row is one text line tall,

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -1474,6 +1474,35 @@ button.tasks-caret,
    third mark, and nothing on this page acts on the distinction — the row's words
    and its time say it anyway. */
 
+/* THE DRAFT LINE'S SEAT, where a message row keeps its status ring
+   (ScheduleTaskViews, the thread's first row when the task carries unsent
+   words — Akshil, 2026-09-12). The one new class this row needs: everything
+   else about it is a message row's, because everything else about it is a
+   message.
+
+   It is sized to `.schedule-ring` and NOT to the glyph inside it — 16px square,
+   `flex: 0 0 16px`, the ring's own box (schedule.css) — because the column of
+   rings running down an expanded thread is the thing this row must not break.
+   The pencil is 11px (ICON_PENCIL_LINE, drawn a step under the row's other
+   marks), so it is centred in the ring's slot rather than filling it, and the
+   ids beside it stay in one line.
+
+   `--error`, which is the chip's colour on the row above and the page's one red
+   (tokens.css): the mark in the thread and the mark on the row are the same
+   news, and a reader who has learned the red pencil once has learned it here.
+   `line-height: 0` for the outcome pill's reason — an inline SVG sits on the
+   text baseline and would otherwise carry the line box's descender with it. */
+.tasks-msg-pencil {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  line-height: 0;
+  color: var(--error);
+}
+
 .tasks-msg-body {
   min-width: 0;
   color: var(--fg);
@@ -1924,15 +1953,32 @@ button.tasks-draft-pill:focus-visible {
 /* …and the WORD STAYS RED under it (Akshil, 2026-09-12): the fill says the
    filter is running, the colour says what the chip is, and they are two
    different facts. Nothing sets `color` here now — the red above carries
-   through — which is also why the fill is a wash rather than a solid accent. */
+   through — which is also why the fill is a wash rather than a solid accent.
+
+   AND THE WASH IS THE WORD'S OWN RED, not the accent (Akshil, 2026-09-12,
+   second pass). The accent fill was borrowed from the folder tag, which is the
+   right instinct for the SHAPE and the wrong one for the colour: a red word
+   sitting in a blue box is two hues arguing inside one 40px chip, and the ON
+   state read as a different control rather than as this one, pressed. A light
+   red — the same `--error` the ink is, at a wash's strength — says the same
+   thing in the chip's own voice, which is what the folder tag's accent fill
+   does for the folder tag.
+
+   14% and a 28% hairline, both of `--error`: deliberately lighter than the
+   folder's 18/22 of `--accent`, because the ink standing IN this fill is the
+   same hue as the fill, and a heavier wash starts eating the word. Checked on
+   both grounds (tokens.css: `--error` is #c62828 on light, #ff6b6b on dark, and
+   both washes sit a step off `--bg` rather than near it). The hairline is what
+   gives the wash an edge on the dark theme, where 14% of a light red over a
+   dark ground is nearly nothing on its own. */
 button.tasks-draft-pill.is-on {
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
+  background: color-mix(in srgb, var(--error) 14%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--error) 28%, transparent);
 }
 
 button.tasks-draft-pill.is-on:hover,
 button.tasks-draft-pill.is-on:focus-visible {
-  background: color-mix(in srgb, var(--accent) 26%, transparent);
+  background: color-mix(in srgb, var(--error) 22%, transparent);
 }
 
 /* -- dropping ONE filter, from the control that set it (D448) -----------------

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -1868,6 +1868,44 @@ button.tasks-draft-pill {
   transition: background-color 120ms ease;
 }
 
+/* …AND THE RED HAS TO BE SAID ON THE BUTTON (Akshil, 2026-09-12, screenshot of
+   the List: the chip came out in the page's plain foreground, not the error
+   colour). The declaration above is on `.tasks-draft-pill`, ONE CLASS — and every
+   view here is drawn inside `<section className="prefs-section">`
+   (Scheduled.tsx), where preferences.css ships
+
+       .prefs-section button { … color: var(--fg) … }
+
+   at (0,1,1). That outranks a lone class, so on the List and the Board — the two
+   views whose chip is a `<button>` — the page's foreground won and the red was
+   never drawn; the Cards wall's inert `<span>`, which that rule cannot reach, was
+   the only chip that was ever red. Nothing in this file's own draft rules could
+   settle it either: `button.tasks-draft-pill` above is (0,1,1) as well and wins
+   its padding, border and background on source order alone, but it never named a
+   colour, so there was nothing there to win with.
+
+   The cure is this page's own, twice over — `.prefs-section button.tasks-caret`
+   and `.schedule-tv-filter-x` both name the opponent by hand rather than lean on
+   load order. (0,2,1) beats it outright and leaves no tie for source order to
+   decide.
+
+   ONE SELECTOR, and its `.deploy-body` twin is gone (review, 2026-09-12). Those
+   neighbouring rules list the modal shell because their controls are drawn in
+   one; this chip is not. Every renderer of it — ScheduleTaskViews' List row and
+   Board card foot, TaskCards' wall card, the List's filter toolbar — is inside
+   `Scheduled`'s `.prefs-section`, which is a PAGE (App.tsx's Tasks route and
+   AppPage's Tasks tab) and never a modal body. A selector that can match nothing
+   is a claim about where a component is drawn, and a wrong one is worse than no
+   claim: the day the chip does go in a modal, the red will be missing and this
+   rule will read as though somebody had already thought about it.
+
+   ONE declaration covers every state, which is why there is no hover or `.is-on`
+   twin of it: neither the wash below nor the ON pill touches `color`, so rest,
+   hover, focus and the filter being on all read this. */
+.prefs-section button.tasks-draft-pill {
+  color: var(--error);
+}
+
 button.tasks-draft-pill:hover,
 button.tasks-draft-pill:focus-visible {
   background: var(--ctl-quiet-bg-hover);

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -1815,6 +1815,27 @@ button.tasks-caret,
    pressed states would be the one thing this seat was chosen to avoid. */
 .tasks-draft-pill {
   gap: 3px;
+  /* RED, and only the ink (Akshil, 2026-09-12) — Gmail's "Draft", which is the
+     reference: the word and the pencil in the error colour and nothing else
+     painted. Red because unsent words are the one thing on these rows that is
+     unfinished rather than merely reported; every other pill here is a verdict
+     about something that already happened.
+
+     --error is the page's own red (tokens.css), which is a DARKER red in the
+     light theme and a lighter one in dark, so the contrast holds both ways
+     without a second colour here. The glyph follows for free: the inline SVG is
+     `currentColor`.
+
+     And NO box: no fill, no hairline — the outcome pill's `currentColor` border
+     is dropped here, or the chip would read as a red-outlined badge (an alarm)
+     instead of a red word (a note). That also makes the three views agree: the
+     List's and the Board's chips are buttons, which already had `border: 0`
+     from the tag skin below, and the Cards wall's inert span is the one that
+     still wore the pill's outline. The hover wash on the pressable arm stays
+     exactly the quiet one it was — the chip is not becoming a danger control. */
+  color: var(--error);
+  border: 0;
+  padding: 0 2px;
 }
 
 .tasks-draft-pill-icon {
@@ -1862,10 +1883,13 @@ button.tasks-draft-pill:focus-visible {
    more here because this filter has NO other control. There is no popover
    holding a count for it and no entry in the Status menu; if the chip did not
    wear the state, a filtered page would be one a reader could not explain. */
+/* …and the WORD STAYS RED under it (Akshil, 2026-09-12): the fill says the
+   filter is running, the colour says what the chip is, and they are two
+   different facts. Nothing sets `color` here now — the red above carries
+   through — which is also why the fill is a wash rather than a solid accent. */
 button.tasks-draft-pill.is-on {
   background: color-mix(in srgb, var(--accent) 18%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
-  color: var(--fg);
 }
 
 button.tasks-draft-pill.is-on:hover,

--- a/fused_render/drafts.py
+++ b/fused_render/drafts.py
@@ -84,11 +84,16 @@ TASK = "task"
 #: first send deleted the draft, and that was the end of it. Round 2 reversed
 #: both halves. A `new:<file>` draft IS a row (the folder is its project, the
 #: first line its title, and it carries a TASK number like any other), and the
-#: first send therefore has somewhere to carry that number TO — which is what
-#: `POST /api/drafts/chat/rekey` is: `new:<file>` → the session id, by the same
-#: `tasks_store.rekey` that moves `pending:<entry-id>` forward. Nothing about
-#: the SHAPE changed; what changed is that the key is now worth keeping
-#: (design.md, "Round 2"; Akshil, 2026-09-11).
+#: first send therefore has somewhere to carry that number TO: `new:<file>` →
+#: the session id, by the same `tasks_store.rekey` that moves
+#: `pending:<entry-id>` forward. WHO makes that move is the SERVER, off the run
+#: the send TAGGED with this key (`draft_key` in its `meta.json`,
+#: `routers/tasks.py::_settle_new_chats`): a page cannot tell which session id
+#: its own send created, and four rounds of trying is how we know (Bugbot, PR
+#: #1118, 2026-09-12) — but it can name the draft it just spent. Nothing about
+#: the SHAPE changed; what
+#: changed is that the key is now worth keeping (design.md, "Round 2"; Akshil,
+#: 2026-09-11).
 NEW_CHAT_PREFIX = "new:"
 
 #: A client-minted uuid, in practice. Validated as a shape rather than parsed as
@@ -120,19 +125,34 @@ TASK_FIELDS = ("title", "description", "target", "when", "repeat", "custom_rule"
                "model", "effort", "permission", "attachments",
                "new_task_each_run", "from_chat_key")
 
-#: The three fields that are plain text. The rest are pass-through (`when`,
-#: `repeat`, `custom_rule`), a tri-state flag (`new_task_each_run`), rows
-#: (`attachments`) or the chat key this draft was moved out of
-#: (`from_chat_key`, which is a chat key rather than free text and is validated
-#: as one).
+#: The fields that are plain text, normalised through `_text` on the way in. The
+#: rest are pass-through (`when`, `repeat`, `custom_rule`), a tri-state flag
+#: (`new_task_each_run`), rows (`attachments`) or the chat key this draft was
+#: moved out of (`from_chat_key`, which is a chat key rather than free text and
+#: is validated as one).
 #:
-#: `from_chat_key` is DELIBERATELY NOT IN HERE, and that is the whole of what
-#: keeps it from changing what a draft is: `_empty_task` asks "is there anything
-#: a person typed in this record", and a provenance key is not that. A form that
+#: THIS IS A LIST OF SHAPES, NOT A DEFINITION OF CONTENT — see `_TASK_CONTENT`
+#: below, which is the one that decides whether there is a draft here at all.
+#: `from_chat_key` is in neither, and for the same reason it was always out of
+#: the second: it is provenance, not something a person typed. A form that
 #: arrives blank is still a delete even when it names the chat it came from —
 #: which is exactly the bargain `an empty task put keeps the chat draft` rests
 #: on (Akshil, 2026-09-11).
 _TASK_TEXT = ("title", "description", "target", "model", "effort", "permission")
+
+#: WHAT MAKES A DRAFT A DRAFT: words. Plus `attachments`, which `_empty_task`
+#: asks about separately because it is rows rather than text.
+#:
+#: Everything else the form holds — the folder, the model, the effort, the
+#: permission mode, the time, the repeat rule — is a SETTING that rides along
+#: with a draft, not a reason for one to exist. They used to count, and the
+#: consequence was a card that minted an "Untitled draft" row on the List the
+#: moment somebody changed the folder or opened the when-row and picked a time,
+#: for a form holding nothing anybody had typed. It also left the reported
+#: dead-end: clear the text and the row reads "Untitled draft"; remove the last
+#: attachment after that and the row still will not go, because `target` alone
+#: was keeping the record alive (Akshil, 2026-09-12).
+_TASK_CONTENT = ("title", "description")
 
 #: What an attachment's `kind` may be — the same two `schedule._ATTACH_KINDS`
 #: allows, and a third local copy of a list that is already spelled twice (see
@@ -187,22 +207,6 @@ def new_chat_file(key: str) -> str:
     if not is_new_chat_key(key):
         return ""
     return key[len(NEW_CHAT_PREFIX):]
-
-
-def session_key(value) -> str:
-    """One SESSION id, or `""` — `chat_key` minus the `new:` shape.
-
-    `POST /api/drafts/chat/rekey` is the one caller that needs the difference
-    spelled out: it moves a draft (and its TASK number) from the folder key a
-    chat had before its first send onto the session that send created, and a
-    `to` that was itself a `new:` key would move a number sideways into another
-    folder row rather than forward onto a conversation (Akshil, 2026-09-11)."""
-    if not isinstance(value, str):
-        return ""
-    key = value.strip()
-    if not key or key.startswith(NEW_CHAT_PREFIX):
-        return ""
-    return key if _SESSION_KEY.match(key) else ""
 
 
 def draft_id(value) -> str:
@@ -469,18 +473,16 @@ def _task_record(rec) -> dict | None:
 def _empty_task(record: dict) -> bool:
     """Is there nothing in this draft at all?
 
-    Every stored field, not a chosen few: the client mints a draft id on the
-    FIRST KEYSTROKE and never for an untouched modal (design.md, "New Task
-    modal"), so a draft that arrives with every field blank is a person having
-    cleared it out by hand, and the honest answer to that is to stop keeping
-    it."""
-    if any(record[field].strip() for field in _TASK_TEXT):
+    Words or files, and nothing else — see `_TASK_CONTENT`. A form whose title
+    and description are blank and whose tray is empty is not an unfinished task,
+    whatever folder or model or time it happens to be carrying: those are
+    settings, and settings are how a task would run if there were one. So a PUT
+    that arrives in that state is a DELETE, which is the same semantics this
+    store has always had for an empty draft — the change is only in what
+    "empty" counts as (Akshil, 2026-09-12)."""
+    if any(record[field].strip() for field in _TASK_CONTENT):
         return False
-    if record["attachments"]:
-        return False
-    return (record["when"] in (None, "") and record["repeat"] in (None, "")
-            and record["custom_rule"] in (None, "")
-            and record["new_task_each_run"] is None)
+    return not record["attachments"]
 
 
 def _project_task(section: dict) -> dict:

--- a/fused_render/drafts.py
+++ b/fused_render/drafts.py
@@ -555,7 +555,7 @@ def get_task(ident) -> dict | None:
     return list_task().get(key) if key else None
 
 
-def put_task(ident, fields) -> dict | None:
+def put_task(ident, fields) -> tuple[dict | None, list[str]]:
     """Upsert one task draft — and DELETE it when every field comes in empty.
 
     Fields the client did not send keep the value the stored draft had, so the
@@ -565,11 +565,26 @@ def put_task(ident, fields) -> dict | None:
 
     `created_at` is written once and then never moves — it is the row's `at` on
     the List and the Board, and a draft that jumped to the top of Upcoming on
-    every keystroke would be a row that will not sit still. Answers the stored
-    record, or None when the write was a delete."""
+    every keystroke would be a row that will not sit still. Answers
+    `(record, evicted_ids)`: the stored record (None when the write was a
+    delete) and the LISTING KEYS (`draft:<id>`) of any other task drafts this
+    write evicted — `[]` on the overwhelmingly common write that bound nobody.
+
+    ONE BOUND DRAFT PER SESSION, enforced here rather than trusted to the
+    client (review, 2026-09-12). A session-bound draft stands in for its
+    session's row (`_bound_chips` in routers/tasks.py) and that row wears
+    exactly one `✎ Draft` chip, so two drafts naming the same session is not
+    two facts, it is one fact and a stale second copy of it — a New task modal
+    opened twice from the same conversation's Schedule button, say, once
+    before a reload and once after. The newest write wins and the loser's
+    words are gone: the same "a draft moves, never duplicates" rule the
+    composer → New task hop already keeps (`from_chat_key`, above), read the
+    other way round. Done inside THIS write's lock rather than as a second
+    request, so nothing can observe the moment two drafts both claim the same
+    session."""
     key = draft_id(ident)
     if not key:
-        return None
+        return None, []
     patch = fields if isinstance(fields, dict) else {}
 
     def mutate(data: dict):
@@ -581,20 +596,37 @@ def put_task(ident, fields) -> dict | None:
         record = _task_record(merged)
         if record is None or _empty_task(record):
             if key not in data[TASK]:
-                return None, False
+                return (None, []), False
             data[TASK].pop(key, None)
-            return None, True
+            return (None, []), True
         now = time.time()
         record["created_at"] = stored.get("created_at") or now
         record["updated_at"] = now
+        evicted: list[str] = []
+        session = record["session_id"]
+        if session:
+            for other_id, other_rec in list(data[TASK].items()):
+                if other_id == key:
+                    continue
+                other = _task_record(other_rec)
+                if other is not None and other["session_id"] == session:
+                    data[TASK].pop(other_id, None)
+                    evicted.append(task_key(other_id))
         data[TASK][key] = record
-        return record, True
+        return (record, evicted), True
 
     return _update(mutate)
 
 
-def unbind_session(session_id) -> int:
-    """Cut every task draft loose from one session; how many were cut.
+def unbind_session(session_id) -> list[str]:
+    """Cut every task draft loose from one session; the LISTING KEYS of the ones
+    that were cut (`draft:<id>`), newest-store order, and `[]` when none were.
+
+    THE KEYS AND NOT A COUNT (bugbot, PR #1126): those rows have just changed —
+    a different number, a different folder, no session — and the caller has to
+    announce them (`tasks_watch.notify`) or the page goes on showing the erased
+    session's number on a draft whose Schedule would send the message back into
+    a conversation that no longer exists. A count cannot be announced.
 
     The erase gesture's share of this store (`POST /api/tasks/erase`). The words
     are NOT deleted — a draft is a task somebody is still writing, and the
@@ -609,14 +641,14 @@ def unbind_session(session_id) -> int:
     allocated one of its own, because the binding was the very thing telling
     `_draft_numbers` that its task already had a number (review, 2026-09-12).
 
-    One pass under one lock, and 0 — no write at all — for the overwhelmingly
+    One pass under one lock, and `[]` — no write at all — for the overwhelmingly
     common erase where nothing was bound to that session."""
     target = bound_session(session_id)
     if not target:
-        return 0
+        return []
 
     def mutate(data: dict):
-        cut = 0
+        cut: list[str] = []
         for ident, rec in list(data[TASK].items()):
             record = _task_record(rec)
             if record is None or record["session_id"] != target:
@@ -625,7 +657,7 @@ def unbind_session(session_id) -> int:
             # ("drafted 5m ago") and sorts on, and nobody typed anything here.
             record["session_id"] = ""
             data[TASK][ident] = record
-            cut += 1
+            cut.append(task_key(ident))
         return cut, bool(cut)
 
     return _update(mutate)

--- a/fused_render/drafts.py
+++ b/fused_render/drafts.py
@@ -123,21 +123,23 @@ PREVIEW_MAX = 120
 #: page), and a field the client omits keeps whatever the stored draft had.
 TASK_FIELDS = ("title", "description", "target", "when", "repeat", "custom_rule",
                "model", "effort", "permission", "attachments",
-               "new_task_each_run", "from_chat_key")
+               "new_task_each_run", "from_chat_key", "session_id")
 
 #: The fields that are plain text, normalised through `_text` on the way in. The
 #: rest are pass-through (`when`, `repeat`, `custom_rule`), a tri-state flag
-#: (`new_task_each_run`), rows (`attachments`) or the chat key this draft was
-#: moved out of (`from_chat_key`, which is a chat key rather than free text and
-#: is validated as one).
+#: (`new_task_each_run`), rows (`attachments`), the chat key this draft was
+#: moved out of (`from_chat_key`) or the session it is going into
+#: (`session_id`) — the last two being keys rather than free text, and each
+#: validated as the key it is.
 #:
 #: THIS IS A LIST OF SHAPES, NOT A DEFINITION OF CONTENT — see `_TASK_CONTENT`
 #: below, which is the one that decides whether there is a draft here at all.
-#: `from_chat_key` is in neither, and for the same reason it was always out of
-#: the second: it is provenance, not something a person typed. A form that
-#: arrives blank is still a delete even when it names the chat it came from —
-#: which is exactly the bargain `an empty task put keeps the chat draft` rests
-#: on (Akshil, 2026-09-11).
+#: `from_chat_key` and `session_id` are in neither, and for the same reason
+#: `from_chat_key` was always out of the second: they are provenance and
+#: destination, not something a person typed. A form that arrives blank is still
+#: a delete even when it names the chat it came from and the session it was
+#: going to — which is exactly the bargain `an empty task put keeps the chat
+#: draft` rests on (Akshil, 2026-09-11).
 _TASK_TEXT = ("title", "description", "target", "model", "effort", "permission")
 
 #: WHAT MAKES A DRAFT A DRAFT: words. Plus `attachments`, which `_empty_task`
@@ -207,6 +209,23 @@ def new_chat_file(key: str) -> str:
     if not is_new_chat_key(key):
         return ""
     return key[len(NEW_CHAT_PREFIX):]
+
+
+def bound_session(value) -> str:
+    """The session a task draft BELONGS TO, or `""` for anything that is not a
+    session id.
+
+    The narrow twin of `chat_key`: that one takes both of a chat's two ages, and
+    this one takes only the older. A draft can be bound to a conversation that
+    EXISTS — the composer → Schedule hop out of a session that has already run —
+    and never to `new:<file>`, which names a folder somebody opened a chat on and
+    no thread at all. There is nothing for a `new:` draft to schedule INTO, and a
+    key of that shape in this field would make the listing hide a session row
+    that does not exist (Akshil, 2026-09-12)."""
+    if not isinstance(value, str):
+        return ""
+    key = value.strip()
+    return key if _SESSION_KEY.match(key) else ""
 
 
 def draft_id(value) -> str:
@@ -465,6 +484,21 @@ def _task_record(rec) -> dict | None:
     # is either a key the chat half can actually be written under or "" (Akshil,
     # 2026-09-11).
     out["from_chat_key"] = chat_key(rec.get("from_chat_key"))
+    # WHICH CONVERSATION THIS DRAFT IS A MESSAGE TO, when it came out of one
+    # that already exists (Akshil, 2026-09-12).
+    #
+    # `from_chat_key` above says where the WORDS were typed and is spent the
+    # moment the chat's own copy is deleted; this says where the TASK is going,
+    # and it has to outlive the modal being closed. Without it the hop worked
+    # only while the page still held the session in memory: press Schedule
+    # straight away and the message landed in the conversation, exit the modal
+    # and the draft on disk knew nothing about it — so reopening that draft and
+    # scheduling it started a NEW session under a NEW task number, and the task
+    # the reader had been watching was gone.
+    #
+    # Validated as a session id and never as `new:<file>` (`bound_session`):
+    # binding is to a thread, not to a folder.
+    out["session_id"] = bound_session(rec.get("session_id"))
     out["created_at"] = _epoch(rec.get("created_at"))
     out["updated_at"] = _epoch(rec.get("updated_at"))
     return out
@@ -555,6 +589,44 @@ def put_task(ident, fields) -> dict | None:
         record["updated_at"] = now
         data[TASK][key] = record
         return record, True
+
+    return _update(mutate)
+
+
+def unbind_session(session_id) -> int:
+    """Cut every task draft loose from one session; how many were cut.
+
+    The erase gesture's share of this store (`POST /api/tasks/erase`). The words
+    are NOT deleted — a draft is a task somebody is still writing, and the
+    conversation it was going to be sent into is only where it was going to go.
+    What goes is the binding, and with it everything the binding stood for: the
+    draft stops borrowing a number that is now a reservation nobody may reissue
+    (`tasks_store.forget_session` stamps the record `erased` and keeps it), stops
+    standing in for a row that no longer exists, and is numbered as the ordinary
+    `draft:<id>` it has become on the next listing.
+
+    Without this the draft showed the dead TASK-nnn for ever and could never be
+    allocated one of its own, because the binding was the very thing telling
+    `_draft_numbers` that its task already had a number (review, 2026-09-12).
+
+    One pass under one lock, and 0 — no write at all — for the overwhelmingly
+    common erase where nothing was bound to that session."""
+    target = bound_session(session_id)
+    if not target:
+        return 0
+
+    def mutate(data: dict):
+        cut = 0
+        for ident, rec in list(data[TASK].items()):
+            record = _task_record(rec)
+            if record is None or record["session_id"] != target:
+                continue
+            # `updated_at` is NOT touched: it is the clock the row prints
+            # ("drafted 5m ago") and sorts on, and nobody typed anything here.
+            record["session_id"] = ""
+            data[TASK][ident] = record
+            cut += 1
+        return cut, bool(cut)
 
     return _update(mutate)
 

--- a/fused_render/drafts.py
+++ b/fused_render/drafts.py
@@ -26,6 +26,16 @@ Shape::
     {"chat": {"<session-id>": {"text": …, "attachments": […], "updated_at": …}},
      "task": {"<draft-id>": {"title": …, …, "created_at": …, "updated_at": …}}}
 
+**One record, two doors.** A task draft that names a session (`session_id`) IS
+that conversation's unsent message, so the composer is a second door onto it:
+a session with a bound form and no chat record of its own reads and writes that
+form's words from the chat half (`bound_chats`, `chat_view`, `put_chat`). Never
+a copy — the words are in exactly one record, and which door the reader comes
+back through does not change what they find. The bug that asked for it: hop out
+of a finished session, type, press Schedule, click outside the modal, and the
+row wore the `✎ Draft` chip while the composer the chip's press led to was
+empty (Akshil, 2026-09-12).
+
 **Empty is never stored.** Writing an empty draft IS deleting it — there is no
 such thing as a draft with nothing in it, and a store that kept one would paint
 a `✎ Draft` badge on a task whose composer is blank. `put_chat` and `put_task`
@@ -380,26 +390,131 @@ def preview(text) -> str:
     return ""
 
 
+def split_draft(text) -> tuple[str, str]:
+    """One box of words as the New task form's two fields: `(title,
+    description)` — the first non-empty line names the thing, the rest
+    describes it.
+
+    THE PYTHON TWIN OF `NewJobModal.splitDraft`, and it has to stay its twin.
+    The hop into the form splits in the client; the composer's door onto a
+    bound draft splits here (`put_chat`), and a rule that drifted would mean
+    one sentence landing in two different shapes depending on which door it
+    came through. Leading blank lines go before the first line is taken, which
+    is what makes "the first NON-EMPTY line" true of both."""
+    body = _text(text).strip()
+    if not body:
+        return "", ""
+    head, _, rest = body.partition("\n")
+    return head.strip(), rest.strip()
+
+
+def join_draft(title, description) -> str:
+    """The form's two fields back as one box of words — `split_draft` run
+    backwards, blank line and all (`NewJobModal.joinDraft`).
+
+    Not an inverse of every input: a title and a description written one
+    newline apart come back a blank line apart, because a blank line is what
+    two fields look like as one box. It IS an inverse of everything this pair
+    itself produces, which is the round trip the composer actually makes."""
+    head = _text(title).strip()
+    body = _text(description).strip()
+    if not head:
+        return body
+    if not body:
+        return head
+    return head + "\n\n" + body
+
+
 # ------------------------------------------------------------- chat drafts
 
 
 def _project_chat(section: dict) -> dict:
     """The chat section of an ALREADY-LOADED store, projected. Split out of
-    `list_chat` so `list_all` can answer both questions off one read."""
+    `list_chat` so `list_all` can answer both questions off one read.
+
+    `bound_draft` is `""` on everything that comes out of here, because a
+    STORED chat record is a record of its own — the field is filled in only by
+    `chat_view`, on the entries it synthesizes out of a task draft. One shape
+    for both, so a reader never has to test for the key."""
     out: dict[str, dict] = {}
     for key, rec in section.items():
         if not chat_key(key) or not isinstance(rec, dict):
             continue
         out[key] = {"text": _text(rec.get("text")),
                     "attachments": _attachments(rec.get("attachments")),
-                    "updated_at": _epoch(rec.get("updated_at"))}
+                    "updated_at": _epoch(rec.get("updated_at")),
+                    "bound_draft": ""}
+    return out
+
+
+def bound_chats(chat: dict, task: dict) -> dict[str, str]:
+    """`{session-id: draft-id}` — every conversation whose unsent words are
+    being kept in a New task FORM rather than in a chat record of its own.
+
+    ONE RECORD, TWO DOORS (Akshil, 2026-09-12). The composer's Schedule hop
+    moves the words out of the chat draft and into a task draft bound to the
+    session (`from_chat_key` deletes the one, `session_id` binds the other), and
+    the reported bug is what the session's row looked like afterwards: it wore
+    the red `✎ Draft` chip, the chip's press took the reader to the chat, and
+    the composer there was empty — the words were on disk the whole time, in a
+    record that door could not see. A session with a bound form and no chat
+    record of its own therefore SHOWS AND EDITS that form's words from the
+    composer too. Two doors onto one record, never a second copy of it.
+
+    THE JOIN ITSELF LIVES HERE and nowhere else, so `/api/drafts`, the composer
+    and `routers/tasks.py`'s row chip cannot disagree about which draft a
+    session's words are in.
+
+    A STORED CHAT RECORD WINS outright: a session can have both — text left in
+    its composer and a form opened out of it — and then they are two different
+    unsent things, the composer's own being the one the composer is holding.
+    That is the same precedence `_row` has always drawn its chip with.
+
+    NEWEST WINS when two forms name one session, the same tie-break
+    `_bound_chips` and `put_task`'s fold take, so every reader agrees on which
+    draft a session is advertising."""
+    out: dict[str, str] = {}
+    stamps: dict[str, float] = {}
+    for ident, record in task.items():
+        session = bound_session(record.get("session_id"))
+        if not session or session in chat:
+            continue
+        updated = _epoch(record.get("updated_at"))
+        if session in out and stamps[session] >= updated:
+            continue
+        out[session], stamps[session] = ident, updated
+    return out
+
+
+def chat_view(chat: dict, task: dict) -> dict:
+    """The chat half as a READER sees it: every stored chat draft, plus one
+    synthesized entry for every session whose words live in a bound form
+    (`bound_chats`).
+
+    A synthesized entry is the form read as a composer would write it — the
+    title and description joined back into one box (`join_draft`, the inverse
+    of the split the hop made), the form's attachments, the form's clock — plus
+    `bound_draft`, the form's id, so a client that cares can tell the two apart.
+    Nothing here writes: this is a projection of one read, and the write that
+    goes back through the same door is `put_chat`'s half of the bargain."""
+    out = dict(chat)
+    for session, ident in bound_chats(chat, task).items():
+        record = task[ident]
+        out[session] = {
+            "text": join_draft(record.get("title"), record.get("description")),
+            "attachments": _attachments(record.get("attachments")),
+            "updated_at": _epoch(record.get("updated_at")),
+            "bound_draft": ident,
+        }
     return out
 
 
 def list_chat() -> dict:
-    """Every chat draft, `{key: {text, attachments, updated_at}}`, unreadable
-    records dropped."""
-    return _project_chat(load()[CHAT])
+    """Every chat draft a reader can open, `{key: {text, attachments,
+    updated_at, bound_draft}}` — stored records and the bound forms that read
+    as one (`chat_view`), unreadable records dropped."""
+    store = load()
+    return chat_view(_project_chat(store[CHAT]), _project_task(store[TASK]))
 
 
 def get_chat(session_id) -> dict | None:
@@ -409,6 +524,60 @@ def get_chat(session_id) -> dict | None:
     return list_chat().get(key) if key else None
 
 
+def bound_chat_draft(session_id) -> str:
+    """The task draft one chat key's words actually live in, or `""` — one
+    read of the file, for a caller that has to name that draft's row.
+
+    The routes' use: both halves of a chat write announce the FORM's key
+    (`draft:<id>`) as well as the session's, because on a bound session the two
+    doors are one record and a page holding a row under either has to hear
+    about it."""
+    key = chat_key(session_id)
+    session = bound_session(key)
+    if not session:
+        return ""
+    store = load()
+    return bound_chats(_project_chat(store[CHAT]),
+                       _project_task(store[TASK])).get(session, "")
+
+
+def _put_bound(data: dict, ident: str, body: str, rows: list[dict]):
+    """The composer's words written into the FORM they live in — `put_chat`'s
+    other half, run inside its lock (`bound_chats` for why there is one).
+
+    The inverse of what the reader was shown: the box is split back across
+    title and description by the same rule the hop split it with
+    (`split_draft`), so typing into the composer and typing into the card's two
+    fields are edits to one record rather than to two copies of it.
+
+    THE TRAY IS A REPLACEMENT AND NOT A UNION, unlike the fold `put_task` does
+    between two FORMS (`_fold_into_bound`). That one reconciles a card that
+    could not read the binding before it wrote, and so cannot tell "no files"
+    from "did not ask"; this door always shows the whole tray, so a file
+    missing from the write is a file the reader took out.
+
+    EMPTY IS A DELETE, the same bargain the chat half has always made: the
+    composer's autosave fires after the send has cleared the box, and the words
+    it is clearing are the ones that were just sent. What goes is the whole
+    form — there is no half of a draft left to keep."""
+    title, description = split_draft(body)
+    if not title and not description and not rows:
+        if ident not in data[TASK]:
+            return None, False
+        data[TASK].pop(ident, None)
+        return None, True
+    record = _task_record(data[TASK].get(ident)) or {}
+    now = time.time()
+    record["title"] = title
+    record["description"] = description
+    record["attachments"] = rows
+    record["created_at"] = record.get("created_at") or now
+    record["updated_at"] = now
+    data[TASK][ident] = record
+    return {"text": join_draft(title, description), "attachments": rows,
+            "updated_at": now, "bound_draft": ident}, True
+
+
 def put_chat(session_id, text=None, attachments=None) -> dict | None:
     """Upsert one chat draft — and DELETE it when it comes in empty.
 
@@ -416,20 +585,47 @@ def put_chat(session_id, text=None, attachments=None) -> dict | None:
     the moment its message is sent. The send path therefore does not have to
     choose between PUT and DELETE: writing what the box now holds is correct in
     both directions. Answers the stored record, or None when the write was a
-    delete."""
+    delete.
+
+    …AND WHEN THIS SESSION'S WORDS ARE IN A BOUND FORM, the write goes THERE
+    and no chat record is made (`bound_chats`, "one record, two doors"). Two
+    records would be two rows, two chips and two versions of one sentence, and
+    which of them the reader saw would depend on which door they came back
+    through. The answer is that form read as a chat draft — the same shape a
+    stored one has, `bound_draft` filled in — so the caller need not know which
+    of the two it just wrote.
+
+    The binding is looked up INSIDE the lock, with the write: a form bound (or
+    emptied) between a read and a write outside one is exactly how the same
+    sentence ends up in both halves of the store."""
     key = chat_key(session_id)
     if not key:
         return None
     body = _text(text)
     rows = _attachments(attachments)
-    if not body.strip() and not rows:
-        delete_chat(key)
-        return None
-    record = {"text": body, "attachments": rows, "updated_at": time.time()}
 
     def mutate(data: dict):
+        ident = ""
+        session = bound_session(key)
+        if session:
+            ident = bound_chats(_project_chat(data[CHAT]),
+                                _project_task(data[TASK])).get(session, "")
+        if ident:
+            return _put_bound(data, ident, body, rows)
+        if not body.strip() and not rows:
+            # The delete, taken here rather than through `delete_chat` so the
+            # question "is this key bound?" and the answer to it are one turn of
+            # the lock.
+            if key not in data[CHAT]:
+                return None, False
+            data[CHAT].pop(key, None)
+            return None, True
+        record = {"text": body, "attachments": rows, "updated_at": time.time()}
         data[CHAT][key] = record
-        return record, True
+        # STORED without `bound_draft` and ANSWERED with it: the field is a fact
+        # about which record these words are in, not a field of the record, and
+        # writing it into the file would be a second place for it to go stale.
+        return dict(record, bound_draft=""), True
 
     return _update(mutate)
 
@@ -544,10 +740,12 @@ def list_all() -> tuple[dict, dict]:
     that want drafts almost always want both — the tasks listing asks for the
     chat drafts to join onto its rows and the task drafts to build draft rows
     from, on every build, including the `/api/tasks/changes` polls. One file,
-    one read. Same projections, so this is interchangeable with calling the
-    two in turn."""
+    one read. Same projections AND the same chat view — a bound form reads as
+    its session's chat draft here exactly as it does through `list_chat` — so
+    this is interchangeable with calling the two in turn."""
     store = load()
-    return _project_task(store[TASK]), _project_chat(store[CHAT])
+    task = _project_task(store[TASK])
+    return task, chat_view(_project_chat(store[CHAT]), task)
 
 
 def get_task(ident) -> dict | None:

--- a/fused_render/drafts.py
+++ b/fused_render/drafts.py
@@ -555,7 +555,54 @@ def get_task(ident) -> dict | None:
     return list_task().get(key) if key else None
 
 
-def put_task(ident, fields) -> tuple[dict | None, list[str]]:
+def _fold_into_bound(existing: dict, incoming: dict) -> dict:
+    """The incoming write folded INTO the draft that already holds its session.
+
+    What survives is everything the incoming write did not actually say. The
+    caller that lands here is a card that could not read the binding before it
+    wrote — `fetchDrafts` answers "unknown" on a failed lookup and the modal
+    opens anyway, because words must not be lost waiting for a request — so the
+    form it is saving may be a fresh one carrying only the composer's sentence,
+    and the draft it is colliding with is the one holding the time, the repeat
+    rule, the model and the tray somebody spent a minute choosing. Overwriting
+    those with the blanks of a form that never asked about them is how the
+    reported loss happened; keeping them is this function.
+
+    NON-EMPTY IS THE WHOLE TEST, field by field. A blank title is not "clear the
+    title", it is "this write has nothing to say about the title" — a draft
+    store is the one place where that reading is always the safe one, since the
+    alternative destroys work and the cost of being wrong is one stale setting
+    the reader can see and change. Attachments are a UNION keyed on `path`, for
+    the same reason read as rows: neither side's files are a statement that the
+    other side's are gone.
+
+    `session_id` is the exception and takes the incoming value outright — it is
+    the very fact that brought these two records together, and it is the same on
+    both sides by construction."""
+    out = dict(existing)
+    for field in _TASK_TEXT:
+        if incoming[field].strip():
+            out[field] = incoming[field]
+    for field in ("when", "repeat", "custom_rule"):
+        if incoming[field] not in (None, "", [], {}):
+            out[field] = incoming[field]
+    if incoming["new_task_each_run"] is not None:
+        out["new_task_each_run"] = incoming["new_task_each_run"]
+    if incoming["from_chat_key"]:
+        out["from_chat_key"] = incoming["from_chat_key"]
+    out["session_id"] = incoming["session_id"]
+    rows: list[dict] = []
+    seen: set[str] = set()
+    for row in list(existing["attachments"]) + list(incoming["attachments"]):
+        if row["path"] in seen:
+            continue
+        seen.add(row["path"])
+        rows.append(row)
+    out["attachments"] = rows
+    return out
+
+
+def put_task(ident, fields) -> tuple[dict | None, str]:
     """Upsert one task draft — and DELETE it when every field comes in empty.
 
     Fields the client did not send keep the value the stored draft had, so the
@@ -566,25 +613,35 @@ def put_task(ident, fields) -> tuple[dict | None, list[str]]:
     `created_at` is written once and then never moves — it is the row's `at` on
     the List and the Board, and a draft that jumped to the top of Upcoming on
     every keystroke would be a row that will not sit still. Answers
-    `(record, evicted_ids)`: the stored record (None when the write was a
-    delete) and the LISTING KEYS (`draft:<id>`) of any other task drafts this
-    write evicted — `[]` on the overwhelmingly common write that bound nobody.
+    `(record, canonical_id)`: the stored record (None when the write was a
+    delete) and the id it is actually stored under, which is `ident` on every
+    ordinary write and somebody else's id when this write was folded into a
+    draft that already held its session (below). The caller has to pass that id
+    back to the page, or the next autosave, the Discard and the Schedule all aim
+    at a record that is no longer there.
 
     ONE BOUND DRAFT PER SESSION, enforced here rather than trusted to the
     client (review, 2026-09-12). A session-bound draft stands in for its
     session's row (`_bound_chips` in routers/tasks.py) and that row wears
     exactly one `✎ Draft` chip, so two drafts naming the same session is not
-    two facts, it is one fact and a stale second copy of it — a New task modal
-    opened twice from the same conversation's Schedule button, say, once
-    before a reload and once after. The newest write wins and the loser's
-    words are gone: the same "a draft moves, never duplicates" rule the
-    composer → New task hop already keeps (`from_chat_key`, above), read the
-    other way round. Done inside THIS write's lock rather than as a second
-    request, so nothing can observe the moment two drafts both claim the same
+    two facts, it is one fact written twice.
+
+    IT IS A MERGE AND NOT AN EVICTION (Bugbot, PR #1126, 2026-09-12). The first
+    version of this rule deleted the loser, which is correct only if the winner
+    is the better-informed of the two — and the write that collides is by
+    construction the one that knows LESS. `fetchDrafts` never rejects: a lookup
+    that fails on the way into the hop reads as "this session has no form", so
+    the card mints a NEW id and saves a fresh form over a stored draft carrying
+    a time, a repeat rule, a model and a tray. Evicting there threw all of that
+    away over one failed GET. Folding the incoming write into the existing
+    record instead (`_fold_into_bound`) makes a failed lookup cost nothing: the
+    words land, the settings stay, the id the reader keeps is the one that was
+    already bound. Done inside THIS write's lock rather than as a second
+    request, so nothing can observe the moment two drafts both claim one
     session."""
     key = draft_id(ident)
     if not key:
-        return None, []
+        return None, ""
     patch = fields if isinstance(fields, dict) else {}
 
     def mutate(data: dict):
@@ -596,24 +653,36 @@ def put_task(ident, fields) -> tuple[dict | None, list[str]]:
         record = _task_record(merged)
         if record is None or _empty_task(record):
             if key not in data[TASK]:
-                return (None, []), False
+                return (None, key), False
             data[TASK].pop(key, None)
-            return (None, []), True
+            return (None, key), True
         now = time.time()
         record["created_at"] = stored.get("created_at") or now
         record["updated_at"] = now
-        evicted: list[str] = []
         session = record["session_id"]
+        bound_id, bound = "", None
         if session:
-            for other_id, other_rec in list(data[TASK].items()):
+            for other_id, other_rec in data[TASK].items():
                 if other_id == key:
                     continue
                 other = _task_record(other_rec)
-                if other is not None and other["session_id"] == session:
-                    data[TASK].pop(other_id, None)
-                    evicted.append(task_key(other_id))
+                if other is None or other["session_id"] != session:
+                    continue
+                # NEWEST WINS if a store somehow holds several — the same
+                # tie-break `_bound_chips` takes, so what this write folds into
+                # is the draft the session's row is advertising.
+                if bound is not None and bound["updated_at"] >= other["updated_at"]:
+                    continue
+                bound_id, bound = other_id, other
+        if bound is not None:
+            record = _fold_into_bound(bound, record)
+            record["created_at"] = bound["created_at"] or now
+            record["updated_at"] = now
+            data[TASK].pop(key, None)
+            data[TASK][bound_id] = record
+            return (record, bound_id), True
         data[TASK][key] = record
-        return (record, evicted), True
+        return (record, key), True
 
     return _update(mutate)
 

--- a/fused_render/server/routers/drafts.py
+++ b/fused_render/server/routers/drafts.py
@@ -22,12 +22,17 @@ travels. The key announced is the key the listing files the row under — the
 session id for a chat draft, `draft:<id>` for a task draft — so the changes
 endpoint rebuilds exactly that row and nothing else.
 
-TWO keys when a task draft is bound to a session, because then two rows move at
-once: the draft appears and the session's own row stands down in its favour (one
-task, one row — `routers/tasks.py`, the tail of `_build_task_rows`), and on the
-discard they swap back. The changes endpoint reports the key it is asked about
-and cannot list as `gone`, which is exactly how each of the two is retired from
-the page the moment the other arrives.
+TWO keys when a task draft is bound to a session, because then two things
+change and only one of them is a row. A session-bound draft is never a row of
+its own (`routers/tasks.py::_draft_rows` skips it outright); the session's own
+row carries it instead, as `bound_draft` and the `✎ Draft` chip (`_bound_chips`,
+joined in `_row`). So the draft's key is announced so a page holding a stale
+row under it — from before the binding, or from an older build — is told to
+drop it (the changes endpoint reports it `gone`, having no row to rebuild), and
+the session's key is announced because that is the row whose chip just
+appeared, changed, or went. Nothing "swaps back" on a discard — the session's
+row was never touched, so there is nothing to reverse; it simply repaints
+without the chip.
 
 `new:<file>` announces itself too, as of round 2. It used to be the one key
 that did not — no session meant no task row meant nothing for a listening page
@@ -130,19 +135,22 @@ def api_draft_task_put(draft_id: str, body: dict = Body(default={})):
     the modal may grow a field without this endpoint learning about it. An
     all-empty form is a delete, the same bargain the chat half makes."""
     ident = _draft_id(draft_id)
-    # WHICH SESSION'S ROW IS AT STAKE BESIDES THIS DRAFT'S, read BEFORE the
+    # WHICH SESSION'S CHIP IS AT STAKE BESIDES THIS DRAFT'S KEY, read BEFORE the
     # write.
     #
-    # A task draft that names a session stands IN for that session's row while
-    # it exists (`routers/tasks.py`, the tail of `_build_task_rows`), so both
-    # keys have to repaint on every write: the draft row appears and the
-    # session's goes, and on the write that turns out to be a DELETE the
-    # session's row comes straight back. The delete is why this is read first —
-    # emptying a form takes the binding away with it, and afterwards there is
-    # nothing left to ask. One small json read on a debounced autosave, against
-    # a session row that would otherwise be stuck until the 20-second listing.
+    # A task draft that names a session is never a row of its own — the
+    # session's own row carries it instead, as `bound_draft` and the `✎ Draft`
+    # chip (`routers/tasks.py::_bound_chips`, joined in `_row`) — so both keys
+    # have to repaint on every write: the session's chip appears, changes or
+    # goes, and the draft's own key is announced so a page holding a stale row
+    # under it drops it. On the write that turns out to be a DELETE the chip
+    # simply goes, because the row underneath it was never touched. The delete
+    # is why this is read first — emptying a form takes the binding away with
+    # it, and afterwards there is nothing left to ask. One small json read on a
+    # debounced autosave, against a chip that would otherwise be stuck showing
+    # stale words until the 20-second listing.
     bound = str((drafts.get_task(ident) or {}).get("session_id") or "")
-    record = drafts.put_task(ident, body)
+    record, evicted = drafts.put_task(ident, body)
     bound = bound or str((record or {}).get("session_id") or "")
     # A DRAFT MOVES, IT NEVER DUPLICATES. The composer → New task hop mints the
     # task draft out of what was in the chat box, so for one instant the same
@@ -168,7 +176,12 @@ def api_draft_task_put(draft_id: str, body: dict = Body(default={})):
     from_chat = drafts.chat_key(body.get("from_chat_key")) if record else ""
     if from_chat:
         drafts.delete_chat(from_chat)
-    _announce(drafts.task_key(ident), from_chat, bound)
+    # ...and EVICTED, when this write bound a session that another draft had
+    # already claimed (`drafts.put_task`, review 2026-09-12: one bound draft
+    # per session). The loser's key is announced alongside the rest so a page
+    # holding that row drops it, rather than going on showing a chip whose form
+    # just vanished out from under it.
+    _announce(drafts.task_key(ident), from_chat, bound, *evicted)
     return {"ok": True, "draft_id": ident, "draft": record,
             "from_chat_key": from_chat}
 
@@ -179,10 +192,10 @@ def api_draft_task_delete(draft_id: str):
     after a draft has been scheduled for real (which `POST /api/schedule` does
     for itself, given a `draft_id`)."""
     ident = _draft_id(draft_id)
-    # …and the session whose row this draft was standing in for, read before the
+    # …and the session whose chip this draft was wearing, read before the
     # delete for the same reason the PUT reads it: afterwards nothing can name
-    # it, and that row has to come back in the same repaint the draft row goes
-    # out on (Akshil, 2026-09-12).
+    # it, and that row has to repaint — chip gone — in the same round the
+    # draft's own key goes out on (Akshil, 2026-09-12).
     bound = str((drafts.get_task(ident) or {}).get("session_id") or "")
     removed = drafts.delete_task(ident)
     _announce(drafts.task_key(ident), bound)

--- a/fused_render/server/routers/drafts.py
+++ b/fused_render/server/routers/drafts.py
@@ -22,6 +22,13 @@ travels. The key announced is the key the listing files the row under — the
 session id for a chat draft, `draft:<id>` for a task draft — so the changes
 endpoint rebuilds exactly that row and nothing else.
 
+TWO keys when a task draft is bound to a session, because then two rows move at
+once: the draft appears and the session's own row stands down in its favour (one
+task, one row — `routers/tasks.py`, the tail of `_build_task_rows`), and on the
+discard they swap back. The changes endpoint reports the key it is asked about
+and cannot list as `gone`, which is exactly how each of the two is retired from
+the page the moment the other arrives.
+
 `new:<file>` announces itself too, as of round 2. It used to be the one key
 that did not — no session meant no task row meant nothing for a listening page
 to repaint — but an unsent chat IS a row now, filed under the folder it was
@@ -118,12 +125,25 @@ def api_draft_task_put(draft_id: str, body: dict = Body(default={})):
 
     The body IS the form — `title`, `description`, `target`, `when`, `repeat`,
     `custom_rule`, `model`, `effort`, `permission`, `attachments`,
-    `new_task_each_run`, `from_chat_key` — and
+    `new_task_each_run`, `from_chat_key`, `session_id` — and
     anything else in it is dropped by the store rather than refused here, so
     the modal may grow a field without this endpoint learning about it. An
     all-empty form is a delete, the same bargain the chat half makes."""
     ident = _draft_id(draft_id)
+    # WHICH SESSION'S ROW IS AT STAKE BESIDES THIS DRAFT'S, read BEFORE the
+    # write.
+    #
+    # A task draft that names a session stands IN for that session's row while
+    # it exists (`routers/tasks.py`, the tail of `_build_task_rows`), so both
+    # keys have to repaint on every write: the draft row appears and the
+    # session's goes, and on the write that turns out to be a DELETE the
+    # session's row comes straight back. The delete is why this is read first —
+    # emptying a form takes the binding away with it, and afterwards there is
+    # nothing left to ask. One small json read on a debounced autosave, against
+    # a session row that would otherwise be stuck until the 20-second listing.
+    bound = str((drafts.get_task(ident) or {}).get("session_id") or "")
     record = drafts.put_task(ident, body)
+    bound = bound or str((record or {}).get("session_id") or "")
     # A DRAFT MOVES, IT NEVER DUPLICATES. The composer → New task hop mints the
     # task draft out of what was in the chat box, so for one instant the same
     # unfinished sentence is two drafts and two rows. `from_chat_key` is the
@@ -148,7 +168,7 @@ def api_draft_task_put(draft_id: str, body: dict = Body(default={})):
     from_chat = drafts.chat_key(body.get("from_chat_key")) if record else ""
     if from_chat:
         drafts.delete_chat(from_chat)
-    _announce(drafts.task_key(ident), from_chat)
+    _announce(drafts.task_key(ident), from_chat, bound)
     return {"ok": True, "draft_id": ident, "draft": record,
             "from_chat_key": from_chat}
 
@@ -159,6 +179,11 @@ def api_draft_task_delete(draft_id: str):
     after a draft has been scheduled for real (which `POST /api/schedule` does
     for itself, given a `draft_id`)."""
     ident = _draft_id(draft_id)
+    # …and the session whose row this draft was standing in for, read before the
+    # delete for the same reason the PUT reads it: afterwards nothing can name
+    # it, and that row has to come back in the same repaint the draft row goes
+    # out on (Akshil, 2026-09-12).
+    bound = str((drafts.get_task(ident) or {}).get("session_id") or "")
     removed = drafts.delete_task(ident)
-    _announce(drafts.task_key(ident))
+    _announce(drafts.task_key(ident), bound)
     return {"ok": True, "draft_id": ident, "removed": removed}

--- a/fused_render/server/routers/drafts.py
+++ b/fused_render/server/routers/drafts.py
@@ -34,6 +34,13 @@ appeared, changed, or went. Nothing "swaps back" on a discard — the session's
 row was never touched, so there is nothing to reverse; it simply repaints
 without the chip.
 
+BOTH CHAT ROUTES ANNOUNCE THE SAME TWO KEYS when the session they name has a
+bound form, and for the same reason: the composer is a second door onto that one
+record ("one record, two doors", `drafts.chat_view`), so a write or a delete
+through this door is a write to the form the other door shows. Which form that
+is, is read before the write (`drafts.bound_chat_draft`) — emptying the box
+deletes it, and afterwards nothing can name it.
+
 `new:<file>` announces itself too, as of round 2. It used to be the one key
 that did not — no session meant no task row meant nothing for a listening page
 to repaint — but an unsent chat IS a row now, filed under the folder it was
@@ -95,7 +102,13 @@ def _announce(*keys: str) -> None:
 def api_drafts():
     """Everything, both kinds. The modal's "resume" affordance reads the task
     half; the composer reads its own key out of the chat half rather than
-    paying for a request per conversation."""
+    paying for a request per conversation.
+
+    The chat half carries the BOUND FORMS too, each under the session it is a
+    message to and marked `bound_draft` (`drafts.chat_view`, "one record, two
+    doors"). It is the same read the tasks listing makes, so what the composer
+    seeds from and what the row's chip says can never be two different
+    answers."""
     task, chat = drafts.list_all()  # one file, one read
     return {"chat": chat, "task": task}
 
@@ -105,10 +118,25 @@ def api_draft_chat_put(key: str, body: dict = Body(default={})):
     """Upsert one chat draft. An empty one is a DELETE, and the answer says so
     (`draft: null`) rather than making the caller infer it — the composer's
     autosave fires on every pause including the one after the send cleared the
-    box, and it must be allowed to keep sending what it now holds."""
+    box, and it must be allowed to keep sending what it now holds.
+
+    …AND IT MAY NOT BE A CHAT RECORD AT ALL. When this session's words live in
+    a New task form bound to it, the store writes THERE and makes no chat
+    record (`drafts.put_chat`, "one record, two doors"): the composer and the
+    card's two fields edit one draft, split and joined by the same rule the hop
+    uses. The answer is that form read as a chat draft, `bound_draft` naming
+    it, so this route has one shape whichever record it wrote."""
     chat = _chat_key(key)
+    # WHICH FORM'S ROW IS AT STAKE BESIDES THIS SESSION'S, read BEFORE the write
+    # for the reason the task PUT reads its binding first: a write that empties
+    # the box deletes the form, and afterwards there is nothing left to ask.
+    # The row under `draft:<id>` does not exist (a bound draft is never a row),
+    # so what the announcement does is tell a page holding a stale one to drop
+    # it — and tell the changes endpoint the session's chip moved.
+    bound = drafts.bound_chat_draft(chat)
     record = drafts.put_chat(chat, body.get("text"), body.get("attachments"))
-    _announce(chat)
+    bound = bound or str((record or {}).get("bound_draft") or "")
+    _announce(chat, drafts.task_key(bound) if bound else "")
     return {"ok": True, "key": chat, "draft": record}
 
 
@@ -117,10 +145,26 @@ def api_draft_chat_delete(key: str):
     """Drop one chat draft — on send, or on an explicit clear. Answers whether
     there was one, and is not a 404 when there was not: the composer clears
     after a send whether or not the debounce ever got round to a first save,
-    and a red line in the console over that would be noise about nothing."""
+    and a red line in the console over that would be noise about nothing.
+
+    THE BOUND FORM GOES WITH IT. This is the composer's send, and what it is
+    saying is that the words under this key have been spent — so when those
+    words were living in a task draft bound to the session ("one record, two
+    doors"), that draft is what the send spent and leaving it behind would put
+    the sentence back on the row as unsent the moment the listing repainted.
+    The whole form goes, the same way an emptied composer takes it
+    (`drafts.put_chat`): there is no half of a draft to keep once the message
+    it was is in the transcript (Akshil, 2026-09-12).
+
+    Only from HERE, and never from `drafts.delete_chat` itself: archive, delete
+    and erase all call that one, and erase in particular is documented to keep
+    a bound draft's words and cut only the binding (`drafts.unbind_session`)."""
     chat = _chat_key(key)
+    bound = drafts.bound_chat_draft(chat)
     removed = drafts.delete_chat(chat)
-    _announce(chat)
+    if bound:
+        removed = drafts.delete_task(bound) or removed
+    _announce(chat, drafts.task_key(bound) if bound else "")
     return {"ok": True, "key": chat, "removed": removed}
 
 

--- a/fused_render/server/routers/drafts.py
+++ b/fused_render/server/routers/drafts.py
@@ -150,7 +150,7 @@ def api_draft_task_put(draft_id: str, body: dict = Body(default={})):
     # debounced autosave, against a chip that would otherwise be stuck showing
     # stale words until the 20-second listing.
     bound = str((drafts.get_task(ident) or {}).get("session_id") or "")
-    record, evicted = drafts.put_task(ident, body)
+    record, canonical = drafts.put_task(ident, body)
     bound = bound or str((record or {}).get("session_id") or "")
     # A DRAFT MOVES, IT NEVER DUPLICATES. The composer → New task hop mints the
     # task draft out of what was in the chat box, so for one instant the same
@@ -176,13 +176,18 @@ def api_draft_task_put(draft_id: str, body: dict = Body(default={})):
     from_chat = drafts.chat_key(body.get("from_chat_key")) if record else ""
     if from_chat:
         drafts.delete_chat(from_chat)
-    # ...and EVICTED, when this write bound a session that another draft had
-    # already claimed (`drafts.put_task`, review 2026-09-12: one bound draft
-    # per session). The loser's key is announced alongside the rest so a page
-    # holding that row drops it, rather than going on showing a chip whose form
-    # just vanished out from under it.
-    _announce(drafts.task_key(ident), from_chat, bound, *evicted)
-    return {"ok": True, "draft_id": ident, "draft": record,
+    # ...and THE ID THIS WRITE ACTUALLY LANDED ON, when it turned out to be
+    # about a session another draft already held and the store folded it into
+    # that one (`drafts.put_task`, Bugbot PR #1126: a merge, not an eviction).
+    # Both keys are announced — the requested id, so a page holding a row under
+    # it drops it, and the canonical one, so the row that grew these words
+    # repaints — and the canonical id is what goes back in the body, because
+    # every later call the card makes (the next autosave, Discard, Schedule)
+    # names the draft by id and would otherwise aim at a record that is not
+    # there.
+    _announce(drafts.task_key(ident), from_chat, bound,
+              drafts.task_key(canonical) if canonical and canonical != ident else "")
+    return {"ok": True, "draft_id": canonical or ident, "draft": record,
             "from_chat_key": from_chat}
 
 

--- a/fused_render/server/routers/drafts.py
+++ b/fused_render/server/routers/drafts.py
@@ -28,13 +28,23 @@ to repaint — but an unsent chat IS a row now, filed under the folder it was
 opened on (`routers/tasks.py::_new_chat_draft_row`), so it has to appear and
 vanish live like every other (design.md, "Round 2"; Akshil, 2026-09-11).
 
+**Moving that key onto a session is not a route here**, and the missing
+endpoint is deliberate. A chat's first send is what creates the session, and no
+page can prove which session id its own send made — every client-side version
+of that inference had a gap (Bugbot, PR #1118, 2026-09-12). What the send does
+say is which draft it is SPENDING: it tags its own run with the key
+(`draft_key`, written into the run's `meta.json` by `agent._start`), and the
+server moves the number when that run's session id appears, at listing time:
+`routers/tasks.py::_settle_new_chats`. The composer still DELETEs its own
+`new:<file>` draft on send, which is the ordinary way one goes away.
+
 Routes take `{key:path}` rather than `{key}` for one reason: a `new:<file>` key
 carries a file path, separators and all, and a plain path parameter stops at
 the first one.
 """
 from fastapi import APIRouter, Body, HTTPException
 
-from fused_render import drafts, tasks_store, tasks_watch
+from fused_render import drafts, tasks_watch
 
 router = APIRouter()
 
@@ -76,61 +86,6 @@ def api_drafts():
     paying for a request per conversation."""
     task, chat = drafts.list_all()  # one file, one read
     return {"chat": chat, "task": task}
-
-
-@router.post("/api/drafts/chat/rekey")
-def api_draft_chat_rekey(body: dict = Body(default={})):
-    """`{from, to}` — the first send has learned the session id.
-
-    A chat opened on a folder is drafted under `new:<file>` and listed under
-    that key, TASK number and all. The moment its first message is sent Claude
-    Code mints a session, and the conversation the user is looking at is now
-    filed somewhere else. Without this the number would be stranded on a row
-    nobody can reach and the session would allocate a second one — the same
-    break `pending:<entry-id>` → session id already has an answer for, which is
-    why this is that answer: one `tasks_store.rekey`, same file, same
-    allocate-once promise, same refusal to overwrite a number `to` already has
-    (design.md, "Round 2").
-
-    A no-op that still answers 200 when `from` has no number — a chat sent
-    before the debounce ever saved a draft never had a row to number — because
-    the client fires this on every first send and cannot know which it was.
-
-    THE TEXT MOVES WITH THE NUMBER, when there is any. Normally there is none:
-    the send is what cleared the composer, so `from` is already empty and this
-    is purely a delete. When the user typed on after sending, the leftover
-    text belongs to the conversation that send created. A draft already stored
-    under `to` is left alone — it is the newer of the two and the one the
-    composer is actually showing.
-    """
-    src = _chat_key(body.get("from"))
-    dst = drafts.session_key(body.get("to"))
-    if not dst:
-        raise HTTPException(
-            status_code=400, detail="to: expected a session id")
-    if src == dst:
-        raise HTTPException(
-            status_code=400, detail="from and to: expected two different keys")
-
-    number = ""
-    try:
-        number = tasks_store.rekey(src, dst)
-    except OSError:
-        # The message IS sent and the conversation IS open; a read-only state
-        # dir must not turn that into a 500. The session simply allocates its
-        # own number on the next listing. Same posture as the rekey in
-        # `routers/schedule.py`.
-        pass
-
-    record = drafts.get_chat(src)
-    moved = False
-    if record and drafts.get_chat(dst) is None:
-        moved = drafts.put_chat(dst, record.get("text"),
-                                record.get("attachments")) is not None
-    drafts.delete_chat(src)
-    _announce(src, dst)
-    return {"ok": True, "from": src, "to": dst,
-            "task_id": number, "moved": moved}
 
 
 @router.put("/api/drafts/chat/{key:path}")

--- a/fused_render/server/routers/schedule.py
+++ b/fused_render/server/routers/schedule.py
@@ -387,12 +387,17 @@ def api_schedule_create(body: dict = Body(...),
                 tasks_store.rekey(drafts.task_key(draft),
                                   tasks_store.pending_key(str(entry.get("id") or "")))
             if drafts.delete_task(draft):
-                # BOTH ROWS MOVE. The draft row goes, and for a session-bound
-                # draft the session's own row — held back while the draft stood
-                # in for it — comes back in its place. `session` below is the
-                # same key and is announced there anyway, but only when the
-                # composer left a chat draft behind; this is the announcement
-                # the swap itself owes.
+                # BOTH KEYS ARE ANNOUNCED, but only one of them was ever a row.
+                # The draft's key repaints as `gone` — for an unbound draft
+                # because the row just left the listing outright, for a
+                # session-bound one because it was never a row to begin with
+                # (`_draft_rows` skips it; the session's own row wore the chip
+                # instead). The session's key repaints because THAT row just
+                # lost the chip it was wearing (`bound_draft`, `_bound_chips`) —
+                # nothing about the row underneath ever moved. `session` below
+                # is the same key and is announced there anyway, but only when
+                # the composer left a chat draft behind; this is the
+                # announcement scheduling itself owes.
                 tasks_watch.notify(
                     {drafts.task_key(draft), str(entry.get("session_id") or "")}
                     - {""})

--- a/fused_render/server/routers/schedule.py
+++ b/fused_render/server/routers/schedule.py
@@ -373,10 +373,29 @@ def api_schedule_create(body: dict = Body(...),
             # actually matter to it — but a failure between the two must leave
             # the draft, which is recoverable, rather than a numberless task,
             # which is not.
-            tasks_store.rekey(drafts.task_key(draft),
-                              tasks_store.pending_key(str(entry.get("id") or "")))
+            #
+            # NOT FOR A DRAFT THAT BELONGS TO A SESSION (Akshil, 2026-09-12).
+            # Such a draft never had a number of its own — the listing skips it
+            # precisely because the session it is bound to holds the task's
+            # number already (`routers/tasks.py::_draft_numbers`) — and this
+            # message is landing IN that session, which is where the number
+            # stays. Moving anything onto `pending:<entry-id>` here would be
+            # inventing a second identity for a task that has one; the entry
+            # naming a session is the whole test, since that is the key the
+            # listing will file it under (`_collect`).
+            if not str(entry.get("session_id") or ""):
+                tasks_store.rekey(drafts.task_key(draft),
+                                  tasks_store.pending_key(str(entry.get("id") or "")))
             if drafts.delete_task(draft):
-                tasks_watch.notify({drafts.task_key(draft)})
+                # BOTH ROWS MOVE. The draft row goes, and for a session-bound
+                # draft the session's own row — held back while the draft stood
+                # in for it — comes back in its place. `session` below is the
+                # same key and is announced there anyway, but only when the
+                # composer left a chat draft behind; this is the announcement
+                # the swap itself owes.
+                tasks_watch.notify(
+                    {drafts.task_key(draft), str(entry.get("session_id") or "")}
+                    - {""})
         except OSError:
             pass
 

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -2098,8 +2098,8 @@ def _new_chat_draft_row(key: str, record: dict, number: str = "") -> dict:
     composer already holding the text (design.md, "Round 2").
 
     THE SAME FIELD SET as `_draft_row` and `_row`, with a draft's answers: no
-    session (there is none until the first send — that send is what
-    `POST /api/drafts/chat/rekey` reports, and it carries this number forward),
+    session (there is none until the first send — and the run that send starts
+    is what carries this number forward, `_settle_new_chats`),
     no messages, nothing that has happened. `form` is null rather than a dict:
     a chat draft is text and attachments, which is what `draft` already
     carries, and there is no form to reopen.
@@ -2213,6 +2213,144 @@ def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
         return tasks_store.ensure_ids(items, reproject=True)
     except OSError:
         return {}
+
+
+# How many run dirs (newest first) one settle pass reads. The run that created
+# the session a `new:<file>` key is waiting for is by construction a recent one
+# — the draft is the message that started it — and nothing prunes RUNS, so the
+# tail of that tree is months of dead runs. Deliberately the same order of
+# magnitude as `_PARKED_SCAN_LIMIT` and agent.py's own `_LIVE_SCAN_LIMIT`.
+_NEW_CHAT_SCAN_LIMIT = 60
+
+
+def _settle_new_chats(chat_drafts: dict) -> bool:
+    """Walk a `new:<file>` key's TASK number onto the session the send that
+    SPENT it created, and drop the draft that send spent. True if anything
+    moved.
+
+    THE SEND NAMES ITS OWN DRAFT, and nothing here infers it. A chat with no
+    session drafts under `new:<file>` and is numbered under that key; the first
+    send creates the session, and the number has to follow it or the row the
+    user has been watching is stranded on a key nothing reads again. So the
+    composer's session-less send puts the key it is spending in the start
+    request (`protocol/run-controller.ts`, `draft_key`), `agent._start` writes
+    it into `meta.json` verbatim before it spawns anything, and this reads it
+    back. The draft key is a RECEIPT written by the process that spent it,
+    which is the one thing about that send nobody has to guess at.
+
+    WHY NOT THE TARGET. The first build of this matched a run to a draft by
+    "same file, and `resumed_from` is empty" — a first-ever run on that
+    folder — and every OTHER way a folder gets its first run passes those same
+    two guards: a scheduled task's first fire (`schedule.py::_send` →
+    `claude_spawn.spawn_helper` → `agent._start`), a `new_task_each_run` entry,
+    canvases.py's own spawn. Any of them would have taken the number off a chat
+    the reader was still typing into and `delete_chat` would have destroyed the
+    unsent words with it (review, 2026-09-12). None of them sends a
+    `draft_key`, so none of them can claim a draft now.
+
+    (The four rounds before that asked the CLIENT which session its own send
+    created, and each answer was an inference with a gap — a send that threw, a
+    refusal that never left `idle`, a Back before the id landed — that left the
+    move owed to whichever session id turned up next. Tagging the run is not
+    that: the page is not saying which session it made, it says which draft
+    it spent, which it knows at the moment it spends it.)
+
+    WHERE IT RUNS. `agent.py` is a TEMPLATE — outside the package's import
+    graph by design (SPEC PY-15), so it cannot call `tasks_store` or `drafts`
+    at the moment it learns the id — and a chat's own run is started and polled
+    in an executor subprocess, never in this process. The nearest thing the
+    server has to that moment is the build below: it is the only reader of the
+    number, it already scans this tree for parked runs, and it runs BEFORE
+    `_numbers` allocates, so the session this settles is still unnumbered when
+    it gets here. Latency is one listing (the changes long-poll the chat itself
+    holds, in practice).
+
+    TWO GUARDS BESIDES THE KEY:
+
+    * **A session id, or nothing happens.** A run that never got one (`_start`
+      failed, the CLI died before its first row) has nothing to carry the
+      number to, and the draft is still the only copy of what was typed. Asked
+      again on the next build.
+    * **Nothing newer than the run.** A draft whose last save is AFTER this run
+      started is not the message it sent — it is words typed into the same box
+      while the session id was still on its way — so the key is left whole,
+      number and text both. Everything else under the key predates the send and
+      IS what was sent, which is why the draft is deleted and its text is never
+      copied forward: the words are in the transcript already.
+    """
+    records = {key: rec for key, rec in chat_drafts.items()
+               if drafts.is_new_chat_key(key)}
+    # The ordinary case has no record at all — the composer deletes the draft
+    # on send, in the same tick as the send — so the NUMBER alone is what is
+    # usually left to move, and the numbers store is the only place it is. That
+    # is why this read is not gated on `records` being non-empty (review perf
+    # note, 2026-09-12): gating it there would skip exactly the common case and
+    # strand the number the send was supposed to carry. One small json file,
+    # read before anything decides to touch the runs tree.
+    waiting = set(records) | {key for key in tasks_store.task_ids()
+                              if drafts.is_new_chat_key(key)}
+    if not waiting:
+        return False  # nothing unsent is numbered: no reason to read the tree
+    agent = _agent_module()
+    runs = getattr(agent, "RUNS", "") if agent is not None else ""
+    if not runs:
+        return False
+    try:
+        names = sorted(os.listdir(runs), reverse=True)[:_NEW_CHAT_SCAN_LIMIT]
+    except OSError:
+        return False  # no runs tree yet: nothing has ever chatted here
+    moved = False
+    for name in names:
+        if not waiting:
+            break  # every key settled; the older runs have nothing to say
+        run_dir = os.path.join(runs, name)
+        meta_path = os.path.join(run_dir, "meta.json")
+        try:
+            # The mtime of the file `_start` writes once, before it spawns: when
+            # this run began, which is the floor the second guard reads.
+            started = os.path.getmtime(meta_path)
+            with open(meta_path, encoding="utf-8") as fh:
+                meta = json.load(fh)
+        except (OSError, ValueError):
+            continue  # one unreadable run, not an unsettled draft for ever
+        if not isinstance(meta, dict):
+            continue
+        # VERBATIM ON BOTH SIDES. The key is stored unnormalised on purpose
+        # (`drafts.chat_key`, `chatDraftKey`) and rides the request untouched,
+        # so this is a string comparison and never a path one: a run tagged for
+        # another key — or for a key some earlier run already settled — is not
+        # this draft's send.
+        key = str(meta.get("draft_key") or "")
+        if key not in waiting:
+            continue
+        # The session this run MADE. `_run_sessions` answers both spellings —
+        # the one it resumed and the one the CLI minted — and a tagged run has
+        # no `resumed_from` by construction (the composer tags only a send with
+        # no session id), so subtracting it is belt and braces rather than a
+        # second guess.
+        ids = _run_sessions(agent, run_dir, meta) - {
+            str(meta.get("resumed_from") or "")}
+        if not ids:
+            continue  # no id minted yet (or ever): ask again next build
+        session_id = sorted(ids)[0]
+        record = records.get(key)
+        if record and float(record.get("updated_at") or 0.0) > started:
+            continue  # typed into again since: not this send's draft
+        try:
+            tasks_store.rekey(key, session_id)
+            drafts.delete_chat(key)
+        except OSError:
+            # A read-only state dir costs the number's continuity and nothing
+            # else. Same posture as `_numbers` and the schedule router's own
+            # rekey: the listing still answers.
+            continue
+        waiting.discard(key)
+        moved = True
+        # Both rows moved: the draft row is gone and the session wears its
+        # number. The chat holding the changes long-poll hears it now rather
+        # than on its next full pass.
+        tasks_watch.notify({key, session_id})
+    return moved
 
 
 def _draft_shaped(only: frozenset | set) -> bool:
@@ -2413,6 +2551,14 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     # `read` and `busy` are read once: it is one small file, the join below
     # asks it per session, and `_draft_rows` asks it again.
     task_drafts, chat_drafts = drafts.list_all()
+    # A FIRST SEND'S SESSION IS SETTLED HERE, before a number is allocated
+    # below: `new:<file>` hands its number to the session that send created and
+    # the spent draft goes (`_settle_new_chats` — and see its docstring for why
+    # this is the server's job and not the composer's). A settle rewrites the
+    # store this build has already read, so the read is taken again; it is one
+    # small file, and it only happens on the build a send is settled in.
+    if _settle_new_chats(chat_drafts):
+        task_drafts, chat_drafts = drafts.list_all()
     for task in tasks.values():
         _place(task)
     numbers = _numbers(tasks)

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -1946,14 +1946,19 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # draft line quotes this preview, and a `"chat"` preview is words in
         # this conversation's composer — pressing it opens the chat and there
         # they are. A `"form"` preview is a New task card bound to this session,
-        # of which the chat holds nothing, so that press has to reopen the card
-        # instead. Spelled here rather than inferred from `bound_draft` by the
-        # page: one fact, one place, and no second rule to go stale the first
-        # time a row carries both kinds at once.
-        "draft": (_chat_draft(task["session_id"], chat_drafts)
-                  or ({"preview": bound["preview"],
-                       "updated_at": bound["updated_at"],
-                       "kind": "form"} if bound else None)),
+        # which holds the time, the repeat rule and the model as well as the
+        # words, so that press reopens the card instead. Spelled by the store
+        # rather than inferred from `bound_draft` by the page: one fact, one
+        # place, and no second rule to go stale the first time a row carries
+        # both kinds at once.
+        #
+        # ONE SOURCE, BOTH KINDS. A bound form reads as its session's chat draft
+        # now (`drafts.chat_view`, "one record, two doors") — the composer shows
+        # and edits the same words — so the join below answers for both and the
+        # old second branch here, which built a preview out of `bound` when the
+        # chat half had nothing, would be a second way of saying what the chat
+        # half already says. `bound` is still read, for `bound_draft` beneath.
+        "draft": _chat_draft(task["session_id"], chat_drafts),
         # WHICH FORM IS BEING WRITTEN INTO THIS CONVERSATION — the bound task
         # draft's id, or "" for the overwhelmingly common row with none. It is
         # not drawn: it is what the composer's Schedule hop reopens, so pressing
@@ -1993,9 +1998,16 @@ def _chat_draft(session_id: str, chat_drafts: dict | None) -> dict | None:
     or None. `None` and "an empty draft" are the same thing — the store never
     keeps an empty one — so the client has exactly one question to ask.
 
-    `kind: "chat"` says where these words are: in this conversation's composer,
-    which is what makes opening the chat the right press for them (see `_row`,
-    and the bound form's `"form"` beside it)."""
+    `kind` says WHERE these words are, and both answers come out of this one
+    join now. `chat_drafts` is the chat half as a reader sees it
+    (`drafts.chat_view`), which carries a stored chat record for every composer
+    that is holding something AND a synthesized one for every session whose
+    words are in a New task form bound to it — the latter marked `bound_draft`,
+    which is the whole of the difference. So `"chat"` is text in this
+    conversation's composer and opening the chat is the press for it; `"form"`
+    is that card, which holds the time, the repeat rule and the model beside the
+    words, and the press reopens it (see `_row`). A session that has both keeps
+    them apart: the stored record wins, and `bound_draft` on it is `""`."""
     if not session_id or not chat_drafts:
         return None
     record = chat_drafts.get(session_id)
@@ -2005,7 +2017,8 @@ def _chat_draft(session_id: str, chat_drafts: dict | None) -> dict | None:
     rows = record.get("attachments") or []
     if not line and not rows:
         return None
-    return {"preview": line, "kind": "chat",
+    return {"preview": line,
+            "kind": "form" if record.get("bound_draft") else "chat",
             "updated_at": float(record.get("updated_at") or 0.0)}
 
 

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -54,12 +54,19 @@ preview of whatever is sitting unsent in that conversation's composer, or None
 `✎ Draft` chip appear and a new draft land in Upcoming without a reload. Both
 are absent from the pulse, deliberately — see `api_tasks_pulse`.
 
-A task draft that names a `session_id` is the exception to "no number": it is
-the next message of a conversation that already has one, so it borrows the
-session's number and the session's folder, and the session's own row stands
-down while the draft exists — one task, one row, one number (`_draft_row`,
-`_bound_sessions`, and the tail of `_build_task_rows`). Never over a session
-that is mid-run, though: a live row is never hidden (`LIVE_STATUSES`).
+A task draft that names a `session_id` is the exception to all of that: it is
+the next message of a conversation that already has a row and a number, so it
+is NOT A ROW AT ALL. No draft row is emitted for it and no number is minted
+(`_draft_rows`, `_draft_numbers`); the session's own row stands exactly as it
+always did — same title, same lane, same number, same click into the chat — and
+merely gains two fields: `bound_draft`, the form's id, and `draft`, its preview,
+so the row wears the red `✎ Draft` chip like any other unsent words
+(`_bound_chips`). Nothing is hidden anywhere, which is the point: a stand-in row
+was a second thing to read, it took the conversation off the Cards wall (a wall
+of transcripts, which a form has none of), and it made one session row open a
+modal where every other opens the chat (bugbot, PR #1126; Akshil, 2026-09-12).
+The way back into the form is the composer's Schedule hop, which reopens the
+draft already bound to that session instead of minting another.
 
 **What a message is.** A user prompt in the transcript, or a scheduled entry.
 Those two overlap: a scheduled message that fired IS a prompt in the transcript
@@ -152,14 +159,11 @@ logger = logging.getLogger(__name__)
 STATUSES = ("upcoming", "in_progress", "needs_attention", "blocked", "done",
             "archived")
 
-# The three of those that mean SOMETHING IS STILL HAPPENING to this task — a
-# turn in flight, a run parked on a card nobody has answered, a run that broke
-# and has not been read. The listing may fold a row away for any number of
-# reasons; it may never fold one of THESE away. A live session is news, and
-# news the page cannot show is news nobody can act on (review, 2026-09-12).
-# Read by the session-bound draft swap at the tail of `_build_task_rows`;
-# `upcoming`, `done` and `archived` are settled and deliberately not here.
-LIVE_STATUSES = ("in_progress", "needs_attention", "blocked")
+# There was a `LIVE_STATUSES` here, read by a swap that hid a session's row
+# behind the task draft bound to it and narrowed to the settled statuses so a
+# run in flight could never vanish. The swap is gone (bugbot, PR #1126): this
+# listing hides nothing, the row says `bound_draft` instead, and there is no
+# pair left for any view to fold together.
 
 # What `blocked_reason` may say. "" is the answer for every task that is neither
 # blocked nor waiting on anybody — most of them.
@@ -1742,7 +1746,8 @@ def _next_run(entries: list[dict]) -> tuple[float, str, bool]:
 
 def _row(task: dict, number: str, triage: dict, read: dict, now: float,
          busy: set[str], revived: list[str], parked: dict | None = None,
-         chat_drafts: dict | None = None) -> dict:
+         chat_drafts: dict | None = None,
+         bound_chips: dict | None = None) -> dict:
     """One listing row. The tail parse only: three messages, and a count.
 
     `parked` is `_parked_runs()` — every session whose live run is waiting on a
@@ -1764,6 +1769,15 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     has no conversation to have been typed into, and a `new:<file>` draft has no
     row at all until its first send makes the session (design.md, "Chat draft
     key").
+
+    `bound_chips` is `_bound_chips(task_drafts)` — the OTHER draft that can be
+    about this conversation: a New task form somebody opened out of it and has
+    not sent. Read once by the caller, like `chat_drafts`, and joined on the
+    same session id. It fills two fields and nothing else: `bound_draft`, which
+    names the draft row standing in for this one, and — only when the composer
+    itself is empty — `draft`, so the row wears the chip either way. A chat
+    draft WINS, because that one is literally sitting in this conversation's
+    composer while the form is a message about to be scheduled into it.
 
     `revived` is an OUT parameter and the only one: a session whose archive
     record this row has just found stale is appended to it, and the caller does
@@ -1872,6 +1886,11 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     status = _status(merged, filed, task["session_id"], live, busy,
                      parked=waiting is not None)
     failed = _failed(speaker)
+    # The New task form bound to this conversation, if there is one — same
+    # keying as `waiting` above and for the same reason: a row with no session
+    # has nothing a draft could be bound TO, and "" must not match.
+    bound = ((bound_chips or {}).get(task["session_id"]) or {}
+             if task["session_id"] else {})
     return {
         "key": task["key"],
         "task_id": number,
@@ -1916,7 +1935,21 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # the composer the user left it in, and a listing that carried every
         # unsent message on the machine would be paying transcript-sized costs
         # for a badge.
-        "draft": _chat_draft(task["session_id"], chat_drafts),
+        # …OR THE FORM BEING WRITTEN INTO IT, when the composer itself is empty
+        # (Akshil, 2026-09-12). A task draft bound to this session is unsent
+        # words about this conversation just as much, and it has no row of its
+        # own to wear a chip — so this row wears it, everywhere, the Cards wall
+        # included. One field, one question for every view: is there anything
+        # unsent here.
+        "draft": (_chat_draft(task["session_id"], chat_drafts)
+                  or ({"preview": bound["preview"],
+                       "updated_at": bound["updated_at"]} if bound else None)),
+        # WHICH FORM IS BEING WRITTEN INTO THIS CONVERSATION — the bound task
+        # draft's id, or "" for the overwhelmingly common row with none. It is
+        # not drawn: it is what the composer's Schedule hop reopens, so pressing
+        # Schedule in a chat that already has an unsent form comes back to THAT
+        # form rather than minting a second one (shell/Scheduled `?new=1`).
+        "bound_draft": bound.get("id", ""),
         "unread": _unread_count(task, total, unfired, read),
         # WHEN THIS TASK BEGAN — the EARLIEST clock it has (`_place`, which
         # explains the choice at length): the scheduled entry's `created`, else
@@ -2000,8 +2033,7 @@ def _draft_title(text, fallback: str) -> str:
     return line or fallback
 
 
-def _draft_row(ident: str, record: dict, number: str = "",
-               project: str = "") -> dict:
+def _draft_row(ident: str, record: dict, number: str = "") -> dict:
     """One task draft as a listing row.
 
     THE SAME FIELD SET AS `_row`, deliberately and in full: the List, the Board
@@ -2011,18 +2043,15 @@ def _draft_row(ident: str, record: dict, number: str = "",
     happened (`happened_at` 0.0 — the desk must not read an unfinished form as
     work that finished under an app).
 
-    A DRAFT CAN BELONG TO A CONVERSATION (Akshil, 2026-09-12). The composer's
-    Schedule button hops out of a chat that may already have run, and the task
-    being written is a message INTO that thread — so `session_id` is the draft's
-    own stored one (`drafts.bound_session`), and such a row borrows the
-    SESSION's identity rather than minting one of its own: the session's TASK
-    number and the session's project, passed in by `_draft_rows`. The key stays
-    `draft:<id>` (it is still a form, and the form is what a click reopens),
-    but there is exactly one row and exactly one number for the one task —
-    the session's own row is held back while this one stands in for it
-    (`_build_task_rows`). Before that, exiting the modal lost the binding: the
-    draft came back as a stranger, scheduling it opened a second session and
-    minted a second number, and the task the reader had been watching was gone.
+    NEVER A SESSION-BOUND DRAFT (Akshil, 2026-09-12). The composer's Schedule
+    button hops out of a chat that may already have run, and the task being
+    written is a message INTO that thread — a thread with a row of its own. That
+    draft is therefore not listed at all: `_draft_rows` skips it before reaching
+    here, the conversation's row wears the `✎ Draft` chip instead
+    (`_bound_chips`), and the form is reopened by the same hop rather than by a
+    row. So every row this builder makes belongs to nobody, and `session_id`
+    below is always "" in practice — emitted anyway because one row shape is one
+    row shape.
 
     IT DOES HAVE A NUMBER. Round 1 printed `task_id: ""` here on the reasoning
     that a number is minted when a task becomes real; round 2 reversed that,
@@ -2033,10 +2062,9 @@ def _draft_row(ident: str, record: dict, number: str = "",
     `pending:<entry-id>` when the draft is scheduled, so the number the row
     showed while it was a form is the number it keeps once it is a task
     (design.md, "Round 2"; Akshil, 2026-09-11). A SESSION-BOUND draft is the
-    one exception, and it is the same rule read the other way: the number
-    already exists, on the session, so nothing is allocated here and nothing is
-    moved when the draft is scheduled (`_draft_numbers`, and the schedule
-    router's own rekey guard).
+    one exception and it never gets this far: the number already exists, on the
+    session, so nothing is allocated for it and nothing is moved when it is
+    scheduled (`_draft_numbers`, and the schedule router's own rekey guard).
 
     The three fields `_row` has no use for — `draft_kind`, `cwd` and `file` —
     are carried by BOTH draft kinds rather than by whichever needs them, for
@@ -2052,20 +2080,18 @@ def _draft_row(ident: str, record: dict, number: str = "",
     if not title:
         title = _draft_title(record.get("description"), "")
     target = str(record.get("target") or "")
-    # THE SESSION'S FOLDER WINS when there is a session, because the row IS that
-    # task and a task sits in one project. `""` is "this draft belongs to
-    # nobody", and then the folder the form points at is the only answer there
-    # is — which is what every draft row said before bindings existed.
-    place = project or tasks_store.project_of(_workdir(target))
+    # THE FOLDER THE FORM POINTS AT, which is the only answer a row here can
+    # have: a draft that belongs to a conversation is not a row (see the
+    # docstring), so there is never a session's project to prefer over it.
+    place = tasks_store.project_of(_workdir(target))
     created = float(record.get("created_at") or 0.0)
     updated = float(record.get("updated_at") or 0.0)
     return {
         "key": drafts.task_key(ident),
         # ALLOCATED, and allocated under `draft:<id>` so it can be moved onto
         # `pending:<entry-id>` by one `tasks_store.rekey` the moment the form
-        # is scheduled — or BORROWED from the session this draft is bound to,
-        # which has one already. "" only when the state dir is unwritable,
-        # which is the same "" every other row falls back to.
+        # is scheduled. "" only when the state dir is unwritable, which is the
+        # same "" every other row falls back to.
         "task_id": number,
         "draft_id": ident,
         "kind": "draft",
@@ -2081,12 +2107,10 @@ def _draft_row(ident: str, record: dict, number: str = "",
         # The raw thing the draft was pointed at, file or folder, BEFORE
         # `_workdir` resolved it to a project. The modal reopens on this.
         "file": canonical_fs_path(target),
-        # THE CONVERSATION THIS FORM IS A MESSAGE TO, or "" for a draft that
-        # belongs to nobody. It is what the reopened modal puts back on the
-        # wire so Schedule lands in the thread rather than starting another one
-        # — and it is how `_build_task_rows` knows whose row this one is
-        # standing in for. It does NOT change where a click goes: a draft row
-        # opens the form, session or no session (shell/ScheduleTaskViews).
+        # THE CONVERSATION THIS FORM IS A MESSAGE TO — always "" here, because
+        # a bound draft is not listed (see the docstring). Read off the record
+        # rather than written as a constant so this stays the row's own answer
+        # and not a claim about the caller.
         "session_id": str(record.get("session_id") or ""),
         "title": title or _UNTITLED_DRAFT,
         "title_source": "draft",
@@ -2099,6 +2123,9 @@ def _draft_row(ident: str, record: dict, number: str = "",
         # The chat half of the store keys on a session, and a draft has none.
         # Present anyway so one row shape answers one question.
         "draft": None,
+        # A draft is never the row being stood in FOR — it is the stand-in.
+        # Present for the same one-row-shape reason as the field above.
+        "bound_draft": "",
         "unread": 0,
         # WHEN: a draft has none, and null is the difference between "runs at
         # no particular time" (an immediate task, which has a time) and "has
@@ -2185,6 +2212,7 @@ def _new_chat_draft_row(key: str, record: dict, number: str = "") -> dict:
         # the session id; this one IS the draft, so the join is the identity.
         "draft": ({"preview": line, "updated_at": updated}
                   if (line or rows) else None),
+        "bound_draft": "",
         "unread": 0,
         "when": None,
         # One clock, because the store keeps one: a chat draft has no
@@ -2245,10 +2273,11 @@ def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
     conversation that already has a number, and the reported bug was exactly
     that a second one got minted: exit the modal, reopen the draft, press
     Schedule, and the task the reader had been watching as TASK-118 came back as
-    TASK-119 in a session of its own. The row still shows a number — the
-    SESSION's, looked up by `_bound_places` — so nothing on the page goes blank;
-    what does not happen is an allocation. `ensure_ids` is never told about the
-    key, so `reproject` cannot spend anything under it either.
+    TASK-119 in a session of its own. Such a draft has no row of its own to put
+    a number on either (`_draft_rows` skips it; the session's row wears the
+    chip), so nothing on the page goes blank — what does not happen is an
+    allocation. `ensure_ids` is never told about the key, so `reproject` cannot
+    spend anything under it either.
     """
     items = []
     for ident, record in task_drafts.items():
@@ -2272,64 +2301,43 @@ def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
         return {}
 
 
-def _bound_sessions(task_drafts: dict) -> dict[str, str]:
-    """`{draft:<id>: <session-id>}` for every task draft that belongs to a
+def _bound_chips(task_drafts: dict) -> dict[str, dict]:
+    """`{session-id: {id, preview, updated_at}}` — the New task form somebody
+    opened out of a conversation and has not sent yet, keyed by that
     conversation.
 
-    One question asked in three places — which numbers are not allocated, which
-    row identity is borrowed, and which session rows stand down — so it is
-    spelled once and read off the STORE rather than off the built rows. That
-    matters for the narrowed build: `/api/tasks/changes` asked about a session
-    alone never runs the draft half at all (`_draft_shaped`), and a claim that
-    depended on a draft row having been built would let the session's row come
-    back for exactly that poll."""
-    out = {}
+    THE WHOLE OF WHAT A BOUND DRAFT DOES TO THIS LISTING (Akshil, 2026-09-12).
+    Such a draft gets no row of its own (`_draft_rows`) and no number
+    (`_draft_numbers`) — it is the next message of a task that already has both
+    — so the only trace of it is here: the session's own row, otherwise exactly
+    as it always was, grows `bound_draft` (which form) and, when that
+    conversation's composer is empty, `draft` (the preview the red `✎ Draft`
+    chip prints). Nothing is hidden, nothing stands in for anything, and a
+    click on the row opens the chat like every other session row; the way back
+    into the form is the composer's Schedule hop, which reopens it by id.
+
+    THE PREVIEW IS THE DRAFT'S FIRST LINE, title before description: the title
+    is what the reader named this thing and what the chip's tooltip should say,
+    and the description's first line is the fallback for a form that has only
+    been typed into. The same one line and the same clipping every other draft
+    preview uses (`drafts.preview`).
+
+    NEWEST WINS when two forms name one session — a shape nothing produces
+    today (the hop reopens the form that is already bound) but one an old store
+    could hold. Deterministic beats first-seen: a dict order is not an answer.
+    """
+    out: dict[str, dict] = {}
     for ident, record in task_drafts.items():
         session = str(record.get("session_id") or "")
-        if session:
-            out[drafts.task_key(ident)] = session
-    return out
-
-
-def _bound_places(bound: dict[str, str]) -> dict[str, tuple[str, str]]:
-    """`{draft:<id>: (TASK number, project)}` — the row identity a session-bound
-    draft borrows from the session it is bound to.
-
-    Both halves come out of `task_ids.json`, which is where a task's number and
-    the project it was allocated in already live together: reading them from the
-    one record is what makes the draft row and the session row it replaces agree
-    by construction rather than by two derivations that could drift.
-
-    AN ERASED RECORD IS NO RECORD (review, 2026-09-12). `forget_session` does
-    not remove a number, it stamps the mapping `erased` and keeps it as a
-    RESERVATION so the number can never be reissued — and a draft still bound to
-    that session was wearing the dead number for ever, with `_draft_numbers`
-    refusing to mint it one of its own because the binding said its task already
-    had a number. The binding itself is cut by the erase (`drafts.unbind_session`
-    in `api_task_erase`); this is the same answer read off the store, for the
-    draft written between the two writes and for any older store that was left
-    bound.
-
-    `("", "")` for a session that has never been numbered — a conversation this
-    machine has not listed yet — and the row then falls back to its own folder
-    and a blank number, which is the same fallback an unwritable state dir gets
-    everywhere else in this file. The ordinary case cannot be that: a draft is
-    bound by a hop OUT of a session, and a session you have chatted in has been
-    through a listing."""
-    if not bound:
-        return {}
-    store = tasks_store.task_ids()
-    # …and which of those records are reservations rather than tasks. Read
-    # separately because `task_ids()` deliberately answers "what number, in what
-    # project" for an erased key too — the number must go on meaning what it
-    # meant — and this is the other question (`tasks_store.erased`).
-    gone = tasks_store.erased()
-    out = {}
-    for key, session in bound.items():
-        rec = store.get(session)
-        if not rec or session in gone:
+        if not session:
             continue
-        out[key] = (tasks_store.format_task_id(rec["n"]), rec["project"])
+        updated = float(record.get("updated_at") or 0.0)
+        if session in out and out[session]["updated_at"] >= updated:
+            continue
+        line = (drafts.preview(record.get("title"))
+                or drafts.preview(record.get("description")))
+        out[session] = {"id": str(ident), "preview": line,
+                        "updated_at": updated}
     return out
 
 
@@ -2510,19 +2518,50 @@ def _draft_rows(only: frozenset | set | None = None,
         if chat_drafts is None:
             chat_drafts = loaded_chat
     numbers = _draft_numbers(task_drafts, chat_drafts)
-    # …and the identity a session-bound draft borrows instead of being allocated
-    # one. One read of `task_ids.json` for the whole build, like the numbers
-    # above, and empty on the overwhelmingly common listing where no draft is
-    # bound to anything.
-    places = _bound_places(_bound_sessions(task_drafts))
+    # Which sessions this machine has ERASED — read at most once per build, and
+    # only when a bound draft is actually seen, because it is a file read and
+    # nearly every listing has nothing bound at all. See the skip below.
+    erased: set[str] | None = None
     rows = []
     for ident, record in task_drafts.items():
         key = drafts.task_key(ident)
         if only is not None and key not in only:
             continue
-        number, project = places.get(key, ("", ""))
-        rows.append(_draft_row(ident, record, number or numbers.get(key, ""),
-                               project))
+        # A DRAFT BOUND TO A SESSION IS NOT A ROW (Akshil, 2026-09-12). It is
+        # the next message of a conversation that already has one, and the
+        # conversation's row is the one the reader knows — its title, its lane,
+        # its number, its place in the list. So nothing is emitted here and
+        # nothing is hidden anywhere: the session's row simply grows the red
+        # `✎ Draft` chip (`_bound_chips`, joined in `_row`), and the way back
+        # into the form is the composer's Schedule hop, which reopens THIS
+        # draft rather than minting another (shell/Scheduled `?new=1`).
+        #
+        # Round 3 built it the other way — a draft row wearing the session's
+        # identity, with the session's own row held back — and that row was a
+        # second thing to read, took the conversation off the Cards wall (a
+        # wall of transcripts, which a draft has none of), and made a click on
+        # it open a modal where every other session row opens the chat
+        # (bugbot, PR #1126).
+        #
+        # …UNLESS THE CONVERSATION IS GONE. `forget_session` does not remove a
+        # number, it stamps the mapping `erased` and keeps it as a reservation,
+        # and the row it belonged to is off the page for good — so a draft still
+        # naming it has nothing left to wear its chip and would be invisible,
+        # with its words unreachable. The erase itself cuts the binding
+        # (`drafts.unbind_session`), and this is the same answer read off the
+        # store for the draft written between that gesture's two writes and for
+        # any older store left bound: an ordinary row again, blank-numbered
+        # until `_draft_numbers` can mint it one (review, 2026-09-12).
+        bound = drafts.bound_session(record.get("session_id"))
+        if bound:
+            if erased is None:
+                try:
+                    erased = tasks_store.erased()
+                except OSError:
+                    erased = set()
+            if bound not in erased:
+                continue
+        rows.append(_draft_row(ident, record, numbers.get(key, "")))
     for key, record in chat_drafts.items():
         if not drafts.is_new_chat_key(key):
             continue
@@ -2684,6 +2723,12 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     # small file, and it only happens on the build a send is settled in.
     if _settle_new_chats(chat_drafts):
         task_drafts, chat_drafts = drafts.list_all()
+    # …and the same read, asked the session's way round: which conversation has
+    # a New task form being written into it. Off the STORE and not off the rows
+    # this build produces, so a `/api/tasks/changes` poll narrowed to the
+    # session alone — which builds no draft rows at all — still answers a row
+    # that knows about its draft (`_bound_chips`).
+    bound_chips = _bound_chips(task_drafts)
     for task in tasks.values():
         _place(task)
     numbers = _numbers(tasks)
@@ -2695,7 +2740,7 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
     for task in tasks.values():
         try:
             row = _row(task, numbers.get(task["key"], ""), triage, read, now,
-                       busy, revived, parked, chat_drafts)
+                       busy, revived, parked, chat_drafts, bound_chips)
         except (OSError, ValueError, KeyError, TypeError):
             continue  # one unreadable task, not an unreadable page
         rows.append(row)
@@ -2738,56 +2783,24 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
             current_apps.observe([r for r in rows if r.get("kind") != "draft"])
         except OSError:
             pass
-    # ONE TASK, ONE ROW — and this is the last thing done, deliberately AFTER
-    # the desk has seen the listing (Akshil, 2026-09-12).
+    # ONE TASK, ONE ROW — and it is the CONVERSATION's row (Akshil,
+    # 2026-09-12).
     #
     # A task draft bound to a session is not a second thing beside that
-    # conversation, it is the conversation's next message being written: same
-    # TASK number, same folder, same work. So while it exists — and while that
-    # conversation is not mid-run, see below — the session's own row stands down
-    # and the draft row takes its place, wearing the number and the `✎ Draft`
-    # chip; Discard or Schedule ends the draft and the session's row is simply
-    # back. Two rows for one task was what the reader actually saw, and no
-    # amount of chip wording makes that read as one thing.
+    # conversation, it is the conversation's next message being written. Round 3
+    # said so by emitting a DRAFT row wearing the session's number and dropping
+    # the session's own row behind it, and every part of that was wrong to read:
+    # the reader lost the title and the lane they knew, the Cards wall lost the
+    # card entirely (it draws transcripts, and `kind:"draft"` has none), and a
+    # click on the row opened a modal where every other session row opens the
+    # chat.
     #
-    # The claim is read off the DRAFT STORE (`_bound_sessions`), never off the
-    # rows this build happened to produce: a `/api/tasks/changes` poll narrowed
-    # to the session alone builds no draft rows at all, and a claim derived
-    # from them would let the hidden row reappear on exactly that poll. The
-    # changes endpoint needs nothing else — a key that is asked about and not
-    # listed is already reported `gone`, which is precisely how the client is
-    # told to drop the row it is still showing.
-    #
-    # WHAT THE HIDING DOES NOT TOUCH. The desk above has already read the
-    # session (a chat with a draft against it is still an app the user is
-    # working in), unread marks live in `read.json` and come back with the row,
-    # and the day-one baseline ran before the drafts were added at all, so this
-    # cannot cost a session its initialisation.
-    #
-    # AND NEVER OVER A LIVE SESSION (review, 2026-09-12). The swap above is a
-    # statement about IDENTITY — these two rows are one task — and a settled
-    # conversation can say it with one row because there is nothing left to
-    # watch. A run that is in flight, parked on a permission card or stopped on
-    # an error is the opposite: hiding it takes the row out of the listing AND
-    # out of the pulse the sidebar dot and Notifications read, so the user
-    # would be waiting on a card they can no longer see, because they started
-    # typing the next message. So while the session's own row is live
-    # (`LIVE_STATUSES`) BOTH rows stand — the session says what the run is
-    # doing, the draft is the way back into the modal — and the swap applies
-    # again on the first build after the run settles.
-    #
-    # Off the BUILT ROW's status, which is the one every view paints (`_row`),
-    # so this cannot disagree with the pill the reader is looking at. A build
-    # narrowed past the session (`only`) has no row to ask, and then nothing is
-    # hidden for that poll either — the same fail-open direction.
-    claimed = set(_bound_sessions(task_drafts).values())
-    if claimed:
-        claimed -= {str(r.get("session_id") or "") for r in rows
-                    if r.get("kind") != "draft"
-                    and r.get("status") in LIVE_STATUSES}
-    if claimed:
-        rows = [r for r in rows
-                if r.get("kind") == "draft" or r.get("session_id") not in claimed]
+    # So there is nothing to do here at all. The bound draft is simply not a row
+    # (`_draft_rows`) and not a number (`_draft_numbers`); the session's row is
+    # untouched but for the chip it now wears (`_bound_chips`, joined in `_row`),
+    # and NOTHING IS HIDDEN — no status to check, no pulse to protect, no claim
+    # to read off a store because no row is being dropped. This tail used to
+    # hold that swap, and the absence is the fix (bugbot, PR #1126).
     return rows
 
 
@@ -3388,7 +3401,9 @@ def api_task_erase(patch: ErasePatch):
     `clear_triage` — there is no session left for a note or a tag to be about),
     and the read marks (`tasks_store.forget_session`), and a task draft bound to
     this session is cut loose from it (`drafts.unbind_session`) — the words
-    stay, the binding does not. The task's NUMBER is the
+    stay, the binding does not, and that draft's own key is announced beside
+    this task's, because the row has just changed its number, its folder and
+    the thread its Schedule would reach. The task's NUMBER is the
     one thing kept: allocation is "max seen plus one" read straight off
     task_ids.json, so the mapping stays as a reservation and a reused TASK-007
     can never point at somebody else's work. See `forget_session`.
@@ -3430,6 +3445,10 @@ def api_task_erase(patch: ErasePatch):
             cancelled += 1
 
     removed, erased, failed, refused = 0, False, 0, 0
+    # The draft rows this erase renumbers, announced beside the task's own key
+    # at the end. Empty for a task with no session and for the ordinary erase
+    # with nothing bound to it, which is nearly all of them.
+    unbound: list[str] = []
     session_id = task["session_id"]
     if session_id:
         removed, erased, failed, refused = _erase_session_files(session_id, task["path"])
@@ -3463,10 +3482,19 @@ def api_task_erase(patch: ErasePatch):
         # reservation (`forget_session`), and the standing-in for a row that no
         # longer exists. The draft is an ordinary `draft:<id>` from the next
         # listing on, numbered in its own folder.
-        drafts.unbind_session(session_id)
+        #
+        # AND THOSE ROWS ARE NEWS (bugbot, PR #1126). Unbinding renumbers the
+        # draft, moves it into its own folder and drops its session — and the
+        # page is still drawing it with the erased session's TASK number, still
+        # holding that `session_id` in the form it would reopen, so pressing
+        # Schedule sent the message back into the conversation this gesture just
+        # destroyed. Announcing only the session's key fixed nothing: the draft
+        # is a different row. So the keys the store hands back are announced
+        # with it, below.
+        unbound = drafts.unbind_session(session_id)
 
     tasks_store.mark_deleted(key)
-    tasks_watch.notify({key})
+    tasks_watch.notify({key} | set(unbound))
     return {"ok": True, "key": key, "cancelled": cancelled,
             "erased_transcript": erased, "removed": removed}
 

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -1941,9 +1941,19 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # own to wear a chip — so this row wears it, everywhere, the Cards wall
         # included. One field, one question for every view: is there anything
         # unsent here.
+        # …and `kind` says WHICH of the two it is, because the two are two
+        # different presses (Bugbot, PR #1126, 2026-09-12). The thread's leading
+        # draft line quotes this preview, and a `"chat"` preview is words in
+        # this conversation's composer — pressing it opens the chat and there
+        # they are. A `"form"` preview is a New task card bound to this session,
+        # of which the chat holds nothing, so that press has to reopen the card
+        # instead. Spelled here rather than inferred from `bound_draft` by the
+        # page: one fact, one place, and no second rule to go stale the first
+        # time a row carries both kinds at once.
         "draft": (_chat_draft(task["session_id"], chat_drafts)
                   or ({"preview": bound["preview"],
-                       "updated_at": bound["updated_at"]} if bound else None)),
+                       "updated_at": bound["updated_at"],
+                       "kind": "form"} if bound else None)),
         # WHICH FORM IS BEING WRITTEN INTO THIS CONVERSATION — the bound task
         # draft's id, or "" for the overwhelmingly common row with none. It is
         # not drawn: it is what the composer's Schedule hop reopens, so pressing
@@ -1981,7 +1991,11 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
 def _chat_draft(session_id: str, chat_drafts: dict | None) -> dict | None:
     """One row's `draft` field: the preview of the unsent text in its composer,
     or None. `None` and "an empty draft" are the same thing — the store never
-    keeps an empty one — so the client has exactly one question to ask."""
+    keeps an empty one — so the client has exactly one question to ask.
+
+    `kind: "chat"` says where these words are: in this conversation's composer,
+    which is what makes opening the chat the right press for them (see `_row`,
+    and the bound form's `"form"` beside it)."""
     if not session_id or not chat_drafts:
         return None
     record = chat_drafts.get(session_id)
@@ -1991,7 +2005,8 @@ def _chat_draft(session_id: str, chat_drafts: dict | None) -> dict | None:
     rows = record.get("attachments") or []
     if not line and not rows:
         return None
-    return {"preview": line, "updated_at": float(record.get("updated_at") or 0.0)}
+    return {"preview": line, "kind": "chat",
+            "updated_at": float(record.get("updated_at") or 0.0)}
 
 
 # What a task draft's row calls itself where a real task names its lane. A
@@ -2210,7 +2225,7 @@ def _new_chat_draft_row(key: str, record: dict, number: str = "") -> dict:
         "live": False,
         # THIS row's chip is about itself. Every other row joins its draft off
         # the session id; this one IS the draft, so the join is the identity.
-        "draft": ({"preview": line, "updated_at": updated}
+        "draft": ({"preview": line, "updated_at": updated, "kind": "chat"}
                   if (line or rows) else None),
         "bound_draft": "",
         "unread": 0,

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -54,6 +54,13 @@ preview of whatever is sitting unsent in that conversation's composer, or None
 `✎ Draft` chip appear and a new draft land in Upcoming without a reload. Both
 are absent from the pulse, deliberately — see `api_tasks_pulse`.
 
+A task draft that names a `session_id` is the exception to "no number": it is
+the next message of a conversation that already has one, so it borrows the
+session's number and the session's folder, and the session's own row stands
+down while the draft exists — one task, one row, one number (`_draft_row`,
+`_bound_sessions`, and the tail of `_build_task_rows`). Never over a session
+that is mid-run, though: a live row is never hidden (`LIVE_STATUSES`).
+
 **What a message is.** A user prompt in the transcript, or a scheduled entry.
 Those two overlap: a scheduled message that fired IS a prompt in the transcript
 (`_send` hands `entry["message"]` over verbatim), so listing both would show it
@@ -144,6 +151,15 @@ logger = logging.getLogger(__name__)
 # fact the whole feature exists to carry.
 STATUSES = ("upcoming", "in_progress", "needs_attention", "blocked", "done",
             "archived")
+
+# The three of those that mean SOMETHING IS STILL HAPPENING to this task — a
+# turn in flight, a run parked on a card nobody has answered, a run that broke
+# and has not been read. The listing may fold a row away for any number of
+# reasons; it may never fold one of THESE away. A live session is news, and
+# news the page cannot show is news nobody can act on (review, 2026-09-12).
+# Read by the session-bound draft swap at the tail of `_build_task_rows`;
+# `upcoming`, `done` and `archived` are settled and deliberately not here.
+LIVE_STATUSES = ("in_progress", "needs_attention", "blocked")
 
 # What `blocked_reason` may say. "" is the answer for every task that is neither
 # blocked nor waiting on anybody — most of them.
@@ -1984,15 +2000,29 @@ def _draft_title(text, fallback: str) -> str:
     return line or fallback
 
 
-def _draft_row(ident: str, record: dict, number: str = "") -> dict:
+def _draft_row(ident: str, record: dict, number: str = "",
+               project: str = "") -> dict:
     """One task draft as a listing row.
 
     THE SAME FIELD SET AS `_row`, deliberately and in full: the List, the Board
     and the changes long-poll all read one row shape, and a row missing half of
     it would make every one of them test for a kind before touching a field.
-    What differs is what a draft actually is — no session, no messages, and
-    nothing that has happened (`happened_at` 0.0 — the desk must not read an
-    unfinished form as work that finished under an app).
+    What differs is what a draft actually is — no messages and nothing that has
+    happened (`happened_at` 0.0 — the desk must not read an unfinished form as
+    work that finished under an app).
+
+    A DRAFT CAN BELONG TO A CONVERSATION (Akshil, 2026-09-12). The composer's
+    Schedule button hops out of a chat that may already have run, and the task
+    being written is a message INTO that thread — so `session_id` is the draft's
+    own stored one (`drafts.bound_session`), and such a row borrows the
+    SESSION's identity rather than minting one of its own: the session's TASK
+    number and the session's project, passed in by `_draft_rows`. The key stays
+    `draft:<id>` (it is still a form, and the form is what a click reopens),
+    but there is exactly one row and exactly one number for the one task —
+    the session's own row is held back while this one stands in for it
+    (`_build_task_rows`). Before that, exiting the modal lost the binding: the
+    draft came back as a stranger, scheduling it opened a second session and
+    minted a second number, and the task the reader had been watching was gone.
 
     IT DOES HAVE A NUMBER. Round 1 printed `task_id: ""` here on the reasoning
     that a number is minted when a task becomes real; round 2 reversed that,
@@ -2002,7 +2032,11 @@ def _draft_row(ident: str, record: dict, number: str = "") -> dict:
     the path `pending:<entry-id>` uses and is rekeyed forward onto
     `pending:<entry-id>` when the draft is scheduled, so the number the row
     showed while it was a form is the number it keeps once it is a task
-    (design.md, "Round 2"; Akshil, 2026-09-11).
+    (design.md, "Round 2"; Akshil, 2026-09-11). A SESSION-BOUND draft is the
+    one exception, and it is the same rule read the other way: the number
+    already exists, on the session, so nothing is allocated here and nothing is
+    moved when the draft is scheduled (`_draft_numbers`, and the schedule
+    router's own rekey guard).
 
     The three fields `_row` has no use for — `draft_kind`, `cwd` and `file` —
     are carried by BOTH draft kinds rather than by whichever needs them, for
@@ -2018,15 +2052,20 @@ def _draft_row(ident: str, record: dict, number: str = "") -> dict:
     if not title:
         title = _draft_title(record.get("description"), "")
     target = str(record.get("target") or "")
-    project = tasks_store.project_of(_workdir(target))
+    # THE SESSION'S FOLDER WINS when there is a session, because the row IS that
+    # task and a task sits in one project. `""` is "this draft belongs to
+    # nobody", and then the folder the form points at is the only answer there
+    # is — which is what every draft row said before bindings existed.
+    place = project or tasks_store.project_of(_workdir(target))
     created = float(record.get("created_at") or 0.0)
     updated = float(record.get("updated_at") or 0.0)
     return {
         "key": drafts.task_key(ident),
         # ALLOCATED, and allocated under `draft:<id>` so it can be moved onto
         # `pending:<entry-id>` by one `tasks_store.rekey` the moment the form
-        # is scheduled. "" only when the state dir is unwritable, which is the
-        # same "" every other row falls back to.
+        # is scheduled — or BORROWED from the session this draft is bound to,
+        # which has one already. "" only when the state dir is unwritable,
+        # which is the same "" every other row falls back to.
         "task_id": number,
         "draft_id": ident,
         "kind": "draft",
@@ -2036,13 +2075,19 @@ def _draft_row(ident: str, record: dict, number: str = "") -> dict:
         # which (Akshil, 2026-09-11).
         "draft_kind": "task",
         "state": "draft",
-        "project": canonical_fs_path(project),
-        "cwd": canonical_fs_path(project),
+        "project": canonical_fs_path(place),
+        "cwd": canonical_fs_path(place),
         "target": canonical_fs_path(target),
         # The raw thing the draft was pointed at, file or folder, BEFORE
         # `_workdir` resolved it to a project. The modal reopens on this.
         "file": canonical_fs_path(target),
-        "session_id": "",
+        # THE CONVERSATION THIS FORM IS A MESSAGE TO, or "" for a draft that
+        # belongs to nobody. It is what the reopened modal puts back on the
+        # wire so Schedule lands in the thread rather than starting another one
+        # — and it is how `_build_task_rows` knows whose row this one is
+        # standing in for. It does NOT change where a click goes: a draft row
+        # opens the form, session or no session (shell/ScheduleTaskViews).
+        "session_id": str(record.get("session_id") or ""),
         "title": title or _UNTITLED_DRAFT,
         "title_source": "draft",
         "description": str(record.get("description") or ""),
@@ -2194,9 +2239,21 @@ def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
     — that rekey onto `pending:` is what fixes it for good (Akshil,
     2026-09-11). `new:<file>` chat drafts carry their file IN the key and so can
     never move, which is why one flag covers both kinds here.
+
+    A SESSION-BOUND TASK DRAFT IS NOT NUMBERED AT ALL, and that absence is the
+    point (Akshil, 2026-09-12). Such a draft is a message being written INTO a
+    conversation that already has a number, and the reported bug was exactly
+    that a second one got minted: exit the modal, reopen the draft, press
+    Schedule, and the task the reader had been watching as TASK-118 came back as
+    TASK-119 in a session of its own. The row still shows a number — the
+    SESSION's, looked up by `_bound_places` — so nothing on the page goes blank;
+    what does not happen is an allocation. `ensure_ids` is never told about the
+    key, so `reproject` cannot spend anything under it either.
     """
     items = []
     for ident, record in task_drafts.items():
+        if record.get("session_id"):
+            continue  # the session holds this task's number — see the docstring
         target = str(record.get("target") or "")
         items.append((drafts.task_key(ident),
                       tasks_store.project_of(_workdir(target)),
@@ -2213,6 +2270,67 @@ def _draft_numbers(task_drafts: dict, chat_drafts: dict) -> dict[str, str]:
         return tasks_store.ensure_ids(items, reproject=True)
     except OSError:
         return {}
+
+
+def _bound_sessions(task_drafts: dict) -> dict[str, str]:
+    """`{draft:<id>: <session-id>}` for every task draft that belongs to a
+    conversation.
+
+    One question asked in three places — which numbers are not allocated, which
+    row identity is borrowed, and which session rows stand down — so it is
+    spelled once and read off the STORE rather than off the built rows. That
+    matters for the narrowed build: `/api/tasks/changes` asked about a session
+    alone never runs the draft half at all (`_draft_shaped`), and a claim that
+    depended on a draft row having been built would let the session's row come
+    back for exactly that poll."""
+    out = {}
+    for ident, record in task_drafts.items():
+        session = str(record.get("session_id") or "")
+        if session:
+            out[drafts.task_key(ident)] = session
+    return out
+
+
+def _bound_places(bound: dict[str, str]) -> dict[str, tuple[str, str]]:
+    """`{draft:<id>: (TASK number, project)}` — the row identity a session-bound
+    draft borrows from the session it is bound to.
+
+    Both halves come out of `task_ids.json`, which is where a task's number and
+    the project it was allocated in already live together: reading them from the
+    one record is what makes the draft row and the session row it replaces agree
+    by construction rather than by two derivations that could drift.
+
+    AN ERASED RECORD IS NO RECORD (review, 2026-09-12). `forget_session` does
+    not remove a number, it stamps the mapping `erased` and keeps it as a
+    RESERVATION so the number can never be reissued — and a draft still bound to
+    that session was wearing the dead number for ever, with `_draft_numbers`
+    refusing to mint it one of its own because the binding said its task already
+    had a number. The binding itself is cut by the erase (`drafts.unbind_session`
+    in `api_task_erase`); this is the same answer read off the store, for the
+    draft written between the two writes and for any older store that was left
+    bound.
+
+    `("", "")` for a session that has never been numbered — a conversation this
+    machine has not listed yet — and the row then falls back to its own folder
+    and a blank number, which is the same fallback an unwritable state dir gets
+    everywhere else in this file. The ordinary case cannot be that: a draft is
+    bound by a hop OUT of a session, and a session you have chatted in has been
+    through a listing."""
+    if not bound:
+        return {}
+    store = tasks_store.task_ids()
+    # …and which of those records are reservations rather than tasks. Read
+    # separately because `task_ids()` deliberately answers "what number, in what
+    # project" for an erased key too — the number must go on meaning what it
+    # meant — and this is the other question (`tasks_store.erased`).
+    gone = tasks_store.erased()
+    out = {}
+    for key, session in bound.items():
+        rec = store.get(session)
+        if not rec or session in gone:
+            continue
+        out[key] = (tasks_store.format_task_id(rec["n"]), rec["project"])
+    return out
 
 
 # How many run dirs (newest first) one settle pass reads. The run that created
@@ -2392,12 +2510,19 @@ def _draft_rows(only: frozenset | set | None = None,
         if chat_drafts is None:
             chat_drafts = loaded_chat
     numbers = _draft_numbers(task_drafts, chat_drafts)
+    # …and the identity a session-bound draft borrows instead of being allocated
+    # one. One read of `task_ids.json` for the whole build, like the numbers
+    # above, and empty on the overwhelmingly common listing where no draft is
+    # bound to anything.
+    places = _bound_places(_bound_sessions(task_drafts))
     rows = []
     for ident, record in task_drafts.items():
         key = drafts.task_key(ident)
         if only is not None and key not in only:
             continue
-        rows.append(_draft_row(ident, record, numbers.get(key, "")))
+        number, project = places.get(key, ("", ""))
+        rows.append(_draft_row(ident, record, number or numbers.get(key, ""),
+                               project))
     for key, record in chat_drafts.items():
         if not drafts.is_new_chat_key(key):
             continue
@@ -2613,6 +2738,56 @@ def _build_task_rows(only: frozenset | set | None = None) -> list[dict]:
             current_apps.observe([r for r in rows if r.get("kind") != "draft"])
         except OSError:
             pass
+    # ONE TASK, ONE ROW — and this is the last thing done, deliberately AFTER
+    # the desk has seen the listing (Akshil, 2026-09-12).
+    #
+    # A task draft bound to a session is not a second thing beside that
+    # conversation, it is the conversation's next message being written: same
+    # TASK number, same folder, same work. So while it exists — and while that
+    # conversation is not mid-run, see below — the session's own row stands down
+    # and the draft row takes its place, wearing the number and the `✎ Draft`
+    # chip; Discard or Schedule ends the draft and the session's row is simply
+    # back. Two rows for one task was what the reader actually saw, and no
+    # amount of chip wording makes that read as one thing.
+    #
+    # The claim is read off the DRAFT STORE (`_bound_sessions`), never off the
+    # rows this build happened to produce: a `/api/tasks/changes` poll narrowed
+    # to the session alone builds no draft rows at all, and a claim derived
+    # from them would let the hidden row reappear on exactly that poll. The
+    # changes endpoint needs nothing else — a key that is asked about and not
+    # listed is already reported `gone`, which is precisely how the client is
+    # told to drop the row it is still showing.
+    #
+    # WHAT THE HIDING DOES NOT TOUCH. The desk above has already read the
+    # session (a chat with a draft against it is still an app the user is
+    # working in), unread marks live in `read.json` and come back with the row,
+    # and the day-one baseline ran before the drafts were added at all, so this
+    # cannot cost a session its initialisation.
+    #
+    # AND NEVER OVER A LIVE SESSION (review, 2026-09-12). The swap above is a
+    # statement about IDENTITY — these two rows are one task — and a settled
+    # conversation can say it with one row because there is nothing left to
+    # watch. A run that is in flight, parked on a permission card or stopped on
+    # an error is the opposite: hiding it takes the row out of the listing AND
+    # out of the pulse the sidebar dot and Notifications read, so the user
+    # would be waiting on a card they can no longer see, because they started
+    # typing the next message. So while the session's own row is live
+    # (`LIVE_STATUSES`) BOTH rows stand — the session says what the run is
+    # doing, the draft is the way back into the modal — and the swap applies
+    # again on the first build after the run settles.
+    #
+    # Off the BUILT ROW's status, which is the one every view paints (`_row`),
+    # so this cannot disagree with the pill the reader is looking at. A build
+    # narrowed past the session (`only`) has no row to ask, and then nothing is
+    # hidden for that poll either — the same fail-open direction.
+    claimed = set(_bound_sessions(task_drafts).values())
+    if claimed:
+        claimed -= {str(r.get("session_id") or "") for r in rows
+                    if r.get("kind") != "draft"
+                    and r.get("status") in LIVE_STATUSES}
+    if claimed:
+        rows = [r for r in rows
+                if r.get("kind") == "draft" or r.get("session_id") not in claimed]
     return rows
 
 
@@ -3211,7 +3386,9 @@ def api_task_erase(patch: ErasePatch):
 
     WHAT COMES OUT OF STATE: the triage record WHOLE (`forget_triage`, not
     `clear_triage` — there is no session left for a note or a tag to be about),
-    and the read marks (`tasks_store.forget_session`). The task's NUMBER is the
+    and the read marks (`tasks_store.forget_session`), and a task draft bound to
+    this session is cut loose from it (`drafts.unbind_session`) — the words
+    stay, the binding does not. The task's NUMBER is the
     one thing kept: allocation is "max seen plus one" read straight off
     task_ids.json, so the mapping stays as a reservation and a reused TASK-007
     can never point at somebody else's work. See `forget_session`.
@@ -3279,6 +3456,14 @@ def api_task_erase(patch: ErasePatch):
         # emphatically something about it — there is no conversation left for
         # it to be typed into.
         drafts.delete_chat(session_id)
+        # A TASK draft bound to it is the other shape, and it is NOT deleted
+        # (review, 2026-09-12): a task draft is a form somebody is still filling
+        # in, and the conversation is only where they had meant to send it. What
+        # goes is the binding — the number this erase has just turned into a
+        # reservation (`forget_session`), and the standing-in for a row that no
+        # longer exists. The draft is an ordinary `draft:<id>` from the next
+        # listing on, numbered in its own folder.
+        drafts.unbind_session(session_id)
 
     tasks_store.mark_deleted(key)
     tasks_watch.notify({key})

--- a/fused_render/tasks_store.py
+++ b/fused_render/tasks_store.py
@@ -250,6 +250,26 @@ def task_ids() -> dict:
     return out
 
 
+def erased(key: str = "") -> set[str]:
+    """Every key whose number is a RESERVATION rather than a live task — the
+    records `forget_session` stamped when the session behind them was erased.
+
+    Split out rather than carried on `task_ids()` because the two answers are
+    read for opposite reasons: `task_ids()` is "what number does this wear, and
+    in which project", and every caller of it wants a reserved number to keep
+    answering that (the number must never be reissued, whatever became of the
+    session). This is the other question — "is there still anything behind it" —
+    and exactly one caller asks it: the tasks listing, deciding whether a draft
+    bound to a session may go on wearing that session's number (routers/tasks.py
+    `_bound_places`, review 2026-09-12).
+
+    `key` narrows it to one lookup; the default answers for the whole store."""
+    store = load_state(TASK_IDS_FILE)
+    keys = [key] if key else list(store)
+    return {k for k in keys
+            if isinstance(store.get(k), dict) and store[k].get("erased")}
+
+
 def _next_numbers(store: dict) -> dict[str, int]:
     """project -> highest number allocated in it. "Max seen plus one" is the
     allocation rule precisely so a deleted task's number is never handed out
@@ -610,8 +630,10 @@ def forget_session(session_id: str) -> dict:
     and a number the user has quoted in a note or a message must keep meaning
     the same thing forever. So the mapping is left in place as a RESERVATION
     and only stamped `erased` — gaps over renumbering, exactly the trade the
-    module docstring makes for deletes. Nothing reads `erased`; it is there so
-    a human reading the store can tell a reserved number from a live one.
+    module docstring makes for deletes. `erased()` is the one reader of the
+    stamp — the listing asks it whether a draft still bound to this session may
+    go on wearing its number — and it is legible in the file besides, so a human
+    reading the store can tell a reserved number from a live one.
 
     Returns `{"read": bool, "number": bool}` — whether each store changed."""
     def forget_read(state: dict):

--- a/fused_render/tasks_store.py
+++ b/fused_render/tasks_store.py
@@ -260,8 +260,9 @@ def erased(key: str = "") -> set[str]:
     answering that (the number must never be reissued, whatever became of the
     session). This is the other question — "is there still anything behind it" —
     and exactly one caller asks it: the tasks listing, deciding whether a draft
-    bound to a session may go on wearing that session's number (routers/tasks.py
-    `_bound_places`, review 2026-09-12).
+    bound to a session may still stand in behind it rather than becoming an
+    ordinary row of its own (routers/tasks.py `_draft_rows`, review
+    2026-09-12).
 
     `key` narrows it to one lookup; the default answers for the whole store."""
     store = load_state(TASK_IDS_FILE)

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -2351,7 +2351,8 @@ def _start(file: str, message: str, session_id: str, model: str,
            effort: str, permission_mode: str = "",
            message_via_stdin: bool = False,
            has_pane: bool | None = None,
-           extra_read_dirs: list | None = None) -> dict:
+           extra_read_dirs: list | None = None,
+           draft_key: str = "") -> dict:
     file = os.path.abspath(file)
     # A directory is a valid target too: this template's app-folder role opens
     # whole project folders (cwd/prompt handled by _workdir/_system_prompt).
@@ -2399,9 +2400,22 @@ def _start(file: str, message: str, session_id: str, model: str,
     # re-attaching page compares against the bubble on screen (which shows the
     # typed text only, so an unstripped copy silently stopped matching). Stripped
     # here, once, rather than at each of those three readers.
+    meta = {"file": file, "message": _strip_app_state(message),
+            "resumed_from": session_id, "mode": mode}
+    # `draft_key` is the composer's RECEIPT for this send, carried verbatim and
+    # read by nothing in this template (fused_render/server/routers/tasks.py
+    # `_settle_new_chats` is its one reader). A chat with no session yet keeps
+    # its half-typed message — and its TASK number — under a `new:<file>` key,
+    # and the number has to follow the session this send is about to create. The
+    # page cannot prove which session that was (four rounds of trying: a send
+    # that threw, a Back before the id landed), so the send TAGS its own run
+    # instead and the server reads the tag back off disk. Written only when the
+    # caller sent one — the apps API, the scheduler and canvases.py all start
+    # runs on the same folders and must not look like a composer's first send.
+    if draft_key:
+        meta["draft_key"] = draft_key
     with _private_open(os.path.join(run_dir, "meta.json")) as f:
-        json.dump({"file": file, "message": _strip_app_state(message),
-                   "resumed_from": session_id, "mode": mode}, f)
+        json.dump(meta, f)
 
     # `err.log` exists from the very first instant, empty — `_poll`'s
     # abnormal-exit fallback reads its tail, and a host that dies before it
@@ -5792,7 +5806,7 @@ def main(action: str = "start", file: str = "", message: str = "",
          deltas: str = "", version_id: str = "", confirm_unique: str = "",
          answers: str = "", note: str = "", custom: str = "",
          read_dirs: str = "", path: str = "", queued: str = "",
-         native: str = "") -> dict:
+         native: str = "", draft_key: str = "") -> dict:
     if action == "start":
         if not file:
             return {"error": "missing target file (no _file param?)"}
@@ -5802,9 +5816,14 @@ def main(action: str = "start", file: str = "", message: str = "",
         # binder is str-shaped). Empty means "the caller did not say" — the apps
         # API, which has no page — and only then does `_start` ask disk. "0" is a
         # real no, so it must not be read as absence.
+        # `draft_key` is optional and absent for every caller but the native
+        # composer's FIRST send — see `_start`. Passed through untouched: it is
+        # the page's own key spelling (`new:<file>`, unnormalised), and a key
+        # normalised on the way through is a key the server cannot match.
         return _start(file, message, session_id, model, effort, permission_mode,
                       has_pane=None if has_pane == "" else has_pane != "0",
-                      extra_read_dirs=_attach_dirs(read_dirs))
+                      extra_read_dirs=_attach_dirs(read_dirs),
+                      draft_key=draft_key)
     if action == "poll":
         # `file` rides along so the poll can refuse a run that is not about
         # this page's target (see _poll) — optional, because not every caller

--- a/tests/test_claude_schedule_button.py
+++ b/tests/test_claude_schedule_button.py
@@ -325,13 +325,21 @@ def test_the_link_opens_the_form_immediately(page):
     # key so a fresh card cannot inherit the previous one's answers. The deep link
     # is an opening like any other, and what this test cares about is unchanged —
     # it opens on arrival, prefilled, with no button left to press.
-    assert "openForm(new Date(" in effect
+    assert "const at = new Date(Date.now() + NEW_LINK_LEAD_MS);" in effect
+    assert "openForm(at, null, seed);" in effect
     # The handoff travels as ONE seed handed to that door (Akshil, 2026-09-12:
     # attachments from a hop were leaking into every later modal because the
     # six loose page states were undone one by one), so the effect builds a
     # `HopSeed` and passes it rather than setting fields.
     assert "const seed: HopSeed" in effect
     assert ", null, seed)" in effect
+    # A HOP OUT OF A CONVERSATION LOOKS FIRST (Akshil, 2026-09-12). A task draft
+    # bound to a session has no row of its own — the session's row wears the
+    # `Draft` chip — so this button is the way back into it, and a second press
+    # has to reopen THAT form rather than mint a second one bound to the same
+    # thread. One small request, only for a hop that names a session, and a miss
+    # opens exactly as it always did.
+    assert "boundDraftSeed(all.task, session, seed.message)" in effect
 
 
 def test_the_prefilled_time_is_valid_the_moment_it_opens(page):

--- a/tests/test_claude_schedule_button.py
+++ b/tests/test_claude_schedule_button.py
@@ -339,7 +339,13 @@ def test_the_link_opens_the_form_immediately(page):
     # has to reopen THAT form rather than mint a second one bound to the same
     # thread. One small request, only for a hop that names a session, and a miss
     # opens exactly as it always did.
-    assert "boundDraftSeed(all.task, session, seed.message)" in effect
+    #
+    # A FAILED LOOKUP IS "UNKNOWN", NOT "NONE" (Bugbot, PR #1126): `fetchDrafts`
+    # answers null for a blip, and the hop still opens on it — the composer's
+    # words must not wait on a GET — but the seed is gated on that answer rather
+    # than read off an empty snapshot, and the tray travels with it.
+    assert "all && boundDraftSeed(all.task, session, seed.message," in effect
+    assert "seed.attachments)" in effect
 
 
 def test_the_prefilled_time_is_valid_the_moment_it_opens(page):

--- a/tests/test_claude_schedule_button.py
+++ b/tests/test_claude_schedule_button.py
@@ -326,7 +326,12 @@ def test_the_link_opens_the_form_immediately(page):
     # is an opening like any other, and what this test cares about is unchanged —
     # it opens on arrival, prefilled, with no button left to press.
     assert "openForm(new Date(" in effect
-    assert "setNewTarget(" in effect
+    # The handoff travels as ONE seed handed to that door (Akshil, 2026-09-12:
+    # attachments from a hop were leaking into every later modal because the
+    # six loose page states were undone one by one), so the effect builds a
+    # `HopSeed` and passes it rather than setting fields.
+    assert "const seed: HopSeed" in effect
+    assert ", null, seed)" in effect
 
 
 def test_the_prefilled_time_is_valid_the_moment_it_opens(page):
@@ -355,11 +360,16 @@ def test_the_deep_linked_values_do_not_outlive_their_own_modal(page):
     """Left standing they would prefill the next "+ New task" with a folder, a
     draft and a session the user arrived from some time ago — the same class of bug
     as a When pill that survived its send."""
-    close = page[page.index("onClose={() => {"):]
-    close = close[:close.index("}}")]
-    for setter in ("setNewTarget(null)", "setNewMessage(null)",
-                   "setNewSession(null)", "setNewBack(null)"):
-        assert setter in close, f"{setter} missing from the modal's close"
+    # Since 2026-09-12 the hop is one value the OPENING seeds — `openForm(at,
+    # entry, seed = NO_HOP)` — so a plain "+ New task" carries no hop by
+    # construction and the close has nothing to forget. The old shape (six page
+    # states cleared one by one in `onClose`) is what let a hop's attachments
+    # outlive their modal: one setter was missing from the list.
+    assert "seed: HopSeed = NO_HOP" in page
+    assert "setHop(seed);" in page
+    for stale in ("setNewTarget(", "setNewMessage(", "setNewAttachments(",
+                  "setNewSession(", "setNewBack("):
+        assert stale not in page, f"{stale} is the shape that leaked"
 
 
 # ------------------------------------------------------------- the modal

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -1394,12 +1394,18 @@ def test_the_conversations_own_composer_outranks_the_form(client, tmp_path,
     A session can have both — text left in its composer AND a New task form
     opened out of it — and `draft` is one field because the reader has one
     question. The composer's copy is literally sitting in that conversation; the
-    form is a message about to be scheduled into it."""
+    form is a message about to be scheduled into it.
+
+    THE COMPOSER HAS TO HAVE WRITTEN FIRST, which is the one order that produces
+    both records now ("one record, two doors"): once a form is bound and the
+    session has no chat record, the composer's own writes go INTO that form
+    rather than beside it (`drafts.put_chat`). A chat record that predates the
+    binding is a record of its own, and this is its precedence."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
-    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
     client.put(_chat_url("sess-a"), json={"text": "half a thought"})
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
 
     row = _by_key(client)["sess-a"]
     assert row["draft"]["preview"] == "half a thought"
@@ -1414,23 +1420,242 @@ def test_the_row_says_WHICH_kind_of_draft_its_preview_is(client, tmp_path,
     The thread's leading line quotes this preview, and pressing your own unsent
     sentence has to land where it is. A `"chat"` preview is in this
     conversation's composer, so the press opens the chat and there it is; a
-    `"form"` preview is a New task card bound to this session, of which the chat
-    holds nothing, so that press has to reopen the card instead. The page used
-    to go to the chat either way and showed the reader an empty composer under
-    the words it had just printed."""
+    `"form"` preview is a New task card bound to this session, which holds the
+    time, the repeat rule and the model beside the words, so that press reopens
+    the card instead. The page used to go to the chat either way and showed the
+    reader an empty composer under the words it had just printed — the composer
+    shows them now ("one record, two doors"), and `kind` is what still sends the
+    press to the record that holds ALL of what was written, not just the
+    sentence."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
 
-    # The bound form, with the composer empty.
+    # The bound form, with no chat record of its own: the words are the card's.
     _bound_draft(client, "draft-0001", "sess-a", elsewhere)
     row = _by_key(client)["sess-a"]
     assert row["draft"]["kind"] == "form"
     assert row["draft"]["preview"] == "Ship the changelog"
 
-    # …and the composer, which outranks it and says so.
+    # …and a conversation whose composer wrote FIRST keeps a record of its own,
+    # which outranks the form bound to it afterwards and says so.
+    _write_transcript(projects_dir, "sess-b", "/home/me/proj", [_user("two", T9)])
+    client.put(_chat_url("sess-b"), json={"text": "half a thought"})
+    _bound_draft(client, "draft-0002", "sess-b", elsewhere)
+    assert _by_key(client)["sess-b"]["draft"]["kind"] == "chat"
+
+
+# --------------------------------------------- round 3: one record, two doors
+#
+# THE BUG (Akshil, 2026-09-12). Finish a session, type into its composer, press
+# Schedule, then click outside the modal. The form is kept — that is the whole
+# point of a draft — and the hop deleted the chat draft it came from, so the
+# session's row wore the red `✎ Draft` chip over a composer with nothing in it.
+# The chip's press leads to the chat; the words were in a record that door could
+# not see.
+#
+# THE RULE: one record, two doors. A session with a bound task draft and no chat
+# draft of its own SHOWS and EDITS that draft's words from the composer too —
+# split and joined by the same rule the New task card's two fields use. Never a
+# copy: which door the reader comes back through does not change what is there.
+
+
+def _stored_chat_half() -> dict:
+    """The chat section as it is ON DISK — what `/api/drafts` synthesizes is a
+    view, and the tests below care that nothing was written into the store
+    beside the form."""
+    with open(os.path.join(drafts.STATE_DIR, drafts.DRAFTS_FILE),
+              encoding="utf-8") as fh:
+        return json.load(fh)["chat"]
+
+
+def test_the_composer_shows_a_bound_forms_words(client, tmp_path, projects_dir):
+    """The door the bug was about. `GET /api/drafts` answers the bound form
+    under the SESSION key, as the composer would have written it."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere,
+                 description="start with the path handling",
+                 attachments=[{"path": "/shots/a1b2.png", "name": "shot.png",
+                               "kind": "image"}])
+
+    chat = client.get("/api/drafts").json()["chat"]
+    # Title, blank line, description — `joinDraft` run in Python, which is the
+    # inverse of the split the hop made on the way in.
+    assert chat["sess-a"]["text"] == ("Ship the changelog\n\n"
+                                      "start with the path handling")
+    assert chat["sess-a"]["attachments"] == [
+        {"path": "/shots/a1b2.png", "name": "shot.png", "kind": "image"}]
+    assert chat["sess-a"]["updated_at"] > 0
+    # …and it says which record these words are really in, so a client that
+    # wants to tell the two apart can.
+    assert chat["sess-a"]["bound_draft"] == "draft-0001"
+    # The store itself is unchanged: this is a view, not a second copy.
+    assert _stored_chat_half() == {}
+
+
+def test_typing_in_the_composer_edits_the_bound_form(client, tmp_path,
+                                                     projects_dir):
+    """The other direction, and the one that keeps it ONE record: the composer's
+    autosave lands in the form, split across its two fields, and no chat record
+    is made."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere, when="2026-09-13T09:00",
+                 model="opus")
+
+    r = client.put(_chat_url("sess-a"),
+                   json={"text": "Roll up the PRs\n\ngroup them by repo",
+                         "attachments": [{"path": "/shots/x.png", "name": "x.png",
+                                          "kind": "image"}]})
+    assert r.status_code == 200, r.text
+    assert r.json()["draft"]["bound_draft"] == "draft-0001"
+
+    form = drafts.get_task("draft-0001")
+    assert form["title"] == "Roll up the PRs"
+    assert form["description"] == "group them by repo"
+    assert form["attachments"] == [
+        {"path": "/shots/x.png", "name": "x.png", "kind": "image"}]
+    # Everything the card holds and the composer knows nothing about is
+    # untouched — this write was about the words.
+    assert form["when"] == "2026-09-13T09:00"
+    assert form["model"] == "opus"
+    assert form["session_id"] == "sess-a"
+    # No chat record anywhere: two records would be two chips and two versions
+    # of one sentence.
+    assert _stored_chat_half() == {}
+    assert client.get("/api/drafts").json()["chat"]["sess-a"]["text"] == (
+        "Roll up the PRs\n\ngroup them by repo")
+
+
+def test_a_one_line_composer_draft_is_all_title(client, tmp_path, projects_dir):
+    """The same split the card makes: one line names the task and there is no
+    description to write."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    client.put(_chat_url("sess-a"), json={"text": "  Update the changelog  "})
+    form = drafts.get_task("draft-0001")
+    assert form["title"] == "Update the changelog"
+    assert form["description"] == ""
+    assert client.get("/api/drafts").json()["chat"]["sess-a"]["text"] == (
+        "Update the changelog")
+
+
+def test_emptying_the_composer_deletes_the_bound_form(client, tmp_path,
+                                                      projects_dir):
+    """Clearing the box IS deleting the draft, whichever record the box is a
+    door onto — and there is no half of a form left behind to wear the chip."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    r = client.put(_chat_url("sess-a"), json={"text": "   ", "attachments": []})
+    assert r.json()["draft"] is None
+    assert drafts.get_task("draft-0001") is None
+    rows = _by_key(client)
+    assert "draft:draft-0001" not in rows
+    assert rows["sess-a"]["draft"] is None
+    assert rows["sess-a"]["bound_draft"] == ""
+    assert rows["sess-a"]["task_id"] == "TASK-001", "the row itself never moved"
+
+
+def test_the_send_takes_the_bound_form_with_it(client, tmp_path, projects_dir):
+    """`DELETE /api/drafts/chat/<session>` is the composer's send, and what it
+    spends is whatever record held those words."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    r = client.delete(_chat_url("sess-a"))
+    assert r.status_code == 200, r.text
+    assert r.json()["removed"] is True
+    assert drafts.get_task("draft-0001") is None
+    assert client.get("/api/drafts").json()["chat"] == {}
+    assert _by_key(client)["sess-a"]["draft"] is None
+
+
+def test_both_doors_announce_the_form_and_the_session(client, tmp_path,
+                                                      projects_dir):
+    """Two keys on every chat write that turned out to be about a form: the
+    session's row, whose chip just changed, and the form's own key, so a page
+    holding a stale row under it drops it (`routers/drafts._announce`)."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    _by_key(client)  # a first full listing, so the session is numbered
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    before = client.get("/api/tasks").json()["generation"]
+    client.put(_chat_url("sess-a"), json={"text": "Roll up the PRs"})
+    body = client.get("/api/tasks/changes?since=%d&wait=0" % before).json()
+    rows = {row["key"]: row for row in body["rows"]}
+    assert rows["sess-a"]["draft"]["preview"] == "Roll up the PRs"
+    assert rows["sess-a"]["bound_draft"] == "draft-0001"
+    assert "draft:draft-0001" in body["gone"]
+
+    gen = body["generation"]
+    client.delete(_chat_url("sess-a"))
+    body = client.get("/api/tasks/changes?since=%d&wait=0" % gen).json()
+    rows = {row["key"]: row for row in body["rows"]}
+    assert rows["sess-a"]["draft"] is None
+    assert "draft:draft-0001" in body["gone"]
+
+
+def test_a_session_with_both_keeps_them_apart(client, tmp_path, projects_dir):
+    """A chat record that PREDATES the binding is a record of its own, and the
+    two doors stop being one: the composer reads and writes its own words, and
+    the form is left exactly as it was."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
     client.put(_chat_url("sess-a"), json={"text": "half a thought"})
-    assert _by_key(client)["sess-a"]["draft"]["kind"] == "chat"
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    chat = client.get("/api/drafts").json()["chat"]
+    assert chat["sess-a"]["text"] == "half a thought", "the chat record wins"
+    assert chat["sess-a"]["bound_draft"] == "", "and it is a record of its own"
+
+    client.put(_chat_url("sess-a"), json={"text": "the rest of the thought"})
+    assert drafts.get_chat("sess-a")["text"] == "the rest of the thought"
+    assert drafts.get_task("draft-0001")["title"] == "Ship the changelog"
+    # …and the row still knows about the form, which is still the way back to it.
+    row = _by_key(client)["sess-a"]
+    assert row["draft"]["preview"] == "the rest of the thought"
+    assert row["bound_draft"] == "draft-0001"
+
+
+def test_a_chat_key_with_no_session_never_looks_for_a_form(client, tmp_path):
+    """`new:<file>` is a folder somebody opened a chat on and no thread at all,
+    so nothing can be bound to it — its writes are ordinary chat writes."""
+    key = "new:" + str(tmp_path)
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Ship the changelog", "target": str(tmp_path)})
+    r = client.put(_chat_url(key), json={"text": "never sent"})
+    assert r.json()["draft"]["text"] == "never sent"
+    assert r.json()["draft"]["bound_draft"] == ""
+    assert drafts.get_task("draft-0001")["title"] == "Ship the changelog"
+
+
+def test_the_split_and_the_join_are_each_others_inverse(state_dir):
+    """The Python twins of `NewJobModal.splitDraft` / `joinDraft`, which is what
+    keeps one sentence the same shape through either door."""
+    assert drafts.split_draft("Port the parquet reader\nstart with the path") == (
+        "Port the parquet reader", "start with the path")
+    assert drafts.split_draft("Update the changelog") == ("Update the changelog", "")
+    assert drafts.split_draft("   \n\n  ") == ("", "")
+    assert drafts.split_draft(None) == ("", "")
+    one = "roll up the PRs\n\ngroup them by repo"
+    assert drafts.join_draft(*drafts.split_draft(one)) == one
+    assert drafts.join_draft("", "just a body") == "just a body"
+    assert drafts.join_draft("just a title", "") == "just a title"
+    assert drafts.join_draft(None, None) == ""
 
 
 def test_a_draft_with_no_session_is_numbered_exactly_as_before(client, tmp_path):

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -1161,6 +1161,424 @@ def test_a_bad_or_absent_from_chat_key_changes_nothing(client, tmp_path):
     assert drafts.get_chat(key) is not None
 
 
+# ------------------------------ round 3: a draft that belongs to a session
+#
+# THE BUG (Akshil, 2026-09-12). The chat composer's Schedule button can hop out
+# of a conversation that has ALREADY RUN, and the task being written is the next
+# message of that thread. Press Schedule straight away and it landed there,
+# because the page still held the session id. Exit the card and the draft on
+# disk knew nothing about it: reopening that draft and scheduling it opened a
+# SECOND session with a SECOND task number, and the TASK-nnn the reader had been
+# watching was gone.
+#
+# So the binding is STORED, and the three consequences below follow from it: no
+# number is minted for a draft whose task already has one, the draft row wears
+# the session's identity, and while it stands the session's own row stands down
+# — one task, one row.
+
+
+def _bound_draft(client, ident, session_id, target, **fields):
+    """The hop's first autosave: a task draft that names the session it is a
+    message to, exactly as `NewJobModal`'s `draftBody` sends it."""
+    body = {"title": "Ship the changelog", "target": str(target),
+            "session_id": session_id}
+    body.update(fields)
+    r = client.put("/api/drafts/task/" + ident, json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_the_session_a_draft_is_going_into_round_trips(state_dir):
+    """Stored and validated as a SESSION id, never as `new:<file>`: binding is to
+    a thread, and a chat that has never been sent has none."""
+    stored = drafts.put_task("draft-0001", {"title": "hi", "session_id": "sess-a"})
+    assert stored["session_id"] == "sess-a"
+    assert drafts.get_task("draft-0001")["session_id"] == "sess-a"
+    assert drafts.bound_session("sess-a") == "sess-a"
+    assert drafts.bound_session("new:/Users/me/x.py") == ""
+    assert drafts.bound_session("/etc/passwd") == ""
+    assert drafts.bound_session(None) == ""
+    # ...and it survives the saves that do not mention it, like every other
+    # stored field (`TASK_FIELDS`): the modal's later autosaves may send only
+    # what changed.
+    assert drafts.put_task("draft-0001",
+                           {"title": "hi again"})["session_id"] == "sess-a"
+
+
+def test_a_session_bound_draft_wears_the_sessions_number(client, tmp_path,
+                                                         projects_dir):
+    """No second number, and no second identity: the row IS that task.
+
+    The number, the project and the cwd all come off the session, so the row the
+    draft stands in for and the row it replaces say the same thing about where
+    this work lives."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    session_number = _by_key(client)["sess-a"]["task_id"]
+    assert session_number == "TASK-001"
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    row = _by_key(client)["draft:draft-0001"]
+    assert row["task_id"] == session_number
+    assert row["session_id"] == "sess-a"
+    assert row["kind"] == "draft"
+    assert row["draft_kind"] == "task"
+    # The SESSION's folder, not the folder the form happens to point at: a task
+    # sits in one project, and the row is that task.
+    assert row["project"] == canonical_fs_path("/home/me/proj")
+    assert row["cwd"] == canonical_fs_path("/home/me/proj")
+    assert row["target"] == canonical_fs_path(str(elsewhere))
+    # ...and nothing was allocated under the draft's own key. The number is the
+    # session's; there is no second one to move, spend or renumber.
+    assert "draft:draft-0001" not in tasks_store.task_ids()
+
+
+def test_a_draft_with_no_session_is_numbered_exactly_as_before(client, tmp_path):
+    """The binding is the exception, not the new rule. A form opened from "+ New
+    task" belongs to nobody and still mints a number of its own."""
+    target = tmp_path / "project"
+    target.mkdir()
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "target": str(target)})
+    row = _by_key(client)["draft:draft-0001"]
+    assert row["task_id"] == "TASK-001"
+    assert row["session_id"] == ""
+    assert "draft:draft-0001" in tasks_store.task_ids()
+
+
+def test_the_session_row_stands_down_while_the_draft_stands_in(client, tmp_path,
+                                                               projects_dir):
+    """ONE TASK, ONE ROW. The draft is the conversation's next message, not a
+    second thing beside it — and two rows for one task is what the reader
+    actually saw."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    rows = _by_key(client)
+    assert "sess-a" not in rows, "the session's own row is held back"
+    assert "draft:draft-0001" in rows
+    assert [key for key, row in rows.items() if row["task_id"] == "TASK-001"] \
+        == ["draft:draft-0001"], "one number, one row"
+
+    # Discard, and the conversation is simply back — number, message count and
+    # all. Nothing about the session was changed to hide it.
+    assert client.delete("/api/drafts/task/draft-0001").status_code == 200
+    rows = _by_key(client)
+    assert "draft:draft-0001" not in rows
+    assert rows["sess-a"]["task_id"] == "TASK-001"
+    assert rows["sess-a"]["message_count"] == 1
+
+
+def test_emptying_a_bound_draft_brings_the_session_row_back(client, tmp_path,
+                                                            projects_dir):
+    """An all-empty form is a DELETE (`_empty_task`), and the swap has to
+    reverse on that door too — not only on Discard."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    assert "sess-a" not in _by_key(client)
+
+    r = client.put("/api/drafts/task/draft-0001",
+                   json={"title": "", "description": "", "target": str(elsewhere),
+                         "session_id": "sess-a", "attachments": []})
+    assert r.json()["draft"] is None
+    rows = _by_key(client)
+    assert "draft:draft-0001" not in rows
+    assert "sess-a" in rows
+
+
+def test_both_rows_repaint_through_the_changes_endpoint(client, tmp_path,
+                                                        projects_dir):
+    """Two rows move at once, so both keys are announced: the draft arrives and
+    the session's row is reported `gone`, then the other way round."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    _by_key(client)  # a first full listing, so the session is numbered
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    before = client.get("/api/tasks").json()["generation"]
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    r = client.get("/api/tasks/changes?since=%d&wait=0" % before)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert [row["key"] for row in body["rows"]] == ["draft:draft-0001"]
+    assert "sess-a" in body["gone"], "the row the page is still showing"
+
+    gen = body["generation"]
+    assert client.delete("/api/drafts/task/draft-0001").status_code == 200
+    body = client.get("/api/tasks/changes?since=%d&wait=0" % gen).json()
+    assert [row["key"] for row in body["rows"]] == ["sess-a"]
+    assert "draft:draft-0001" in body["gone"]
+
+
+def test_a_poll_about_the_session_alone_does_not_bring_its_row_back(
+        client, tmp_path, projects_dir):
+    """The claim is read off the DRAFT STORE, never off the rows a build
+    happened to produce.
+
+    A narrowed build asking about a session alone runs no draft half at all
+    (`_draft_shaped`), so a claim derived from built rows would let the hidden
+    row reappear on exactly that poll — and the page would show the task twice
+    until the next full listing."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    assert tasks_mod._task_rows(only=frozenset({"sess-a"})) == []
+
+
+def test_scheduling_a_bound_draft_lands_in_the_session_and_keeps_the_number(
+        client, tmp_path, projects_dir):
+    """The whole bug, end to end: reopen the draft, press Schedule, and the
+    message is the next turn of the SAME conversation under the SAME number."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    number = _by_key(client)["sess-a"]["task_id"]
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(elsewhere), "message": "ship it",
+                          "delay_seconds": 600, "title": "Ship the changelog",
+                          "draft_id": "draft-0001", "session_id": "sess-a"})
+    assert r.status_code == 200, r.text
+    entry = r.json()["entry"]
+    assert entry["session_id"] == "sess-a"
+
+    rows = _by_key(client)
+    assert "draft:draft-0001" not in rows, "the draft's whole purpose is over"
+    assert "pending:" + entry["id"] not in rows, "the entry is filed on the session"
+    assert rows["sess-a"]["task_id"] == number
+    # ...and no number was invented on the way. `pending:<entry-id>` is not a key
+    # this task is ever filed under, so a rekey onto it would have been a second
+    # identity for a task that already has one.
+    store = tasks_store.task_ids()
+    assert "pending:" + entry["id"] not in store
+    assert "draft:draft-0001" not in store
+
+
+def test_an_unbound_draft_still_rekeys_onto_its_pending_entry(client, tmp_path):
+    """The guard is only for the bound case — pinned here as the other side of
+    the branch. A draft that belongs to nobody still carries its number forward
+    onto the entry it becomes."""
+    target = tmp_path / "project"
+    target.mkdir()
+    client.put("/api/drafts/task/draft-0001",
+               json={"title": "Nightly report", "target": str(target)})
+    # A number is allocated by the LISTING, not by the save, so the draft has to
+    # have been listed once before there is anything to carry forward.
+    assert _by_key(client)["draft:draft-0001"]["task_id"] == "TASK-001"
+    r = client.post("/api/schedule", headers=WRITE,
+                    json={"target": str(target), "message": "roll it up",
+                          "delay_seconds": 600, "draft_id": "draft-0001"})
+    entry_id = r.json()["entry"]["id"]
+    assert "pending:" + entry_id in tasks_store.task_ids()
+
+
+def test_a_bound_draft_never_reaches_the_new_chat_settle(client, tmp_path,
+                                                         projects_dir, runs):
+    """`_settle_new_chats` is untouched by any of this: it reads `new:<file>`
+    CHAT drafts and the run that spent one, and a task draft bound to a session
+    is neither."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    _task_drafts, chat_drafts = drafts.list_all()
+    assert tasks_mod._settle_new_chats(chat_drafts) is False
+    assert drafts.get_task("draft-0001")["session_id"] == "sess-a"
+
+
+class _SettledAgent:
+    """The same runs tree with nobody waiting on it — what `_park` leaves behind
+    once the card has been answered."""
+
+    def __init__(self, runs):
+        self.RUNS = str(runs)
+
+    def _permissions(self, run_dir):
+        return [{"id": "p1", "tool": "Bash", "decision": "allow", "input": {}}]
+
+    def _alive(self, run_dir):
+        return False
+
+    def _session_from_out(self, run_dir):
+        return ""
+
+
+def _park(monkeypatch, runs, session_id):
+    """One LIVE run, parked on a permission card nobody has answered — the state
+    `_status` reads as `needs_attention`.
+
+    A stand-in agent of the same shape the `runs` fixture installs, with the two
+    answers `_parked_runs` actually asks for: an undecided request, and a process
+    that is still alive to be unblocked."""
+    _stage_run(runs, "r-1", "/home/me/proj", session_id)
+
+    class _Parked:
+        RUNS = str(runs)
+
+        def _permissions(self, run_dir):
+            return [{"id": "p1", "tool": "Bash", "decision": "",
+                     "input": {"command": "rm -rf build"}}]
+
+        def _alive(self, run_dir):
+            return True
+
+        def _session_from_out(self, run_dir):
+            return ""
+
+        def _tool_detail(self, name, inp):
+            return str((inp or {}).get("command") or "")
+
+    monkeypatch.setattr(tasks_mod, "_agent_module", lambda: _Parked())
+
+
+def test_a_live_session_is_never_hidden_by_a_draft_bound_to_it(
+        client, tmp_path, projects_dir, runs, monkeypatch):
+    """The one thing the swap may not do (review, 2026-09-12).
+
+    "One task, one row" is a statement about identity, and a settled conversation
+    can say it with a single row because there is nothing left to watch. A run
+    parked on a permission card is the opposite: hiding it takes the row out of
+    the listing AND out of the pulse the sidebar dot and Notifications read, so
+    the user would be waiting on a card they can no longer see — because they
+    started typing the next message."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    _park(monkeypatch, runs, "sess-a")
+
+    rows = _by_key(client)
+    assert rows["sess-a"]["status"] == "needs_attention"
+    assert "draft:draft-0001" in rows, "and the way back into the modal stays too"
+    # Both rows, and both wearing the one number: while the run is live the
+    # session says what it is doing and the draft says what is being written to
+    # it. The number is the task's, and they are the same task.
+    assert rows["draft:draft-0001"]["task_id"] == rows["sess-a"]["task_id"]
+
+    # The pulse is the half the sidebar reads, and it is the half that mattered:
+    # a hidden row is a dot that never lights and a Notification nobody gets.
+    pulse = {t["key"] for t in client.get("/api/tasks/pulse").json()["tasks"]}
+    assert "sess-a" in pulse
+
+    # …and the narrowed build the changes long-poll runs says the same thing. It
+    # builds no draft half at all (`_draft_shaped`) and still has to answer with
+    # the row, or the page drops the live task the moment the watcher mentions
+    # it — the settled case, which answers `gone` here, is pinned separately.
+    assert [r["key"] for r in
+            tasks_mod._task_rows(only=frozenset({"sess-a"}))] == ["sess-a"]
+
+    # …and the moment the card is answered and the run is over, the swap is back
+    # on — no second gesture needed, just the next build.
+    monkeypatch.setattr(tasks_mod, "_agent_module", lambda: _SettledAgent(runs))
+    rows = _by_key(client)
+    assert "sess-a" not in rows
+    assert "draft:draft-0001" in rows
+
+
+def test_a_settled_session_with_a_bound_draft_is_still_hidden(
+        client, tmp_path, projects_dir):
+    """The other side of the rule, pinned beside it: `done` is settled, and a
+    settled conversation still stands down. The live check narrows the swap; it
+    does not undo it."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    rows = _by_key(client)
+    assert "sess-a" not in rows
+    assert "draft:draft-0001" in rows
+
+
+def test_erasing_a_session_cuts_its_task_draft_loose(client, tmp_path,
+                                                     projects_dir):
+    """The words stay, the binding does not (review, 2026-09-12).
+
+    A chat draft is deleted by an erase — there is no conversation left for it to
+    be typed into — but a TASK draft is a form somebody is still filling in, and
+    the session was only where they had meant to send it."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    assert _by_key(client)["sess-a"]["task_id"] == "TASK-001"
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+
+    assert client.post("/api/tasks/erase",
+                       json={"key": "sess-a"}).status_code == 200
+    stored = drafts.get_task("draft-0001")
+    assert stored["session_id"] == "", "the binding"
+    assert stored["title"] == "Ship the changelog", "and not the words"
+
+    # An ordinary `draft:<id>` again: its own number, in its own folder. The
+    # session's TASK-001 is a reservation now (`forget_session` stamps it
+    # `erased` so it can never be reissued), and a draft wearing it for ever was
+    # the bug.
+    row = _by_key(client)["draft:draft-0001"]
+    assert row["session_id"] == ""
+    assert row["project"] == canonical_fs_path(str(elsewhere))
+    ids = tasks_store.task_ids()
+    assert "draft:draft-0001" in ids, "an allocation of its own at last"
+    # Numbers are per project and this draft points at a folder of its own, so
+    # the digits may perfectly well read TASK-001 again — what changed is WHOSE
+    # number it is. The session's record stays as a reservation nobody may
+    # reissue, and the draft is no longer wearing it.
+    assert ids["draft:draft-0001"]["project"] != ids["sess-a"]["project"]
+    assert row["task_id"] == tasks_store.format_task_id(ids["draft:draft-0001"]["n"])
+    assert tasks_store.erased() == {"sess-a"}
+
+
+def test_a_draft_left_bound_to_an_erased_session_wears_no_dead_number(
+        client, tmp_path, projects_dir):
+    """AN ERASED RECORD IS NO RECORD, read off the store rather than trusted to
+    have been unbound.
+
+    `forget_session` keeps the mapping as a reservation, so a draft bound to an
+    erased session found a record and printed that number for ever — and
+    `_draft_numbers`, told by the binding that this task already had one, never
+    minted it another. Covers the draft written between the erase's two writes,
+    and any store left bound by an older build."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    assert _by_key(client)["sess-a"]["task_id"] == "TASK-001"
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    tasks_store.forget_session("sess-a")   # the erase's share of it, by hand
+
+    row = _by_key(client)["draft:draft-0001"]
+    assert row["task_id"] == "", "a blank number, never a dead one"
+    assert row["project"] == canonical_fs_path(str(elsewhere))
+
+
+def test_unbind_session_cuts_that_session_and_nothing_else(state_dir):
+    """The store's half on its own: one pass, one lock, and no write at all when
+    nothing is bound."""
+    drafts.put_task("draft-0001", {"title": "a", "session_id": "sess-a"})
+    drafts.put_task("draft-0002", {"title": "b", "session_id": "sess-b"})
+    drafts.put_task("draft-0003", {"title": "c"})
+    typed_at = drafts.get_task("draft-0001")["updated_at"]
+
+    assert drafts.unbind_session("sess-a") == 1
+    cut = drafts.get_task("draft-0001")
+    assert cut["session_id"] == ""
+    assert cut["title"] == "a", "the words are not what an erase takes"
+    # …and the clock the row prints and sorts on did not move: nobody typed.
+    assert cut["updated_at"] == typed_at
+    assert drafts.get_task("draft-0002")["session_id"] == "sess-b"
+    assert drafts.get_task("draft-0003")["session_id"] == ""
+
+    assert drafts.unbind_session("sess-a") == 0, "nothing bound, nothing written"
+    assert drafts.unbind_session("") == 0
+    assert drafts.unbind_session(None) == 0
+
+
 def test_a_custom_repeat_keeps_its_rule(state_dir):
     """`repeat` is a preset KEY, and "custom" is a pointer at a rule the
     recurrence dialog built. A draft that stored the key and dropped the rule

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -141,6 +141,14 @@ def _by_key(client):
     return {t["key"]: t for t in r.json()["tasks"]}
 
 
+def _put(ident, fields) -> dict | None:
+    """`drafts.put_task`, minus the evicted-ids half most tests here have no
+    reason to look at — the tests that ARE about eviction (below, "one bound
+    draft per session") call `drafts.put_task` directly to see both."""
+    record, _evicted = drafts.put_task(ident, fields)
+    return record
+
+
 # ---------------------------------------------------------------- the store
 
 
@@ -200,17 +208,17 @@ def test_a_draft_id_is_a_token(state_dir):
     assert drafts.draft_id("d-1234-abcd") == "d-1234-abcd"
     assert drafts.draft_id("short") == "", "under eight characters"
     assert drafts.draft_id("has/slash/init") == ""
-    assert drafts.put_task("nope", {"title": "x"}) is None
+    assert _put("nope", {"title": "x"}) is None
 
 
 def test_a_task_draft_merges_fields_and_keeps_created_at(state_dir):
-    first = drafts.put_task("draft-0001", {"title": "Ship it", "junk": "dropped"})
+    first = _put("draft-0001", {"title": "Ship it", "junk": "dropped"})
     assert "junk" not in first
     assert first["title"] == "Ship it"
     assert first["created_at"] == first["updated_at"]
 
     # A second autosave sends only what changed; the rest stands.
-    second = drafts.put_task("draft-0001", {"target": "/tmp/proj"})
+    second = _put("draft-0001", {"target": "/tmp/proj"})
     assert second["title"] == "Ship it"
     assert second["target"] == "/tmp/proj"
     assert second["created_at"] == first["created_at"], "the row must sit still"
@@ -219,7 +227,7 @@ def test_a_task_draft_merges_fields_and_keeps_created_at(state_dir):
 def test_when_and_repeat_pass_through_whatever_the_form_held(state_dir):
     """A structured repeat is an object and a cron line is a string; the modal
     has to reopen on exactly what it closed on."""
-    stored = drafts.put_task("draft-0001", {
+    stored = _put("draft-0001", {
         "title": "Standup",
         "when": "2026-09-12T09:00", "repeat": {"every": "week", "on": ["mon"]}})
     assert stored["when"] == "2026-09-12T09:00"
@@ -240,15 +248,15 @@ def test_only_words_or_files_make_a_task_draft(state_dir):
                      {"when": "2026-09-12T09:00"}, {"repeat": "week"},
                      {"custom_rule": {"freq": "day"}},
                      {"new_task_each_run": True}):
-        assert drafts.put_task("draft-0001", settings) is None, settings
+        assert _put("draft-0001", settings) is None, settings
         assert drafts.get_task("draft-0001") is None, settings
 
     # The three that DO make one, each on its own.
-    assert drafts.put_task("draft-0001", {"title": "Ship it"}) is not None
+    assert _put("draft-0001", {"title": "Ship it"}) is not None
     assert drafts.delete_task("draft-0001") is True
-    assert drafts.put_task("draft-0001", {"description": "roll up the PRs"}) is not None
+    assert _put("draft-0001", {"description": "roll up the PRs"}) is not None
     assert drafts.delete_task("draft-0001") is True
-    assert drafts.put_task("draft-0001", {"attachments": [
+    assert _put("draft-0001", {"attachments": [
         {"path": "/shots/a1b2.png", "name": "shot.png", "kind": "image"}]}) is not None
 
 
@@ -258,18 +266,18 @@ def test_clearing_the_words_then_the_last_file_lets_the_draft_go(state_dir):
     draft". `target` was counted as content, so the record outlived everything
     a person had actually put in it."""
     shot = [{"path": "/shots/a1b2.png", "name": "shot.png", "kind": "image"}]
-    drafts.put_task("draft-0001", {"title": "Ship it", "target": "/tmp/proj",
-                                   "model": "opus", "attachments": shot})
+    _put("draft-0001", {"title": "Ship it", "target": "/tmp/proj",
+                        "model": "opus", "attachments": shot})
     # Text cleared: still a draft, because the picture is still in the tray.
-    assert drafts.put_task("draft-0001", {"title": "", "description": ""}) is not None
+    assert _put("draft-0001", {"title": "", "description": ""}) is not None
     # …and the picture removed after it: now there is nothing left to keep.
-    assert drafts.put_task("draft-0001", {"attachments": []}) is None
+    assert _put("draft-0001", {"attachments": []}) is None
     assert drafts.get_task("draft-0001") is None
 
 
 def test_an_all_empty_task_draft_is_a_delete(state_dir):
-    drafts.put_task("draft-0001", {"title": "Ship it"})
-    assert drafts.put_task("draft-0001", {"title": "  "}) is None
+    _put("draft-0001", {"title": "Ship it"})
+    assert _put("draft-0001", {"title": "  "}) is None
     assert drafts.get_task("draft-0001") is None
     assert drafts.delete_task("draft-0001") is False
 
@@ -495,7 +503,7 @@ def test_a_schedule_without_a_draft_id_is_unchanged(client, tmp_path):
     `?new=1` hop still does not."""
     target = tmp_path / "project"
     target.mkdir()
-    drafts.put_task("draft-0001", {"title": "keep me"})
+    _put("draft-0001", {"title": "keep me"})
     r = client.post("/api/schedule", headers=WRITE,
                     json={"target": str(target), "message": "hi",
                           "delay_seconds": 600})
@@ -1171,10 +1179,17 @@ def test_a_bad_or_absent_from_chat_key_changes_nothing(client, tmp_path):
 # SECOND session with a SECOND task number, and the TASK-nnn the reader had been
 # watching was gone.
 #
-# So the binding is STORED, and the three consequences below follow from it: no
-# number is minted for a draft whose task already has one, the draft row wears
-# the session's identity, and while it stands the session's own row stands down
-# — one task, one row.
+# So the binding is STORED, and everything below follows from it: such a draft
+# is not a row and not a number — the CONVERSATION's row is the one the reader
+# knows, and it simply grows the red `✎ Draft` chip — and the way back into the
+# form is the composer's own Schedule button, which reopens the draft already
+# bound to that session instead of minting a second one.
+#
+# Round 3 built it the other way, with a draft row wearing the session's
+# identity and the session's own row held back behind it, and every part of that
+# read wrong: a second thing to read, the conversation gone from the Cards wall
+# (which draws transcripts, and a form has none), and one session row that
+# opened a modal where every other opens the chat (bugbot, PR #1126).
 
 
 def _bound_draft(client, ident, session_id, target, **fields):
@@ -1191,7 +1206,7 @@ def _bound_draft(client, ident, session_id, target, **fields):
 def test_the_session_a_draft_is_going_into_round_trips(state_dir):
     """Stored and validated as a SESSION id, never as `new:<file>`: binding is to
     a thread, and a chat that has never been sent has none."""
-    stored = drafts.put_task("draft-0001", {"title": "hi", "session_id": "sess-a"})
+    stored = _put("draft-0001", {"title": "hi", "session_id": "sess-a"})
     assert stored["session_id"] == "sess-a"
     assert drafts.get_task("draft-0001")["session_id"] == "sess-a"
     assert drafts.bound_session("sess-a") == "sess-a"
@@ -1201,37 +1216,140 @@ def test_the_session_a_draft_is_going_into_round_trips(state_dir):
     # ...and it survives the saves that do not mention it, like every other
     # stored field (`TASK_FIELDS`): the modal's later autosaves may send only
     # what changed.
-    assert drafts.put_task("draft-0001",
-                           {"title": "hi again"})["session_id"] == "sess-a"
+    assert _put("draft-0001",
+                {"title": "hi again"})["session_id"] == "sess-a"
 
 
-def test_a_session_bound_draft_wears_the_sessions_number(client, tmp_path,
-                                                         projects_dir):
-    """No second number, and no second identity: the row IS that task.
+# --------------------------------------- one bound draft per session (server)
+#
+# THE OWNER'S OWN RULE, "a draft moves, never duplicates" (design.md, Round 2),
+# read the other way round. `from_chat_key` above keeps it for the chat → task
+# hop; this is the same promise for two TASK drafts that both end up naming the
+# same session — a New task form opened twice out of one conversation's
+# Schedule button, say, once before a reload and once after. The session's row
+# can wear exactly one `✎ Draft` chip (`_bound_chips`), so binding a second
+# draft to it is not a second fact, it is a stale copy of the first one, and
+# the newest write is the one that is telling the truth (review, 2026-09-12).
 
-    The number, the project and the cwd all come off the session, so the row the
-    draft stands in for and the row it replaces say the same thing about where
-    this work lives."""
+
+def test_binding_a_second_draft_evicts_the_first_bound_to_the_same_session(
+        state_dir):
+    first, evicted = drafts.put_task(
+        "draft-0001", {"title": "one", "session_id": "sess-a"})
+    assert first is not None
+    assert evicted == [], "nothing else was bound yet"
+
+    second, evicted = drafts.put_task(
+        "draft-0002", {"title": "two", "session_id": "sess-a"})
+    assert second is not None
+    assert second["session_id"] == "sess-a"
+    # THE LISTING KEY (`draft:<id>`), same shape `unbind_session` answers in —
+    # the caller announces it and a page holding that row has to be told to
+    # drop it.
+    assert evicted == ["draft:draft-0001"]
+    assert drafts.get_task("draft-0001") is None, "the loser's words are gone"
+    assert drafts.get_task("draft-0002") is not None
+
+
+def test_a_put_for_the_same_id_updates_in_place_and_evicts_nobody(state_dir):
+    """The ordinary autosave — the SAME draft, saved again and again — must
+    never read as a second draft colliding with itself."""
+    drafts.put_task("draft-0001", {"title": "one", "session_id": "sess-a"})
+    record, evicted = drafts.put_task("draft-0001", {"title": "one, edited"})
+    assert record["title"] == "one, edited"
+    assert record["session_id"] == "sess-a", "unmentioned fields survive"
+    assert evicted == []
+    assert drafts.get_task("draft-0001") is not None
+
+
+def test_unbound_drafts_are_untouched_by_a_binding_elsewhere(state_dir):
+    """Only a draft bound to the SAME session is at risk. An unbound draft, and
+    a draft bound to a DIFFERENT session, are not the fact "one per session" is
+    about, whatever else is going on in the store at the time."""
+    drafts.put_task("draft-unbound", {"title": "no session at all"})
+    drafts.put_task(
+        "draft-other", {"title": "a different thread", "session_id": "sess-b"})
+
+    _record, evicted = drafts.put_task(
+        "draft-0001", {"title": "one", "session_id": "sess-a"})
+    assert evicted == []
+    assert drafts.get_task("draft-unbound") is not None
+    assert drafts.get_task("draft-other")["session_id"] == "sess-b"
+
+
+def test_the_router_announces_the_draft_a_binding_evicted(client, tmp_path):
+    """The eviction happens inside `put_task`'s own lock; a page holding the
+    loser's row would go on showing it until the next full listing without the
+    router telling the long-poll too (`routers/drafts.py`, the PUT handler)."""
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    before = client.get("/api/tasks").json()["generation"]
+
+    _bound_draft(client, "draft-0002", "sess-a", elsewhere)
+    assert drafts.get_task("draft-0001") is None
+
+    body = client.get(f"/api/tasks/changes?since={before}&wait=0").json()
+    assert "draft:draft-0001" in body["gone"]
+
+
+def test_a_session_bound_draft_is_not_a_row_and_the_session_wears_the_chip(
+        client, tmp_path, projects_dir):
+    """ONE TASK, ONE ROW — and it is the CONVERSATION's row (Akshil,
+    2026-09-12).
+
+    The draft is the thread's next message being written, so it is not a second
+    thing beside the thread. Nothing is emitted for it and nothing is hidden for
+    it: the session's row stands exactly as it always did — same title, same
+    number, same message count, same lane — and grows two fields, the id of the
+    form being written into it and that form's preview for the chip."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
-    session_number = _by_key(client)["sess-a"]["task_id"]
-    assert session_number == "TASK-001"
+    before = _by_key(client)["sess-a"]
+    assert before["task_id"] == "TASK-001"
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
 
-    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
-    row = _by_key(client)["draft:draft-0001"]
-    assert row["task_id"] == session_number
-    assert row["session_id"] == "sess-a"
-    assert row["kind"] == "draft"
-    assert row["draft_kind"] == "task"
-    # The SESSION's folder, not the folder the form happens to point at: a task
-    # sits in one project, and the row is that task.
-    assert row["project"] == canonical_fs_path("/home/me/proj")
-    assert row["cwd"] == canonical_fs_path("/home/me/proj")
-    assert row["target"] == canonical_fs_path(str(elsewhere))
-    # ...and nothing was allocated under the draft's own key. The number is the
-    # session's; there is no second one to move, spend or renumber.
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere,
+                 description="ship the changelog, then tag it")
+    rows = _by_key(client)
+    assert "draft:draft-0001" not in rows, "a bound draft is not a row"
+    row = rows["sess-a"]
+    # Untouched, field for field: this is the row the reader already knew.
+    assert row["task_id"] == before["task_id"] == "TASK-001"
+    assert row["title"] == before["title"]
+    assert row["status"] == before["status"]
+    assert row["message_count"] == before["message_count"] == 1
+    assert row["project"] == before["project"]
+    assert row.get("kind") == before.get("kind"), "not a draft row, and never was"
+    # …and the two fields that are new. The chip's words are the form's TITLE,
+    # which is what the reader named this thing; the description is the fallback
+    # for a form that has only been typed into.
+    assert row["bound_draft"] == "draft-0001"
+    assert row["draft"]["preview"] == "Ship the changelog"
+    assert row["draft"]["updated_at"] > 0
+
+    # Nothing was allocated under the draft's own key either — the number is the
+    # session's, and minting a second one was the whole bug.
     assert "draft:draft-0001" not in tasks_store.task_ids()
+
+
+def test_the_conversations_own_composer_outranks_the_form(client, tmp_path,
+                                                          projects_dir):
+    """One row, one chip, and the chat's own unsent words win.
+
+    A session can have both — text left in its composer AND a New task form
+    opened out of it — and `draft` is one field because the reader has one
+    question. The composer's copy is literally sitting in that conversation; the
+    form is a message about to be scheduled into it."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    client.put(_chat_url("sess-a"), json={"text": "half a thought"})
+
+    row = _by_key(client)["sess-a"]
+    assert row["draft"]["preview"] == "half a thought"
+    assert row["bound_draft"] == "draft-0001", "still the way back to the form"
 
 
 def test_a_draft_with_no_session_is_numbered_exactly_as_before(client, tmp_path):
@@ -1247,40 +1365,33 @@ def test_a_draft_with_no_session_is_numbered_exactly_as_before(client, tmp_path)
     assert "draft:draft-0001" in tasks_store.task_ids()
 
 
-def test_the_session_row_stands_down_while_the_draft_stands_in(client, tmp_path,
-                                                               projects_dir):
-    """ONE TASK, ONE ROW. The draft is the conversation's next message, not a
-    second thing beside it — and two rows for one task is what the reader
-    actually saw."""
+def test_discarding_a_bound_draft_takes_the_chip_off_the_row(client, tmp_path,
+                                                             projects_dir):
+    """The chip is the only trace, so Discard is the only thing that has to
+    reverse — the row itself never moved."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
     _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    assert _by_key(client)["sess-a"]["bound_draft"] == "draft-0001"
 
-    rows = _by_key(client)
-    assert "sess-a" not in rows, "the session's own row is held back"
-    assert "draft:draft-0001" in rows
-    assert [key for key, row in rows.items() if row["task_id"] == "TASK-001"] \
-        == ["draft:draft-0001"], "one number, one row"
-
-    # Discard, and the conversation is simply back — number, message count and
-    # all. Nothing about the session was changed to hide it.
     assert client.delete("/api/drafts/task/draft-0001").status_code == 200
-    rows = _by_key(client)
-    assert "draft:draft-0001" not in rows
-    assert rows["sess-a"]["task_id"] == "TASK-001"
-    assert rows["sess-a"]["message_count"] == 1
+    row = _by_key(client)["sess-a"]
+    assert row["bound_draft"] == ""
+    assert row["draft"] is None
+    assert row["task_id"] == "TASK-001", "nothing about the row was ever changed"
+    assert row["message_count"] == 1
 
 
-def test_emptying_a_bound_draft_brings_the_session_row_back(client, tmp_path,
-                                                            projects_dir):
-    """An all-empty form is a DELETE (`_empty_task`), and the swap has to
-    reverse on that door too — not only on Discard."""
+def test_emptying_a_bound_draft_takes_the_chip_off_too(client, tmp_path,
+                                                       projects_dir):
+    """An all-empty form is a DELETE (`_empty_task`), and the chip has to go on
+    that door as well — not only on Discard."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
     _bound_draft(client, "draft-0001", "sess-a", elsewhere)
-    assert "sess-a" not in _by_key(client)
+    assert _by_key(client)["sess-a"]["bound_draft"] == "draft-0001"
 
     r = client.put("/api/drafts/task/draft-0001",
                    json={"title": "", "description": "", "target": str(elsewhere),
@@ -1288,13 +1399,15 @@ def test_emptying_a_bound_draft_brings_the_session_row_back(client, tmp_path,
     assert r.json()["draft"] is None
     rows = _by_key(client)
     assert "draft:draft-0001" not in rows
-    assert "sess-a" in rows
+    assert rows["sess-a"]["bound_draft"] == ""
+    assert rows["sess-a"]["draft"] is None
 
 
-def test_both_rows_repaint_through_the_changes_endpoint(client, tmp_path,
+def test_the_chip_repaints_through_the_changes_endpoint(client, tmp_path,
                                                         projects_dir):
-    """Two rows move at once, so both keys are announced: the draft arrives and
-    the session's row is reported `gone`, then the other way round."""
+    """One row moves, and it is the session's — the draft write announces that
+    key too (`routers/drafts._announce`), which is what makes the chip appear
+    and vanish without a reload."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
     _by_key(client)  # a first full listing, so the session is numbered
     elsewhere = tmp_path / "elsewhere"
@@ -1302,34 +1415,40 @@ def test_both_rows_repaint_through_the_changes_endpoint(client, tmp_path,
 
     before = client.get("/api/tasks").json()["generation"]
     _bound_draft(client, "draft-0001", "sess-a", elsewhere)
-    r = client.get("/api/tasks/changes?since=%d&wait=0" % before)
-    assert r.status_code == 200, r.text
-    body = r.json()
-    assert [row["key"] for row in body["rows"]] == ["draft:draft-0001"]
-    assert "sess-a" in body["gone"], "the row the page is still showing"
+    body = client.get("/api/tasks/changes?since=%d&wait=0" % before).json()
+    rows = {row["key"]: row for row in body["rows"]}
+    assert rows["sess-a"]["bound_draft"] == "draft-0001"
+    assert rows["sess-a"]["draft"]["preview"] == "Ship the changelog"
+    # The draft's own key is announced as well and answers `gone`: it is not a
+    # row, and a page holding one from an older build is told to drop it.
+    assert "draft:draft-0001" in body["gone"]
 
     gen = body["generation"]
     assert client.delete("/api/drafts/task/draft-0001").status_code == 200
     body = client.get("/api/tasks/changes?since=%d&wait=0" % gen).json()
-    assert [row["key"] for row in body["rows"]] == ["sess-a"]
-    assert "draft:draft-0001" in body["gone"]
+    rows = {row["key"]: row for row in body["rows"]}
+    assert rows["sess-a"]["bound_draft"] == ""
+    assert rows["sess-a"]["draft"] is None
 
 
-def test_a_poll_about_the_session_alone_does_not_bring_its_row_back(
-        client, tmp_path, projects_dir):
-    """The claim is read off the DRAFT STORE, never off the rows a build
-    happened to produce.
+def test_a_poll_about_the_session_alone_carries_the_chip(client, tmp_path,
+                                                         projects_dir):
+    """The chip is read off the DRAFT STORE, never off the rows a build happened
+    to produce.
 
     A narrowed build asking about a session alone runs no draft half at all
-    (`_draft_shaped`), so a claim derived from built rows would let the hidden
-    row reappear on exactly that poll — and the page would show the task twice
-    until the next full listing."""
+    (`_draft_shaped`), so a join that depended on a draft row having been built
+    would drop the chip on exactly that poll — and the row the page is holding
+    would lose it until the next full listing."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
     _bound_draft(client, "draft-0001", "sess-a", elsewhere)
 
-    assert tasks_mod._task_rows(only=frozenset({"sess-a"})) == []
+    narrowed = tasks_mod._task_rows(only=frozenset({"sess-a"}))
+    assert [r["key"] for r in narrowed] == ["sess-a"]
+    assert narrowed[0]["bound_draft"] == "draft-0001"
+    assert narrowed[0]["draft"]["preview"] == "Ship the changelog"
 
 
 def test_scheduling_a_bound_draft_lands_in_the_session_and_keeps_the_number(
@@ -1439,16 +1558,16 @@ def _park(monkeypatch, runs, session_id):
     monkeypatch.setattr(tasks_mod, "_agent_module", lambda: _Parked())
 
 
-def test_a_live_session_is_never_hidden_by_a_draft_bound_to_it(
+def test_a_live_session_is_untouched_by_a_draft_bound_to_it(
         client, tmp_path, projects_dir, runs, monkeypatch):
-    """The one thing the swap may not do (review, 2026-09-12).
+    """Nothing is hidden, whatever the conversation is doing — and a run parked
+    on a permission card is the case that used to be worth a rule of its own.
 
-    "One task, one row" is a statement about identity, and a settled conversation
-    can say it with a single row because there is nothing left to watch. A run
-    parked on a permission card is the opposite: hiding it takes the row out of
-    the listing AND out of the pulse the sidebar dot and Notifications read, so
-    the user would be waiting on a card they can no longer see — because they
-    started typing the next message."""
+    Round 3 dropped a settled session's row behind its draft and had to carve
+    out the live statuses so a run in flight could never vanish from the listing
+    or from the pulse the sidebar dot and Notifications read. Nothing is dropped
+    now, so there is no rule to carve: the row is the row, the pill says what
+    the run is doing, and the chip says a message is being written to it."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
@@ -1457,45 +1576,23 @@ def test_a_live_session_is_never_hidden_by_a_draft_bound_to_it(
 
     rows = _by_key(client)
     assert rows["sess-a"]["status"] == "needs_attention"
-    assert "draft:draft-0001" in rows, "and the way back into the modal stays too"
-    # Both rows, and both wearing the one number: while the run is live the
-    # session says what it is doing and the draft says what is being written to
-    # it. The number is the task's, and they are the same task.
-    assert rows["draft:draft-0001"]["task_id"] == rows["sess-a"]["task_id"]
+    assert rows["sess-a"]["bound_draft"] == "draft-0001"
+    assert "draft:draft-0001" not in rows
 
-    # The pulse is the half the sidebar reads, and it is the half that mattered:
-    # a hidden row is a dot that never lights and a Notification nobody gets.
+    # The pulse is the half the sidebar reads, and a listing that hid rows was a
+    # dot that never lit and a Notification nobody got.
     pulse = {t["key"] for t in client.get("/api/tasks/pulse").json()["tasks"]}
     assert "sess-a" in pulse
 
-    # …and the narrowed build the changes long-poll runs says the same thing. It
-    # builds no draft half at all (`_draft_shaped`) and still has to answer with
-    # the row, or the page drops the live task the moment the watcher mentions
-    # it — the settled case, which answers `gone` here, is pinned separately.
+    # …and the narrowed build the changes long-poll runs says the same thing.
     assert [r["key"] for r in
             tasks_mod._task_rows(only=frozenset({"sess-a"}))] == ["sess-a"]
 
-    # …and the moment the card is answered and the run is over, the swap is back
-    # on — no second gesture needed, just the next build.
+    # …and the settled case is the same case. There is no second behaviour here.
     monkeypatch.setattr(tasks_mod, "_agent_module", lambda: _SettledAgent(runs))
     rows = _by_key(client)
-    assert "sess-a" not in rows
-    assert "draft:draft-0001" in rows
-
-
-def test_a_settled_session_with_a_bound_draft_is_still_hidden(
-        client, tmp_path, projects_dir):
-    """The other side of the rule, pinned beside it: `done` is settled, and a
-    settled conversation still stands down. The live check narrows the swap; it
-    does not undo it."""
-    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
-    elsewhere = tmp_path / "elsewhere"
-    elsewhere.mkdir()
-    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
-
-    rows = _by_key(client)
-    assert "sess-a" not in rows
-    assert "draft:draft-0001" in rows
+    assert rows["sess-a"]["bound_draft"] == "draft-0001"
+    assert "draft:draft-0001" not in rows
 
 
 def test_erasing_a_session_cuts_its_task_draft_loose(client, tmp_path,
@@ -1511,6 +1608,7 @@ def test_erasing_a_session_cuts_its_task_draft_loose(client, tmp_path,
     elsewhere.mkdir()
     _bound_draft(client, "draft-0001", "sess-a", elsewhere)
 
+    before = client.get("/api/tasks").json()["generation"]
     assert client.post("/api/tasks/erase",
                        json={"key": "sess-a"}).status_code == 200
     stored = drafts.get_task("draft-0001")
@@ -1534,17 +1632,32 @@ def test_erasing_a_session_cuts_its_task_draft_loose(client, tmp_path,
     assert row["task_id"] == tasks_store.format_task_id(ids["draft:draft-0001"]["n"])
     assert tasks_store.erased() == {"sess-a"}
 
+    # AND THE DRAFT'S OWN KEY IS ANNOUNCED (bugbot, PR #1126). The erase used to
+    # notify the session key alone, so the page went on holding a row — or, for
+    # the build where it was one, a draft row — carrying the dead TASK number and
+    # the erased `session_id`, and pressing Schedule on it sent the message back
+    # into the conversation this gesture had just destroyed. A narrowed poll for
+    # the draft's key now answers the re-numbered, unbound row.
+    body = client.get("/api/tasks/changes?since=%d&wait=0" % before).json()
+    moved = {r["key"]: r for r in body["rows"]}
+    assert "draft:draft-0001" in moved, "the row that just changed its number"
+    assert moved["draft:draft-0001"]["session_id"] == ""
+    assert moved["draft:draft-0001"]["project"] == canonical_fs_path(str(elsewhere))
+    assert "sess-a" in body["gone"], "and the conversation itself"
+
 
 def test_a_draft_left_bound_to_an_erased_session_wears_no_dead_number(
         client, tmp_path, projects_dir):
     """AN ERASED RECORD IS NO RECORD, read off the store rather than trusted to
     have been unbound.
 
-    `forget_session` keeps the mapping as a reservation, so a draft bound to an
-    erased session found a record and printed that number for ever — and
-    `_draft_numbers`, told by the binding that this task already had one, never
-    minted it another. Covers the draft written between the erase's two writes,
-    and any store left bound by an older build."""
+    A bound draft is not a row — the conversation's row wears its chip instead —
+    and an ERASED conversation has no row to wear one, so a draft still naming it
+    would be words nobody can reach. `forget_session` keeps the mapping as a
+    reservation, which is exactly the fact that says so, and such a draft is an
+    ordinary row again: blank-numbered (nothing may reissue the session's TASK
+    number) and in its own folder. Covers the draft written between the erase's
+    two writes, and any store left bound by an older build."""
     _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
     assert _by_key(client)["sess-a"]["task_id"] == "TASK-001"
     elsewhere = tmp_path / "elsewhere"
@@ -1559,13 +1672,17 @@ def test_a_draft_left_bound_to_an_erased_session_wears_no_dead_number(
 
 def test_unbind_session_cuts_that_session_and_nothing_else(state_dir):
     """The store's half on its own: one pass, one lock, and no write at all when
-    nothing is bound."""
-    drafts.put_task("draft-0001", {"title": "a", "session_id": "sess-a"})
-    drafts.put_task("draft-0002", {"title": "b", "session_id": "sess-b"})
-    drafts.put_task("draft-0003", {"title": "c"})
+    nothing is bound.
+
+    It answers the LISTING KEYS it cut, not a count (bugbot, PR #1126): those
+    rows have just changed their number, their folder and the thread they would
+    be sent to, and the caller has to announce them."""
+    _put("draft-0001", {"title": "a", "session_id": "sess-a"})
+    _put("draft-0002", {"title": "b", "session_id": "sess-b"})
+    _put("draft-0003", {"title": "c"})
     typed_at = drafts.get_task("draft-0001")["updated_at"]
 
-    assert drafts.unbind_session("sess-a") == 1
+    assert drafts.unbind_session("sess-a") == ["draft:draft-0001"]
     cut = drafts.get_task("draft-0001")
     assert cut["session_id"] == ""
     assert cut["title"] == "a", "the words are not what an erase takes"
@@ -1574,9 +1691,9 @@ def test_unbind_session_cuts_that_session_and_nothing_else(state_dir):
     assert drafts.get_task("draft-0002")["session_id"] == "sess-b"
     assert drafts.get_task("draft-0003")["session_id"] == ""
 
-    assert drafts.unbind_session("sess-a") == 0, "nothing bound, nothing written"
-    assert drafts.unbind_session("") == 0
-    assert drafts.unbind_session(None) == 0
+    assert drafts.unbind_session("sess-a") == [], "nothing bound, nothing written"
+    assert drafts.unbind_session("") == []
+    assert drafts.unbind_session(None) == []
 
 
 def test_a_custom_repeat_keeps_its_rule(state_dir):
@@ -1585,36 +1702,36 @@ def test_a_custom_repeat_keeps_its_rule(state_dir):
     reopened saying Custom, holding nothing, with Save refused and nothing on the
     card saying why."""
     rule = {"freq": "week", "interval": 2, "byday": [1, 3]}
-    stored = drafts.put_task("draft-0001", {"title": "Standup notes",
-                                            "repeat": "custom",
-                                            "custom_rule": rule})
+    stored = _put("draft-0001", {"title": "Standup notes",
+                                 "repeat": "custom",
+                                 "custom_rule": rule})
     assert stored["custom_rule"] == rule
     assert drafts.get_task("draft-0001")["custom_rule"] == rule
     # Pass-through, not parsed: this store is not the authority on what a
     # recurrence rule looks like, and a shape it validated would be a second
     # copy of `recur`'s grammar going stale.
-    assert drafts.put_task("draft-0002", {"title": "Retro",
-                                         "custom_rule": {"freq": "fortnight"}}
-                           )["custom_rule"] == {"freq": "fortnight"}
+    assert _put("draft-0002", {"title": "Retro",
+                               "custom_rule": {"freq": "fortnight"}}
+               )["custom_rule"] == {"freq": "fortnight"}
     # A field the client omits keeps what the stored draft had, like every other.
-    assert drafts.put_task("draft-0001", {"title": "Standup"}
-                           )["custom_rule"] == rule
+    assert _put("draft-0001", {"title": "Standup"}
+               )["custom_rule"] == rule
     # …and clearing the choice clears the rule with it.
-    assert drafts.put_task("draft-0001", {"repeat": None, "custom_rule": None}
-                           )["custom_rule"] is None
+    assert _put("draft-0001", {"repeat": None, "custom_rule": None}
+               )["custom_rule"] is None
 
 
 def test_a_rule_alone_is_not_a_draft(state_dir):
     """A recurrence rule is a SETTING — how a task would run, not a task
     (Akshil, 2026-09-12). It used to count, and the cost was an "Untitled draft"
     row minted by opening the when-row and picking a time."""
-    assert drafts.put_task("draft-0001",
-                           {"custom_rule": {"freq": "month"}}) is None
+    assert _put("draft-0001",
+                {"custom_rule": {"freq": "month"}}) is None
     assert drafts.get_task("draft-0001") is None
     # …and it rides along perfectly well once there are words to ride with.
-    assert drafts.put_task("draft-0001", {"title": "Monthly report",
-                                          "custom_rule": {"freq": "month"}}
-                           )["custom_rule"] == {"freq": "month"}
+    assert _put("draft-0001", {"title": "Monthly report",
+                               "custom_rule": {"freq": "month"}}
+               )["custom_rule"] == {"freq": "month"}
 
 
 def test_the_rule_rides_down_on_the_draft_row(client, tmp_path):
@@ -1635,7 +1752,7 @@ def test_the_rule_rides_down_on_the_draft_row(client, tmp_path):
 def test_list_all_answers_both_halves_off_one_read(state_dir, monkeypatch):
     """`list_task()` and `list_chat()` are each a whole `load()`, and the tasks
     listing wants both on every build. Same projections, half the reads."""
-    drafts.put_task("draft-0001", {"title": "Nightly report"})
+    _put("draft-0001", {"title": "Nightly report"})
     drafts.put_chat("sess-a", "half a thought", [])
 
     reads = []

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -11,7 +11,11 @@ Nothing here reads the real ~/.claude or the real ~/.fused-render: every path is
 under tmp_path, and `drafts.STATE_DIR` is redirected alongside tasks_store's
 because both are computed at import from the same env var.
 """
+import importlib.util
+import io
 import json
+import os
+import time
 from urllib.parse import quote
 
 import pytest
@@ -66,6 +70,39 @@ def _clear_caches():
 @pytest.fixture(autouse=True)
 def no_real_wake(monkeypatch):
     monkeypatch.setattr(schedule_wake, "sync", lambda due: None)
+
+
+@pytest.fixture(autouse=True)
+def runs(tmp_path, monkeypatch):
+    """A runs tree of our own, and the stand-in that reads it.
+
+    The listing looks in here to settle a `new:<file>` key onto the session its
+    first send created (`tasks_mod._settle_new_chats`), and the real tree is a
+    per-user directory under the machine's temp root — the developer's own live
+    chats. Autouse, so no test in this file can read it, and so a draft test
+    that stages no run gets the same empty answer every time.
+
+    A stand-in rather than the real `agent.py` for the reason `test_tasks_api`'s
+    own fake gives: it is a TEMPLATE, outside the package's import graph by
+    design (SPEC PY-15), and what is under test is what the router does with its
+    answers."""
+    d = tmp_path / "runs"
+    d.mkdir()
+
+    class _Agent:
+        RUNS = str(d)
+
+        def _permissions(self, run_dir):
+            return []
+
+        def _alive(self, run_dir):
+            return False
+
+        def _session_from_out(self, run_dir):
+            return ""   # the `session` file is the only id these tests write
+
+    monkeypatch.setattr(tasks_mod, "_agent_module", lambda: _Agent())
+    return d
 
 
 @pytest.fixture()
@@ -183,9 +220,51 @@ def test_when_and_repeat_pass_through_whatever_the_form_held(state_dir):
     """A structured repeat is an object and a cron line is a string; the modal
     has to reopen on exactly what it closed on."""
     stored = drafts.put_task("draft-0001", {
+        "title": "Standup",
         "when": "2026-09-12T09:00", "repeat": {"every": "week", "on": ["mon"]}})
     assert stored["when"] == "2026-09-12T09:00"
     assert stored["repeat"] == {"every": "week", "on": ["mon"]}
+
+
+def test_only_words_or_files_make_a_task_draft(state_dir):
+    """WHAT A DRAFT IS: `title.strip() or description.strip() or attachments`,
+    and nothing else (Akshil, 2026-09-12).
+
+    Everything else the form holds — the folder, the model, the effort, the
+    permission mode, the time, the repeat rule — is a setting that rides along
+    with a draft. They used to count, so changing the folder or picking a time
+    on an untouched card minted an "Untitled draft" row holding nothing anybody
+    had typed."""
+    for settings in ({"target": "/tmp/proj"}, {"model": "opus"},
+                     {"effort": "high"}, {"permission": "auto"},
+                     {"when": "2026-09-12T09:00"}, {"repeat": "week"},
+                     {"custom_rule": {"freq": "day"}},
+                     {"new_task_each_run": True}):
+        assert drafts.put_task("draft-0001", settings) is None, settings
+        assert drafts.get_task("draft-0001") is None, settings
+
+    # The three that DO make one, each on its own.
+    assert drafts.put_task("draft-0001", {"title": "Ship it"}) is not None
+    assert drafts.delete_task("draft-0001") is True
+    assert drafts.put_task("draft-0001", {"description": "roll up the PRs"}) is not None
+    assert drafts.delete_task("draft-0001") is True
+    assert drafts.put_task("draft-0001", {"attachments": [
+        {"path": "/shots/a1b2.png", "name": "shot.png", "kind": "image"}]}) is not None
+
+
+def test_clearing_the_words_then_the_last_file_lets_the_draft_go(state_dir):
+    """THE REPORTED DEAD END (Akshil, 2026-09-12): "if I clear the text it says
+    untitled draft, after that if I lose the attachment it doesn't clear the
+    draft". `target` was counted as content, so the record outlived everything
+    a person had actually put in it."""
+    shot = [{"path": "/shots/a1b2.png", "name": "shot.png", "kind": "image"}]
+    drafts.put_task("draft-0001", {"title": "Ship it", "target": "/tmp/proj",
+                                   "model": "opus", "attachments": shot})
+    # Text cleared: still a draft, because the picture is still in the tray.
+    assert drafts.put_task("draft-0001", {"title": "", "description": ""}) is not None
+    # …and the picture removed after it: now there is nothing left to keep.
+    assert drafts.put_task("draft-0001", {"attachments": []}) is None
+    assert drafts.get_task("draft-0001") is None
 
 
 def test_an_all_empty_task_draft_is_a_delete(state_dir):
@@ -333,7 +412,10 @@ def test_a_draft_row_falls_back_to_its_description_then_to_a_name(client):
                json={"description": "  \nroll up yesterday's PRs\nand file them"})
     assert _by_key(client)["draft:draft-0001"]["title"] == "roll up yesterday's PRs"
 
-    client.put("/api/drafts/task/draft-0002", json={"model": "opus"})
+    # …and "Untitled draft" is now reachable ONLY by an attachment-only draft:
+    # a settings-only form is not a draft at all (Akshil, 2026-09-12).
+    client.put("/api/drafts/task/draft-0002", json={"attachments": [
+        {"path": "/shots/a1b2.png", "name": "shot.png", "kind": "image"}]})
     assert _by_key(client)["draft:draft-0002"]["title"] == "Untitled draft"
 
 
@@ -635,11 +717,55 @@ def test_new_chat_draft_rows_appear_and_vanish_through_the_changes_endpoint(
     assert [t["key"] for t in client.get("/api/tasks/pulse").json()["tasks"]] == []
 
 
-# ------------------------------------------------- round 2: rekey forward
+# ----------------------------------- round 2: the first send's session
+#
+# A chat with no session drafts under `new:<file>` and is numbered under that
+# key. The first send creates the session, and the number has to follow it —
+# but WHICH session a send created is not a question the page can answer, and
+# four rounds of bugbot went into trying (PR #1118, 2026-09-12). What the send
+# CAN say is which draft it is spending, so it says that: a session-less start
+# carries `draft_key`, `agent._start` writes it into the run's `meta.json`, and
+# the listing build moves the number onto the session that run made
+# (`routers/tasks.py::_settle_new_chats`).
+#
+# The first build of this matched on the target and an empty `resumed_from`
+# instead — "a first-ever run on this folder" — and every other way a folder
+# gets its first run passes those guards too: a scheduled task's first fire,
+# a `new_task_each_run` entry, canvases.py's spawn. Each would have taken the
+# number AND deleted the unsent words (review, 2026-09-12). That is the second
+# test below, and it is the one this round exists for.
 
 
-def test_the_rekey_route_moves_the_number_onto_the_session(client, projects_dir,
-                                                           tmp_path):
+def _stage_run(runs, name, file, session_id="", resumed_from="", started=None,
+               draft_key=None):
+    """One run dir as `agent._start` leaves it: `meta.json` with the target, the
+    session it resumed (empty when the send had none) and — for a native
+    composer's session-less send only — the draft key that send is spending,
+    plus the `session` file `_poll` writes once the CLI reports an id.
+
+    `draft_key=None` is every OTHER caller of `_start`: the scheduler, the apps
+    API, canvases.py. They write no such field, which is exactly what stops them
+    claiming a draft.
+
+    `started` back-dates `meta.json` — the run's own clock, which is what tells
+    a draft the send spent from one typed into after it."""
+    d = runs / name
+    d.mkdir(parents=True, exist_ok=True)
+    meta = {"file": str(file), "resumed_from": resumed_from,
+            "message": "first message"}
+    if draft_key is not None:
+        meta["draft_key"] = draft_key
+    path = d / "meta.json"
+    path.write_text(json.dumps(meta))
+    if started is not None:
+        os.utime(path, (started, started))
+    if session_id:
+        (d / "session").write_text(session_id)
+    return d
+
+
+def test_a_session_less_send_carries_the_number_onto_the_session_it_made(
+        client, projects_dir, runs, tmp_path):
     folder = tmp_path / "proj"
     folder.mkdir()
     key = "new:" + str(folder)
@@ -647,67 +773,214 @@ def test_the_rekey_route_moves_the_number_onto_the_session(client, projects_dir,
     number = _by_key(client)[key]["task_id"]
     assert number == "TASK-001"
 
-    # The send happened: Claude Code minted a session and wrote a transcript.
+    # The send: a run tagged with this draft's key, and Claude Code minted a
+    # session for it.
     _write_transcript(projects_dir, "sess-a", str(folder),
                       [_user("first message", T9)])
-    r = client.post("/api/drafts/chat/rekey", json={"from": key, "to": "sess-a"})
-    assert r.status_code == 200, r.text
-    assert r.json()["task_id"] == number
+    _stage_run(runs, "20260912-090000-aa", folder, "sess-a", draft_key=key,
+               started=time.time() + 5)
 
     rows = _by_key(client)
     assert key not in rows, "the folder row is the session's row now"
     assert rows["sess-a"]["task_id"] == number
     assert tasks_store.task_number("sess-a") == number
+    # And the draft the send spent is gone — never copied onto the session:
+    # those words are in the transcript.
+    assert client.get("/api/drafts").json()["chat"] == {}
 
 
-def test_the_rekey_route_deletes_a_draft_the_send_already_emptied(client, tmp_path):
-    """The normal case: the send cleared the box, so there is nothing to move
-    and the `new:` key is simply gone."""
+def test_a_first_run_nobody_tagged_leaves_the_draft_whole(
+        client, projects_dir, runs, tmp_path):
+    """THE ONE THIS ROUND EXISTS FOR (review, 2026-09-12).
+
+    A scheduled task's first fire on the same folder is a run with no
+    `resumed_from` and a brand-new session — identical, on disk, to a composer's
+    first send in every way except the tag. It must leave the unsent words, the
+    draft and the number exactly where they are; the earlier target-matching
+    version deleted all three.
+    """
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "still typing this"})
+    number = _by_key(client)[key]["task_id"]
+
+    _write_transcript(projects_dir, "sess-a", str(folder),
+                      [_user("the scheduled prompt", T9)])
+    _stage_run(runs, "20260912-090000-aa", folder, "sess-a",
+               started=time.time() + 5)
+
+    rows = _by_key(client)
+    assert rows[key]["task_id"] == number
+    assert rows["sess-a"]["task_id"] != number, "the scheduler gets its own"
+    assert client.get("/api/drafts").json()["chat"][key]["text"] == \
+        "still typing this"
+
+
+def test_a_run_tagged_for_another_chat_is_not_this_key_s_send(
+        client, projects_dir, runs, tmp_path):
+    """The tag is matched verbatim and nothing else is consulted. A folder and a
+    file inside it are two chats to draft in, and a number that crossed between
+    them would land on a conversation the reader never typed into."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    (folder / "app.py").write_text("x = 1\n")
+    key = "new:" + str(folder / "app.py")
+    client.put(_chat_url(key), json={"text": "first message"})
+    number = _by_key(client)[key]["task_id"]
+
+    _write_transcript(projects_dir, "sess-a", str(folder),
+                      [_user("first message", T9)])
+    _stage_run(runs, "20260912-090000-aa", folder, "sess-a",
+               draft_key="new:" + str(folder), started=time.time() + 5)
+
+    assert _by_key(client)[key]["task_id"] == number
+    assert client.get("/api/drafts").json()["chat"][key]["text"] == "first message"
+
+
+def test_a_send_into_a_session_leaves_another_chats_draft_alone(
+        client, projects_dir, runs, tmp_path):
+    """The bug this whole move was rewritten for. Opening a recent session in a
+    folder that holds an unsent draft used to walk that row — words, number and
+    all — onto a conversation the send had nothing to do with. A send with a
+    session to send into creates nothing, so it carries no tag."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "still typing this"})
+    number = _by_key(client)[key]["task_id"]
+
+    _write_transcript(projects_dir, "sess-a", str(folder),
+                      [_user("something else", T9)])
+    _stage_run(runs, "20260912-090000-aa", folder, "sess-a",
+               resumed_from="sess-a", started=time.time() + 5)
+
+    rows = _by_key(client)
+    assert rows[key]["task_id"] == number
+    assert rows["sess-a"]["task_id"] != number
+    assert client.get("/api/drafts").json()["chat"][key]["text"] == "still typing this"
+
+
+def test_a_run_that_never_minted_a_session_leaves_the_draft_alone(
+        client, runs, tmp_path):
+    """`_start` failed, or the CLI died before its first row. There is nothing
+    to carry the number to, and the draft is still the only copy of what the
+    user typed."""
     folder = tmp_path / "proj"
     folder.mkdir()
     key = "new:" + str(folder)
     client.put(_chat_url(key), json={"text": "first message"})
-    client.put(_chat_url(key), json={"text": ""})  # the send
+    number = _by_key(client)[key]["task_id"]
 
-    r = client.post("/api/drafts/chat/rekey", json={"from": key, "to": "sess-a"})
-    assert r.status_code == 200, r.text
-    assert r.json()["moved"] is False
-    assert drafts.get_chat(key) is None
-    assert drafts.get_chat("sess-a") is None
+    _stage_run(runs, "20260912-090000-aa", folder, draft_key=key,
+               started=time.time() + 5)
+
+    assert _by_key(client)[key]["task_id"] == number
+    assert client.get("/api/drafts").json()["chat"][key]["text"] == "first message"
 
 
-def test_the_rekey_route_carries_text_typed_after_the_send(client, tmp_path):
+def test_words_typed_after_the_run_started_are_not_that_run_s_draft(
+        client, projects_dir, runs, tmp_path):
+    """A draft saved AFTER the run began is not the message it sent — it is the
+    next one, typed into the same box while the session id was still on its way
+    — so the key keeps both its words and its number."""
     folder = tmp_path / "proj"
     folder.mkdir()
     key = "new:" + str(folder)
+    _write_transcript(projects_dir, "sess-a", str(folder),
+                      [_user("first message", T9)])
+    _stage_run(runs, "20260912-090000-aa", folder, "sess-a", draft_key=key,
+               started=time.time() - 60)
     client.put(_chat_url(key), json={"text": "and one more thing"})
+    number = _by_key(client)[key]["task_id"]
 
-    r = client.post("/api/drafts/chat/rekey", json={"from": key, "to": "sess-a"})
-    assert r.json()["moved"] is True
-    assert drafts.get_chat(key) is None
-    assert drafts.get_chat("sess-a")["text"] == "and one more thing"
-
-
-def test_the_rekey_route_is_a_no_op_for_a_draft_that_never_existed(client, tmp_path):
-    """The client fires this on every first send and cannot know whether the
-    debounce ever got round to a first save."""
-    key = "new:" + str(tmp_path / "proj")
-    r = client.post("/api/drafts/chat/rekey", json={"from": key, "to": "sess-a"})
-    assert r.status_code == 200, r.text
-    assert r.json() == {"ok": True, "from": key, "to": "sess-a",
-                        "task_id": "", "moved": False}
+    rows = _by_key(client)
+    assert rows[key]["task_id"] == number
+    assert client.get("/api/drafts").json()["chat"][key]["text"] == "and one more thing"
 
 
-def test_the_rekey_route_refuses_a_to_that_is_not_a_session(client, tmp_path):
-    key = "new:" + str(tmp_path / "proj")
-    assert client.post("/api/drafts/chat/rekey",
-                       json={"from": key, "to": "new:/tmp/x"}).status_code == 400
-    assert client.post("/api/drafts/chat/rekey",
-                       json={"from": key, "to": "/etc/passwd"}).status_code == 400
-    assert client.post("/api/drafts/chat/rekey",
-                       json={"from": "/etc/passwd", "to": "sess-a"}).status_code == 400
-    assert client.post("/api/drafts/chat/rekey",
-                       json={"from": "sess-a", "to": "sess-a"}).status_code == 400
+def test_the_number_moves_even_though_the_composer_deleted_the_draft(
+        client, projects_dir, runs, tmp_path):
+    """The ORDINARY case, and the one with no draft record left to read: the
+    composer deletes its own `new:<file>` draft in the same tick as the send, so
+    by the next build the number is all that is still filed under the key. It
+    still has to reach the session — which is why the settle asks the numbers
+    store and not only the drafts store."""
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    client.put(_chat_url(key), json={"text": "first message"})
+    number = _by_key(client)[key]["task_id"]
+    client.delete(_chat_url(key))
+    assert client.get("/api/drafts").json()["chat"] == {}
+
+    _write_transcript(projects_dir, "sess-a", str(folder),
+                      [_user("first message", T9)])
+    _stage_run(runs, "20260912-090000-aa", folder, "sess-a", draft_key=key,
+               started=time.time() + 5)
+
+    assert _by_key(client)["sess-a"]["task_id"] == number
+    assert tasks_store.task_number(key) == ""
+
+
+# ------------------------------- round 2: the template's half of the tag
+#
+# The settle above reads a field somebody else writes. `agent.py` is a TEMPLATE
+# — outside the package's import graph by design (SPEC PY-15), so it cannot be
+# imported, only loaded by path — and it is the process that actually spends the
+# draft. These two tests are the contract between the halves: the key goes into
+# `meta.json` verbatim when a send hands one over, and the field is ABSENT for
+# every other caller of `_start` (the scheduler, the apps API, canvases.py),
+# which is what keeps them from claiming a draft.
+
+
+def _load_agent_template():
+    path = os.path.join("fused_render", "templates", "claude", "agent.py")
+    spec = importlib.util.spec_from_file_location("claude_agent_drafts", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeHost:
+    """The session host `_start` spawns. What is under test is the file it
+    writes BEFORE the spawn, and a real host would go looking for a CLI."""
+
+    pid = 4242
+
+    def __init__(self):
+        self.stdin = io.BytesIO()
+
+
+def _start_a_run(tmp_path, monkeypatch, target, **kw):
+    agent = _load_agent_template()
+    monkeypatch.setattr(agent, "RUNS", str(tmp_path / "runs"))
+    monkeypatch.setattr(agent.subprocess, "Popen",
+                        lambda *a, **kwargs: _FakeHost())
+    out = agent._start(str(target), "first message", "", "", "", **kw)
+    assert "error" not in out, out
+    with open(os.path.join(agent.RUNS, out["run_id"], "meta.json"),
+              encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_start_writes_the_draft_key_it_was_handed(tmp_path, monkeypatch):
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    key = "new:" + str(folder)
+    meta = _start_a_run(tmp_path, monkeypatch, folder, draft_key=key)
+    # VERBATIM: the key is stored unnormalised on both sides on purpose, so a
+    # tilde or a trailing slash that the template "helpfully" resolved would be
+    # a key the server can never match.
+    assert meta["draft_key"] == key
+    assert meta["resumed_from"] == ""
+
+
+def test_start_writes_no_draft_key_when_nobody_sent_one(tmp_path, monkeypatch):
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    meta = _start_a_run(tmp_path, monkeypatch, folder)
+    assert "draft_key" not in meta
 
 
 # --------------------------------------- round 2: a draft moves, never twice
@@ -902,7 +1175,8 @@ def test_a_custom_repeat_keeps_its_rule(state_dir):
     # Pass-through, not parsed: this store is not the authority on what a
     # recurrence rule looks like, and a shape it validated would be a second
     # copy of `recur`'s grammar going stale.
-    assert drafts.put_task("draft-0002", {"custom_rule": {"freq": "fortnight"}}
+    assert drafts.put_task("draft-0002", {"title": "Retro",
+                                         "custom_rule": {"freq": "fortnight"}}
                            )["custom_rule"] == {"freq": "fortnight"}
     # A field the client omits keeps what the stored draft had, like every other.
     assert drafts.put_task("draft-0001", {"title": "Standup"}
@@ -912,13 +1186,17 @@ def test_a_custom_repeat_keeps_its_rule(state_dir):
                            )["custom_rule"] is None
 
 
-def test_a_rule_alone_is_still_a_draft(state_dir):
-    """`_empty_task` asks "is there anything a person chose here", and opening
-    the recurrence dialog and building a rule is exactly that."""
+def test_a_rule_alone_is_not_a_draft(state_dir):
+    """A recurrence rule is a SETTING — how a task would run, not a task
+    (Akshil, 2026-09-12). It used to count, and the cost was an "Untitled draft"
+    row minted by opening the when-row and picking a time."""
     assert drafts.put_task("draft-0001",
-                           {"custom_rule": {"freq": "month"}}) is not None
-    assert drafts.put_task("draft-0001", {"custom_rule": None}) is None
+                           {"custom_rule": {"freq": "month"}}) is None
     assert drafts.get_task("draft-0001") is None
+    # …and it rides along perfectly well once there are words to ride with.
+    assert drafts.put_task("draft-0001", {"title": "Monthly report",
+                                          "custom_rule": {"freq": "month"}}
+                           )["custom_rule"] == {"freq": "month"}
 
 
 def test_the_rule_rides_down_on_the_draft_row(client, tmp_path):

--- a/tests/test_drafts.py
+++ b/tests/test_drafts.py
@@ -142,10 +142,10 @@ def _by_key(client):
 
 
 def _put(ident, fields) -> dict | None:
-    """`drafts.put_task`, minus the evicted-ids half most tests here have no
-    reason to look at — the tests that ARE about eviction (below, "one bound
+    """`drafts.put_task`, minus the canonical-id half most tests here have no
+    reason to look at — the tests that ARE about the binding (below, "one bound
     draft per session") call `drafts.put_task` directly to see both."""
-    record, _evicted = drafts.put_task(ident, fields)
+    record, _canonical = drafts.put_task(ident, fields)
     return record
 
 
@@ -1228,37 +1228,85 @@ def test_the_session_a_draft_is_going_into_round_trips(state_dir):
 # same session — a New task form opened twice out of one conversation's
 # Schedule button, say, once before a reload and once after. The session's row
 # can wear exactly one `✎ Draft` chip (`_bound_chips`), so binding a second
-# draft to it is not a second fact, it is a stale copy of the first one, and
-# the newest write is the one that is telling the truth (review, 2026-09-12).
+# draft to it is not a second fact, it is one fact written twice.
+#
+# IT IS A MERGE AND NOT AN EVICTION (Bugbot, PR #1126, 2026-09-12). The first
+# version of this rule deleted the loser, which is right only if the winner is
+# the better-informed of the two — and the write that collides is by
+# construction the one that knows LESS: `fetchDrafts` never rejects, so a lookup
+# that fails on the way into the hop reads as "no bound form", the card mints a
+# new id, and a form carrying one sentence used to destroy a draft holding a
+# time, a repeat rule, a model and a tray. The incoming write is folded into the
+# existing record instead, and the id it landed on comes back so the card can
+# follow it.
 
 
-def test_binding_a_second_draft_evicts_the_first_bound_to_the_same_session(
-        state_dir):
-    first, evicted = drafts.put_task(
-        "draft-0001", {"title": "one", "session_id": "sess-a"})
+def test_a_second_draft_bound_to_one_session_is_MERGED_into_the_first(state_dir):
+    """NOT evicted (Bugbot, PR #1126, 2026-09-12).
+
+    The write that collides is by construction the one that knows LESS. A
+    Schedule hop whose `GET /api/drafts` failed reads as "this session has no
+    form", mints a fresh id and saves a form carrying only the composer's
+    sentence — over a stored draft holding the time, the repeat rule, the model
+    and the tray somebody spent a minute choosing. The first version of this
+    rule deleted all of that over one failed request."""
+    first, canonical = drafts.put_task("draft-0001", {
+        "title": "one", "session_id": "sess-a", "when": "2026-09-12T09:00",
+        "repeat": "weekly", "model": "opus", "effort": "high",
+        "target": "/Users/me/proj",
+        "attachments": [{"path": "/shots/a.png", "name": "a", "kind": "image"}],
+    })
     assert first is not None
-    assert evicted == [], "nothing else was bound yet"
+    assert canonical == "draft-0001", "nothing else was bound yet"
 
-    second, evicted = drafts.put_task(
-        "draft-0002", {"title": "two", "session_id": "sess-a"})
-    assert second is not None
-    assert second["session_id"] == "sess-a"
-    # THE LISTING KEY (`draft:<id>`), same shape `unbind_session` answers in —
-    # the caller announces it and a page holding that row has to be told to
-    # drop it.
-    assert evicted == ["draft:draft-0001"]
-    assert drafts.get_task("draft-0001") is None, "the loser's words are gone"
-    assert drafts.get_task("draft-0002") is not None
+    second, canonical = drafts.put_task("draft-0002", {
+        "title": "two", "session_id": "sess-a", "when": None, "repeat": None,
+        "model": "", "effort": "", "target": "",
+        "attachments": [{"path": "/shots/b.png", "name": "b", "kind": "image"}],
+    })
+    # THE EXISTING ID COMES BACK, so the caller can tell the page which record
+    # its card is really writing into.
+    assert canonical == "draft-0001"
+    assert drafts.get_task("draft-0002") is None, "no second draft was created"
+    stored = drafts.get_task("draft-0001")
+    assert stored is not None
+    assert stored == second
+    # The incoming write's words land...
+    assert stored["title"] == "two"
+    # ...and everything it said nothing about survives it.
+    assert stored["when"] == "2026-09-12T09:00"
+    assert stored["repeat"] == "weekly"
+    assert stored["model"] == "opus"
+    assert stored["effort"] == "high"
+    assert stored["target"] == "/Users/me/proj"
+    # Files are a union keyed on `path`: neither side's tray is a statement that
+    # the other side's is gone.
+    assert [a["path"] for a in stored["attachments"]] == ["/shots/a.png", "/shots/b.png"]
+    assert stored["session_id"] == "sess-a"
+    assert stored["created_at"] == first["created_at"], "the row does not move"
 
 
-def test_a_put_for_the_same_id_updates_in_place_and_evicts_nobody(state_dir):
+def test_the_merge_takes_a_setting_the_incoming_write_did_name(state_dir):
+    """Non-empty is the whole test. A blank field is "this write has nothing to
+    say about it"; a filled one is an answer, and answers win."""
+    drafts.put_task("draft-0001", {"title": "one", "session_id": "sess-a",
+                                   "when": "2026-09-12T09:00", "model": "opus"})
+    record, canonical = drafts.put_task("draft-0002", {
+        "title": "two", "session_id": "sess-a",
+        "when": "2026-09-13T17:30", "model": "haiku"})
+    assert canonical == "draft-0001"
+    assert record["when"] == "2026-09-13T17:30"
+    assert record["model"] == "haiku"
+
+
+def test_a_put_for_the_same_id_updates_in_place_and_merges_with_nobody(state_dir):
     """The ordinary autosave — the SAME draft, saved again and again — must
     never read as a second draft colliding with itself."""
     drafts.put_task("draft-0001", {"title": "one", "session_id": "sess-a"})
-    record, evicted = drafts.put_task("draft-0001", {"title": "one, edited"})
+    record, canonical = drafts.put_task("draft-0001", {"title": "one, edited"})
     assert record["title"] == "one, edited"
     assert record["session_id"] == "sess-a", "unmentioned fields survive"
-    assert evicted == []
+    assert canonical == "draft-0001"
     assert drafts.get_task("draft-0001") is not None
 
 
@@ -1270,27 +1318,33 @@ def test_unbound_drafts_are_untouched_by_a_binding_elsewhere(state_dir):
     drafts.put_task(
         "draft-other", {"title": "a different thread", "session_id": "sess-b"})
 
-    _record, evicted = drafts.put_task(
+    _record, canonical = drafts.put_task(
         "draft-0001", {"title": "one", "session_id": "sess-a"})
-    assert evicted == []
+    assert canonical == "draft-0001"
     assert drafts.get_task("draft-unbound") is not None
     assert drafts.get_task("draft-other")["session_id"] == "sess-b"
 
 
-def test_the_router_announces_the_draft_a_binding_evicted(client, tmp_path):
-    """The eviction happens inside `put_task`'s own lock; a page holding the
-    loser's row would go on showing it until the next full listing without the
-    router telling the long-poll too (`routers/drafts.py`, the PUT handler)."""
+def test_the_router_answers_and_announces_the_id_the_write_landed_on(
+        client, tmp_path):
+    """The merge happens inside `put_task`'s own lock. The page has to be told
+    twice over: in the answer, because every later call the card makes names the
+    draft by id, and on the long-poll, because a page holding a row under the id
+    that was folded away would go on showing it until the next full listing
+    (`routers/drafts.py`, the PUT handler)."""
     elsewhere = tmp_path / "elsewhere"
     elsewhere.mkdir()
     _bound_draft(client, "draft-0001", "sess-a", elsewhere)
     before = client.get("/api/tasks").json()["generation"]
 
-    _bound_draft(client, "draft-0002", "sess-a", elsewhere)
-    assert drafts.get_task("draft-0001") is None
+    body = _bound_draft(client, "draft-0002", "sess-a", elsewhere,
+                        title="written by a card that could not look first")
+    assert body["draft_id"] == "draft-0001"
+    assert drafts.get_task("draft-0002") is None
+    assert drafts.get_task("draft-0001")["title"].startswith("written by a card")
 
-    body = client.get(f"/api/tasks/changes?since={before}&wait=0").json()
-    assert "draft:draft-0001" in body["gone"]
+    changed = client.get(f"/api/tasks/changes?since={before}&wait=0").json()
+    assert "draft:draft-0002" in changed["gone"]
 
 
 def test_a_session_bound_draft_is_not_a_row_and_the_session_wears_the_chip(
@@ -1350,6 +1404,33 @@ def test_the_conversations_own_composer_outranks_the_form(client, tmp_path,
     row = _by_key(client)["sess-a"]
     assert row["draft"]["preview"] == "half a thought"
     assert row["bound_draft"] == "draft-0001", "still the way back to the form"
+    assert row["draft"]["kind"] == "chat"
+
+
+def test_the_row_says_WHICH_kind_of_draft_its_preview_is(client, tmp_path,
+                                                         projects_dir):
+    """`draft.kind` — "chat" or "form" (Bugbot, PR #1126, 2026-09-12).
+
+    The thread's leading line quotes this preview, and pressing your own unsent
+    sentence has to land where it is. A `"chat"` preview is in this
+    conversation's composer, so the press opens the chat and there it is; a
+    `"form"` preview is a New task card bound to this session, of which the chat
+    holds nothing, so that press has to reopen the card instead. The page used
+    to go to the chat either way and showed the reader an empty composer under
+    the words it had just printed."""
+    _write_transcript(projects_dir, "sess-a", "/home/me/proj", [_user("one", T9)])
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    # The bound form, with the composer empty.
+    _bound_draft(client, "draft-0001", "sess-a", elsewhere)
+    row = _by_key(client)["sess-a"]
+    assert row["draft"]["kind"] == "form"
+    assert row["draft"]["preview"] == "Ship the changelog"
+
+    # …and the composer, which outranks it and says so.
+    client.put(_chat_url("sess-a"), json={"text": "half a thought"})
+    assert _by_key(client)["sess-a"]["draft"]["kind"] == "chat"
 
 
 def test_a_draft_with_no_session_is_numbered_exactly_as_before(client, tmp_path):


### PR DESCRIPTION
## What

Second pass on drafts (#1118), from the owner's first round of testing plus the open Bugbot thread.

## Rows and views

- **One open rule.** A row without a session is a draft and always opens the New Task modal: task drafts as before; a never-sent chat (`new:<file>`) opens seeded as a hop, so Schedule turns it into a task and "Back to chat" returns the words to the composer. A row with a session always opens the chat. The chip says "Draft" everywhere.
- **Red chip.** `.tasks-draft-pill` uses `--error` for text and glyph; nothing else changes.
- **Done-lane chip.** Board lanes show the first 20 by last run; draft-carrying cards weren't hoisted like the List does, so a Done card with a draft often never reached the visible set. `groupByColumn` now hoists drafts within every lane; Cards uses the same order.
- **Cards = sessions only** (In progress, Done, Archive, Blocked); pending rows with no transcript are not drawn.

## New Task modal

- **Attachment leak fixed.** Hop state lived in six page-level `useState`s undone one by one on close, and the attachments setter was missing, so every later modal was re-seeded. The hop is now one `HopSeed` value passed to `openForm`; non-hop openings carry none by construction.
- **A draft exists only with words or files.** Title, description or attachments make a draft; folder, model, effort, permission, time, repeat alone mint nothing and cannot keep one alive. Fixes "clear the text, remove the attachment, the draft stays".
- **Discard** shares Delete task's classes, icon and far-left seat.

## Rekey, server-owned

Four Bugbot rounds showed every client-side "this session is the one my send created" inference has a gap. Now the composer's first send tags its run with `draft_key` (template `agent.py` writes it into `meta.json`, stdlib only), and the server's listing build (`_settle_new_chats`) moves the TASK number onto the session that run created and deletes the `new:<file>` draft. Untagged first runs on the same folder (a scheduler's fire) leave the draft whole. `POST /api/drafts/chat/rekey` and all client rekey code are removed.

## Tests

- pytest: 12343 pass. Remaining failures are pre-existing on main: `test_claude_health` / `test_ai_metrics` (real `claude` binary on this machine), `test_calls` (`/proc/self/fd`, Linux-only), `test_env_install_worker_progress`, `test_ai_worker_base[*]` (socket flake).
- Frontend: `bun test` 5480 pass, `tsc` clean.
- Reviewed for regressions against `origin/main` (drafts feature already merged); the one blocking finding (settle could misattribute a scheduler's first run) is what the `draft_key` tag closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches draft identity, session binding, and first-send TASK numbering across chat, scheduling, and list/board/card navigation—high user-visible impact but logic is heavily documented and regression-tested.
> 
> **Overview**
> Moves **TASK number migration** off the chat page: session-less agent starts now send optional `draft_key` (`new:<file>`) from the run controller, and client **`rekeyChatDraft` / `pendingRekey` / the rekey API route are removed**. The composer still deletes the spent `new:<file>` draft on send; the server is expected to attach the number when the run’s session appears.
> 
> **Session-bound New task forms** get first-class support: task drafts carry **`session_id`**, listings expose **`draft.kind`** (`chat` | `form`) and **`bound_draft`**, and Schedule / reopen paths use **`boundDraftSeed`**, **`HopSeed`**, and **`openBoundDraft`** so a second Schedule press reopens the same form instead of minting another. **`saveTaskDraft`** returns the canonical **`draft_id`** after server merge; Discard, Back to chat, and Schedule read that id **after `settle`**. Bound “Back to chat” navigates without re-seeding/deleting the shared record; unbound paths still move words back to the composer.
> 
> **Draft UX rules** tighten: never-sent chat rows open the **New Task modal** (hop fetch + generation guard), thread expansion shows an **unsent draft line** (form drafts open the card via **`onOpenBoundDraft`**), and **Draft chips** filter on Cards too. **NewJobModal** only autosaves drafts when there are words/files (or after one exists), remembers **`boundSessionId`** on every save, and **Discard** matches Delete styling. **`fetchDrafts`** returns **`null`** on failure so bound-draft lookup is not confused with “no drafts”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3610ffd64a597eebaabe59b7738d0a60abb6a514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->